### PR TITLE
Miopen dialect opt step5 : start to build index diff maps.

### DIFF
--- a/mlir/examples/prototypes/lower_index_diff.mlir
+++ b/mlir/examples/prototypes/lower_index_diff.mlir
@@ -1,0 +1,11 @@
+func @miopen_lower_index_diff_all_constants() -> (index, index, index, index) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %c4 = constant 4 : index
+
+  %u0, %l0, %l1, %l2 = miopen.lower_index_diff(%c1, %c3, %c4, %c0, %c0, %c2) { map = affine_map<(d0) -> (d0 floordiv 9, (d0 mod 9) floordiv 3, (d0 mod 9) mod 3)>, bound = [1024, 3, 3] } : index, index, index, index, index, index
+
+  return %u0, %l0, %l1, %l2 : index, index, index, index
+}

--- a/mlir/examples/prototypes/lower_index_diff_2.mlir
+++ b/mlir/examples/prototypes/lower_index_diff_2.mlir
@@ -1,0 +1,11 @@
+func @miopen_lower_index_diff_some_dynamic(%arg0 : index, %arg1 : index, %arg2 : index) -> (index, index, index, index) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %c4 = constant 4 : index
+
+  %u0, %l0, %l1, %l2 = miopen.lower_index_diff(%c1, %c3, %c4, %arg0, %arg1, %arg2) { map = affine_map<(d0) -> (d0 floordiv 9, (d0 mod 9) floordiv 3, (d0 mod 9) mod 3)>, bound = [1024, 3, 3] } : index, index, index, index, index, index
+
+  return %u0, %l0, %l1, %l2 : index, index, index, index
+}

--- a/mlir/examples/prototypes/scf_if_v0.mlir
+++ b/mlir/examples/prototypes/scf_if_v0.mlir
@@ -1,0 +1,66 @@
+func @test(%arg0: index, %arg1: index, %arg2: index) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %c1024 = constant 1024 : index
+
+  %idx_low_new_0 = addi %arg0, %c0 : index
+  %idx_low_new_1 = addi %arg1, %c0 : index
+  %idx_low_new_2 = addi %arg2, %c1 : index
+
+  // carry / borrow logic.
+
+  // 2nd digit
+  %carry_2 = constant 0 : i1
+  %idx_low_new_2_carried = scf.if %carry_2 -> (index) {
+    %carried = addi %idx_low_new_2, %c1 : index
+    scf.yield %carried : index
+  } else {
+    scf.yield %idx_low_new_2 : index
+  }
+
+  %carry_1 = cmpi "sgt", %idx_low_new_2_carried, %c3 : index
+  %idx_low_new_2_updated = scf.if %carry_1 -> (index) {
+    %updated = subi %idx_low_new_2_carried, %c3 : index
+    scf.yield %updated : index
+  } else {
+    scf.yield %idx_low_new_2_carried : index
+  }
+
+  // 1st digit
+  %idx_low_new_1_carried = scf.if %carry_1 -> (index) {
+    %carried = addi %idx_low_new_1, %c1 : index
+    scf.yield %carried : index
+  } else {
+    scf.yield %idx_low_new_1 : index
+  }
+
+  %carry_0 = cmpi "sgt", %idx_low_new_1_carried, %c3 : index
+  %idx_low_new_1_updated = scf.if %carry_0 -> (index) {
+    %updated = subi %idx_low_new_1_carried, %c3 : index
+    scf.yield %updated : index
+  } else {
+    scf.yield %idx_low_new_1_carried : index
+  }
+
+  // 0th digit
+  %idx_low_new_0_carried = scf.if %carry_0 -> (index) {
+    %carried = addi %idx_low_new_0, %c1 : index
+    scf.yield %carried : index
+  } else {
+    scf.yield %idx_low_new_0 : index
+  }
+
+  // no need to emit carry logic for the 0th digit
+  // %carry_m1 = cmpi "sgt", %idx_low_new_0_carried, %c1024 : index
+  // %idx_low_new_0_updated = scf.if %carry_m1 -> (index) {
+  //   %updated = subi %idx_low_new_0_carried, %c1024 : index
+  //   scf.yield %updated : index
+  // } else {
+  //   scf.yield %idx_low_new_0_carried : index
+  // }
+  %idx_low_new_0_updated = subi %idx_low_new_0, %c0 : index
+
+  return
+}

