### PR TITLE
Test static checks

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             image 'rocm/dev-ubuntu-18.04:3.7'
-            args '--user "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
+            args '--user "$(id -u):$(id -g)"  --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'rocm'
         }
     }
@@ -21,14 +21,15 @@ pipeline {
 
                     # install pkg dependencies
                     sudo apt update
-                    sudo apt install -y ninja-build wget git python cmake miopen-hip libsqlite3-dev
+                    sudo apt install -y ninja-build wget git python cmake miopen-hip libsqlite3-dev python3-pip
+                    pip3 install pathspec unidiff
                 '''
             }
         }
-        stage('Test') {
+        stage('Build and Test') {
             steps {
                 checkout scm
-                sh '''
+                sh ''' 
                     # make build directory
                     mkdir -p build && cd build
 
@@ -47,9 +48,27 @@ pipeline {
 
                     # build LLVM / MLR and run tests
                     cmake --build . --target check-mlir
+	  	    cd ..
                 '''
             }
         }
+        stage('Static Test') {
+	    steps {
+            	sh """
+	     	    # premerge checks
+                    # Must be invoked from the root directory
+                    if [ ! -f ./compile_commands.json ]; then
+                       ln -s build/compile_commands.json compile_commands.json
+                    fi
+
+		    # Set the path to the clang-format executable 
+                    PATH=$PATH:/opt/rocm/llvm/bin/
+
+		    python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py
+
+                """ 
+            }
+	}
     }
     post { 
         always { 

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             image 'rocm/dev-ubuntu-18.04:3.7'
-            args '--user "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
+            args '--user "$(id -u):$(id -g)"  --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'rocm'
         }
     }
