### PR TITLE
Fix miopen dialect issue 136

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -2678,6 +2678,10 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
     int64_t GemmBBlockCopyClusterLengths_GemmN =
         NPerBlock / GemmBBlockCopyThreadSliceLengths_GemmN;
 
+    // llvm::errs() << "thread cluster lengths for Matrix B\n";
+    // llvm::errs() << GemmBBlockCopyClusterLengths_GemmK << " ";
+    // llvm::errs() << GemmBBlockCopyClusterLengths_GemmN << "\n";
+
     // Compute thread_data_id_begin for Matrix A.
     // ClusterArrangeOrder for Matrix A is <1, 0>.
     // So divide by GemmABlockCopyClusterLengths_GemmK.
@@ -4285,7 +4289,7 @@ struct ThreadwiseCopyRewritePattern
         //   // load address = lower indices from affine transform.
         // } else {
         //   // OOB. Prepare an address known NOT OOB.
-        //   // load address = {0, 0, 0, 0}
+        //   // load address = {0, 0, 0, 0, 0}
         // }
         // V = load(load address)
         // if (withinBounds) {

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -5114,20 +5114,19 @@ struct XdlopsGemmV2RewritePattern
       //         a[k_i] = p_a_wave[(k_i + blk_id) * M + blk_td];
       //         b[k_i] = p_b_wave[(k_i + blk_id) * N + blk_td];
       //     }
-      // p_a_wave need to be offseted by threadOffsetA.
-      // p_b_wave need to be offseted by threadOffsetB.
+      // p_a_wave need to be offseted by waveOffsetA.
+      // p_b_wave need to be offseted by waveOffsetB.
 
       auto NumInputBlksConstantOp = b.create<ConstantIndexOp>(loc, num_input_blks);
       auto loopKLoad = b.create<scf::ForOp>(loc, zeroConstantOp, KConstantOp, NumInputBlksConstantOp);
       auto lklb = OpBuilder::atBlockTerminator(loopKLoad.getBody());
       auto lkliv = loopKLoad.getInductionVar();
 
-      // TBD. Check if we need to apply coord_transform as well.
       //         a[k_i] = p_a_wave[(k_i + blk_id) * M + blk_td];
       //         b[k_i] = p_b_wave[(k_i + blk_id) * N + blk_td];
-      // p_a_wave need to be offseted by threadOffsetA.
-      // p_b_wave need to be offseted by threadOffsetB.
-      auto sourceOffsetA = lklb.create<AddIOp>(
+      // p_a_wave need to be offseted by waveOffsetA.
+      // p_b_wave need to be offseted by waveOffsetB.
+      Value sourceOffsetBeforeTransformA = lklb.create<AddIOp>(
           loc, op.waveOffsetA(),
           lklb.create<AddIOp>(
               loc,
@@ -5135,17 +5134,37 @@ struct XdlopsGemmV2RewritePattern
                                   MConstantOp),
               blk_td));
 
+      // Apply coord_transform for matrix A if necessarily.
+      SmallVector<Value, 8> sourceOffsetA;
+      if (transformMatrixA)
+        sourceOffsetA =
+            expandAffineMap(lklb, loc, transformMatrixA,
+                            ValueRange{sourceOffsetBeforeTransformA})
+                .getValue();
+      else
+        sourceOffsetA.push_back(sourceOffsetBeforeTransformA);
+
       auto valueA = lklb.create<LoadOp>(loc, dataType, op.matrixA(),
                                         ValueRange{sourceOffsetA});
       lklb.create<StoreOp>(loc, valueA, op.bufferA(), ValueRange{lkliv});
 
-      auto sourceOffsetB = lklb.create<AddIOp>(
+      Value sourceOffsetBeforeTransformB = lklb.create<AddIOp>(
           loc, op.waveOffsetB(),
           lklb.create<AddIOp>(
               loc,
               lklb.create<MulIOp>(loc, lklb.create<AddIOp>(loc, lkliv, blk_id),
                                   NConstantOp),
               blk_td));
+
+      // Apply coord_transform for matrix B if necessarily.
+      SmallVector<Value, 8> sourceOffsetB;
+      if (transformMatrixB)
+        sourceOffsetB =
+            expandAffineMap(lklb, loc, transformMatrixB,
+                            ValueRange{sourceOffsetBeforeTransformB})
+                .getValue();
+      else
+        sourceOffsetB.push_back(sourceOffsetBeforeTransformB);
 
       auto valueB = lklb.create<LoadOp>(loc, dataType, op.matrixB(),
                                         ValueRange{sourceOffsetB});

--- a/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation.mlir
+++ b/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation.mlir
@@ -486,3 +486,21 @@
 // CHECK_RESNET101_NHWC_CONFIG7_BWD: [1]
 // CHECK_RESNET101_NHWC_CONFIG7_WRW: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_RESNET101_NHWC_CONFIG7_WRW: [1]
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/136
+///////////////////////////////////////////////////////////////////////////////////////////
+
+// RUN: mlir-miopen-driver -pv -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk -batchsize=256 -in_channels=32 -out_channels=32 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=2 --conv_stride_w=2 --operation=conv2d_bwd_weight -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_136_1
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw -batchsize=32 -in_channels=1 -out_channels=64 -in_h=14 -in_w=14 -fil_h=14 -fil_w=14 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=1 --conv_stride_w=1 --operation=conv2d -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_136_2
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw -batchsize=32 -in_channels=1 -out_channels=32 -in_h=14 -in_w=14 -fil_h=14 -fil_w=14 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=1 --conv_stride_w=1 --operation=conv2d -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_136_3
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw -batchsize=16 -in_channels=1 -out_channels=16 -in_h=14 -in_w=14 -fil_h=14 -fil_w=14 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=1 --conv_stride_w=1 --operation=conv2d -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_136_4
+
+// CHECK_ISSUE_136_1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_136_1: [1]
+// CHECK_ISSUE_136_2: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_136_2: [1]
+// CHECK_ISSUE_136_3: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_136_3: [1]
+// CHECK_ISSUE_136_4: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_136_4: [1]


### PR DESCRIPTION
ticket: https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/136

Fix `miopen.xdlops_gemm_v2` code emission logic so `coord_transforms` attribute is applied in `KReduction` case.