### PR TITLE
Adding xdlops tuning support

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/GridwiseConvCppOutputHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/GridwiseConvCppOutputHelper.h
@@ -1,0 +1,40 @@
+//===- GridwiseConvCppOutputHelper.h - MLIR convolution cpp output helper
+//--===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines MLIR cpp convolution output helper
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_MIOPEN_GRIDWISECONVCPPOUTPUTHELPER_H
+#define MLIR_DIALECT_MIOPEN_GRIDWISECONVCPPOUTPUTHELPER_H
+
+#include "mlir/IR/Attributes.h"
+
+using namespace mlir;
+
+static constexpr int kConv2DTensorDimension = 4;
+static constexpr StringLiteral kVarName[3] = {"weight", "input", "output"};
+
+static inline void
+EmitLayoutString(llvm::raw_ostream &output,
+                 llvm::ArrayRef<mlir::Attribute> &layoutArrayAttr,
+                 llvm::StringRef prefix, llvm::StringRef suffix,
+                 llvm::StringRef delimiter = "") {
+  for (int i = 0; i < kConv2DTensorDimension; ++i) {
+    auto attr = layoutArrayAttr[i];
+    if (auto strAttr = attr.dyn_cast<StringAttr>()) {
+      output << prefix << strAttr.getValue() << suffix;
+    }
+    if (i < kConv2DTensorDimension - 1) {
+      output << delimiter;
+    }
+  }
+}
+
+#endif // MLIR_DIALECT_MIOPEN_GRIDWISECONVCPPOUTPUTHELPER_H

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/SqliteDb.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/SqliteDb.h
@@ -25,8 +25,6 @@
 #include <unordered_map>
 #include <vector>
 
-#define DEBUG_TYPE "miopen-sqlite-db"
-
 namespace mlir {
 
 const auto MIOPEN_SQL_BUSY_TIMEOUT_MS = 60000;
@@ -52,6 +50,8 @@ public:
 };
 
 class DbRecord {
+#define DEBUG_TYPE "miopen-sqlite-dbrecord"
+
 public:
   bool getValues(const std::string &id, std::string &values) const;
   bool setValues(const std::string &id, const std::string &values);
@@ -79,6 +79,8 @@ public:
 private:
   std::string key;
   std::unordered_map<std::string, std::string> map;
+
+#undef DEBUG_TYPE
 };
 
 template <class Vector, class T> void printVector(Vector v) {
@@ -88,6 +90,8 @@ template <class Vector, class T> void printVector(Vector v) {
 }
 
 class SQLitePerfDb {
+#define DEBUG_TYPE "miopen-sqlite-perfdb"
+
 public:
   std::string filename;
   std::string arch;
@@ -141,11 +145,12 @@ public:
             return false;
         return record->getValues(id, values);
     }
+
+#undef DEBUG_TYPE
 };
 
 SQLitePerfDb getDb(const llvm::SmallString<8> &arch, size_t num_cu);
