### PR TITLE
Randomize the input data of cpu validation

### DIFF
--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -331,13 +331,13 @@ extern "C" void mgpuMemCopy2DFloat(float *sourceAllocated, float *sourceAligned,
             static_cast<hipMemcpyKind>(copyDirection));
 }
 
-// 4D float memref utility routines.
-
-short tensorValue(short min, short max) {
+short randomValue(short min, short max) {
   if (min == max)
     return min;
   return (std::rand() % (max - min)) + min;
 }
+
+// 4D float memref utility routines.
 
 extern "C" void mcpuMemset4DFloat(float *allocated, float *aligned,
                                   int64_t offset, int64_t size0, int64_t size1,
@@ -370,7 +370,7 @@ extern "C" void mcpuMemset4DFloatRand(float *allocated, float *aligned,
     for (unsigned j = 0; j < size1; ++j)
       for (unsigned k = 0; k < size2; ++k)
         for (unsigned l = 0; l < size3; ++l) {
-          value = (float)tensorValue(min, max);
+          value = (float)randomValue(min, max);
           aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] =
               value;
         }
@@ -467,7 +467,7 @@ extern "C" void mcpuMemset4DHalfRand(unsigned short *allocated,
     for (unsigned j = 0; j < size1; ++j)
       for (unsigned k = 0; k < size2; ++k)
         for (unsigned l = 0; l < size3; ++l) {
-          value = (unsigned short)tensorValue(min, max);
+          value = (unsigned short)randomValue(min, max);
           aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] =
               int_to_fp16(value);
         }
@@ -546,7 +546,7 @@ extern "C" void mcpuMemset4DBF16Rand(unsigned short *allocated,
     for (unsigned j = 0; j < size1; ++j)
       for (unsigned k = 0; k < size2; ++k)
         for (unsigned l = 0; l < size3; ++l) {
-          value = float_to_bfloat16((float)tensorValue(min, max));
+          value = float_to_bfloat16((float)randomValue(min, max));
           aligned[i * stride0 + j * stride1 + k * stride2 + l * stride3] =
               value;
         }

--- a/mlir/test/mlir-miopen-driver/e2e/conv2d_harness_cpu_verifier_kyxc_nhwc_nhwk.mlir
+++ b/mlir/test/mlir-miopen-driver/e2e/conv2d_harness_cpu_verifier_kyxc_nhwc_nhwk.mlir
@@ -15,45 +15,48 @@ module {
     %5 = memref_cast %2 : memref<128x30x30x128xf32> to memref<?x?x?x?xf32>
 
     // populate initial values.
-    %cst = constant 1.000000e+00 : f32
-    %cst_0 = constant 0.000000e+00 : f32
-    call @mcpuMemset4DFloat(%3, %cst) : (memref<?x?x?x?xf32>, f32) -> ()
-    call @mcpuMemset4DFloat(%4, %cst) : (memref<?x?x?x?xf32>, f32) -> ()
-    call @mcpuMemset4DFloat(%5, %cst_0) : (memref<?x?x?x?xf32>, f32) -> ()
+    %c0_i16 = constant 0 : i16
+    %c1_i16 = constant 1 : i16
+    %c1_i16_0 = constant 1 : i16
+    %c1_i32 = constant 1 : i32
+    call @mcpuMemset4DFloatRand(%3, %c1_i16, %c1_i16_0, %c1_i32) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+    call @mcpuMemset4DFloatRand(%4, %c1_i16, %c1_i16_0, %c1_i32) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+    call @mcpuMemset4DFloatRand(%5, %c0_i16, %c0_i16, %c1_i32) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
 
     // launch gpu convolution
     call @gpu_conv(%0, %1, %2) : (memref<128x3x3x8xf32>, memref<128x32x32x8xf32>, memref<128x30x30x128xf32>) -> ()
 
-    // allocate CPU memory for cpu_conv and populate initial values.
+    // allocate CPU memory and initialize
     %6 = alloc() : memref<128x3x3x8xf32>
     %7 = memref_cast %6 : memref<128x3x3x8xf32> to memref<?x?x?x?xf32>
-    call @mcpuMemset4DFloat(%7, %cst) : (memref<?x?x?x?xf32>, f32) -> ()
+    call @mcpuMemset4DFloatRand(%7, %c1_i16, %c1_i16_0, %c1_i32) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
 
-    %8 = alloc() : memref<128x32x32x8xf32>
-    %9 = memref_cast %8 : memref<128x32x32x8xf32> to memref<?x?x?x?xf32>
-    call @mcpuMemset4DFloat(%9, %cst) : (memref<?x?x?x?xf32>, f32) -> ()
+    %9 = alloc() : memref<128x32x32x8xf32>
+    %10 = memref_cast %9 : memref<128x32x32x8xf32> to memref<?x?x?x?xf32>
+    call @mcpuMemset4DFloatRand(%10, %c1_i16, %c1_i16_0, %c1_i32) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
 
-    %10 = alloc() : memref<128x30x30x128xf32>
-    %11 = memref_cast %10 : memref<128x30x30x128xf32> to memref<?x?x?x?xf32>
-    call @mcpuMemset4DFloat(%11, %cst_0) : (memref<?x?x?x?xf32>, f32) -> ()
-
+    %12 = alloc() : memref<128x30x30x128xf32>
+    %13 = memref_cast %12 : memref<128x30x30x128xf32> to memref<?x?x?x?xf32>
+    call @mcpuMemset4DFloatRand(%13, %c0_i16, %c0_i16, %c1_i32) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+    
     // launch cpu convolution
-    call @conv2d_host(%6, %8, %10) : (memref<128x3x3x8xf32>, memref<128x32x32x8xf32>, memref<128x30x30x128xf32>) -> ()
+    call @conv2d_host(%6, %9, %12) : (memref<128x3x3x8xf32>, memref<128x32x32x8xf32>, memref<128x30x30x128xf32>) -> ()
 
     // verity results
-    call @verify_results(%10, %2) : (memref<128x30x30x128xf32>, memref<128x30x30x128xf32>) -> ()
+    call @verify_results(%12, %2) : (memref<128x30x30x128xf32>, memref<128x30x30x128xf32>) -> ()
 
     // deallocate CPU memory.
     dealloc %0 : memref<128x3x3x8xf32>
     dealloc %1 : memref<128x32x32x8xf32>
     dealloc %2 : memref<128x30x30x128xf32>
     dealloc %6 : memref<128x3x3x8xf32>
-    dealloc %8 : memref<128x32x32x8xf32>
-    dealloc %10 : memref<128x30x30x128xf32>
+    dealloc %9 : memref<128x32x32x8xf32>
+    dealloc %12 : memref<128x30x30x128xf32>
     return
   }
 
-  func private @mcpuMemset4DFloat(memref<?x?x?x?xf32>, f32)
+  func private @mcpuMemset4DFloatRand(memref<?x?x?x?xf32>, i16, i16, i32)
+  func private @mcpuMemCopy4DFloat(memref<?x?x?x?xf32>, memref<?x?x?x?xf32>)
 
   func @gpu_conv(%arg0: memref<128x3x3x8xf32>, %arg1: memref<128x32x32x8xf32>, %arg2: memref<128x30x30x128xf32>) {
     %0 = memref_cast %arg0 : memref<128x3x3x8xf32> to memref<?x?x?x?xf32>

--- a/mlir/test/mlir-miopen-driver/e2e/conv2d_harness_cpu_verifier_kyxc_nhwc_nhwk_f16.mlir
+++ b/mlir/test/mlir-miopen-driver/e2e/conv2d_harness_cpu_verifier_kyxc_nhwc_nhwk_f16.mlir
@@ -1,0 +1,274 @@
+// RUN: mlir-miopen-driver -p -t f16 -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk --host %s -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
+
+module  {
+  func @main() {
+    // allocate CPU memory for gpu_conv.    
+    %0 = alloc() : memref<128x3x3x8xf16>
+    %1 = alloc() : memref<128x32x32x8xf16>
+    %2 = alloc() : memref<128x30x30x128xf16>
+
+    %3 = memref_cast %0 : memref<128x3x3x8xf16> to memref<?x?x?x?xf16>
+    %4 = memref_cast %1 : memref<128x32x32x8xf16> to memref<?x?x?x?xf16>
+    %5 = memref_cast %2 : memref<128x30x30x128xf16> to memref<?x?x?x?xf16>
+
+    // populate initial values.
+    %c0_i16 = constant 0 : i16
+    %c1_i16 = constant 1 : i16
+    %c1_i16_0 = constant 1 : i16
+    %c1_i32 = constant 1 : i32
+    call @mcpuMemset4DHalfRand(%3, %c1_i16, %c1_i16_0, %c1_i32) : (memref<?x?x?x?xf16>, i16, i16, i32) -> ()
+    call @mcpuMemset4DHalfRand(%4, %c1_i16, %c1_i16_0, %c1_i32) : (memref<?x?x?x?xf16>, i16, i16, i32) -> ()
+    call @mcpuMemset4DHalfRand(%5, %c0_i16, %c0_i16, %c1_i32) : (memref<?x?x?x?xf16>, i16, i16, i32) -> ()
+
+    // launch gpu convolution
+    call @gpu_conv(%0, %1, %2) : (memref<128x3x3x8xf16>, memref<128x32x32x8xf16>, memref<128x30x30x128xf16>) -> ()
+    %6 = alloc() : memref<128x30x30x128xf32>
+
+    // convert gpu results to f32
+    call @convert_tensor128x30x30x128(%2, %6) : (memref<128x30x30x128xf16>, memref<128x30x30x128xf32>) -> ()
+
+    // allocate CPU memory for cpu filter tensor
+    %7 = alloc() : memref<128x3x3x8xf32>
+    %8 = memref_cast %7 : memref<128x3x3x8xf32> to memref<?x?x?x?xf32>
+
+    // convert gpu filter tensor to f32
+    %9 = alloc() : memref<128x3x3x8xf32>
+    %10 = memref_cast %9 : memref<128x3x3x8xf32> to memref<?x?x?x?xf32>
+    call @convert_tensor128x3x3x8(%0, %9) : (memref<128x3x3x8xf16>, memref<128x3x3x8xf32>) -> ()
+
+    // copy values of gpu filter tensor to cpu filter tensor 
+    call @mcpuMemCopy4DFloat(%10, %8) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>) -> ()
+
+    // allocate CPU memory for cpu input tensor
+    %11 = alloc() : memref<128x32x32x8xf32>
+    %12 = memref_cast %11 : memref<128x32x32x8xf32> to memref<?x?x?x?xf32>
+
+    // convert gpu input tensor to f32
+    %13 = alloc() : memref<128x32x32x8xf32>
+    %14 = memref_cast %13 : memref<128x32x32x8xf32> to memref<?x?x?x?xf32>
+    call @convert_tensor128x32x32x8(%1, %13) : (memref<128x32x32x8xf16>, memref<128x32x32x8xf32>) -> ()
+
+    // copy values of gpu input tensor to cpu input tensor 
+    call @mcpuMemCopy4DFloat(%14, %12) : (memref<?x?x?x?xf32>, memref<?x?x?x?xf32>) -> ()
+
+    // allocate CPU memory for cpu output tensor and initialize
+    %15 = alloc() : memref<128x30x30x128xf32>
+    %16 = memref_cast %15 : memref<128x30x30x128xf32> to memref<?x?x?x?xf32>
+    call @mcpuMemset4DFloatRand(%16, %c0_i16, %c0_i16, %c1_i32) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+
+    // launch cpu convolution
+    call @conv2d_host(%7, %11, %15) : (memref<128x3x3x8xf32>, memref<128x32x32x8xf32>, memref<128x30x30x128xf32>) -> ()
+
+    // verify results
+    call @verify_results(%15, %6) : (memref<128x30x30x128xf32>, memref<128x30x30x128xf32>) -> ()
+
+    // deallocate CPU memory
+    dealloc %6 : memref<128x30x30x128xf32>
+    dealloc %0 : memref<128x3x3x8xf16>
+    dealloc %1 : memref<128x32x32x8xf16>
+    dealloc %2 : memref<128x30x30x128xf16>
+    dealloc %7 : memref<128x3x3x8xf32>
+    dealloc %11 : memref<128x32x32x8xf32>
+    dealloc %15 : memref<128x30x30x128xf32>
+    return
+  }
+
+  func private @mcpuMemset4DHalfRand(memref<?x?x?x?xf16>, i16, i16, i32)
+
+  func @gpu_conv(%arg0: memref<128x3x3x8xf16>, %arg1: memref<128x32x32x8xf16>, %arg2: memref<128x30x30x128xf16>) {
+    %0 = memref_cast %arg0 : memref<128x3x3x8xf16> to memref<?x?x?x?xf16>
+    %1 = memref_cast %arg1 : memref<128x32x32x8xf16> to memref<?x?x?x?xf16>
+    %2 = memref_cast %arg2 : memref<128x30x30x128xf16> to memref<?x?x?x?xf16>
+    
+    // allocate GPU memory
+    %3 = call @mgpuMemAlloc4DHalf(%0) : (memref<?x?x?x?xf16>) -> memref<?x?x?x?xf16>
+    %4 = call @mgpuMemAlloc4DHalf(%1) : (memref<?x?x?x?xf16>) -> memref<?x?x?x?xf16>
+    %5 = call @mgpuMemAlloc4DHalf(%2) : (memref<?x?x?x?xf16>) -> memref<?x?x?x?xf16>
+
+    // copy direction constants
+    %c1_i32 = constant 1 : i32
+    %c2_i32 = constant 2 : i32
+
+    // transfer data CPU -> GPU
+    call @mgpuMemCopy4DHalf(%0, %3, %c1_i32) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+    call @mgpuMemCopy4DHalf(%1, %4, %c1_i32) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+    call @mgpuMemCopy4DHalf(%2, %5, %c1_i32) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+
+    // launch kernel 
+    %6 = memref_cast %3 : memref<?x?x?x?xf16> to memref<128x3x3x8xf16>
+    %7 = memref_cast %4 : memref<?x?x?x?xf16> to memref<128x32x32x8xf16>
+    %8 = memref_cast %5 : memref<?x?x?x?xf16> to memref<128x30x30x128xf16>
+    call @conv2d(%6, %7, %8) : (memref<128x3x3x8xf16>, memref<128x32x32x8xf16>, memref<128x30x30x128xf16>) -> ()
+    call @mgpuMemCopy4DHalf(%5, %2, %c2_i32) : (memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32) -> ()
+
+    // deallocate GPU memory
+    call @mgpuMemDealloc4DHalf(%0) : (memref<?x?x?x?xf16>) -> ()
+    call @mgpuMemDealloc4DHalf(%1) : (memref<?x?x?x?xf16>) -> ()
+    call @mgpuMemDealloc4DHalf(%2) : (memref<?x?x?x?xf16>) -> ()
+    return
+  }
+
+  func private @mgpuMemAlloc4DHalf(memref<?x?x?x?xf16>) -> memref<?x?x?x?xf16>
+
+  func private @mgpuMemCopy4DHalf(memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, i32)
+
+  func @conv2d(%arg0: memref<128x3x3x8xf16>, %arg1: memref<128x32x32x8xf16>, %arg2: memref<128x30x30x128xf16>) {
+    return
+  }
+
+  func private @mgpuMemDealloc4DHalf(memref<?x?x?x?xf16>)
+
+  func @convert_tensor128x30x30x128(%arg0: memref<128x30x30x128xf16>, %arg1: memref<128x30x30x128xf32>) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %c128 = constant 128 : index
+    %c30 = constant 30 : index
+    %c30_0 = constant 30 : index
+    %c128_1 = constant 128 : index
+    scf.for %arg2 = %c0 to %c128 step %c1 {
+      scf.for %arg3 = %c0 to %c30 step %c1 {
+        scf.for %arg4 = %c0 to %c30_0 step %c1 {
+          scf.for %arg5 = %c0 to %c128_1 step %c1 {
+            %0 = load %arg0[%arg2, %arg3, %arg4, %arg5] : memref<128x30x30x128xf16>
+            %1 = fpext %0 : f16 to f32
+            store %1, %arg1[%arg2, %arg3, %arg4, %arg5] : memref<128x30x30x128xf32>
+          }
+        }
+      }
+    }
+    return
+  }
+
+  func private @mcpuMemCopy4DFloat(memref<?x?x?x?xf32>, memref<?x?x?x?xf32>)
+
+  func private @mcpuMemset4DFloatRand(memref<?x?x?x?xf32>, i16, i16, i32)
+
+  func @convert_tensor128x3x3x8(%arg0: memref<128x3x3x8xf16>, %arg1: memref<128x3x3x8xf32>) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %c128 = constant 128 : index
+    %c3 = constant 3 : index
+    %c3_0 = constant 3 : index
+    %c8 = constant 8 : index
+    scf.for %arg2 = %c0 to %c128 step %c1 {
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        scf.for %arg4 = %c0 to %c3_0 step %c1 {
+          scf.for %arg5 = %c0 to %c8 step %c1 {
+            %0 = load %arg0[%arg2, %arg3, %arg4, %arg5] : memref<128x3x3x8xf16>
+            %1 = fpext %0 : f16 to f32
+            store %1, %arg1[%arg2, %arg3, %arg4, %arg5] : memref<128x3x3x8xf32>
+          }
+        }
+      }
+    }
+    return
+  }
+
+  func @convert_tensor128x32x32x8(%arg0: memref<128x32x32x8xf16>, %arg1: memref<128x32x32x8xf32>) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %c128 = constant 128 : index
+    %c32 = constant 32 : index
+    %c32_0 = constant 32 : index
+    %c8 = constant 8 : index
+    scf.for %arg2 = %c0 to %c128 step %c1 {
+      scf.for %arg3 = %c0 to %c32 step %c1 {
+        scf.for %arg4 = %c0 to %c32_0 step %c1 {
+          scf.for %arg5 = %c0 to %c8 step %c1 {
+            %0 = load %arg0[%arg2, %arg3, %arg4, %arg5] : memref<128x32x32x8xf16>
+            %1 = fpext %0 : f16 to f32
+            store %1, %arg1[%arg2, %arg3, %arg4, %arg5] : memref<128x32x32x8xf32>
+          }
+        }
+      }
+    }
+    return
+  }
+
+  func @conv2d_host(%arg0: memref<128x3x3x8xf32>, %arg1: memref<128x32x32x8xf32>, %arg2: memref<128x30x30x128xf32>) {
+    %0 = memref_cast %arg0 : memref<128x3x3x8xf32> to memref<*xf32>
+    %1 = memref_cast %arg1 : memref<128x32x32x8xf32> to memref<*xf32>
+    %2 = memref_cast %arg2 : memref<128x30x30x128xf32> to memref<*xf32>
+    %c1_i32 = constant 1 : i32
+    %c1_i32_0 = constant 1 : i32
+    %c0_i32 = constant 0 : i32
+    %c0_i32_1 = constant 0 : i32
+    %c1_i32_2 = constant 1 : i32
+    %c1_i32_3 = constant 1 : i32
+
+    // set up constant indices
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %c2 = constant 2 : index
+    %c3 = constant 3 : index
+
+    // set up constants (ascii code) for layout letters
+    %c107_i8 = constant 107 : i8
+    %c99_i8 = constant 99 : i8
+    %c121_i8 = constant 121 : i8
+    %c120_i8 = constant 120 : i8
+    %c110_i8 = constant 110 : i8
+    %c104_i8 = constant 104 : i8
+    %c119_i8 = constant 119 : i8
+
+    // allocate memory for layouts
+    %3 = alloca() : memref<4xi8>
+    %4 = alloca() : memref<4xi8>
+    %5 = alloca() : memref<4xi8>
+
+    // store layouts
+    store %c107_i8, %3[%c0] : memref<4xi8>
+    store %c121_i8, %3[%c1] : memref<4xi8>
+    store %c120_i8, %3[%c2] : memref<4xi8>
+    store %c99_i8, %3[%c3] : memref<4xi8>
+    store %c110_i8, %4[%c0] : memref<4xi8>
+    store %c104_i8, %4[%c1] : memref<4xi8>
+    store %c119_i8, %4[%c2] : memref<4xi8>
+    store %c99_i8, %4[%c3] : memref<4xi8>
+    store %c110_i8, %5[%c0] : memref<4xi8>
+    store %c104_i8, %5[%c1] : memref<4xi8>
+    store %c119_i8, %5[%c2] : memref<4xi8>
+    store %c107_i8, %5[%c3] : memref<4xi8>
+    %6 = memref_cast %3 : memref<4xi8> to memref<*xi8>
+    %7 = memref_cast %4 : memref<4xi8> to memref<*xi8>
+    %8 = memref_cast %5 : memref<4xi8> to memref<*xi8>
+    call @mcpuConv2d(%0, %1, %2, %6, %7, %8, %c1_i32, %c1_i32_0, %c0_i32, %c0_i32_1, %c1_i32_2, %c1_i32_3) : (memref<*xf32>, memref<*xf32>, memref<*xf32>, memref<*xi8>, memref<*xi8>, memref<*xi8>, i32, i32, i32, i32, i32, i32) -> ()
+    return
+  }
+
+  func private @mcpuConv2d(memref<*xf32>, memref<*xf32>, memref<*xf32>, memref<*xi8>, memref<*xi8>, memref<*xi8>, i32, i32, i32, i32, i32, i32)
+
+  func @verify_results(%arg0: memref<128x30x30x128xf32>, %arg1: memref<128x30x30x128xf32>) {
+    %c0 = constant 0 : index
+    %0 = alloca() : memref<1xi32>
+    %c0_i32 = constant 0 : i32
+    %c1_i32 = constant 1 : i32
+    store %c1_i32, %0[%c0] : memref<1xi32>
+    %c1 = constant 1 : index
+    %c128 = constant 128 : index
+    %c30 = constant 30 : index
+    %c30_0 = constant 30 : index
+    %c128_1 = constant 128 : index
+    scf.for %arg2 = %c0 to %c128 step %c1 {
+      scf.for %arg3 = %c0 to %c30 step %c1 {
+        scf.for %arg4 = %c0 to %c30_0 step %c1 {
+          scf.for %arg5 = %c0 to %c128_1 step %c1 {
+            %2 = load %arg0[%arg2, %arg3, %arg4, %arg5] : memref<128x30x30x128xf32>
+            %3 = load %arg1[%arg2, %arg3, %arg4, %arg5] : memref<128x30x30x128xf32>
+            %4 = cmpf une, %2, %3 : f32
+            scf.if %4 {
+              store %c0_i32, %0[%c0] : memref<1xi32>
+            }
+          }
+        }
+      }
+    }
+    %1 = memref_cast %0 : memref<1xi32> to memref<*xi32>
+    call @print_memref_i32(%1) : (memref<*xi32>) -> ()
+    return
+  }
+  func private @print_memref_i32(memref<*xi32>)
+}
+
+// E2E: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// E2E: [1]

