### PR TITLE
Miopen dialect opt step3 : introduce miopen.blockwise_load and miopen.blockwise_store.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -234,22 +234,22 @@ def MIOpen_BlockwiseLoadOp:
   }];
 }
 
-// // blockwise_store
-// def MIOpen_BlockwiseStoreOp:
-//     MIOpen_Op<"blockwise_store">,
-//     Arguments<(ins AnyTypeOf<[F32, F16, I16,
-//                               VectorOfLengthAndType<[2, 4], [F32]>,
-//                               VectorOfLengthAndType<[2, 4, 8], [F16]>, 
-//                               VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
-//                    AnyMemRef:$dest,
-//                    VectorOfLengthAndType<[2], [I32]>:$destCoordVector)> {
-//   let summary = "Blockwise GPU data store";
-//   let description = [{
-//     The `miopen.blockwise_store` op moves data on GPU. Following movements are
-//     allowed:
-//     - Register (naive tensor) to LDS (naive tensor).
-//   }];
-// }
+// blockwise_store
+def MIOpen_BlockwiseStoreOp:
+    MIOpen_Op<"blockwise_store">,
+    Arguments<(ins AnyTypeOf<[F32, F16, I16,
+                              VectorOfLengthAndType<[2, 4], [F32]>,
+                              VectorOfLengthAndType<[2, 4, 8], [F16]>, 
+                              VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
+                   AnyMemRef:$dest,
+                   VectorOfLengthAndType<[2], [I32]>:$destCoordVector)> {
+  let summary = "Blockwise GPU data store";
+  let description = [{
+    The `miopen.blockwise_store` op moves data on GPU. Following movements are
+    allowed:
+    - Register (naive tensor) to LDS (naive tensor).
+  }];
+}
 
 // threadwise_copy
 def MIOpen_ThreadwiseCopyOp:

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -217,6 +217,40 @@ def MIOpen_BlockwiseCopyOp:
   }];
 }
 
