### PR TITLE
Adding ROCm execution engine from mlir-rocm-runner

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
+++ b/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
@@ -1,0 +1,60 @@
+//===- BackendUtils.h - MLIR to C++ option parsing ---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares mlir rocm backend utils
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_EXECUTIONENGINE_ROCM_BACKENDUTILS_H_
+#define MLIR_EXECUTIONENGINE_ROCM_BACKENDUTILS_H_
+
+#include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/GPU/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Target/ROCDLIR.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+
+class BackendUtils {
+public:
+  BackendUtils();
+  BackendUtils(const std::string &triple, const std::string &chip,
+               const std::string &feature);
+  OwnedBlob compileISAToHsaco(const std::string isa, Location loc,
+                              StringRef name);
+  std::unique_ptr<llvm::Module> compileModuleToROCDLIR(Operation *m);
+  std::string getChip() { return chip; }
+  std::string getFeatures() { return features; }
+  std::string getTriple() { return triple; }
+
+private:
+  std::string triple;
+  std::string chip;
+  std::string features;
+
+  using Blob = SmallVector<char, 0>;
+  void setupDefaults(std::string &chip, std::string &features,
+                     std::string &triple);
+  LogicalResult assembleIsa(const std::string isa, StringRef name,
+                            Blob &result);
+  LogicalResult assembleIsa(const std::string isa, StringRef name, Blob &result,
+                            const std::string &tripleName,
+                            const std::string &targetChip,
+                            const std::string &features);
+  LogicalResult createHsaco(const Blob &isaBlob, StringRef name,
+                            Blob &hsacoBlob);
+  void configTargetChip(std::string &targetChip);
+  void configTargetFeatures(std::string &features);
+};
+} // namespace mlir
+
+#endif // MLIR_EXECUTIONENGINE_ROCM_BACKENDUTILS_H_

--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Exclude these from libMLIR.so because the JIT infrastructure
 # is a big dependency which most don't need.
 