--- a/mlir/examples/prototypes/scf_if_v1.mlir
+++ b/mlir/examples/prototypes/scf_if_v1.mlir
@@ -1,0 +1,121 @@
+func @test(%carry_or_borrow: i1, %arg0: index, %arg1: index, %arg2: index) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %c1024 = constant 1024 : index
+
+  %idx_low_new_0 = addi %arg0, %c0 : index
+  %idx_low_new_1 = addi %arg1, %c0 : index
+  %idx_low_new_2 = addi %arg2, %c1 : index
+
+  scf.if %carry_or_borrow {
+    // carry logic.
+
+    // 2nd digit
+    %carry_2 = constant 0 : i1
+    %idx_low_new_2_carried = scf.if %carry_2 -> (index) {
+      %carried = addi %idx_low_new_2, %c1 : index
+      scf.yield %carried : index
+    } else {
+      scf.yield %idx_low_new_2 : index
+    }
+
+    %carry_1 = cmpi "sgt", %idx_low_new_2_carried, %c3 : index
+    %idx_low_new_2_updated = scf.if %carry_1 -> (index) {
+      %updated = subi %idx_low_new_2_carried, %c3 : index
+      scf.yield %updated : index
+    } else {
+      scf.yield %idx_low_new_2_carried : index
+    }
+
+    // 1st digit
+    %idx_low_new_1_carried = scf.if %carry_1 -> (index) {
+      %carried = addi %idx_low_new_1, %c1 : index
+      scf.yield %carried : index
+    } else {
+      scf.yield %idx_low_new_1 : index
+    }
+
+    %carry_0 = cmpi "sgt", %idx_low_new_1_carried, %c3 : index
+    %idx_low_new_1_updated = scf.if %carry_0 -> (index) {
+      %updated = subi %idx_low_new_1_carried, %c3 : index
+      scf.yield %updated : index
+    } else {
+      scf.yield %idx_low_new_1_carried : index
+    }
+
+    // 0th digit
+    %idx_low_new_0_carried = scf.if %carry_0 -> (index) {
+      %carried = addi %idx_low_new_0, %c1 : index
+      scf.yield %carried : index
+    } else {
+      scf.yield %idx_low_new_0 : index
+    }
+
+    // no need to emit carry logic for the 0th digit
+    // %carry_m1 = cmpi "sgt", %idx_low_new_0_carried, %c1024 : index
+    // %idx_low_new_0_updated = scf.if %carry_m1 -> (index) {
+    //   %updated = subi %idx_low_new_0_carried, %c1024 : index
+    //   scf.yield %updated : index
+    // } else {
+    //   scf.yield %idx_low_new_0_carried : index
+    // }
+    %idx_low_new_0_updated = subi %idx_low_new_0, %c0 : index
+  } else {
+    // borrow logic.
+
+    // 2nd digit
+    %borrow_2 = constant 0 : i1
+    %idx_low_new_2_borrowed = scf.if %borrow_2 -> (index) {
+      %borrowed = subi %idx_low_new_2, %c1 : index
+      scf.yield %borrowed : index
+    } else {
+      scf.yield %idx_low_new_2 : index
+    }
+
+    %borrow_1 = cmpi "slt", %idx_low_new_2_borrowed, %c0 : index
+    %idx_low_new_2_updated = scf.if %borrow_1 -> (index) {
+      %updated = addi %idx_low_new_2_borrowed, %c3 : index
+      scf.yield %updated : index
+    } else {
+      scf.yield %idx_low_new_2_borrowed : index
+    }
+
+    // 1st digit
+    %idx_low_new_1_borrowed = scf.if %borrow_1 -> (index) {
+      %borrowed = subi %idx_low_new_1, %c1 : index
+      scf.yield %borrowed : index
+    } else {
+      scf.yield %idx_low_new_1 : index
+    }
+
+    %borrow_0 = cmpi "slt", %idx_low_new_1_borrowed, %c0 : index
+    %idx_low_new_1_updated = scf.if %borrow_0 -> (index) {
+      %updated = addi %idx_low_new_1_borrowed, %c3 : index
+      scf.yield %updated : index
+    } else {
+      scf.yield %idx_low_new_1_borrowed : index
+    }
+
+    // 0th digit
+    %idx_low_new_0_borrowed = scf.if %borrow_0 -> (index) {
+      %borrowed = subi %idx_low_new_0, %c1 : index
+      scf.yield %borrowed : index
+    } else {
+      scf.yield %idx_low_new_0 : index
+    }
+
+    // no need to emit borrow logic for the 0th digit
+    // %borrow_m1 = cmpi "slt", %idx_low_new_0_borrowed, %c0 : index
+    // %idx_low_new_0_updated = scf.if %borrow_m1 -> (index) {
+    //   %updated = addi %idx_low_new_0_borrowed, %c1024 : index
+    //   scf.yield %updated : index
+    // } else {
+    //   scf.yield %idx_low_new_0_carried : index
+    // }
+    %idx_low_new_0_updated = addi %idx_low_new_0, %c0 : index
+  }
+
+  return
+}

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -7348,20 +7348,20 @@ struct LowerIndexDiffRewritePattern
         op.upperIndexLength().getDefiningOp<ConstantIndexOp>().getValue();
     int64_t lowerIndexLength =
         op.lowerIndexLength().getDefiningOp<ConstantIndexOp>().getValue();
-    //llvm::errs() << "upper index length: " << upperIndexLength
+    // llvm::errs() << "upper index length: " << upperIndexLength
     //             << "\nlower index length: " << lowerIndexLength << "\n";
 
     // Fetch index upper diff
     SmallVector<Attribute, 2> indexUpperDiff;
-    //llvm::errs() << "index upper diff:\n";
+    // llvm::errs() << "index upper diff:\n";
     for (int64_t iter = 0; iter < upperIndexLength; ++iter) {
       int64_t v = op.upperIndexDiffAndLowerIndexOld()[iter]
                       .getDefiningOp<ConstantIndexOp>()
                       .getValue();
-      //llvm::errs() << v << " ";
+      // llvm::errs() << v << " ";
       indexUpperDiff.push_back(b.getI32IntegerAttr(v));
     }
-    //llvm::errs() << "\n";
+    // llvm::errs() << "\n";
 
     // Fetch index lower old
 
@@ -7379,13 +7379,13 @@ struct LowerIndexDiffRewritePattern
 
     // index lower old as Value instances
     SmallVector<Value, 8> indexLowerOld;
-    //llvm::errs() << "index lower old:\n";
+    // llvm::errs() << "index lower old:\n";
     for (int64_t iter = 0; iter < lowerIndexLength; ++iter) {
       auto v = op.upperIndexDiffAndLowerIndexOld()[iter + upperIndexLength];
-      //v.dump();
+      // v.dump();
       indexLowerOld.push_back(v);
     }
-    //llvm::errs() << "\n";
+    // llvm::errs() << "\n";
 
     // Apply map to compute index lower diff tmp, from index upper diff
     // using constantFold.
@@ -7393,20 +7393,20 @@ struct LowerIndexDiffRewritePattern
     SmallVector<int64_t, 4> indexLowerDiffTmp;
     SmallVector<Value, 8> indexLowerDiffTmpOp;
     auto map = op->template getAttrOfType<AffineMapAttr>("map").getValue();
-    //llvm::errs() << "affine transform map: ";
-    //map.dump();
-    //llvm::errs() << "\n";
+    // llvm::errs() << "affine transform map: ";
+    // map.dump();
+    // llvm::errs() << "\n";
     (void)map.constantFold(indexUpperDiff, indexLowerDiffTmpAttr);
-    //llvm::errs() << "index lower diff tmp:\n";
+    // llvm::errs() << "index lower diff tmp:\n";
     for (auto attr : indexLowerDiffTmpAttr) {
       int64_t v = attr.template dyn_cast<IntegerAttr>().getInt();
-      //llvm::errs() << v << " ";
+      // llvm::errs() << v << " ";
       indexLowerDiffTmp.push_back(v);
 
       auto cv = b.create<ConstantIndexOp>(loc, v);
       indexLowerDiffTmpOp.push_back(cv);
     }
-    //llvm::errs() << "\n";
+    // llvm::errs() << "\n";
 
     // Add: index lower old + index lower diff tmp
 
@@ -7422,29 +7422,29 @@ struct LowerIndexDiffRewritePattern
 
     // index lower new as Value instances.
     SmallVector<Value, 8> indexLowerNew;
-    //llvm::errs() << "index lower new before borrow/carry:\n";
+    // llvm::errs() << "index lower new before borrow/carry:\n";
     for (int64_t iter = 0; iter < lowerIndexLength; ++iter) {
       Value v =
           b.create<AddIOp>(loc, indexLowerOld[iter], indexLowerDiffTmpOp[iter]);
-      //v.dump();
+      // v.dump();
       indexLowerNew.push_back(v);
     }
