### PR TITLE
Add sanity tests for -pv .

### DIFF
--- a/mlir/test/mlir-miopen-driver/sanity_pv.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_pv.mlir
@@ -2,8 +2,5 @@
 // lowering paths.
 
 // RUN: mlir-miopen-driver -p -pv -c | mlir-opt
-// RUN: mlir-miopen-driver -p -pv -x2 -c | mlir-opt
 // RUN: mlir-miopen-driver -p -pv -t f16 -c | mlir-opt
-// RUN: mlir-miopen-driver -p -pv -t f16 -x2 -c | mlir-opt
 // RUN: mlir-miopen-driver -p -pv -t bf16 -c | mlir-opt
-// RUN: mlir-miopen-driver -p -pv -t bf16 -x2 -c | mlir-opt

--- a/mlir/test/mlir-miopen-driver/sanity_pv.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_pv.mlir
@@ -1,0 +1,9 @@
+// Sanity test to -pv produces valid MLIR for all possible data types and
+// lowering paths.
+
+// RUN: mlir-miopen-driver -p -pv -c | mlir-opt
+// RUN: mlir-miopen-driver -p -pv -x2 -c | mlir-opt
+// RUN: mlir-miopen-driver -p -pv -t f16 -c | mlir-opt
+// RUN: mlir-miopen-driver -p -pv -t f16 -x2 -c | mlir-opt
+// RUN: mlir-miopen-driver -p -pv -t bf16 -c | mlir-opt
+// RUN: mlir-miopen-driver -p -pv -t bf16 -x2 -c | mlir-opt

--- a/mlir/test/mlir-miopen-driver/sanity_pv_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_pv_xdlops.mlir
@@ -1,0 +1,8 @@
+// UNSUPPORTED: native
+// Sanity test to -pv produces valid MLIR for all possible data types and
+// XDLOPS lowering paths.
+
+// FIXME: investigate why these commands fail on non-gfx908 CI nodes.
+// RUN: mlir-miopen-driver -p -x2 -pv -c | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -pv -t f16 -c | mlir-opt
+// RUN: mlir-miopen-driver -p -x2 -pv -t bf16 -c | mlir-opt


### PR DESCRIPTION
Add one sanity test to check -pv always produces valid MLIR for all possible data types and lowering paths.