+add_subdirectory(ROCm)
+
 set(LLVM_OPTIONAL_SOURCES
   CRunnerUtils.cpp
   ExecutionEngine.cpp

--- a/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
@@ -1,0 +1,283 @@
+//===- BackendUtils.cpp - MLIR to C++ option parsing ---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements mlir rocm backend utils
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ExecutionEngine/ROCm/BackendUitls.h"
+
+#include "llvm/Support/FileUtilities.h"
+#include "llvm/Support/LineIterator.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/TargetRegistry.h"
+
+// MC headers.
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCParser/AsmLexer.h"
+#include "llvm/MC/MCParser/MCTargetAsmParser.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/MCTargetOptionsCommandFlags.h"
+
+// lld headers.
+#include "lld/Common/Driver.h"
+
+// HIP headers.
+#include "hip/hip_version.h"
+
+using namespace mlir;
+
+static constexpr const char kRunnerProgram[] = "mlir-rocm-runner";
+static constexpr const char kRocmAgentEnumerator[] = "rocm_agent_enumerator";
+
+BackendUtils::BackendUtils(const std::string &defaultTriple,
+                           const std::string &defaultChip,
+                           const std::string &defaultFeatures)
+    : triple(defaultTriple), chip(defaultChip), features(defaultFeatures) {
+  setupDefaults(chip, features, triple);
+}
+
+BackendUtils::BackendUtils() : BackendUtils("", "", "") {}
+
+LogicalResult BackendUtils::assembleIsa(const std::string isa, StringRef name,
+                                        Blob &result,
+                                        const std::string &tripleName,
+                                        const std::string &targetChip,
+                                        const std::string &features) {
+  llvm::raw_svector_ostream os(result);
+
+  std::string error;
+  llvm::Triple theTriple(llvm::Triple::normalize(tripleName));
+  const llvm::Target *theTarget =
+      llvm::TargetRegistry::lookupTarget(theTriple.normalize(), error);
+  if (!theTarget) {
+    llvm::WithColor::error(llvm::errs(), name) << error;
+    return failure();
+  }
+
+  llvm::SourceMgr srcMgr;
+  srcMgr.AddNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(isa),
+                            llvm::SMLoc());
+
+  const llvm::MCTargetOptions mcOptions;
+  std::unique_ptr<llvm::MCRegisterInfo> mri(
+      theTarget->createMCRegInfo(tripleName));
+  std::unique_ptr<llvm::MCAsmInfo> mai(
+      theTarget->createMCAsmInfo(*mri, tripleName, mcOptions));
+  mai->setRelaxELFRelocations(true);
+
+  llvm::MCObjectFileInfo mofi;
+  llvm::MCContext ctx(mai.get(), mri.get(), &mofi, &srcMgr, &mcOptions);
+  mofi.InitMCObjectFileInfo(theTriple, false, ctx, false);
+
+  SmallString<128> cwd;
+  if (!llvm::sys::fs::current_path(cwd))
+    ctx.setCompilationDir(cwd);
+
+  std::unique_ptr<llvm::MCStreamer> mcStreamer;
+  std::unique_ptr<llvm::MCInstrInfo> mcii(theTarget->createMCInstrInfo());
+  std::unique_ptr<llvm::MCSubtargetInfo> sti(
+      theTarget->createMCSubtargetInfo(tripleName, targetChip, features));
+
+  llvm::MCCodeEmitter *ce = theTarget->createMCCodeEmitter(*mcii, *mri, ctx);
+  llvm::MCAsmBackend *mab =
+      theTarget->createMCAsmBackend(*sti, *mri, mcOptions);
+  mcStreamer.reset(theTarget->createMCObjectStreamer(
+      theTriple, ctx, std::unique_ptr<llvm::MCAsmBackend>(mab),
+      mab->createObjectWriter(os), std::unique_ptr<llvm::MCCodeEmitter>(ce),
+      *sti, mcOptions.MCRelaxAll, mcOptions.MCIncrementalLinkerCompatible,
+      /*DWARFMustBeAtTheEnd*/ false));
+  mcStreamer->setUseAssemblerInfoForParsing(true);
+
+  std::unique_ptr<llvm::MCAsmParser> parser(
+      createMCAsmParser(srcMgr, ctx, *mcStreamer, *mai));
+  std::unique_ptr<llvm::MCTargetAsmParser> tap(
+      theTarget->createMCAsmParser(*sti, *parser, *mcii, mcOptions));
+
+  if (!tap) {
+    llvm::WithColor::error(llvm::errs(), name)
+        << "assembler initialization error.\n";
+    return failure();
+  }
+
+  parser->setTargetParser(*tap);
+  parser->Run(false);
+
+  return success();
+}
+
+LogicalResult BackendUtils::assembleIsa(const std::string isa, StringRef name,
+                                        Blob &result) {
+  return assembleIsa(isa, name, result, triple, chip, features);
+}
+
+LogicalResult BackendUtils::createHsaco(const Blob &isaBlob, StringRef name,
+                                        Blob &hsacoBlob) {
+  // Save the ISA binary to a temp file.
+  int tempIsaBinaryFd = -1;
+  SmallString<128> tempIsaBinaryFilename;
+  std::error_code ec = llvm::sys::fs::createTemporaryFile(
+      "kernel", "o", tempIsaBinaryFd, tempIsaBinaryFilename);
+  if (ec) {
+    llvm::WithColor::error(llvm::errs(), name)
+        << "temporary file for ISA binary creation error.\n";
+    return failure();
+  }
+  llvm::FileRemover cleanupIsaBinary(tempIsaBinaryFilename);
+  llvm::raw_fd_ostream tempIsaBinaryOs(tempIsaBinaryFd, true);
+  tempIsaBinaryOs << isaBlob;
+  tempIsaBinaryOs.close();
+
+  // Create a temp file for HSA code object.
+  int tempHsacoFD = -1;
+  SmallString<128> tempHsacoFilename;
+  ec = llvm::sys::fs::createTemporaryFile("kernel", "hsaco", tempHsacoFD,
+                                          tempHsacoFilename);
+  if (ec) {
+    llvm::WithColor::error(llvm::errs(), name)
+        << "temporary file for HSA code object creation error.\n";
+    return failure();
+  }
+  llvm::FileRemover cleanupHsaco(tempHsacoFilename);
+
+  // Invoke lld. Expect a true return value from lld.
+  bool ret = lld::elf::link({"ld.lld", "-shared", tempIsaBinaryFilename.c_str(),
+                             "-o", tempHsacoFilename.c_str()},
+                            /*canEarlyExit=*/false, llvm::outs(), llvm::errs());
+  if (!ret) {
+    llvm::WithColor::error(llvm::errs(), name) << "lld invocation error.\n";
+    return failure();
+  }
+
+  // Load the HSA code object.
+  auto hsacoFile = mlir::openInputFile(tempHsacoFilename);
+  if (!hsacoFile) {
+    llvm::WithColor::error(llvm::errs(), name)
+        << "read HSA code object from temp file error.\n";
+    return failure();
+  }
+  hsacoBlob.assign(hsacoFile->getBuffer().begin(),
+                   hsacoFile->getBuffer().end());
+
+  return success();
+}
+
+OwnedBlob BackendUtils::compileISAToHsaco(const std::string isa, Location loc,
+                                          StringRef name) {
+  // ISA -> ISA in binary form via MC.
+  // Use lld to create HSA code object.
+  Blob isaBlob;
+  Blob hsacoBlob;
+
+  if (succeeded(assembleIsa(isa, name, isaBlob)) &&
+      succeeded(createHsaco(isaBlob, name, hsacoBlob)))
+    return std::make_unique<std::vector<char>>(hsacoBlob.begin(),
+                                               hsacoBlob.end());
+
+  llvm::WithColor::error(llvm::errs(), name)
+      << "producing HSA code object error.\n";
+  return {};
+}
+
+std::unique_ptr<llvm::Module>
+BackendUtils::compileModuleToROCDLIR(Operation *m) {
+  auto llvmModule = translateModuleToROCDLIR(m);
+  // TODO(whchung): Link with ROCm-Device-Libs in case needed (ex: the Module
+  // depends on math functions).
+  return llvmModule;
+}
+
+void BackendUtils::configTargetChip(std::string &targetChip) {
+  // Locate rocm_agent_enumerator.
+  llvm::ErrorOr<std::string> rocmAgentEnumerator = llvm::sys::findProgramByName(
+      kRocmAgentEnumerator, {__ROCM_PATH__ "/bin"});
+  std::error_code ec = rocmAgentEnumerator.getError();
+  if (ec) {
+    llvm::WithColor::warning(llvm::errs(), kRunnerProgram)
+        << kRocmAgentEnumerator << " couldn't be located under "
+        << __ROCM_PATH__ << ", set target as " << chip << "\n";
+    return;
+  }
+
+  // Prepare temp file to hold the outputs.
+  int tempFd = -1;
+  SmallString<128> tempFilename;
+  ec = llvm::sys::fs::createTemporaryFile("rocm_agent", "txt", tempFd,
+                                          tempFilename);
+  if (ec) {
+    llvm::WithColor::warning(llvm::errs(), kRunnerProgram)
+        << "temporary file for " << kRocmAgentEnumerator
+        << " creation error, set target as " << chip << "\n";
+    return;
+  }
+  llvm::FileRemover cleanup(tempFilename);
+
+  // Invoke rocm_agent_enumerator.
+  std::string errorMessage;
+  SmallVector<StringRef, 2> args{"-t", "GPU"};
+  Optional<StringRef> redirects[3] = {{""}, tempFilename.str(), {""}};
+  int result =
+      llvm::sys::ExecuteAndWait(rocmAgentEnumerator.get(), args, llvm::None,
+                                redirects, 0, 0, &errorMessage);
+  if (result) {
+    llvm::WithColor::warning(llvm::errs(), kRunnerProgram)
+        << kRocmAgentEnumerator << " invocation error: " << errorMessage
+        << ", set target as " << chip << "\n";
+    return;
+  }
+
+  // Load and parse the result.
+  auto gfxIsaList = mlir::openInputFile(tempFilename);
+  if (!gfxIsaList) {
+    llvm::WithColor::error(llvm::errs(), kRunnerProgram)
+        << "read ROCm agent list temp file error, set target as " << chip
+        << "\n";
+    return;
+  }
+  for (llvm::line_iterator lines(*gfxIsaList); !lines.is_at_end(); ++lines) {
+    // Skip the line with content "gfx000".
+    if (*lines == "gfx000")
+      continue;
+    // Use the first ISA version found.
+    targetChip = lines->str();
+    break;
+  }
+}
+
+void BackendUtils::setupDefaults(std::string &chip, std::string &features,
+                                 std::string &triple) {
+  // Configure target chip ISA version if it has not been specified.
+  if (!chip.size())
+    configTargetChip(chip);
+
+  if (!triple.size()) {
+    triple = "amdgcn-amd-amdhsa";
+  }
+
+  // Configure target features per ROCm / HIP version.
+  configTargetFeatures(features);
+}
+
+void BackendUtils::configTargetFeatures(std::string &features) {
+  if (features.size() > 0)
+    features += ",";
+  // After ROCm 3.5, adopt HSA code object V3.
+  if (HIP_VERSION_MAJOR >= 3 && HIP_VERSION_MINOR >= 5)
+    features += "+code-object-v3";
+  else
+    features += "-code-object-v3";
+}