--- a/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_random.mlir
+++ b/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_random.mlir
@@ -1,0 +1,63 @@
+// kcyx_nchw_nkhw
+// filter 3x3 f32
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw  -batchsize=256 -in_channels=64 -out_channels=64 -in_h=56 -in_w=56 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -rand 1 -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KCYX_NCHW_NKHW_4
+
+// CHECK_KCYX_NCHW_NKHW_4: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KCYX_NCHW_NKHW_4: [1]
+
+// filter 1x1 f16
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw  -batchsize=256 -in_channels=64 -out_channels=64 -in_h=56 -in_w=56 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f16 -rand 1 -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KCYX_NCHW_NKHW_5
+
+// CHECK_KCYX_NCHW_NKHW_5: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KCYX_NCHW_NKHW_5: [1]
+
+// filter 1x1 dilation=2 f16
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw  -batchsize=256 -in_channels=64 -out_channels=64 -in_h=56 -in_w=56 -fil_h=1 -fil_w=1 --dilation_h=2 --dilation_w=2 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f16 -rand 1 -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KCYX_NCHW_NKHW_6
+
+// CHECK_KCYX_NCHW_NKHW_6: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KCYX_NCHW_NKHW_6: [1]
+
+// filter 3x3 f16
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw  -batchsize=256 -in_channels=64 -out_channels=64 -in_h=56 -in_w=56 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f16 -rand 1 -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KCYX_NCHW_NKHW_7
+
+// CHECK_KCYX_NCHW_NKHW_7: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KCYX_NCHW_NKHW_7: [1]
+
+// filter 3x3 padding=1 f16
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw  -batchsize=256 -in_channels=64 -out_channels=64 -in_h=56 -in_w=56 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f16 -rand 1 -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KCYX_NCHW_NKHW_8
+
+// CHECK_KCYX_NCHW_NKHW_8: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KCYX_NCHW_NKHW_8: [1]
+
+
+// kyxc_nhwc_nhwk
+// filter 1x1 f32
+// RUN: mlir-miopen-driver -pv -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk  -batchsize=64 -in_channels=4 -out_channels=64 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1   --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f32 -c -rand 1| mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KYXC_NHWC_NHWK_1
+
+// CHECK_KYXC_NHWC_NHWK_1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KYXC_NHWC_NHWK_1: [1]
+
+// filter 1x1 f32
+// RUN: mlir-miopen-driver -pv -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk  -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -rand 1  -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KYXC_NHWC_NHWK_2
+
+// CHECK_KYXC_NHWC_NHWK_2: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KYXC_NHWC_NHWK_2: [1]
+
+// filter 1x1 dilation=2 f32
+// RUN: mlir-miopen-driver -pv -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk  -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=2 --dilation_w=2 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -rand 1  -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KYXC_NHWC_NHWK_3
+
+// CHECK_KYXC_NHWC_NHWK_3: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KYXC_NHWC_NHWK_3: [1]
+
+// filter 1x1 f16
+// RUN: mlir-miopen-driver -pv -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk  -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f16 -rand 1  -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KYXC_NHWC_NHWK_4
+
+// CHECK_KYXC_NHWC_NHWK_4: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KYXC_NHWC_NHWK_4: [1]
+
+// filter 1x1 dilation=2 f16
+// RUN: mlir-miopen-driver -pv -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk  -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=2 --dilation_w=2 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f16 -rand 1  -c | mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_KYXC_NHWC_NHWK_5
+
+// CHECK_KYXC_NHWC_NHWK_5: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_KYXC_NHWC_NHWK_5: [1]
+

