### PR TITLE
Miopen dialect opt step1 : Introduce miopen.move_pos_v2 op and its tests and lowering logic.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -3866,6 +3866,40 @@ struct MovePosRewritePattern : public OpRewritePattern<miopen::MovePosOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// MovePosV2 lowering.
+//===----------------------------------------------------------------------===//
+
+struct MovePosV2RewritePattern : public OpRewritePattern<miopen::MovePosV2Op> {
+  using OpRewritePattern<miopen::MovePosV2Op>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(miopen::MovePosV2Op op,
+                                PatternRewriter &b) const override {
+    auto loc = op.getLoc();
+    auto vectorType = op.input().getType().cast<VectorType>();
+    auto vector = op.input();
+    for (unsigned i = 0; i < vectorType.getShape()[0]; ++i) {
+      auto iter = b.create<ConstantIntOp>(loc, i, b.getIntegerType(32));
+      // vector.extractelement
+      auto element = b.create<vector::ExtractElementOp>(
+          loc, vectorType.getElementType(), vector, iter);
+      // add
+      Value add;
+      if (vectorType.getElementType().isa<IntegerType>()) {
+        add = b.create<AddIOp>(loc, element, op.getOperand(1 + i));
+      } else {
+        add = b.create<AddFOp>(loc, element, op.getOperand(1 + i));
+      }
+      // vector.insertelement
+      vector =
+          b.create<vector::InsertElementOp>(loc, vectorType, add, vector, iter);
+    }
+    op.replaceAllUsesWith(vector);
+    op.erase();
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // ThreadwiseGemm lowering.
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -155,13 +155,25 @@ def MIOpen_FillOp:
   }];
 }
 