--- a/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
@@ -1,0 +1,98 @@
+set(LLVM_OPTIONAL_SOURCES
+  BackendUtils.cpp
+  rocm-runtime-wrappers.cpp
+  )
+
+if (NOT ("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD))
+  message(SEND_ERROR
+    "Building the mlir rocm runner requires the AMDGPU backend")
+endif()
+
+# Ensure lld is enabled.
+if (NOT "lld" IN_LIST LLVM_ENABLE_PROJECTS)
+  message(SEND_ERROR "lld is not enabled. Please revise LLVM_ENABLE_PROJECTS")
+endif()
+
+# lld header files.
+include_directories(${MLIR_SOURCE_DIR}/../lld/include)
+
+set(HIP_PATH "${ROCM_PATH}/hip" CACHE PATH " Path to which HIP has been installed")
+set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
+find_package(HIP)
+if (NOT HIP_FOUND)
+  message(SEND_ERROR "Build the mlir rocm runner requires a working ROCm and HIP install")
+else()
+  message(STATUS "ROCm HIP version: ${HIP_VERSION}")
+endif()
+
+# Set compile-time flags for ROCm path.
+add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
+
+# Locate HIP runtime library.
+find_library(ROCM_RUNTIME_LIBRARY amdhip64
+             PATHS "${HIP_PATH}/lib")
+if (NOT ROCM_RUNTIME_LIBRARY)
+  message(SEND_ERROR "Could not locate ROCm HIP runtime library")
+else()
+  message(STATUS "ROCm HIP runtime lib: ${ROCM_RUNTIME_LIBRARY}")
+endif()
+
+# Set HIP compile-time flags.
+add_definitions(-D__HIP_PLATFORM_HCC__)
+
+add_llvm_library(rocm-runtime-wrappers SHARED
+  rocm-runtime-wrappers.cpp
+)
+target_include_directories(rocm-runtime-wrappers
+  PRIVATE
+  "${HIP_PATH}/../include"
+  "${HIP_PATH}/include"
+  LLVMSupport
+)
+target_link_libraries(rocm-runtime-wrappers
+  PUBLIC
+  LLVMSupport
+  ${ROCM_RUNTIME_LIBRARY}
+)
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+set(LIBS
+  ${dialect_libs}
+  ${conversion_libs}
+  lldCommon
+  lldDriver
+  lldELF
+  LLVMCore
+  LLVMLTO
+  LLVMMC
+  LLVMMCParser
+  LLVMOption
+  LLVMSupport
+  MLIRTargetROCDLIR
+  ${ROCM_RUNTIME_LIBRARY}
+)
+
+# Manually expand the target library, since our MLIR libraries
+# aren't plugged into the LLVM dependency tracking. If we don't
+# do this then we can't insert the CodeGen library after ourselves
+llvm_expand_pseudo_components(TARGET_LIBS AllTargetsCodeGens AllTargetsAsmParsers)
+# Prepend LLVM in front of every target, this is how the library
+# are named with CMake
+SET(targets_to_link)
+FOREACH(t ${TARGET_LIBS})
+  LIST(APPEND targets_to_link "LLVM${t}")
+ENDFOREACH(t)
+
+add_llvm_library(LLVMROCmBackendUtils
+  BackendUtils.cpp
+  )
+
+llvm_update_compile_flags(LLVMROCmBackendUtils)
+target_include_directories(LLVMROCmBackendUtils
+  PRIVATE
+  "${HIP_PATH}/../include"
+  "${HIP_PATH}/include"
+)
+target_link_libraries(LLVMROCmBackendUtils PRIVATE ${LIBS} ${targets_to_link})
+

--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -119,8 +119,7 @@ extern "C" void mgpuMemHostRegisterInt32(int64_t rank, void *ptr) {
   mgpuMemHostRegisterMemRef(desc->data + desc->offset, sizes, strides, 123);
 }
 
-template <typename T>
-void mgpuMemGetDevicePointer(T *hostPtr, T **devicePtr) {
+template <typename T> void mgpuMemGetDevicePointer(T *hostPtr, T **devicePtr) {
   reportErrorIfAny(hipSetDevice(0), "hipSetDevice");
   reportErrorIfAny(
       hipHostGetDevicePointer((void **)devicePtr, hostPtr, /*flags=*/0),
@@ -154,21 +153,20 @@ extern "C" StridedMemRefType<float, 1>
 mgpuMemAlloc(float *allocated, float *aligned, int64_t offset, int64_t size,
              int64_t stride) {
   float *gpuPtr;
-  hipMalloc((void**)&gpuPtr, size * sizeof(float));
+  hipMalloc((void **)&gpuPtr, size * sizeof(float));
   return {gpuPtr, gpuPtr, offset, {size}, {stride}};
 }
 
-extern "C" void mgpuMemDealloc(float *allocated, float *aligned,
-                               int64_t offset, int64_t size, int64_t stride) {
+extern "C" void mgpuMemDealloc(float *allocated, float *aligned, int64_t offset,
+                               int64_t size, int64_t stride) {
   hipFree(aligned);
 }
 
 extern "C" void mgpuMemCopy(float *sourceAllocated, float *sourceAligned,
                             int64_t sourceOffset, int64_t sourceSize,
-                            int64_t sourceStride,
-                            float *destAllocated, float *destAligned,
-                            int64_t destOffset, int64_t destSize,
-                            int64_t destStride,
+                            int64_t sourceStride, float *destAllocated,
+                            float *destAligned, int64_t destOffset,
+                            int64_t destSize, int64_t destStride,
                             unsigned copyDirection) {
   hipMemcpy(destAligned, sourceAligned, sourceSize * sizeof(float),
             static_cast<hipMemcpyKind>(copyDirection));
@@ -216,139 +214,164 @@ extern "C" void mgpuMemCopy2DFloat(float *sourceAllocated, float *sourceAligned,
 
 // 4D float memref utility routines.
 
-extern "C" void mcpuMemset4DFloat(float *allocated, float *aligned, int64_t offset,
-                                  int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                                  int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-                                  float value) {
+extern "C" void mcpuMemset4DFloat(float *allocated, float *aligned,
+                                  int64_t offset, int64_t size0, int64_t size1,
+                                  int64_t size2, int64_t size3, int64_t stride0,
+                                  int64_t stride1, int64_t stride2,
+                                  int64_t stride3, float value) {
   for (unsigned i = 0; i < size0; ++i)
     for (unsigned j = 0; j < size1; ++j)
       for (unsigned k = 0; k < size2; ++k)
         for (unsigned l = 0; l < size3; ++l)
-          aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] = value;
+          aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] =
+              value;
 }
 
 extern "C" StridedMemRefType<float, 4>
 mgpuMemAlloc4DFloat(float *allocated, float *aligned, int64_t offset,
                     int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                    int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3) {
+                    int64_t stride0, int64_t stride1, int64_t stride2,
+                    int64_t stride3) {
   float *gpuPtr;
-  hipMalloc((void**)&gpuPtr, size0 * size1 * size2 * size3 * sizeof(float));
-  return {gpuPtr, gpuPtr, offset, {size0, size1, size2, size3}, {stride0, stride1, stride2, stride3}};
+  hipMalloc((void **)&gpuPtr, size0 * size1 * size2 * size3 * sizeof(float));
+  return {gpuPtr,
+          gpuPtr,
+          offset,
+          {size0, size1, size2, size3},
+          {stride0, stride1, stride2, stride3}};
 }
 
 extern "C" void mgpuMemDealloc4DFloat(float *allocated, float *aligned,
-                                      int64_t offset,
-                                      int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                                      int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3) {
+                                      int64_t offset, int64_t size0,
+                                      int64_t size1, int64_t size2,
+                                      int64_t size3, int64_t stride0,
+                                      int64_t stride1, int64_t stride2,
+                                      int64_t stride3) {
   hipFree(aligned);
 }
 
-extern "C" void mgpuMemCopy4DFloat(float *sourceAllocated, float *sourceAligned,
-                                   int64_t sourceOffset,
-                                   int64_t sourceSize0, int64_t sourceSize1,
-                                   int64_t sourceSize2, int64_t sourceSize3,
-                                   int64_t sourceStride0, int64_t sourceStride1,
-                                   int64_t sourceStride2, int64_t sourceStride3,
-                                   float *destAllocated, float *destAligned,
-                                   int64_t destOffset,
-                                   int64_t destSize0, int64_t destSize1,
-                                   int64_t destSize2, int64_t destSize3,
-                                   int64_t destStride0, int64_t destStride1,
-                                   int64_t destStride2, int64_t destStride3,
-                                   unsigned copyDirection) {
-  hipMemcpy(destAligned, sourceAligned, sourceSize0 * sourceSize1 * sourceSize2 * sourceSize3 * sizeof(float),
+extern "C" void mgpuMemCopy4DFloat(
+    float *sourceAllocated, float *sourceAligned, int64_t sourceOffset,
+    int64_t sourceSize0, int64_t sourceSize1, int64_t sourceSize2,
+    int64_t sourceSize3, int64_t sourceStride0, int64_t sourceStride1,
+    int64_t sourceStride2, int64_t sourceStride3, float *destAllocated,
+    float *destAligned, int64_t destOffset, int64_t destSize0,
+    int64_t destSize1, int64_t destSize2, int64_t destSize3,
+    int64_t destStride0, int64_t destStride1, int64_t destStride2,
+    int64_t destStride3, unsigned copyDirection) {
+  hipMemcpy(destAligned, sourceAligned,
+            sourceSize0 * sourceSize1 * sourceSize2 * sourceSize3 *
+                sizeof(float),
             static_cast<hipMemcpyKind>(copyDirection));
 }
 
 // 4D half memref utility routines.
 
-extern "C" void mcpuMemset4DHalf(unsigned short *allocated, unsigned short *aligned, int64_t offset,
-                                 int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                                 int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-                                 unsigned short value) {
+extern "C" void mcpuMemset4DHalf(unsigned short *allocated,
+                                 unsigned short *aligned, int64_t offset,
+                                 int64_t size0, int64_t size1, int64_t size2,
+                                 int64_t size3, int64_t stride0,
+                                 int64_t stride1, int64_t stride2,
+                                 int64_t stride3, unsigned short value) {
   for (unsigned i = 0; i < size0; ++i)
     for (unsigned j = 0; j < size1; ++j)
       for (unsigned k = 0; k < size2; ++k)
         for (unsigned l = 0; l < size3; ++l)
-          aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] = value;
+          aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] =
+              value;
 }
 
 extern "C" StridedMemRefType<unsigned short, 4>
-mgpuMemAlloc4DHalf(unsigned short *allocated, unsigned short *aligned, int64_t offset,
-                   int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                   int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3) {
+mgpuMemAlloc4DHalf(unsigned short *allocated, unsigned short *aligned,
+                   int64_t offset, int64_t size0, int64_t size1, int64_t size2,
+                   int64_t size3, int64_t stride0, int64_t stride1,
+                   int64_t stride2, int64_t stride3) {
   unsigned short *gpuPtr;
-  hipMalloc((void**)&gpuPtr, size0 * size1 * size2 * size3 * sizeof(unsigned short));
-  return {gpuPtr, gpuPtr, offset, {size0, size1, size2, size3}, {stride0, stride1, stride2, stride3}};
+  hipMalloc((void **)&gpuPtr,
+            size0 * size1 * size2 * size3 * sizeof(unsigned short));
+  return {gpuPtr,
+          gpuPtr,
+          offset,
+          {size0, size1, size2, size3},
+          {stride0, stride1, stride2, stride3}};
 }
 
-extern "C" void mgpuMemDealloc4DHalf(unsigned short *allocated, unsigned short *aligned,
-                                     int64_t offset,
-                                     int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                                     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3) {
+extern "C" void mgpuMemDealloc4DHalf(unsigned short *allocated,
+                                     unsigned short *aligned, int64_t offset,
+                                     int64_t size0, int64_t size1,
+                                     int64_t size2, int64_t size3,
+                                     int64_t stride0, int64_t stride1,
+                                     int64_t stride2, int64_t stride3) {
   hipFree(aligned);
 }
 
-extern "C" void mgpuMemCopy4DHalf(unsigned short *sourceAllocated, unsigned short *sourceAligned,
-                                  int64_t sourceOffset,
-                                  int64_t sourceSize0, int64_t sourceSize1,
-                                  int64_t sourceSize2, int64_t sourceSize3,
-                                  int64_t sourceStride0, int64_t sourceStride1,
-                                  int64_t sourceStride2, int64_t sourceStride3,
-                                  unsigned short *destAllocated, unsigned short *destAligned,
-                                  int64_t destOffset,
-                                  int64_t destSize0, int64_t destSize1,
-                                  int64_t destSize2, int64_t destSize3,
-                                  int64_t destStride0, int64_t destStride1,
-                                  int64_t destStride2, int64_t destStride3,
-                                  unsigned copyDirection) {
-  hipMemcpy(destAligned, sourceAligned, sourceSize0 * sourceSize1 * sourceSize2 * sourceSize3 * sizeof(unsigned short),
+extern "C" void mgpuMemCopy4DHalf(
+    unsigned short *sourceAllocated, unsigned short *sourceAligned,
+    int64_t sourceOffset, int64_t sourceSize0, int64_t sourceSize1,
+    int64_t sourceSize2, int64_t sourceSize3, int64_t sourceStride0,
+    int64_t sourceStride1, int64_t sourceStride2, int64_t sourceStride3,
+    unsigned short *destAllocated, unsigned short *destAligned,
+    int64_t destOffset, int64_t destSize0, int64_t destSize1, int64_t destSize2,
+    int64_t destSize3, int64_t destStride0, int64_t destStride1,
+    int64_t destStride2, int64_t destStride3, unsigned copyDirection) {
+  hipMemcpy(destAligned, sourceAligned,
+            sourceSize0 * sourceSize1 * sourceSize2 * sourceSize3 *
+                sizeof(unsigned short),
             static_cast<hipMemcpyKind>(copyDirection));
 }
 
 // 4D bf16 memref utility routines.
 
-extern "C" void mcpuMemset4DBF16(unsigned short *allocated, unsigned short *aligned, int64_t offset,
-                                 int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                                 int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-                                 unsigned short value) {
+extern "C" void mcpuMemset4DBF16(unsigned short *allocated,
+                                 unsigned short *aligned, int64_t offset,
+                                 int64_t size0, int64_t size1, int64_t size2,
+                                 int64_t size3, int64_t stride0,
+                                 int64_t stride1, int64_t stride2,
+                                 int64_t stride3, unsigned short value) {
   for (unsigned i = 0; i < size0; ++i)
     for (unsigned j = 0; j < size1; ++j)
       for (unsigned k = 0; k < size2; ++k)
         for (unsigned l = 0; l < size3; ++l)
-          aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] = value;
+          aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] =
+              value;
 }
 
 extern "C" StridedMemRefType<unsigned short, 4>
-mgpuMemAlloc4DBF16(unsigned short *allocated, unsigned short *aligned, int64_t offset,
-                   int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                   int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3) {
+mgpuMemAlloc4DBF16(unsigned short *allocated, unsigned short *aligned,
+                   int64_t offset, int64_t size0, int64_t size1, int64_t size2,
+                   int64_t size3, int64_t stride0, int64_t stride1,
+                   int64_t stride2, int64_t stride3) {
   unsigned short *gpuPtr;
-  hipMalloc((void**)&gpuPtr, size0 * size1 * size2 * size3 * sizeof(unsigned short));
-  return {gpuPtr, gpuPtr, offset, {size0, size1, size2, size3}, {stride0, stride1, stride2, stride3}};
+  hipMalloc((void **)&gpuPtr,
+            size0 * size1 * size2 * size3 * sizeof(unsigned short));
+  return {gpuPtr,
+          gpuPtr,
+          offset,
+          {size0, size1, size2, size3},
+          {stride0, stride1, stride2, stride3}};
 }
 
-extern "C" void mgpuMemDealloc4DBF16(unsigned short *allocated, unsigned short *aligned,
-                                     int64_t offset,
-                                     int64_t size0, int64_t size1, int64_t size2, int64_t size3,
-                                     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3) {
+extern "C" void mgpuMemDealloc4DBF16(unsigned short *allocated,
+                                     unsigned short *aligned, int64_t offset,
+                                     int64_t size0, int64_t size1,
+                                     int64_t size2, int64_t size3,
+                                     int64_t stride0, int64_t stride1,
+                                     int64_t stride2, int64_t stride3) {
   hipFree(aligned);
 }
 
-extern "C" void mgpuMemCopy4DBF16(unsigned short *sourceAllocated, unsigned short *sourceAligned,
-                                  int64_t sourceOffset,
-                                  int64_t sourceSize0, int64_t sourceSize1,
-                                  int64_t sourceSize2, int64_t sourceSize3,
-                                  int64_t sourceStride0, int64_t sourceStride1,
-                                  int64_t sourceStride2, int64_t sourceStride3,
-                                  unsigned short *destAllocated, unsigned short *destAligned,
-                                  int64_t destOffset,
-                                  int64_t destSize0, int64_t destSize1,
-                                  int64_t destSize2, int64_t destSize3,
-                                  int64_t destStride0, int64_t destStride1,
-                                  int64_t destStride2, int64_t destStride3,
-                                  unsigned copyDirection) {
-  hipMemcpy(destAligned, sourceAligned, sourceSize0 * sourceSize1 * sourceSize2 * sourceSize3 * sizeof(unsigned short),
+extern "C" void mgpuMemCopy4DBF16(
+    unsigned short *sourceAllocated, unsigned short *sourceAligned,
+    int64_t sourceOffset, int64_t sourceSize0, int64_t sourceSize1,
+    int64_t sourceSize2, int64_t sourceSize3, int64_t sourceStride0,
+    int64_t sourceStride1, int64_t sourceStride2, int64_t sourceStride3,
+    unsigned short *destAllocated, unsigned short *destAligned,
+    int64_t destOffset, int64_t destSize0, int64_t destSize1, int64_t destSize2,
+    int64_t destSize3, int64_t destStride0, int64_t destStride1,
+    int64_t destStride2, int64_t destStride3, unsigned copyDirection) {
+  hipMemcpy(destAligned, sourceAligned,
+            sourceSize0 * sourceSize1 * sourceSize2 * sourceSize3 *
+                sizeof(unsigned short),
             static_cast<hipMemcpyKind>(copyDirection));
 }
 

--- a/mlir/tools/mlir-rocm-runner/CMakeLists.txt
+++ b/mlir/tools/mlir-rocm-runner/CMakeLists.txt
@@ -1,75 +1,17 @@
 set(LLVM_OPTIONAL_SOURCES
-  rocm-runtime-wrappers.cpp
   mlir-rocm-runner.cpp
   )
 
 if(MLIR_ROCM_RUNNER_ENABLED)
-  if (NOT ("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD))
-    message(SEND_ERROR
-      "Building the mlir rocm runner requires the AMDGPU backend")
-  endif()
-
-  # Ensure lld is enabled.
-  if (NOT "lld" IN_LIST LLVM_ENABLE_PROJECTS)
-    message(SEND_ERROR "lld is not enabled. Please revise LLVM_ENABLE_PROJECTS")
-  endif()
-
-  # lld header files.
-  include_directories(${MLIR_SOURCE_DIR}/../lld/include)
-
-  set(HIP_PATH "${ROCM_PATH}/hip" CACHE PATH " Path to which HIP has been installed")
-  set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
-  find_package(HIP)
-  if (NOT HIP_FOUND)
-    message(SEND_ERROR "Build the mlir rocm runner requires a working ROCm and HIP install")
-  else()
-    message(STATUS "ROCm HIP version: ${HIP_VERSION}")
-  endif()
-
-  # Set compile-time flags for ROCm path.
-  add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
-
-  # Locate HIP runtime library.
-  find_library(ROCM_RUNTIME_LIBRARY amdhip64
-               PATHS "${HIP_PATH}/lib")
-  if (NOT ROCM_RUNTIME_LIBRARY)
-    message(SEND_ERROR "Could not locate ROCm HIP runtime library")
-  else()
-    message(STATUS "ROCm HIP runtime lib: ${ROCM_RUNTIME_LIBRARY}")
-  endif()
-
-  # Set HIP compile-time flags.
-  add_definitions(-D__HIP_PLATFORM_HCC__)
-
-  add_llvm_library(rocm-runtime-wrappers SHARED
-    rocm-runtime-wrappers.cpp
-  )
-  target_include_directories(rocm-runtime-wrappers
-    PRIVATE
-    "${HIP_PATH}/../include"
-    "${HIP_PATH}/include"
-    LLVMSupport
-  )
-  target_link_libraries(rocm-runtime-wrappers
-    PUBLIC
-    LLVMSupport
-    ${ROCM_RUNTIME_LIBRARY}
-  )
 
   get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
   get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
   set(LIBS
     ${dialect_libs}
     ${conversion_libs}
-    lldCommon
-    lldDriver
-    lldELF
-    LLVMCore
-    LLVMLTO
-    LLVMMC
-    LLVMMCParser
-    LLVMOption
-    LLVMSupport
+    LLVMX86AsmParser
+    LLVMAMDGPUAsmParser
+    LLVMROCmBackendUtils
     MLIRJitRunner
     MLIRAnalysis
     MLIREDSC
@@ -82,25 +24,15 @@ if(MLIR_ROCM_RUNNER_ENABLED)
     MLIRTargetROCDLIR
     MLIRTransforms
     MLIRTranslation
-    ${ROCM_RUNTIME_LIBRARY}
   )
-
-  # Manually expand the target library, since our MLIR libraries
-  # aren't plugged into the LLVM dependency tracking. If we don't
-  # do this then we can't insert the CodeGen library after ourselves
-  llvm_expand_pseudo_components(TARGET_LIBS AllTargetsCodeGens AllTargetsAsmParsers)
-  # Prepend LLVM in front of every target, this is how the library
-  # are named with CMake
-  SET(targets_to_link)
-  FOREACH(t ${TARGET_LIBS})
-    LIST(APPEND targets_to_link "LLVM${t}")
-  ENDFOREACH(t)
 
   add_llvm_tool(mlir-rocm-runner
     mlir-rocm-runner.cpp
 
     DEPENDS
+    LLVMROCmBackendUtils
     rocm-runtime-wrappers
+    ${LIBS}
     )
   llvm_update_compile_flags(mlir-rocm-runner)
   target_include_directories(mlir-rocm-runner
@@ -108,6 +40,6 @@ if(MLIR_ROCM_RUNNER_ENABLED)
     "${HIP_PATH}/../include"
     "${HIP_PATH}/include"
   )
-  target_link_libraries(mlir-rocm-runner PRIVATE ${LIBS} ${targets_to_link})
+  target_link_libraries(mlir-rocm-runner PRIVATE ${LIBS})
 
 endif()

--- a/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
+++ b/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
@@ -12,66 +12,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ADT/STLExtras.h"
+#include "mlir/ExecutionEngine/ROCm/BackendUitls.h"
 
-#include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
 #include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
-#include "mlir/Dialect/GPU/GPUDialect.h"
-#include "mlir/Dialect/GPU/Passes.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/TargetSelect.h"
+
 #include "mlir/ExecutionEngine/JitRunner.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/Function.h"
 #include "mlir/IR/Module.h"
 #include "mlir/InitAllDialects.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Support/FileUtilities.h"
-#include "mlir/Target/ROCDLIR.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/Passes.h"
-#include "llvm/Support/ErrorOr.h"
-#include "llvm/Support/FileUtilities.h"
-#include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/LineIterator.h"
-#include "llvm/Support/Program.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetRegistry.h"
-#include "llvm/Support/TargetSelect.h"
-
-// MC headers.
-#include "llvm/MC/MCAsmBackend.h"
-#include "llvm/MC/MCAsmInfo.h"
-#include "llvm/MC/MCCodeEmitter.h"
-#include "llvm/MC/MCContext.h"
-#include "llvm/MC/MCInstPrinter.h"
-#include "llvm/MC/MCInstrInfo.h"
-#include "llvm/MC/MCObjectFileInfo.h"
-#include "llvm/MC/MCObjectWriter.h"
-#include "llvm/MC/MCParser/AsmLexer.h"
-#include "llvm/MC/MCParser/MCTargetAsmParser.h"
-#include "llvm/MC/MCRegisterInfo.h"
-#include "llvm/MC/MCStreamer.h"
-#include "llvm/MC/MCSubtargetInfo.h"
-#include "llvm/MC/MCTargetOptionsCommandFlags.h"
-
-// lld headers.
-#include "lld/Common/Driver.h"
-
-// HIP headers.
-#include "hip/hip_version.h"
 
 using namespace mlir;
 using namespace llvm;
 
-using Blob = SmallVector<char, 0>;
-
 static cl::opt<std::string> tripleName("triple", cl::desc("target triple"),
                                        cl::value_desc("triple string"),
-                                       cl::init("amdgcn-amd-amdhsa"));
+                                       cl::init(""));
 
 static cl::opt<std::string> targetChip("target", cl::desc("target chip"),
                                        cl::value_desc("AMDGPU ISA version"),
@@ -81,231 +42,23 @@ static cl::opt<std::string> features("feature", cl::desc("target features"),
                                      cl::value_desc("AMDGPU target features"),
                                      cl::init(""));
 
-static constexpr const char kRunnerProgram[] = "mlir-rocm-runner";
-static constexpr const char kRocmAgentEnumerator[] = "rocm_agent_enumerator";
-static constexpr const char kDefaultTargetChip[] = "gfx900";
-
-static LogicalResult assembleIsa(const std::string isa, StringRef name,
-                                 Blob &result) {
-  raw_svector_ostream os(result);
-
-  std::string error;
-  Triple theTriple(Triple::normalize(tripleName));
-  const Target *theTarget =
-      TargetRegistry::lookupTarget(theTriple.normalize(), error);
-  if (!theTarget) {
-    WithColor::error(errs(), name) << error;
-    return failure();
-  }
-
-  SourceMgr srcMgr;
-  srcMgr.AddNewSourceBuffer(MemoryBuffer::getMemBuffer(isa), SMLoc());
-
-  const MCTargetOptions mcOptions;
-  std::unique_ptr<MCRegisterInfo> mri(theTarget->createMCRegInfo(tripleName));
-  std::unique_ptr<MCAsmInfo> mai(
-      theTarget->createMCAsmInfo(*mri, tripleName, mcOptions));
-  mai->setRelaxELFRelocations(true);
-
-  MCObjectFileInfo mofi;
-  MCContext ctx(mai.get(), mri.get(), &mofi, &srcMgr, &mcOptions);
-  mofi.InitMCObjectFileInfo(theTriple, false, ctx, false);
-
-  SmallString<128> cwd;
-  if (!sys::fs::current_path(cwd))
-    ctx.setCompilationDir(cwd);
-
-  std::unique_ptr<MCStreamer> mcStreamer;
-  std::unique_ptr<MCInstrInfo> mcii(theTarget->createMCInstrInfo());
-  std::unique_ptr<MCSubtargetInfo> sti(
-      theTarget->createMCSubtargetInfo(tripleName, targetChip, features));
-
-  MCCodeEmitter *ce = theTarget->createMCCodeEmitter(*mcii, *mri, ctx);
-  MCAsmBackend *mab = theTarget->createMCAsmBackend(*sti, *mri, mcOptions);
-  mcStreamer.reset(theTarget->createMCObjectStreamer(
-      theTriple, ctx, std::unique_ptr<MCAsmBackend>(mab),
-      mab->createObjectWriter(os), std::unique_ptr<MCCodeEmitter>(ce), *sti,
-      mcOptions.MCRelaxAll, mcOptions.MCIncrementalLinkerCompatible,
-      /*DWARFMustBeAtTheEnd*/ false));
-  mcStreamer->setUseAssemblerInfoForParsing(true);
-
-  std::unique_ptr<MCAsmParser> parser(
-      createMCAsmParser(srcMgr, ctx, *mcStreamer, *mai));
-  std::unique_ptr<MCTargetAsmParser> tap(
-      theTarget->createMCAsmParser(*sti, *parser, *mcii, mcOptions));
-
-  if (!tap) {
-    WithColor::error(errs(), name) << "assembler initialization error.\n";
-    return failure();
-  }
-
-  parser->setTargetParser(*tap);
-  parser->Run(false);
-
-  return success();
-}
-
-static LogicalResult createHsaco(const Blob &isaBlob, StringRef name,
-                                 Blob &hsacoBlob) {
-  // Save the ISA binary to a temp file.
-  int tempIsaBinaryFd = -1;
-  SmallString<128> tempIsaBinaryFilename;
-  std::error_code ec = sys::fs::createTemporaryFile(
-      "kernel", "o", tempIsaBinaryFd, tempIsaBinaryFilename);
-  if (ec) {
-    WithColor::error(errs(), name)
-        << "temporary file for ISA binary creation error.\n";
-    return failure();
-  }
-  FileRemover cleanupIsaBinary(tempIsaBinaryFilename);
-  raw_fd_ostream tempIsaBinaryOs(tempIsaBinaryFd, true);
-  tempIsaBinaryOs << isaBlob;
-  tempIsaBinaryOs.close();
-
-  // Create a temp file for HSA code object.
-  int tempHsacoFD = -1;
-  SmallString<128> tempHsacoFilename;
-  ec = sys::fs::createTemporaryFile("kernel", "hsaco", tempHsacoFD,
-                                    tempHsacoFilename);
-  if (ec) {
-    WithColor::error(errs(), name)
-        << "temporary file for HSA code object creation error.\n";
-    return failure();
-  }
-  FileRemover cleanupHsaco(tempHsacoFilename);
-
-  // Invoke lld. Expect a true return value from lld.
-  bool ret = lld::elf::link({"ld.lld", "-shared", tempIsaBinaryFilename.c_str(),
-                             "-o", tempHsacoFilename.c_str()},
-                            /*canEarlyExit=*/false, llvm::outs(), llvm::errs());
-  if (!ret) {
-    WithColor::error(errs(), name) << "lld invocation error.\n";
-    return failure();
-  }
-
-  // Load the HSA code object.
-  auto hsacoFile = mlir::openInputFile(tempHsacoFilename);
-  if (!hsacoFile) {
-    WithColor::error(errs(), name)
-        << "read HSA code object from temp file error.\n";
-    return failure();
-  }
-  hsacoBlob.assign(hsacoFile->getBuffer().begin(),
-                   hsacoFile->getBuffer().end());
-
-  return success();
-}
-
-static std::unique_ptr<llvm::Module> compileModuleToROCDLIR(Operation *m) {
-  auto llvmModule = translateModuleToROCDLIR(m);
-  // TODO(whchung): Link with ROCm-Device-Libs in case needed (ex: the Module
-  // depends on math functions).
-  return llvmModule;
-}
-
-static OwnedBlob compileISAToHsaco(const std::string isa, Location loc,
-                                   StringRef name) {
-  // ISA -> ISA in binary form via MC.
-  // Use lld to create HSA code object.
-  Blob isaBlob;
-  Blob hsacoBlob;
-
-  if (succeeded(assembleIsa(isa, name, isaBlob)) &&
-      succeeded(createHsaco(isaBlob, name, hsacoBlob)))
-    return std::make_unique<std::vector<char>>(hsacoBlob.begin(),
-                                               hsacoBlob.end());
-
-  WithColor::error(errs(), name) << "producing HSA code object error.\n";
-  return {};
-}
-
-static void configTargetChip() {
-  // Set targetChip to default value first.
-  targetChip = kDefaultTargetChip;
-
-  // Locate rocm_agent_enumerator.
-  llvm::ErrorOr<std::string> rocmAgentEnumerator = llvm::sys::findProgramByName(
-      kRocmAgentEnumerator, {__ROCM_PATH__ "/bin"});
-  std::error_code ec;
-  if (ec = rocmAgentEnumerator.getError()) {
-    WithColor::warning(errs(), kRunnerProgram)
-        << kRocmAgentEnumerator << " couldn't be located under "
-        << __ROCM_PATH__ << ", set target as " << kDefaultTargetChip << "\n";
-    return;
-  }
-
-  // Prepare temp file to hold the outputs.
-  int tempFd = -1;
-  SmallString<128> tempFilename;
-  ec = sys::fs::createTemporaryFile("rocm_agent", "txt", tempFd, tempFilename);
-  if (ec) {
-    WithColor::warning(errs(), kRunnerProgram)
-        << "temporary file for " << kRocmAgentEnumerator
-        << " creation error, set target as " << kDefaultTargetChip << "\n";
-    return;
-  }
-  FileRemover cleanup(tempFilename);
-
-  // Invoke rocm_agent_enumerator.
-  std::string errorMessage;
-  SmallVector<StringRef, 2> args{"-t", "GPU"};
-  Optional<StringRef> redirects[3] = {{""}, tempFilename.str(), {""}};
-  int result =
-      llvm::sys::ExecuteAndWait(rocmAgentEnumerator.get(), args, llvm::None,
-                                redirects, 0, 0, &errorMessage);
-  if (result) {
-    WithColor::warning(errs(), kRunnerProgram)
-        << kRocmAgentEnumerator << " invocation error: " << errorMessage
-        << ", set target as " << kDefaultTargetChip << "\n";
-    return;
-  }
-
-  // Load and parse the result.
-  auto gfxIsaList = mlir::openInputFile(tempFilename);
-  if (!gfxIsaList) {
-    WithColor::error(errs(), kRunnerProgram)
-        << "read ROCm agent list temp file error, set target as "
-        << kDefaultTargetChip << "\n";
-    return;
-  }
-  for (line_iterator lines(*gfxIsaList); !lines.is_at_end(); ++lines) {
-    // Skip the line with content "gfx000".
-    if (*lines == "gfx000")
-      continue;
-    // Use the first ISA version found.
-    targetChip = lines->str();
-    break;
-  }
-}
-
-static void configTargetFeatures() {
-  if (features.size() > 0)
-    features += ",";
-  // After ROCm 3.5, adopt HSA code object V3.
-  if (HIP_VERSION_MAJOR >= 3 && HIP_VERSION_MINOR >= 5)
-    features += "+code-object-v3";
-  else
-    features += "-code-object-v3";
-}
-
 static LogicalResult runMLIRPasses(ModuleOp m) {
   PassManager pm(m.getContext());
   applyPassManagerCLOptions(pm);
 
-  // Configure target chip ISA version if it has not been specified.
-  if (!targetChip.size())
-    configTargetChip();
-
-  // Configure target features per ROCm / HIP version.
-  configTargetFeatures();
+  BackendUtils utils(tripleName, targetChip, features);
 
   pm.addPass(createGpuKernelOutliningPass());
   auto &kernelPm = pm.nest<gpu::GPUModuleOp>();
   kernelPm.addPass(createStripDebugInfoPass());
   kernelPm.addPass(createLowerGpuOpsToROCDLOpsPass());
   kernelPm.addPass(createConvertGPUKernelToBlobPass(
-      compileModuleToROCDLIR, compileISAToHsaco, tripleName, targetChip,
-      features, /*gpuBinaryAnnotation=*/"rocdl.hsaco"));
+      [&utils](Operation *m) { return utils.compileModuleToROCDLIR(m); },
+      [&utils](const std::string isa, Location loc, StringRef name) {
+        return utils.compileISAToHsaco(isa, loc, name);
+      },
+      utils.getTriple(), utils.getChip(), utils.getFeatures(),
+      /*gpuBinaryAnnotation=*/"rocdl.hsaco"));
   pm.addPass(createLowerToLLVMPass());
   pm.addPass(createConvertGpuLaunchFuncToGpuRuntimeCallsPass(
       /*gpuBinaryAnnotation=*/"rocdl.hsaco"));
@@ -328,5 +81,5 @@ int main(int argc, char **argv) {
   LLVMInitializeAMDGPUAsmPrinter();
 
   mlir::initializeLLVMPasses();
-  return mlir::JitRunnerMain(argc, argv, &runMLIRPasses);
+  return mlir::JitRunnerMain(argc, argv, runMLIRPasses);
 }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -59,7 +59,7 @@ pipeline {
                     mkdir -p build && cd build
 
                     cmake -G "Unix Makefiles" ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir" \
+                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
                         -DCMAKE_BUILD_TYPE=Release \
                         -DBUILD_SHARED_LIBS=OFF \
                         -DLLVM_BUILD_LLVM_DYLIB=OFF \


### PR DESCRIPTION
This PR does mostly refactoring so that rocm runner infrastrcture can be shared across different components

- Moved and refactored the following components
  - majority of logic from mlir-rocm-runner to the LLVM component: BackendUitls
  - rocm-runtime-wrappers to be part of executionengine
- mlir-rocm-runner is a thin level and application implementation now