### PR TITLE
Step1 of fixing padding logic.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -358,8 +358,14 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
           reorderedPaddedInputDimNames.push_back(cDimName);
           paddedInputShape.push_back(inputShape[cDim.getInt()]);
         } else {
-          // TBD: padding parameters.
-          paddedInputShape.push_back(inputShape[hwDims[j].getInt()]);
+          // Set padded dimension.
+          auto strAttr =
+              inputLayoutAttr.getValue()[i].template dyn_cast<StringAttr>();
+          if (strAttr.getValue() == "hi") {
+            paddedInputShape.push_back(hiPadded);
+          } else if (strAttr.getValue() == "wi") {
+            paddedInputShape.push_back(wiPadded);
+          }
 
           reorderedPaddedInputDimNames.push_back(hwPaddedDimNames[j++]);
         }
@@ -397,11 +403,11 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                                               hwPaddedDimNames.begin(),
                                               hwPaddedDimNames.end()))),
                   b.getNamedAttr("transformation", b.getStringAttr("Pad")),
-                  // TBD: padding parmeters.
-                  b.getNamedAttr("parameters", b.getArrayAttr({
-                                                   b.getI32IntegerAttr(0),
-                                                   b.getI32IntegerAttr(0),
-                                               })),
+                  b.getNamedAttr("parameters",
+                                 b.getArrayAttr({
+                                     b.getI32IntegerAttr(leftPadH),
+                                     b.getI32IntegerAttr(leftPadW),
+                                 })),
                   b.getNamedAttr("source_dimensions",
                                  b.getArrayAttr(ArrayRef<Attribute>(
                                      hwDims.begin(), hwDims.end()))),

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -537,7 +537,7 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                                               b.getStringAttr("ho"),
                                           })),
                   b.getNamedAttr("transformation", b.getStringAttr("Embed")),
