### PR TITLE
Enable atomic fadd intrinsics.

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -985,4 +985,19 @@ def GPU_MubufStoreOp :
   let verifier = [{ return ::verify(*this); }];
 }
 
+// atomic add
+def GPU_AtomicFAddOp :
+    GPU_Op<"atomic_fadd">,
+    Arguments<(ins AnyTypeOf<[F32, VectorOfLengthAndType<[2, 4], [F32]>]>:$value,
+                   AnyMemRef:$memref,
+                   Variadic<I32>:$indices)> {
+  let summary = "AMD GPU Atomic Floating Point Add";
+  let description = [{
+    The `gpu.atomic_add` op is an abstraction of AMD GPU atomic floating point add
+    intrinsics.
+  }];
+  let parser = [{ return parseAtomicFAddOp(parser, result); }];
+  let printer = [{ return ::print(p, *this); }];
+  let verifier = [{ return ::verify(*this); }];
+}
 #endif // GPU_OPS

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -245,4 +245,29 @@ def ROCDL_RawbufStoreOp :
   }];
 }
 
+//===---------------------------------------------------------------------===//
+// Float atomic add intrinsic
+
+def ROCDL_AtomicFAddOp :
+  ROCDL_Op<"atomic.fadd">,
+  Arguments<(ins LLVM_Type:$vdata,
+                 LLVM_Type:$rsrc,
+                 LLVM_Type:$vindex,
+                 LLVM_Type:$offset,
+                 LLVM_Type:$slc)>{
+  string llvmBuilder = [{
+      auto vdataType = op.vdata().getType().cast<LLVM::LLVMType>()
+                         .getUnderlyingType();
+      createIntrinsicCall(builder,
+          llvm::Intrinsic::amdgcn_buffer_atomic_fadd, {$vdata, $rsrc, $vindex, $offset,
+            $slc}, {vdataType});
+  }];
+  let parser = [{ return parseROCDLAtomicFAddOp(parser, result); }];
+  let printer = [{
+    Operation *op = this->getOperation();
+    p << op->getName() << " " << op->getOperands()
+      << " : " << vdata().getType();
+  }];
+}
+
 #endif // ROCDLIR_OPS

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -256,8 +256,7 @@ def ROCDL_AtomicFAddOp :
                  LLVM_Type:$offset,
                  LLVM_Type:$slc)>{
   string llvmBuilder = [{
-      auto vdataType = op.vdata().getType().cast<LLVM::LLVMType>()
-                         .getUnderlyingType();
+      auto vdataType = convertType(op.vdata().getType());
       createIntrinsicCall(builder,
           llvm::Intrinsic::amdgcn_buffer_atomic_fadd, {$vdata, $rsrc, $vindex, $offset,
             $slc}, {vdataType});

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -823,7 +823,9 @@ void mlir::populateGpuToROCDLConversionPatterns(
   patterns.insert<MubufLoadOpLowering>(converter.getDialect()->getContext(),
                                        converter);
   patterns.insert<MubufStoreOpLowering>(converter.getDialect()->getContext(),
+                                        converter);
   patterns.insert<AtomicFAddOpLowering>(converter.getDialect()->getContext(),
+                                        converter);
 }
 
 std::unique_ptr<OperationPass<gpu::GPUModuleOp>>

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -441,6 +441,160 @@ struct MubufStoreOpLowering : ConvertToLLVMPattern {
   }
 };
 
+struct AtomicFAddOpLowering : ConvertToLLVMPattern {
+  explicit AtomicFAddOpLowering(MLIRContext *context,
+                                LLVMTypeConverter &typeConverter)
+      : ConvertToLLVMPattern(gpu::AtomicFAddOp::getOperationName(), context,
+                             typeConverter) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto atomicAddOp = cast<gpu::AtomicFAddOp>(op);
+    auto adaptor = gpu::AtomicFAddOpOperandAdaptor(operands);
+    auto loc = atomicAddOp.getLoc();
+
+    MemRefType dstMemRefType =
+        atomicAddOp.memref().getType().cast<MemRefType>();
+    Type dstElementType = dstMemRefType.getElementType();
+    auto dstShape = dstMemRefType.getShape();
+    auto adaptorIndices = adaptor.indices();
+    auto adaptorValue = adaptor.value();
+
+    Type valueType = atomicAddOp.value().getType();
+    Type LLVMValueType = typeConverter.convertType(valueType);
+
+    // use rocdl.atomic_add.
+
+    Type I1Type = rewriter.getI1Type();
+    Type LLVMI1Type = typeConverter.convertType(I1Type);
+
+    Type I32Type = rewriter.getIntegerType(32);
+    Type LLVMI32Type = typeConverter.convertType(I32Type);
+
+    Type I64Type = rewriter.getIntegerType(64);
+    Type LLVMI64Type = typeConverter.convertType(I64Type);
+
+    Type rsrcVectorType = VectorType::get({4}, I32Type);
+    Type LLVMRsrcVectorType = typeConverter.convertType(rsrcVectorType);
+
+    Type I32x2Type = VectorType::get({2}, I32Type);
+    Type LLVMI32x2Type = typeConverter.convertType(I32x2Type);
+
+    // word 0-1: pointer to memref.
+    MemRefDescriptor memrefDescriptor(adaptor.memref());
+    Value ptr = memrefDescriptor.alignedPtr(rewriter, loc);
+    Value ptrToInt = rewriter.create<LLVM::PtrToIntOp>(loc, LLVMI64Type, ptr);
+
+    // word 0-1: pointer to memref.
+    Value ptrBitcasted =
+        rewriter.create<LLVM::BitcastOp>(loc, LLVMI32x2Type, ptrToInt);
+    Value rsrcUndefTwoItems =
+        rewriter.create<LLVM::UndefOp>(loc, LLVMI32x2Type);
+    Value rsrcFirstTwoItems = rewriter.create<LLVM::ShuffleVectorOp>(
+        loc, ptrBitcasted, rsrcUndefTwoItems,
+        rewriter.getI32ArrayAttr({0, 1, -1, -1}));
+
+    Value rsrcUndef = rewriter.create<LLVM::UndefOp>(loc, LLVMRsrcVectorType);
+    // word 2: fixed as -1 .
+    Value constant2 = rewriter.create<LLVM::ConstantOp>(
+        loc, LLVMI32Type, rewriter.getI32IntegerAttr(2));
+    Value minusOne = rewriter.create<LLVM::ConstantOp>(
+        loc, LLVMI32Type, rewriter.getI32IntegerAttr(-1));
+    Value rsrc2 = rewriter.create<LLVM::InsertElementOp>(
+        loc, LLVMRsrcVectorType, rsrcUndef, minusOne, constant2);
+
+    // word 3: fixed as 0x00027000 .
+    Value constant3 = rewriter.create<LLVM::ConstantOp>(
+        loc, LLVMI32Type, rewriter.getI32IntegerAttr(3));
+    Value bufferLoadConstant = rewriter.create<LLVM::ConstantOp>(
+        loc, LLVMI32Type, rewriter.getI32IntegerAttr(0x00027000));
+    Value rsrcLastTwoItems = rewriter.create<LLVM::InsertElementOp>(
+        loc, LLVMRsrcVectorType, rsrc2, bufferLoadConstant, constant3);
+
+    Value rsrc = rewriter.create<LLVM::ShuffleVectorOp>(
+        loc, rsrcFirstTwoItems, rsrcLastTwoItems,
+        rewriter.getI32ArrayAttr({0, 1, 6, 7}));
+
+    // populate vindex : fixed as 0 of type i32.
+    Value vindex = rewriter.create<LLVM::ConstantOp>(
+        loc, LLVMI32Type, rewriter.getI32IntegerAttr(0));
+
+    // populate slc : fixed as 0 of type i1.
+    Value slc = rewriter.create<LLVM::ConstantOp>(
+        loc, LLVMI1Type, rewriter.getIntegerAttr(I1Type, 0));
+
+    if (valueType.isa<VectorType>()) {
+      // Iteratively do floating point atomic add for each element of the
+      // vector.
+      VectorType valueVectorType = valueType.template cast<VectorType>();
+      Type valueElementType = valueVectorType.getElementType();
+      Type LLVMValueElementType = typeConverter.convertType(valueElementType);
+
+      for (unsigned iter = 0; iter < valueVectorType.getShape()[0]; ++iter) {
+        auto iterConstant = rewriter.create<LLVM::ConstantOp>(
+            loc, LLVMI32Type, rewriter.getI32IntegerAttr(iter));
+        auto element = rewriter.create<LLVM::ExtractElementOp>(
+            loc, LLVMValueElementType, adaptorValue, iterConstant);
+
+        // populate voffset.
+        SmallVector<Value, 4> indices;
+        SmallVector<Value, 4> allocSizes;
+        for (unsigned i = 0; i < dstShape.size(); ++i) {
+          indices.push_back(adaptorIndices[i]);
+          allocSizes.push_back(rewriter.create<LLVM::ConstantOp>(
+              loc, LLVMI32Type, rewriter.getI32IntegerAttr(dstShape[i])));
+        }
+        Value voffsetElements = linearizeSubscripts(
+            rewriter, loc, ArrayRef<Value>{indices.begin(), indices.end()},
+            ArrayRef<Value>{allocSizes.begin(), allocSizes.end()});
+
+        // vindex is counted in bytes. Times size of element type.
+        Value elementBytes = rewriter.create<LLVM::ConstantOp>(
+            loc, LLVMI32Type,
+            rewriter.getI32IntegerAttr(dstMemRefType.getElementTypeBitWidth() /
+                                       8));
+        Value voffset = rewriter.create<LLVM::MulOp>(
+            loc, LLVMI32Type, ArrayRef<Value>{voffsetElements, elementBytes});
+
+        // voffset is added with the iter * size of element type.
+        Value elementOffset = rewriter.create<LLVM::MulOp>(
+            loc, LLVMI32Type, ArrayRef<Value>{iterConstant, elementBytes});
+        Value voffsetUpdated = rewriter.create<LLVM::AddOp>(
+            loc, LLVMI32Type, voffset, elementOffset);
+
+        rewriter.replaceOpWithNewOp<ROCDL::AtomicFAddOp>(
+            op, element, rsrc, vindex, voffsetUpdated, slc);
+      }
+    } else {
+      // populate voffset.
+      SmallVector<Value, 4> indices;
+      SmallVector<Value, 4> allocSizes;
+      for (unsigned i = 0; i < dstShape.size(); ++i) {
+        indices.push_back(adaptorIndices[i]);
+        allocSizes.push_back(rewriter.create<LLVM::ConstantOp>(
+            loc, LLVMI32Type, rewriter.getI32IntegerAttr(dstShape[i])));
+      }
+      Value voffsetElements = linearizeSubscripts(
+          rewriter, loc, ArrayRef<Value>{indices.begin(), indices.end()},
+          ArrayRef<Value>{allocSizes.begin(), allocSizes.end()});
+
+      // vindex is counted in bytes. Times size of element type.
+      Value elementBytes = rewriter.create<LLVM::ConstantOp>(
+          loc, LLVMI32Type,
+          rewriter.getI32IntegerAttr(dstMemRefType.getElementTypeBitWidth() /
+                                     8));
+      Value voffset = rewriter.create<LLVM::MulOp>(
+          loc, LLVMI32Type, ArrayRef<Value>{voffsetElements, elementBytes});
+
+      rewriter.replaceOpWithNewOp<ROCDL::AtomicFAddOp>(op, adaptorValue, rsrc,
+                                                       vindex, voffset, slc);
+    }
+
+    return success();
+  }
+};
+
 struct MFMAOpLowering : ConvertToLLVMPattern {
   explicit MFMAOpLowering(MLIRContext *context,
                           LLVMTypeConverter &typeConverter)
@@ -660,10 +814,11 @@ void mlir::populateGpuToROCDLConversionPatterns(
 
   patterns.insert<BFOpLowering>(converter.getDialect()->getContext(),
                                 converter);
+
   patterns.insert<MubufLoadOpLowering>(converter.getDialect()->getContext(),
                                        converter);
   patterns.insert<MubufStoreOpLowering>(converter.getDialect()->getContext(),
-                                        converter);
+  patterns.insert<AtomicFAddOpLowering>(converter.getDialect()->getContext(),
 }
 
 std::unique_ptr<OperationPass<gpu::GPUModuleOp>>

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -563,8 +563,13 @@ struct AtomicFAddOpLowering : ConvertToLLVMPattern {
         Value voffsetUpdated = rewriter.create<LLVM::AddOp>(
             loc, LLVMI32Type, voffset, elementOffset);
 
-        rewriter.replaceOpWithNewOp<ROCDL::AtomicFAddOp>(
-            op, element, rsrc, vindex, voffsetUpdated, slc);
+        if (iter == 0) {
+          rewriter.replaceOpWithNewOp<ROCDL::AtomicFAddOp>(
+              op, element, rsrc, vindex, voffsetUpdated, slc);
+        } else {
+          rewriter.create<ROCDL::AtomicFAddOp>(loc, element, rsrc, vindex,
+                                               voffsetUpdated, slc);
+        }
       }
     } else {
       // populate voffset.

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -451,7 +451,7 @@ struct AtomicFAddOpLowering : ConvertToLLVMPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     auto atomicAddOp = cast<gpu::AtomicFAddOp>(op);
-    auto adaptor = gpu::AtomicFAddOpOperandAdaptor(operands);
+    auto adaptor = gpu::AtomicFAddOpAdaptor(operands);
     auto loc = atomicAddOp.getLoc();
 
     MemRefType dstMemRefType =
@@ -462,24 +462,24 @@ struct AtomicFAddOpLowering : ConvertToLLVMPattern {
     auto adaptorValue = adaptor.value();
 
     Type valueType = atomicAddOp.value().getType();
-    Type LLVMValueType = typeConverter.convertType(valueType);
+    Type LLVMValueType = typeConverter->convertType(valueType);
 
     // use rocdl.atomic_add.
 
     Type I1Type = rewriter.getI1Type();
-    Type LLVMI1Type = typeConverter.convertType(I1Type);
+    Type LLVMI1Type = typeConverter->convertType(I1Type);
 
     Type I32Type = rewriter.getIntegerType(32);
-    Type LLVMI32Type = typeConverter.convertType(I32Type);
+    Type LLVMI32Type = typeConverter->convertType(I32Type);
 
     Type I64Type = rewriter.getIntegerType(64);
-    Type LLVMI64Type = typeConverter.convertType(I64Type);
+    Type LLVMI64Type = typeConverter->convertType(I64Type);
 
     Type rsrcVectorType = VectorType::get({4}, I32Type);
-    Type LLVMRsrcVectorType = typeConverter.convertType(rsrcVectorType);
+    Type LLVMRsrcVectorType = typeConverter->convertType(rsrcVectorType);
 
     Type I32x2Type = VectorType::get({2}, I32Type);
-    Type LLVMI32x2Type = typeConverter.convertType(I32x2Type);
+    Type LLVMI32x2Type = typeConverter->convertType(I32x2Type);
 
     // word 0-1: pointer to memref.
     MemRefDescriptor memrefDescriptor(adaptor.memref());
@@ -529,7 +529,7 @@ struct AtomicFAddOpLowering : ConvertToLLVMPattern {
       // vector.
       VectorType valueVectorType = valueType.template cast<VectorType>();
       Type valueElementType = valueVectorType.getElementType();
-      Type LLVMValueElementType = typeConverter.convertType(valueElementType);
+      Type LLVMValueElementType = typeConverter->convertType(valueElementType);
 
       for (unsigned iter = 0; iter < valueVectorType.getShape()[0]; ++iter) {
         auto iterConstant = rewriter.create<LLVM::ConstantOp>(

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -912,6 +912,7 @@ static void print(OpAsmPrinter &p, gpu::MFMAOp op) {
 
 static LogicalResult verify(gpu::MFMAOp op) { return success(); }
 
+//===----------------------------------------------------------------------===//
 // BFConvertOp
 //===----------------------------------------------------------------------===//
 static ParseResult parseBFConvertOp(OpAsmParser &parser,
@@ -998,6 +999,38 @@ static void print(OpAsmPrinter &p, gpu::MubufStoreOp op) {
 }
 
 static LogicalResult verify(gpu::MubufStoreOp op) { return success(); }
+
+//===----------------------------------------------------------------------===//
+// AtomicFAddOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseAtomicFAddOp(OpAsmParser &parser,
+                                     OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 5> ops;
+  SmallVector<Type, 5> types;
+
+  auto ret = parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+             parser.parseOptionalAttrDict(result.attributes) ||
+             parser.parseColonTypeList(types) ||
+             parser.resolveOperand(ops[0], types[0], result.operands) ||
+             parser.resolveOperand(ops[1], types[1], result.operands);
+
+  // resolve source coorindates.
+  for (unsigned i = 2; i < ops.size(); ++i) {
+    ret &= succeeded(parser.resolveOperand(
+        ops[i], parser.getBuilder().getIntegerType(32), result.operands));
+  }
+
+  return failure(ret);
+}
+
+static void print(OpAsmPrinter &p, gpu::AtomicFAddOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.value().getType() << ", " << op.memref().getType();
+}
+
+static LogicalResult verify(gpu::AtomicFAddOp op) { return success(); }
 
 #include "mlir/Dialect/GPU/GPUOpInterfaces.cpp.inc"
 #define GET_OP_CLASSES

--- a/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
@@ -124,12 +124,12 @@ static ParseResult parseROCDLAtomicFAddOp(OpAsmParser &parser,
   if (parser.parseOperandList(ops, 5) || parser.parseColonType(type))
     return failure();
 
-  auto int32Ty = LLVM::LLVMType::getInt32Ty(getLlvmDialect(parser));
-  auto int1Ty = LLVM::LLVMType::getInt1Ty(getLlvmDialect(parser));
-  auto i32x4Ty = LLVM::LLVMType::getVectorTy(int32Ty, 4);
+  auto bldr = parser.getBuilder();
+  auto int32Ty = bldr.getI32Type();
+  auto int1Ty = bldr.getI1Type();
+  auto i32x4Ty = VectorType::get({4}, int32Ty);
 
-  if (parser.resolveOperands(ops,
-                             {type, i32x4Ty, int32Ty, int32Ty, int1Ty},
+  if (parser.resolveOperands(ops, {type, i32x4Ty, int32Ty, int32Ty, int1Ty},
                              parser.getNameLoc(), result.operands))
     return failure();
   return success();

--- a/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
@@ -114,6 +114,27 @@ static ParseResult parseROCDLRawbufStoreOp(OpAsmParser &parser,
   return success();
 }
 
+// <operation> ::=
+//     `llvm.amdgcn.buffer.atomic.fadd.* %vdata, %rsrc, %vindex, %offset, %slc :
+//     result_type`
+static ParseResult parseROCDLAtomicFAddOp(OpAsmParser &parser,
+                                          OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 5> ops;
+  Type type;
+  if (parser.parseOperandList(ops, 5) || parser.parseColonType(type))
+    return failure();
+
+  auto int32Ty = LLVM::LLVMType::getInt32Ty(getLlvmDialect(parser));
+  auto int1Ty = LLVM::LLVMType::getInt1Ty(getLlvmDialect(parser));
+  auto i32x4Ty = LLVM::LLVMType::getVectorTy(int32Ty, 4);
+
+  if (parser.resolveOperands(ops,
+                             {type, i32x4Ty, int32Ty, int32Ty, int1Ty},
+                             parser.getNameLoc(), result.operands))
+    return failure();
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // ROCDLDialect initialization, type parsing, and registration.
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Conversion/GPUToROCDL/atomic_fadd.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/atomic_fadd.mlir
@@ -1,0 +1,41 @@
+// RUN: mlir-opt %s -convert-gpu-to-rocdl | FileCheck %s --dump-input-on-failure
+
+gpu.module @mubuf_store {
+  // f32 tests.
+
+  // CHECK-LABEL: func @atomic_fadd_f32_to_rank_1
+  func @atomic_fadd_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %offset0 : i32) {
+    gpu.atomic_fadd(%value, %dst, %offset0) : f32, memref<128xf32>
+    return
+  }
+
+  // CHECK-LABEL: func @atomic_fadd_f32_to_rank_4
+  func @atomic_fadd_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
+    return
+  }
+
+  // CHECK-LABEL: func @atomic_fadd_2xf32_to_rank_1
+  func @atomic_fadd_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %offset0 : i32) {
+    gpu.atomic_fadd(%value, %dst, %offset0) : vector<2xf32>, memref<128xf32>
+    return
+  }
+
+  // CHECK-LABEL: func @atomic_fadd_2xf32_to_rank_4
+  func @atomic_fadd_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
+    return
+  }
+
+  // CHECK-LABEL: func @atomic_fadd_4xf32_to_rank_1
+  func @atomic_fadd_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %offset0 : i32) {
+    gpu.atomic_fadd(%value, %dst, %offset0) : vector<4xf32>, memref<128xf32>
+    return
+  }
+
+  // CHECK-LABEL: func @atomic_fadd_4xf32_to_rank_4
+  func @atomic_fadd_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
+    return
+  }
+}

--- a/mlir/test/Conversion/GPUToROCDL/atomic_fadd.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/atomic_fadd.mlir
@@ -1,54 +1,54 @@
-// RUN: mlir-opt %s -convert-gpu-to-rocdl | FileCheck %s --dump-input-on-failure
+// RUN: mlir-opt %s -convert-gpu-to-rocdl | FileCheck %s
 
-gpu.module @mubuf_store {
+gpu.module @atomic_fadd {
   // f32 tests.
 
   // CHECK-LABEL: llvm.func @atomic_fadd_f32_to_rank_1
   func @atomic_fadd_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %offset0 : i32) {
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
     gpu.atomic_fadd(%value, %dst, %offset0) : f32, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: llvm.func @atomic_fadd_f32_to_rank_4
   func @atomic_fadd_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
     gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
     return
   }
 
   // CHECK-LABEL: llvm.func @atomic_fadd_2xf32_to_rank_1
   func @atomic_fadd_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %offset0 : i32) {
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
     gpu.atomic_fadd(%value, %dst, %offset0) : vector<2xf32>, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: llvm.func @atomic_fadd_2xf32_to_rank_4
   func @atomic_fadd_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
     gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
     return
   }
 
   // CHECK-LABEL: llvm.func @atomic_fadd_4xf32_to_rank_1
   func @atomic_fadd_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %offset0 : i32) {
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
     gpu.atomic_fadd(%value, %dst, %offset0) : vector<4xf32>, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: llvm.func @atomic_fadd_4xf32_to_rank_4
   func @atomic_fadd_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
-    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
     gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
     return
   }

--- a/mlir/test/Conversion/GPUToROCDL/atomic_fadd.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/atomic_fadd.mlir
@@ -3,38 +3,52 @@
 gpu.module @mubuf_store {
   // f32 tests.
 
-  // CHECK-LABEL: func @atomic_fadd_f32_to_rank_1
+  // CHECK-LABEL: llvm.func @atomic_fadd_f32_to_rank_1
   func @atomic_fadd_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %offset0 : i32) {
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
     gpu.atomic_fadd(%value, %dst, %offset0) : f32, memref<128xf32>
     return
   }
 
-  // CHECK-LABEL: func @atomic_fadd_f32_to_rank_4
+  // CHECK-LABEL: llvm.func @atomic_fadd_f32_to_rank_4
   func @atomic_fadd_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
     gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
     return
   }
 
-  // CHECK-LABEL: func @atomic_fadd_2xf32_to_rank_1
+  // CHECK-LABEL: llvm.func @atomic_fadd_2xf32_to_rank_1
   func @atomic_fadd_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %offset0 : i32) {
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
     gpu.atomic_fadd(%value, %dst, %offset0) : vector<2xf32>, memref<128xf32>
     return
   }
 
-  // CHECK-LABEL: func @atomic_fadd_2xf32_to_rank_4
+  // CHECK-LABEL: llvm.func @atomic_fadd_2xf32_to_rank_4
   func @atomic_fadd_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
     gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
     return
   }
 
-  // CHECK-LABEL: func @atomic_fadd_4xf32_to_rank_1
+  // CHECK-LABEL: llvm.func @atomic_fadd_4xf32_to_rank_1
   func @atomic_fadd_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %offset0 : i32) {
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
     gpu.atomic_fadd(%value, %dst, %offset0) : vector<4xf32>, memref<128xf32>
     return
   }
 
-  // CHECK-LABEL: func @atomic_fadd_4xf32_to_rank_4
+  // CHECK-LABEL: llvm.func @atomic_fadd_4xf32_to_rank_4
   func @atomic_fadd_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
+    // CHECK: rocdl.atomic.fadd %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.float
     gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
     return
   }

