### PR TITLE
Revert "MLIR#112: unify C-API interface with mlir-miopen-driver (#128)"

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -20,49 +20,25 @@
 namespace mlir {
 class Conv2dGenerator {
 public:
-  struct Config {
-    std::string arch;
-    int num_cu;
-    bool xdlops;
-    std::string operation;
-    std::string dataTypeStr;
-    int dilationHeight, dilationWidth;
-    int strideHeight, strideWidth;
-    int paddingHeight, paddingWidth;
-    std::string filterLayout;
-    std::string inputLayout;
-    std::string outputLayout;
+  LogicalResult
+  parseConvDims(std::string &inputLayout, std::string &outputLayout,
+                std::string &filterLayout, int64_t groupSize, int64_t batchSize,
+                int64_t inputChannel, int64_t inputHeight, int64_t inputWidth,
+                int64_t outputChannel, int64_t outputHeight,
+                int64_t outputWidth, int64_t filterHeight, int64_t filterWidth,
+                SmallVector<int64_t, 5> &filterDimension,
+                SmallVector<int64_t, 5> &inputDimension,
+                SmallVector<int64_t, 5> &outputDimension);
 
-    std::string kernelName;
-
-    int outputSize;
-    SmallVector<int64_t, 5> filterDimension;
-    SmallVector<int64_t, 5> inputDimension;
-    SmallVector<int64_t, 5> outputDimension;
-  };
-
-  Conv2dGenerator(const std::string &arch = "", int num_cu = 0,
-                  bool xdlops = false, const std::string &operation = "conv2d",
-                  const std::string &dataTypeStr = "f32",
-                  int dilationHeight = 1, int dilationWidth = 1,
-                  int strideHeight = 1, int strideWidth = 1,
-                  int paddingHeight = 0, int paddingWidth = 0,
-                  const std::string &filterLayout = "kcyx",
-                  const std::string &inputLayout = "nchw",
-                  const std::string &outputLayout = "nkhw",
-                  const std::string &kernelName = "");
-
-  const Config &getConfig() const { return config; }
-
-  LogicalResult parseConvConfig(const char *arguments);
-
-  LogicalResult parseConvDims(int64_t batchSize, int64_t groupSize,
-                              int64_t inputChannel, int64_t inputHeight,
-                              int64_t inputWidth, int64_t outputChannel,
-                              int64_t outputHeight, int64_t outputWidth,
-                              int64_t filterHeight, int64_t filterWidth);
-
-  LogicalResult genConvModule(ModuleOp &module, OpBuilder &builder);
+  LogicalResult genConvModule(
+      std::string &arch, int num_cu, std::string &operation,
+      std::string &inputLayout, std::string &outputLayout,
+      std::string &filterLayout, const SmallVector<int64_t, 5> &filterDimension,
+      const SmallVector<int64_t, 5> &inputDimension,
+      const SmallVector<int64_t, 5> &outputDimension, int dilationHeight,
+      int dilationWidth, int strideHeight, int strideWidth, int paddingHeight,
+      int paddingWidth, ModuleOp &module, OpBuilder &builder,
+      std::string &kernelName, mlir::Type dataType, bool xdlops = false);
 
   template <typename Vector>
   std::string translateLayout(const Vector &src, const Vector &srcSpec,
@@ -88,9 +64,6 @@ private:
                    });
     return permutation;
   }
-
-  // Generator config
-  Config config;
 };
 
 } // namespace mlir

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -10,193 +10,88 @@
 
 using namespace mlir;
 
