### PR TITLE
Add -O3 compiling LLVM IR.

### DIFF
--- a/mlir/lib/Conversion/GPUCommon/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUCommon/CMakeLists.txt
@@ -23,6 +23,7 @@ add_mlir_conversion_library(MLIRGPUtoGPURuntimeTransforms
   intrinsics_gen
 
   LINK_COMPONENTS
+  ipo
   Core
   MC
   ${AMDGPU_LIBS}

--- a/mlir/lib/Conversion/GPUCommon/ConvertKernelFuncToBlob.cpp
+++ b/mlir/lib/Conversion/GPUCommon/ConvertKernelFuncToBlob.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 using namespace mlir;
 
@@ -116,7 +117,10 @@ GpuKernelToBlobPass::translateModuleToISA(llvm::Module &module,
 
     llvm::raw_string_ostream stream(targetISA);
     llvm::buffer_ostream pstream(stream);
+    llvm::PassManagerBuilder builder;
+    builder.OptLevel = 3;
     llvm::legacy::PassManager codegenPasses;
+    builder.populateModulePassManager(codegenPasses);
     targetMachine.addPassesToEmitFile(codegenPasses, pstream, nullptr,
                                       llvm::CGFT_AssemblyFile);
     codegenPasses.run(*clone);


### PR DESCRIPTION
This patch not only increases overall performance to the ISA generated, but also prevents the weird crashing issue when invoking this command;

```
./bin/mlir-miopen-driver -p=false -x2 -c -t f32 fil_layout=kcyx -in_layout=nchw -out_layout=nkhw  -batchsize=64 -in_channels=4 -out_channels=64 -in_h=32 -in_w=32 -fil_h=3 -fil_w=3  --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=2 --conv_stride_w=2 -pv  | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void
```

Turns out if the LLVM IR is not optimized enough, AMDGPU backend might crash.