--- a/mlir/test/Dialect/GPU/ops.mlir
+++ b/mlir/test/Dialect/GPU/ops.mlir
@@ -545,4 +545,50 @@ module attributes {gpu.container_module} {
       gpu.return
     }
   }
+
+  gpu.module @atomic_fadd {
+    // f32 tests.
+
+    // CHECK-LABEL: gpu.func @atomic_fadd_f32_to_rank_1
+    //   CHECK: gpu.atomic_fadd(%{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128xf32>
+    gpu.func @atomic_fadd_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %offset0 : i32) {
+      gpu.atomic_fadd(%value, %dst, %offset0) : f32, memref<128xf32>
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @atomic_fadd_f32_to_rank_4
+    //   CHECK: gpu.atomic_fadd(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128x64x32x16xf32>
+    gpu.func @atomic_fadd_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+      gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @atomic_fadd_2xf32_to_rank_1
+    //   CHECK: gpu.atomic_fadd(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128xf32>
+    gpu.func @atomic_fadd_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %offset0 : i32) {
+      gpu.atomic_fadd(%value, %dst, %offset0) : vector<2xf32>, memref<128xf32>
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @atomic_fadd_2xf32_to_rank_4
+    //   CHECK: gpu.atomic_fadd(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128x64x32x16xf32>
+    gpu.func @atomic_fadd_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+      gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @atomic_fadd_4xf32_to_rank_1
+    //   CHECK: gpu.atomic_fadd(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128xf32>
+    gpu.func @atomic_fadd_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %offset0 : i32) {
+      gpu.atomic_fadd(%value, %dst, %offset0) : vector<4xf32>, memref<128xf32>
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @atomic_fadd_4xf32_to_rank_4
+    //   CHECK: gpu.atomic_fadd(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128x64x32x16xf32>
+    gpu.func @atomic_fadd_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+      gpu.atomic_fadd(%value, %dst, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
+      gpu.return
+    }
+  }
 }

