### PR TITLE
Add +sramecc switch gfx908.

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
+++ b/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
@@ -55,7 +55,8 @@ private:
   LogicalResult createHsaco(const Blob &isaBlob, StringRef name,
                             Blob &hsacoBlob);
   void configTargetChip(std::string &targetChip);
-  void configTargetFeatures(std::string &features);
+  void configTargetFeatures(const std::string &chip, const std::string &triple,
+                            std::string &features);
 };
 } // namespace mlir
 

--- a/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
@@ -276,9 +276,15 @@ void BackendUtils::setupDefaults(std::string &chip, std::string &features,
     triple = "amdgcn-amd-amdhsa";
   }
 
-  // Configure target features per ROCm / HIP version.
-  configTargetFeatures(features);
+  // Configure target features per ROCm / HIP version, and target GPU.
+  configTargetFeatures(chip, triple, features);
 }
 
-void BackendUtils::configTargetFeatures(std::string &features) {
+void BackendUtils::configTargetFeatures(const std::string &chip,
+                                        const std::string &triple,
+                                        std::string &features) {
+  // For gfx908, add +sramecc by default to be compatible with ROCm 4.1+.
+  if (chip == "gfx908") {
+    features += "+sramecc";
+  }
 }


### PR DESCRIPTION
This lets HIP runtime on ROCm 4.1+ to accept code objects produced for
gfx908.