### PR TITLE
Adding mutex to avoid possible race condition for libMLIRMIOpen

### DIFF
--- a/mlir/tools/mlir-miopen-lib/Miir.h
+++ b/mlir/tools/mlir-miopen-lib/Miir.h
@@ -12,7 +12,7 @@
 
 #include <stddef.h>
 
-#define MIIR_VERSION_FLAT 2
+#define MIIR_VERSION_FLAT 3
 
 enum MiirStatus {
   MIIR_SUCCESS = 0,
@@ -31,10 +31,6 @@ typedef void *MiirHandle;
  *  @return        MLIR handle
  */
 extern "C" MiirHandle miirCreateHandle(const char *options);
-
-/*! @brief Initialize the Miir Lowering APIs
- */
-extern "C" void miirLowerInit();
 
 /*! @brief Lower the MLIR module to c++ code
  *  @param handle   MLIR handle

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
@@ -45,8 +45,6 @@ int main(int argc, char **argv) {
     }
     // Bin backend binary generation
   } else if (option.getValue() == "tuningparams") {
-    miirLowerInit();
-
     status = miirLowerTuningParams(handle);
     if (status != MIIR_SUCCESS) {
       return status;
@@ -61,8 +59,6 @@ int main(int argc, char **argv) {
               << ", localSize=" << localSize << std::endl;
 
   } else if (option.getValue() == "bin") {
-    miirLowerInit();
-
     status = miirLowerBin(handle);
     if (status != MIIR_SUCCESS) {
       return status;

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -57,10 +57,13 @@ void strToTokens(const std::string &arguments,
 }
 
 // In multi-threaded context, static intialization is guaranteed to
-// be thread safe and atomic. With this guarantee, we are protected
-// from the possible race condition of one thread doing intialization
-// and another doing lowering.
-bool lazy_init() {
+// be thread safe, since C++11. Refer to
+// https://en.cppreference.com/w/cpp/language/storage_duration
+//
+// With this guarantee, we are protected from the possible race
+// condition of one thread doing intialization and another doing
+// lowering.
+bool miirLazyInit() {
   static const bool once = []() {
     llvm::InitializeAllTargetInfos();
     llvm::InitializeAllTargetMCs();
@@ -284,7 +287,7 @@ extern "C" const char *miirGenIgemmCflags(MiirHandle mlirHandle) {
 }
 
 extern "C" MiirStatus miirLowerTuningParams(MiirHandle mlirHandle) {
-  lazy_init();
+  miirLazyInit();
 
   MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
   if (handle == nullptr)
@@ -305,7 +308,7 @@ extern "C" MiirStatus miirLowerTuningParams(MiirHandle mlirHandle) {
 }
 
 extern "C" MiirStatus miirLowerBin(MiirHandle mlirHandle) {
-  lazy_init();
+  miirLazyInit();
 
   MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
   if (handle == nullptr)


### PR DESCRIPTION
* Removed the initialization API
* Wrap initialization code into a static lambda so it doesn't initialize more than once

Note: Please do not merge until @atamazov approve the PR