--- a/mlir/test/mlir-miopen-driver/populate_host.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host.mlir
@@ -10,11 +10,13 @@
 // CHECK-NEXT: memref_cast {{.*}} : memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // CHECK-NEXT: memref_cast {{.*}} : memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // CHECK-NEXT: memref_cast {{.*}} : memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
-// CHECK-NEXT: constant {{.*}} : [[TYPE]]
-// CHECK-NEXT: constant {{.*}} : [[TYPE]]
-// CHECK-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// CHECK-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// CHECK-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
+// CHECK-NEXT: constant 0 : i16
+// CHECK-NEXT: constant {{.*}} : i16
+// CHECK-NEXT: constant {{.*}} : i16
+// CHECK-NEXT: constant {{.*}} : i32
+// CHECK-NEXT: call @mcpuMemset4D{{.*}}Rand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// CHECK-NEXT: call @mcpuMemset4D{{.*}}Rand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// CHECK-NEXT: call @mcpuMemset4D{{.*}}Rand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
 // CHECK-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
 // CHECK-NEXT: dealloc {{.*}} : memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
 // CHECK-NEXT: dealloc {{.*}} : memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>

--- a/mlir/test/mlir-miopen-driver/populate_host_convert.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host_convert.mlir
@@ -2,7 +2,7 @@
 // RUN: mlir-miopen-driver -p -ph -pr -t f16 | FileCheck %s --check-prefix=F16
 // RUN: mlir-miopen-driver -p -ph -pr -t bf16 | FileCheck %s --check-prefix=BF16
 
