### PR TITLE
Add a new test target

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -80,6 +80,8 @@ set(MLIR_VULKAN_RUNNER_ENABLED 0 CACHE BOOL "Enable building the mlir Vulkan run
 # MIOpen dialect.
 set(MLIR_MIOPEN_DRIVER_ENABLED 0 CACHE BOOL "Enable build MIOpen driver")
 set(MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build E2E tests for MIOpen driver")
+set(MLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED "none" CACHE STRING "Enable E2E tests using random data")
+set(MLIR_MIOPEN_DRIVER_XDLOPV2_TEST_ENABLED 0 CACHE BOOL "Enable build E2E tests for xdlop")
 
 set(MLIR_MIOPEN_SQLITE_ENABLED 0 CACHE BOOL "Enable SQLite integration")
 

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -81,7 +81,7 @@ set(MLIR_VULKAN_RUNNER_ENABLED 0 CACHE BOOL "Enable building the mlir Vulkan run
 set(MLIR_MIOPEN_DRIVER_ENABLED 0 CACHE BOOL "Enable build MIOpen driver")
 set(MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build E2E tests for MIOpen driver")
 set(MLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED "none" CACHE STRING "Enable E2E tests using random data")
-set(MLIR_MIOPEN_DRIVER_XDLOPV2_TEST_ENABLED 0 CACHE BOOL "Enable build E2E tests for xdlop")
+set(MLIR_MIOPEN_DRIVER_XDLOPS_TEST_ENABLED 0 CACHE BOOL "Enable build E2E tests for XDLops")
 
 set(MLIR_MIOPEN_SQLITE_ENABLED 0 CACHE BOOL "Enable SQLite integration")
 

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -119,12 +119,15 @@ if(MLIR_MIOPEN_DRIVER_ENABLED)
     )
 endif()
 
+# check-mlir runs MLIR regression tests including E2E tests 
+# if MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED
 add_lit_testsuite(check-mlir "Running the MLIR regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${MLIR_TEST_DEPENDS}
   )
 set_target_properties(check-mlir PROPERTIES FOLDER "Tests")
 
+# check-e2e only runs MLIR E2E tests in the subdirectory auto_e2e 
 if(MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED)
   list(APPEND MLIR_TEST_DEPENDS
       check-e2e

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(CAPI)
 add_subdirectory(EDSC)
 add_subdirectory(SDBM)
 add_subdirectory(lib)
+add_subdirectory(auto_e2e)
 
 llvm_canonicalize_cmake_booleans(
   MLIR_BINDINGS_PYTHON_ENABLED
@@ -123,6 +124,12 @@ add_lit_testsuite(check-mlir "Running the MLIR regression tests"
   DEPENDS ${MLIR_TEST_DEPENDS}
   )
 set_target_properties(check-mlir PROPERTIES FOLDER "Tests")
+
+if(MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED)
+  list(APPEND MLIR_TEST_DEPENDS
+      check-e2e
+      )
+endif()
 
 add_lit_testsuites(MLIR ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${MLIR_TEST_DEPENDS}

--- a/mlir/test/auto_e2e/CMakeLists.txt
+++ b/mlir/test/auto_e2e/CMakeLists.txt
@@ -1,0 +1,49 @@
+llvm_canonicalize_cmake_booleans(
+ MLIR_ROCM_CONVERSIONS_ENABLED
+ MLIR_ROCM_RUNNER_ENABLED
+  )
+
+# Passed to lit.site.cfg.py.in to set up the path where to find the libraries
+# for linalg integration tests.
+set(MLIR_DIALECT_LINALG_INTEGRATION_TEST_LIB_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
+# Passed to lit.site.cfg.py.in to set up the path where to find the libraries
+# for the mlir cuda / rocm / spirv / vulkan runner tests.
+set(MLIR_ROCM_WRAPPER_LIBRARY_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
+if(MLIR_MIOPEN_DRIVER_XDLOPV2_TEST_ENABLED)
+  set(MLIR_XDLOPV2 "-x2")
+endif()
+
+if(NOT MLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED STREQUAL "none")
+  set(MLIR_RANDOM_DATA "-rand ${MLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED} ")
+endif()
+
+
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  )
+
+set(MLIR_E2E_TEST_DEPENDS
+  FileCheck count not
+  mlir-miopen-driver
+  mlir-rocm-runner
+  mlir-miopen-lib-test
+  mlir-opt
+  mlir-translate
+  opt
+  llc
+  )
+
+add_lit_testsuite(check-e2e "Running the MLIR end-to-end tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${MLIR_E2E_TEST_DEPENDS}
+  )
+set_target_properties(check-e2e PROPERTIES FOLDER "Tests")
+
+add_lit_testsuites(MLIR ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${MLIR_E2E_TEST_DEPENDS}
+)

--- a/mlir/test/auto_e2e/CMakeLists.txt
+++ b/mlir/test/auto_e2e/CMakeLists.txt
@@ -1,6 +1,6 @@
 llvm_canonicalize_cmake_booleans(
- MLIR_ROCM_CONVERSIONS_ENABLED
- MLIR_ROCM_RUNNER_ENABLED
+  MLIR_ROCM_CONVERSIONS_ENABLED
+  MLIR_ROCM_RUNNER_ENABLED
   )
 
 # Passed to lit.site.cfg.py.in to set up the path where to find the libraries
@@ -30,7 +30,6 @@ configure_lit_site_cfg(
 set(MLIR_E2E_TEST_DEPENDS
   FileCheck count not
   mlir-miopen-driver
-  mlir-rocm-runner
   mlir-miopen-lib-test
   mlir-opt
   mlir-translate

--- a/mlir/test/auto_e2e/CMakeLists.txt
+++ b/mlir/test/auto_e2e/CMakeLists.txt
@@ -11,10 +11,12 @@ set(MLIR_DIALECT_LINALG_INTEGRATION_TEST_LIB_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTOR
 # for the mlir cuda / rocm / spirv / vulkan runner tests.
 set(MLIR_ROCM_WRAPPER_LIBRARY_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
-if(MLIR_MIOPEN_DRIVER_XDLOPV2_TEST_ENABLED)
-  set(MLIR_XDLOPV2 "-x2")
+# Passed to lit.site.cfg.py.in to set the -x2 flag for the mlir E2E tests.
+if(MLIR_MIOPEN_DRIVER_XDLOPS_TEST_ENABLED)
+  set(MLIR_XDLOPS "-x2")
 endif()
 
+# Passed to lit.site.cfg.py.in to set the -rand flag for the mlir E2E tests.
 if(NOT MLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED STREQUAL "none")
   set(MLIR_RANDOM_DATA "-rand ${MLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED} ")
 endif()
@@ -37,6 +39,7 @@ set(MLIR_E2E_TEST_DEPENDS
   llc
   )
 
+# check-e2e runs MLIR E2E tests with or without -x2 or -rand flags
 add_lit_testsuite(check-e2e "Running the MLIR end-to-end tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${MLIR_E2E_TEST_DEPENDS}

--- a/mlir/test/auto_e2e/conv2d_host_validation.mlir
+++ b/mlir/test/auto_e2e/conv2d_host_validation.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-miopen-driver -p -pv %random_data %xdlopv2 -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_1
+// RUN: mlir-miopen-driver -p -pv %random_data %xdlops -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_1
 
 // CHECK_1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_1: [1]

--- a/mlir/test/auto_e2e/conv2d_host_validation.mlir
+++ b/mlir/test/auto_e2e/conv2d_host_validation.mlir
@@ -1,0 +1,4 @@
+// RUN: mlir-miopen-driver -p -pv %random_data %xdlopv2 -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_1
+
+// CHECK_1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_1: [1]

--- a/mlir/test/auto_e2e/lit.cfg.py
+++ b/mlir/test/auto_e2e/lit.cfg.py
@@ -1,0 +1,63 @@
+# -*- Python -*-
+
+import os
+import platform
+import re
+import subprocess
+import tempfile
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+from lit.llvm.subst import FindTool
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = 'MLIR'
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.mlir']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.mlir_obj_root, 'test')
+
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
+config.substitutions.append(("%mlir_src_root", config.mlir_src_root))
+config.substitutions.append(('%random_data', config.random_data))
+config.substitutions.append(('%xdlopv2', config.xdlopv2))
+
+llvm_config.with_system_environment(
+    ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+
+llvm_config.use_default_substitutions()
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ['Inputs', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt',
+                   'lit.cfg.py', 'lit.site.cfg.py']
+
+# Tweak the PATH to include the tools dir.
+llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+
+tool_dirs = [config.mlir_tools_dir, config.llvm_tools_dir]
+
+tools = [ToolSubst('%linalg_test_lib_dir', config.linalg_test_lib_dir, unresolved='ignore'),
+         ToolSubst('%rocm_wrapper_library_dir', config.rocm_wrapper_library_dir, unresolved='ignore')]
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)
+
+
+# FileCheck -enable-var-scope is enabled by default in MLIR test
+# This option avoids to accidentally reuse variable across -LABEL match,
+# it can be explicitly opted-in by prefixing the variable name with $
+config.environment['FILECHECK_OPTS'] = "-enable-var-scope --allow-unused-prefixes=false"

--- a/mlir/test/auto_e2e/lit.cfg.py
+++ b/mlir/test/auto_e2e/lit.cfg.py
@@ -33,7 +33,7 @@ config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
 config.substitutions.append(("%mlir_src_root", config.mlir_src_root))
 config.substitutions.append(('%random_data', config.random_data))
-config.substitutions.append(('%xdlopv2', config.xdlopv2))
+config.substitutions.append(('%xdlops', config.xdlops))
 
 llvm_config.with_system_environment(
     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])

--- a/mlir/test/auto_e2e/lit.local.cfg
+++ b/mlir/test/auto_e2e/lit.local.cfg
@@ -1,0 +1,2 @@
+if not config.enable_miopen_driver_e2e_test:
+  config.unsupported = True

--- a/mlir/test/auto_e2e/lit.site.cfg.py.in
+++ b/mlir/test/auto_e2e/lit.site.cfg.py.in
@@ -1,0 +1,57 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.host_triple = "@LLVM_HOST_TRIPLE@"
+config.target_triple = "@TARGET_TRIPLE@"
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_lib_dir = "@LLVM_LIBRARY_DIR@"
+config.llvm_shlib_dir = "@SHLIBDIR@"
+config.llvm_shlib_ext = "@SHLIBEXT@"
+config.llvm_exe_ext = "@EXEEXT@"
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.python_executable = "@Python3_EXECUTABLE@"
+config.gold_executable = "@GOLD_EXECUTABLE@"
+config.ld64_executable = "@LD64_EXECUTABLE@"
+config.enable_shared = @ENABLE_SHARED@
+config.enable_assertions = @ENABLE_ASSERTIONS@
+config.targets_to_build = "@TARGETS_TO_BUILD@"
+config.native_target = "@LLVM_NATIVE_ARCH@"
+config.llvm_bindings = "@LLVM_BINDINGS@".split(' ')
+config.host_os = "@HOST_OS@"
+config.host_cc = "@HOST_CC@"
+config.host_cxx = "@HOST_CXX@"
+config.host_cmake = "@CMAKE_COMMAND@"
+# Note: ldflags can contain double-quoted paths, so must use single quotes here.
+config.host_ldflags = '@HOST_LDFLAGS@'
+config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
+config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
+config.host_arch = "@HOST_ARCH@"
+config.mlir_src_root = "@MLIR_SOURCE_DIR@"
+config.mlir_obj_root = "@MLIR_BINARY_DIR@"
+config.mlir_tools_dir = "@MLIR_TOOLS_DIR@"
+config.linalg_test_lib_dir = "@MLIR_DIALECT_LINALG_INTEGRATION_TEST_LIB_DIR@"
+config.rocm_wrapper_library_dir = "@MLIR_ROCM_WRAPPER_LIBRARY_DIR@"
+config.enable_rocm_runner = @MLIR_ROCM_RUNNER_ENABLED@
+config.enable_miopen_driver = @MLIR_MIOPEN_DRIVER_ENABLED@
+config.enable_miopen_driver_e2e_test = @MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED@
+config.random_data = "@MLIR_RANDOM_DATA@"
+config.xdlopv2 = "@MLIR_XDLOPV2@"
+
+# Support substitution of the tools_dir with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_shlib_dir = config.llvm_shlib_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@MLIR_SOURCE_DIR@/test/auto_e2e/lit.cfg.py")

--- a/mlir/test/auto_e2e/lit.site.cfg.py.in
+++ b/mlir/test/auto_e2e/lit.site.cfg.py.in
@@ -38,7 +38,7 @@ config.enable_rocm_runner = @MLIR_ROCM_RUNNER_ENABLED@
 config.enable_miopen_driver = @MLIR_MIOPEN_DRIVER_ENABLED@
 config.enable_miopen_driver_e2e_test = @MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED@
 config.random_data = "@MLIR_RANDOM_DATA@"
-config.xdlopv2 = "@MLIR_XDLOPV2@"
+config.xdlops = "@MLIR_XDLOPS@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -45,10 +45,10 @@ config.excludes = ['Inputs', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt',
                    'lit.cfg.py', 'lit.site.cfg.py']
 
 # test_source_root: The root path where tests are located.
-#config.test_source_root = os.path.dirname(__file__)
+config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-#config.test_exec_root = os.path.join(config.mlir_obj_root, 'test')
+config.test_exec_root = os.path.join(config.mlir_obj_root, 'test')
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -45,10 +45,10 @@ config.excludes = ['Inputs', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt',
                    'lit.cfg.py', 'lit.site.cfg.py']
 
 # test_source_root: The root path where tests are located.
-config.test_source_root = os.path.dirname(__file__)
+#config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.mlir_obj_root, 'test')
+#config.test_exec_root = os.path.join(config.mlir_obj_root, 'test')
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)

--- a/mlir/utils/jenkins/Jenkinsfile.nightly
+++ b/mlir/utils/jenkins/Jenkinsfile.nightly
@@ -43,6 +43,33 @@ pipeline {
                 '''
             }
         }
+        stage('Test Random E2E') {
+            steps {
+                sh '''
+                    mkdir -p build && cd build
+                    # Set the path to llvm-symbolizer
+                    PATH=$PATH:/opt/rocm-4.0.0/llvm/bin/
+
+                    cmake -G Ninja ../llvm \
+                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
+                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
+                        -DCMAKE_BUILD_TYPE=Release \
+                        -DLLVM_ENABLE_ASSERTIONS=ON \
+                        -DBUILD_SHARED_LIBS=ON \
+                        -DLLVM_BUILD_LLVM_DYLIB=ON \
+                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
+                        -DMLIR_MIOPEN_DRIVER_ENABLED=1 \
+                        -DMLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED=1 \
+                        -DMLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED=1
+
+                    # Build LLVM / MLIR and run E2E tests
+                    cmake --build . --target check-e2e
+
+                    # Clean up build directory
+                    rm -rf build
+                '''
+            }
+        }
     }
     post {
         always {


### PR DESCRIPTION
These changes allow us to run e2e tests with or without -x2 and -rand flags.

  - Add a new test target check-e2e for running e2e tests in the mlir/test/auto_e2e folder.
  - Add an environment variable MLIR_MIOPEN_DRIVER_XDLOPV2_TEST_ENABLED to automatically add -x2 to a test.
  - Add an environment variable MLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED to specify the seed of random number generator and automatically add -rand \<seed\> to a test.
  - Add a new stage in Jenkins.nightly to run auto_e2e tests with the -rand flag. 

The target check-mlir runs non-e2e mlir tests, mlir-miopen-driver/e2e and auto_e2e tests. The new target check-e2e runs tests in auto-e2e.

In this PR, I only have one test in the mlir/test/auto_e2e folder.  I'll gradually move test cases from mlir-miopen-driver/e2e into auto_e2e. Eventually all tests will be in auto_e2e and run with and without -rand nightly. They will also be tested with -x2 on an XDL server.

The CI console output related to this PR is [here](http://ml-ci.amd.com:21096/job/MLIR/job/check-e2e/2/console).

I've manually tested MLIR_MIOPEN_DRIVER_XDLOPV2_TEST_ENABLED and -x2 flag, and they worked correctly. But they cannot be run on the non-xdl server.

I created auto_e2e in test directory because I found it easy for me to add a new test target. Jerry has suggested to group test cases based on the target, for example. put all Resnet50 tests in integration_test directory. I tried, but couldn't make it work. The whole cmake thing is new to me. As I'm getting more familiar to cmake, I can re-arrange the test cases if needed.
