### PR TITLE
Use f32 for accumulator.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -3429,8 +3429,6 @@ struct BlockwiseCopyRewritePattern : public OpRewritePattern<miopen::BlockwiseCo
     if (op.buffer())
       bufferType = op.buffer().getType().cast<MemRefType>();
 
-    auto elementType = destType.getElementType();
-
     // Prepare some useful constants.
     auto zeroConstantI32Op =
         b.create<ConstantIntOp>(loc, 0, b.getIntegerType(32));

--- a/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_f16.mlir
+++ b/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_f16.mlir
@@ -211,11 +211,21 @@
 // Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/127
 ///////////////////////////////////////////////////////////////////////////////////////////
 
+// Foward cases.
+
 // RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kyxc --in_layout nhwc --out_layout nhwk --batchsize 256 --in_channels 256 --in_h 30 --in_w 30 --out_channels 256 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_1
 // RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kyxc --in_layout nhwc --out_layout nhwk --batchsize 256 --in_channels 512 --in_h 16 --in_w 16 --out_channels 512 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_2
 // RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 58 --in_w 58 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_3
 // RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 58 --in_w 58 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_3
 // RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 256 --in_h 30 --in_w 30 --out_channels 256 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_4
+// RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 256 --in_h 14 --in_w 14 --out_channels 256 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 1 --padding_w 1  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_5
+
+// Backward weight cases.
+// RUN: mlir-miopen-driver -pv -c --operation conv2d_bwd_weight -t f16 --fil_layout kyxc --in_layout nhwc --out_layout nhwk --batchsize 256 --in_channels 1024 --in_h 14 --in_w 14 --out_channels 2048 --fil_w 1 --fil_h 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_6
+// RUN: mlir-miopen-driver -pv -c --operation conv2d_bwd_weight -t f16 --fil_layout kyxc --in_layout nhwc --out_layout nhwk --batchsize 256 --in_channels 1024 --in_h 14 --in_w 14 --out_channels 256 --fil_w 1 --fil_h 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_7
+// RUN: mlir-miopen-driver -pv -c --operation conv2d_bwd_weight -t f16 --fil_layout kyxc --in_layout nhwc --out_layout nhwk --batchsize 256 --in_channels 128 --in_h 58 --in_w 58 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_8
+// RUN: mlir-miopen-driver -pv -c --operation conv2d_bwd_weight -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 28 --in_w 28 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 1 --padding_w 1  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_9
+// RUN: mlir-miopen-driver -pv -c --operation conv2d_bwd_weight -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 58 --in_w 58 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_10
 
 // CHECK_ISSUE_127_1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_ISSUE_127_1: [1]
@@ -225,6 +235,18 @@
 // CHECK_ISSUE_127_3: [1]
 // CHECK_ISSUE_127_4: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_ISSUE_127_4: [1]
+// CHECK_ISSUE_127_5: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_5: [1]
+// CHECK_ISSUE_127_6: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_6: [1]
+// CHECK_ISSUE_127_7: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_7: [1]
+// CHECK_ISSUE_127_8: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_8: [1]
+// CHECK_ISSUE_127_9: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_9: [1]
+// CHECK_ISSUE_127_10: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_10: [1]
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // FIXME Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/40

--- a/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_f16.mlir
+++ b/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_f16.mlir
@@ -207,5 +207,28 @@
 // CHECK_ISSUE_40_3: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_ISSUE_40_3: [1]
 
+///////////////////////////////////////////////////////////////////////////////////////////
+// Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/127
+///////////////////////////////////////////////////////////////////////////////////////////
+
+// RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kyxc --in_layout nhwc --out_layout nhwk --batchsize 256 --in_channels 256 --in_h 30 --in_w 30 --out_channels 256 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_1
+// RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kyxc --in_layout nhwc --out_layout nhwk --batchsize 256 --in_channels 512 --in_h 16 --in_w 16 --out_channels 512 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_2
+// RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 58 --in_w 58 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_3
+// RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 58 --in_w 58 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_3
+// RUN: mlir-miopen-driver -pv -c --operation conv2d -t f16 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 256 --in_h 30 --in_w 30 --out_channels 256 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_127_4
+
+// CHECK_ISSUE_127_1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_1: [1]
+// CHECK_ISSUE_127_2: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_2: [1]
+// CHECK_ISSUE_127_3: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_3: [1]
+// CHECK_ISSUE_127_4: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_127_4: [1]
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// FIXME Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/40
+///////////////////////////////////////////////////////////////////////////////////////////
+
 // FIXME: mlir-miopen-driver -t f16 -pv -fil_layout=yxck -in_layout=nhwc -out_layout=nhwk -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=5 -fil_w=5 --padding_h=1 --padding_w=1 -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_40_4
 // FIXME: mlir-miopen-driver -t f16 -pv -fil_layout=yxck -in_layout=nhwc -out_layout=nhwk -batchsize=64 -in_channels=8 -out_channels=128 -in_h=16 -in_w=64 -fil_h=3 -fil_w=5 -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_40_5


### PR DESCRIPTION
This PR fixes overflow issues observed in various different cases in f16 type:

- fwd, 3x3, stride=2
- fwd, 3x3, padding=1
- wrw

The idea is to use f32 type on the VGPR to act as the accumulator for matrix C, and do fpext/fptrunc while load/store.