### PR TITLE
MLIR#125: Change kernel naming to be fully user controlled

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -55,7 +55,7 @@ public:
                   const std::string &kernelName = "");
 
   const Config &getConfig() const { return config; }
-  std::string getKernelName(int kernelId) const;
+  LogicalResult setKernelName(std::string newName);
 
   int getKernelCount() const;
 

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -246,6 +246,10 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module,
                              ArrayRef<NamedAttribute>(kernelAttrs));
   module.push_back(func);
 
+  if (func.getName() != kernelName) {
+    return failure();
+  }
+
   // Construct a new Block.
   Block *block = func.addEntryBlock();
 

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -49,7 +49,7 @@ int Conv2dGenerator::getKernelCount() const {
   if (config.kernelId > 0) { // generate only 1 specified kernel
     count = 1;
   } else if (config.operation == "conv2d") {
-    count = 1;
+    count = 4;
   } else if (config.operation == "conv2d_bwd_data") {
     count = 1;
   } else if (config.operation == "conv2d_bwd_weight") {
@@ -201,12 +201,9 @@ Conv2dGenerator::parseConvDims(int64_t batchSize, int64_t groupSize,
   return success();
 }
 
-std::string Conv2dGenerator::getKernelName(int kernelId) const {
-  std::string kname = config.kernelName;
-  if (kernelId > 0) {
-    kname += "_" + std::to_string(kernelId);
-  }
-  return kname;
+LogicalResult Conv2dGenerator::setKernelName(std::string newName) {
+  config.kernelName = newName;
+  return success();
 }
 
 LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module,
@@ -237,7 +234,7 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module,
   auto funcType =
       builder.getFunctionType({filterArgType, inputArgType, outputArgType}, {});
 
-  std::string kernelName = getKernelName(kernel_id);
+  std::string kernelName = config.kernelName;
 
   // Annotate kernel attribute to the FuncOp.
   SmallVector<NamedAttribute, 1> kernelAttrs{

--- a/mlir/test/mlir-miopen-driver/populate_subkernels.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_subkernels.mlir
@@ -8,14 +8,14 @@
 // KERNEL0-NEXT: miopen.conv2d(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 
 // KERNEL1-LABEL: module
-// KERNEL1-NEXT:  func @conv2d_fwd_1(%arg0: memref<1x1024x1024x1x1xf32>, %arg1: memref<64x1x1024x14x14xf32>, %arg2: memref<64x1x1024x14x14xf32>) attributes {kernel = 1 : i32} {
+// KERNEL1-NEXT:  func @conv2d_fwd(%arg0: memref<1x1024x1024x1x1xf32>, %arg1: memref<64x1x1024x14x14xf32>, %arg2: memref<64x1x1024x14x14xf32>) attributes {kernel = 1 : i32} {
 // KERNEL1-NEXT: miopen.conv2d_dummy(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 
 // KERNEL2-LABEL: module
-// KERNEL2-NEXT:  func @conv2d_fwd_2(%arg0: memref<1x1024x1024x1x1xf32>, %arg1: memref<64x1x1024x14x14xf32>, %arg2: memref<64x1x1024x14x14xf32>) attributes {kernel = 2 : i32} {
+// KERNEL2-NEXT:  func @conv2d_fwd(%arg0: memref<1x1024x1024x1x1xf32>, %arg1: memref<64x1x1024x14x14xf32>, %arg2: memref<64x1x1024x14x14xf32>) attributes {kernel = 2 : i32} {
 // KERNEL2-NEXT: miopen.conv2d_dummy(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 
 // KERNEL3-LABEL: module
-// KERNEL3-NEXT:  func @conv2d_fwd_3(%arg0: memref<1x1024x1024x1x1xf32>, %arg1: memref<64x1x1024x14x14xf32>, %arg2: memref<64x1x1024x14x14xf32>) attributes {kernel = 3 : i32} {
+// KERNEL3-NEXT:  func @conv2d_fwd(%arg0: memref<1x1024x1024x1x1xf32>, %arg1: memref<64x1x1024x14x14xf32>, %arg2: memref<64x1x1024x14x14xf32>) attributes {kernel = 3 : i32} {
 // KERNEL3-NEXT: miopen.conv2d_dummy(%arg0, %arg1, %arg2) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -2311,12 +2311,18 @@ int main(int argc, char **argv) {
     if (genConfig.kernelId < 0) {
       // generate all sub-kernels
       int kernelCount = conv2dGenerator.getKernelCount();
+      std::string kernelBaseName = genConfig.kernelName;
       for (int i = 0; i < kernelCount; ++i) {
+        std::string kName = kernelBaseName;
+        if (i > 0) {
+          kName += "_" + std::to_string(i);
+        }
+        conv2dGenerator.setKernelName(kName);
         if (failed(conv2dGenerator.genConvModule(module, builder, i))) {
           llvm::errs() << "Module population failed.\n";
           exit(1);
         }
-        kernels.push_back(conv2dGenerator.getKernelName(i));
+        kernels.push_back(kName);
       }
     } else {
       // generate a specific kernel (kernel_id >= 0)
@@ -2324,7 +2330,7 @@ int main(int argc, char **argv) {
         llvm::errs() << "Module population failed.\n";
         exit(1);
       }
-      kernels.push_back(conv2dGenerator.getKernelName(genConfig.kernelId));
+      kernels.push_back(genConfig.kernelName);
     }
   }
 


### PR DESCRIPTION
* use --kernel_name exactly
* error if it is not unique