### PR TITLE
Speed up Jenkins CI jobs a bit by reducing build targets.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -22,7 +22,7 @@ pipeline {
                     cmake -G Ninja ../llvm \
                         -DLLVM_ENABLE_PROJECTS="mlir;lld" \
                         -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;NVPTX;AMDGPU" \
+                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
                         -DCMAKE_BUILD_TYPE=Release \
                         -DLLVM_ENABLE_ASSERTIONS=ON \
                         -DBUILD_SHARED_LIBS=ON \

--- a/mlir/utils/jenkins/Jenkinsfile.perf
+++ b/mlir/utils/jenkins/Jenkinsfile.perf
@@ -24,7 +24,7 @@ pipeline {
                     cmake -G Ninja ../llvm \
                         -DLLVM_ENABLE_PROJECTS="mlir;lld" \
                         -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;NVPTX;AMDGPU" \
+                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
                         -DCMAKE_BUILD_TYPE=Release \
                         -DLLVM_ENABLE_ASSERTIONS=ON \
                         -DBUILD_SHARED_LIBS=ON \

--- a/mlir/utils/jenkins/Jenkinsfile.perf-gfx908
+++ b/mlir/utils/jenkins/Jenkinsfile.perf-gfx908
@@ -28,7 +28,7 @@ pipeline {
                     cmake -G Ninja ../llvm \
                         -DLLVM_ENABLE_PROJECTS="mlir;lld" \
                         -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;NVPTX;AMDGPU" \
+                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
                         -DCMAKE_BUILD_TYPE=Release \
                         -DLLVM_ENABLE_ASSERTIONS=ON \
                         -DBUILD_SHARED_LIBS=ON \

--- a/mlir/utils/jenkins/Jenkinsfile.upstream
+++ b/mlir/utils/jenkins/Jenkinsfile.upstream
@@ -24,7 +24,7 @@ pipeline {
                     cmake -G Ninja ../llvm \
                         -DLLVM_ENABLE_PROJECTS="mlir;lld" \
                         -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;NVPTX;AMDGPU" \
+                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
                         -DCMAKE_BUILD_TYPE=Release \
                         -DLLVM_ENABLE_ASSERTIONS=ON \
                         -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
Remove NVPTX target from Jenkinsfile. We don't need to worry about testing this target downstream.