### PR TITLE
Fix miopen.fill / miopen.threadwise_gemm in fp16 / bf16 cases.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -1369,13 +1369,18 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
   LogicalResult matchAndRewrite(miopen::GridwiseGemmOp op, PatternRewriter &b) const override {
     auto loc = op.getLoc();
 
-    auto elementType = op.output().getType().cast<MemRefType>().getElementType();
+    auto elementType = op.output().getType().cast<MemRefType>().getElementType().template dyn_cast<Type>();
 
     // Prepare some useful constants.
-    auto zeroConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
-    auto oneConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(1.0f), b.getF32Type());
+    Value zeroConstantFloatOp;
+    if (elementType == b.getF32Type()) {
+      zeroConstantFloatOp = b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
+    } else if (elementType == b.getF16Type() || elementType == b.getBF16Type()) {
+      auto zeroF32Op = b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
+      zeroConstantFloatOp = b.create<FPTruncOp>(loc, zeroF32Op, elementType);
+    } else if (elementType == b.getIntegerType(16)) {
+      zeroConstantFloatOp = b.create<ConstantIntOp>(loc, 0, b.getIntegerType(16));
+    }
     auto zeroConstantI32Op =
         b.create<ConstantIntOp>(loc, 0, b.getIntegerType(32));
 

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -1369,17 +1369,25 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
   LogicalResult matchAndRewrite(miopen::GridwiseGemmOp op, PatternRewriter &b) const override {
     auto loc = op.getLoc();
 
-    auto elementType = op.output().getType().cast<MemRefType>().getElementType().template dyn_cast<Type>();
+    auto elementType = op.output()
+                           .getType()
+                           .cast<MemRefType>()
+                           .getElementType()
+                           .template dyn_cast<Type>();
 
     // Prepare some useful constants.
     Value zeroConstantFloatOp;
     if (elementType == b.getF32Type()) {
-      zeroConstantFloatOp = b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
-    } else if (elementType == b.getF16Type() || elementType == b.getBF16Type()) {
-      auto zeroF32Op = b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
+      zeroConstantFloatOp =
+          b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
+    } else if (elementType == b.getF16Type() ||
+               elementType == b.getBF16Type()) {
+      auto zeroF32Op =
+          b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
       zeroConstantFloatOp = b.create<FPTruncOp>(loc, zeroF32Op, elementType);
     } else if (elementType == b.getIntegerType(16)) {
-      zeroConstantFloatOp = b.create<ConstantIntOp>(loc, 0, b.getIntegerType(16));
+      zeroConstantFloatOp =
+          b.create<ConstantIntOp>(loc, 0, b.getIntegerType(16));
     }
     auto zeroConstantI32Op =
         b.create<ConstantIntOp>(loc, 0, b.getIntegerType(32));
@@ -3600,7 +3608,8 @@ struct ThreadwiseGemmRewritePattern
     auto gemmA = op.matrixA();
     auto gemmB = op.matrixB();
     auto gemmC = op.matrixC();
-    auto dataType = gemmA.getType().template dyn_cast<MemRefType>().getElementType();
+    auto dataType =
+        gemmA.getType().template dyn_cast<MemRefType>().getElementType();
 
     ArrayRef<int64_t> gemmAShape =
         gemmA.getType().dyn_cast<MemRefType>().getShape();

--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -32,10 +32,10 @@
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 
 // RUN: mlir-miopen-driver -p -t f16 -x2 | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering | mlir-opt
@@ -56,10 +56,10 @@
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 
 // RUN: mlir-miopen-driver -p -t bf16 -x2 | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering | mlir-opt

--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -19,10 +19,10 @@
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 
 // fp16 tests.
 
@@ -43,10 +43,10 @@
 // RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 
 // bf16(i16) tests.
 
@@ -67,7 +67,7 @@
 // RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt

--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -1,0 +1,73 @@
+// Sanity test to ensure every step of the lowering process gets valid MLIR.
+
+// fp32 tests.
+
+// RUN: mlir-miopen-driver -p | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+
+// RUN: mlir-miopen-driver -p -x2 | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+
+// fp16 tests.
+
+// RUN: mlir-miopen-driver -p -t f16 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+
+// RUN: mlir-miopen-driver -p -t f16 -x2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+
+// bf16(i16) tests.
+
+// RUN: mlir-miopen-driver -p -t bf16 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+
+// RUN: mlir-miopen-driver -p -t bf16 -x2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt

--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -13,17 +13,6 @@
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 
-// RUN: mlir-miopen-driver -p -x2 | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
-// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
-
 // fp16 tests.
 
 // RUN: mlir-miopen-driver -p -t f16 | mlir-opt
@@ -37,17 +26,6 @@
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 
-// RUN: mlir-miopen-driver -p -t f16 -x2 | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
-// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
-
 // bf16(i16) tests.
 
 // RUN: mlir-miopen-driver -p -t bf16 | mlir-opt
@@ -60,14 +38,3 @@
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
-
-// RUN: mlir-miopen-driver -p -t bf16 -x2 | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
-// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
-// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt

--- a/mlir/test/mlir-miopen-driver/sanity_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_xdlops.mlir
@@ -1,0 +1,40 @@
+// Sanity test to ensure every step of the XDLOPS lowering process gets valid MLIR.
+
+// fp32 tests.
+
+// RUN: mlir-miopen-driver -p -x2 | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+
+// fp16 tests.
+
+// RUN: mlir-miopen-driver -p -t f16 -x2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
+
+// bf16(i16) tests.
+
+// RUN: mlir-miopen-driver -p -t bf16 -x2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | mlir-opt
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
+// FIXME: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt


### PR DESCRIPTION
Fix logic in `miopen.gridwise_gemm` so `miopen.fill` is properly used in f16/bf16 cases.

Fix logic in `miopen.threadwise_gemm` in f16/bf16 cases.

Add sanity tests to ensure each lowering step produces valid MLIR.