### PR TITLE
[WORKAROUND] Issue 155: Incorrect results when padding=1 with RNG on

### DIFF
--- a/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_random.mlir
+++ b/mlir/test/mlir-miopen-driver/e2e/conv2d_host_validation_random.mlir
@@ -165,3 +165,15 @@
 // CHECK_ISSUE_146_14: [1]
 // CHECK_ISSUE_146_15: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_ISSUE_146_15: [1]
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/155
+///////////////////////////////////////////////////////////////////////////////////////////
+
+// RUN: mlir-miopen-driver -pv -fil_layout=kcyx -in_layout=nchw -out_layout=nkhw -batchsize=64 -in_channels=4 -out_channels=64 -in_h=4 -in_w=4 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=1 --conv_stride_w=1 -p=false -c -rand 1| mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_155_1
+// RUN: mlir-miopen-driver -pv -fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk -batchsize=64 -in_channels=4 -out_channels=64 -in_h=4 -in_w=4 -fil_h=3 -fil_w=3 --dilation_h=1 --dilation_w=1 --padding_h=1 --padding_w=1 --conv_stride_h=1 --conv_stride_w=1 -p=false -c -rand 1| mlir-rocm-runner  --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_155_2
+
+// CHECK_ISSUE_155_1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_155_1: [1]
+// CHECK_ISSUE_155_2: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_155_2: [1]


### PR DESCRIPTION
Turns out this could be a compiler backend issue.
Workaround it by changing the loading address to tame memory controller and potentially cache lines.