### PR TITLE
NFC. Minor code refactor.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
@@ -43,8 +43,8 @@ inline bool hasDivisionOrRemainder(AffineMap map) {
 }
 
 //===----------------------------------------------------------------------===//
-// Check if an AffineExpr has padding, which is represented as a minus expression
-// with a constant operand.
+// Check if an AffineExpr has padding, which is represented as a minus
+// expression with a constant operand.
 //===----------------------------------------------------------------------===//
 inline bool hasPadding(AffineExpr expr) {
   bool ret = false;
@@ -74,9 +74,7 @@ inline bool hasPadding(AffineMap map) {
   bool ret = false;
   if (!map)
     return false;
-  map.walkExprs([&ret](AffineExpr expr) {
-    ret |= hasPadding(expr);
-  });
+  map.walkExprs([&ret](AffineExpr expr) { ret |= hasPadding(expr); });
   return ret;
 }
 

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -2351,8 +2351,6 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
     // Prepare some useful constants.
     auto zeroConstantFloatOp =
         b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
-    auto oneConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(1.0f), b.getF32Type());
     auto zeroConstantI32Op =
         b.create<ConstantIntOp>(loc, 0, b.getIntegerType(32));
 
@@ -4115,8 +4113,6 @@ struct ThreadwiseCopyV2RewritePattern
 
     auto zeroConstantFloatOp =
         b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
-    auto oneConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(1.0f), b.getF32Type());
     auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
     auto oneConstantOp = b.create<ConstantIndexOp>(loc, 1);
     auto zeroConstantI32Op =
@@ -4679,9 +4675,6 @@ struct XdlopsGemmV2RewritePattern
     auto MRepeatsConstantOp = b.create<ConstantIndexOp>(loc, MRepeats);
     auto NRepeatsConstantOp = b.create<ConstantIndexOp>(loc, NRepeats);
     auto KRepeatsConstantOp = b.create<ConstantIndexOp>(loc, KRepeats);
-
-    auto oneConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(1.0f), b.getF32Type());
 
     if (!IsKReduction) {
       // store bufferA logic.

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -45,6 +45,25 @@ using namespace mlir;
 using namespace mlir::miopen;
 
 //===----------------------------------------------------------------------===//
+// Utility function to emit zero constant float op.
+//===----------------------------------------------------------------------===//
+inline Value createZeroConstantFloatOp(PatternRewriter &b, Location loc,
+                                       Type elementType) {
+  Value zeroConstantFloatOp;
+  if (elementType == b.getF32Type()) {
+    zeroConstantFloatOp =
+        b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
+  } else if (elementType == b.getF16Type()) {
+    auto zeroF32Op =
+        b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
+    zeroConstantFloatOp = b.create<FPTruncOp>(loc, zeroF32Op, elementType);
+  } else if (elementType == b.getIntegerType(16)) {
+    zeroConstantFloatOp = b.create<ConstantIntOp>(loc, 0, b.getIntegerType(16));
+  }
+  return zeroConstantFloatOp;
+}
+
+//===----------------------------------------------------------------------===//
 // Conv2D (forward, backward) lowering.
 //===----------------------------------------------------------------------===//
 
@@ -1398,18 +1417,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
                            .template dyn_cast<Type>();
 
     // Prepare some useful constants.
-    Value zeroConstantFloatOp;
-    if (elementType == b.getF32Type()) {
-      zeroConstantFloatOp =
-          b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
-    } else if (elementType == b.getF16Type()) {
-      auto zeroF32Op =
-          b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
-      zeroConstantFloatOp = b.create<FPTruncOp>(loc, zeroF32Op, elementType);
-    } else if (elementType == b.getIntegerType(16)) {
-      zeroConstantFloatOp =
-          b.create<ConstantIntOp>(loc, 0, b.getIntegerType(16));
-    }
+    Value zeroConstantFloatOp = createZeroConstantFloatOp(b, loc, elementType);
     auto zeroConstantI32Op =
         b.create<ConstantIntOp>(loc, 0, b.getIntegerType(32));
 
@@ -3688,11 +3696,9 @@ struct ThreadwiseCopyRewritePattern
   LogicalResult matchAndRewrite(miopen::ThreadwiseCopyOp op,
                                 PatternRewriter &b) const override {
     auto loc = op.getLoc();
+    auto elementType = op.dest().getType().cast<MemRefType>().getElementType();
 
-    auto zeroConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
-    auto oneConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(1.0f), b.getF32Type());
+    Value zeroConstantFloatOp = createZeroConstantFloatOp(b, loc, elementType);
     auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
     auto oneConstantOp = b.create<ConstantIndexOp>(loc, 1);
 
@@ -4111,8 +4117,6 @@ struct ThreadwiseCopyV2RewritePattern
                                 PatternRewriter &b) const override {
     auto loc = op.getLoc();
 
-    auto zeroConstantFloatOp =
-        b.create<ConstantFloatOp>(loc, APFloat(0.0f), b.getF32Type());
     auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
     auto oneConstantOp = b.create<ConstantIndexOp>(loc, 1);
     auto zeroConstantI32Op =


### PR DESCRIPTION
Allow `hasPadding` check operate on individual `AffineExpr`.

Remove some unused codes.
Refactor how constant 0 for fp types get prepared.