### PR TITLE
Introduce miopen.conv2d_dummy op and its associated logic.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -56,7 +56,7 @@ def MIOpen_Conv2DBwdDataOp :
                    MemRefRankOf<[F32, F16, I16], [4]>:$output)> {
   let summary = "2D convolution backward data";
   let description = [{
-    The `miopen.conv2d` op computes 2D convolution backward data.
+    The `miopen.conv2d_bwd_data` op computes 2D convolution backward data.
   }];
 }
 
@@ -67,9 +67,21 @@ def MIOpen_Conv2DBwdWeightOp :
                    MemRefRankOf<[F32, F16, I16], [4]>:$output)> {
   let summary = "2D convolution backward weight";
   let description = [{
-    The `miopen.conv2d` op computes 2D convolution backward weight.
+    The `miopen.conv2d_bwd_weight` op computes 2D convolution backward weight.
   }];
 }
+
+def MIOpen_Conv2DDummyOp :
+    MIOpen_Op<"conv2d_dummy">,
+    Arguments<(ins MemRefRankOf<[F32, F16, I16], [4]>:$filter,
+                   MemRefRankOf<[F32, F16, I16], [4]>:$input,
+                   MemRefRankOf<[F32, F16, I16], [4]>:$output)> {
+  let summary = "Dummy op for 2D convolution";
+  let description = [{
+    The `miopen.conv2d_dummy` op is an empty op which takes the same operands as a regular 2D conv op.
+  }];
+}
+
 
 def MIOpen_TransformOp :
     MIOpen_Op<"transform">,

--- a/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
+++ b/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
@@ -308,7 +308,8 @@ void LowerMIOpenOpsToGPUPass::runOnOperation() {
         op.replaceAllUsesWith(gpuMfmaOp.destD());
         op.erase();
       });
-   
+
+      gpuFunc.walk([&](miopen::Conv2DDummyOp op) { op.erase(); });
     });
   }
 }

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -165,6 +165,13 @@ LogicalResult Conv2dGenerator::genConvModule(
                    func.getArgument(2)},
         attributes);
     block->push_back(convOp);
+  } else if (operation.compare("conv2d_dummy") == 0) {
+    auto convOp = builder.create<miopen::Conv2DDummyOp>(
+        builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
+        ValueRange{func.getArgument(0), func.getArgument(1),
+                   func.getArgument(2)},
+        attributes);
+    block->push_front(convOp);
   }
 
   auto returnOp =

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -109,6 +109,29 @@ static void print(OpAsmPrinter &p, Conv2DBwdWeightOp op) {
 static LogicalResult verify(Conv2DBwdWeightOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
+// Conv2DDummyOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseConv2DDummyOp(OpAsmParser &parser,
+                                      OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 3> ops;
+  SmallVector<Type, 3> types;
+  return failure(
+      parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+      parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColonTypeList(types) ||
+      parser.resolveOperands(ops, types, parser.getNameLoc(), result.operands));
+}
+
+static void print(OpAsmPrinter &p, Conv2DDummyOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.getOperandTypes();
+}
+
+static LogicalResult verify(Conv2DDummyOp op) { return success(); }
+
+//===----------------------------------------------------------------------===//
 // TransformOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -126,6 +126,14 @@ void AffixTuningParameters::runOnFunction() {
   func.walk([&](miopen::GridwiseGemmV2Op op) {
     affixTuningParametersImpl(op);
   });
+
+  func.walk([&](miopen::Conv2DDummyOp op) {
+    OpBuilder b(op.getContext());
+    // Set attributes for the dummy conv2d op.
+    getFunction()->setAttr("kernel", b.getI32IntegerAttr(1));
+    getFunction()->setAttr("block_size", b.getI32IntegerAttr(1));
+    getFunction()->setAttr("grid_size", b.getI32IntegerAttr(1));
+  });
 }
 
 

