### PR TITLE
Fix misplaced filter width / height when generating convolution configs.

### DIFF
--- a/mlir/test/auto_e2e/conv2d_host_validation_f16_fwd.mlir
+++ b/mlir/test/auto_e2e/conv2d_host_validation_f16_fwd.mlir
@@ -238,10 +238,10 @@
 // CHECK_ISSUE_127_14: [1]
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// Cases remained to be studied.
+// Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/40
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-// FIXME: mlir-miopen-driver -t f16 -pv %random_data -fil_layout=yxck -in_layout=nhwc -out_layout=nhwk -batchsize=64 -in_channels=8 -out_channels=128 -in_h=16 -in_w=64 -fil_h=3 -fil_w=5 -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_40_5
+// RUN: mlir-miopen-driver -t f16 -pv %random_data -fil_layout=yxck -in_layout=nhwc -out_layout=nhwk -batchsize=64 -in_channels=8 -out_channels=128 -in_h=16 -in_w=64 -fil_h=3 -fil_w=5 -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_40_5
 
 // CHECK_ISSUE_40_5: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_ISSUE_40_5: [1]

--- a/mlir/test/auto_e2e/conv2d_host_validation_f32_fwd.mlir
+++ b/mlir/test/auto_e2e/conv2d_host_validation_f32_fwd.mlir
@@ -266,11 +266,13 @@
 // CHECK_ISSUE_127_4: [1]
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// Cases remained to be studied.
+// Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/40
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-// FIXME: mlir-miopen-driver -pv %random_data %xdlops -fil_layout=yxck -in_layout=nhwc -out_layout=nhwk -batchsize=64 -in_channels=8 -out_channels=128 -in_h=16 -in_w=64 -fil_h=3 -fil_w=5 -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_40_5
+// RUN: mlir-miopen-driver -pv %random_data %xdlops -fil_layout=yxck -in_layout=nhwc -out_layout=nhwk -batchsize=64 -in_channels=8 -out_channels=128 -in_h=16 -in_w=64 -fil_h=3 -fil_w=5 -p=false -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_ISSUE_40_5
 
+// CHECK_ISSUE_40_5: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_ISSUE_40_5: [1]
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/136

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -2382,7 +2382,7 @@ int main(int argc, char **argv) {
   } else {
     (void)conv2dGenerator.parseConvDims(
         batchSize, groupSize, inputChannel, inputHeight, inputWidth,
-        outputChannel, outputHeight, outputWidth, filterWidth, filterHeight);
+        outputChannel, outputHeight, outputWidth, filterHeight, filterWidth);
   }
 
   const auto &genConfig = conv2dGenerator.getConfig();


### PR DESCRIPTION
Fix this remaining config at:
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/40

```
./bin/mlir-miopen-driver -pv -fil_layout=yxck -in_layout=nhwc -out_layout=nhwk -batchsize=64 -in_channels=8 -out_channels=128 -in_h=16 -in_w=64 -fil_h=3 -fil_w=5 -p=false -c | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void
```