### PR TITLE
Fix issue 124 : XDLOPS fp16 

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -2567,9 +2567,11 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
     // llvm::errs() << "MWaves = MPerBlock / MPerWave: " << MWaves << "\n";
     // llvm::errs() << "NWaves = NPerBlock / NPerWave: " << NWaves << "\n";
     // llvm::errs() << "MWavesPerBlock = MPerBlock / MPerWave: " <<
-    // MWavePerBlock << "\n";
+    // MWavePerBlock
+    //              << "\n";
     // llvm::errs() << "NWavesPerBlock = NPerBlock / NPerWave: " <<
-    // NWavePerBlock << "\n";
+    // NWavePerBlock
+    //              << "\n";
 
     // llvm::errs() << "matrix_a_source_data_per_read: "
     //              << matrix_a_source_data_per_read << "\n";
@@ -2905,10 +2907,10 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
     // -----
 
     // Logic to do XDLOPS code selection.
-    llvm::errs() << "Invoke XDLOPS code selection logic:\n";
-    llvm::errs() << "dataType: "; dataType.dump(); llvm::errs() << "\n";
-    llvm::errs() << "MPerWave: " << MPerWave << "\n";
-    llvm::errs() << "NPerWave: " << NPerWave << "\n";
+    // llvm::errs() << "Invoke XDLOPS code selection logic:\n";
+    // llvm::errs() << "dataType: "; dataType.dump(); llvm::errs() << "\n";
+    // llvm::errs() << "MPerWave: " << MPerWave << "\n";
+    // llvm::errs() << "NPerWave: " << NPerWave << "\n";
 
     XdlopsCodeSelection xcs = XdlopsCodeSelection::get(dataType, MPerWave, NPerWave, b);
 
@@ -4894,10 +4896,10 @@ struct XdlopsGemmV2RewritePattern
     auto KConstantOp = b.create<ConstantIndexOp>(loc, K);
 
     // Logic to do XDLOPS code selection.
-    llvm::errs() << "Invoke XDLOPS code selection logic:\n";
-    llvm::errs() << "dataType: "; dataType.dump(); llvm::errs() << "\n";
-    llvm::errs() << "MPerWave: " << MPerWave << "\n";
-    llvm::errs() << "NPerWave: " << NPerWave << "\n";
+    // llvm::errs() << "Invoke XDLOPS code selection logic:\n";
+    // llvm::errs() << "dataType: "; dataType.dump(); llvm::errs() << "\n";
+    // llvm::errs() << "MPerWave: " << MPerWave << "\n";
+    // llvm::errs() << "NPerWave: " << NPerWave << "\n";
 
     XdlopsCodeSelection xcs = XdlopsCodeSelection::get(dataType, MPerWave, NPerWave, b);
 

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -2905,6 +2905,11 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
     // -----
 
     // Logic to do XDLOPS code selection.
+    llvm::errs() << "Invoke XDLOPS code selection logic:\n";
+    llvm::errs() << "dataType: "; dataType.dump(); llvm::errs() << "\n";
+    llvm::errs() << "MPerWave: " << MPerWave << "\n";
+    llvm::errs() << "NPerWave: " << NPerWave << "\n";
+
     XdlopsCodeSelection xcs = XdlopsCodeSelection::get(dataType, MPerWave, NPerWave, b);
 
     // Extract values from XdlopsCodeSelection.
@@ -4887,6 +4892,12 @@ struct XdlopsGemmV2RewritePattern
     auto MConstantOp = b.create<ConstantIndexOp>(loc, M);
     auto NConstantOp = b.create<ConstantIndexOp>(loc, N);
     auto KConstantOp = b.create<ConstantIndexOp>(loc, K);
