### PR TITLE
Convert CPU convolution results for printing

### DIFF
--- a/mlir/test/mlir-miopen-driver/populate_host_print.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host_print.mlir
@@ -69,7 +69,7 @@
 // BF16-NEXT: call @mcpuMemset5DBF16Rand({{.*}}, {{.*}}, {{.*}}, {{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, i16, i16, i32) -> ()
 // BF16-NEXT: call @gpu_conv({{.*}}, {{.*}}, {{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
 // BF16-NEXT: memref_cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]> to memref<?x?x?x?x?x[[PRINT_TYPE]]>
-// BF16-NEXT: call @mcpuMemBF16ConvertFloat({{.*}}, {{.*}}) : (memref<?x?x?x?x?xi16>, memref<?x?x?x?x?xf32>) -> ()
+// BF16-NEXT: call @mcpuMem5DBF16ConvertFloat({{.*}}, {{.*}}) : (memref<?x?x?x?x?xi16>, memref<?x?x?x?x?xf32>) -> ()
 // BF16-NEXT: memref_cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]> to memref<*x[[PRINT_TYPE]]>
 // BF16-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*x[[PRINT_TYPE]]>) -> ()
 // BF16-NEXT: dealloc {{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>

--- a/mlir/test/mlir-miopen-driver/populate_prc.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_prc.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-miopen-driver -p -prc | FileCheck %s --check-prefix=F32
+
+// F32:  [[RES:%.*]] = memref_cast {{.*}} : memref<{{.*}}> to memref<*xf32>
+// F32-NEXT:    call @print_memref_f32([[RES]]) : (memref<*xf32>) -> () 
+
+// RUN: mlir-miopen-driver -p -prc -t f16 | FileCheck %s --check-prefix=F16
+
+// F16:   call @convert_tensor[[TYPE:[a-zA-Z0-9]+]]({{.*}}, [[FLT:%.*]]) : (memref<[[TYPE]]xf16>, memref<[[TYPE]]xf32>) -> ()
+// F16-NEXT:    [[RES:%.*]] = memref_cast [[FLT]] : memref<[[TYPE]]xf32> to memref<*xf32>
+// F16-NEXT:    call @print_memref_f32([[RES]]) : (memref<*xf32>) -> ()
+
+
+// RUN: mlir-miopen-driver -p -prc -t bf16 | FileCheck %s --check-prefix=BF16
+
+// BF16:  call @mcpuMem5DBF16ConvertFloat({{.*}}, {{.*}}) : (memref<?x?x?x?x?xi16>, memref<?x?x?x?x?xf32>) -> ()
+// BF16-NEXT:    [[RES:%.*]] = memref_cast {{.*}} : memref<{{.*}}> to memref<*xf32>
+// BF16-NEXT:    call @print_memref_f32([[RES]]) : (memref<*xf32>) -> ()
+


### PR DESCRIPTION
Convert CPU convolution results of f16 or bf16 to f32 for printing

[issue158](https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/158)