-    //llvm::errs() << "\n";
+    // llvm::errs() << "\n";
 
     // Get bounds.
     SmallVector<int64_t, 4> bound;
     SmallVector<Value, 4> boundOp;
     auto boundAttr = op->template getAttrOfType<ArrayAttr>("bound").getValue();
-    //llvm::errs() << "bound:\n";
+    // llvm::errs() << "bound:\n";
     for (auto attr : boundAttr) {
       int64_t v = attr.template dyn_cast<IntegerAttr>().getInt();
-      //llvm::errs() << v << " ";
+      // llvm::errs() << v << " ";
       bound.push_back(v);
 
       auto cv = b.create<ConstantIndexOp>(loc, v);
       boundOp.push_back(cv);
     }
-    //llvm::errs() << "\n";
+    // llvm::errs() << "\n";
 
     // Apply carry / borrow logic to compute index lower new
 
@@ -7499,7 +7499,7 @@ struct LowerIndexDiffRewritePattern
                                                     constantZeroOp);
         ifCarryElseBuilder.create<scf::YieldOp>(loc, carried.getResult());
 
-        //ifCarryOp.dump();
+        // ifCarryOp.dump();
 
         auto carriedResult = ifCarryOp.results()[0];
         indexLowerNewCarried.push_back(carriedResult);
@@ -7508,7 +7508,7 @@ struct LowerIndexDiffRewritePattern
         carryOp = b.create<CmpIOp>(loc, CmpIPredicate::sgt, carriedResult,
                                    boundOp[iter]);
 
-        //carryOp.dump();
+        // carryOp.dump();
 
         // overflow logic.
         auto ifOverflowOp = b.create<scf::IfOp>(loc, b.getIndexType(), carryOp,
@@ -7522,7 +7522,7 @@ struct LowerIndexDiffRewritePattern
                                                        constantZeroOp);
         ifOverflowElseBuilder.create<scf::YieldOp>(loc, updated.getResult());
 
-        //ifOverflowOp.dump();
+        // ifOverflowOp.dump();
 
         auto updatedResult = ifOverflowOp.results()[0];
         indexLowerNewUpdated.push_back(updatedResult);
@@ -7550,16 +7550,16 @@ struct LowerIndexDiffRewritePattern
       indexLowerDiff.push_back(op.upperIndexDiffAndLowerIndexOld()[iter]);
     }
 
-    //llvm::errs() << "index lower diff:\n";
+    // llvm::errs() << "index lower diff:\n";
     for (int64_t iter = 0; iter < lowerIndexLength; ++iter) {
       Value v = b.create<SubIOp>(loc, indexLowerNewUpdated[iter],
                                  indexLowerOld[iter]);
-      //v.dump();
+      // v.dump();
       indexLowerDiff.push_back(v);
     }
-    //llvm::errs() << "\n";
+    // llvm::errs() << "\n";
 
-    //op.getOperation()->getBlock()->dump();
+    // op.getOperation()->getBlock()->dump();
     op.replaceAllUsesWith(indexLowerDiff);
     op.erase();
     return success();

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -7348,20 +7348,20 @@ struct LowerIndexDiffRewritePattern
         op.upperIndexLength().getDefiningOp<ConstantIndexOp>().getValue();
     int64_t lowerIndexLength =
         op.lowerIndexLength().getDefiningOp<ConstantIndexOp>().getValue();
-    llvm::errs() << "upper index length: " << upperIndexLength
-                 << "\nlower index length: " << lowerIndexLength << "\n";
+    //llvm::errs() << "upper index length: " << upperIndexLength
+    //             << "\nlower index length: " << lowerIndexLength << "\n";
 
     // Fetch index upper diff
     SmallVector<Attribute, 2> indexUpperDiff;
-    llvm::errs() << "index upper diff:\n";
+    //llvm::errs() << "index upper diff:\n";
     for (int64_t iter = 0; iter < upperIndexLength; ++iter) {
       int64_t v = op.upperIndexDiffAndLowerIndexOld()[iter]
                       .getDefiningOp<ConstantIndexOp>()
                       .getValue();
-      llvm::errs() << v << " ";
+      //llvm::errs() << v << " ";
       indexUpperDiff.push_back(b.getI32IntegerAttr(v));
     }
-    llvm::errs() << "\n";
+    //llvm::errs() << "\n";
 
     // Fetch index lower old
 
@@ -7379,13 +7379,13 @@ struct LowerIndexDiffRewritePattern
 
     // index lower old as Value instances
     SmallVector<Value, 8> indexLowerOld;
-    llvm::errs() << "index lower old:\n";
+    //llvm::errs() << "index lower old:\n";
     for (int64_t iter = 0; iter < lowerIndexLength; ++iter) {
       auto v = op.upperIndexDiffAndLowerIndexOld()[iter + upperIndexLength];
-      v.dump();
+      //v.dump();
       indexLowerOld.push_back(v);
     }
-    llvm::errs() << "\n";
+    //llvm::errs() << "\n";
 
     // Apply map to compute index lower diff tmp, from index upper diff
     // using constantFold.
@@ -7393,20 +7393,20 @@ struct LowerIndexDiffRewritePattern
     SmallVector<int64_t, 4> indexLowerDiffTmp;
     SmallVector<Value, 8> indexLowerDiffTmpOp;
     auto map = op->template getAttrOfType<AffineMapAttr>("map").getValue();
-    llvm::errs() << "affine transform map: ";
-    map.dump();
-    llvm::errs() << "\n";
-    map.constantFold(indexUpperDiff, indexLowerDiffTmpAttr);
-    llvm::errs() << "index lower diff tmp:\n";
+    //llvm::errs() << "affine transform map: ";
+    //map.dump();
+    //llvm::errs() << "\n";
+    (void)map.constantFold(indexUpperDiff, indexLowerDiffTmpAttr);
+    //llvm::errs() << "index lower diff tmp:\n";
     for (auto attr : indexLowerDiffTmpAttr) {
       int64_t v = attr.template dyn_cast<IntegerAttr>().getInt();
-      llvm::errs() << v << " ";
+      //llvm::errs() << v << " ";
       indexLowerDiffTmp.push_back(v);
 
       auto cv = b.create<ConstantIndexOp>(loc, v);
       indexLowerDiffTmpOp.push_back(cv);
     }
-    llvm::errs() << "\n";
+    //llvm::errs() << "\n";
 
     // Add: index lower old + index lower diff tmp
 
@@ -7422,29 +7422,29 @@ struct LowerIndexDiffRewritePattern
 
     // index lower new as Value instances.
     SmallVector<Value, 8> indexLowerNew;