--- a/mlir/test/Dialect/MIOpen/ops.mlir
+++ b/mlir/test/Dialect/MIOpen/ops.mlir
@@ -87,6 +87,34 @@ func @miopen_conv2d_bwd_weight_f16(%filter : memref<?x?x?x?xf16>, %input : memre
 // CHECK-LABEL: func @miopen_conv2d_bwd_weight_f16
 // CHECK-NEXT: miopen.conv2d_bwd_weight
 
+func @miopen_conv2d_dummy(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+  miopen.conv2d_dummy(%filter, %input, %output) {
+    filter_layout = ["k", "c", "y", "x"],
+    input_layout = ["n", "c", "hi", "wi"],
+    output_layout = ["n", "k", "ho", "wo"],
+    dilations = [1, 1],
+    strides = [1, 1],
+    padding = [0, 0]
+  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  return
+}
+// CHECK-LABEL: func @miopen_conv2d_dummy
+// CHECK-NEXT: miopen.conv2d_dummy
+
+func @miopen_conv2d_dummy_f16(%filter : memref<?x?x?x?xf16>, %input : memref<?x?x?x?xf16>, %output : memref<?x?x?x?xf16>) {
+  miopen.conv2d_dummy(%filter, %input, %output) {
+    filter_layout = ["k", "c", "y", "x"],
+    input_layout = ["n", "c", "hi", "wi"],
+    output_layout = ["n", "k", "ho", "wo"],
+    dilations = [1, 1],
+    strides = [1, 1],
+    padding = [0, 0]
+  } : memref<?x?x?x?xf16>, memref<?x?x?x?xf16>, memref<?x?x?x?xf16>
+  return
+}
+// CHECK-LABEL: func @miopen_conv2d_dummy_f16
+// CHECK-NEXT: miopen.conv2d_dummy
+
 // test 1-1 dimension mappings.
 func @miopen_transform_1_to_1(%memref: memref<?x?x?x?xf32>) {
   %transformed_memref = miopen.transform(%memref) {

--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -17,6 +17,7 @@
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 // RUN: mlir-miopen-driver -p -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p --operation conv2d_dummy -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 
 // fp16 tests.
 
@@ -34,6 +35,7 @@
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 // RUN: mlir-miopen-driver -p -t f16 -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p -t f16 --operation conv2d_dummy -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 
 // bf16(i16) tests.
 
@@ -51,3 +53,4 @@
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 // RUN: mlir-miopen-driver -p -t bf16 -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p -t bf16 --operation conv2d_dummy -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -889,7 +889,8 @@ static FuncOp launchGPUConvolution(ModuleOp &module, OpBuilder &builder,
 
   // Emit mgpuMemCopy4DFloat function call.
   mlir::Value resultGpuValue, resultCpuValue;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     resultGpuValue = outputGpuAllocOp.getResult(0);
     resultCpuValue = outputMemRefCastOp;
   } else if (operation.getValue() == "conv2d_bwd_data") {
@@ -968,7 +969,8 @@ static LogicalResult populateHostHarnessLogic(
   // Backward data convolution: input tensor.
   // Backward weight convolution: filter tensor.
   MemRefType printMemRefType;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     printMemRefType = MemRefType::get(
         ArrayRef<int64_t>(outputDimension.begin(), outputDimension.end()),
         builder.getF32Type());
@@ -1051,7 +1053,8 @@ static LogicalResult populateHostHarnessLogic(
 
   // Populate initial values.
   mlir::Value filterMemsetValue, inputMemsetValue, outputMemsetValue;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     filterMemsetValue = oneConstantFloatOp;
     inputMemsetValue = oneConstantFloatOp;
     outputMemsetValue = zeroConstantFloatOp;
@@ -1089,7 +1092,8 @@ static LogicalResult populateHostHarnessLogic(
 
   mlir::Value resultCpuValue, resultOriginalCpuValue;
   mlir::MemRefType resultOriginalCpuType;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     resultCpuValue = outputMemRefCastOp;
     resultOriginalCpuValue = outputHostAllocOp;
     resultOriginalCpuType = outputMemRefType;
@@ -1265,7 +1269,8 @@ static LogicalResult populateValidationLogic(
 
   // Populate initial values.
   mlir::Value filterMemsetValue, inputMemsetValue, outputMemsetValue;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     filterMemsetValue = oneConstantFloatOp;
     inputMemsetValue = oneConstantFloatOp;
     outputMemsetValue = zeroConstantFloatOp;
@@ -1335,7 +1340,8 @@ static LogicalResult populateValidationLogic(
 
   AllocOp gpuOriginalResults, gpuF32Results;
   MemRefType gpuOriginalResultType, gpuF32ResultType;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     gpuF32ResultType = MemRefType::get(
         ArrayRef<int64_t>(outputDimension.begin(), outputDimension.end()),
         builder.getF32Type());
@@ -1421,7 +1427,8 @@ static LogicalResult populateValidationLogic(
   }
 
   // Set initial values.
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     filterMemsetValue = oneConstantFloatOp;
     inputMemsetValue = oneConstantFloatOp;
     outputMemsetValue = zeroConstantFloatOp;
@@ -1460,7 +1467,8 @@ static LogicalResult populateValidationLogic(
   block->push_back(cpuConvCallOp);
 
   mlir::AllocOp cpuResults;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     cpuResults = cpuOutputHostAllocOp;
   } else if (operation.getValue() == "conv2d_bwd_data") {
     cpuResults = cpuInputHostAllocOp;
@@ -1469,7 +1477,8 @@ static LogicalResult populateValidationLogic(
   }
 
   mlir::FuncOp verifyFuncOp;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     verifyFuncOp = createVerifyFuncOp(module, builder, outputDimension,
                                       cpuResults, gpuF32Results);
   } else if (operation.getValue() == "conv2d_bwd_data") {
@@ -1566,7 +1575,8 @@ populateCpuConvolutionLogic(ModuleOp &module, OpBuilder &builder,
 
   // Populate initial values.
   mlir::Value filterMemsetValue, inputMemsetValue, outputMemsetValue;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     filterMemsetValue = oneConstantFloatOp;
     inputMemsetValue = oneConstantFloatOp;
     outputMemsetValue = zeroConstantFloatOp;
@@ -1605,7 +1615,8 @@ populateCpuConvolutionLogic(ModuleOp &module, OpBuilder &builder,
   block->push_back(cpuConvCallOp);
 
   mlir::AllocOp cpuResults;
-  if (operation.getValue() == "conv2d") {
+  if (operation.getValue() == "conv2d" ||
+      operation.getValue() == "conv2d_dummy") {
     cpuResults = cpuOutputHostAllocOp;
   } else if (operation.getValue() == "conv2d_bwd_data") {
     cpuResults = cpuInputHostAllocOp;


### PR DESCRIPTION
- Op definition / parsing / unit test.
- Lowering logic. The op would be erased in convert-miopen-to-gpu pass.
- mlir-miopen-driver changes to add a new --operation=conv2d_dummy
target.

The net effect is to create an op which looks like `miopen.conv2d` but after lowering we get an empty GPU kernel.

This is a preparatory PR to enable the infrastructure of splitting `miopen.conv2d_bwd_data` into multiple kernel calls.