### PR TITLE
MLIR-29: Get rid of blockSizeOveride, gridSize and its callback function

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -16,8 +16,6 @@
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 
-using LaunchDimensionCallback = std::function<void(int64_t, int64_t)>;
-
 namespace mlir {
 class Pass;
 
@@ -47,7 +45,7 @@ std::unique_ptr<Pass> createAffineTransformPass();
 /// Create a pass to affix tuning parameters to gridwise gemm ops.
 std::unique_ptr<Pass> createAffixTuningParametersPass(
     int64_t blockSizeOverride = 0,
-    LaunchDimensionCallback launchDimCallback = nullptr);
+    int64_t gridSizeOverride = 0);
 
 } // namespace miopen
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -43,9 +43,9 @@ std::unique_ptr<Pass> createLowerMIOpenOpsStep5Pass();
 std::unique_ptr<Pass> createAffineTransformPass();
 
 /// Create a pass to affix tuning parameters to gridwise gemm ops.
-std::unique_ptr<Pass> createAffixTuningParametersPass(
-    int64_t blockSizeOverride = 0,
-    int64_t gridSizeOverride = 0);
+std::unique_ptr<Pass>
+createAffixTuningParametersPass(int64_t blockSizeOverride = 0,
+                                int64_t gridSizeOverride = 0);
 
 } // namespace miopen
 } // namespace mlir

--- a/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
+++ b/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
@@ -123,6 +123,7 @@ void LowerMIOpenOpsToGPUPass::runOnOperation() {
       // Set kernel attribute.
       gpuFunc.setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
                       b.getUnitAttr());
+
       break;
     }
   }
@@ -153,6 +154,8 @@ void LowerMIOpenOpsToGPUPass::runOnOperation() {
 
     // Set kernel attribute.
     gpuFunc.setAttr(gpu::GPUDialect::getKernelFuncAttrName(), b.getUnitAttr());
+    gpuFunc.setAttr("block_size", theFunc.getAttr("block_size"));
+    gpuFunc.setAttr("grid_size", theFunc.getAttr("grid_size"));
 
     // associate arguments for newly created GPUFuncOp.
     BlockAndValueMapping map;

--- a/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
+++ b/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
@@ -123,7 +123,6 @@ void LowerMIOpenOpsToGPUPass::runOnOperation() {
       // Set kernel attribute.
       gpuFunc.setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
                       b.getUnitAttr());
-
       break;
     }
   }