--- a/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -195,15 +195,15 @@ llvm.func @rocdl.rawbuf(%rsrc : vector<4xi32>,
   llvm.return
 }
 
-llvm.func @rocdl.atomic.fadd(%rsrc : !llvm<"<4 x i32>">, %vindex : !llvm.i32,
-                             %offset : !llvm.i32, %slc : !llvm.i1,
-                             %vdata1 : !llvm.float, %vdata2 : !llvm<"<2 x half>">) {
+llvm.func @rocdl.atomic.fadd(%rsrc : vector<4xi32>, %vindex : i32,
+                             %offset : i32, %slc : i1,
+                             %vdata1 : f32, %vdata2 : vector<2xf16>) {
   // CHECK-LABEL: rocdl.atomic.fadd
 
-  // CHECK: rocdl.atomic.fadd %{{.*}} %{{.*}} %{{.*}} %{{.*}} %{{.*}} : !llvm.float
-  rocdl.atomic.fadd %vdata1, %rsrc, %vindex, %offset, %slc : !llvm.float
-  // CHECK: rocdl.atomic.fadd %{{.*}} %{{.*}} %{{.*}} %{{.*}} %{{.*}} : !llvm<"<2 x half>">
-  rocdl.atomic.fadd %vdata2, %rsrc, %vindex, %offset, %slc : !llvm<"<2 x half>">
+  // CHECK: rocdl.atomic.fadd %{{.*}} %{{.*}} %{{.*}} %{{.*}} %{{.*}} : f32
+  rocdl.atomic.fadd %vdata1, %rsrc, %vindex, %offset, %slc : f32
+  // CHECK: rocdl.atomic.fadd %{{.*}} %{{.*}} %{{.*}} %{{.*}} %{{.*}} : vector<2xf16>
+  rocdl.atomic.fadd %vdata2, %rsrc, %vindex, %offset, %slc : vector<2xf16>
 
   llvm.return
 }

--- a/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -195,3 +195,16 @@ llvm.func @rocdl.rawbuf(%rsrc : vector<4xi32>,
   llvm.return
 }
 
+llvm.func @rocdl.atomic.fadd(%rsrc : !llvm<"<4 x i32>">, %vindex : !llvm.i32,
+                             %offset : !llvm.i32, %slc : !llvm.i1,
+                             %vdata1 : !llvm.float, %vdata2 : !llvm<"<2 x half>">) {
+  // CHECK-LABEL: rocdl.atomic.fadd
+
+  // CHECK: rocdl.atomic.fadd %{{.*}} %{{.*}} %{{.*}} %{{.*}} %{{.*}} : !llvm.float
+  rocdl.atomic.fadd %vdata1, %rsrc, %vindex, %offset, %slc : !llvm.float
+  // CHECK: rocdl.atomic.fadd %{{.*}} %{{.*}} %{{.*}} %{{.*}} %{{.*}} : !llvm<"<2 x half>">
+  rocdl.atomic.fadd %vdata2, %rsrc, %vindex, %offset, %slc : !llvm<"<2 x half>">
+
+  llvm.return
+}
+


### PR DESCRIPTION
Preparatory steps to migrate logic in `miopen-dialect-index-diff-map` back to `miopen-dialect`.

Enable `atomic_fadd` op in `gpu` and `rocdl` dialects.