### PR TITLE
Step2 of fixing padding logic.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
@@ -1,0 +1,85 @@
+//===- AffineMapHelper.h - Utility routines for AffineMap ---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provide utility routines to check AffineMap instances.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_MIOPEN_AFFINEMAP_HELPER_H
+#define MLIR_DIALECT_MIOPEN_AFFINEMAP_HELPER_H
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Module.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace miopen {
+
+//===----------------------------------------------------------------------===//
+// Check if an AffineMap has division or remainder inside.
+//===----------------------------------------------------------------------===//
+inline bool hasDivisionOrRemainder(AffineMap map) {
+  bool ret = false;
+  if (!map) return false;
+  map.walkExprs([&ret](AffineExpr expr) {
+    if (expr.getKind() == AffineExprKind::Mod ||
+        expr.getKind() == AffineExprKind::FloorDiv ||
+	expr.getKind() == AffineExprKind::CeilDiv)
+      ret = true;
+  });
+
+  // XXX. hack. always return false for now for performance reason.
+  // May need more sophisticated checks to determine if we would truly go OOB.
+  //return ret;
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// Check if an AffineMap has padding, which is represented as a minus expression
+// with a constant operand.
+//===----------------------------------------------------------------------===//
+inline bool hasPadding(AffineMap map) {
+  bool ret = false;
+  if (!map) return false;
+  map.walkExprs([&ret](AffineExpr expr) {
+    auto hasMinusConstant = [](AffineExpr expr) -> bool {
+      if (expr.getKind() == AffineExprKind::Constant) {
+        auto constantExpr = expr.template dyn_cast<AffineConstantExpr>();
+        if (constantExpr.getValue() < 0)
+          return true;
+      }
+      return false;
+    };
+    auto binaryExpr = expr.template dyn_cast<AffineBinaryOpExpr>();
+    if (binaryExpr) {
+      ret |= hasMinusConstant(binaryExpr.getLHS());
+      if (ret)
+        return;
+      ret |= hasMinusConstant(binaryExpr.getRHS());
+    }
+  });
+  return ret;
+}
+
+} // end namespace miopen
+} // end namespace mlir
+#endif // MLIR_DIALECT_MIOPEN_AFFINEMAP_HELPER_H

--- a/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
@@ -16,18 +16,6 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Attributes.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/Module.h"
-#include "mlir/IR/Operation.h"
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/IR/StandardTypes.h"
-#include "mlir/IR/Types.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Pass/PassRegistry.h"
-#include "mlir/Support/LogicalResult.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
 

--- a/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
@@ -39,17 +39,18 @@ namespace miopen {
 //===----------------------------------------------------------------------===//
 inline bool hasDivisionOrRemainder(AffineMap map) {
   bool ret = false;
-  if (!map) return false;
+  if (!map)
+    return false;
   map.walkExprs([&ret](AffineExpr expr) {
     if (expr.getKind() == AffineExprKind::Mod ||
         expr.getKind() == AffineExprKind::FloorDiv ||
-	expr.getKind() == AffineExprKind::CeilDiv)
+        expr.getKind() == AffineExprKind::CeilDiv)
       ret = true;
   });
 
   // XXX. hack. always return false for now for performance reason.
   // May need more sophisticated checks to determine if we would truly go OOB.
-  //return ret;
+  // return ret;
   return false;
 }
 
