### PR TITLE
Miopen dialect opt step14 : Defer compose affine maps.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
@@ -23,6 +23,33 @@ namespace mlir {
 namespace miopen {
 
 //===----------------------------------------------------------------------===//
+// Utility lambda to compose affine maps.
+//===----------------------------------------------------------------------===//
+inline AffineMap composeTransformsFromArrayRef(ArrayRef<AffineMap> affineMaps) {
+  int64_t iter = affineMaps.size() - 1;
+  AffineMap transform = affineMaps[iter];
+  --iter;
+  while (iter >= 0) {
+    transform = transform.compose(affineMaps[iter]);
+    --iter;
+  }
+  return transform;
+}
+
+inline AffineMap composeTransformsFromArrayAttr(ArrayAttr affineMaps) {
+  int64_t iter = affineMaps.size() - 1;
+  AffineMap transform =
+      affineMaps[iter].template cast<AffineMapAttr>().getValue();
+  --iter;
+  while (iter >= 0) {
+    transform = transform.compose(
+        affineMaps[iter].template cast<AffineMapAttr>().getValue());
+    --iter;
+  }
+  return transform;
+}
+
+//===----------------------------------------------------------------------===//
 // Check if an AffineMap has division or remainder inside.
 //===----------------------------------------------------------------------===//
 inline bool hasDivisionOrRemainder(AffineMap map) {

--- a/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
@@ -25,7 +25,7 @@ namespace miopen {
 //===----------------------------------------------------------------------===//
 // Utility lambda to compose affine maps.
 //===----------------------------------------------------------------------===//
-inline AffineMap composeTransformsFromArrayRef(ArrayRef<AffineMap> affineMaps) {
+inline AffineMap composeTransforms(ArrayRef<AffineMap> affineMaps) {
   int64_t iter = affineMaps.size() - 1;
   AffineMap transform = affineMaps[iter];
   --iter;
@@ -36,7 +36,7 @@ inline AffineMap composeTransformsFromArrayRef(ArrayRef<AffineMap> affineMaps) {
   return transform;
 }
 
-inline AffineMap composeTransformsFromArrayAttr(ArrayAttr affineMaps) {
+inline AffineMap composeTransforms(ArrayAttr affineMaps) {
   int64_t iter = affineMaps.size() - 1;
   AffineMap transform =
       affineMaps[iter].template cast<AffineMapAttr>().getValue();

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -4075,7 +4075,11 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
 
     // compose with output tensor affine map.
     auto outputType = op.output().getType().template dyn_cast<MemRefType>();
-    auto outputAffineMap3to5 = outputType.getAffineMaps()[0];
+    auto outputAffineMaps = outputType.getAffineMaps();
+    SmallVector<AffineMap> newOutputAffineMaps;
+    newOutputAffineMaps.assign(outputAffineMaps.begin(),
+                               outputAffineMaps.end());
+    newOutputAffineMaps.insert(newOutputAffineMaps.begin(), affineMap5to3);
 
     // emit TransformOp for output tensor.
     llvm::SmallVector<NamedAttribute, 3> transformedNewOutputAttrs;
@@ -4090,9 +4094,8 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
         b.getArrayAttr({b.getStringAttr("g"), b.getStringAttr("m0"),
                         b.getStringAttr("m1"), b.getStringAttr("n0"),
                         b.getStringAttr("n1")})));
-    auto newOutputType =
-        MemRefType::get({G, M0, M1, N0, N1}, outputType.getElementType(),
-                        {affineMap5to3, outputAffineMap3to5});
+    auto newOutputType = MemRefType::get(
+        {G, M0, M1, N0, N1}, outputType.getElementType(), newOutputAffineMaps);
     auto newOutputTransformOp = b.create<miopen::TransformOp>(
         loc, newOutputType, op.output(), transformedNewOutputAttrs);
 
@@ -5103,7 +5106,11 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
 
     // compose with output tensor affine map.
     auto outputType = op.output().getType().template dyn_cast<MemRefType>();
-    auto outputAffineMap3to5 = outputType.getAffineMaps()[0];
+    auto outputAffineMaps = outputType.getAffineMaps();
+    SmallVector<AffineMap> newOutputAffineMaps;
+    newOutputAffineMaps.assign(outputAffineMaps.begin(),
+                               outputAffineMaps.end());
+    newOutputAffineMaps.insert(newOutputAffineMaps.begin(), affineMap5to3);
 
     // emit TransformOp for output tensor.
     llvm::SmallVector<NamedAttribute, 3> transformedNewOutputAttrs;
@@ -5118,9 +5125,8 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
         b.getArrayAttr({b.getStringAttr("g"), b.getStringAttr("m0"),
                         b.getStringAttr("m1"), b.getStringAttr("m2"),
                         b.getStringAttr("n")})));
-    auto newOutputType =
-        MemRefType::get({G, M0, M1, M2, N}, outputType.getElementType(),
-                        {affineMap5to3, outputAffineMap3to5});
+    auto newOutputType = MemRefType::get(
+        {G, M0, M1, M2, N}, outputType.getElementType(), newOutputAffineMaps);
     auto newOutputTransformOp = b.create<miopen::TransformOp>(
         loc, newOutputType, op.output(), transformedNewOutputAttrs);
 

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -6732,19 +6732,13 @@ struct TransformRewritePattern : public OpRewritePattern<miopen::TransformOp> {
             } else {
               auto existingTransforms =
                   dictAttr.get("transforms").cast<ArrayAttr>();
-              llvm::SmallVector<Attribute, 4> augmentedTransforms;
-              augmentedTransforms.append(existingTransforms.begin(),
-                                         existingTransforms.end());
-              augmentedTransforms.push_back(
-                  AffineMapAttr::get(outputType.getAffineMaps()[0]));
 
               auto existingDomain = dictAttr.get("domain").cast<ArrayAttr>();
 
               augmentedArrayAttr.push_back(b.getDictionaryAttr(
                   {b.getNamedAttr("operand",
                                   b.getI32IntegerAttr(userOperandIndex)),
-                   b.getNamedAttr("transforms",
-                                  b.getArrayAttr(augmentedTransforms)),
+                   b.getNamedAttr("transforms", existingTransforms),
                    b.getNamedAttr("domain", existingDomain)}));
               augmented = true;
             }

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -5866,14 +5866,14 @@ struct ThreadwiseCopyRewritePattern
     if (sourceTypeAffineMaps.size()) {
       sourceCoordLength = sourceTypeAffineMaps[0].getNumInputs();
       sourceEmbeddedTransform = true;
-      // Compose affine maps in the attribute array.
-      sourceTransform = composeTransformsFromArrayRef(sourceTypeAffineMaps);
+      // Compose affine maps.
+      sourceTransform = composeTransforms(sourceTypeAffineMaps);
     }
     if (destTypeAffineMaps.size()) {
       destCoordLength = destTypeAffineMaps[0].getNumInputs();
       destEmbeddedTransform = true;
-      // Compose affine maps in the attribute array.
-      destTransform = composeTransformsFromArrayRef(destTypeAffineMaps);
+      // Compose affine maps.
+      destTransform = composeTransforms(destTypeAffineMaps);
     }
     if (coordTransformsAttr) {
       for (auto attr : coordTransformsAttr) {
@@ -5887,16 +5887,16 @@ struct ThreadwiseCopyRewritePattern
                                   .getValue()
                                   .getNumInputs();
           sourceExternalTransform = true;
-          // Compose affine maps in the attribute array.
-          sourceTransform = composeTransformsFromArrayAttr(transforms);
+          // Compose affine maps.
+          sourceTransform = composeTransforms(transforms);
         } else {
           destCoordLength = transforms[0]
                                 .template cast<AffineMapAttr>()
                                 .getValue()
                                 .getNumInputs();
           destExternalTransform = true;
-          // Compose affine maps in the attribute array.
-          destTransform = composeTransformsFromArrayAttr(transforms);
+          // Compose affine maps.
+          destTransform = composeTransforms(transforms);
         }
       }
     }
@@ -6365,10 +6365,10 @@ struct ThreadwiseCopyV2RewritePattern
     AffineMap destTransform;
 
     if (destTypeAffineMaps.size()) {
-      // Use the first affine map in the attribute array.
       destCoordLength = destTypeAffineMaps[0].getNumInputs();
       destEmbeddedTransform = true;
-      destTransform = destTypeAffineMaps[0];
+      // Compose affine maps.
+      destTransform = composeTransforms(destTypeAffineMaps);
     }
     if (coordTransformsAttr) {
       for (auto attr : coordTransformsAttr.template cast<ArrayAttr>()) {
@@ -6376,16 +6376,22 @@ struct ThreadwiseCopyV2RewritePattern
         auto operandIndex =
             dictAttr.get("operand").template cast<IntegerAttr>().getInt();
         auto transforms = dictAttr.get("transforms").template cast<ArrayAttr>();
-        // Use the first affine map in the transforms array.
-        auto affineMap = transforms[0].template cast<AffineMapAttr>();
         if (operandIndex == 0) {
-          sourceCoordLength = affineMap.getValue().getNumInputs();
+          sourceCoordLength = transforms[0]
+                                  .template cast<AffineMapAttr>()
+                                  .getValue()
+                                  .getNumInputs();
           sourceExternalTransform = true;
-          sourceTransform = affineMap.getValue();
+          // Compose affine maps.
+          sourceTransform = composeTransforms(transforms);
         } else {
-          destCoordLength = affineMap.getValue().getNumInputs();
+          destCoordLength = transforms[0]
+                                .template cast<AffineMapAttr>()
+                                .getValue()
+                                .getNumInputs();
           destExternalTransform = true;
-          destTransform = affineMap.getValue();
+          // Compose affine maps.
+          destTransform = composeTransforms(transforms);
         }
       }
     }

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -5864,16 +5864,16 @@ struct ThreadwiseCopyRewritePattern
     AffineMap destTransform;
 
     if (sourceTypeAffineMaps.size()) {
-      // Use the first affine map in the attribute array.
       sourceCoordLength = sourceTypeAffineMaps[0].getNumInputs();
       sourceEmbeddedTransform = true;
-      sourceTransform = sourceTypeAffineMaps[0];
+      // Compose affine maps in the attribute array.
+      sourceTransform = composeTransformsFromArrayRef(sourceTypeAffineMaps);
     }
     if (destTypeAffineMaps.size()) {
-      // Use the first affine map in the attribute array.
       destCoordLength = destTypeAffineMaps[0].getNumInputs();
       destEmbeddedTransform = true;
-      destTransform = destTypeAffineMaps[0];
+      // Compose affine maps in the attribute array.
+      destTransform = composeTransformsFromArrayRef(destTypeAffineMaps);
     }
     if (coordTransformsAttr) {
       for (auto attr : coordTransformsAttr) {
@@ -5881,16 +5881,22 @@ struct ThreadwiseCopyRewritePattern
         auto operandIndex =
             dictAttr.get("operand").template cast<IntegerAttr>().getInt();
         auto transforms = dictAttr.get("transforms").template cast<ArrayAttr>();
-        // Use the first affine map in the transforms array.
-        auto affineMap = transforms[0].template cast<AffineMapAttr>();
         if (operandIndex == 0) {
-          sourceCoordLength = affineMap.getValue().getNumInputs();
+          sourceCoordLength = transforms[0]
+                                  .template cast<AffineMapAttr>()
+                                  .getValue()
+                                  .getNumInputs();
           sourceExternalTransform = true;
-          sourceTransform = affineMap.getValue();
+          // Compose affine maps in the attribute array.
+          sourceTransform = composeTransformsFromArrayAttr(transforms);
         } else {
-          destCoordLength = affineMap.getValue().getNumInputs();
+          destCoordLength = transforms[0]
+                                .template cast<AffineMapAttr>()
+                                .getValue()
+                                .getNumInputs();
           destExternalTransform = true;
-          destTransform = affineMap.getValue();
+          // Compose affine maps in the attribute array.
+          destTransform = composeTransformsFromArrayAttr(transforms);
         }
       }
     }

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -4076,7 +4076,6 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     // compose with output tensor affine map.
     auto outputType = op.output().getType().template dyn_cast<MemRefType>();
     auto outputAffineMap3to5 = outputType.getAffineMaps()[0];
-    auto affineMap5to3to5 = outputAffineMap3to5.compose(affineMap5to3);
 
     // emit TransformOp for output tensor.
     llvm::SmallVector<NamedAttribute, 3> transformedNewOutputAttrs;
@@ -4091,8 +4090,9 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
         b.getArrayAttr({b.getStringAttr("g"), b.getStringAttr("m0"),
                         b.getStringAttr("m1"), b.getStringAttr("n0"),
                         b.getStringAttr("n1")})));
-    auto newOutputType = MemRefType::get(
-        {G, M0, M1, N0, N1}, outputType.getElementType(), {affineMap5to3to5});
+    auto newOutputType =
+        MemRefType::get({G, M0, M1, N0, N1}, outputType.getElementType(),
+                        {affineMap5to3, outputAffineMap3to5});
     auto newOutputTransformOp = b.create<miopen::TransformOp>(
         loc, newOutputType, op.output(), transformedNewOutputAttrs);
 
@@ -5104,7 +5104,6 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
     // compose with output tensor affine map.
     auto outputType = op.output().getType().template dyn_cast<MemRefType>();
     auto outputAffineMap3to5 = outputType.getAffineMaps()[0];
-    auto affineMap5to3to5 = outputAffineMap3to5.compose(affineMap5to3);
 
     // emit TransformOp for output tensor.
     llvm::SmallVector<NamedAttribute, 3> transformedNewOutputAttrs;
@@ -5119,8 +5118,9 @@ struct GridwiseGemmV2RewritePattern : public OpRewritePattern<miopen::GridwiseGe
         b.getArrayAttr({b.getStringAttr("g"), b.getStringAttr("m0"),
                         b.getStringAttr("m1"), b.getStringAttr("m2"),
                         b.getStringAttr("n")})));
