### PR TITLE
Improve fp16/bf16 memref print out logic.

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/RunnerUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/RunnerUtils.h
@@ -222,10 +222,6 @@ extern "C" MLIR_RUNNERUTILS_EXPORT void
 _mlir_ciface_print_memref_f32(UnrankedMemRefType<float> *M);
 extern "C" MLIR_RUNNERUTILS_EXPORT void
 _mlir_ciface_print_memref_f64(UnrankedMemRefType<double> *M);
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-_mlir_ciface_print_memref_f16(UnrankedMemRefType<unsigned short> *M);
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-_mlir_ciface_print_memref_bf16(UnrankedMemRefType<unsigned short> *M);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void print_memref_i32(int64_t rank,
                                                          void *ptr);
@@ -235,10 +231,6 @@ extern "C" MLIR_RUNNERUTILS_EXPORT void print_memref_f32(int64_t rank,
                                                          void *ptr);
 extern "C" MLIR_RUNNERUTILS_EXPORT void print_memref_f64(int64_t rank,
                                                          void *ptr);
-extern "C" MLIR_RUNNERUTILS_EXPORT void print_memref_f16(int64_t rank,
-                                                         void *ptr);
-extern "C" MLIR_RUNNERUTILS_EXPORT void print_memref_bf16(int64_t rank,
-                                                          void *ptr);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void
 _mlir_ciface_print_memref_0d_f32(StridedMemRefType<float, 0> *M);

--- a/mlir/lib/ExecutionEngine/RunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/RunnerUtils.cpp
@@ -40,14 +40,6 @@ extern "C" void _mlir_ciface_print_memref_f64(UnrankedMemRefType<double> *M) {
   impl::printMemRef(*M);
 }
 