-// F32: func @convert_result([[SOURCE:%[a-zA-Z_0-9]+]]: memref<[[N:[0-9]+]]x[[K:[0-9]+]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>, [[DEST:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>)
+// F32: func @convert_tensor[[N:[0-9]+]]x[[K:[0-9]+]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]([[SOURCE:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE:[a-zA-Z0-9]+]]>, [[DEST:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>)
 // F32-NEXT: [[ZERO:%[a-zA-Z_0-9]+]] = constant 0 : index
 // F32-NEXT: [[ONE:%[a-zA-Z_0-9]+]] = constant 1 : index
 // F32-NEXT: [[BOUND_N:%[a-zA-Z_0-9]+]] = constant [[N]] : index
@@ -21,7 +21,7 @@
 // F32-NEXT: }
 // F32-NEXT: return
 
-// F16: func @convert_result([[SOURCE:%[a-zA-Z_0-9]+]]: memref<[[N:[0-9]+]]x[[K:[0-9]+]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>, [[DEST:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>)
+// F16: func @convert_tensor[[N:[0-9]+]]x[[K:[0-9]+]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]([[SOURCE:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE:[a-zA-Z0-9]+]]>, [[DEST:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>)
 // F16-NEXT: [[ZERO:%[a-zA-Z_0-9]+]] = constant 0 : index
 // F16-NEXT: [[ONE:%[a-zA-Z_0-9]+]] = constant 1 : index
 // F16-NEXT: [[BOUND_N:%[a-zA-Z_0-9]+]] = constant [[N]] : index
