### PR TITLE
Adding ROCm profiler dependencies

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -79,7 +79,9 @@ RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   rocm-dev \
+  rocminfo \
   miopen-hip \
+  rocprofiler-dev \
   libelf1 \
   sudo \
   vim \


### PR DESCRIPTION
Follow-up of #25. Wants to use a trivial change to test out the push hook and the jenkins job.