### PR TITLE
Miopen dialect opt step4 : introduce miopen.threadwise_load and miopen.threadwise_store. 

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -251,22 +251,22 @@ def MIOpen_ThreadwiseLoadOp:
   }];
 }
 
-// // threadwise_store
-// def MIOpen_ThreadwiseStoreOp:
-//     MIOpen_Op<"threadwise_store">,
-//     Arguments<(ins AnyTypeOf<[F32, F16, I16,
-//                               VectorOfLengthAndType<[2, 4], [F32]>,
-//                               VectorOfLengthAndType<[2, 4, 8], [F16]>,
-//                               VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
-//                    AnyMemRef:$dest,
-//                    Variadic<I32>:$destCoord)> {
-//   let summary = "Threadwise GPU data store";
-//   let description = [{
-//     The `miopen.threadwise_store` op moves data on GPU. Following movements are
-//     allowed:
-//     - Register (naive tensor) to LDS (naive tensor).
-//   }];
-// }
+// threadwise_store
+def MIOpen_ThreadwiseStoreOp:
+    MIOpen_Op<"threadwise_store">,
+    Arguments<(ins AnyTypeOf<[F32, F16, I16,
+                              VectorOfLengthAndType<[2, 4], [F32]>,
+                              VectorOfLengthAndType<[2, 4, 8], [F16]>,
+                              VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
+                   AnyMemRef:$dest,
+                   Variadic<I32>:$destCoord)> {
+  let summary = "Threadwise GPU data store";
+  let description = [{
+    The `miopen.threadwise_store` op moves data on GPU. Following movements are
+    allowed:
+    - Register (naive tensor) to LDS (naive tensor).
+  }];
+}
 
 // threadwise_copy_v2
 def MIOpen_ThreadwiseCopyV2Op:

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -234,6 +234,40 @@ def MIOpen_ThreadwiseCopyOp:
   }];
 }
 
