### PR TITLE
Set kernel function attribute and recognize it in miopen-to-gpu pass.

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -160,7 +160,7 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
     // Set attributes on the function.
-    getFunction()->setAttr("kernel", b.getI32IntegerAttr(1));
+    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size", b.getI32IntegerAttr(blockSize));
     getFunction()->setAttr(
         "grid_size",
@@ -210,7 +210,7 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
 
     // Set attributes on the function.
-    getFunction()->setAttr("kernel", b.getI32IntegerAttr(1));
+    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size",
                            b.getI32IntegerAttr(validParams.blockSize));
     getFunction()->setAttr(

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -159,6 +159,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("n_per_wave", b.getI32IntegerAttr(validParams.gemmNPerWave));
     op->setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
+    // Set attributes on the function.
+    getFunction()->setAttr("kernel", b.getI32IntegerAttr(1));
     getFunction()->setAttr("block_size", b.getI32IntegerAttr(blockSize));
     getFunction()->setAttr(
         "grid_size",
@@ -207,6 +209,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
                 b.getI32IntegerAttr(validParams.gemmNPerThread));
     op->setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
 
+    // Set attributes on the function.
+    getFunction()->setAttr("kernel", b.getI32IntegerAttr(1));
     getFunction()->setAttr("block_size",
                            b.getI32IntegerAttr(validParams.blockSize));
     getFunction()->setAttr(

--- a/mlir/test/Conversion/MIOpenToGPU/multiple_kernels.mlir
+++ b/mlir/test/Conversion/MIOpenToGPU/multiple_kernels.mlir
@@ -4,6 +4,7 @@
 // RUN: mlir-opt -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu="kernel-name=step1" %s | FileCheck %s --check-prefix=SUBSET1
 // RUN: mlir-opt -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu="kernel-name=step1,step3" %s | FileCheck %s --check-prefix=SUBSET2
 // RUN: mlir-opt -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu="kernel-name=step5" %s | FileCheck %s --check-prefix=NONEXIST
+// RUN: mlir-opt -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu %s | FileCheck %s
 
 // The last kernel be converted would appear as the first.
 

--- a/mlir/test/Dialect/MIOpen/lowering_affix_params.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_affix_params.mlir
@@ -1,0 +1,4 @@
+// RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s
+
+// CHECK: module {{.*}}
+// CHECK-NEXT: func @miopen_conv2d_kcyx_nchw_nkhw(%{{.*}}: memref<{{.*}}>, %{{.*}}: memref<{{.*}}>, %arg2: memref<{{.*}}>) attributes {block_size = {{.*}} : i32, grid_size = {{.*}} : i32, kernel}


### PR DESCRIPTION
Set kernel function attribute in miopen-affix-params to mark functions
enclosing 2D conv ops. Recognize such attribute when converting those
functions to GPU functions.