-    auto newOutputType = MemRefType::get(
-        {G, M0, M1, M2, N}, outputType.getElementType(), {affineMap5to3to5});
+    auto newOutputType =
+        MemRefType::get({G, M0, M1, M2, N}, outputType.getElementType(),
+                        {affineMap5to3, outputAffineMap3to5});
     auto newOutputTransformOp = b.create<miopen::TransformOp>(
         loc, newOutputType, op.output(), transformedNewOutputAttrs);
 

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -636,26 +636,28 @@ static LogicalResult verify(ThreadwiseCopyOp op) {
       auto coordTransformDictAttr = coordTransformAttr.cast<DictionaryAttr>();
       auto operandIndex =
           coordTransformDictAttr.get("operand").cast<IntegerAttr>().getInt();
-      auto transform = coordTransformDictAttr.get("transforms")
-                           .cast<ArrayAttr>()
-                           .getValue()[0]
-                           .cast<AffineMapAttr>()
-                           .getValue();
+      auto affineMapsArrayAttr =
+          coordTransformDictAttr.get("transforms").cast<ArrayAttr>().getValue();
+      auto firstTransform =
+          affineMapsArrayAttr[0].cast<AffineMapAttr>().getValue();
+      auto lastTransform = affineMapsArrayAttr[affineMapsArrayAttr.size() - 1]
+                               .cast<AffineMapAttr>()
+                               .getValue();
 
       if (operandIndex == 0) {
-        if (transform.getNumResults() != sourceRank)
+        if (lastTransform.getNumResults() != sourceRank)
           return op.emitError(
               "Number of coordindates in externally defined affine map doesn't "
               "match the rank of the source memref");
 
-        expectedSourceCoords = transform.getNumInputs();
+        expectedSourceCoords = firstTransform.getNumInputs();
       } else if (operandIndex == 1) {
-        if (transform.getNumResults() != destRank)
+        if (lastTransform.getNumResults() != destRank)
           return op.emitError(
               "Number of coordindates in externally defined affine map doesn't "
               "match the rank of the destination memref");
 
-        expectedDestCoords = transform.getNumInputs();
+        expectedDestCoords = firstTransform.getNumInputs();
       }
     }
   }

