### PR TITLE
Adding protection to link related failure in multi-threaded context

### DIFF
--- a/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
@@ -39,6 +39,8 @@
 // HIP headers.
 #include "hip/hip_version.h"
 
+#include <mutex>
+
 using namespace mlir;
 
 static constexpr const char kRunnerProgram[] = "mlir-rocm-runner";
@@ -125,8 +127,10 @@ LogicalResult BackendUtils::assembleIsa(const std::string isa, StringRef name,
   return assembleIsa(isa, name, result, triple, chip, features);
 }
 
+static std::mutex mutex;
 LogicalResult BackendUtils::createHsaco(const Blob &isaBlob, StringRef name,
                                         Blob &hsacoBlob) {
+  const std::lock_guard<std::mutex> lock(mutex);
   // Save the ISA binary to a temp file.
   int tempIsaBinaryFd = -1;
   SmallString<128> tempIsaBinaryFilename;

--- a/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
+++ b/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
@@ -47,8 +47,6 @@ static cl::opt<std::string> features("feature", cl::desc("target features"),
                                      cl::init(""));
 
 static LogicalResult runMLIRPasses(ModuleOp m) {
-  // TODO(sjw): fix multi-threading race condition
-  m.getContext()->disableMultithreading();
   PassManager pm(m.getContext());
   applyPassManagerCLOptions(pm);
 


### PR DESCRIPTION
This seem to fix https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/125 observation 2.

We do need multi-threaded tests to be able to capture cases like those.