### PR TITLE
Removing llvm::errs before affix tuning params lowering

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -114,7 +114,8 @@ LogicalResult PopulateParams::paramsFromCtx(
 
   if (failed(res)) {
     // All initParameters have failed, shouldn't happen
-    llvm::errs() << "FATAL ERROR! COULD NOT FIND VALID TUNING PARAMETERS!\n";
+    LLVM_DEBUG(llvm::dbgs() << "FATAL ERROR! COULD NOT FIND VALID TUNING"
+                            << " PARAMETERS!\n");
   } else {
     LLVM_DEBUG(llvm::dbgs() << "Successfully picked tuning params from backup"
                             << " path.\n");
@@ -236,7 +237,8 @@ LogicalResult PopulateParamsXDL::paramsFromCtx(
 
   if (failed(res)) {
     // All initParameters have failed, shouldn't happen
-    llvm::errs() << "FATAL ERROR! COULD NOT FIND VALID TUNING PARAMETERS!\n";
+    LLVM_DEBUG(llvm::dbgs() << "FATAL ERROR! COULD NOT FIND VALID TUNING"
+                            << " PARAMETERS!\n");
   } else {
     LLVM_DEBUG(llvm::dbgs() << "Successfully picked tuning params from backup"
                             << " path.\n");

--- a/mlir/lib/Dialect/MIOpen/Tuning/SqliteDb.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/SqliteDb.cpp
@@ -31,8 +31,7 @@ class SQLite::impl {
       rc = sqlite3_open_v2(filepath.c_str(), &ptr_tmp, SQLITE_OPEN_READONLY,
                            nullptr);
     } else {
-      llvm::errs() << "FATAL ERROR! Does not support user db"
-                   << "\n";
+      LLVM_DEBUG(dbgs() << "FATAL ERROR! Does not support user db\n");
     }
     ptrDb = Sqlite3Ptr{ptr_tmp};
     return rc;
@@ -45,8 +44,8 @@ public:
     sqlite3_busy_timeout(ptrDb.get(), MIOPEN_SQL_BUSY_TIMEOUT_MS);
     isValid = (rc == 0);
     if (!isValid) {
-      llvm::errs() << "FATAL ERROR! COULD NOT OPEN DB CONNECTION to "
-                   << filename_ << "\n";
+      LLVM_DEBUG(dbgs() << "FATAL ERROR! COULD NOT OPEN DB "
+                              << "CONNECTION to " << filename_ << "\n";
     } else {
       LLVM_DEBUG(dbgs() << "Successfully opened connection to PerfDb.\n");
     }
@@ -80,7 +79,7 @@ SQLite::ResultType SQLite::exec(const std::string &query) const {
                           static_cast<void *>(&res), nullptr);
     });
     if (rc != SQLITE_OK) {
-      llvm::errs() << "Query[" << query << "] failed: " << errorMessage();
+      LLVM_DEBUG(dbgs() << "Query[" << query << "] failed: " << errorMessage());
     }
   }
   return res;
@@ -89,7 +88,7 @@ SQLite::ResultType SQLite::exec(const std::string &query) const {
 int SQLite::retry(std::function<int()> f, std::string filename) {
   int rc = f();
   if (rc == SQLITE_BUSY) {
-    llvm::errs() << "Timeout while waiting for Database: " + filename;
+    LLVM_DEBUG(dbgs() << "Timeout while waiting for Database: " + filename);
   }
   return rc;
 }


### PR DESCRIPTION
This PR removes all `llvm::errs()` by affix tuning params stage. This make sure client do not get a `FATAL` error stderr when it is not actually a fatal error. Instead, client should act according to the fatal return status of `miirLowerTuningParams()`. The PR addresses mlir side of concerns of: https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/161

The behavior of client using the miir library should follow the below behaviors:
  - Call `miirLowerTuningParams()` in the sanity check of the config
    - If the return is not `MIIR_SUCCESS`, client should give up and never execute this config
  - If any other failure happen after the affix tuning params, this is a bug in the lowering process. Only in this situation can library print to stderr