@@ -41,4 +41,4 @@
 // F16-NEXT: }
 // F16-NEXT: return
 
-//BF16-NOT: func @convert_result([[SOURCE:%[a-zA-Z_0-9]+]]: memref<[[N:[0-9]+]]x[[K:[0-9]+]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>, [[DEST:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>)
+//BF16-NOT: func @convert_tensor[[N:[0-9]+]]x[[K:[0-9]+]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]([[SOURCE:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE:[a-zA-Z0-9]+]]>, [[DEST:%[a-zA-Z_0-9]+]]: memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>)

--- a/mlir/test/mlir-miopen-driver/populate_host_print.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host_print.mlir
@@ -10,13 +10,15 @@
 // F32-NEXT: memref_cast {{.*}} : memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // F32-NEXT: memref_cast {{.*}} : memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // F32-NEXT: memref_cast {{.*}} : memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
-// F32-NEXT: constant {{.*}} : [[TYPE]]
-// F32-NEXT: constant {{.*}} : [[TYPE]]
-// F32-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// F32-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// F32-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
+// F32-NEXT: constant 0 : i16
+// F32-NEXT: constant {{.*}} : i16
+// F32-NEXT: constant {{.*}} : i16
+// F32-NEXT: constant {{.*}} : i32
+// F32-NEXT: call @mcpuMemset4DFloatRand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// F32-NEXT: call @mcpuMemset4DFloatRand{{.*}}({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// F32-NEXT: call @mcpuMemset4DFloatRand{{.*}}({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
 // F32-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