@@ -59,7 +60,8 @@ inline bool hasDivisionOrRemainder(AffineMap map) {
 //===----------------------------------------------------------------------===//
 inline bool hasPadding(AffineMap map) {
   bool ret = false;
-  if (!map) return false;
+  if (!map)
+    return false;
   map.walkExprs([&ret](AffineExpr expr) {
     auto hasMinusConstant = [](AffineExpr expr) -> bool {
       if (expr.getKind() == AffineExprKind::Constant) {

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -42,6 +42,26 @@
 
 using namespace mlir;
 
+
+//===----------------------------------------------------------------------===//
+// Check if an AffineMap has division or remainder inside.
+//===----------------------------------------------------------------------===//
+static bool hasDivisionOrRemainder(AffineMap map) {
+  bool ret = false;
+  if (!map) return false;
+  map.walkExprs([&ret](AffineExpr expr) {
+    if (expr.getKind() == AffineExprKind::Mod ||
+        expr.getKind() == AffineExprKind::FloorDiv ||
+	expr.getKind() == AffineExprKind::CeilDiv)
+      ret = true;
+  });
+
+  // XXX. hack. always return false for now for performance reason.
+  // May need more sophisticated checks to determine if we would truly go OOB.
+  //return ret;
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // Conv2D (forward, backward) lowering.
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -63,6 +63,33 @@ static bool hasDivisionOrRemainder(AffineMap map) {
 }
 
 //===----------------------------------------------------------------------===//
+// Check if an AffineMap has padding, which is represented as a minus expression
+// with a constant operand.
+//===----------------------------------------------------------------------===//
+static bool hasPadding(AffineMap map) {
+  bool ret = false;
+  if (!map) return false;
+  map.walkExprs([&ret](AffineExpr expr) {
+    auto hasMinusConstant = [](AffineExpr expr) -> bool {
+      if (expr.getKind() == AffineExprKind::Constant) {
+        auto constantExpr = expr.template dyn_cast<AffineConstantExpr>();
+        if (constantExpr.getValue() < 0)
+          return true;
+      }
+      return false;
+    };
+    auto binaryExpr = expr.template dyn_cast<AffineBinaryOpExpr>();
+    if (binaryExpr) {
+      ret |= hasMinusConstant(binaryExpr.getLHS());
+      if (ret)
+        return;
+      ret |= hasMinusConstant(binaryExpr.getRHS());
+    }
+  });
+  return ret;
+}
+
+//===----------------------------------------------------------------------===//
 // Conv2D (forward, backward) lowering.
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -41,6 +41,9 @@ std::unique_ptr<Pass> createLowerMIOpenOpsStep5Pass();
 /// Create a pass to convert transform operations to affine maps.
 std::unique_ptr<Pass> createAffineTransformPass();
 
+/// Create a pass to convert transform operations to affine maps.
+std::unique_ptr<Pass> createTestAffineTransformPass();
+
 /// Create a pass to affix tuning parameters to gridwise gemm ops.
 std::unique_ptr<Pass>
 createAffixTuningParametersPass(int64_t blockSizeOverride = 0,

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.td
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.td
@@ -23,6 +23,15 @@ def MIOpenOpsAffineTransformPass : FunctionPass<"miopen-affine-transform"> {
   let dependentDialects = ["miopen::MIOpenDialect"];
 }
 
+def MIOpenOpsTestAffineTransformPass : FunctionPass<"miopen-test-affine-transform"> {
+  let summary = "test affine maps for miopen.transform ops";
+  let constructor = "mlir::miopen::createTestAffineTransformPass()";
+  let options = [
+    Option<"testMethod", "test-method", "std::string", "\"hasPadding\"",
+           "method to be tested">
+  ];
+}
+
 def MIOpenOpsAffixTuningParametersPass : FunctionPass<"miopen-affix-params"> {
   let summary = "populate tuning parameters for miopen.gridwise_gemm ops";
   let constructor = "mlir::miopen::createAffixTuningParametersPass()";

--- a/mlir/lib/Dialect/MIOpen/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/MIOpen/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_dialect_library(MLIRMIOpenTransforms
   AffixTuningParameters.cpp
   AffineTransforms.cpp
   LowerMIOpenOps.cpp
+  TestAffineTransforms.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Transforms

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -25,7 +25,6 @@
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
-#include "mlir/Dialect/MIOpen/AffineMapHelper.h"
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
 #include "mlir/Dialect/MIOpen/Passes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -25,6 +25,7 @@
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
+#include "mlir/Dialect/MIOpen/AffineMapHelper.h"
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
 #include "mlir/Dialect/MIOpen/Passes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"

--- a/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
@@ -18,7 +18,8 @@ using namespace mlir;
 using namespace mlir::miopen;
 
 namespace {
-struct TestAffineTransforms : public MIOpenOpsTestAffineTransformPassBase<TestAffineTransforms> {
+struct TestAffineTransforms
+    : public MIOpenOpsTestAffineTransformPassBase<TestAffineTransforms> {
   void runOnFunction() override;
 };
 } // anonymous namespace

--- a/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
@@ -5,9 +5,7 @@
 #include "mlir/Dialect/MIOpen/Passes.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
-#include "mlir/IR/Function.h"
 #include "mlir/IR/Operation.h"
-#include "mlir/IR/StandardTypes.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Pass/Pass.h"
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
@@ -1,0 +1,46 @@
+#include "PassDetail.h"
+
+#include "mlir/Dialect/MIOpen/AffineMapHelper.h"
+#include "mlir/Dialect/MIOpen/MIOpenOps.h"
+#include "mlir/Dialect/MIOpen/Passes.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Function.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/MapVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace mlir::miopen;
+
+namespace {
+struct TestAffineTransforms : public MIOpenOpsTestAffineTransformPassBase<TestAffineTransforms> {
+  void runOnFunction() override;
+};
+} // anonymous namespace
+
+void TestAffineTransforms::runOnFunction() {
+  FuncOp func = getFunction();
+
+  func.walk([&](miopen::TransformOp op) {
+    OpBuilder b(op.getOperation());
+    auto output = op.output();
+    auto outputType = output.getType().dyn_cast<MemRefType>();
+    auto outputAffineMaps = outputType.getAffineMaps();
+
+    if (testMethod == "hasPadding") {
+      bool ret = false;
+      for (auto &affineMap : outputAffineMaps)
+        ret |= hasPadding(affineMap);
+      op.setAttr("hasPadding", b.getBoolAttr(ret));
+    }
+  });
+}
+
+std::unique_ptr<Pass> mlir::miopen::createTestAffineTransformPass() {
+  return std::make_unique<TestAffineTransforms>();
+}

--- a/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/TestAffineTransforms.cpp
@@ -35,7 +35,7 @@ void TestAffineTransforms::runOnFunction() {
       bool ret = false;
       for (auto &affineMap : outputAffineMaps)
         ret |= hasPadding(affineMap);
-      op.setAttr("hasPadding", b.getBoolAttr(ret));
+      op->setAttr("hasPadding", b.getBoolAttr(ret));
     }
   });
 }

--- a/mlir/test/Dialect/MIOpen/lowering_affine_transform_padding_check.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_affine_transform_padding_check.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-miopen-driver --operation conv2d -t f32 -x2 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 28 --in_w 28 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 -miopen-lowering -miopen-affine-transform -miopen-test-affine-transform | FileCheck %s --check-prefix=CHECK0
+// RUN: mlir-miopen-driver --operation conv2d -t f32 -x2 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 28 --in_w 28 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 1 --padding_w 1 -miopen-lowering -miopen-affine-transform -miopen-test-affine-transform | FileCheck %s --check-prefix=CHECK1
+
+// CHECK0: hasPadding = false
+// CHECK0-NEXT: hasPadding = false
+// CHECK0-NEXT: hasPadding = false
+// CHECK0-NEXT: hasPadding = false
+// CHECK0-NEXT: hasPadding = false
+
+// CHECK1: hasPadding = false
+// CHECK1-NEXT: hasPadding = true
+// CHECK1-NEXT: hasPadding = true
+// CHECK1-NEXT: hasPadding = true
+// CHECK1-NEXT: hasPadding = false


### PR DESCRIPTION
Provide a utility routine to check if padding presides in the affine transformation maps.

Create a test `FunctionPass` `-miopen-test-affine-transform` to walk over `miopen.transform` and use such utility function.

Add unit test to use the pass.

The pass allows extensions, and another utility routine is also provided in this PR, but it is currently not in use yet. The utility routine is used in `miopen-dialect-index-diff-map` branch, and logic to enable it would be filed in subsequent PRs.