### PR TITLE
Annotate miopen.alloc as an operation that allocates memory

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.h
@@ -19,6 +19,8 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Types.h"
 
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
 namespace mlir {
 
 namespace miopen {

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -15,6 +15,7 @@
 
 include "mlir/IR/OpBase.td"
 //include "mlir/Transforms/LoopLikeInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def MIOpen_Dialect : Dialect {
   let name = "miopen";
@@ -119,7 +120,7 @@ def MIOpen_GridwiseGemmV2Op :
 // Memory allocation on GPU memory hierachy.
 def MIOpen_GpuAllocOp:
     MIOpen_Op<"alloc">,
-    Results<(outs AnyMemRef:$output)> {
+    Results<(outs Res<AnyMemRef, "", [MemAlloc]>:$output)> {
   let summary = "Memory allocation on GPU";
   let description = [{
     The `miopen.alloc` op allocates memory on GPU.

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -14,7 +14,6 @@
 #define MIOPEN_OPS
 
 include "mlir/IR/OpBase.td"
-//include "mlir/Transforms/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def MIOpen_Dialect : Dialect {

--- a/mlir/test/Conversion/MIOpenToGPU/alloc.mlir
+++ b/mlir/test/Conversion/MIOpenToGPU/alloc.mlir
@@ -5,8 +5,12 @@
 // CHECK-NEXT: gpu.func @allockernel(%{{.*}}: memref<?x?x?x?xf32>) workgroup(%{{.*}}: memref<16xf32, 3>) private(%{{.*}}: memref<16xf32, 5>) kernel
 module {
   func @allockernel(%arg0: memref<?x?x?x?xf32>) attributes {kernel = 0 : i32} {
+    %cst = constant 0.0 : f32
+    %c0 = constant 0 : index
     %buffer_lds = miopen.alloc() : memref<16xf32, 3>
     %buffer_vgpr = miopen.alloc() : memref<16xf32, 5>
+    store %cst, %buffer_lds[%c0] : memref<16xf32, 3>
+    store %cst, %buffer_vgpr[%c0] : memref<16xf32, 5>
     return
   }
 }


### PR DESCRIPTION
MLIR has an annotation that indicates when an operation allocates
memory, which is present in the GPU dialect. This operation is added
to the miopen.alloc op as well, enabling us to take advantage of
optimization passes that operate on heap buffers before the lowering
to GPU dialect takes place.

The alloc kernel test has been modified to add dummy stores. Not
including these stores caused the memory allocations to be optimized
out.