-// F32-NEXT: call @convert_result(%{{.*}}, %{{.*}}) : (memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]>) -> ()
+// F32-NEXT: call @convert_tensor[[N]]x[[K]]x[[HO]]x[[WO]](%{{.*}}, %{{.*}}) : (memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]>) -> ()
 // F32-NEXT: memref_cast %{{.*}} : memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]> to memref<*x[[PRINT_TYPE]]>
 // F32-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*x[[PRINT_TYPE]]>) -> ()
 // F32-NEXT: dealloc {{.*}} : memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
@@ -33,13 +35,15 @@
 // F16-NEXT: memref_cast {{.*}} : memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // F16-NEXT: memref_cast {{.*}} : memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // F16-NEXT: memref_cast {{.*}} : memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
-// F16-NEXT: constant {{.*}} : [[TYPE]]
-// F16-NEXT: constant {{.*}} : [[TYPE]]
-// F16-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// F16-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// F16-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
+// F16-NEXT: constant 0 : i16
+// F16-NEXT: constant {{.*}} : i16 
+// F16-NEXT: constant {{.*}} : i16
+// F16-NEXT: constant {{.*}} : i32
+// F16-NEXT: call @mcpuMemset4DHalfRand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// F16-NEXT: call @mcpuMemset4DHalfRand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// F16-NEXT: call @mcpuMemset4DHalfRand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
 // F16-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
