### PR TITLE
MLIR#125: Add API for generation of multiple kernels per operation

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -25,6 +25,7 @@ public:
     int num_cu;
     bool xdlops;
     std::string operation;
+    int kernelId;
     std::string dataTypeStr;
     int dilationHeight, dilationWidth;
     int strideHeight, strideWidth;
@@ -43,7 +44,7 @@ public:
 
   Conv2dGenerator(const std::string &arch = "", int num_cu = 0,
                   bool xdlops = false, const std::string &operation = "conv2d",
-                  const std::string &dataTypeStr = "f32",
+                  int kernelId = 0, const std::string &dataTypeStr = "f32",
                   int dilationHeight = 1, int dilationWidth = 1,
                   int strideHeight = 1, int strideWidth = 1,
                   int paddingHeight = 0, int paddingWidth = 0,
@@ -53,6 +54,8 @@ public:
                   const std::string &kernelName = "");
 
   const Config &getConfig() const { return config; }
+
+  static int getKernelCount(const char *arguments);
 
   LogicalResult parseConvConfig(const char *arguments);
 

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -2088,10 +2088,11 @@ int main(int argc, char **argv) {
 
   auto convConfig = populateConvConfig.getValue();
   auto dataTypeStr = tensorDataType.getValue();
+  int kernelId = 0;
 
   Conv2dGenerator conv2dGenerator(
       arch.getValue(), num_cu.getValue(), xdlopsV2.getValue(),
-      operation.getValue(), dataTypeStr, dilationHeight.getValue(),
+      operation.getValue(), kernelId, dataTypeStr, dilationHeight.getValue(),
       dilationWidth.getValue(), strideHeight.getValue(), strideWidth.getValue(),
       paddingHeight.getValue(), paddingWidth.getValue(),
       filterLayout.getValue(), inputLayout.getValue(), outputLayout.getValue());

--- a/mlir/tools/mlir-miopen-lib/Miir.h
+++ b/mlir/tools/mlir-miopen-lib/Miir.h
@@ -12,7 +12,7 @@
 
 #include <stddef.h>
 
-#define MIIR_VERSION_FLAT 3
+#define MIIR_VERSION_FLAT 4
 
 enum MiirStatus {
   MIIR_SUCCESS = 0,

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -65,6 +65,10 @@ bool miirLazyInit() {
 
 typedef void *MiirHandle;
 
+extern "C" int miirGetKernelCount(const char *arguments) {
+  return Conv2dGenerator::getKernelCount(arguments);
+};
+
 extern "C" MiirHandle miirCreateHandle(const char *arguments) {
   mlir::registerAllPasses();
 


### PR DESCRIPTION
* Add miirGetKernelCount function to return number of kernels needed per operation
* Add --kernel_id to miirCreateHandle to specify which sub-kernel to generate
  * currently only supports 1 kernel