+
+    // Logic to do XDLOPS code selection.
+    llvm::errs() << "Invoke XDLOPS code selection logic:\n";
+    llvm::errs() << "dataType: "; dataType.dump(); llvm::errs() << "\n";
+    llvm::errs() << "MPerWave: " << MPerWave << "\n";
+    llvm::errs() << "NPerWave: " << NPerWave << "\n";
 
     XdlopsCodeSelection xcs = XdlopsCodeSelection::get(dataType, MPerWave, NPerWave, b);
 

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -622,6 +622,7 @@ private:
       {8, 64, 8, 8, 64, 0, false, false},
       {4, 64, 16, 4, 64, 0, false, false},
       {32, 64, 4, 32, 64, 0, false, false},
+      {16, 16, 16, 16, 16, 0, false, false},
       {16, 16, 4, 16, 16, 0, false, false},
   };
   const int64_t waveSize = 64;

--- a/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
+++ b/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
@@ -674,33 +674,33 @@ struct XdlopsCodeSelection {
     result.cycles = cycles;
     result.k_base = k_base;
 
-    llvm::errs() << "XDLOPS code selection result:\n";
-    llvm::errs() << "mfmaInstr: " << mfmaInstr << "\n";
-    llvm::errs() << "MPerXdlops: " << MPerXdlops << "\n";
-    llvm::errs() << "NPerXdlops: " << NPerXdlops << "\n";
-    llvm::errs() << "MRepeats: " << MRepeats << "\n";
-    llvm::errs() << "NRepeats: " << NRepeats << "\n";
-    llvm::errs() << "vectorType: " << vectorType << "\n";
-    llvm::errs() << "vectorNumber: " << vectorNumber << "\n";
-    llvm::errs() << "imms:\n";
-    for (auto imm : imms) {
-	    llvm::errs() << imm[0] << " " << imm[1] << " " << imm[2] << "\n";
-    }
-    llvm::errs() << "argType: " << argType << "\n";
+    // llvm::errs() << "XDLOPS code selection result:\n";
+    // llvm::errs() << "mfmaInstr: " << mfmaInstr << "\n";
+    // llvm::errs() << "MPerXdlops: " << MPerXdlops << "\n";
+    // llvm::errs() << "NPerXdlops: " << NPerXdlops << "\n";
+    // llvm::errs() << "MRepeats: " << MRepeats << "\n";
+    // llvm::errs() << "NRepeats: " << NRepeats << "\n";
+    // llvm::errs() << "vectorType: " << vectorType << "\n";
+    // llvm::errs() << "vectorNumber: " << vectorNumber << "\n";
+    // llvm::errs() << "imms:\n";
+    // for (auto imm : imms) {
+    //         llvm::errs() << imm[0] << " " << imm[1] << " " << imm[2] << "\n";
+    // }
+    // llvm::errs() << "argType: " << argType << "\n";
 
-    llvm::errs() << "group_size: " << group_size << "\n";
-    llvm::errs() << "num_groups_blk: " << num_groups_blk << "\n";
-    llvm::errs() << "num_regs_blk: " << num_regs_blk << "\n";
-    llvm::errs() << "num_threads_blk: " << num_threads_blk << "\n";
-    llvm::errs() << "wave_size: " << wave_size << "\n";
-    llvm::errs() << "num_input_blks: " << num_input_blks << "\n";
-    llvm::errs() << "num_output_blks: " << num_output_blks << "\n";
-    llvm::errs() << "num_regs_xdlops: " << num_regs_xdlops << "\n";
-    llvm::errs() << "m: " << m << "\n";
-    llvm::errs() << "n: " << n << "\n";
-    llvm::errs() << "k: " << k << "\n";
-    llvm::errs() << "cycles: " << cycles << "\n";
-    llvm::errs() << "k_base: " << k_base << "\n";
+    // llvm::errs() << "group_size: " << group_size << "\n";
+    // llvm::errs() << "num_groups_blk: " << num_groups_blk << "\n";
+    // llvm::errs() << "num_regs_blk: " << num_regs_blk << "\n";
+    // llvm::errs() << "num_threads_blk: " << num_threads_blk << "\n";
+    // llvm::errs() << "wave_size: " << wave_size << "\n";
+    // llvm::errs() << "num_input_blks: " << num_input_blks << "\n";
+    // llvm::errs() << "num_output_blks: " << num_output_blks << "\n";
+    // llvm::errs() << "num_regs_xdlops: " << num_regs_xdlops << "\n";
+    // llvm::errs() << "m: " << m << "\n";
+    // llvm::errs() << "n: " << n << "\n";
+    // llvm::errs() << "k: " << k << "\n";
+    // llvm::errs() << "cycles: " << cycles << "\n";
+    // llvm::errs() << "k_base: " << k_base << "\n";
 
     return result;
   }