+// TBD: eventually replace this with move_pos_v2.
 def MIOpen_MovePosOp:
     MIOpen_Op<"move_pos">,
     Arguments<(ins AnyMemRef:$memref,
                    Variadic<AnyTypeOf<[AnyInteger, AnyFloat]>>:$values)> {
     let summary = "Add values to indices within the memref.";
     let description = [{
-      The `miopen.fill` op adds values to indices within the memref.
+      The `miopen.move_pos` op adds values to indices within the memref.
+    }];
+}
+
+def MIOpen_MovePosV2Op:
+    MIOpen_Op<"move_pos_v2">,
+    Arguments<(ins VectorOfRankAndType<[1], [AnyInteger, AnyFloat]>:$input,
+                   Variadic<AnyTypeOf<[AnyInteger, AnyFloat]>>:$values)>,
+    Results<(outs VectorOfRankAndType<[1], [AnyInteger, AnyFloat]>:$output)> {
+    let summary = "Add values to indices within the vector.";
+    let description = [{
+      The `miopen.move_pos_v2` op adds values to indices within the vector.
     }];
 }
 

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.td
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.td
@@ -47,7 +47,7 @@ def MIOpenOpsStep2Pass : Pass<"miopen-lowering-step2", "ModuleOp"> {
 def MIOpenOpsStep3Pass : Pass<"miopen-lowering-step3", "ModuleOp"> {
   let summary = "expand blockwise copy into threadwise copy, blockwise gemm into threadwise gemm";
   let constructor = "mlir::miopen::createLowerMIOpenOpsStep3Pass()";
-  let dependentDialects = ["miopen::MIOpenDialect", "scf::SCFDialect"];
+  let dependentDialects = ["miopen::MIOpenDialect", "scf::SCFDialect", "vector::VectorDialect"];
 }
 
 def MIOpenOpsStep4Pass : Pass<"miopen-lowering-step4", "ModuleOp"> {

--- a/mlir/lib/Dialect/MIOpen/CMakeLists.txt
+++ b/mlir/lib/Dialect/MIOpen/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(MLIRMIOpenOps
   )
 target_link_libraries(MLIRMIOpenOps
   PUBLIC
+  MLIRGPU
   MLIRIR
   LLVMSupport
   )

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -388,6 +388,34 @@ static void print(OpAsmPrinter &p, MovePosOp op) {
 static LogicalResult verify(MovePosOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
+// MovePosV2Op
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseMovePosV2Op(OpAsmParser &parser,
+                                    OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 3> ops;
+  Type srcType;
+
+  auto ret = parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+             parser.parseColonType(srcType) ||
+             parser.resolveOperand(ops[0], srcType, result.operands) ||
+             parser.addTypeToList(srcType, result.types);
+
+  for (unsigned i = 1; i < ops.size(); ++i) {
+    ret &= succeeded(parser.resolveOperand(
+        ops[i], srcType.cast<VectorType>().getElementType(), result.operands));
+  }
+  return failure(ret);
+}
+
+static void print(OpAsmPrinter &p, MovePosV2Op op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p << " : " << op.getType();
+}
+
+static LogicalResult verify(MovePosV2Op op) { return success(); }
+
+//===----------------------------------------------------------------------===//
 // WorkgroupBarrierOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -136,6 +136,7 @@ void LowerMIOpenOpsStep3Pass::runOnOperation() {
   OwningRewritePatternList patterns;
   patterns.insert<FillRewritePattern>(&getContext());
   patterns.insert<MovePosRewritePattern>(&getContext());
+  patterns.insert<MovePosV2RewritePattern>(&getContext());
   patterns.insert<SubviewRewritePattern>(&getContext());
   patterns.insert<TransformRewritePattern>(&getContext());
   patterns.insert<BlockwiseGemmRewritePattern>(&getContext());

--- a/mlir/test/Dialect/MIOpen/lowering_move_pos_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_move_pos_v2.mlir
@@ -1,0 +1,31 @@
+// RUN: mlir-opt -miopen-lowering-step3 %s | FileCheck %s
+
+// CHECK-LABEL: @miopen_lowering_move_pos_v2_i32
+func @miopen_lowering_move_pos_v2_i32(%vector_i32 : vector<2xi32>) -> vector<2xi32> {
+  %deltaY_i32 = constant 16 : i32
+  %deltaX_i32 = constant 8 : i32
+  // CHECK: %{{.*}} = vector.extractelement %{{.*}}[%{{.*}} : i32] : vector<2xi32>
+  // CHECK: %{{.*}} = addi %{{.*}}, %{{.*}} : i32
+  // CHECK: %[[VECTOR0:.*]] = vector.insertelement %{{.*}}, %{{.*}}[%{{.*}} : i32] : vector<2xi32>
+  // CHECK: %{{.*}} = vector.extractelement %[[VECTOR0]][%{{.*}} : i32] : vector<2xi32>
+  // CHECK: %{{.*}} = addi %{{.*}}, %{{.*}} : i32
+  // CHECK: %[[VECTOR1:.*]] = vector.insertelement %{{.*}}, %{{.*}}[%{{.*}} : i32] : vector<2xi32>
+  %output = miopen.move_pos_v2(%vector_i32, %deltaY_i32, %deltaX_i32) : vector<2xi32>
+  // CHECK: return %[[VECTOR1]] : vector<2xi32>
+  return %output : vector<2xi32>
+}
+
+// CHECK-LABEL: @miopen_lowering_move_pos_v2_f32
+func @miopen_lowering_move_pos_v2_f32(%vector_f32 : vector<2xf32>) -> vector<2xf32> {
+  %deltaY_f32 = constant 16.0 : f32
+  %deltaX_f32 = constant 8.0 : f32
+  // CHECK: %{{.*}} = vector.extractelement %{{.*}}[%{{.*}} : i32] : vector<2xf32>
+  // CHECK: %{{.*}} = addf %{{.*}}, %{{.*}} : f32
+  // CHECK: %[[VECTOR0:.*]] = vector.insertelement %{{.*}}, %{{.*}}[%{{.*}} : i32] : vector<2xf32>
+  // CHECK: %{{.*}} = vector.extractelement %[[VECTOR0]][%{{.*}} : i32] : vector<2xf32>
+  // CHECK: %{{.*}} = addf %{{.*}}, %{{.*}} : f32
+  // CHECK: %[[VECTOR1:.*]] = vector.insertelement %{{.*}}, %{{.*}}[%{{.*}} : i32] : vector<2xf32>
+  %output = miopen.move_pos_v2(%vector_f32, %deltaY_f32, %deltaX_f32) : vector<2xf32>
+  // CHECK: return %[[VECTOR1]] : vector<2xf32>
+  return %output : vector<2xf32>
+}

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -104,9 +104,24 @@ func @miopen_move_pos(%buffer_f32 : memref<2xf32, 5>, %buffer_i32 : memref<2xi32
 }
 
 // CHECK-LABEL: func @miopen_move_pos
-//   CHECK: miopen.move_pos
-//   CHECK: miopen.move_pos
-//   CHECK: miopen.move_pos
+//   CHECK: miopen.move_pos(%{{.*}}, %{{.*}}, %{{.*}}) : memref<2xi32, 5>
+//   CHECK: miopen.move_pos(%{{.*}}, %{{.*}}, %{{.*}}) : memref<2xf32, 5>
+
+func @miopen_move_pos_v2(%vector_f32 : vector<2xf32>, %vector_i32 : vector<2xi32>) {
+  %deltaY_i32 = constant 16 : i32
+  %deltaX_i32 = constant 8 : i32
+  %output1 = miopen.move_pos_v2(%vector_i32, %deltaY_i32, %deltaX_i32) : vector<2xi32>
+ 
+  %deltaY_f32 = constant 16.0 : f32
+  %deltaX_f32 = constant 8.0 : f32
+  %output2 = miopen.move_pos_v2(%vector_f32, %deltaY_f32, %deltaX_f32) : vector<2xf32>
+
+  return
+}
+
+// CHECK-LABEL: func @miopen_move_pos_v2
+//   CHECK: %{{.*}} = miopen.move_pos_v2(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi32>
+//   CHECK: %{{.*}} = miopen.move_pos_v2(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>
 
 func @miopen_workgroup_barrier() {
   miopen.workgroup_barrier


### PR DESCRIPTION
- op definition.
- op tests.
- lowering logic.
- lowering tests.

This `miopen.move_pos_v2` uses vector types and will replace `miopen.move_pos` op.

Subsequent PR is #191 .