@@ -21,11 +21,12 @@ pipeline {
 
                     # install pkg dependencies
                     sudo apt update
-                    sudo apt install -y ninja-build wget git python cmake miopen-hip libsqlite3-dev
+                    sudo apt install -y ninja-build wget git python cmake miopen-hip libsqlite3-dev python3-pip
+                    pip3 install pathspec unidiff
                 '''
             }
         }
-        stage('Test') {
+        stage('Build and Test') {
             steps {
                 checkout scm
                 sh '''
@@ -47,9 +48,27 @@ pipeline {
 
                     # build LLVM / MLR and run tests
                     cmake --build . --target check-mlir
+                    cd ..
                 '''
             }
         }
+        stage('Static Test') {
+            steps {
+                sh """
+                    # premerge checks
+                    # Must be invoked from the root directory
+                    if [ ! -f ./compile_commands.json ]; then
+                       ln -s build/compile_commands.json compile_commands.json
+                    fi
+
+                    # Set the path to the clang-format executable
+                    PATH=$PATH:/opt/rocm/llvm/bin/
+
+                    python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py
+
+                """
+            }
+	}
     }
     post { 
         always { 

--- a/mlir/utils/jenkins/static-checks/clang-format.ignore
+++ b/mlir/utils/jenkins/static-checks/clang-format.ignore
@@ -1,0 +1,3 @@
+# Reference:  https://github.com/google/llvm-premerge-checks/blob/master/scripts/clang-format.ignore
+# Patterns for clang-format to ignore.
+**/test

--- a/mlir/utils/jenkins/static-checks/clang-tidy.ignore
+++ b/mlir/utils/jenkins/static-checks/clang-tidy.ignore
@@ -1,0 +1,6 @@
+# Reference: https://github.com/google/llvm-premerge-checks/blob/master/scripts/clang-tidy.ignore
+# Files to be ignored by clang-tidy. Will not appear in short report and inline comments.
+mlir/examples/standalone 
+mlir/test
+mlir/tools/mlir-cuda-runner
+mlir/tools/mlir-rocm-runner

--- a/mlir/utils/jenkins/static-checks/premerge-checks.py
+++ b/mlir/utils/jenkins/static-checks/premerge-checks.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+""" A script to perform static tests for the mlir project.
+
+This script runs clang-format and clang-tidy on the changes before a user 
+merges them to the master branch.
+
+The code was extracted from https://github.com/google/llvm-premerge-checks.
+
+Example usage:
+~/llvm-project-mlir#  ln -s build/compile_commands.json compile_commands.json
+~/llvm-project-mlir#  python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py
+"""
+
+
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import re
+import subprocess
+from typing import Tuple, Optional
+import pathspec
+import unidiff
+
+
+def get_diff(base_commit) -> Tuple[bool, str]:
+  r = subprocess.run(f'/opt/rocm-3.7.0/llvm/bin/git-clang-format {base_commit}', shell=True)
+  if r.returncode != 0:
+    r = subprocess.run(f'git checkout -- .', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    return False, ''
+  diff_run = subprocess.run(f'git diff -U0 --no-prefix --exit-code', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+  r = subprocess.run(f'git checkout -- .', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+  return True, diff_run.stdout.decode()
+
+def run_clang_format(base_commit, ignore_config):
+  """Apply clang-format and return if no issues were found.
+  Extracted from https://github.com/google/llvm-premerge-checks/blob/master/scripts/clang_format_report.py"""
+
+  r, patch = get_diff(base_commit)
+  if not r:
+    return False
+
+  patches = unidiff.PatchSet(patch)
+  ignore_lines = []
+
+  if ignore_config is not None and os.path.exists(ignore_config):
+    ignore_lines = open(ignore_config, 'r').readlines()
+  ignore = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore_lines)
+  patched_file: unidiff.PatchedFile
+  success = True
+  for patched_file in patches:
+    if ignore.match_file(patched_file.source_file) or ignore.match_file(patched_file.target_file):
+      continue
+    hunk: unidiff.Hunk
+    for hunk in patched_file:
+      success = False
+
+  if not success:
+    print('Please format your changes with clang-format by running `git-clang-format HEAD^` or applying patch.')
+    return False
+
+  return True
+
+def remove_ignored(diff_lines, ignore_patterns_lines):
+  ignore = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore_patterns_lines)
+  good = True
+  result = []
+  for line in diff_lines:
+    match = re.search(r'^diff --git (.*) (.*)$', line)
+    if match:
+      good = not (ignore.match_file(match.group(1)) and ignore.match_file(match.group(2)))
+    if good:
+      result.append(line)
+  return result
+
+
+def run_clang_tidy(base_commit, ignore_config): 
+  """Apply clang-tidy and return if no issues were found.
+  Extracted from https://github.com/google/llvm-premerge-checks/blob/master/scripts/clang_tidy_report.py"""
+
+  r = subprocess.run(f'git diff -U0 --no-prefix {base_commit}', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  diff = r.stdout.decode()
+  if ignore_config is not None and os.path.exists(ignore_config):
+    ignore = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern,
+                                          open(ignore_config, 'r').readlines())
+    diff = remove_ignored(diff.splitlines(keepends=True), open(ignore_config, 'r'))
+  else:
+    ignore = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, [])
+  p = subprocess.Popen(['./clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py', '-p0', '-quiet'],
+                       stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+  a = ''.join(diff)
+  out = p.communicate(input=a.encode())[0].decode()
+  # Typical finding looks like:
+  # [cwd/]clang/include/clang/AST/DeclCXX.h:3058:20: error: ... [clang-diagnostic-error]
+  pattern = '^([^:]*):(\\d+):(\\d+): (.*): (.*)'
+  errors_count = 0
+  warn_count = 0
+  for line in out.splitlines(keepends=False):
+    line = line.strip()
+    line = line.replace(os.getcwd() + os.sep, '')
+
+    if len(line) == 0 or line == 'No relevant changes found.':
+      continue
+    match = re.search(pattern, line)
+    if match:
+      file_name = match.group(1)
+      line_pos = match.group(2)
+      char_pos = match.group(3)
+      severity = match.group(4)
+      if severity in ['warning', 'error']:
+        if severity == 'warning':
+          warn_count += 1
+        if severity == 'error':
+          print('clang-tidy found error:',line)
+          errors_count += 1
+        if ignore.match_file(file_name):
+          print('{} is ignored by pattern and no comment will be added'.format(file_name))
+
+  if errors_count + warn_count != 0:
+    print('clang-tidy found {} errors and {} warnings.'.format(errors_count, warn_count))
+
+  if errors_count != 0:
+    return False
+
+  return True
+
+
+if __name__ == '__main__':
+  if  not (   run_clang_format('HEAD~1','./mlir/utils/jenkins/static-checks/clang-format.ignore')
+          and run_clang_tidy('HEAD~1', './mlir/utils/jenkins/static-checks/clang-tidy.ignore') ):
+    exit(1)


### PR DESCRIPTION
 -  Add a new "Static Test" Jenkins stage.
 -  Set the path to the clang-format executable in the "Static Test" sh step.
 -  Invoke the static tests after cmake build to make generated .inc files accessible by clang-tidy.