-                  // TBD: padding parmeters.
+                  // TBD: embed parmeters.
                   b.getNamedAttr("parameters", b.getArrayAttr({
                                                    b.getI32IntegerAttr(1),
                                                    b.getI32IntegerAttr(1),

--- a/mlir/test/Dialect/MIOpen/lowering_filter_tensor_ckyx_cnhw_knhw.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_filter_tensor_ckyx_cnhw_knhw.mlir
@@ -3,7 +3,7 @@
 
 // RUN: mlir-opt -miopen-lowering %s | FileCheck %s
 
-func @miopen_conv2d_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_ckyx_cnhw_knhw(%filter : memref<8x128x3x3xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -13,7 +13,7 @@ func @miopen_conv2d_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memre
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x128x3x3xf32>, memref<8x128x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d
@@ -25,7 +25,7 @@ func @miopen_conv2d_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memre
 // CHECK:       source_names = ["k"]
 // CHECK-NEXT:  miopen.transform
 
-func @miopen_conv2d_bwd_data_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_data_ckyx_cnhw_knhw(%filter : memref<8x128x3x3xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_data(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -35,7 +35,7 @@ func @miopen_conv2d_bwd_data_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %inpu
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x128x3x3xf32>, memref<8x128x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_data
@@ -47,7 +47,7 @@ func @miopen_conv2d_bwd_data_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %inpu
 // CHECK:       source_names = ["c", "y", "x"]
 // CHECK-NEXT:  miopen.transform(%arg1)
 
-func @miopen_conv2d_bwd_weight_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_weight_ckyx_cnhw_knhw(%filter : memref<8x128x3x3xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_weight(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -57,7 +57,7 @@ func @miopen_conv2d_bwd_weight_ckyx_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %in
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x128x3x3xf32>, memref<8x128x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_weight

--- a/mlir/test/Dialect/MIOpen/lowering_gridwise_gemm_position_cyxk_chwn_khwn.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_gridwise_gemm_position_cyxk_chwn_khwn.mlir
@@ -3,7 +3,7 @@
 
 // RUN: mlir-opt -miopen-lowering %s | FileCheck %s
 
-func @miopen_conv2d_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_cyxk_chwn_khwn(%filter : memref<8x3x3x128xf32>, %input : memref<8x32x32x128xf32>, %output : memref<128x30x30x128xf32>) {
   miopen.conv2d(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -13,7 +13,7 @@ func @miopen_conv2d_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %input : memre
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x3x3x128xf32>, memref<8x32x32x128xf32>, memref<128x30x30x128xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d
@@ -27,7 +27,7 @@ func @miopen_conv2d_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %input : memre
 // CHECK:       gridwise_gemm_argument_position = 2
 // CHECK-NEXT:  miopen.gridwise_gemm(%0, %3, %4)
 
-func @miopen_conv2d_bwd_data_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_data_cyxk_chwn_khwn(%filter : memref<8x3x3x128xf32>, %input : memref<8x32x32x128xf32>, %output : memref<128x30x30x128xf32>) {
   miopen.conv2d_bwd_data(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -37,7 +37,7 @@ func @miopen_conv2d_bwd_data_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %inpu
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x3x3x128xf32>, memref<8x32x32x128xf32>, memref<128x30x30x128xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_data
@@ -51,7 +51,7 @@ func @miopen_conv2d_bwd_data_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %inpu
 // CHECK:       gridwise_gemm_argument_position = 1
 // CHECK-NEXT:  miopen.gridwise_gemm(%0, %4, %3)
 
-func @miopen_conv2d_bwd_weight_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_weight_cyxk_chwn_khwn(%filter : memref<8x3x3x128xf32>, %input : memref<8x32x32x128xf32>, %output : memref<128x30x30x128xf32>) {
   miopen.conv2d_bwd_weight(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -61,7 +61,7 @@ func @miopen_conv2d_bwd_weight_cyxk_chwn_khwn(%filter : memref<?x?x?x?xf32>, %in
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x3x3x128xf32>, memref<8x32x32x128xf32>, memref<128x30x30x128xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_weight

--- a/mlir/test/Dialect/MIOpen/lowering_input_tensor_cyxk_cnhw_hnhw.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_input_tensor_cyxk_cnhw_hnhw.mlir
@@ -4,7 +4,7 @@
 
 // RUN: mlir-opt -miopen-lowering %s | FileCheck %s
 
-func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -14,7 +14,7 @@ func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memre
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d
@@ -27,7 +27,7 @@ func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memre
 // CHECK:       output_layout = ["gemmK", "gemmN"]
 // CHECK-NEXT:  miopen.transform(%arg2)
 
-func @miopen_conv2d_bwd_data_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_data_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_data(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -37,7 +37,7 @@ func @miopen_conv2d_bwd_data_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %inpu
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_data
@@ -50,7 +50,7 @@ func @miopen_conv2d_bwd_data_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %inpu
 // CHECK:       output_layout = ["gemmM", "gemmN"]
 // CHECK-NEXT:  miopen.transform(%arg2)
 
-func @miopen_conv2d_bwd_weight_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_weight_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_weight(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -60,7 +60,7 @@ func @miopen_conv2d_bwd_weight_cyxk_cnhw_knhw(%filter : memref<?x?x?x?xf32>, %in
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_weight

--- a/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
@@ -1,0 +1,79 @@
+// This tests checks the following aspects of lowering component:
+// * Input has three transformations in total
+// * Input has correct output_layout across transformations
+// * Input tensor has non-zero padding.
+
+// RUN: mlir-opt -miopen-lowering %s | FileCheck %s
+
+func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x32x32xf32>) {
+  miopen.conv2d(%filter, %input, %output) {
+    arch = "gfx906",
+    num_cu = 64,
+    filter_layout = ["c", "y", "x", "k"],
+    input_layout = ["ci", "ni", "hi", "wi"],
+    output_layout = ["ko", "no", "ho", "wo"],
+    dilations = [1, 1],
+    strides = [1, 1],
+    padding = [1, 1]
+  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x32x32xf32>
+  return
+}
+
+// CHECK-LABEL: func @miopen_conv2d
+// CHECK-NEXT:  miopen.transform(%arg0)
+// CHECK-NEXT:  miopen.transform(%arg1)
+// CHECK:       output_layout = ["ci", "ni", "hipad", "wipad"]
+// CHECK:       memref<8x128x34x34xf32>
+// CHECK-NEXT:  miopen.transform
+// CHECK:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
+// CHECK-NEXT:  miopen.transform
+// CHECK:       output_layout = ["gemmK", "gemmN"]
+// CHECK-NEXT:  miopen.transform(%arg2)
+
+func @miopen_conv2d_bwd_data_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x32x32xf32>) {
+  miopen.conv2d_bwd_data(%filter, %input, %output) {
+    arch = "gfx906",
+    num_cu = 64,
+    filter_layout = ["c", "y", "x", "k"],
+    input_layout = ["ci", "ni", "hi", "wi"],
+    output_layout = ["ko", "no", "ho", "wo"],
+    dilations = [1, 1],
+    strides = [1, 1],
+    padding = [1, 1]
+  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x32x32xf32>
+  return
+}
+// CHECK-LABEL: func @miopen_conv2d_bwd_data
+// CHECK-NEXT:  miopen.transform(%arg0)
+// CHECK-NEXT:  miopen.transform(%arg1)
+// CHECK:       output_layout = ["ci", "ni", "hipad", "wipad"]
+// CHECK:       memref<8x128x34x34xf32>
+// CHECK-NEXT:  miopen.transform
+// CHECK:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
+// CHECK-NEXT:  miopen.transform
+// CHECK:       output_layout = ["gemmM", "gemmN"]
+// CHECK-NEXT:  miopen.transform(%arg2)
+
+func @miopen_conv2d_bwd_weight_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x32x32xf32>) {
+  miopen.conv2d_bwd_weight(%filter, %input, %output) {
+    arch = "gfx906",
+    num_cu = 64,
+    filter_layout = ["c", "y", "x", "k"],
+    input_layout = ["ci", "ni", "hi", "wi"],
+    output_layout = ["ko", "no", "ho", "wo"],
+    dilations = [1, 1],
+    strides = [1, 1],
+    padding = [1, 1]
+  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x32x32xf32>
+  return
+}
+// CHECK-LABEL: func @miopen_conv2d_bwd_weight
+// CHECK-NEXT:  miopen.transform(%arg0)
+// CHECK-NEXT:  miopen.transform(%arg1)
+// CHECK:       output_layout = ["ci", "ni", "hipad", "wipad"]
+// CHECK:       memref<8x128x34x34xf32>
+// CHECK-NEXT:  miopen.transform
+// CHECK:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
+// CHECK-NEXT:  miopen.transform
+// CHECK:       output_layout = ["gemmK", "gemmN"]
+// CHECK-NEXT:  miopen.transform(%arg2)

--- a/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
@@ -3,7 +3,8 @@
 // * Input has correct output_layout across transformations
 // * Input tensor has non-zero padding.
 
-// RUN: mlir-opt -miopen-lowering %s | FileCheck %s
+// RUN: mlir-opt -miopen-lowering %s | FileCheck %s --check-prefix=LOWERING
+// RUN: mlir-opt -miopen-lowering -miopen-affine-transform %s | FileCheck %s --check-prefix=AFFINE
 
 func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x32x32xf32>) {
   miopen.conv2d(%filter, %input, %output) {
@@ -19,61 +20,19 @@ func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : mem
   return
 }
 
-// CHECK-LABEL: func @miopen_conv2d
-// CHECK-NEXT:  miopen.transform(%arg0)
-// CHECK-NEXT:  miopen.transform(%arg1)
-// CHECK:       output_layout = ["ci", "ni", "hipad", "wipad"]
-// CHECK:       memref<8x128x34x34xf32>
-// CHECK-NEXT:  miopen.transform
-// CHECK:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
-// CHECK-NEXT:  miopen.transform
-// CHECK:       output_layout = ["gemmK", "gemmN"]
-// CHECK-NEXT:  miopen.transform(%arg2)
+// LOWERING-LABEL: func @miopen_conv2d
+// LOWERING-NEXT:  miopen.transform(%arg0)
+// LOWERING-NEXT:  miopen.transform(%arg1)
+// LOWERING:       output_layout = ["ci", "ni", "hipad", "wipad"]
+// LOWERING:       memref<8x128x34x34xf32>
+// LOWERING-NEXT:  miopen.transform
+// LOWERING:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
+// LOWERING-NEXT:  miopen.transform
+// LOWERING:       output_layout = ["gemmK", "gemmN"]
+// LOWERING-NEXT:  miopen.transform(%arg2)
 
-func @miopen_conv2d_bwd_data_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x32x32xf32>) {
-  miopen.conv2d_bwd_data(%filter, %input, %output) {
-    arch = "gfx906",
-    num_cu = 64,
-    filter_layout = ["c", "y", "x", "k"],
-    input_layout = ["ci", "ni", "hi", "wi"],
-    output_layout = ["ko", "no", "ho", "wo"],
-    dilations = [1, 1],
-    strides = [1, 1],
-    padding = [1, 1]
-  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x32x32xf32>
-  return
-}
-// CHECK-LABEL: func @miopen_conv2d_bwd_data
-// CHECK-NEXT:  miopen.transform(%arg0)
-// CHECK-NEXT:  miopen.transform(%arg1)
-// CHECK:       output_layout = ["ci", "ni", "hipad", "wipad"]
-// CHECK:       memref<8x128x34x34xf32>
-// CHECK-NEXT:  miopen.transform
-// CHECK:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
-// CHECK-NEXT:  miopen.transform
-// CHECK:       output_layout = ["gemmM", "gemmN"]
-// CHECK-NEXT:  miopen.transform(%arg2)
-
-func @miopen_conv2d_bwd_weight_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : memref<8x128x32x32xf32>, %output : memref<128x128x32x32xf32>) {
-  miopen.conv2d_bwd_weight(%filter, %input, %output) {
-    arch = "gfx906",
-    num_cu = 64,
-    filter_layout = ["c", "y", "x", "k"],
-    input_layout = ["ci", "ni", "hi", "wi"],
-    output_layout = ["ko", "no", "ho", "wo"],
-    dilations = [1, 1],
-    strides = [1, 1],
-    padding = [1, 1]
-  } : memref<8x3x3x128xf32>, memref<8x128x32x32xf32>, memref<128x128x32x32xf32>
-  return
-}
-// CHECK-LABEL: func @miopen_conv2d_bwd_weight
-// CHECK-NEXT:  miopen.transform(%arg0)
-// CHECK-NEXT:  miopen.transform(%arg1)
-// CHECK:       output_layout = ["ci", "ni", "hipad", "wipad"]
-// CHECK:       memref<8x128x34x34xf32>
-// CHECK-NEXT:  miopen.transform
-// CHECK:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
-// CHECK-NEXT:  miopen.transform
-// CHECK:       output_layout = ["gemmK", "gemmN"]
-// CHECK-NEXT:  miopen.transform(%arg2)
+// AFFINE: #map{{[0-9]+}} = affine_map<(d0, d1) -> (d0 floordiv 9, (d0 mod 9) floordiv 3, (d0 mod 9) mod 3, d1)>
+// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2 - 1, d3 - 1)>
+// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2 + d3 - 1, d4 + d5 - 1)>
+// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1) -> (d0 floordiv 9, d1 floordiv 1024, (d0 mod 9) floordiv 3 + (d1 mod 1024) floordiv 32 - 1, (d0 mod 9) mod 3 + (d1 mod 1024) mod 32 - 1)>
+// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1) -> (d0, d1 floordiv 1024, (d1 mod 1024) floordiv 32, (d1 mod 1024) mod 32)>

--- a/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
@@ -1,6 +1,4 @@
 // This tests checks the following aspects of lowering component:
-// * Input has three transformations in total
-// * Input has correct output_layout across transformations
 // * Input tensor has non-zero padding.
 
 // RUN: mlir-opt -miopen-lowering %s | FileCheck %s --check-prefix=LOWERING
@@ -21,15 +19,9 @@ func @miopen_conv2d_cyxk_cnhw_knhw(%filter : memref<8x3x3x128xf32>, %input : mem
 }
 
 // LOWERING-LABEL: func @miopen_conv2d
-// LOWERING-NEXT:  miopen.transform(%arg0)
-// LOWERING-NEXT:  miopen.transform(%arg1)
-// LOWERING:       output_layout = ["ci", "ni", "hipad", "wipad"]
-// LOWERING:       memref<8x128x34x34xf32>
-// LOWERING-NEXT:  miopen.transform
-// LOWERING:       output_layout = ["ci", "ni", "y", "ho", "x", "wo"]
-// LOWERING-NEXT:  miopen.transform
-// LOWERING:       output_layout = ["gemmK", "gemmN"]
-// LOWERING-NEXT:  miopen.transform(%arg2)
+// LOWERING:  miopen.transform(%arg1)
+// LOWERING:  output_layout = ["ci", "ni", "hipad", "wipad"]
+// LOWERING:  memref<8x128x34x34xf32>
 
 // AFFINE: #map{{[0-9]+}} = affine_map<(d0, d1) -> (d0 floordiv 9, (d0 mod 9) floordiv 3, (d0 mod 9) mod 3, d1)>
 // AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2 - 1, d3 - 1)>

--- a/mlir/test/Dialect/MIOpen/lowering_memref_kcyx_nchw_nkhw.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_memref_kcyx_nchw_nkhw.mlir
@@ -4,7 +4,7 @@
 
 // RUN: mlir-opt -miopen-lowering %s | FileCheck %s
 
-func @miopen_conv2d_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_kcyx_nchw_nkhw(%filter : memref<128x8x3x3xf32>, %input : memref<128x8x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -14,7 +14,7 @@ func @miopen_conv2d_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %input : memre
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d
@@ -25,7 +25,7 @@ func @miopen_conv2d_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %input : memre
 // CHECK-NEXT:  {{miopen.transform.*{.*}.*memref.*memref}}
 // CHECK-NEXT:  {{miopen.gridwise_gemm.*{.*}.*memref.*memref.*memref}}
 
-func @miopen_conv2d_bwd_data_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_data_kcyx_nchw_nkhw(%filter : memref<128x8x3x3xf32>, %input : memref<128x8x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_data(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -35,7 +35,7 @@ func @miopen_conv2d_bwd_data_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %inpu
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_data
@@ -46,7 +46,7 @@ func @miopen_conv2d_bwd_data_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %inpu
 // CHECK-NEXT:  {{miopen.transform.*{.*}.*memref.*memref}}
 // CHECK-NEXT:  {{miopen.gridwise_gemm.*{.*}.*memref.*memref.*memref}}
 
-func @miopen_conv2d_bwd_weight_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_weight_kcyx_nchw_nkhw(%filter : memref<128x8x3x3xf32>, %input : memref<128x8x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_weight(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -56,7 +56,7 @@ func @miopen_conv2d_bwd_weight_kcyx_nchw_nkhw(%filter : memref<?x?x?x?xf32>, %in
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_weight

--- a/mlir/test/Dialect/MIOpen/lowering_output_tensor_kyxc_nhwc_nhwk.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_output_tensor_kyxc_nhwc_nhwk.mlir
@@ -3,7 +3,7 @@
 
 // RUN: mlir-opt -miopen-lowering -split-input-file %s | FileCheck %s
 
-func @miopen_conv2d_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_kyxc_nhwc_nhwk(%filter : memref<128x3x3x8xf32>, %input : memref<128x32x32x8xf32>, %output : memref<128x30x30x128xf32>) {
   miopen.conv2d(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -13,7 +13,7 @@ func @miopen_conv2d_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %input : memre
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x3x3x8xf32>, memref<128x32x32x8xf32>, memref<128x30x30x128xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d
@@ -24,7 +24,7 @@ func @miopen_conv2d_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %input : memre
 // CHECK:       source_names = ["no", "ho", "wo"]
 // CHECK:       miopen.gridwise_gemm
 
-func @miopen_conv2d_bwd_data_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_data_kyxc_nhwc_nhwk(%filter : memref<128x3x3x8xf32>, %input : memref<128x32x32x8xf32>, %output : memref<128x30x30x128xf32>) {
   miopen.conv2d_bwd_data(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -34,7 +34,7 @@ func @miopen_conv2d_bwd_data_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %inpu
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x3x3x8xf32>, memref<128x32x32x8xf32>, memref<128x30x30x128xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_data
@@ -45,7 +45,7 @@ func @miopen_conv2d_bwd_data_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %inpu
 // CHECK:       source_names = ["no", "ho", "wo"]
 // CHECK:       miopen.gridwise_gemm
 
-func @miopen_conv2d_bwd_weight_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_weight_kyxc_nhwc_nhwk(%filter : memref<128x3x3x8xf32>, %input : memref<128x32x32x8xf32>, %output : memref<128x30x30x128xf32>) {
   miopen.conv2d_bwd_weight(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -55,7 +55,7 @@ func @miopen_conv2d_bwd_weight_kyxc_nhwc_nhwk(%filter : memref<?x?x?x?xf32>, %in
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x3x3x8xf32>, memref<128x32x32x8xf32>, memref<128x30x30x128xf32>
   return
 }
 // CHECK-LABEL: func @miopen_conv2d_bwd_weight

--- a/mlir/test/Dialect/MIOpen/lowering_top_level.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_top_level.mlir
@@ -6,7 +6,7 @@
 
 // RUN: mlir-opt -miopen-lowering %s | FileCheck %s
 
-func @miopen_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d(%filter : memref<128x8x3x3xf32>, %input : memref<128x8x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -16,7 +16,7 @@ func @miopen_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>,
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func {{@miopen_conv2d.*%arg0.*%arg1.*%arg2}}
@@ -28,7 +28,7 @@ func @miopen_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>,
 // CHECK-NEXT:  miopen.transform(%arg2)
 // CHECK-NEXT:  miopen.gridwise_gemm
 
-func @miopen_conv2d_bwd_data(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_data(%filter : memref<128x8x3x3xf32>, %input : memref<128x8x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_data(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -38,7 +38,7 @@ func @miopen_conv2d_bwd_data(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func {{@miopen_conv2d_bwd_data.*%arg0.*%arg1.*%arg2}}
@@ -50,7 +50,7 @@ func @miopen_conv2d_bwd_data(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x
 // CHECK-NEXT:  miopen.transform(%arg2)
 // CHECK-NEXT:  miopen.gridwise_gemm
 
-func @miopen_conv2d_bwd_weight(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+func @miopen_conv2d_bwd_weight(%filter : memref<128x8x3x3xf32>, %input : memref<128x8x32x32xf32>, %output : memref<128x128x30x30xf32>) {
   miopen.conv2d_bwd_weight(%filter, %input, %output) {
     arch = "gfx906",
     num_cu = 64,
@@ -60,7 +60,7 @@ func @miopen_conv2d_bwd_weight(%filter : memref<?x?x?x?xf32>, %input : memref<?x
     dilations = [1, 1],
     strides = [1, 1],
     padding = [0, 0]
-  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  } : memref<128x8x3x3xf32>, memref<128x8x32x32xf32>, memref<128x128x30x30xf32>
   return
 }
 // CHECK-LABEL: func {{@miopen_conv2d_bwd_weight.*%arg0.*%arg1.*%arg2}}


### PR DESCRIPTION
When converting `miopen.conv2dxxx` to `miopen.transform`, padding parameters were not used. Fix it in this PR.

Unit test to check affine transforms with padding is also added.

Subsequent PR would add logic in `miopen.threadwise_copy` to consider whether low-level index falls within proper boundaries.