-extern "C" void _mlir_ciface_print_memref_f16(UnrankedMemRefType<unsigned short> *M) {
-  impl::printMemRef(*M);
-}
-
-extern "C" void _mlir_ciface_print_memref_bf16(UnrankedMemRefType<unsigned short> *M) {
-  impl::printMemRef(*M);
-}
-
 extern "C" void print_memref_i32(int64_t rank, void *ptr) {
   UnrankedMemRefType<int32_t> descriptor = {rank, ptr};
   _mlir_ciface_print_memref_i32(&descriptor);
@@ -66,16 +58,6 @@ extern "C" void print_memref_f32(int64_t rank, void *ptr) {
 extern "C" void print_memref_f64(int64_t rank, void *ptr) {
   UnrankedMemRefType<double> descriptor = {rank, ptr};
   _mlir_ciface_print_memref_f64(&descriptor);
-}
-
-extern "C" void print_memref_f16(int64_t rank, void *ptr) {
-  UnrankedMemRefType<unsigned short> descriptor = {rank, ptr};
-  _mlir_ciface_print_memref_f16(&descriptor);
-}
-
-extern "C" void print_memref_bf16(int64_t rank, void *ptr) {
-  UnrankedMemRefType<unsigned short> descriptor = {rank, ptr};
-  _mlir_ciface_print_memref_bf16(&descriptor);
 }
 
 extern "C" void

--- a/mlir/test/mlir-miopen-driver/populate_host.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host.mlir
@@ -1,43 +1,150 @@
-// RUN: mlir-miopen-driver -p -ph | FileCheck %s
+// RUN: mlir-miopen-driver -p -ph | FileCheck %s --check-prefix=F32
+// RUN: mlir-miopen-driver -p -ph -t f16 | FileCheck %s --check-prefix=F16
+// RUN: mlir-miopen-driver -p -ph -t bf16 | FileCheck %s --check-prefix=BF16
 
-// CHECK-LABEL: module
-// CHECK-NEXT: func @miopen_conv2d_kcyx_nchw_nkhw({{.*}}: memref<128x8x3x3xf32>, {{.*}}: memref<128x8x32x32xf32>, {{.*}}: memref<128x128x30x30xf32>)
-// CHECK-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x"], input_layout = ["ni", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
+// F32-LABEL: module
+// F32-NEXT: func @miopen_conv2d_kcyx_nchw_nkhw({{.*}}: memref<128x8x3x3xf32>, {{.*}}: memref<128x8x32x32xf32>, {{.*}}: memref<128x128x30x30xf32>)
+// F32-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x"], input_layout = ["ni", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
 
-// CHECK-LABEL: func @main()
-// CHECK-NEXT: alloc() : memref<128x8x3x3xf32>
-// CHECK-NEXT: alloc() : memref<128x8x32x32xf32>
-// CHECK-NEXT: alloc() : memref<128x128x30x30xf32>
-// CHECK-NEXT: memref_cast {{.*}} : memref<128x8x3x3xf32> to memref<?x?x?x?xf32>
-// CHECK-NEXT: memref_cast {{.*}} : memref<128x8x32x32xf32> to memref<?x?x?x?xf32>
-// CHECK-NEXT: memref_cast {{.*}} : memref<128x128x30x30xf32> to memref<?x?x?x?xf32>
-// CHECK-NEXT: constant 1.000000e+00 : f32
-// CHECK-NEXT: constant 0.000000e+00 : f32
-// CHECK-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
-// CHECk-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
-// CHECk-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
-// CHECk-NEXT: call @mgpuMemAlloc4DFloat({{.*}}) : (memref<?x?x?x?xf32>) -> memref<?x?x?x?xf32>
-// CHECk-NEXT: call @mgpuMemAlloc4DFloat({{.*}}) : (memref<?x?x?x?xf32>) -> memref<?x?x?x?xf32>
-// CHECk-NEXT: call @mgpuMemAlloc4DFloat({{.*}}) : (memref<?x?x?x?xf32>) -> memref<?x?x?x?xf32>
-// CHECk-NEXT: constant 1 : i32
-// CHECk-NEXT: constant 2 : i32
-// CHECk-NEXT: call @mgpuMemCopy4DFloat({{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
-// CHECk-NEXT: call @mgpuMemCopy4DFloat({{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
-// CHECk-NEXT: call @mgpuMemCopy4DFloat({{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
-// CHECk-NEXT: memref_cast {{.*}} : memref<?x?x?x?xf32> to memref<128x8x3x3xf32>
-// CHECk-NEXT: memref_cast {{.*}} : memref<?x?x?x?xf32> to memref<128x8x32x32xf32>
-// CHECk-NEXT: memref_cast {{.*}} : memref<?x?x?x?xf32> to memref<128x128x30x30xf32>
-// CHECk-NEXT: call @conv2d({{.*}}, {{.*}}, {{.*}}) : (memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>) -> ()
-// CHECk-NEXT: call @mgpuMemCopy4DFloat({{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
-// CHECk-NEXT: memref_cast {{.*}} : memref<?x?x?x?xf32> to memref<*xf32>
-// CHECk-NEXT: call @print_memref_f32({{.*}}) : (memref<*xf32>) -> ()
-// CHECk-NEXT: call @mgpuMemDealloc4DFloat({{.*}}) : (memref<?x?x?x?xf32>) -> ()
-// CHECk-NEXT: call @mgpuMemDealloc4DFloat({{.*}}) : (memref<?x?x?x?xf32>) -> ()
-// CHECk-NEXT: call @mgpuMemDealloc4DFloat({{.*}}) : (memref<?x?x?x?xf32>) -> ()
-// CHECk-NEXT: dealloc %0 : memref<128x8x3x3xf32>
-// CHECk-NEXT: dealloc %1 : memref<128x8x32x32xf32>
-// CHECk-NEXT: dealloc %2 : memref<128x128x30x30xf32>
-// CHECk-NEXT: return
+// F16-LABEL: module
+// F16-NEXT: func @miopen_conv2d_kcyx_nchw_nkhw({{.*}}: memref<128x8x3x3xf16>, {{.*}}: memref<128x8x32x32xf16>, {{.*}}: memref<128x128x30x30xf16>)
+// F16-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x"], input_layout = ["ni", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<128x8x3x3xf16>, memref<128x8x32x32xf16>, memref<128x128x30x30xf16>
 
-// CHECK-LABEL: func @conv2d(%arg0: memref<128x8x3x3xf32>, %arg1: memref<128x8x32x32xf32>, %arg2: memref<128x128x30x30xf32>)
-// CHECK-NEXT: return
+// BF16-LABEL: module
+// BF16-NEXT: func @miopen_conv2d_kcyx_nchw_nkhw({{.*}}: memref<128x8x3x3xbf16>, {{.*}}: memref<128x8x32x32xbf16>, {{.*}}: memref<128x128x30x30xbf16>)
+// BF16-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x"], input_layout = ["ni", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<128x8x3x3xbf16>, memref<128x8x32x32xbf16>, memref<128x128x30x30xbf16>
+
+// F32-LABEL: func @main()
+// F32-NEXT: alloc() : memref<128x8x3x3xf32>
+// F32-NEXT: alloc() : memref<128x8x32x32xf32>
+// F32-NEXT: alloc() : memref<128x128x30x30xf32>
+// F32-NEXT: alloc() : memref<128x128x30x30xf32>
+// F32-NEXT: memref_cast {{.*}} : memref<128x8x3x3xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: memref_cast {{.*}} : memref<128x8x32x32xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: memref_cast {{.*}} : memref<128x128x30x30xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: constant 1.000000e+00 : f32
+// F32-NEXT: constant 0.000000e+00 : f32
+// F32-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
+// F32-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
+// F32-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
+// F32-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>) -> ()
+// F32-NEXT: dealloc {{.*}} : memref<128x8x3x3xf32>
+// F32-NEXT: dealloc {{.*}} : memref<128x8x32x32xf32>
+// F32-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// F32-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// F32-NEXT: return
+
+// F16-LABEL: func @main()
+// F16-NEXT: alloc() : memref<128x8x3x3xf16>
+// F16-NEXT: alloc() : memref<128x8x32x32xf16>
+// F16-NEXT: alloc() : memref<128x128x30x30xf16>
+// F16-NEXT: alloc() : memref<128x128x30x30xf32>
+// F16-NEXT: memref_cast {{.*}} : memref<128x8x3x3xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: memref_cast {{.*}} : memref<128x8x32x32xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: memref_cast {{.*}} : memref<128x128x30x30xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: constant 1.000000e+00 : f16
+// F16-NEXT: constant 0.000000e+00 : f16
+// F16-NEXT: call @mcpuMemset4DHalf({{.*}}, {{.*}}) : (memref<?x?x?x?xf16>, f16) -> ()
+// F16-NEXT: call @mcpuMemset4DHalf({{.*}}, {{.*}}) : (memref<?x?x?x?xf16>, f16) -> ()
+// F16-NEXT: call @mcpuMemset4DHalf({{.*}}, {{.*}}) : (memref<?x?x?x?xf16>, f16) -> ()
+// F16-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<128x8x3x3xf16>, memref<128x8x32x32xf16>, memref<128x128x30x30xf16>) -> ()
+// F16-NEXT: dealloc {{.*}} : memref<128x8x3x3xf16>
+// F16-NEXT: dealloc {{.*}} : memref<128x8x32x32xf16>
+// F16-NEXT: dealloc {{.*}} : memref<128x128x30x30xf16>
+// F16-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// F16-NEXT: return
+
+// BF16-LABEL: func @main()
+// BF16-NEXT: alloc() : memref<128x8x3x3xbf16>
+// BF16-NEXT: alloc() : memref<128x8x32x32xbf16>
+// BF16-NEXT: alloc() : memref<128x128x30x30xbf16>
+// BF16-NEXT: alloc() : memref<128x128x30x30xf32>
+// BF16-NEXT: memref_cast {{.*}} : memref<128x8x3x3xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: memref_cast {{.*}} : memref<128x8x32x32xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: memref_cast {{.*}} : memref<128x128x30x30xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: constant 1.000000e+00 : bf16
+// BF16-NEXT: constant 0.000000e+00 : bf16
+// BF16-NEXT: call @mcpuMemset4DBF16({{.*}}, {{.*}}) : (memref<?x?x?x?xbf16>, bf16) -> ()
+// BF16-NEXT: call @mcpuMemset4DBF16({{.*}}, {{.*}}) : (memref<?x?x?x?xbf16>, bf16) -> ()
+// BF16-NEXT: call @mcpuMemset4DBF16({{.*}}, {{.*}}) : (memref<?x?x?x?xbf16>, bf16) -> ()
+// BF16-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<128x8x3x3xbf16>, memref<128x8x32x32xbf16>, memref<128x128x30x30xbf16>) -> ()
+// BF16-NEXT: dealloc {{.*}} : memref<128x8x3x3xbf16>
+// BF16-NEXT: dealloc {{.*}} : memref<128x8x32x32xbf16>
+// BF16-NEXT: dealloc {{.*}} : memref<128x128x30x30xbf16>
+// BF16-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// BF16-NEXT: return
+
+// F32-LABEL: func @gpu_conv(%{{.*}}: memref<128x8x3x3xf32>, %{{.*}}: memref<128x8x32x32xf32>, %{{.*}}: memref<128x128x30x30xf32>)
+// F32-NEXT: memref_cast %{{.*}} : memref<128x8x3x3xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: memref_cast %{{.*}} : memref<128x8x32x32xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: memref_cast %{{.*}} : memref<128x128x30x30xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: call @mgpuMemAlloc4DFloat(%{{.*}}) : (memref<?x?x?x?xf32>) -> memref<?x?x?x?xf32>
+// F32-NEXT: call @mgpuMemAlloc4DFloat(%{{.*}}) : (memref<?x?x?x?xf32>) -> memref<?x?x?x?xf32>
+// F32-NEXT: call @mgpuMemAlloc4DFloat(%{{.*}}) : (memref<?x?x?x?xf32>) -> memref<?x?x?x?xf32>
+// F32-NEXT: constant 1 : i32
+// F32-NEXT: constant 2 : i32
+// F32-NEXT: call @mgpuMemCopy4DFloat(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
+// F32-NEXT: call @mgpuMemCopy4DFloat(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
+// F32-NEXT: call @mgpuMemCopy4DFloat(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
+// F32-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xf32> to memref<128x8x3x3xf32>
+// F32-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xf32> to memref<128x8x32x32xf32>
+// F32-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xf32> to memref<128x128x30x30xf32>
+// F32-NEXT: call @conv2d(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>) -> ()
+// F32-NEXT: call @mgpuMemCopy4DFloat(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, i32) -> ()
+// F32-NEXT: call @mgpuMemDealloc4DFloat(%{{.*}}) : (memref<?x?x?x?xf32>) -> ()
+// F32-NEXT: call @mgpuMemDealloc4DFloat(%{{.*}}) : (memref<?x?x?x?xf32>) -> ()
+// F32-NEXT: call @mgpuMemDealloc4DFloat(%{{.*}}) : (memref<?x?x?x?xf32>) -> ()
+// F32-NEXT: return
+
+// F16-LABEL: func @gpu_conv(%{{.*}}: memref<128x8x3x3xf16>, %{{.*}}: memref<128x8x32x32xf16>, %{{.*}}: memref<128x128x30x30xf16>)
+// F16-NEXT: memref_cast %{{.*}} : memref<128x8x3x3xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: memref_cast %{{.*}} : memref<128x8x32x32xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: memref_cast %{{.*}} : memref<128x128x30x30xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: call @mgpuMemAlloc4DHalf(%{{.*}}) : (memref<?x?x?x?xf16>) -> memref<?x?x?x?xf16>
+// F16-NEXT: call @mgpuMemAlloc4DHalf(%{{.*}}) : (memref<?x?x?x?xf16>) -> memref<?x?x?x?xf16>
+// F16-NEXT: call @mgpuMemAlloc4DHalf(%{{.*}}) : (memref<?x?x?x?xf16>) -> memref<?x?x?x?xf16>
+// F16-NEXT: constant 1 : i32
+// F16-NEXT: constant 2 : i32
+// F16-NEXT: call @mgpuMemCopy4DHalf(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+// F16-NEXT: call @mgpuMemCopy4DHalf(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+// F16-NEXT: call @mgpuMemCopy4DHalf(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+// F16-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xf16> to memref<128x8x3x3xf16>
+// F16-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xf16> to memref<128x8x32x32xf16>
+// F16-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xf16> to memref<128x128x30x30xf16>
+// F16-NEXT: call @conv2d(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<128x8x3x3xf16>, memref<128x8x32x32xf16>, memref<128x128x30x30xf16>) -> ()
+// F16-NEXT: call @mgpuMemCopy4DHalf(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+// F16-NEXT: call @mgpuMemDealloc4DHalf(%{{.*}}) : (memref<?x?x?x?xf16>) -> ()
+// F16-NEXT: call @mgpuMemDealloc4DHalf(%{{.*}}) : (memref<?x?x?x?xf16>) -> ()
+// F16-NEXT: call @mgpuMemDealloc4DHalf(%{{.*}}) : (memref<?x?x?x?xf16>) -> ()
+// F16-NEXT: return
+
+// BF16-LABEL: func @gpu_conv(%{{.*}}: memref<128x8x3x3xbf16>, %{{.*}}: memref<128x8x32x32xbf16>, %{{.*}}: memref<128x128x30x30xbf16>)
+// BF16-NEXT: memref_cast %{{.*}} : memref<128x8x3x3xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: memref_cast %{{.*}} : memref<128x8x32x32xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: memref_cast %{{.*}} : memref<128x128x30x30xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: call @mgpuMemAlloc4DBF16(%{{.*}}) : (memref<?x?x?x?xbf16>) -> memref<?x?x?x?xbf16>
+// BF16-NEXT: call @mgpuMemAlloc4DBF16(%{{.*}}) : (memref<?x?x?x?xbf16>) -> memref<?x?x?x?xbf16>
+// BF16-NEXT: call @mgpuMemAlloc4DBF16(%{{.*}}) : (memref<?x?x?x?xbf16>) -> memref<?x?x?x?xbf16>
+// BF16-NEXT: constant 1 : i32
+// BF16-NEXT: constant 2 : i32
+// BF16-NEXT: call @mgpuMemCopy4DBF16(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xbf16>, memref<?x?x?x?xbf16>, i32) -> ()
+// BF16-NEXT: call @mgpuMemCopy4DBF16(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xbf16>, memref<?x?x?x?xbf16>, i32) -> ()
+// BF16-NEXT: call @mgpuMemCopy4DBF16(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xbf16>, memref<?x?x?x?xbf16>, i32) -> ()
+// BF16-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xbf16> to memref<128x8x3x3xbf16>
+// BF16-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xbf16> to memref<128x8x32x32xbf16>
+// BF16-NEXT: memref_cast %{{.*}} : memref<?x?x?x?xbf16> to memref<128x128x30x30xbf16>
+// BF16-NEXT: call @conv2d(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<128x8x3x3xbf16>, memref<128x8x32x32xbf16>, memref<128x128x30x30xbf16>) -> ()
+// BF16-NEXT: call @mgpuMemCopy4DBF16(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?xbf16>, memref<?x?x?x?xbf16>, i32) -> ()
+// BF16-NEXT: call @mgpuMemDealloc4DBF16(%{{.*}}) : (memref<?x?x?x?xbf16>) -> ()
+// BF16-NEXT: call @mgpuMemDealloc4DBF16(%{{.*}}) : (memref<?x?x?x?xbf16>) -> ()
+// BF16-NEXT: call @mgpuMemDealloc4DBF16(%{{.*}}) : (memref<?x?x?x?xbf16>) -> ()
+// BF16-NEXT: return
+
+// F32-LABEL: func @conv2d(%arg0: memref<128x8x3x3xf32>, %arg1: memref<128x8x32x32xf32>, %arg2: memref<128x128x30x30xf32>)
+// F32-NEXT: return
+
+// F16-LABEL: func @conv2d(%arg0: memref<128x8x3x3xf16>, %arg1: memref<128x8x32x32xf16>, %arg2: memref<128x128x30x30xf16>)
+// F16-NEXT: return
+
+// BF16-LABEL: func @conv2d(%arg0: memref<128x8x3x3xbf16>, %arg1: memref<128x8x32x32xbf16>, %arg2: memref<128x128x30x30xbf16>)
+// BF16-NEXT: return

--- a/mlir/test/mlir-miopen-driver/populate_host_print.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host_print.mlir
@@ -1,0 +1,119 @@
+// RUN: mlir-miopen-driver -p -ph -pr | FileCheck %s --check-prefix=F32
+// RUN: mlir-miopen-driver -p -ph -pr -t f16 | FileCheck %s --check-prefix=F16
+// RUN: mlir-miopen-driver -p -ph -pr -t bf16 | FileCheck %s --check-prefix=BF16
+
+// F32-LABEL: func @main()
+// F32-NEXT: alloc() : memref<128x8x3x3xf32>
+// F32-NEXT: alloc() : memref<128x8x32x32xf32>
+// F32-NEXT: alloc() : memref<128x128x30x30xf32>
+// F32-NEXT: alloc() : memref<128x128x30x30xf32>
+// F32-NEXT: memref_cast {{.*}} : memref<128x8x3x3xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: memref_cast {{.*}} : memref<128x8x32x32xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: memref_cast {{.*}} : memref<128x128x30x30xf32> to memref<?x?x?x?xf32>
+// F32-NEXT: constant 1.000000e+00 : f32
+// F32-NEXT: constant 0.000000e+00 : f32
+// F32-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
+// F32-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
+// F32-NEXT: call @mcpuMemset4DFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xf32>, f32) -> ()
+// F32-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>) -> ()
+// F32-NEXT: constant 0 : index
+// F32-NEXT: constant 1 : index
+// F32-NEXT: constant 128 : index
+// F32-NEXT: constant 128 : index
+// F32-NEXT: constant 30 : index
+// F32-NEXT: constant 30 : index
+// F32-NEXT: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F32-NEXT:   scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F32-NEXT:     scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F32-NEXT:       scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F32-NEXT:         %{{.*}} = load %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : memref<128x128x30x30xf32>
+// F32-NEXT:         store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : memref<128x128x30x30xf32>
+// F32-NEXT:       }
+// F32-NEXT:     }
+// F32-NEXT:   }
+// F32-NEXT: }
+// F32-NEXT: memref_cast %{{.*}} : memref<128x128x30x30xf32> to memref<*xf32>
+// F32-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*xf32>) -> ()
+// F32-NEXT: dealloc {{.*}} : memref<128x8x3x3xf32>
+// F32-NEXT: dealloc {{.*}} : memref<128x8x32x32xf32>
+// F32-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// F32-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// F32-NEXT: return
+
+// F16-LABEL: func @main()
+// F16-NEXT: alloc() : memref<128x8x3x3xf16>
+// F16-NEXT: alloc() : memref<128x8x32x32xf16>
+// F16-NEXT: alloc() : memref<128x128x30x30xf16>
+// F16-NEXT: alloc() : memref<128x128x30x30xf32>
+// F16-NEXT: memref_cast {{.*}} : memref<128x8x3x3xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: memref_cast {{.*}} : memref<128x8x32x32xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: memref_cast {{.*}} : memref<128x128x30x30xf16> to memref<?x?x?x?xf16>
+// F16-NEXT: constant 1.000000e+00 : f16
+// F16-NEXT: constant 0.000000e+00 : f16
+// F16-NEXT: call @mcpuMemset4DHalf({{.*}}, {{.*}}) : (memref<?x?x?x?xf16>, f16) -> ()
+// F16-NEXT: call @mcpuMemset4DHalf({{.*}}, {{.*}}) : (memref<?x?x?x?xf16>, f16) -> ()
+// F16-NEXT: call @mcpuMemset4DHalf({{.*}}, {{.*}}) : (memref<?x?x?x?xf16>, f16) -> ()
+// F16-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<128x8x3x3xf16>, memref<128x8x32x32xf16>, memref<128x128x30x30xf16>) -> ()
+// F16-NEXT: constant 0 : index
+// F16-NEXT: constant 1 : index
+// F16-NEXT: constant 128 : index
+// F16-NEXT: constant 128 : index
+// F16-NEXT: constant 30 : index
+// F16-NEXT: constant 30 : index
+// F16-NEXT: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F16-NEXT:   scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F16-NEXT:     scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F16-NEXT:       scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// F16-NEXT:         %{{.*}} = load %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : memref<128x128x30x30xf16>
+// F16-NEXT:         %{{.*}} = fpext %{{.*}} : f16 to f32
+// F16-NEXT:         store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : memref<128x128x30x30xf32>
+// F16-NEXT:       }
+// F16-NEXT:     }
+// F16-NEXT:   }
+// F16-NEXT: }
+// F16-NEXT: %{{.*}} = memref_cast %{{.*}} : memref<128x128x30x30xf32> to memref<*xf32>
+// F16-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*xf32>) -> ()
+// F16-NEXT: dealloc {{.*}} : memref<128x8x3x3xf16>
+// F16-NEXT: dealloc {{.*}} : memref<128x8x32x32xf16>
+// F16-NEXT: dealloc {{.*}} : memref<128x128x30x30xf16>
+// F16-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// F16-NEXT: return
+
+// BF16-LABEL: func @main()
+// BF16-NEXT: alloc() : memref<128x8x3x3xbf16>
+// BF16-NEXT: alloc() : memref<128x8x32x32xbf16>
+// BF16-NEXT: alloc() : memref<128x128x30x30xbf16>
+// BF16-NEXT: alloc() : memref<128x128x30x30xf32>
+// BF16-NEXT: memref_cast {{.*}} : memref<128x8x3x3xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: memref_cast {{.*}} : memref<128x8x32x32xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: memref_cast {{.*}} : memref<128x128x30x30xbf16> to memref<?x?x?x?xbf16>
+// BF16-NEXT: constant 1.000000e+00 : bf16
+// BF16-NEXT: constant 0.000000e+00 : bf16
+// BF16-NEXT: call @mcpuMemset4DBF16({{.*}}, {{.*}}) : (memref<?x?x?x?xbf16>, bf16) -> ()
+// BF16-NEXT: call @mcpuMemset4DBF16({{.*}}, {{.*}}) : (memref<?x?x?x?xbf16>, bf16) -> ()
+// BF16-NEXT: call @mcpuMemset4DBF16({{.*}}, {{.*}}) : (memref<?x?x?x?xbf16>, bf16) -> ()
+// BF16-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<128x8x3x3xbf16>, memref<128x8x32x32xbf16>, memref<128x128x30x30xbf16>) -> ()
+// BF16-NEXT: constant 0 : index
+// BF16-NEXT: constant 1 : index
+// BF16-NEXT: constant 128 : index
+// BF16-NEXT: constant 128 : index
+// BF16-NEXT: constant 30 : index
+// BF16-NEXT: constant 30 : index
+// BF16-NEXT: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// BF16-NEXT:   scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// BF16-NEXT:     scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// BF16-NEXT:       scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// BF16-NEXT:         %{{.*}} = load %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : memref<128x128x30x30xbf16>
+// BF16-NEXT:         %{{.*}} = fpext %{{.*}} : bf16 to f32
+// BF16-NEXT:         store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : memref<128x128x30x30xf32>
+// BF16-NEXT:       }
+// BF16-NEXT:     }
+// BF16-NEXT:   }
+// BF16-NEXT: }
+// BF16-NEXT: memref_cast %{{.*}} : memref<128x128x30x30xf32> to memref<*xf32>
+// BF16-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*xf32>) -> ()
+// BF16-NEXT: dealloc {{.*}} : memref<128x8x3x3xbf16>
+// BF16-NEXT: dealloc {{.*}} : memref<128x8x32x32xbf16>
+// BF16-NEXT: dealloc {{.*}} : memref<128x128x30x30xbf16>
+// BF16-NEXT: dealloc {{.*}} : memref<128x128x30x30xf32>
+// BF16-NEXT: return


### PR DESCRIPTION
Use `print_memref_f32`, after converting output tensor from f16/bf16 to f32.

Remove incorrect `print_memref_f16` and `print_memref_bf16`.