+// threadwise_load
+def MIOpen_ThreadwiseLoadOp:
+    MIOpen_Op<"threadwise_load">,
+    Arguments<(ins AnyMemRef:$source,
+                   Variadic<I32>:$sourceCoord)>,
+    Results<(outs AnyTypeOf<[F32, F16, I16,
+                             VectorOfLengthAndType<[2, 4], [F32]>,
+                             VectorOfLengthAndType<[2, 4, 8], [F16]>,
+                             VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$result)> {
+  let summary = "Threadwise GPU data load";
+  let description = [{
+    The `miopen.threadwise_load` op moves data on GPU. Following movements are
+    allowed:
+    - Global (generic tensor) to register (naive tensor).
+  }];
+}
+
+// // threadwise_store
+// def MIOpen_ThreadwiseStoreOp:
+//     MIOpen_Op<"threadwise_store">,
+//     Arguments<(ins AnyTypeOf<[F32, F16, I16,
+//                               VectorOfLengthAndType<[2, 4], [F32]>,
+//                               VectorOfLengthAndType<[2, 4, 8], [F16]>,
+//                               VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
+//                    AnyMemRef:$dest,
+//                    Variadic<I32>:$destCoord)> {
+//   let summary = "Threadwise GPU data store";
+//   let description = [{
+//     The `miopen.threadwise_store` op moves data on GPU. Following movements are
+//     allowed:
+//     - Register (naive tensor) to LDS (naive tensor).
+//   }];
+// }
+
 // threadwise_copy_v2
 def MIOpen_ThreadwiseCopyV2Op:
     MIOpen_Op<"threadwise_copy_v2">,

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -614,7 +614,8 @@ static LogicalResult verify(ThreadwiseCopyOp op) {
 // ThreadwiseLoadOp
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseThreadwiseLoadOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseThreadwiseLoadOp(OpAsmParser &parser,
+                                         OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 6> ops;
   SmallVector<Type, 2> types;
 
@@ -637,15 +638,14 @@ static void print(OpAsmPrinter &p, ThreadwiseLoadOp op) {
   p << " : " << op.getOperand(0).getType() << ", " << op.getType();
 }
 
-static LogicalResult verify(ThreadwiseLoadOp op) {
-  return success();
-}
+static LogicalResult verify(ThreadwiseLoadOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
 // ThreadwiseStoreOp
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseThreadwiseStoreOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseThreadwiseStoreOp(OpAsmParser &parser,
+                                          OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 6> ops;
   SmallVector<Type, 2> types;
 
@@ -665,12 +665,11 @@ static ParseResult parseThreadwiseStoreOp(OpAsmParser &parser, OperationState &r
 static void print(OpAsmPrinter &p, ThreadwiseStoreOp op) {
   p << op.getOperationName() << "(" << op.getOperands() << ")";
   p.printOptionalAttrDict(op.getAttrs());
-  p << " : " << op.getOperand(0).getType() << ", " << op.getOperand(1).getType();
+  p << " : " << op.getOperand(0).getType() << ", "
+    << op.getOperand(1).getType();
 }
 
-static LogicalResult verify(ThreadwiseStoreOp op) {
-  return success();
-}
+static LogicalResult verify(ThreadwiseStoreOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
 // ThreadwiseCopyV2Op

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -642,6 +642,37 @@ static LogicalResult verify(ThreadwiseLoadOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// ThreadwiseStoreOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseThreadwiseStoreOp(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 6> ops;
+  SmallVector<Type, 2> types;
+
+  auto ret = parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+             parser.parseOptionalAttrDict(result.attributes) ||
+             parser.parseColonTypeList(types) ||
+             parser.resolveOperand(ops[0], types[0], result.operands) ||
+             parser.resolveOperand(ops[1], types[1], result.operands);
+
+  for (unsigned i = 2; i < ops.size(); ++i) {
+    ret &= succeeded(parser.resolveOperand(
+        ops[i], parser.getBuilder().getIntegerType(32), result.operands));
+  }
+  return failure(ret);
+}
+
+static void print(OpAsmPrinter &p, ThreadwiseStoreOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.getOperand(0).getType() << ", " << op.getOperand(1).getType();
+}
+
+static LogicalResult verify(ThreadwiseStoreOp op) {
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ThreadwiseCopyV2Op
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -611,6 +611,37 @@ static LogicalResult verify(ThreadwiseCopyOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// ThreadwiseLoadOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseThreadwiseLoadOp(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 6> ops;
+  SmallVector<Type, 2> types;
+
+  auto ret = parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+             parser.parseOptionalAttrDict(result.attributes) ||
+             parser.parseColonTypeList(types) ||
+             parser.resolveOperand(ops[0], types[0], result.operands) ||
+             parser.addTypeToList(types[1], result.types);
+
+  for (unsigned i = 1; i < ops.size(); ++i) {
+    ret &= succeeded(parser.resolveOperand(
+        ops[i], parser.getBuilder().getIntegerType(32), result.operands));
+  }
+  return failure(ret);
+}
+
+static void print(OpAsmPrinter &p, ThreadwiseLoadOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.getOperand(0).getType() << ", " << op.getType();
+}
+
+static LogicalResult verify(ThreadwiseLoadOp op) {
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ThreadwiseCopyV2Op
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -279,6 +279,60 @@ func @miopen_threadwise_load(%source_coord : memref<2xi32, 5>,
 }
 
 // --------------------------
+// threadwise_store tests.
+
+// CHECK-LABEL: func @miopen_threadwise_store
+func @miopen_threadwise_store(%data_scalar : f32,
+                              %data_vector : vector<4xf32>,
+                              %dest_coord : memref<2xi32, 5>,
+                              %dest : memref<?x?xf32>,
+                              %dest_with_embedded_affine : memref<?x?xf32, #map1>,
+                              %dest_with_externally_defined_affine : memref<?x?x?x?xf32>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %dest_coord_y = load %dest_coord[%c0] : memref<2xi32, 5>
+  %dest_coord_x = load %dest_coord[%c0] : memref<2xi32, 5>
+
+  // check dest as vanilla memrefs, data as scalar.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<?x?xf32>
+  miopen.threadwise_store(%data_scalar, %dest, %dest_coord_x, %dest_coord_y) : f32, memref<?x?xf32>
+
+  // check dest as vanilla memrefs, data as vector.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<?x?xf32>
+  miopen.threadwise_store(%data_vector, %dest, %dest_coord_x, %dest_coord_y) : vector<4xf32>, memref<?x?xf32>
+
+  // -----
+
+  // check dest with embedded affine maps, data as scalar.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f32
+  miopen.threadwise_store(%data_scalar, %dest_with_embedded_affine, %dest_coord_x, %dest_coord_y) : f32, memref<?x?xf32, #map1>
+
+  // check dest with embedded affine maps, data as vector.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>
+  miopen.threadwise_store(%data_vector, %dest_with_embedded_affine, %dest_coord_x, %dest_coord_y) : vector<4xf32>, memref<?x?xf32, #map1>
+
+  // -----
+
+  // check destination with one externally defined affine map, data as scalar.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
+  miopen.threadwise_store(%data_scalar, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2] } ] } : f32, memref<?x?x?x?xf32>
+
+  // check destination with one externally defined affine map, data as vector.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
+  miopen.threadwise_store(%data_vector, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2] } ] } : vector<4xf32>, memref<?x?x?x?xf32>
+
+  // check destination with multiple externally defined affine map, data as scalar.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
+  miopen.threadwise_store(%data_scalar, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2, #map3] } ] } : f32, memref<?x?x?x?xf32>
+
+  // check destination with multiple externally defined affine map, data as vector.
+  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
+  miopen.threadwise_store(%data_vector, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2, #map3] } ] } : vector<4xf32>, memref<?x?x?x?xf32>
+
+  return
+}
+
+// --------------------------
 // threadwise_copy_v2 tests.
 
 #map11 = affine_map<(d0, d1) -> (d1, d0, d1, d0)>

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -226,6 +226,61 @@ func @miopen_threadwise_copy(%source_coord : memref<2xi32, 5>, %dest_coord : mem
 // CHECK-LABEL: func @miopen_threadwise_copy
 //  CHECK: miopen.threadwise_copy
 
+// --------------------------
+// threadwise_load tests.
+
+// CHECK-LABEL: func @miopen_threadwise_load
+func @miopen_threadwise_load(%source_coord : memref<2xi32, 5>,
+                             %source : memref<?x?xf32>,
+                             %source_with_embedded_affine : memref<?x?xf32, #map0>,
+                             %source_with_externally_defined_affine : memref<?x?x?x?xf32>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %source_coord_y = load %source_coord[%c0] : memref<2xi32, 5>
+  %source_coord_x = load %source_coord[%c0] : memref<2xi32, 5>
+
+  // check source as vanilla memref, dest as scalar.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32>, f32
+  %v0 = miopen.threadwise_load(%source, %source_coord_x, %source_coord_y) : memref<?x?xf32>, f32
+
+  // check source as vanilla memref, dest as vector.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32>, vector<4xf32>
+  %v1 = miopen.threadwise_load(%source, %source_coord_x, %source_coord_y) : memref<?x?xf32>, vector<4xf32>
+
+  // -----
+
+  // check source with embedded affine maps, dest as scalar.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32, #map0>, f32
+  %v2 = miopen.threadwise_load(%source_with_embedded_affine, %source_coord_x, %source_coord_y) : memref<?x?xf32, #map0>, f32
+
+  // check source with embedded affine maps, dest as vector.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32, #map0>, vector<4xf32>
+  %v3 = miopen.threadwise_load(%source_with_embedded_affine, %source_coord_x, %source_coord_y) : memref<?x?xf32, #map0>, vector<4xf32>
+
+  // -----
+
+  // check source with one externally defined affine map, dest as scalar.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
+  %v4 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2] } ] } : memref<?x?x?x?xf32>, f32
+
+  // check source with one externally defined affine map, dest as vector.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
+  %v5 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2] } ] } : memref<?x?x?x?xf32>, vector<4xf32>
+
+  // check source with multiple externally defined affine maps, dest as scalar.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
+  %v6 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2, #map3] } ] } : memref<?x?x?x?xf32>, f32
+
+  // check source with multiple externally defined affine maps, dest as vector.
+  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
+  %v7 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2, #map3] } ] } : memref<?x?x?x?xf32>, vector<4xf32>
+
+  return
+}
+
+// --------------------------
+// threadwise_copy_v2 tests.
+
 #map11 = affine_map<(d0, d1) -> (d1, d0, d1, d0)>
 
 #map12 = affine_map<(d0, d1) -> (d1, d0 floordiv 9, (d0 mod 9) floordiv 3, (d0 mod 9) mod 3)>


### PR DESCRIPTION
Introduce 2 new ops:

- `miopen.threadwise_load`
- `miopen.threadwise_store`

They would be used to replace existing `miopen.threadwise_copy`.

This PR has no relationship with #190, #191, #192, and can be reviewed / merged independently.