### PR TITLE
Annotate kernel function attribute inside mlir-miopen-driver.

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -94,7 +94,14 @@ LogicalResult Conv2dGenerator::genConvModule(
                  inputLayout + "_" + outputLayout;
   }
 
-  auto func = FuncOp::create(builder.getUnknownLoc(), kernelName, funcType);
+  // Annotate kernel attribute to the FuncOp.
+  SmallVector<NamedAttribute, 1> kernelAttrs{
+      builder.getNamedAttr("kernel", builder.getUnitAttr()),
+  };
+
+  // Construct the FuncOp.
+  auto func = FuncOp::create(builder.getUnknownLoc(), kernelName, funcType,
+                             ArrayRef<NamedAttribute>(kernelAttrs));
   module.push_back(func);
 
   // Construct a new Block.

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -130,7 +130,6 @@ void AffixTuningParameters::runOnFunction() {
   func.walk([&](miopen::Conv2DDummyOp op) {
     OpBuilder b(op.getContext());
     // Set attributes for the dummy conv2d op.
-    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size", b.getI32IntegerAttr(1));
     getFunction()->setAttr("grid_size", b.getI32IntegerAttr(1));
   });
@@ -168,7 +167,6 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
     // Set attributes on the function.
-    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size", b.getI32IntegerAttr(blockSize));
     getFunction()->setAttr(
         "grid_size",
@@ -218,7 +216,6 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
 
     // Set attributes on the function.
-    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size",
                            b.getI32IntegerAttr(validParams.blockSize));
     getFunction()->setAttr(

--- a/mlir/test/Conversion/MIOpenToGPU/multiple_kernels.mlir
+++ b/mlir/test/Conversion/MIOpenToGPU/multiple_kernels.mlir
@@ -45,22 +45,22 @@
 // NONEXIST-NOT: gpu.func @step1
 
 module  {
-  func @step1(%arg0: memref<1x1216x16x3x3xf32>, %arg1: memref<1216x1x16x32x32xf32>, %arg2: memref<1216x1x1216x30x30xf32>) {
+  func @step1(%arg0: memref<1x1216x16x3x3xf32>, %arg1: memref<1216x1x16x32x32xf32>, %arg2: memref<1216x1x1216x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1216x16x3x3xf32>, memref<1216x1x16x32x32xf32>, memref<1216x1x1216x30x30xf32>
     return
   }
 
-  func @step2(%arg0: memref<1x64x16x3x3xf32>, %arg1: memref<64x1x16x32x32xf32>, %arg2: memref<64x1x64x30x30xf32>) {
+  func @step2(%arg0: memref<1x64x16x3x3xf32>, %arg1: memref<64x1x16x32x32xf32>, %arg2: memref<64x1x64x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x64x16x3x3xf32>, memref<64x1x16x32x32xf32>, memref<64x1x64x30x30xf32>
     return
   }
 
-  func @step3(%arg0: memref<1x32x16x3x3xf32>, %arg1: memref<32x1x16x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) {
+  func @step3(%arg0: memref<1x32x16x3x3xf32>, %arg1: memref<32x1x16x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x32x16x3x3xf32>, memref<32x1x16x32x32xf32>, memref<32x1x32x30x30xf32>
     return
   }
 
-  func @step4(%arg0: memref<1x32x8x3x3xf32>, %arg1: memref<32x1x8x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) {
+  func @step4(%arg0: memref<1x32x8x3x3xf32>, %arg1: memref<32x1x8x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x32x8x3x3xf32>, memref<32x1x8x32x32xf32>, memref<32x1x32x30x30xf32>
     return
   }

--- a/mlir/test/mlir-miopen-driver/populate.mlir
+++ b/mlir/test/mlir-miopen-driver/populate.mlir
@@ -3,13 +3,13 @@
 // RUN: mlir-miopen-driver -p -t bf16 | FileCheck %s --check-prefix=BF16
 
 // F32-LABEL: module
-// F32-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf32>, {{.*}}: memref<128x1x8x32x32xf32>, {{.*}}: memref<128x1x128x30x30xf32>)
+// F32-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf32>, {{.*}}: memref<128x1x8x32x32xf32>, {{.*}}: memref<128x1x128x30x30xf32>) attributes {kernel}
 // F32-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x128x8x3x3xf32>, memref<128x1x8x32x32xf32>, memref<128x1x128x30x30xf32>
 
 // F16-LABEL: module
-// F16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf16>, {{.*}}: memref<128x1x8x32x32xf16>, {{.*}}: memref<128x1x128x30x30xf16>)
+// F16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf16>, {{.*}}: memref<128x1x8x32x32xf16>, {{.*}}: memref<128x1x128x30x30xf16>) attributes {kernel}
 // F16-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x128x8x3x3xf16>, memref<128x1x8x32x32xf16>, memref<128x1x128x30x30xf16>
 
 // BF16-LABEL: module
-// BF16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xi16>, {{.*}}: memref<128x1x8x32x32xi16>, {{.*}}: memref<128x1x128x30x30xi16>)
+// BF16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xi16>, {{.*}}: memref<128x1x8x32x32xi16>, {{.*}}: memref<128x1x128x30x30xi16>) attributes {kernel}
 // BF16-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x128x8x3x3xi16>, memref<128x1x8x32x32xi16>, memref<128x1x128x30x30xi16>


### PR DESCRIPTION
Originally it was carried out in -miopen-affix-params pass, move ahead
in the pipeline so the function attribute is assigned inside
mlir-miopen-driver when the enclosing function of a conv2d op is
populated.

This would make the implementation of the "kernel splitting pass" be easier.