-    llvm::errs() << "index lower new before borrow/carry:\n";
+    //llvm::errs() << "index lower new before borrow/carry:\n";
     for (int64_t iter = 0; iter < lowerIndexLength; ++iter) {
       Value v =
           b.create<AddIOp>(loc, indexLowerOld[iter], indexLowerDiffTmpOp[iter]);
-      v.dump();
+      //v.dump();
       indexLowerNew.push_back(v);
     }
-    llvm::errs() << "\n";
+    //llvm::errs() << "\n";
 
     // Get bounds.
     SmallVector<int64_t, 4> bound;
     SmallVector<Value, 4> boundOp;
     auto boundAttr = op->template getAttrOfType<ArrayAttr>("bound").getValue();
-    llvm::errs() << "bound:\n";
+    //llvm::errs() << "bound:\n";
     for (auto attr : boundAttr) {
       int64_t v = attr.template dyn_cast<IntegerAttr>().getInt();
-      llvm::errs() << v << " ";
+      //llvm::errs() << v << " ";
       bound.push_back(v);
 
       auto cv = b.create<ConstantIndexOp>(loc, v);
       boundOp.push_back(cv);
     }
-    llvm::errs() << "\n";
+    //llvm::errs() << "\n";
 
     // Apply carry / borrow logic to compute index lower new
 
@@ -7499,7 +7499,7 @@ struct LowerIndexDiffRewritePattern
                                                     constantZeroOp);
         ifCarryElseBuilder.create<scf::YieldOp>(loc, carried.getResult());
 
-        ifCarryOp.dump();
+        //ifCarryOp.dump();
 
         auto carriedResult = ifCarryOp.results()[0];
         indexLowerNewCarried.push_back(carriedResult);
@@ -7508,7 +7508,7 @@ struct LowerIndexDiffRewritePattern
         carryOp = b.create<CmpIOp>(loc, CmpIPredicate::sgt, carriedResult,
                                    boundOp[iter]);
 
-        carryOp.dump();
+        //carryOp.dump();
 
         // overflow logic.
         auto ifOverflowOp = b.create<scf::IfOp>(loc, b.getIndexType(), carryOp,
@@ -7522,7 +7522,7 @@ struct LowerIndexDiffRewritePattern
                                                        constantZeroOp);
         ifOverflowElseBuilder.create<scf::YieldOp>(loc, updated.getResult());
 
-        ifOverflowOp.dump();
+        //ifOverflowOp.dump();
 
         auto updatedResult = ifOverflowOp.results()[0];
         indexLowerNewUpdated.push_back(updatedResult);
@@ -7550,16 +7550,16 @@ struct LowerIndexDiffRewritePattern
       indexLowerDiff.push_back(op.upperIndexDiffAndLowerIndexOld()[iter]);
     }
 
-    llvm::errs() << "index lower diff:\n";
+    //llvm::errs() << "index lower diff:\n";
     for (int64_t iter = 0; iter < lowerIndexLength; ++iter) {
       Value v = b.create<SubIOp>(loc, indexLowerNewUpdated[iter],
                                  indexLowerOld[iter]);
-      v.dump();
+      //v.dump();
       indexLowerDiff.push_back(v);
     }
-    llvm::errs() << "\n";
+    //llvm::errs() << "\n";
 
-    op.getOperation()->getBlock()->dump();
+    //op.getOperation()->getBlock()->dump();
     op.replaceAllUsesWith(indexLowerDiff);
     op.erase();
     return success();

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -7392,7 +7392,7 @@ struct LowerIndexDiffRewritePattern
     SmallVector<Attribute, 4> indexLowerDiffTmpAttr;
     SmallVector<int64_t, 4> indexLowerDiffTmp;
     SmallVector<Value, 8> indexLowerDiffTmpOp;
-    auto map = op.template getAttrOfType<AffineMapAttr>("map").getValue();
+    auto map = op->template getAttrOfType<AffineMapAttr>("map").getValue();
     llvm::errs() << "affine transform map: ";
     map.dump();
     llvm::errs() << "\n";
@@ -7434,7 +7434,7 @@ struct LowerIndexDiffRewritePattern
     // Get bounds.
     SmallVector<int64_t, 4> bound;
     SmallVector<Value, 4> boundOp;
-    auto boundAttr = op.template getAttrOfType<ArrayAttr>("bound").getValue();
+    auto boundAttr = op->template getAttrOfType<ArrayAttr>("bound").getValue();
     llvm::errs() << "bound:\n";
     for (auto attr : boundAttr) {
       int64_t v = attr.template dyn_cast<IntegerAttr>().getInt();

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -409,4 +409,18 @@ def MIOpen_DataConvertOp :
     The `miopen.data_convert` op will convert f32 to bf16, but we use i16 to replace bf16 here.
   }];
 }
+
+// compute lower index diff
+def MIOpen_LowerIndexDiffOp:
+    MIOpen_Op<"lower_index_diff">,
+    Arguments<(ins Index: $upperIndexLength,
+                   Index: $lowerIndexLength,
+                   Variadic<Index>: $upperIndexDiffAndLowerIndexOld)>,
+    Results<(outs Variadic<Index>: $lowerIndexDiff)> {
+  let summary = "lower_index_diff op";
+  let description = [{
+    Given upper index diff, and old lower index, compute diff to lower index.
+  }];
+}
+
 #endif // MIOPEN_OPS

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -883,6 +883,41 @@ static void print(OpAsmPrinter &p, DataConvertOp op) {
 }
 
 static LogicalResult verify(DataConvertOp op) { return success(); }