-// F16-NEXT: call @convert_result(%{{.*}}, %{{.*}}) : (memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]>) -> ()
+// F16-NEXT: call @convert_tensor[[N]]x[[K]]x[[HO]]x[[WO]](%{{.*}}, %{{.*}}) : (memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]>) -> ()
 // F16-NEXT: memref_cast %{{.*}} : memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]> to memref<*x[[PRINT_TYPE]]>
 // F16-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*x[[PRINT_TYPE]]>) -> ()
 // F16-NEXT: dealloc {{.*}} : memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
@@ -56,11 +60,13 @@
 // BF16-NEXT: memref_cast {{.*}} : memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // BF16-NEXT: memref_cast {{.*}} : memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
 // BF16-NEXT: memref_cast {{.*}} : memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<?x?x?x?x[[TYPE]]>
-// BF16-NEXT: constant {{.*}} : [[TYPE]]
-// BF16-NEXT: constant {{.*}} : [[TYPE]]
-// BF16-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// BF16-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
-// BF16-NEXT: call @mcpuMemset4D{{.*}}({{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, [[TYPE]]) -> ()
+// BF16-NEXT: constant 0 : i16 
+// BF16-NEXT: constant {{.*}} : i16 
+// BF16-NEXT: constant {{.*}} : i16
+// BF16-NEXT: constant {{.*}} : i32
+// BF16-NEXT: call @mcpuMemset4DBF16Rand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// BF16-NEXT: call @mcpuMemset4DBF16Rand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
+// BF16-NEXT: call @mcpuMemset4DBF16Rand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
 // BF16-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
 // BF16-NEXT: memref_cast %{{.*}} : memref<[[N]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]> to memref<?x?x?x?x[[PRINT_TYPE]]>
 // BF16-NEXT: call @mcpuMemBF16ConvertFloat({{.*}}, {{.*}}) : (memref<?x?x?x?xi16>, memref<?x?x?x?xf32>) -> ()

--- a/mlir/test/mlir-miopen-driver/populate_random_data_seed.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_random_data_seed.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-miopen-driver -ph -p -rand 1| FileCheck %s --check-prefix=RAND1
+
+// RAND1:  [[MIN:%.*]] = constant -5 : i16
+// RAND1-NEXT:   [[MAX:%.*]] = constant 5 : i16
+// RAND1-NEXT:   [[SEED:%.*]] = constant 1 : i32
+// RAND1-NEXT:    call @mcpuMemset4DFloatRand({{.*}}, [[MIN]], [[MAX]], [[SEED]]) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+// RAND1-NEXT:    call @mcpuMemset4DFloatRand({{.*}}, [[MIN]], [[MAX]], [[SEED]]) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+
+// RUN: mlir-miopen-driver -ph -p -rand 2| FileCheck %s --check-prefix=RAND2
+
+// RAND2:  [[MIN:%.*]] = constant -5 : i16
+// RAND2-NEXT:   [[MAX:%.*]] = constant 5 : i16
+// RAND2-NEXT:   [[SEED:%.*]] = constant 2 : i32
+// RAND2-NEXT:    call @mcpuMemset4DFloatRand({{.*}}, [[MIN]], [[MAX]], [[SEED]]) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+// RAND2-NEXT:    call @mcpuMemset4DFloatRand({{.*}}, [[MIN]], [[MAX]], [[SEED]]) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()