--- a/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
+++ b/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
@@ -674,6 +674,34 @@ struct XdlopsCodeSelection {
     result.cycles = cycles;
     result.k_base = k_base;
 
+    llvm::errs() << "XDLOPS code selection result:\n";
+    llvm::errs() << "mfmaInstr: " << mfmaInstr << "\n";
+    llvm::errs() << "MPerXdlops: " << MPerXdlops << "\n";
+    llvm::errs() << "NPerXdlops: " << NPerXdlops << "\n";
+    llvm::errs() << "MRepeats: " << MRepeats << "\n";
+    llvm::errs() << "NRepeats: " << NRepeats << "\n";
+    llvm::errs() << "vectorType: " << vectorType << "\n";
+    llvm::errs() << "vectorNumber: " << vectorNumber << "\n";
+    llvm::errs() << "imms:\n";
+    for (auto imm : imms) {
+	    llvm::errs() << imm[0] << " " << imm[1] << " " << imm[2] << "\n";
+    }
+    llvm::errs() << "argType: " << argType << "\n";
+
+    llvm::errs() << "group_size: " << group_size << "\n";
+    llvm::errs() << "num_groups_blk: " << num_groups_blk << "\n";
+    llvm::errs() << "num_regs_blk: " << num_regs_blk << "\n";
+    llvm::errs() << "num_threads_blk: " << num_threads_blk << "\n";
+    llvm::errs() << "wave_size: " << wave_size << "\n";
+    llvm::errs() << "num_input_blks: " << num_input_blks << "\n";
+    llvm::errs() << "num_output_blks: " << num_output_blks << "\n";
+    llvm::errs() << "num_regs_xdlops: " << num_regs_xdlops << "\n";
+    llvm::errs() << "m: " << m << "\n";
+    llvm::errs() << "n: " << n << "\n";
+    llvm::errs() << "k: " << k << "\n";
+    llvm::errs() << "cycles: " << cycles << "\n";
+    llvm::errs() << "k_base: " << k_base << "\n";
+
     return result;
   }
 };


### PR DESCRIPTION
This used to fail:

```
./bin/mlir-miopen-driver -p=false -x2 fil_layout=kcyx -in_layout=nchw -out_layout=nkhw -batchsize=16 -in_channels=16 -out_channels=64 -in_h=31 -in_w=31 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1 -pr -ph -c -t f16 | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void
```

While investigating this issue, we identified several issues in XDLOPS fp16 code selection logic:

Multiple issues found:

1. In f16 case, tuning parameter KPerBlock can't be smaller than the XDLOP instruction selected. In this failing case, 16x16x16f16 is selected but KPerBlock was picked as 4. This makes the outer loop iteration incorrect.
2. !KReduction case: loop iteration number shall be increased by k_base instead of 1.
3. !KReduction case: offset doesn't need to be multiplied by k_base as the induction variable has already been multiplied by k_base in the previous step.
4. KReduction case: loop outer loop iteration number shall be increased by num_input_blks * k_base instead of num_input_blks.
5. KReduction case: LDS -> VGPR data load is strided. Can't use vector.transfer_read. Must use std.load + vector.insertelement.

Also, we found a bug in the original C++ code, although it doesn't affect correctness:

1. KReduction case: a[] and b[] are overly allocated. Uses 4X of VGPRs than really necessary. This issue causes issue 5. above in MLIR path.