-Conv2dGenerator::Conv2dGenerator(
-    const std::string &arch, int num_cu, bool xdlops,
-    const std::string &operation, const std::string &dataTypeStr,
-    int dilationHeight, int dilationWidth, int strideHeight, int strideWidth,
-    int paddingHeight, int paddingWidth, const std::string &filterLayout,
-    const std::string &inputLayout, const std::string &outputLayout,
-    const std::string &kernelName)
-    : config{arch,        num_cu,         xdlops,        operation,
-             dataTypeStr, dilationHeight, dilationWidth, strideHeight,
-             strideWidth, paddingHeight,  paddingWidth,  filterLayout,
-             inputLayout, outputLayout,   kernelName} {}
-
-namespace {
-
-void strToTokens(const std::string &arguments,
-                 std::map<std::string, std::string> &argMap) {
-  std::istringstream iss(arguments);
-  std::string token;
-  std::string argKey;
-  while (iss >> token) {
-    auto pos = token.find("--");
-    if (pos != std::string::npos) {
-      argKey = token.substr(pos + 2);
-    } else {
-      if (!argKey.empty()) {
-        argMap[argKey] = token;
-        argKey.clear();
-      }
-    }
-  }
-}
-
-} // namespace
-
-LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
-  std::map<std::string, std::string> argMap;
-  strToTokens(arguments, argMap);
-
-  auto isValid = [&argMap]() {
-    // only require tensor configs
-    static const std::vector<std::string> validKeys = {
-        "batchsize",   "groupsize",    "in_layout", "in_type",
-        "in_channels", "in_h",         "in_w",      "out_layout",
-        "out_type",    "out_channels", "out_h",     "out_w",
-        "fil_layout",  "fil_type",     "fil_w",     "fil_h"};
-    return std::all_of(
-        validKeys.cbegin(), validKeys.cend(),
-        [&argMap](const std::string &key) { return argMap.count(key) > 0; });
-  };
-
-  // Proceed only if we have a valid argMap. Otherwise leave the handle to be
-  // empty
-  if (isValid()) {
-
-    auto strToLong = [&argMap](std::string argKey) {
-      return std::stoul(argMap[argKey]);
-    };
-
-    auto strToInt = [&argMap](const std::string &key, auto &setting) {
-      if (argMap.find(key) != argMap.end()) {
-        setting = std::stoi(argMap[key]);
-      }
-    };
-
-    auto strToStr = [&argMap](const std::string &key, std::string &setting) {
-      if (argMap.find(key) != argMap.end()) {
-        setting = argMap[key];
-      }
-    };
-
-    // arch settings
-    strToStr("arch", config.arch);
-    strToInt("num_cu", config.num_cu);
-    strToInt("x2", config.xdlops);
-
-    // conv settings
-    config.operation = argMap["operation"];
-    config.dataTypeStr = argMap["out_type"];
-    strToInt("dilation_h", config.dilationHeight);
-    strToInt("dilation_w", config.dilationWidth);
-    strToInt("conv_stride_h", config.strideHeight);
-    strToInt("conv_stride_w", config.strideWidth);
-    strToInt("padding_h", config.paddingHeight);
-    strToInt("padding_w", config.paddingWidth);
-
-    strToStr("kernel_name", config.kernelName);
-
-    // MIOpen has NCHW as layout string for all three tensors
-    strToStr("fil_layout", config.filterLayout);
-    strToStr("in_layout", config.inputLayout);
-    strToStr("out_layout", config.outputLayout);
-
-    // Determine tensor dimensions.
-    return parseConvDims(strToLong("batchsize"), strToLong("groupsize"),
-                         strToLong("in_channels"), strToLong("in_h"),
-                         strToLong("in_w"), strToLong("out_channels"),
-                         strToLong("out_h"), strToLong("out_w"),
-                         strToLong("fil_w"), strToLong("fil_h"));
-  }
-
-  return failure();
-}
-
-LogicalResult
-Conv2dGenerator::parseConvDims(int64_t batchSize, int64_t groupSize,
-                               int64_t inputChannel, int64_t inputHeight,
-                               int64_t inputWidth, int64_t outputChannel,
-                               int64_t outputHeight, int64_t outputWidth,
-                               int64_t filterHeight, int64_t filterWidth) {
-
-  static const std::string filterKeys = "kgcyx";
-  int64_t filterVals[] = {outputChannel, groupSize, inputChannel / groupSize,
-                          filterHeight, filterWidth};
-
-  static const std::string inputKeys = "ngchw";
-  int64_t inputVals[] = {batchSize, groupSize, inputChannel / groupSize,
-                         inputHeight, inputWidth};
-
-  static const std::string outputKeys = "ngkhw";
-  int64_t outputVals[] = {batchSize, groupSize, outputChannel / groupSize,
-                          outputHeight, outputWidth};
-
-  auto convertLayout = [](char &key, const std::string &kmap, int64_t vals[],
-                          auto &dims) {
-    auto keyl = std::tolower(key);
-    auto ii = kmap.find(keyl);
-    if (ii == std::string::npos) {
-      static std::string nchw = "ngchw";
-      ii = nchw.find(keyl);
-      if (ii == std::string::npos)
-        return false;
-    }
-    dims.push_back(vals[ii]);
-    key = kmap[ii];
-    return true;
-  };
-
+LogicalResult Conv2dGenerator::parseConvDims(
+    std::string &inputLayout, std::string &outputLayout,
+    std::string &filterLayout, int64_t groupSize, int64_t batchSize,
+    int64_t inputChannel, int64_t inputHeight, int64_t inputWidth,
+    int64_t outputChannel, int64_t outputHeight, int64_t outputWidth,
+    int64_t filterHeight, int64_t filterWidth,
+    SmallVector<int64_t, 5> &filterDimension,
+    SmallVector<int64_t, 5> &inputDimension,
+    SmallVector<int64_t, 5> &outputDimension) {
   // Determine dimensions.
   for (size_t i = 0; i < 5; ++i) {
-    if (!convertLayout(config.filterLayout[i], filterKeys, filterVals,
-                       config.filterDimension) ||
-        !convertLayout(config.inputLayout[i], inputKeys, inputVals,
-                       config.inputDimension) ||
-        !convertLayout(config.outputLayout[i], outputKeys, outputVals,
-                       config.outputDimension)) {
-      return failure();
+    auto &filterDim = filterLayout[i];
+    auto &inputDim = inputLayout[i];
+    auto &outputDim = outputLayout[i];
+
+    if (filterDim == 'k') {
+      filterDimension.push_back(outputChannel / groupSize);
+    } else if (filterDim == 'c') {
+      filterDimension.push_back(inputChannel / groupSize);
+    } else if (filterDim == 'y') {
+      filterDimension.push_back(filterHeight);
+    } else if (filterDim == 'x') {
+      filterDimension.push_back(filterWidth);
+    } else if (filterDim == 'g') {
+      filterDimension.push_back(groupSize);
+    }
+
+    if (inputDim == 'n') {
+      inputDimension.push_back(batchSize);
+    } else if (inputDim == 'c') {
+      inputDimension.push_back(inputChannel / groupSize);
+    } else if (inputDim == 'h') {
+      inputDimension.push_back(inputHeight);
+    } else if (inputDim == 'w') {
+      inputDimension.push_back(inputWidth);
+    } else if (inputDim == 'g') {
+      inputDimension.push_back(groupSize);
+    }
+
+    if (outputDim == 'n') {
+      outputDimension.push_back(batchSize);
+    } else if (outputDim == 'k') {
+      outputDimension.push_back(outputChannel / groupSize);
+    } else if (outputDim == 'h') {
+      outputDimension.push_back(outputHeight);
+    } else if (outputDim == 'w') {
+      outputDimension.push_back(outputWidth);
+    } else if (outputDim == 'g') {
+      outputDimension.push_back(groupSize);
     }
   }
 
   return success();
 }
 
-LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module,
-                                             OpBuilder &builder) {
-
-  mlir::Type dataType;
-  if (config.dataTypeStr == "f32" || config.dataTypeStr == "fp32") {
-    dataType = builder.getF32Type();
-  } else if (config.dataTypeStr == "f16" || config.dataTypeStr == "fp16") {
-    dataType = builder.getF16Type();
-  } else if (config.dataTypeStr == "bf16") {
-    dataType = builder.getIntegerType(16);
-  } else {
-    return failure();
-  }
+LogicalResult Conv2dGenerator::genConvModule(
+    std::string &arch, int num_cu, std::string &operation,
+    std::string &inputLayout, std::string &outputLayout,
+    std::string &filterLayout, const SmallVector<int64_t, 5> &filterDimension,
+    const SmallVector<int64_t, 5> &inputDimension,
+    const SmallVector<int64_t, 5> &outputDimension, int dilationHeight,
+    int dilationWidth, int strideHeight, int strideWidth, int paddingHeight,
+    int paddingWidth, ModuleOp &module, OpBuilder &builder,
+    std::string &kernelName, mlir::Type dataType, bool xdlops) {
 
   // Construct a new FuncOp.
-  auto filterArgType =
-      MemRefType::get(ArrayRef<int64_t>(config.filterDimension.begin(),
-                                        config.filterDimension.end()),
-                      dataType);
-  auto inputArgType =
-      MemRefType::get(ArrayRef<int64_t>(config.inputDimension.begin(),
-                                        config.inputDimension.end()),
-                      dataType);
-  auto outputArgType =
-      MemRefType::get(ArrayRef<int64_t>(config.outputDimension.begin(),
-                                        config.outputDimension.end()),
-                      dataType);
+  auto filterArgType = MemRefType::get(
+      ArrayRef<int64_t>(filterDimension.begin(), filterDimension.end()),
+      dataType);
+  auto inputArgType = MemRefType::get(
+      ArrayRef<int64_t>(inputDimension.begin(), inputDimension.end()),
+      dataType);
+  auto outputArgType = MemRefType::get(
+      ArrayRef<int64_t>(outputDimension.begin(), outputDimension.end()),
+      dataType);
   auto funcType =
       builder.getFunctionType({filterArgType, inputArgType, outputArgType}, {});
 
   // Determine kernel name, if there isn't one.
-  if (config.kernelName.empty()) {
-    config.kernelName = "miopen_" + config.operation + "_" +
-                        config.filterLayout + "_" + config.inputLayout + "_" +
-                        config.outputLayout;
+  if (kernelName.size() == 0) {
+    kernelName = "miopen_" + operation + "_" + filterLayout + "_" +
+                 inputLayout + "_" + outputLayout;
   }
 
   // Annotate kernel attribute to the FuncOp.
@@ -205,8 +100,8 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module,
   };
 
   // Construct the FuncOp.
-  auto func = FuncOp::create(builder.getUnknownLoc(), config.kernelName,
-                             funcType, ArrayRef<NamedAttribute>(kernelAttrs));
+  auto func = FuncOp::create(builder.getUnknownLoc(), kernelName, funcType,
+                             ArrayRef<NamedAttribute>(kernelAttrs));
   module.push_back(func);
 
   // Construct a new Block.
@@ -218,16 +113,16 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module,
   SmallVector<StringAttr, 5> outputLayoutSpec;
   for (size_t i = 0; i < 5; ++i) {
     filterLayoutSpec.push_back(
-        builder.getStringAttr(StringRef(&config.filterLayout[i], 1)));
-    inputLayoutSpec.push_back(builder.getStringAttr(
-        (StringRef(&config.inputLayout[i], 1) + "i").str()));
-    outputLayoutSpec.push_back(builder.getStringAttr(
-        (StringRef(&config.outputLayout[i], 1) + "o").str()));
+        builder.getStringAttr(StringRef(&filterLayout[i], 1)));
+    inputLayoutSpec.push_back(
+        builder.getStringAttr((StringRef(&inputLayout[i], 1) + "i").str()));
+    outputLayoutSpec.push_back(
+        builder.getStringAttr((StringRef(&outputLayout[i], 1) + "o").str()));
   }
 
   std::vector<NamedAttribute> attributes{
-      builder.getNamedAttr("arch", builder.getStringAttr(config.arch)),
-      builder.getNamedAttr("num_cu", builder.getI32IntegerAttr(config.num_cu)),
+      builder.getNamedAttr("arch", builder.getStringAttr(arch)),
+      builder.getNamedAttr("num_cu", builder.getI32IntegerAttr(num_cu)),
 
       builder.getNamedAttr(
           "filter_layout",
@@ -243,48 +138,48 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module,
 
       builder.getNamedAttr("dilations",
                            builder.getArrayAttr({
-                               builder.getI32IntegerAttr(config.dilationHeight),
-                               builder.getI32IntegerAttr(config.dilationWidth),
+                               builder.getI32IntegerAttr(dilationHeight),
+                               builder.getI32IntegerAttr(dilationWidth),
                            })),
       builder.getNamedAttr("strides",
                            builder.getArrayAttr({
-                               builder.getI32IntegerAttr(config.strideHeight),
-                               builder.getI32IntegerAttr(config.strideWidth),
+                               builder.getI32IntegerAttr(strideHeight),
+                               builder.getI32IntegerAttr(strideWidth),
                            })),
       builder.getNamedAttr("padding",
                            builder.getArrayAttr({
-                               builder.getI32IntegerAttr(config.paddingHeight),
-                               builder.getI32IntegerAttr(config.paddingWidth),
+                               builder.getI32IntegerAttr(paddingHeight),
+                               builder.getI32IntegerAttr(paddingWidth),
                            })),
   };
 
   // xdlops v2.
-  if (config.xdlops)
+  if (xdlops)
     attributes.push_back(
         builder.getNamedAttr("xdlopsV2", builder.getBoolAttr(true)));
 
-  if (config.operation == "conv2d") {
+  if (operation.compare("conv2d") == 0) {
     auto convOp = builder.create<miopen::Conv2DOp>(
         builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
         ValueRange{func.getArgument(0), func.getArgument(1),
                    func.getArgument(2)},
         attributes);
     block->push_front(convOp);
-  } else if (config.operation == "conv2d_bwd_data") {
+  } else if (operation.compare("conv2d_bwd_data") == 0) {
     auto convOp = builder.create<miopen::Conv2DBwdDataOp>(
         builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
         ValueRange{func.getArgument(0), func.getArgument(1),
                    func.getArgument(2)},
         attributes);
     block->push_front(convOp);
-  } else if (config.operation == "conv2d_bwd_weight") {
+  } else if (operation.compare("conv2d_bwd_weight") == 0) {
     auto convOp = builder.create<miopen::Conv2DBwdWeightOp>(
         builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
         ValueRange{func.getArgument(0), func.getArgument(1),
                    func.getArgument(2)},
         attributes);
     block->push_back(convOp);
-  } else if (config.operation == "conv2d_dummy") {
+  } else if (operation.compare("conv2d_dummy") == 0) {
     auto convOp = builder.create<miopen::Conv2DDummyOp>(
         builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
         ValueRange{func.getArgument(0), func.getArgument(1),

--- a/mlir/test/mlir-miopen-lib/populate_bwd.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_bwd.mlir
@@ -3,13 +3,9 @@
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_data --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name bar --groupsize 1" --option header | FileCheck %s --check-prefix=HEADER
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_data --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_nchw_nchw --groupsize 1" --option bin | FileCheck %s --check-prefix=BIN
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_data --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name bar --groupsize 1" --option tuningparams | FileCheck %s --check-prefix=TUNING
-// RUN: mlir-miopen-driver --conv-config "--operation conv2d_bwd_data --arch   gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name bar  --groupsize  1   " | FileCheck %s --check-prefix=DRIVER
 
 // CFLAGS: conv2d_bwd
 // SOURCE: void mlir_gen_igemm_conv2d_cpp_v1r1_bwd
 // HEADER: struct MlirGenIgemmConv2dV1r1Bwd
 // BIN: ELF
 // TUNING: globalSize{{.*}}localSize{{.*}}
-// DRIVER: miopen.conv2d_bwd_data(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
-
-

--- a/mlir/test/mlir-miopen-lib/populate_bww.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_bww.mlir
@@ -3,13 +3,9 @@
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_weight --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name bar --groupsize 1" --option header | FileCheck %s --check-prefix=HEADER
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_weight --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d --groupsize 1" --option bin | FileCheck %s --check-prefix=BIN
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_weight --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d --groupsize 1" --option tuningparams | FileCheck %s --check-prefix=TUNING
-// RUN: mlir-miopen-driver --conv-config " --operation conv2d_bwd_weight --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d   --groupsize    1 " | FileCheck %s --check-prefix=DRIVER
-
 
 // CFLAGS: conv2d_bww
 // SOURCE: void mlir_gen_igemm_conv2d_cpp_v4r4_wrw
 // HEADER: struct MlirGenIgemmConv2dV4r4Wrw
 // BIN: ELF
 // TUNING: globalSize{{.*}}localSize{{.*}}
-
-// DRIVER: miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>

--- a/mlir/test/mlir-miopen-lib/populate_fw.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_fw.mlir
@@ -3,14 +3,9 @@
 // RUN: mlir-miopen-lib-test --args " --operation conv2d --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name bar --groupsize 1" --option header | FileCheck %s --check-prefix=HEADER
 // RUN: mlir-miopen-lib-test --args " --operation conv2d --arch gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GKCYX --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option bin | FileCheck %s --check-prefix=BIN
 // RUN: mlir-miopen-lib-test --args " --operation conv2d --arch gfx906 --num_cu 64 --fil_layout GKCYX --in_type fp32 --fil_type fp32 --out_type fp32 --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_fwd --groupsize 1" --option tuningparams | FileCheck %s --check-prefix=TUNING
-// RUN: mlir-miopen-driver --conv-config "--operation conv2d --arch gfx906 --num_cu 64 --fil_layout GKCYX --in_type fp32 --fil_type fp32 --out_type fp32 --in_layout NGCHW --out_layout NGKHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_fwd --groupsize 1" | FileCheck %s --check-prefix=DRIVER
-    
+
 // CFLAGS: conv2d_fwd
 // SOURCE: void mlir_gen_igemm_conv2d_cpp_v4r4_fwd
 // HEADER: struct MlirGenIgemmConv2dV4r4Fwd 
 // BIN: ELF
 // TUNING: globalSize{{.*}}localSize{{.*}}
-
-// DRIVER: miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
-
-

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -23,8 +23,7 @@ set(LIBS
   MLIRSupport
   MLIRIR
   MLIRTargetMIOpenCppTranslation
-  MLIRMIOpenThin
-  )
+)
 
 add_llvm_executable(mlir-miopen-driver
   PARTIAL_SOURCES_INTENDED

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -162,12 +162,6 @@ static cl::opt<int> paddingWidth("padding_w", cl::desc("Padding width"),
                                  cl::value_desc("attribute value"),
                                  cl::init(0));
 
-// conv-config
-static cl::opt<std::string> populateConvConfig(
-    "conv-config",
-    cl::desc("Populate full config settings (overrides all specific settings)"),
-    cl::value_desc("config settings"), cl::init(""));
-
 // populate default values
 static cl::opt<bool>
     populateDefaultValues("p", cl::desc("To populate default values"),
@@ -471,7 +465,7 @@ static AllocOp
 allocAndCopyTensor(ModuleOp &module, OpBuilder &builder, Block *block,
                    mlir::FuncOp &mcpuMemCopy5DFuncOp,
                    mlir::AllocOp &sourceOriginalAllocOp,
-                   const SmallVector<int64_t, 5> &sourceDimension,
+                   SmallVector<int64_t, 5> &sourceDimension,
                    std::unordered_map<std::string, FuncOp> &convertFuncs) {
   auto floatType = builder.getF32Type();
   auto fiveDimUnknownSizeFloatType =
@@ -764,7 +758,7 @@ static FuncOp createCPUConvolution(ModuleOp &module, OpBuilder &builder,
 }
 
 static FuncOp createVerifyFuncOp(ModuleOp &module, OpBuilder &builder,
-                                 const SmallVector<int64_t, 5> &outputDimension,
+                                 SmallVector<int64_t, 5> &outputDimension,
                                  mlir::AllocOp &cpuAllocOp,
                                  mlir::AllocOp &gpuAllocOp) {
   // Emit verify_results function call
@@ -1371,9 +1365,9 @@ static LogicalResult populateHostHarnessLogic(
 
 static LogicalResult populateValidationLogic(
     ModuleOp &module, OpBuilder &builder, MLIRContext &context,
-    const SmallVector<int64_t, 5> &filterDimension,
-    const SmallVector<int64_t, 5> &inputDimension,
-    const SmallVector<int64_t, 5> &outputDimension, mlir::Type dataType) {
+    SmallVector<int64_t, 5> &filterDimension,
+    SmallVector<int64_t, 5> &inputDimension,
+    SmallVector<int64_t, 5> &outputDimension, mlir::Type dataType) {
   // Construct main function.
   auto func = FuncOp::create(builder.getUnknownLoc(), "main",
                              builder.getFunctionType({}, {}));
@@ -1755,9 +1749,9 @@ static LogicalResult populateValidationLogic(
 static LogicalResult
 populateCpuConvolutionLogic(ModuleOp &module, OpBuilder &builder,
                             MLIRContext &context,
-                            const SmallVector<int64_t, 5> &filterDimension,
-                            const SmallVector<int64_t, 5> &inputDimension,
-                            const SmallVector<int64_t, 5> &outputDimension) {
+                            SmallVector<int64_t, 5> &filterDimension,
+                            SmallVector<int64_t, 5> &inputDimension,
+                            SmallVector<int64_t, 5> &outputDimension) {
   // Construct main function.
   auto func = FuncOp::create(builder.getUnknownLoc(), "main",
                              builder.getFunctionType({}, {}));
@@ -2083,55 +2077,51 @@ int main(int argc, char **argv) {
     module = ModuleOp::create(builder.getUnknownLoc());
   }
 
-  correctParameters();
-  populateDefaults();
-
-  auto convConfig = populateConvConfig.getValue();
-  auto dataTypeStr = tensorDataType.getValue();
-
-  Conv2dGenerator conv2dGenerator(
-      arch.getValue(), num_cu.getValue(), xdlopsV2.getValue(),
-      operation.getValue(), dataTypeStr, dilationHeight.getValue(),
-      dilationWidth.getValue(), strideHeight.getValue(), strideWidth.getValue(),
-      paddingHeight.getValue(), paddingWidth.getValue(),
-      filterLayout.getValue(), inputLayout.getValue(), outputLayout.getValue());
-
-  if (!convConfig.empty()) {
-    if (failed(conv2dGenerator.parseConvConfig(convConfig.c_str()))) {
-      llvm::errs() << "Module population failed.\n";
-      exit(1);
-    }
-  } else {
-    conv2dGenerator.parseConvDims(
-        batchSize, groupSize, inputChannel, inputHeight, inputWidth,
-        outputChannel, outputHeight, outputWidth, filterWidth, filterHeight);
-  }
-
   // Determine data type.
   mlir::Type dataType = builder.getF32Type();
-  if (dataTypeStr == "f32") {
+  if (tensorDataType == "f32") {
     dataType = builder.getF32Type();
-  } else if (dataTypeStr == "f16") {
+  } else if (tensorDataType == "f16") {
     dataType = builder.getF16Type();
-  } else if (dataTypeStr == "bf16") {
+  } else if (tensorDataType == "bf16") {
     dataType = builder.getIntegerType(16);
   }
 
+  correctParameters();
+  populateDefaults();
+
+  Conv2dGenerator conv2dGenerator;
+  // Determine dimensions.
+  SmallVector<int64_t, 5> filterDimension;
+  SmallVector<int64_t, 5> inputDimension;
+  SmallVector<int64_t, 5> outputDimension;
+  conv2dGenerator.parseConvDims(
+      inputLayout, outputLayout, filterLayout, groupSize, batchSize,
+      inputChannel, inputHeight, inputWidth, outputChannel, outputHeight,
+      outputWidth, filterWidth, filterHeight, filterDimension, inputDimension,
+      outputDimension);
+
   // Populate the module.
+  std::string kernelName;
   if (!populateCpuConvolution.getValue()) {
-    if (failed(conv2dGenerator.genConvModule(module, builder))) {
+    if (failed(conv2dGenerator.genConvModule(
+            arch.getValue(), num_cu.getValue(), operation.getValue(),
+            inputLayout, outputLayout, filterLayout, filterDimension,
+            inputDimension, outputDimension, dilationHeight.getValue(),
+            dilationWidth.getValue(), strideHeight.getValue(),
+            strideWidth.getValue(), paddingHeight.getValue(),
+            paddingWidth.getValue(), module, builder, kernelName, dataType,
+            xdlopsV2.getValue()))) {
       llvm::errs() << "Module population failed.\n";
       exit(1);
     }
   }
 
-  const auto &genConfig = conv2dGenerator.getConfig();
-
   // populate host harness and host validation.
   if (populateValidation.getValue()) {
-    if (failed(populateValidationLogic(
-            module, builder, context, genConfig.filterDimension,
-            genConfig.inputDimension, genConfig.outputDimension, dataType))) {
+    if (failed(populateValidationLogic(module, builder, context,
+                                       filterDimension, inputDimension,
+                                       outputDimension, dataType))) {
       llvm::errs() << "Host validation populated failed.\n";
       exit(1);
     }
@@ -2139,25 +2129,25 @@ int main(int argc, char **argv) {
 
   // populate CPU convolution and print the results.
   if (populateCpuConvolution.getValue()) {
-    if (failed(populateCpuConvolutionLogic(
-            module, builder, context, genConfig.filterDimension,
-            genConfig.inputDimension, genConfig.outputDimension))) {
+    if (failed(populateCpuConvolutionLogic(module, builder, context,
+                                           filterDimension, inputDimension,
+                                           outputDimension))) {
       llvm::errs() << "Cpu Convolution populated failed.\n";
       exit(1);
     }
   }
 
   // Apply passes.
-  if (failed(runMLIRPasses(module, passPipeline, genConfig.kernelName))) {
+  if (failed(runMLIRPasses(module, passPipeline, kernelName))) {
     llvm::errs() << "Lowering failed.\n";
     exit(1);
   }
 
   // populate host logic.
   if (populateHostHarness.getValue()) {
-    if (failed(populateHostHarnessLogic(
-            module, builder, context, genConfig.filterDimension,
-            genConfig.inputDimension, genConfig.outputDimension, dataType))) {
+    if (failed(populateHostHarnessLogic(module, builder, context,
+                                        filterDimension, inputDimension,
+                                        outputDimension, dataType))) {
       llvm::errs() << "Host logic populated failed.\n";
       exit(1);
     }
@@ -2166,8 +2156,8 @@ int main(int argc, char **argv) {
   // populate host launch logic.
   if (useHostHarness.getValue() || populateHostHarness.getValue() ||
       populateValidation.getValue()) {
-    if (failed(populateKernelLaunchLogic(module, builder, context,
-                                         genConfig.kernelName))) {
+    if (failed(
+            populateKernelLaunchLogic(module, builder, context, kernelName))) {
       llvm::errs() << "Host kernel launch logic populated failed.\n";
       exit(1);
     }

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -37,6 +37,25 @@ struct MiirHandle_s {
   std::string genTxt;
 };
 
+void strToTokens(const std::string &arguments,
+                 std::map<std::string, std::string> &argMap) {
+  std::istringstream iss(arguments);
+  std::string token;
+  std::string argKey;
+  std::string argVal;
+  while (std::getline(iss, token, ' ')) {
+    auto pos = token.find("--");
+    if (pos != std::string::npos) {
+      argKey = token.substr(pos + 2, token.size());
+    } else {
+      argVal = token;
+      if (argKey.empty() || argVal.empty())
+        continue;
+      argMap[argKey] = argVal;
+    }
+  }
+}
+
 // In multi-threaded context, static intialization is guaranteed to
 // be thread safe, since C++11. Refer to
 // https://en.cppreference.com/w/cpp/language/storage_duration
@@ -70,18 +89,84 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
 
   MiirHandle_s *handle = nullptr;
 
-  Conv2dGenerator conv2dGenerator;
+  std::map<std::string, std::string> argMap;
+  strToTokens(arguments, argMap);
 
-  if (succeeded(conv2dGenerator.parseConvConfig(arguments))) {
+  auto isValid = [&argMap]() {
+    static const std::vector<std::string> validKeys = {
+        "operation",    "batchsize",     "arch",          "num_cu",
+        "kernel_name",  "in_layout",     "in_type",       "in_channels",
+        "in_h",         "in_w",          "out_layout",    "out_type",
+        "out_channels", "out_h",         "out_w",         "fil_layout",
+        "fil_type",     "fil_w",         "fil_h",         "padding_h",
+        "padding_w",    "conv_stride_h", "conv_stride_w", "dilation_h",
+        "dilation_w",   "groupsize"};
+    return std::all_of(
+        validKeys.cbegin(), validKeys.cend(),
+        [&argMap](const std::string &key) { return argMap.count(key) > 0; });
+  };
+
+  auto getType = [](mlir::MLIRContext *context, const std::string &type_s) {
+    mlir::Type type;
+    if (type_s == "fp32") {
+      type = mlir::FloatType::getF32(context);
+    } else if (type_s == "fp16") {
+      type = mlir::FloatType::getF16(context);
+    }
+    return type;
+  };
+
+  // Proceed only if we have a valid argMap. Otherwise leave the handle to be
+  // empty
+  if (isValid()) {
 
     handle = new MiirHandle_s;
     OpBuilder builder(&(handle->context));
 
-    handle->arch = conv2dGenerator.getConfig().arch;
+    handle->arch = argMap["arch"];
+
+    mlir::Type type = getType(&(handle->context), argMap["out_type"]);
+    if (!type) {
+      delete handle;
+      return nullptr;
+    }
+
+    auto strToLong = [&argMap](std::string argKey) {
+      return std::stoul(argMap[argKey]);
+    };
+
+    auto strToInt = [&argMap](std::string argKey) {
+      return std::stoi(argMap[argKey]);
+    };
+
+    Conv2dGenerator conv2dGenerator;
+    // MIOpen has NCHW as layout string for all three tensors
+    std::string inLayout = conv2dGenerator.translateLayout(
+        argMap["in_layout"], std::string("NGCHW"), std::string("ngchw"));
+    std::string filLayout = conv2dGenerator.translateLayout(
+        argMap["fil_layout"], std::string("GKCYX"), std::string("gkcyx"));
+    std::string outLayout = conv2dGenerator.translateLayout(
+        argMap["out_layout"], std::string("NGKHW"), std::string("ngkhw"));
 
     ModuleOp module = handle->getModule();
+    // Determine dimensions.
+    SmallVector<int64_t, 5> filterDimension;
+    SmallVector<int64_t, 5> inputDimension;
+    SmallVector<int64_t, 5> outputDimension;
+    conv2dGenerator.parseConvDims(
+        inLayout, outLayout, filLayout, strToLong("groupsize"),
+        strToLong("batchsize"), strToLong("in_channels"), strToLong("in_h"),
+        strToLong("in_w"), strToLong("out_channels"), strToLong("out_h"),
+        strToLong("out_w"), strToLong("fil_w"), strToLong("fil_h"),
+        filterDimension, inputDimension, outputDimension);
 
-    conv2dGenerator.genConvModule(module, builder);
+    conv2dGenerator.genConvModule(
+        argMap["arch"], strToInt("num_cu"), argMap["operation"], inLayout,
+        outLayout, filLayout, filterDimension, inputDimension, outputDimension,
+        strToInt("dilation_h"), strToInt("dilation_w"),
+        strToInt("conv_stride_h"), strToInt("conv_stride_w"),
+        strToInt("padding_h"), strToInt("padding_w"), module, builder,
+        argMap["kernel_name"], type, false);
   }
 
   return handle;


### PR DESCRIPTION
This reverts commit e23cf48262c494c05d03551a292b66ba5a6dfb9a.

The following regressions are caused by the commit:

```
./bin/mlir-miopen-driver -pv -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk -groupsize=4 -batchsize=256 -in_channels=256 -out_channels=256 -in_h=56 -in_w=56 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -p=false -t f16 -rand 1 -c | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void

./bin/mlir-miopen-driver --operation conv2d_bwd_weight -t f32 -p=false -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk -batchsize=256 -groupsize=32 -in_channels=1024 -out_channels=1024 -in_h=7 -in_w=7 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=1 --conv_stride_w=1 -pv -c | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void

./bin/mlir-miopen-driver --operation conv2d -t f16 -p=false -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk -batchsize=256 -groupsize=32 -in_channels=1024 -out_channels=1024 -in_h=14 -in_w=14 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=2 --conv_stride_w=2 -pv -c | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void
```

Internal ticket: https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/145 has been assigned to @sjw36 