### PR TITLE
Drop c++ filepath experimental lib

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -885,10 +885,8 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
 
     auto hiPadded = 1 + (y - 1) * dilationH + (ho - 1) * strideH;
     auto wiPadded = 1 + (x - 1) * dilationW + (wo - 1) * strideW;
-    auto rightPadH =
-        hiPadded > (leftPadH + hi) ? hiPadded - (leftPadH + hi) : 0;
-    auto rightPadW =
-        wiPadded > (leftPadW + wi) ? wiPadded - (leftPadW + wi) : 0;
+    int rightPadH = hiPadded > (leftPadH + hi) ? hiPadded - (leftPadH + hi) : 0;
+    int rightPadW = wiPadded > (leftPadW + wi) ? wiPadded - (leftPadW + wi) : 0;
 
     // Set attributes for gridwise_gemm op.
     llvm::SmallVector<NamedAttribute, 8> gridwiseGemmAttrs{

--- a/mlir/lib/Dialect/MIOpen/Tuning/CMakeLists.txt
+++ b/mlir/lib/Dialect/MIOpen/Tuning/CMakeLists.txt
@@ -35,6 +35,5 @@ target_include_directories(MLIRMIOpenTuning
 target_link_libraries(MLIRMIOpenTuning
   PRIVATE
   MLIRIR
-  stdc++fs
   ${SQLITE3_LIBRARIES}
 )

--- a/mlir/lib/Dialect/MIOpen/Tuning/SqliteDb.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/SqliteDb.cpp
@@ -3,7 +3,6 @@
 #include "mlir/Dialect/MIOpen/Tuning/SqliteDb.h"
 #include "llvm/Support/Debug.h"
 
-#include <experimental/filesystem>
 #include <thread>
 
 using namespace mlir;
@@ -24,14 +23,13 @@ class SQLite::impl {
     }
   };
   using Sqlite3Ptr = std::unique_ptr<sqlite3, SQLiteCloser>;
-  int createFileDb(const std::experimental::filesystem::path &filepath,
-                   bool isSystem) {
+  int createFileDb(const std::string &filepath, bool isSystem) {
     sqlite3 *ptr_tmp = nullptr;
     int rc = 0;
     if (isSystem) {
 
-      rc = sqlite3_open_v2(filepath.string().c_str(), &ptr_tmp,
-                           SQLITE_OPEN_READONLY, nullptr);
+      rc = sqlite3_open_v2(filepath.c_str(), &ptr_tmp, SQLITE_OPEN_READONLY,
+                           nullptr);
     } else {
       llvm::errs() << "FATAL ERROR! Does not support user db"
                    << "\n";
@@ -42,9 +40,8 @@ class SQLite::impl {
 
 public:
   impl(const std::string &filename_, bool isSystem) {
-    std::experimental::filesystem::path filepath(filename_);
     int rc = 0;
-    rc = createFileDb(filepath, isSystem);
+    rc = createFileDb(filename_, isSystem);
     sqlite3_busy_timeout(ptrDb.get(), MIOPEN_SQL_BUSY_TIMEOUT_MS);
     isValid = (rc == 0);
     if (!isValid) {

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-lib.cpp
@@ -62,7 +62,8 @@ extern "C" MlirHandle CreateMlirHandle(const char *arguments) {
         "batchsize",     "in_channels", "in_h",       "in_w",
         "out_channels",  "out_h",       "out_w",      "fil_w",
         "fil_h",         "dilation_h",  "dilation_w", "conv_stride_h",
-        "conv_stride_w", "padding_h",   "padding_w"};
+        "conv_stride_w", "padding_h",   "padding_w",  "arch",
+        "num_cu"};
     return std::all_of(
         validKeys.begin(), validKeys.end(),
         [&argMap](std::string &key) { return argMap.count(key) > 0; });


### PR DESCRIPTION
`stdc++fs` will cause a linker error when linking with MIOpen. Dropping it can conveniently fix the linker error.