### PR TITLE
Introduce -target flag to mlir-miopen-driver so target dialect of the lowering pipeline can be specified.

### DIFF
--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -16,6 +16,7 @@
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 
 // fp16 tests.
 
@@ -32,6 +33,7 @@
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p -t f16 -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 
 // bf16(i16) tests.
 
@@ -48,3 +50,4 @@
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p -t bf16 -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900

--- a/mlir/test/mlir-miopen-driver/sanity_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_xdlops.mlir
@@ -14,6 +14,7 @@
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 // RUN: mlir-miopen-driver -p -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir
+// RUN: mlir-miopen-driver -p -x2 -c -target=rocdl | mlir-translate -mlir-to-rocdlir
 
 // fp16 tests.
 
@@ -28,6 +29,7 @@
 // RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 // RUN: mlir-miopen-driver -p -t f16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir
+// RUN: mlir-miopen-driver -p -t f16 -x2 -c -target=rocdl | mlir-translate -mlir-to-rocdlir
 
 // bf16(i16) tests.
 
@@ -42,3 +44,4 @@
 // RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-opt
 // RUN: mlir-miopen-driver -p -t bf16 -x2 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir
+// RUN: mlir-miopen-driver -p -t bf16 -x2 -c -target=rocdl | mlir-translate -mlir-to-rocdlir


### PR DESCRIPTION
By deafult, with -c flag, mlir-miopen-driver would produce a GPU kernel
in GPU dialect, which can be consumed by mlir-rocm-runner.

Introduce a -target flag which instructs the target dialect to be
compiled to. Currently it supports two options:

-target=gpu : the default behavior, compiles down to GPU dialect.
-target=rocdl : compiles down to ROCDL dialect. The output can be
consumed by mlir-translate -mlir-to-rocdlir directly.