@@ -154,8 +153,10 @@ void LowerMIOpenOpsToGPUPass::runOnOperation() {
 
     // Set kernel attribute.
     gpuFunc.setAttr(gpu::GPUDialect::getKernelFuncAttrName(), b.getUnitAttr());
-    gpuFunc.setAttr("block_size", theFunc.getAttr("block_size"));
-    gpuFunc.setAttr("grid_size", theFunc.getAttr("grid_size"));
+    if (auto attr = theFunc.getAttr("block_size"))
+      gpuFunc.setAttr("block_size", attr);
+    if (auto attr = theFunc.getAttr("grid_size"))
+      gpuFunc.setAttr("grid_size", attr);
 
     // associate arguments for newly created GPUFuncOp.
     BlockAndValueMapping map;

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -161,7 +161,9 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op.setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
     getFunction().setAttr("block_size", b.getI32IntegerAttr(blockSize));
-    getFunction().setAttr("grid_size", b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
+    getFunction().setAttr(
+        "grid_size",
+        b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
 
     op.setAttr("m_per_block", b.getI32IntegerAttr(validParams.gemmMPerBlock));
     op.setAttr("n_per_block", b.getI32IntegerAttr(validParams.gemmNPerBlock));
@@ -204,8 +206,11 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op.setAttr("n_per_thread", b.getI32IntegerAttr(validParams.gemmNPerThread));
     op.setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
 
-    getFunction().setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
-    getFunction().setAttr("grid_size", b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
+    getFunction().setAttr("block_size",
+                          b.getI32IntegerAttr(validParams.blockSize));
+    getFunction().setAttr(
+        "grid_size",
+        b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
 
     op.setAttr("m_per_block", b.getI32IntegerAttr(validParams.gemmMPerBlock));
     op.setAttr("n_per_block", b.getI32IntegerAttr(validParams.gemmNPerBlock));

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -255,8 +255,9 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
              b.getI32IntegerAttr(3));
 }
 
-std::unique_ptr<Pass> mlir::miopen::createAffixTuningParametersPass(
-    int64_t blockSizeOverride, int64_t gridSizeOverride) {
+std::unique_ptr<Pass>
+mlir::miopen::createAffixTuningParametersPass(int64_t blockSizeOverride,
+                                              int64_t gridSizeOverride) {
   return std::make_unique<AffixTuningParameters>(blockSizeOverride,
                                                  gridSizeOverride);
 }

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -37,9 +37,6 @@ private:
   int64_t blockSizeOverride;
   int64_t gridSizeOverride;
 
-  // Current function
-  FuncOp func;
-
   // Actual implementation.
   template<typename T>
   void affixTuningParametersImpl(T &op);
@@ -47,7 +44,7 @@ private:
 } // anonymous namespace
 
 void AffixTuningParameters::runOnFunction() {
-  func = getFunction();
+  FuncOp func = getFunction();
 
   // In the original C++ implementation, template arguments used by GridwiseGemmOp are:
   // template <index_t GridSize,                                 - NOT USED
@@ -163,8 +160,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op.setAttr("n_per_thread", b.getI32IntegerAttr(validParams.gemmNPerWave));
     op.setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
-    func.setAttr("block_size", b.getI32IntegerAttr(blockSize));
-    func.setAttr("grid_size", b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
+    getFunction().setAttr("block_size", b.getI32IntegerAttr(blockSize));
+    getFunction().setAttr("grid_size", b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
 
     op.setAttr("m_per_block", b.getI32IntegerAttr(validParams.gemmMPerBlock));
     op.setAttr("n_per_block", b.getI32IntegerAttr(validParams.gemmNPerBlock));
@@ -207,8 +204,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op.setAttr("n_per_thread", b.getI32IntegerAttr(validParams.gemmNPerThread));
     op.setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
 
-    func.setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
-    func.setAttr("grid_size", b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
+    getFunction().setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
+    getFunction().setAttr("grid_size", b.getI32IntegerAttr(gridSizeOverride ? gridSizeOverride : gridSize));
 
     op.setAttr("m_per_block", b.getI32IntegerAttr(validParams.gemmMPerBlock));
     op.setAttr("n_per_block", b.getI32IntegerAttr(validParams.gemmNPerBlock));

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -1219,9 +1219,10 @@ static LogicalResult populateKernelLaunchLogic(ModuleOp &module,
   Block *block = &(theFunc.getBody().front());
   block->clear();
 
-  auto blockSizeAttr = 
-      theGpuFunc.getAttr("block_size").template dyn_cast<IntegerAttr>().getInt();
-  auto gridSizeAttr = 
+  auto blockSizeAttr = theGpuFunc.getAttr("block_size")
+                           .template dyn_cast<IntegerAttr>()
+                           .getInt();
+  auto gridSizeAttr =
       theGpuFunc.getAttr("grid_size").template dyn_cast<IntegerAttr>().getInt();
   auto cstOne = builder.create<ConstantIndexOp>(builder.getUnknownLoc(), 1);
   auto cstBlockSize =
@@ -1255,7 +1256,8 @@ static LogicalResult runMLIRPasses(ModuleOp &module, mlir::PassPipelineCLParser 
     // Passes for lowering MIOpen dialect.
     pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
     pm.addPass(mlir::miopen::createAffineTransformPass());
-    pm.addPass(mlir::miopen::createAffixTuningParametersPass(blockSize, gridSize));
+    pm.addPass(
+        mlir::miopen::createAffixTuningParametersPass(blockSize, gridSize));
     pm.addPass(mlir::miopen::createLowerMIOpenOpsStep2Pass());
     pm.addPass(mlir::miopen::createLowerMIOpenOpsStep3Pass());
     pm.addPass(mlir::miopen::createLowerMIOpenOpsStep4Pass());


### PR DESCRIPTION
PR for https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/29