--- a/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
@@ -25,6 +25,6 @@ func @miopen_conv2d_gcyxk_gcnhw_gknhw(%filter : memref<1x8x3x3x128xf32>, %input 
 
 // AFFINE: #map{{[0-9]+}} = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 9, (d1 mod 9) floordiv 3, (d1 mod 9) mod 3, d2)>
 // AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 - 1, d4 - 1)>
-// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3 + d4 - 1, d5 + d6 - 1)>
-// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 9, d2 floordiv 1024, (d1 mod 9) floordiv 3 + (d2 mod 1024) floordiv 32 - 1, (d1 mod 9) mod 3 + (d2 mod 1024) mod 32 - 1)>
+// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3 + d4, d5 + d6)>
+// AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 9, d2 floordiv 1024, (d1 mod 9) floordiv 3, (d2 mod 1024) floordiv 32, (d1 mod 9) mod 3, (d2 mod 1024) mod 32)>
 // AFFINE-NEXT: #map{{[0-9]+}} = affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 1024, (d2 mod 1024) floordiv 32, (d2 mod 1024) mod 32)>

--- a/mlir/test/Dialect/MIOpen/lowering_threadwise_copy_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_threadwise_copy_v2.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-opt -miopen-lowering-step4 %s | FileCheck %s
 
-#map0 = affine_map<(d0, d1) -> (d0 * 8 + d1)>
+#map0 = affine_map<(d0, d1) -> (d0 * 8 + d1, d1)>
 #map1 = affine_map<(d0, d1) -> (d0 * 999 + d1 * 998)>
 
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0 * 16 + d1 * 8 + d2 * 4 + d3)>


### PR DESCRIPTION
Defer compose affine maps until `threadwise_copy` and `threadwise_copy_v2`.

This paves the way for properly implementing `F_infinite` algorithm for index diff maps.

+ @ltqin . Need to discuss with you on the impact to #203 .