+
+//===----------------------------------------------------------------------===//
+// LowerIndexDiffOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseLowerIndexDiffOp(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 5> ops;
+  SmallVector<Type, 5> types;
+
+  auto ret = parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+             parser.parseOptionalAttrDict(result.attributes) ||
+             parser.parseColonTypeList(types) ||
+             parser.resolveOperand(ops[0], types[0], result.operands) ||
+             parser.resolveOperand(ops[1], types[1], result.operands);
+
+  // resolve source offset.
+  // resolve destination coordinates.
+  for (unsigned i = 2; i < ops.size(); ++i) {
+    ret &= succeeded(parser.resolveOperand(
+        ops[i], parser.getBuilder().getIndexType(), result.operands));
+    parser.addTypeToList(parser.getBuilder().getIndexType(), result.types);
+  }
+  return failure(ret);
+}
+
+static void print(OpAsmPrinter &p, LowerIndexDiffOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.getOperandTypes();
+}
+
+static LogicalResult verify(LowerIndexDiffOp op) {
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -888,7 +888,8 @@ static LogicalResult verify(DataConvertOp op) { return success(); }
 // LowerIndexDiffOp
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseLowerIndexDiffOp(OpAsmParser &parser, OperationState &result) {
+static ParseResult parseLowerIndexDiffOp(OpAsmParser &parser,
+                                         OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 5> ops;
   SmallVector<Type, 5> types;
 
@@ -914,9 +915,7 @@ static void print(OpAsmPrinter &p, LowerIndexDiffOp op) {
   p << " : " << op.getOperandTypes();
 }
 
-static LogicalResult verify(LowerIndexDiffOp op) {
-  return success();
-}
+static LogicalResult verify(LowerIndexDiffOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
 // TableGen'd op method definitions

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
@@ -502,8 +502,8 @@ void AffineTransforms::runOnFunction() {
   func.walk([&](miopen::TransformOp op) {
     AffineMap indexAffineMap = buildIndexAffineMap(op);
     AffineMap indexDiffAffineMap = buildIndexDiffAffineMap(op);
-    llvm::errs() << "index affine map: "; indexAffineMap.dump(); llvm::errs() << "\n";
-    llvm::errs() << "index diff affine map: "; indexDiffAffineMap.dump(); llvm::errs() << "\n";
+    // llvm::errs() << "index affine map: "; indexAffineMap.dump(); llvm::errs() << "\n";
+    // llvm::errs() << "index diff affine map: "; indexDiffAffineMap.dump(); llvm::errs() << "\n";
 
     auto outputType = op.output().getType().dyn_cast<MemRefType>();
     auto outputShape = outputType.getShape();
@@ -514,19 +514,19 @@ void AffineTransforms::runOnFunction() {
     auto loc = op.getLoc();
     auto newOp = b.create<miopen::TransformOp>(loc, transformedOutputType, op.input(), op.getAttrs());
 
-    llvm::errs() << "constant fold:\n";
-    SmallVector<Attribute, 1> result;
-    SmallVector<Attribute, 2> operands;
-    for (unsigned i = 0; i < indexAffineMap.getNumDims(); ++i) {
-      if (i == 0)
-        operands.push_back(b.getI32IntegerAttr(8));
-      else
-        operands.push_back(b.getI32IntegerAttr(0));
-    }
-    indexAffineMap.constantFold(operands, result);
-    for (auto attr : result)
-      attr.dump();
-    llvm::errs() << "\n";
+    // llvm::errs() << "constant fold:\n";
+    // SmallVector<Attribute, 1> result;
+    // SmallVector<Attribute, 2> operands;
+    // for (unsigned i = 0; i < indexAffineMap.getNumDims(); ++i) {
+    //   if (i == 0)
+    //     operands.push_back(b.getI32IntegerAttr(8));
+    //   else
+    //     operands.push_back(b.getI32IntegerAttr(0));
+    // }
+    // indexAffineMap.constantFold(operands, result);
+    // for (auto attr : result)
+    //   attr.dump();
+    // llvm::errs() << "\n";
 
     op.output().replaceAllUsesWith(newOp);
     op.erase();

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
@@ -149,6 +149,122 @@ AffineMap AffineTransforms::buildIndexDiffAffineMap(miopen::TransformOp op) {
 AffineMap AffineTransforms::buildIndexAffineMap(miopen::TransformOp op) {
   auto inputType = op.input().getType().dyn_cast<MemRefType>();
   auto inputShape = inputType.getShape();
+  auto inputRank = inputType.getRank();
+  auto inputElementType = inputType.getElementType();
+  auto inputAffineMaps = inputType.getAffineMaps();
+
+  auto layoutAttr = op.template getAttrOfType<ArrayAttr>("layout");
+
+  auto sourceLayoutAttr = op.template getAttrOfType<ArrayAttr>("source_layout");
+  if (!sourceLayoutAttr)
+    sourceLayoutAttr = op.template getAttrOfType<ArrayAttr>("intermediate_layout");
+  auto outputLayoutAttr = op.template getAttrOfType<ArrayAttr>("output_layout");
+
+  llvm::SmallMapVector<int64_t, AffineExpr, 8> affExprsMap;
+  for (unsigned i = 0; i < layoutAttr.size(); ++i) {
+    if (auto dimLayoutAttr = layoutAttr.getValue()[i].dyn_cast<DictionaryAttr>()) {
+      auto srcDimAttr = dimLayoutAttr.get("source_dimensions").dyn_cast<ArrayAttr>();
+      auto destDimAttr = dimLayoutAttr.get("dimensions").dyn_cast<ArrayAttr>();
+      auto transformAttr = dimLayoutAttr.get("transformation").dyn_cast<StringAttr>();
+
+      if (transformAttr.getValue() == "PassThrough") {
+        assert(srcDimAttr.size() == 1);
+        assert(destDimAttr.size() == 1);
+
+        auto srcDim = srcDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+        auto destDim = destDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+        auto expr = getAffineDimExpr(destDim, op.getContext());
+        affExprsMap.insert({srcDim, expr});
+      } else if (transformAttr.getValue() == "Pad") {
+        assert(srcDimAttr.size() == destDimAttr.size());
+
+        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
+          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          auto destDim = destDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+
+          auto expr = getAffineDimExpr(destDim, op.getContext());
+          affExprsMap.insert({srcDim, expr});
+        }
+      } else if (transformAttr.getValue() == "Merge" ||
+                 transformAttr.getValue() == "Unfold") {
+        assert(destDimAttr.size() == 1);
+        assert(srcDimAttr.size() > 1);
+
+        auto destDim = destDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+
+        // Find source dimension lengths.
+        llvm::SmallVector<int64_t, 4> srcDimLengthVec;
+        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
+          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          auto srcDimLength = inputShape[srcDim];
+          srcDimLengthVec.push_back(srcDimLength);
+        }
+
+        // Compute source dimension strides.
+        llvm::SmallVector<int64_t, 4> srcDimStrideVec;
+        int64_t stride = 1;
+        srcDimStrideVec.push_back(stride);
+        for (unsigned j = srcDimAttr.size() - 1; j > 0; --j) {
+          stride *= srcDimLengthVec[j];
+          srcDimStrideVec.push_back(stride);
+        }
+        std::reverse(srcDimStrideVec.begin(), srcDimStrideVec.end());
+
+        // Build affine transformation expressions.
+        auto remainderExpr = getAffineDimExpr(destDim, op.getContext());
+        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
+          auto strideExpr = getAffineConstantExpr(srcDimStrideVec[j], op.getContext());
+          auto expr = remainderExpr.floorDiv(strideExpr);
+          remainderExpr = remainderExpr % strideExpr;
+
+          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          affExprsMap.insert({srcDim, expr});
+        }
+      } else if (transformAttr.getValue() == "Embed") {
+        assert(srcDimAttr.size() == 1);
+        assert(destDimAttr.size() > 1);
+
+        auto srcDim = srcDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+        auto parameters = dimLayoutAttr.get("parameters").dyn_cast<ArrayAttr>();
+
+        // # of parameters would always be 1 more than the # of destDim.
+        // populate the initial affine expr.
+        auto param = parameters.getValue()[parameters.size() - 1].dyn_cast<IntegerAttr>().getInt();
+        auto expr = getAffineConstantExpr(param, op.getContext());
+
+        // Build affine transformation expressions.
+        for (unsigned j = 0; j < destDimAttr.size(); ++j) {
+          auto destDim = destDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          param = parameters.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          auto partialExpr = getAffineDimExpr(destDim, op.getContext()) * getAffineConstantExpr(param, op.getContext());
+          expr = expr + partialExpr;
+        }
+        affExprsMap.insert({srcDim, expr});
+      }
+    }
+  }
+
+  llvm::SmallVector<AffineExpr, 8> affExprsVec;
+  for (unsigned i = 0; i < sourceLayoutAttr.size(); ++i) {
+    affExprsVec.push_back(affExprsMap[i]);
+  }
+
+  auto transformAffineMap = AffineMap::get(outputLayoutAttr.size(), 0, affExprsVec, op.getContext());
+  AffineMap outputAffineMap;
+
+  if (inputAffineMaps.size() != 0) {
+    auto inputAffineMap = inputAffineMaps[0];
+    outputAffineMap = inputAffineMap.compose(transformAffineMap);
+  } else {
+    outputAffineMap = transformAffineMap;
+  }
+
+  return outputAffineMap;
+}
+
+AffineMap AffineTransforms::buildIndexAffineMap(miopen::TransformOp op) {
+  auto inputType = op.input().getType().dyn_cast<MemRefType>();
+  auto inputShape = inputType.getShape();
   auto inputAffineMaps = inputType.getAffineMaps();
 
   auto layoutAttr = op->template getAttrOfType<ArrayAttr>("layout");

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
@@ -385,7 +385,7 @@ void AffineTransforms::runOnFunction() {
 
   func.walk([&](miopen::TransformOp op) {
     AffineMap indexAffineMap = buildIndexAffineMap(op);
-    AffineMap indexDiffAffineMap = buildIndexDiffAffineMap(op);
+    // AffineMap indexDiffAffineMap = buildIndexDiffAffineMap(op);
     // llvm::errs() << "index affine map: "; indexAffineMap.dump(); llvm::errs()
     // << "\n"; llvm::errs() << "index diff affine map: ";
     // indexDiffAffineMap.dump(); llvm::errs() << "\n";

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
@@ -33,16 +33,17 @@ private:
 AffineMap AffineTransforms::buildIndexDiffAffineMap(miopen::TransformOp op) {
   auto inputType = op.input().getType().dyn_cast<MemRefType>();
   auto inputShape = inputType.getShape();
-  auto inputRank = inputType.getRank();
-  auto inputElementType = inputType.getElementType();
   auto inputAffineMaps = inputType.getAffineMaps();
 
-  auto layoutAttr = op.template getAttrOfType<ArrayAttr>("layout");
+  auto layoutAttr = op->template getAttrOfType<ArrayAttr>("layout");
 
-  auto sourceLayoutAttr = op.template getAttrOfType<ArrayAttr>("source_layout");
+  auto sourceLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("source_layout");
   if (!sourceLayoutAttr)
-    sourceLayoutAttr = op.template getAttrOfType<ArrayAttr>("intermediate_layout");
-  auto outputLayoutAttr = op.template getAttrOfType<ArrayAttr>("output_layout");
+    sourceLayoutAttr =
+        op->template getAttrOfType<ArrayAttr>("intermediate_layout");
+  auto outputLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("output_layout");
 
   llvm::SmallMapVector<int64_t, AffineExpr, 8> affExprsMap;
   for (unsigned i = 0; i < layoutAttr.size(); ++i) {
@@ -149,123 +150,6 @@ AffineMap AffineTransforms::buildIndexDiffAffineMap(miopen::TransformOp op) {
 
   auto transformAffineMap =
       AffineMap::get(outputLayoutAttr.size(), 0, affExprsVec, op.getContext());
-  AffineMap outputAffineMap;
-
-  if (inputAffineMaps.size() != 0) {
-    auto inputAffineMap = inputAffineMaps[0];
-    outputAffineMap = inputAffineMap.compose(transformAffineMap);
-  } else {
-    outputAffineMap = transformAffineMap;
-  }
-
-  return outputAffineMap;
-}
-
-AffineMap AffineTransforms::buildIndexAffineMap(miopen::TransformOp op) {
-  auto inputType = op.input().getType().dyn_cast<MemRefType>();
-  auto inputShape = inputType.getShape();
-  auto inputRank = inputType.getRank();
-  auto inputElementType = inputType.getElementType();
-  auto inputAffineMaps = inputType.getAffineMaps();
-
-  auto layoutAttr = op.template getAttrOfType<ArrayAttr>("layout");
-
-  auto sourceLayoutAttr = op.template getAttrOfType<ArrayAttr>("source_layout");
-  if (!sourceLayoutAttr)
-    sourceLayoutAttr =
-        op.template getAttrOfType<ArrayAttr>("intermediate_layout");
-  auto outputLayoutAttr = op.template getAttrOfType<ArrayAttr>("output_layout");
-
-  llvm::SmallMapVector<int64_t, AffineExpr, 8> affExprsMap;
-  for (unsigned i = 0; i < layoutAttr.size(); ++i) {
-    if (auto dimLayoutAttr = layoutAttr.getValue()[i].dyn_cast<DictionaryAttr>()) {
-      auto srcDimAttr = dimLayoutAttr.get("source_dimensions").dyn_cast<ArrayAttr>();
-      auto destDimAttr = dimLayoutAttr.get("dimensions").dyn_cast<ArrayAttr>();
-      auto transformAttr = dimLayoutAttr.get("transformation").dyn_cast<StringAttr>();
-
-      if (transformAttr.getValue() == "PassThrough") {
-        assert(srcDimAttr.size() == 1);
-        assert(destDimAttr.size() == 1);
-
-        auto srcDim = srcDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
-        auto destDim = destDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
-        auto expr = getAffineDimExpr(destDim, op.getContext());
-        affExprsMap.insert({srcDim, expr});
-      } else if (transformAttr.getValue() == "Pad") {
-        assert(srcDimAttr.size() == destDimAttr.size());
-
-        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
-          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
-          auto destDim = destDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
-
-          auto expr = getAffineDimExpr(destDim, op.getContext());
-          affExprsMap.insert({srcDim, expr});
-        }
-      } else if (transformAttr.getValue() == "Merge" ||
-                 transformAttr.getValue() == "Unfold") {
-        assert(destDimAttr.size() == 1);
-        assert(srcDimAttr.size() > 1);
-
-        auto destDim = destDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
-
-        // Find source dimension lengths.
-        llvm::SmallVector<int64_t, 4> srcDimLengthVec;
-        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
-          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
-          auto srcDimLength = inputShape[srcDim];
-          srcDimLengthVec.push_back(srcDimLength);
-        }
-
-        // Compute source dimension strides.
-        llvm::SmallVector<int64_t, 4> srcDimStrideVec;
-        int64_t stride = 1;
-        srcDimStrideVec.push_back(stride);
-        for (unsigned j = srcDimAttr.size() - 1; j > 0; --j) {
-          stride *= srcDimLengthVec[j];
-          srcDimStrideVec.push_back(stride);
-        }
-        std::reverse(srcDimStrideVec.begin(), srcDimStrideVec.end());
-
-        // Build affine transformation expressions.
-        auto remainderExpr = getAffineDimExpr(destDim, op.getContext());
-        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
-          auto strideExpr = getAffineConstantExpr(srcDimStrideVec[j], op.getContext());
-          auto expr = remainderExpr.floorDiv(strideExpr);
-          remainderExpr = remainderExpr % strideExpr;
-
-          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
-          affExprsMap.insert({srcDim, expr});
-        }
-      } else if (transformAttr.getValue() == "Embed") {
-        assert(srcDimAttr.size() == 1);
-        assert(destDimAttr.size() > 1);
-
-        auto srcDim = srcDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
-        auto parameters = dimLayoutAttr.get("parameters").dyn_cast<ArrayAttr>();
-
-        // # of parameters would always be 1 more than the # of destDim.
-        // populate the initial affine expr.
-        auto param = parameters.getValue()[parameters.size() - 1].dyn_cast<IntegerAttr>().getInt();
-        auto expr = getAffineConstantExpr(param, op.getContext());
-
-        // Build affine transformation expressions.
-        for (unsigned j = 0; j < destDimAttr.size(); ++j) {
-          auto destDim = destDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
-          param = parameters.getValue()[j].dyn_cast<IntegerAttr>().getInt();
-          auto partialExpr = getAffineDimExpr(destDim, op.getContext()) * getAffineConstantExpr(param, op.getContext());
-          expr = expr + partialExpr;
-        }
-        affExprsMap.insert({srcDim, expr});
-      }
-    }
-  }
-
-  llvm::SmallVector<AffineExpr, 8> affExprsVec;
-  for (unsigned i = 0; i < sourceLayoutAttr.size(); ++i) {
-    affExprsVec.push_back(affExprsMap[i]);
-  }
-
-  auto transformAffineMap = AffineMap::get(outputLayoutAttr.size(), 0, affExprsVec, op.getContext());
   AffineMap outputAffineMap;
 
   if (inputAffineMaps.size() != 0) {

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
@@ -19,9 +19,132 @@ struct AffineTransforms : public MIOpenOpsAffineTransformPassBase<AffineTransfor
   void runOnFunction() override;
 
 private:
+  // we use full pass only for 1 scenario:
+  // - when constructing threadwise copy, each thread need to calculate it's initial tensor coordinate for copy
   AffineMap buildIndexAffineMap(miopen::TransformOp);
+
+  // we use diff for 2 scenario:
+  // - when loop over each element in the threadwise tensor in threadwise_copy.Run() 
+  // - when calling move_slice_window
+  AffineMap buildIndexDiffAffineMap(miopen::TransformOp);
 };
 } // anonymous namespace
+
+AffineMap AffineTransforms::buildIndexDiffAffineMap(miopen::TransformOp op) {
+  auto inputType = op.input().getType().dyn_cast<MemRefType>();
+  auto inputShape = inputType.getShape();
+  auto inputRank = inputType.getRank();
+  auto inputElementType = inputType.getElementType();
+  auto inputAffineMaps = inputType.getAffineMaps();
+
+  auto layoutAttr = op.template getAttrOfType<ArrayAttr>("layout");
+
+  auto sourceLayoutAttr = op.template getAttrOfType<ArrayAttr>("source_layout");
+  if (!sourceLayoutAttr)
+    sourceLayoutAttr = op.template getAttrOfType<ArrayAttr>("intermediate_layout");
+  auto outputLayoutAttr = op.template getAttrOfType<ArrayAttr>("output_layout");
+
+  llvm::SmallMapVector<int64_t, AffineExpr, 8> affExprsMap;
+  for (unsigned i = 0; i < layoutAttr.size(); ++i) {
+    if (auto dimLayoutAttr = layoutAttr.getValue()[i].dyn_cast<DictionaryAttr>()) {
+      auto srcDimAttr = dimLayoutAttr.get("source_dimensions").dyn_cast<ArrayAttr>();
+      auto destDimAttr = dimLayoutAttr.get("dimensions").dyn_cast<ArrayAttr>();
+      auto transformAttr = dimLayoutAttr.get("transformation").dyn_cast<StringAttr>();
+
+      if (transformAttr.getValue() == "PassThrough") {
+        assert(srcDimAttr.size() == 1);
+        assert(destDimAttr.size() == 1);
+
+        auto srcDim = srcDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+        auto destDim = destDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+        auto expr = getAffineDimExpr(destDim, op.getContext());
+        affExprsMap.insert({srcDim, expr});
+      } else if (transformAttr.getValue() == "Pad") {
+        assert(srcDimAttr.size() == destDimAttr.size());
+
+        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
+          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          auto destDim = destDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+
+          auto expr = getAffineDimExpr(destDim, op.getContext());
+          affExprsMap.insert({srcDim, expr});
+        }
+      } else if (transformAttr.getValue() == "Merge" ||
+                 transformAttr.getValue() == "Unfold") {
+        assert(destDimAttr.size() == 1);
+        assert(srcDimAttr.size() > 1);
+
+        auto destDim = destDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+
+        // Find source dimension lengths.
+        llvm::SmallVector<int64_t, 4> srcDimLengthVec;
+        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
+          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          auto srcDimLength = inputShape[srcDim];
+          srcDimLengthVec.push_back(srcDimLength);
+        }
+
+        // Compute source dimension strides.
+        llvm::SmallVector<int64_t, 4> srcDimStrideVec;
+        int64_t stride = 1;
+        srcDimStrideVec.push_back(stride);
+        for (unsigned j = srcDimAttr.size() - 1; j > 0; --j) {
+          stride *= srcDimLengthVec[j];
+          srcDimStrideVec.push_back(stride);
+        }
+        std::reverse(srcDimStrideVec.begin(), srcDimStrideVec.end());
+
+        // Build affine transformation expressions.
+        auto remainderExpr = getAffineDimExpr(destDim, op.getContext());
+        for (unsigned j = 0; j < srcDimAttr.size(); ++j) {
+          auto strideExpr = getAffineConstantExpr(srcDimStrideVec[j], op.getContext());
+          auto expr = remainderExpr.floorDiv(strideExpr);
+          remainderExpr = remainderExpr % strideExpr;
+
+          auto srcDim = srcDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          affExprsMap.insert({srcDim, expr});
+        }
+      } else if (transformAttr.getValue() == "Embed") {
+        assert(srcDimAttr.size() == 1);
+        assert(destDimAttr.size() > 1);
+
+        auto srcDim = srcDimAttr.getValue()[0].dyn_cast<IntegerAttr>().getInt();
+        auto parameters = dimLayoutAttr.get("parameters").dyn_cast<ArrayAttr>();
+
+        // # of parameters would always be 1 more than the # of destDim.
+        // populate the initial affine expr.
+        auto param = parameters.getValue()[parameters.size() - 1].dyn_cast<IntegerAttr>().getInt();
+        auto expr = getAffineConstantExpr(param, op.getContext());
+
+        // Build affine transformation expressions.
+        for (unsigned j = 0; j < destDimAttr.size(); ++j) {
+          auto destDim = destDimAttr.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          param = parameters.getValue()[j].dyn_cast<IntegerAttr>().getInt();
+          auto partialExpr = getAffineDimExpr(destDim, op.getContext()) * getAffineConstantExpr(param, op.getContext());
+          expr = expr + partialExpr;
+        }
+        affExprsMap.insert({srcDim, expr});
+      }
+    }
+  }
+
+  llvm::SmallVector<AffineExpr, 8> affExprsVec;
+  for (unsigned i = 0; i < sourceLayoutAttr.size(); ++i) {
+    affExprsVec.push_back(affExprsMap[i]);
+  }
+
+  auto transformAffineMap = AffineMap::get(outputLayoutAttr.size(), 0, affExprsVec, op.getContext());
+  AffineMap outputAffineMap;
+
+  if (inputAffineMaps.size() != 0) {
+    auto inputAffineMap = inputAffineMaps[0];
+    outputAffineMap = inputAffineMap.compose(transformAffineMap);
+  } else {
+    outputAffineMap = transformAffineMap;
+  }
+
+  return outputAffineMap;
+}
 
 AffineMap AffineTransforms::buildIndexAffineMap(miopen::TransformOp op) {
   auto inputType = op.input().getType().dyn_cast<MemRefType>();
@@ -246,6 +369,9 @@ void AffineTransforms::runOnFunction() {
 
   func.walk([&](miopen::TransformOp op) {
     AffineMap indexAffineMap = buildIndexAffineMap(op);
+    AffineMap indexDiffAffineMap = buildIndexDiffAffineMap(op);
+    llvm::errs() << "index affine map: "; indexAffineMap.dump(); llvm::errs() << "\n";
+    llvm::errs() << "index diff affine map: "; indexDiffAffineMap.dump(); llvm::errs() << "\n";
 
     auto outputType = op.output().getType().dyn_cast<MemRefType>();
     auto outputShape = outputType.getShape();
@@ -255,6 +381,20 @@ void AffineTransforms::runOnFunction() {
     OpBuilder b(op.getOperation());
     auto loc = op.getLoc();
     auto newOp = b.create<miopen::TransformOp>(loc, transformedOutputType, op.input(), op.getAttrs());
+
+    llvm::errs() << "constant fold:\n";
+    SmallVector<Attribute, 1> result;
+    SmallVector<Attribute, 2> operands;
+    for (unsigned i = 0; i < indexAffineMap.getNumDims(); ++i) {
+      if (i == 0)
+        operands.push_back(b.getI32IntegerAttr(8));
+      else
+        operands.push_back(b.getI32IntegerAttr(0));
+    }
+    indexAffineMap.constantFold(operands, result);
+    for (auto attr : result)
+      attr.dump();
+    llvm::errs() << "\n";
 
     op.output().replaceAllUsesWith(newOp);
     op.erase();

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffineTransforms.cpp
@@ -502,8 +502,9 @@ void AffineTransforms::runOnFunction() {
   func.walk([&](miopen::TransformOp op) {
     AffineMap indexAffineMap = buildIndexAffineMap(op);
     AffineMap indexDiffAffineMap = buildIndexDiffAffineMap(op);
-    // llvm::errs() << "index affine map: "; indexAffineMap.dump(); llvm::errs() << "\n";
-    // llvm::errs() << "index diff affine map: "; indexDiffAffineMap.dump(); llvm::errs() << "\n";
+    // llvm::errs() << "index affine map: "; indexAffineMap.dump(); llvm::errs()
+    // << "\n"; llvm::errs() << "index diff affine map: ";
+    // indexDiffAffineMap.dump(); llvm::errs() << "\n";
 
     auto outputType = op.output().getType().dyn_cast<MemRefType>();
     auto outputShape = outputType.getShape();

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -120,6 +120,7 @@ void LowerMIOpenOpsStep1Pass::runOnOperation() {
   patterns.insert<Conv2DRewritePattern<miopen::Conv2DBwdDataOp>>(&getContext());
   patterns.insert<Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>>(
       &getContext());
+  patterns.insert<LowerIndexDiffRewritePattern>(&getContext());
   if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
     signalPassFailure();
 }

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -687,3 +687,13 @@ func @miopen_blockwise_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>, %mat
 
 // CHECK-LABEL: func @miopen_blockwise_gemm_v2_two_results
 //  CHECK: miopen.blockwise_gemm_v2
+
+// ----
+
+func @miopen_lower_index_diff() {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c3 = constant 3 : index
+  %u0, %l0, %l1, %l2 = miopen.lower_index_diff(%c1, %c3, %c1, %c0, %c0, %c0) { map = affine_map<(d0) -> (d0 floordiv 9, (d0 mod 9) floordiv 3, (d0 mod 9) mod 3)> } : index, index
+  return
+}


### PR DESCRIPTION
Build index diff affine maps.

`miopen.threadwise_load` and `miopen.threadwise_store` would leverage `buildIndexDiffMap` function introduced in this PR to reduce address calculation logic.

Additional unit tests are needed. Do not merge for now.