### PR TITLE
Fixing mlir-miopen-lib API

### DIFF
--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
@@ -23,20 +23,20 @@ int main(int argc, char **argv) {
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, "MLIR MIOpen Dialect driver\n");
 
-  mlir::MlirHandle handle = mlir::CreateMlirHandle(args.getValue().c_str());
+  MlirHandle handle = CreateMlirHandle(args.getValue().c_str());
 
   // Cpp backend source/header/cflags generation
   if ((option.getValue() == "source") || (option.getValue() == "header") ||
       (option.getValue() == "cflags")) {
-    mlir::MlirLowerCpp(handle);
+    MlirLowerCpp(handle);
     if (option.getValue() == "source") {
-      std::string source = mlir::MlirGenIgemmSource(handle);
+      std::string source = MlirGenIgemmSource(handle);
       std::cout << source << std::endl;
     } else if (option.getValue() == "header") {
-      std::string header = mlir::MlirGenIgemmHeader(handle);
+      std::string header = MlirGenIgemmHeader(handle);
       std::cout << header << std::endl;
     } else if (option.getValue() == "cflags") {
-      std::string cflags = mlir::MlirGenIgemmCflags(handle);
+      std::string cflags = MlirGenIgemmCflags(handle);
       std::cout << cflags << std::endl;
     }
     // Bin backend binary generation
@@ -44,11 +44,11 @@ int main(int argc, char **argv) {
     char tmp[] = "";
     char *buffer = &tmp[0];
     size_t size = 0;
-    mlir::MlirLowerBin(handle);
-    mlir::MlirGenIgemmBin(handle, &buffer, &size);
+    MlirLowerBin(handle);
+    MlirGenIgemmBin(handle, &buffer, &size);
     std::string res(buffer, size);
     std::cout << res << std::endl;
   }
 
-  mlir::DestroyMlirHandle(handle);
+  DestroyMlirHandle(handle);
 }

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.hpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.hpp
@@ -1,6 +1,6 @@
 #include <cstddef>
 
-namespace mlir {
+#define MLIRMIOPEN_VERSION_FLAT 0
 
 /*! @brief The MLIR handle used for lowering and code generation
  */
@@ -52,5 +52,3 @@ extern "C" void MlirGenIgemmBin(MlirHandle mlirHandle, char **buffer,
  *  @param handle MLIR handle
  */
 extern "C" void DestroyMlirHandle(MlirHandle handle);
-
-} // namespace mlir


### PR DESCRIPTION
- Removing redundant namespace
- Added a flat version that give client the capability to test with different version of libMLIRMIOpen.a