### PR TITLE
[DO NOT MERGE] Experimental codes to split fwd conv2d into smaller ops.

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -530,10 +530,10 @@ def ConvertMIOpenToGPU : Pass<"convert-miopen-to-gpu", "ModuleOp"> {
   let options = [
     Option<"kernelNameList", "kernel-name", "std::string",
            "\"miopen_conv2d_gkcyx_ngchw_ngkhw\"",
-           "kernel name to be lowered">,
-    Option<"gpuModuleName", "gpu-module-name", "std::string",
+           "kernel name(s) to be lowered">,
+    Option<"gpuModuleNameList", "gpu-module-name", "std::string",
            "\"miopen_kernel_module\"",
-           "GPU kernel module name to be lowered">,
+           "GPU kernel module(s) name to be lowered">,
   ];
   let dependentDialects = [
     "miopen::MIOpenDialect",

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -49,6 +49,10 @@ std::unique_ptr<Pass>
 createAffixTuningParametersPass(int64_t blockSizeOverride = 0,
                                 int64_t gridSizeOverride = 0);
 
+/// Create a pass to split MIOpen conv2d operations to multiple
+/// conv2d and conv2d_dummy operations.
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createSplitConv2DPass();
+
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/MIOpen/Passes.h.inc"
 

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.td
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.td
@@ -62,4 +62,10 @@ def MIOpenOpsStep5Pass : Pass<"miopen-lowering-step5", "ModuleOp"> {
   let dependentDialects = ["miopen::MIOpenDialect", "scf::SCFDialect", "AffineDialect", "StandardOpsDialect"];
 }
 
+def MIOpenOpsSplitConv2DPass : Pass<"miopen-split-conv2d", "ModuleOp"> {
+  let summary = "split convolution into one convolution with multiple dummy ops";
+  let constructor = "mlir::miopen::createSplitConv2DPass()";
+  let dependentDialects = ["miopen::MIOpenDialect"];
+}
+
 #endif // MLIR_DIALECT_MIOPEN_PASSES

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -94,7 +94,14 @@ LogicalResult Conv2dGenerator::genConvModule(
                  inputLayout + "_" + outputLayout;
   }
 
-  auto func = FuncOp::create(builder.getUnknownLoc(), kernelName, funcType);
+  // Annotate kernel attribute to the FuncOp.
+  SmallVector<NamedAttribute, 1> kernelAttrs{
+      builder.getNamedAttr("kernel", builder.getUnitAttr()),
+  };
+
+  // Construct the FuncOp.
+  auto func = FuncOp::create(builder.getUnknownLoc(), kernelName, funcType,
+                             ArrayRef<NamedAttribute>(kernelAttrs));
   module.push_back(func);
 
   // Construct a new Block.

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -130,7 +130,6 @@ void AffixTuningParameters::runOnFunction() {
   func.walk([&](miopen::Conv2DDummyOp op) {
     OpBuilder b(op.getContext());
     // Set attributes for the dummy conv2d op.
-    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size", b.getI32IntegerAttr(1));
     getFunction()->setAttr("grid_size", b.getI32IntegerAttr(1));
   });
@@ -168,7 +167,6 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
     // Set attributes on the function.
-    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size", b.getI32IntegerAttr(blockSize));
     getFunction()->setAttr(
         "grid_size",
@@ -218,7 +216,6 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
 
     // Set attributes on the function.
-    getFunction()->setAttr("kernel", b.getUnitAttr());
     getFunction()->setAttr("block_size",
                            b.getI32IntegerAttr(validParams.blockSize));
     getFunction()->setAttr(

--- a/mlir/lib/Dialect/MIOpen/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/MIOpen/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_dialect_library(MLIRMIOpenTransforms
   AffineTransforms.cpp
   LowerMIOpenOps.cpp
   TestAffineTransforms.cpp
+  SplitConv2D.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Transforms

--- a/mlir/lib/Dialect/MIOpen/Transforms/SplitConv2D.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/SplitConv2D.cpp
@@ -1,0 +1,72 @@
+#include "PassDetail.h"
+
+#include "mlir/Dialect/MIOpen/MIOpenOps.h"
+#include "mlir/Dialect/MIOpen/Passes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/MapVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+namespace {
+struct SplitConv2D : public MIOpenOpsSplitConv2DPassBase<SplitConv2D> {
+public:
+  SplitConv2D() = default;
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+void SplitConv2D::runOnOperation() {
+  auto op = getOperation();
+  OpBuilder b(op.getContext());
+  auto loc = op.getLoc();
+
+  SymbolTable symbolTable(op);
+
+  static int const cloneFactor = 3;
+
+  // Traverse all FuncOps, identify those with kernel attribute.
+  for (auto func : op.getOps<FuncOp>()) {
+    if (func->getAttrDictionary().get("kernel")) {
+      if (func.getName().startswith("cloned"))
+        continue;
+
+      // Clone multiple copies of the kernel function.
+      for (int i = 0; i < cloneFactor; ++i) {
+        // Create a new cloned function.
+        auto clonedFunc = func.clone();
+
+        // Set the name to the clone function.
+        std::string newName =
+            "cloned_" + std::to_string(i) + "_" + func.getName().str();
+        clonedFunc.setName(newName);
+
+        // Traverse all conv2d ops, replace with conv2d_dummy ops.
+        for (auto conv : clonedFunc.getOps<miopen::Conv2DOp>()) {
+          // Create an equivalent conv2d_dummy op.
+          b.setInsertionPointToStart(&(clonedFunc.body()).front());
+          auto dummy_conv = b.create<miopen::Conv2DDummyOp>(
+              loc, ArrayRef<mlir::Type>{},
+              ValueRange{clonedFunc.getArgument(0), clonedFunc.getArgument(1),
+                         clonedFunc.getArgument(2)},
+              conv.getAttrs());
+          conv->replaceAllUsesWith(dummy_conv);
+          conv.erase();
+          break;
+        }
+
+        // Insert the cloned function into ModuleOp.
+        symbolTable.insert(clonedFunc);
+      }
+    }
+  }
+}
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+mlir::miopen::createSplitConv2DPass() {
+  return std::make_unique<SplitConv2D>();
+}

--- a/mlir/test/Conversion/MIOpenToGPU/multiple_kernels.mlir
+++ b/mlir/test/Conversion/MIOpenToGPU/multiple_kernels.mlir
@@ -45,22 +45,22 @@
 // NONEXIST-NOT: gpu.func @step1
 
 module  {
-  func @step1(%arg0: memref<1x1216x16x3x3xf32>, %arg1: memref<1216x1x16x32x32xf32>, %arg2: memref<1216x1x1216x30x30xf32>) {
+  func @step1(%arg0: memref<1x1216x16x3x3xf32>, %arg1: memref<1216x1x16x32x32xf32>, %arg2: memref<1216x1x1216x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1216x16x3x3xf32>, memref<1216x1x16x32x32xf32>, memref<1216x1x1216x30x30xf32>
     return
   }
 
-  func @step2(%arg0: memref<1x64x16x3x3xf32>, %arg1: memref<64x1x16x32x32xf32>, %arg2: memref<64x1x64x30x30xf32>) {
+  func @step2(%arg0: memref<1x64x16x3x3xf32>, %arg1: memref<64x1x16x32x32xf32>, %arg2: memref<64x1x64x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x64x16x3x3xf32>, memref<64x1x16x32x32xf32>, memref<64x1x64x30x30xf32>
     return
   }
 
-  func @step3(%arg0: memref<1x32x16x3x3xf32>, %arg1: memref<32x1x16x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) {
+  func @step3(%arg0: memref<1x32x16x3x3xf32>, %arg1: memref<32x1x16x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x32x16x3x3xf32>, memref<32x1x16x32x32xf32>, memref<32x1x32x30x30xf32>
     return
   }
 
-  func @step4(%arg0: memref<1x32x8x3x3xf32>, %arg1: memref<32x1x8x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) {
+  func @step4(%arg0: memref<1x32x8x3x3xf32>, %arg1: memref<32x1x8x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel} {
     miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x32x8x3x3xf32>, memref<32x1x8x32x32xf32>, memref<32x1x32x30x30xf32>
     return
   }

--- a/mlir/test/mlir-miopen-driver/populate.mlir
+++ b/mlir/test/mlir-miopen-driver/populate.mlir
@@ -3,13 +3,13 @@
 // RUN: mlir-miopen-driver -p -t bf16 | FileCheck %s --check-prefix=BF16
 
 // F32-LABEL: module
-// F32-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf32>, {{.*}}: memref<128x1x8x32x32xf32>, {{.*}}: memref<128x1x128x30x30xf32>)
+// F32-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf32>, {{.*}}: memref<128x1x8x32x32xf32>, {{.*}}: memref<128x1x128x30x30xf32>) attributes {kernel}
 // F32-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x128x8x3x3xf32>, memref<128x1x8x32x32xf32>, memref<128x1x128x30x30xf32>
 
 // F16-LABEL: module
-// F16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf16>, {{.*}}: memref<128x1x8x32x32xf16>, {{.*}}: memref<128x1x128x30x30xf16>)
+// F16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xf16>, {{.*}}: memref<128x1x8x32x32xf16>, {{.*}}: memref<128x1x128x30x30xf16>) attributes {kernel}
 // F16-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x128x8x3x3xf16>, memref<128x1x8x32x32xf16>, memref<128x1x128x30x30xf16>
 
 // BF16-LABEL: module
-// BF16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xi16>, {{.*}}: memref<128x1x8x32x32xi16>, {{.*}}: memref<128x1x128x30x30xi16>)
+// BF16-NEXT: func @miopen_conv2d_gkcyx_ngchw_ngkhw({{.*}}: memref<1x128x8x3x3xi16>, {{.*}}: memref<128x1x8x32x32xi16>, {{.*}}: memref<128x1x128x30x30xi16>) attributes {kernel}
 // BF16-NEXT: miopen.conv2d({{.*}}, {{.*}}, {{.*}})  {arch = "{{gfx[0-9]+}}", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = {{[0-9]+}} : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x128x8x3x3xi16>, memref<128x1x8x32x32xi16>, memref<128x1x128x30x30xi16>

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -1998,7 +1998,7 @@ static void populateDefaultLoweringPipeline(PassManager &pm,
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep3Pass());
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep4Pass());
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep5Pass());
-  pm.addPass(mlir::createLowerMIOpenOpsToGPUPass(kernelName));
+  pm.addPass(mlir::createLowerMIOpenOpsToGPUPass());
 
   // Passes for lowering linalg dialect.
   pm.addPass(mlir::createConvertLinalgToAffineLoopsPass());

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -1958,7 +1958,7 @@ static LogicalResult populateKernelLaunchLogic(ModuleOp &module,
 
   bool gpuKernelFound = false;
   module.walk([&](gpu::GPUModuleOp gpuModule) {
-    module.walk([&](gpu::GPUFuncOp gpuFunc) {
+    gpuModule.walk([&](gpu::GPUFuncOp gpuFunc) {
       if (gpuFunc.isKernel()) {
         // Remove the ReturnOp previously populated.
         if (!gpuKernelFound) {

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -1989,6 +1989,7 @@ static LogicalResult populateKernelLaunchLogic(ModuleOp &module,
 static void populateDefaultLoweringPipeline(PassManager &pm,
                                             StringRef kernelName) {
   // Passes for lowering MIOpen dialect.
+  pm.addPass(mlir::miopen::createSplitConv2DPass());
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
   pm.addPass(mlir::miopen::createAffineTransformPass());
   pm.addPass(


### PR DESCRIPTION
Experimental codes. DO NOT MERGE.

Show case how we could split `miopen.conv2d` into several kernel invocations including `miopen.conv2d` + `miopen.conv2d_dummy`.

The infrastructure in this PR would eventually be evolved to split `miopen.conv2d_bwd_data` into multiple pieces.

This PR depends on #137 .

One pass, `-miopen-split-conv2d` was added and introduced to the beginning of the pipeline.

Compilation part is finished. Changes needed in `mlir-rocm-runner` is undergoing. Unit tests ARE EXPECTED TO FAIL FOR NOW.
