### PR TITLE
Only link with sqlite3 when it's truly needed.

### DIFF
--- a/mlir/tools/mlir-shlib/CMakeLists.txt
+++ b/mlir/tools/mlir-shlib/CMakeLists.txt
@@ -30,6 +30,10 @@ if(MLIR_LINK_MLIR_DYLIB)
   set(INSTALL_WITH_TOOLCHAIN INSTALL_WITH_TOOLCHAIN)
 endif()
 
+if(MLIR_MIOPEN_SQLITE_ENABLED)
+  list(APPEND _DEPS "sqlite3")
+endif()
+
 if(LLVM_BUILD_LLVM_DYLIB)
   add_mlir_library(
     MLIR
@@ -39,7 +43,6 @@ if(LLVM_BUILD_LLVM_DYLIB)
     ${_OBJECTS}
     LINK_LIBS
     ${_DEPS}
-    sqlite3
 
     LINK_COMPONENTS
     ${mlir_llvm_link_components}


### PR DESCRIPTION
Derived from #72 . Only link with sqlite3 when it's truly needed.