+// blockwise_load
+def MIOpen_BlockwiseLoadOp:
+    MIOpen_Op<"blockwise_load">,
+    Arguments<(ins AnyMemRef:$source,
+                   VectorOfLengthAndType<[2], [I32]>:$sourceCoordVector)>,
+    Results<(outs AnyTypeOf<[F32, F16, I16,
+                             VectorOfLengthAndType<[2, 4], [F32]>,
+                             VectorOfLengthAndType<[2, 4, 8], [F16]>, 
+                             VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$result)> {
+  let summary = "Blockwise GPU data load";
+  let description = [{
+    The `miopen.blockwise_load` op moves data on GPU. Following movements are
+    allowed:
+    - Global (generic tensor) to register (naive tensor).
+  }];
+}
+
+// // blockwise_store
+// def MIOpen_BlockwiseStoreOp:
+//     MIOpen_Op<"blockwise_store">,
+//     Arguments<(ins AnyTypeOf<[F32, F16, I16,
+//                               VectorOfLengthAndType<[2, 4], [F32]>,
+//                               VectorOfLengthAndType<[2, 4, 8], [F16]>, 
+//                               VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
+//                    AnyMemRef:$dest,
+//                    VectorOfLengthAndType<[2], [I32]>:$destCoordVector)> {
+//   let summary = "Blockwise GPU data store";
+//   let description = [{
+//     The `miopen.blockwise_store` op moves data on GPU. Following movements are
+//     allowed:
+//     - Register (naive tensor) to LDS (naive tensor).
+//   }];
+// }
+
 // threadwise_copy
 def MIOpen_ThreadwiseCopyOp:
     MIOpen_Op<"threadwise_copy">,

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -554,6 +554,34 @@ static LogicalResult verify(BlockwiseLoadOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// BlockwiseStoreOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseBlockwiseStoreOp(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 2> ops;
+  SmallVector<Type, 2> types;
+  VectorType coordVectorType = VectorType::get(2,
+		  parser.getBuilder().getIntegerType(32));
+  return failure(
+      parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+      parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColonTypeList(types) ||
+      parser.resolveOperand(ops[0], types[0], result.operands) ||
+      parser.resolveOperand(ops[1], types[1], result.operands) ||
+      parser.resolveOperand(ops[2], coordVectorType, result.operands));
+}
+
+static void print(OpAsmPrinter &p, BlockwiseStoreOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.getOperand(0).getType() << ", " << op.getOperand(1).getType();
+}
+
+static LogicalResult verify(BlockwiseStoreOp op) {
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ThreadwiseCopyOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -529,11 +529,12 @@ static LogicalResult verify(BlockwiseCopyOp op) {
 // BlockwiseLoadOp
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseBlockwiseLoadOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseBlockwiseLoadOp(OpAsmParser &parser,
+                                        OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 2> ops;
   SmallVector<Type, 2> types;
-  VectorType coordVectorType = VectorType::get(2,
-		  parser.getBuilder().getIntegerType(32));
+  VectorType coordVectorType =
+      VectorType::get(2, parser.getBuilder().getIntegerType(32));
   return failure(
       parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
       parser.parseOptionalAttrDict(result.attributes) ||
@@ -549,19 +550,18 @@ static void print(OpAsmPrinter &p, BlockwiseLoadOp op) {
   p << " : " << op.getOperand(0).getType() << ", " << op.getType();
 }
 
-static LogicalResult verify(BlockwiseLoadOp op) {
-  return success();
-}
+static LogicalResult verify(BlockwiseLoadOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
 // BlockwiseStoreOp
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseBlockwiseStoreOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseBlockwiseStoreOp(OpAsmParser &parser,
+                                         OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 2> ops;
   SmallVector<Type, 2> types;
-  VectorType coordVectorType = VectorType::get(2,
-		  parser.getBuilder().getIntegerType(32));
+  VectorType coordVectorType =
+      VectorType::get(2, parser.getBuilder().getIntegerType(32));
   return failure(
       parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
       parser.parseOptionalAttrDict(result.attributes) ||
@@ -574,12 +574,11 @@ static ParseResult parseBlockwiseStoreOp(OpAsmParser &parser, OperationState &re
 static void print(OpAsmPrinter &p, BlockwiseStoreOp op) {
   p << op.getOperationName() << "(" << op.getOperands() << ")";
   p.printOptionalAttrDict(op.getAttrs());
-  p << " : " << op.getOperand(0).getType() << ", " << op.getOperand(1).getType();
+  p << " : " << op.getOperand(0).getType() << ", "
+    << op.getOperand(1).getType();
 }
 
-static LogicalResult verify(BlockwiseStoreOp op) {
-  return success();
-}
+static LogicalResult verify(BlockwiseStoreOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
 // ThreadwiseCopyOp

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -526,6 +526,34 @@ static LogicalResult verify(BlockwiseCopyOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// BlockwiseLoadOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseBlockwiseLoadOp(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 2> ops;
+  SmallVector<Type, 2> types;
+  VectorType coordVectorType = VectorType::get(2,
+		  parser.getBuilder().getIntegerType(32));
+  return failure(
+      parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+      parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColonTypeList(types) ||
+      parser.resolveOperand(ops[0], types[0], result.operands) ||
+      parser.resolveOperand(ops[1], coordVectorType, result.operands) ||
+      parser.addTypeToList(types[1], result.types));
+}
+
+static void print(OpAsmPrinter &p, BlockwiseLoadOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.getOperand(0).getType() << ", " << op.getType();
+}
+
+static LogicalResult verify(BlockwiseLoadOp op) {
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ThreadwiseCopyOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -165,6 +165,106 @@ func @miopen_blockwise_copy(%source : memref<?x?xf32>, %dest : memref<?x?xf32, 3
 //  CHECK-NEXT: miopen.blockwise_copy
 //  CHECK-NEXT: miopen.blockwise_copy
 
+// --------------------------
+// blockwise_load tests.
+
+// f32 tests.
+
+func @miopen_blockwise_load_f32(%source : memref<?x?xf32>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> f32  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xf32>, f32
+  return %result : f32
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_f32
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xf32>, f32
+
+func @miopen_blockwise_load_2xf32(%source : memref<?x?xf32>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<2xf32>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xf32>, vector<2xf32>
+  return %result : vector<2xf32>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_2xf32
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xf32>, vector<2xf32>
+
+func @miopen_blockwise_load_4xf32(%source : memref<?x?xf32>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<4xf32>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xf32>, vector<4xf32>
+  return %result : vector<4xf32>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_4xf32
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xf32>, vector<4xf32>
+
+// f16 tests.
+
+func @miopen_blockwise_load_f16(%source : memref<?x?xf16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> f16  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xf16>, f16
+  return %result : f16
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_f16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xf16>, f16
+
+func @miopen_blockwise_load_2xf16(%source : memref<?x?xf16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<2xf16>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xf16>, vector<2xf16>
+  return %result : vector<2xf16>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_2xf16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xf16>, vector<2xf16>
+
+func @miopen_blockwise_load_4xf16(%source : memref<?x?xf16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<4xf16>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xf16>, vector<4xf16>
+  return %result : vector<4xf16>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_4xf16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xf16>, vector<4xf16>
+
+func @miopen_blockwise_load_8xf16(%source : memref<?x?xf16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<8xf16>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xf16>, vector<8xf16>
+  return %result : vector<8xf16>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_8xf16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xf16>, vector<8xf16>
+
+// i16 tests.
+
+func @miopen_blockwise_load_i16(%source : memref<?x?xi16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> i16  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xi16>, i16
+  return %result : i16
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_i16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xi16>, i16
+
+func @miopen_blockwise_load_2xi16(%source : memref<?x?xi16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<2xi16>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xi16>, vector<2xi16>
+  return %result : vector<2xi16>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_2xi16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xi16>, vector<2xi16>
+
+func @miopen_blockwise_load_4xi16(%source : memref<?x?xi16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<4xi16>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xi16>, vector<4xi16>
+  return %result : vector<4xi16>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_4xi16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xi16>, vector<4xi16>
+
+func @miopen_blockwise_load_8xi16(%source : memref<?x?xi16>, %source_coord : vector<2xi32>, %dest_coord : memref<2xi32>) -> vector<8xi16>  {
+  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?xi16>, vector<8xi16>
+  return %result : vector<8xi16>
+}
+
+// CHECK-LABEL: func @miopen_blockwise_load_8xi16
+//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xi16>, vector<8xi16>
+
+// --------------------------
+// threadwise_copy tests.
+
 #map0 = affine_map<(d0, d1) -> (d0, d1, d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1, d0, d1, d0)>
 

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -263,6 +263,103 @@ func @miopen_blockwise_load_8xi16(%source : memref<?x?xi16>, %source_coord : vec
 //  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?xi16>, vector<8xi16>
 
 // --------------------------
+// blockwise_store tests.
+
+// f32 tests.
+
+func @miopen_blockwise_store_f32(%data : f32, %dest : memref<?x?xf32, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : f32, memref<?x?xf32, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_f32
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<?x?xf32, 3>
+
+func @miopen_blockwise_store_2xf32(%data : vector<2xf32>, %dest : memref<?x?xf32, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<2xf32>, memref<?x?xf32, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_2xf32
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<?x?xf32, 3>
+
+func @miopen_blockwise_store_4xf32(%data : vector<4xf32>, %dest : memref<?x?xf32, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<4xf32>, memref<?x?xf32, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_4xf32
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<?x?xf32, 3>
+
+// f16 tests.
+
+func @miopen_blockwise_store_f16(%data : f16, %dest : memref<?x?xf16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : f16, memref<?x?xf16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_f16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : f16, memref<?x?xf16, 3>
+
+func @miopen_blockwise_store_2xf16(%data : vector<2xf16>, %dest : memref<?x?xf16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<2xf16>, memref<?x?xf16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_2xf16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf16>, memref<?x?xf16, 3>
+
+func @miopen_blockwise_store_4xf16(%data : vector<4xf16>, %dest : memref<?x?xf16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<4xf16>, memref<?x?xf16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_4xf16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf16>, memref<?x?xf16, 3>
+
+func @miopen_blockwise_store_8xf16(%data : vector<8xf16>, %dest : memref<?x?xf16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<8xf16>, memref<?x?xf16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_8xf16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xf16>, memref<?x?xf16, 3>
+
+// i16 tests.
+
+func @miopen_blockwise_store_i16(%data : i16, %dest : memref<?x?xi16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : i16, memref<?x?xi16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_i16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : i16, memref<?x?xi16, 3>
+
+func @miopen_blockwise_store_2xi16(%data : vector<2xi16>, %dest : memref<?x?xi16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<2xi16>, memref<?x?xi16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_2xi16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi16>, memref<?x?xi16, 3>
+
+func @miopen_blockwise_store_4xi16(%data : vector<4xi16>, %dest : memref<?x?xi16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<4xi16>, memref<?x?xi16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_4xi16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi16>, memref<?x?xi16, 3>
+
+func @miopen_blockwise_store_8xi16(%data : vector<8xi16>, %dest : memref<?x?xi16, 3>, %dest_coord : vector<2xi32>) {
+  miopen.blockwise_store(%data, %dest, %dest_coord) : vector<8xi16>, memref<?x?xi16, 3>
+  return
+}
+
+// CHECK-LABEL: func @miopen_blockwise_store_8xi16
+//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xi16>, memref<?x?xi16, 3>
+
+// --------------------------
 // threadwise_copy tests.
 
 #map0 = affine_map<(d0, d1) -> (d0, d1, d0, d1)>


### PR DESCRIPTION
Introduce 2 new ops:
- `miopen.blockwise_load`
- `miopen.blockwise_store`

They would be used to replace existing `miopen.blockwise_copy`.

This PR has no relationship with #190 and #191 and can be reviewed / merged independently.