### PR TITLE
Rename m/n_per_thread to m/n_per_wave

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -2198,12 +2198,10 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
           gop->getAttr("m_per_block").template dyn_cast<IntegerAttr>().getInt();
       int64_t NPerBlock =
           gop->getAttr("n_per_block").template dyn_cast<IntegerAttr>().getInt();
-      int64_t MPerWave = gop->getAttr("m_per_wave")
-                             .template dyn_cast<IntegerAttr>()
-                             .getInt();
-      int64_t NPerWave = gop->getAttr("n_per_wave")
-                             .template dyn_cast<IntegerAttr>()
-                             .getInt();
+      int64_t MPerWave =
+          gop->getAttr("m_per_wave").template dyn_cast<IntegerAttr>().getInt();
+      int64_t NPerWave =
+          gop->getAttr("n_per_wave").template dyn_cast<IntegerAttr>().getInt();
       int64_t MWaves = MPerBlock / MPerWave;
       int64_t NWaves = NPerBlock / NPerWave;
 

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -2198,10 +2198,10 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
           gop->getAttr("m_per_block").template dyn_cast<IntegerAttr>().getInt();
       int64_t NPerBlock =
           gop->getAttr("n_per_block").template dyn_cast<IntegerAttr>().getInt();
-      int64_t MPerWave = gop->getAttr("m_per_thread")
+      int64_t MPerWave = gop->getAttr("m_per_wave")
                              .template dyn_cast<IntegerAttr>()
                              .getInt();
-      int64_t NPerWave = gop->getAttr("n_per_thread")
+      int64_t NPerWave = gop->getAttr("n_per_wave")
                              .template dyn_cast<IntegerAttr>()
                              .getInt();
       int64_t MWaves = MPerBlock / MPerWave;

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -2207,8 +2207,8 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
       int64_t MWaves = MPerBlock / MPerWave;
       int64_t NWaves = NPerBlock / NPerWave;
 
-      xop->setAttr("m_per_wave", gop->getAttr("m_per_thread"));
-      xop->setAttr("n_per_wave", gop->getAttr("n_per_thread"));
+      xop->setAttr("m_per_wave", gop->getAttr("m_per_wave"));
+      xop->setAttr("n_per_wave", gop->getAttr("n_per_wave"));
       xop->setAttr("m_waves", b.getI32IntegerAttr(MWaves));
       xop->setAttr("n_waves", b.getI32IntegerAttr(NWaves));
 
@@ -2226,14 +2226,14 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
     int64_t NPerBlock =
         gop->getAttr("n_per_block").template dyn_cast<IntegerAttr>().getInt();
     int64_t MPerWave =
-        gop->getAttr("m_per_thread").template dyn_cast<IntegerAttr>().getInt();
+        gop->getAttr("m_per_wave").template dyn_cast<IntegerAttr>().getInt();
     int64_t NPerWave =
-        gop->getAttr("n_per_thread").template dyn_cast<IntegerAttr>().getInt();
+        gop->getAttr("n_per_wave").template dyn_cast<IntegerAttr>().getInt();
     int64_t MWaves = MPerBlock / MPerWave;
     int64_t NWaves = NPerBlock / NPerWave;
 
-    bop->setAttr("m_per_wave", gop->getAttr("m_per_thread"));
-    bop->setAttr("n_per_wave", gop->getAttr("n_per_thread"));
+    bop->setAttr("m_per_wave", gop->getAttr("m_per_wave"));
+    bop->setAttr("n_per_wave", gop->getAttr("n_per_wave"));
     bop->setAttr("m_waves", b.getI32IntegerAttr(MWaves));
     bop->setAttr("n_waves", b.getI32IntegerAttr(NWaves));
 
@@ -2329,9 +2329,9 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
 
     // Obtain XDLOPS-related attributes.
     int64_t MPerWave =
-        op->getAttr("m_per_thread").template dyn_cast<IntegerAttr>().getInt();
+        op->getAttr("m_per_wave").template dyn_cast<IntegerAttr>().getInt();
     int64_t NPerWave =
-        op->getAttr("n_per_thread").template dyn_cast<IntegerAttr>().getInt();
+        op->getAttr("n_per_wave").template dyn_cast<IntegerAttr>().getInt();
     int64_t MWaves = MPerBlock / MPerWave;
     int64_t NWaves = NPerBlock / NPerWave;
     auto dataType =

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -155,8 +155,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
       signalPassFailure();
     }
 
-    op->setAttr("m_per_thread", b.getI32IntegerAttr(validParams.gemmMPerWave));
-    op->setAttr("n_per_thread", b.getI32IntegerAttr(validParams.gemmNPerWave));
+    op->setAttr("m_per_wave", b.getI32IntegerAttr(validParams.gemmMPerWave));
+    op->setAttr("n_per_wave", b.getI32IntegerAttr(validParams.gemmNPerWave));
     op->setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
     getFunction()->setAttr("block_size", b.getI32IntegerAttr(blockSize));

--- a/mlir/test/mlir-miopen-driver/tuning_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/tuning_xdlops.mlir
@@ -3,12 +3,12 @@
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s --check-prefix=STEP1
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | FileCheck %s --check-prefix=STEP2
 
-//STEP1: m_per_wave
-//STEP1: n_per_wave
-//STEP1-NOT: m_per_thread
-//STEP1-NOT: n_per_thread
+// STEP1: m_per_wave
+// STEP1: n_per_wave
+// STEP1-NOT: m_per_thread
+// STEP1-NOT: n_per_thread
 
-//STEP2: m_per_wave
-//STEP2: n_per_wave
-//STEP1-NOT: m_per_thread
-//STEP1-NOT: n_per_thread
+// STEP2: m_per_wave
+// STEP2: n_per_wave
+// STEP2-NOT: m_per_thread
+// STEP2-NOT: n_per_thread

--- a/mlir/test/mlir-miopen-driver/tuning_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/tuning_xdlops.mlir
@@ -1,0 +1,14 @@
+// Check the naming of tuning parameters for xdlops
+
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s --check-prefix=STEP1
+// RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 | FileCheck %s --check-prefix=STEP2
+
+//STEP1: m_per_wave
+//STEP1: n_per_wave
+//STEP1-NOT: m_per_thread
+//STEP1-NOT: n_per_thread
+
+//STEP2: m_per_wave
+//STEP2: n_per_wave
+//STEP1-NOT: m_per_thread
+//STEP1-NOT: n_per_thread


### PR DESCRIPTION
- Fix issue https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/121
- Rename m/n_per_thread to m/n_per_wave tuning parameters for xdlops