### PR TITLE
Add dependencies needed to move MIOpen tests to MLIR dockerfile

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -88,7 +88,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   kmod \
   file \
   cmake \
-  libsqlite3-dev && \
+  libsqlite3-dev \
+  parallel \
+  python3-venv  && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
To use the mlir docker image in the new CI infrastructure, instead of relying on an out-of-date miopen_test image, we much install
  - python3-venv, a dependency of cget (which is used to build MIOpen's dependencies)
  - parallel, which the CI pipeline currently installs but shouldn't need to

This change does not depend on the aforementioned CI changes, but does block followup work on improving the testing infrastructure.