### PR TITLE
Adding StridedMemRefType from interface

### DIFF
--- a/mlir/tools/mlir-miopen-lib/Miir.h
+++ b/mlir/tools/mlir-miopen-lib/Miir.h
@@ -11,8 +11,9 @@
 #define MLIR_C_MIIR_H
 
 #include <stddef.h>
+#include <stdint.h>
 
-#define MIIR_VERSION_FLAT 3
+#define MIIR_VERSION_FLAT 4
 
 enum MiirStatus {
   MIIR_SUCCESS = 0,
@@ -25,6 +26,29 @@ typedef enum MiirStatus MiirStatus;
 /*! @brief The MLIR handle used for lowering and code generation
  */
 typedef void *MiirHandle;
+
+// A convolution includes three arguments of StridedMemRef to
+// represent filter, input and output tensors
+
+/*! @brief Device interface argument type for 2D convolution
+ */
+struct StridedMemRef4D {
+  void *basePtr;
+  void *data;
+  int64_t offset;
+  int64_t sizes[4];
+  int64_t strides[4];
+};
+
+/*! @brief Device interface argument type for 3D convolution
+ */
+struct StridedMemRef5D {
+  void *basePtr;
+  void *data;
+  int64_t offset;
+  int64_t sizes[5];
+  int64_t strides[5];
+};
 
 /*! @brief Create the MLIR handle according to options string
  *  @param options Command-line options as a string

--- a/mlir/tools/mlir-miopen-lib/Miir.h
+++ b/mlir/tools/mlir-miopen-lib/Miir.h
@@ -31,16 +31,7 @@ typedef void *MiirHandle;
 // represent filter, input and output tensors
 
 /*! @brief Device interface argument type for 2D convolution
- */
-struct StridedMemRef4D {
-  void *basePtr;
-  void *data;
-  int64_t offset;
-  int64_t sizes[4];
-  int64_t strides[4];
-};
-
-/*! @brief Device interface argument type for 3D convolution
+ * There is an additional group dimension before channel dimension
  */
 struct StridedMemRef5D {
   void *basePtr;


### PR DESCRIPTION
This PR adds StridedMemRefType per client request.

I have to get rid of the template because it is C API.

CC: @whchung FYI, once this PR is in, group conv PR is good to go.