--- a/mlir/test/mlir-miopen-driver/populate_random_data_seed.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_random_data_seed.mlir
@@ -1,3 +1,11 @@
+// RUN: mlir-miopen-driver -ph -p | FileCheck %s 
+
+// CHECK:  [[MIN:%.*]] = constant 1 : i16
+// CHECK-NEXT:   [[MAX:%.*]] = constant 1 : i16
+// CHECK-NEXT:   [[SEED:%.*]] = constant 1 : i32
+// CHECK-NEXT:    call @mcpuMemset4DFloatRand({{.*}}, [[MIN]], [[MAX]], [[SEED]]) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+// CHECK-NEXT:    call @mcpuMemset4DFloatRand({{.*}}, [[MIN]], [[MAX]], [[SEED]]) : (memref<?x?x?x?xf32>, i16, i16, i32) -> ()
+
 // RUN: mlir-miopen-driver -ph -p -rand 1| FileCheck %s --check-prefix=RAND1
 
 // RAND1:  [[MIN:%.*]] = constant -5 : i16

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -229,10 +229,13 @@ static cl::opt<std::string> tensorDataType("t", cl::desc("Data type for convolut
                                            cl::value_desc("Data type for convolution"),
                                            cl::init("f32"));
 
-static cl::opt<std::string>
-    randomData("rand", cl::desc("To specify the seed of random data generator for host validation"),
-               cl::value_desc("To specify the seed of random data generator for host validation"),
-               cl::init("none"));
+static cl::opt<std::string> randomData(
+    "rand",
+    cl::desc(
+        "To specify the seed of random data generator for host validation"),
+    cl::value_desc(
+        "To specify the seed of random data generator for host validation"),
+    cl::init("none"));
 static void populateDefaults() {
   if (populateDefaultValues == true) {
     if (xdlopsV2.getValue() == false) {
@@ -1034,8 +1037,7 @@ static FuncOp launchGPUConvolution(ModuleOp &module, OpBuilder &builder,
 }
 
 // Determine the range and seed for the random data generator
-static std::tuple<short, short, int> configRandomTestData()
-{
+static std::tuple<short, short, int> configRandomTestData() {
   short min, max;
   int seed = 1;
   if (randomData.getValue() == "none") {

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -232,8 +232,9 @@ static cl::opt<std::string> tensorDataType("t", cl::desc("Data type for convolut
 static cl::opt<std::string> randomData(
     "rand",
     cl::desc(
-        "To specify the seed of random data generator for convolution inputs,"
-        " e.g. -rand 1. By default, use all ones"),
+        "A positive integer indicates the seed of random data generator for "
+        "convolution inputs, e.g. -rand 1. If not specifed or -rand none, "
+        "use all ones. Otherwise, use time(0) as the seed."),
     cl::value_desc("seed"), cl::init("none"));
 
 static void populateDefaults() {

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -185,10 +185,10 @@ static cl::opt<bool> loweringWithBuiltinPipeline(
     cl::init(false));
 
 static cl::opt<std::string> loweringTargetDialect(
-    "target", cl::desc("Target dialect"),
-    cl::value_desc("By default, compiles down to GPU dialect. Set "
-                   "-target=rocdl compiles to ROCDL dialect."),
-    cl::init("gpu"));
+    "target",
+    cl::desc("By default, compiles down to GPU dialect. Set "
+             "-target=rocdl compiles to ROCDL dialect."),
+    cl::value_desc("Target dialect"), cl::init("gpu"));
 
 // use host harness program.
 static cl::opt<bool> useHostHarness(
@@ -232,10 +232,10 @@ static cl::opt<std::string> tensorDataType("t", cl::desc("Data type for convolut
 static cl::opt<std::string> randomData(
     "rand",
     cl::desc(
-        "To specify the seed of random data generator for host validation"),
-    cl::value_desc(
-        "To specify the seed of random data generator for host validation"),
-    cl::init("none"));
+        "To specify the seed of random data generator for convolution inputs,"
+        " e.g. -rand 1. By default, use all ones"),
+    cl::value_desc("seed"), cl::init("none"));
+
 static void populateDefaults() {
   if (populateDefaultValues == true) {
     if (xdlopsV2.getValue() == false) {


### PR DESCRIPTION
- Add a mlir-miopen-driver option "-rand" to generate random input data for cpu validation. If -rand is not specified, use all 1s. If a positive number follows -rand, use it as the seed of rand(). Otherwise use rand(time(0)).

- If -rand is specified, random values between [-5, 5) are used.

- If random data is used, the values of inputs to gpu_conv() are copied into inputs to cpu_conv().

- The option "-rand" applies to -ph and -prc as well.

These changes have passed bf16 test cases on gfx908.