### PR TITLE
Remove compile-time warnings related with LogicalResult.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -1247,10 +1247,9 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
   }
 };
 
-// Explicitly instantiate the template to operation type
-template struct Conv2DRewritePattern<miopen::Conv2DOp>;
-template struct Conv2DRewritePattern<miopen::Conv2DBwdDataOp>;
-template struct Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>;
+// Delcaration of static member variables of Conv2DRewritePattern template.
+template <typename T> typename Conv2DRewritePattern<T>::ArgumentFields fields;
+template <typename T> typename Conv2DRewritePattern<T>::ConvOpType convOpType;
 
 //===----------------------------------------------------------------------===//
 // Assigning attributes.

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -63,7 +63,7 @@ struct LowerGpuOpsToROCDLOpsPass
     OwningRewritePatternList patterns, llvmPatterns;
 
     populateGpuRewritePatterns(m.getContext(), patterns);
-    applyPatternsAndFoldGreedily(m, std::move(patterns));
+    (void)applyPatternsAndFoldGreedily(m, std::move(patterns));
 
     populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
     populateVectorToROCDLConversionPatterns(converter, llvmPatterns);
@@ -313,7 +313,6 @@ struct MubufStoreOpLowering : ConvertToLLVMPattern {
     auto adaptorValue = adaptor.value();
 
     Type valueType = mubufStoreOp.value().getType();
-    Type LLVMValueType = typeConverter->convertType(valueType);
 
     // use standard store for storing scalar f16 and i16 (bf16).
     if ((dstElementType.getIntOrFloatBitWidth() != 32) &&
@@ -456,13 +455,11 @@ struct AtomicFAddOpLowering : ConvertToLLVMPattern {
 
     MemRefType dstMemRefType =
         atomicAddOp.memref().getType().cast<MemRefType>();
-    Type dstElementType = dstMemRefType.getElementType();
     auto dstShape = dstMemRefType.getShape();
     auto adaptorIndices = adaptor.indices();
     auto adaptorValue = adaptor.value();
 
     Type valueType = atomicAddOp.value().getType();
-    Type LLVMValueType = typeConverter->convertType(valueType);
 
     // use rocdl.atomic_add.
 

--- a/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
+++ b/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
@@ -350,7 +350,7 @@ void LowerMIOpenOpsWithinGPUModulePass::runOnOperation() {
   populateAffineToStdConversionPatterns(patterns, &getContext());
   populateLoopToStdConversionPatterns(patterns, &getContext());
 
-  applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 }
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>

--- a/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
+++ b/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
@@ -350,7 +350,8 @@ void LowerMIOpenOpsWithinGPUModulePass::runOnOperation() {
   populateAffineToStdConversionPatterns(patterns, &getContext());
   populateLoopToStdConversionPatterns(patterns, &getContext());
 
-  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
 }
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
@@ -26,8 +26,6 @@ private:
 AffineMap AffineTransforms::buildIndexAffineMap(miopen::TransformOp op) {
   auto inputType = op.input().getType().dyn_cast<MemRefType>();
   auto inputShape = inputType.getShape();
-  auto inputRank = inputType.getRank();
-  auto inputElementType = inputType.getElementType();
   auto inputAffineMaps = inputType.getAffineMaps();
 
   auto layoutAttr = op->template getAttrOfType<ArrayAttr>("layout");
@@ -60,7 +58,6 @@ AffineMap AffineTransforms::buildIndexAffineMap(miopen::TransformOp op) {
 
         auto parameters = dimLayoutAttr.get("parameters").dyn_cast<ArrayAttr>();
         auto leftPad = parameters.getValue()[0].dyn_cast<IntegerAttr>().getInt();
-        auto rightPad = parameters.getValue()[0].dyn_cast<IntegerAttr>().getInt();
         for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
           auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
           auto destDim = destDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
@@ -161,7 +158,7 @@ AffineMap AffineTransforms::buildIndexAffineMap(miopen::TransformOp op) {
         auto outputType = op.output().getType().dyn_cast<MemRefType>();
         auto outputShape = outputType.getShape();
 
-        for (int j = 0; j < begins.size(); j++) {
+        for (unsigned j = 0; j < begins.size(); j++) {
           auto begin = begins.getValue()[j].dyn_cast<IntegerAttr>().getInt();
           auto end = ends.getValue()[j].dyn_cast<IntegerAttr>().getInt();
           auto destDim =
@@ -205,7 +202,6 @@ void AffineTransforms::runOnFunction() {
 
     auto outputType = op.output().getType().dyn_cast<MemRefType>();
     auto outputShape = outputType.getShape();
-    auto outputElementType = outputType.getElementType();
     auto transformedOutputType = MemRefType::get(outputShape, outputType.getElementType(),
                                                  {indexAffineMap});
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -114,14 +114,16 @@ void LowerMIOpenOpsStep1Pass::runOnOperation() {
   patterns.insert<Conv2DRewritePattern<miopen::Conv2DBwdDataOp>>(&getContext());
   patterns.insert<Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>>(
       &getContext());
-  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
 }
 
 void LowerMIOpenOpsStep2Pass::runOnOperation() {
   OwningRewritePatternList patterns;
   patterns.insert<GridwiseGemmRewritePattern>(&getContext());
   patterns.insert<GridwiseGemmV2RewritePattern>(&getContext());
-  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
 }
 
 void LowerMIOpenOpsStep3Pass::runOnOperation() {
@@ -133,7 +135,8 @@ void LowerMIOpenOpsStep3Pass::runOnOperation() {
   patterns.insert<BlockwiseGemmRewritePattern>(&getContext());
   patterns.insert<BlockwiseGemmV2RewritePattern>(&getContext());
   patterns.insert<BlockwiseCopyRewritePattern>(&getContext());
-  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
 }
 
 void LowerMIOpenOpsStep4Pass::runOnOperation() {
@@ -142,14 +145,16 @@ void LowerMIOpenOpsStep4Pass::runOnOperation() {
   patterns.insert<ThreadwiseCopyRewritePattern>(&getContext());
   patterns.insert<ThreadwiseCopyV2RewritePattern>(&getContext());
   patterns.insert<XdlopsGemmV2RewritePattern>(&getContext());
-  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
 }
 
 void LowerMIOpenOpsStep5Pass::runOnOperation() {
   OwningRewritePatternList patterns;
   populateAffineToStdConversionPatterns(patterns, &getContext());
   populateLoopToStdConversionPatterns(patterns, &getContext());
-  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
 }
 
 std::unique_ptr<Pass> mlir::miopen::createLowerMIOpenOpsStep1Pass() {

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -77,6 +77,7 @@ struct LowerMIOpenOpsStep5Pass
 // hight level convolution operations is the argument sequence. For
 // simplicity, we always arrange the first two arguments to be input
 // and the last argument to be output
+
 template <>
 const ArgumentFields Conv2DRewritePattern<miopen::Conv2DOp>::fields = {
     {0, 1, 2},
@@ -107,6 +108,11 @@ template <>
 const miopen::ConvOpType
     Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>::convOpType =
         miopen::ConvOpType::Conv2DBwdWeightOpType;
+
+// Explicitly instantiate the template to operation type
+template struct Conv2DRewritePattern<miopen::Conv2DOp>;
+template struct Conv2DRewritePattern<miopen::Conv2DBwdDataOp>;
+template struct Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>;
 
 void LowerMIOpenOpsStep1Pass::runOnOperation() {
   OwningRewritePatternList patterns;

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -114,14 +114,14 @@ void LowerMIOpenOpsStep1Pass::runOnOperation() {
   patterns.insert<Conv2DRewritePattern<miopen::Conv2DBwdDataOp>>(&getContext());
   patterns.insert<Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>>(
       &getContext());
-  applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 }
 
 void LowerMIOpenOpsStep2Pass::runOnOperation() {
   OwningRewritePatternList patterns;
   patterns.insert<GridwiseGemmRewritePattern>(&getContext());
   patterns.insert<GridwiseGemmV2RewritePattern>(&getContext());
-  applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 }
 
 void LowerMIOpenOpsStep3Pass::runOnOperation() {
@@ -133,7 +133,7 @@ void LowerMIOpenOpsStep3Pass::runOnOperation() {
   patterns.insert<BlockwiseGemmRewritePattern>(&getContext());
   patterns.insert<BlockwiseGemmV2RewritePattern>(&getContext());
   patterns.insert<BlockwiseCopyRewritePattern>(&getContext());
-  applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 }
 
 void LowerMIOpenOpsStep4Pass::runOnOperation() {
@@ -142,14 +142,14 @@ void LowerMIOpenOpsStep4Pass::runOnOperation() {
   patterns.insert<ThreadwiseCopyRewritePattern>(&getContext());
   patterns.insert<ThreadwiseCopyV2RewritePattern>(&getContext());
   patterns.insert<XdlopsGemmV2RewritePattern>(&getContext());
-  applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 }
 
 void LowerMIOpenOpsStep5Pass::runOnOperation() {
   OwningRewritePatternList patterns;
   populateAffineToStdConversionPatterns(patterns, &getContext());
   populateLoopToStdConversionPatterns(patterns, &getContext());
-  applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 }
 
 std::unique_ptr<Pass> mlir::miopen::createLowerMIOpenOpsStep1Pass() {

--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -104,8 +104,7 @@ static unsigned short float_to_fp16(float src_val,
 
 extern "C" hipModule_t mgpuModuleLoad(void *data) {
   hipModule_t module = nullptr;
-  int32_t err =
-      reportErrorIfAny(hipModuleLoadData(&module, data), "ModuleLoad");
+  (void)reportErrorIfAny(hipModuleLoadData(&module, data), "ModuleLoad");
   return module;
 }
 
@@ -116,8 +115,8 @@ extern "C" void mgpuModuleUnload(hipModule_t module) {
 extern "C" hipFunction_t mgpuModuleGetFunction(hipModule_t module,
                                                const char *name) {
   hipFunction_t function = nullptr;
-  int32_t err = reportErrorIfAny(hipModuleGetFunction(&function, module, name),
-                                 "GetFunction");
+  (void)reportErrorIfAny(hipModuleGetFunction(&function, module, name),
+                         "GetFunction");
   return function;
 }
 

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
@@ -917,9 +917,9 @@ void mlir::translateModuleFromMIOpenToCFlags(ModuleOp m, std::string &cflags) {
       int64_t gemmCDstPerWrite;
       int64_t gridSize;
       PopulateParams populateParams;
-      populateParams.paramsFromCtx(ctx, 0, validParams, gemmADerivedParam,
-                                   gemmBDerivedParam, blockGemmDerivedParam,
-                                   gemmCDstPerWrite, gridSize);
+      (void)populateParams.paramsFromCtx(
+          ctx, 0, validParams, gemmADerivedParam, gemmBDerivedParam,
+          blockGemmDerivedParam, gemmCDstPerWrite, gridSize);
 
       std::map<std::string, int> parameters;
 

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -814,8 +814,9 @@ mlir::translateModuleFromMIOpenToCFlagsXDLOPS(ModuleOp m) {
       DerivedParams gemmBDerivedParam;
       int64_t blockSize = 0;
       int64_t gridSize = 0;
-      populateParams.paramsFromCtx(ctx, 0, validParams, gemmADerivedParam,
-                                   gemmBDerivedParam, blockSize, gridSize);
+      (void)populateParams.paramsFromCtx(ctx, 0, validParams, gemmADerivedParam,
+                                         gemmBDerivedParam, blockSize,
+                                         gridSize);
 
       parameters["CK_PARAM_TUNABLE_BLOCK_SIZE"] = blockSize;
       parameters["CK_PARAM_DEPENDENT_GRID_SIZE"] = gridSize;

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -952,7 +952,6 @@ static FuncOp createVerifyFuncOp(ModuleOp &module, OpBuilder &builder,
   }
   auto thenBody = ifOp.getThenBodyBuilder();
 
-  auto storeOp0 =
       thenBody.create<StoreOp>(builder.getUnknownLoc(), c0ConstantInt32Op,
                                cmpResultAllocOp, ValueRange{c0IndexOp});
 
@@ -2190,7 +2189,7 @@ int main(int argc, char **argv) {
       exit(1);
     }
   } else {
-    conv2dGenerator.parseConvDims(
+    (void)conv2dGenerator.parseConvDims(
         batchSize, groupSize, inputChannel, inputHeight, inputWidth,
         outputChannel, outputHeight, outputWidth, filterWidth, filterHeight);
   }

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -75,6 +75,7 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
   MiirHandle_s *handle = nullptr;
 
   Conv2dGenerator conv2dGenerator;
+  LogicalResult result = LogicalResult::failure();
 
   if (succeeded(conv2dGenerator.parseConvConfig(arguments))) {
 
@@ -85,10 +86,10 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
 
     ModuleOp module = handle->getModule();
 
-    conv2dGenerator.genConvModule(module, builder);
+    result = conv2dGenerator.genConvModule(module, builder);
   }
 
-  return handle;
+  return (result.succeeded()) ? handle : nullptr;
 }
 
 extern "C" MiirStatus miirDestroyHandle(MiirHandle mlirHandle) {
@@ -171,8 +172,8 @@ extern "C" MiirStatus miirLowerCpp(MiirHandle mlirHandle) {
 
   PassManager pm(module.getContext(), PassManager::Nesting::Implicit);
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
-  pm.run(module);
-  return MIIR_SUCCESS;
+  LogicalResult result = pm.run(module);
+  return (result.succeeded()) ? MIIR_SUCCESS : MIIR_BUILD_FAILURE;
 }
 
 extern "C" const char *miirGenIgemmSource(MiirHandle mlirHandle) {


### PR DESCRIPTION
Clean up compile-time warnings. `LogicalResult` is declared with `[[nodiscard]]` attribute so need to explicitly add `(void)` to suppress it, or invoke `signalPassFailure()` to propagate the errors.

Cleaned up a couple of other unused variables and type checks.