-
-}
+} // namespace MLIR
 
 #endif // MLIR_ENABLE_SQLITE
 #endif // MLIR_DIALECT_MIOPEN_SQLITE_DB_H

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -52,11 +52,13 @@ LogicalResult PopulateParams::populateDerived(
 }
 
 LogicalResult PopulateParams::paramsFromCtx(
-    ConvolutionContext &ctx, InitParamsNonXDL &validParams, GemmSize &gemmSize,
-    DerivedParams &gemmADerivedParam, DerivedParams &gemmBDerivedParam,
+    ConvolutionContext &ctx, int64_t blockSizeOverride,
+    InitParamsNonXDL &validParams, DerivedParams &gemmADerivedParam,
+    DerivedParams &gemmBDerivedParam,
     DerivedBlockGemmParams &blockGemmDerivedParam, int64_t &gemmCDstPerWrite,
     int64_t &gridSize) {
 
+  GemmSize gemmSize;
   obtainGemmSize(ctx, gemmSize);
 
 #if __MLIR_ENABLE_SQLITE__
@@ -73,7 +75,8 @@ LogicalResult PopulateParams::paramsFromCtx(
   bool loadRes = perfDb.load(ctx, solverId, validParams);
   if (loadRes) {
     LLVM_DEBUG(llvm::dbgs()
-               << "DB load succeed, block size: " << validParams.blockSize
+               << "DB load succeed,"
+               << " block size: " << validParams.blockSize
                << " M/block: " << validParams.gemmMPerBlock
                << " N/block: " << validParams.gemmNPerBlock
                << " K/block: " << validParams.gemmKPerBlock
@@ -94,9 +97,8 @@ LogicalResult PopulateParams::paramsFromCtx(
   for (auto &params : initParameters) {
     // We have an override on the blockSize, only loop through the
     // initParameters with the same blockSize
-    if ((validParams.blockSize != 0) &&
-        (validParams.blockSize != params.blockSize)) {
-      return failure();
+    if ((blockSizeOverride != 0) && (blockSizeOverride != params.blockSize)) {
+      continue;
     }
 
     res = populateDerived(ctx, params, gemmSize, gemmADerivedParam,
@@ -113,63 +115,118 @@ LogicalResult PopulateParams::paramsFromCtx(
   if (failed(res)) {
     // All initParameters have failed, shouldn't happen
     llvm::errs() << "FATAL ERROR! COULD NOT FIND VALID TUNING PARAMETERS!\n";
+  } else {
+    LLVM_DEBUG(llvm::dbgs() << "Successfully picked tuning params from backup"
+                            << " path.\n");
   }
 
   return res;
 }
 
-LogicalResult PopulateParamsXDL::paramsFromCtx(ConvolutionContext &ctx,
-                                               InitParamsXDL &validParams,
-                                               DerivedParams &gemmADerivedParam,
-                                               DerivedParams &gemmBDerivedParam,
-                                               int64_t &blockSize,
-                                               int64_t &gridSize) {
+LogicalResult PopulateParamsXDL::populateDerived(
+    ConvolutionContext &ctx, InitParamsXDL &params, GemmSize &gemmSize,
+    DerivedParams &gemmADerivedParam, DerivedParams &gemmBDerivedParam,
+    int64_t &blockSize, int64_t &gridSize) {
+  LogicalResult res = isValidGemm(&params, gemmSize);
+  if (failed(res)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Gemm sizes, M: " << gemmSize.gemmM
+               << " N: " << gemmSize.gemmN << " K: " << gemmSize.gemmK << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Gemm size and gemm/block "
+                            << "size does not divide exactly.\n");
+    return failure();
+  }
+
+  blockSize = obtainBlockSize(params, waveSize);
+
+  res = isValidblockwisegemmxdlops(params, blockSize);
+  if (failed(res)) {
+    LLVM_DEBUG(llvm::dbgs() << "Invalid XDLOps gemm.\n");
+    return failure();
+  }
+
+  res = calculateGemmABlockCopyPerformanceParameters(&params, ctx,
+                                                     gemmADerivedParam);
+  if (failed(res)) {
+    LLVM_DEBUG(llvm::dbgs() << "Incoherent gemmA tuning parameter "
+                            << " size.\n");
+    return failure();
+  }
+
+  res = calculateGemmBBlockCopyPerformanceParameters(&params, ctx,
+                                                     gemmBDerivedParam);
+  if (failed(res)) {
+    LLVM_DEBUG(llvm::dbgs() << "Incoherent gemmB tuning parameter "
+                            << " size.\n");
+    return failure();
+  }
+
+  std::size_t ldsSize = 0;
+  res = calculateLdsNumberOfByte(params, ctx, gemmADerivedParam,
+                                 gemmBDerivedParam, ldsSize);
+
+  if (failed(res)) {
+    LLVM_DEBUG(llvm::dbgs() << "LDS size too large.\n");
+    return failure();
+  }
+
+  // parameters derivable from tunable parameters.
+  gridSize = obtainGridSize(gemmSize, &params);
+  return success();
+}
+
+LogicalResult PopulateParamsXDL::paramsFromCtx(
+    ConvolutionContext &ctx, int64_t blockSizeOverride,
+    InitParamsXDL &validParams, DerivedParams &gemmADerivedParam,
+    DerivedParams &gemmBDerivedParam, int64_t &blockSize, int64_t &gridSize) {
 
   GemmSize gemmSize;
   obtainGemmSize(ctx, gemmSize);
 
+#if __MLIR_ENABLE_SQLITE__
+  std::string solverId;
+  if (ctx.opType == miopen::ConvOpType::Conv2DOpType) {
+    solverId = "ConvHipImplicitGemmForwardV4R4Xdlops";
+  } else if (ctx.opType == miopen::ConvOpType::Conv2DBwdDataOpType) {
+    solverId = "ConvHipImplicitGemmBwdDataV4R1Xdlops";
+  } else {
+    solverId = "ConvHipImplicitGemmWrwV4R4Xdlops";
+  }
+
+  SQLitePerfDb perfDb = getDb(ctx.arch, ctx.num_cu);
+  bool loadRes = perfDb.load(ctx, solverId, validParams);
+  if (loadRes) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "DB load succeed,"
+               << " M/block: " << validParams.gemmMPerBlock
+               << " N/block: " << validParams.gemmNPerBlock
+               << " K/block: " << validParams.gemmKPerBlock
+               << " M/Wave: " << validParams.gemmMPerWave
+               << " N/Wave: " << validParams.gemmNPerWave
+               << " KPack: " << validParams.gemmKPack
+               << " ACopyGemmK: " << validParams.gemmAThreadCopyMoreGemmK
+               << " BCopyKPack: " << validParams.gemmBThreadCopyMoreGemmKPack
+               << "\n");
+    return populateDerived(ctx, validParams, gemmSize, gemmADerivedParam,
+                           gemmBDerivedParam, blockSize, gridSize);
+  } else {
+    LLVM_DEBUG(llvm::dbgs()
+               << "DB load failed, falling back to backup path.\n");
+  }
+#endif // MLIR_ENABLE_SQLITE
+
   LogicalResult res(LogicalResult::Failure);
   for (auto &params : initParameters) {
-    res = isValidGemm(&params, gemmSize);
-    if (failed(res)) {
-      LLVM_DEBUG(llvm::dbgs() << "Gemm sizes, M: " << gemmSize.gemmM
-                              << " N: " << gemmSize.gemmN
-                              << " K: " << gemmSize.gemmK << "\n");
-      LLVM_DEBUG(llvm::dbgs() << "Gemm size and gemm/block "
-                              << "size does not divide exactly.\n");
-      continue;
-    }
-
     blockSize = obtainBlockSize(params, waveSize);
-
-    res = isValidXDLOPSGemm(&params, blockSize);
-    if (failed(res)) {
-      LLVM_DEBUG(llvm::dbgs() << "Invalid XDLOps gemm.\n");
+    // We have an override on the blockSize, only loop through the
+    // initParameters with the same blockSize
+    if ((blockSizeOverride != 0) && (blockSizeOverride != blockSize)) {
       continue;
     }
 
-    res = calculateGemmABlockCopyPerformanceParameters(&params, ctx,
-                                                       gemmADerivedParam);
+    res = populateDerived(ctx, params, gemmSize, gemmADerivedParam,
+                          gemmBDerivedParam, blockSize, gridSize);
     if (failed(res)) {
-      LLVM_DEBUG(llvm::dbgs() << "Incoherent gemmA tuning parameter "
-                              << " size.\n");
-      continue;
-    }
-
-    res = calculateGemmBBlockCopyPerformanceParameters(&params, ctx,
-                                                       gemmBDerivedParam);
-    if (failed(res)) {
-      LLVM_DEBUG(llvm::dbgs() << "Incoherent gemmB tuning parameter "
-                              << " size.\n");
-      continue;
-    }
-
-    std::size_t ldsSize = 0;
-    res = calculateLdsNumberOfByte(&params, ctx, gemmADerivedParam,
-                                   gemmBDerivedParam, ldsSize);
-
-    if (failed(res)) {
-      LLVM_DEBUG(llvm::dbgs() << "LDS size too large.\n");
       continue;
     }
 
@@ -180,8 +237,10 @@ LogicalResult PopulateParamsXDL::paramsFromCtx(ConvolutionContext &ctx,
   if (failed(res)) {
     // All initParameters have failed, shouldn't happen
     llvm::errs() << "FATAL ERROR! COULD NOT FIND VALID TUNING PARAMETERS!\n";
+  } else {
+    LLVM_DEBUG(llvm::dbgs() << "Successfully picked tuning params from backup"
+                            << " path.\n");
   }
 
-  // parameters derivable from tunable parameters.
-  gridSize = obtainGridSize(gemmSize, &validParams);
+  return res;
 }

--- a/mlir/lib/Dialect/MIOpen/Tuning/SqliteDb.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/SqliteDb.cpp
@@ -9,6 +9,8 @@
 using namespace mlir;
 using llvm::dbgs;
 
+#define DEBUG_TYPE "miopen-sqlite-db"
+
 class SQLite::impl {
   struct SQLiteCloser {
     void operator()(sqlite3 *ptr) {

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/MIOpen/GridwiseConvCppOutputHelper.h"
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
 #include "mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -904,18 +905,16 @@ void mlir::translateModuleToMIOpenCFlags(ModuleOp m, std::string &cflags) {
 
     f.walk([&output](miopen::GridwiseGemmOp op) {
       ConvolutionContext ctx = populateConvContext(op);
-      InitParamsNonXDL validParams{0, 0, 0, 0, 0, 0};
-      GemmSize gemmSize;
+      InitParamsNonXDL validParams;
       DerivedParams gemmADerivedParam;
       DerivedParams gemmBDerivedParam;
       DerivedBlockGemmParams blockGemmDerivedParam;
       int64_t gemmCDstPerWrite;
       int64_t gridSize;
-
       PopulateParams populateParams;
-      populateParams.paramsFromCtx(
-          ctx, validParams, gemmSize, gemmADerivedParam, gemmBDerivedParam,
-          blockGemmDerivedParam, gemmCDstPerWrite, gridSize);
+      populateParams.paramsFromCtx(ctx, 0, validParams, gemmADerivedParam,
+                                   gemmBDerivedParam, blockGemmDerivedParam,
+                                   gemmCDstPerWrite, gridSize);
 
       std::map<std::string, int> parameters;
 

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/MIOpen/GridwiseConvCppOutputHelper.h"
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
 #include "mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -664,20 +665,18 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenHeaderXDLOPS(Modul
       auto filterLayoutAttr = op.getAttrOfType<ArrayAttr>("filter_layout");
       auto inputLayoutAttr = op.getAttrOfType<ArrayAttr>("input_layout");
 
-      size_t dimKF, dimCF, dimYF, dimXF;
-      size_t dimNI, dimCI, dimHI, dimWI;
-
+      size_t dimKF, dimNI, dimCI;
       for (size_t i = 0; i < 4; ++i) {
         auto filterDim = filterLayoutAttr.getValue()[i].dyn_cast<StringAttr>().getValue();
 
         if (filterDim.str() == "k") {
           dimKF = i;
         } else if (filterDim.str() == "c") {
-          dimCF = i;
+          // dimCF = i;
         } else if (filterDim.str() == "y") {
-          dimYF = i;
+          // dimYF = i;
         } else if (filterDim.str() == "x") {
-          dimXF = i;
+          // dimXF = i;
         }
 
         auto inputDim = inputLayoutAttr.getValue()[i].dyn_cast<StringAttr>().getValue();
@@ -686,9 +685,9 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenHeaderXDLOPS(Modul
         } else if (inputDim.str() == "ci") {
           dimCI = i;
         } else if (inputDim.str() == "hi") {
-          dimHI = i;
+          // dimHI = i;
         } else if (inputDim.str() == "wi") {
-          dimWI = i;
+          // dimWI = i;
         }
       }
 
@@ -815,12 +814,12 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCFlagsXDLOPS(Modul
       parameters["CK_PARAM_PROBLEM_RIGHT_PAD_W"] = ctx.paddingVal[3];
 
       PopulateParamsXDL populateParams;
-      InitParamsXDL validParams{0, 0, 0, 0, 0};
+      InitParamsXDL validParams;
       DerivedParams gemmADerivedParam;
       DerivedParams gemmBDerivedParam;
       int64_t blockSize = 0;
       int64_t gridSize = 0;
-      populateParams.paramsFromCtx(ctx, validParams, gemmADerivedParam,
+      populateParams.paramsFromCtx(ctx, 0, validParams, gemmADerivedParam,
                                    gemmBDerivedParam, blockSize, gridSize);
 
       parameters["CK_PARAM_TUNABLE_BLOCK_SIZE"] = blockSize;
@@ -861,7 +860,6 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCFlagsXDLOPS(Modul
       parameters["MIOPEN_USE_FP16"] = 0;
       parameters["MIOPEN_USE_BFP16"] = 0;
 
-      miopen::ConvOpType opType = ObtainConvDirection(op);
       parameters["CK_PARAM_PROBLEM_CONV_DIRECTION_FORWARD"] = 1;
       parameters["CK_PARAM_PROBLEM_CONV_DIRECTION_BACKWARD_DATA"] = 0;
       parameters["CK_PARAM_PROBLEM_CONV_DIRECTION_BACKWARD_WEIGHT"] = 0;

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -669,14 +669,10 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenHeaderXDLOPS(Modul
       for (size_t i = 0; i < 4; ++i) {
         auto filterDim = filterLayoutAttr.getValue()[i].dyn_cast<StringAttr>().getValue();
 
+        // Since XDLOPS cpp backend only supports forward pass so not all
+        // variables are used
         if (filterDim.str() == "k") {
           dimKF = i;
-        } else if (filterDim.str() == "c") {
-          // dimCF = i;
-        } else if (filterDim.str() == "y") {
-          // dimYF = i;
-        } else if (filterDim.str() == "x") {
-          // dimXF = i;
         }
 
         auto inputDim = inputLayoutAttr.getValue()[i].dyn_cast<StringAttr>().getValue();
@@ -684,10 +680,6 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenHeaderXDLOPS(Modul
           dimNI = i;
         } else if (inputDim.str() == "ci") {
           dimCI = i;
-        } else if (inputDim.str() == "hi") {
-          // dimHI = i;
-        } else if (inputDim.str() == "wi") {
-          // dimWI = i;
         }
       }
 

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -227,8 +227,8 @@ static void populateDefaults() {
       inputWidth.setValue(14);
       filterHeight.setValue(1);
       filterWidth.setValue(1);
-      dilationHeight.setValue(0);
-      dilationWidth.setValue(0);
+      dilationHeight.setValue(1);
+      dilationWidth.setValue(1);
       strideHeight.setValue(1);
       strideWidth.setValue(1);
       paddingHeight.setValue(0);


### PR DESCRIPTION
This is follow up to #14 

* added xdlops tuning implementation in GridwiseGemmParams component
* Backward compatible changes in v4r4 and v4r4_gen_xdlops Cppoutput
* Updated default config of xdlops to be db loadable
* Fixed various clang-tidy issues

-----------

Local tests/validations:

./bin/mlir-miopen-driver -p -x2 -c -debug
> Successfully opened connection to PerfDb.
SQLite Query: SELECT solver, params FROM perf_db INNER JOIN config ON perf_db.config = config.id WHERE ( (batchsize = 128 ) AND (in_channels = 1024 ) AND (in_h = 14 ) AND (in_w = 14 ) AND (fil_h = 1 ) AND (fil_w = 1 ) AND (out_channels = 1024 ) AND (pad_h = 0 ) AND (pad_w = 0 ) AND (conv_stride_h = 1 ) AND (conv_stride_w = 1 ) AND (conv_stride_d = 0 ) AND (dilation_h = 1 ) AND (dilation_w = 1 ) AND (dilation_d = 0 ) AND (bias = 0 ) AND (group_count = 1 ) AND (layout = 'NCHW' ) AND (data_type = 'FP32' ) AND (direction = 'F' ) )AND (arch ='gfx908' ) AND (num_cu = '120');                    
, content inserted: ConvOclDirectFwd1x1:1,64,1,1,1,1,16,128,0, content inserted: ConvAsm1x1U:3,16,4,64,1,2,1,8, content inserted: ConvBinWinogradRxSf2x3:98, content inserted: ConvHipImplicitGemmForwardV4R4Xdlops:128,256,4,128,64,2,0,1
=ConvHipImplicitGemmForwardV4R4Xdlops:128,256,4,128,64,2,0,1
DB load succeed, M/block: 128 N/block: 256 K/block: 4 M/Wave: 128 N/Wave: 64 KPack: 2 ACopyGemmK: 0 BCopyKPack: 1
