### PR TITLE
Add `alwaysPull true` to docker agents in Jenkins

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -4,6 +4,7 @@ pipeline {
             image 'rocm/mlir:rocm4.1-latest'
             args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'rocm'
+            alwaysPull true
         }
     }
     stages {

--- a/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
@@ -4,6 +4,7 @@ pipeline {
             image 'rocm/mlir:rocm4.1-latest'
             args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'gfx908'
+            alwaysPull true
         }
     }
     stages {

--- a/mlir/utils/jenkins/Jenkinsfile.nightly
+++ b/mlir/utils/jenkins/Jenkinsfile.nightly
@@ -4,6 +4,7 @@ pipeline {
             image 'rocm/mlir:rocm4.1-latest'
             args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'rocm'
+            alwaysPull true
         }
     }
     stages {

--- a/mlir/utils/jenkins/Jenkinsfile.nightly-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.nightly-xdlop
@@ -4,6 +4,7 @@ pipeline {
             image 'rocm/mlir:rocm4.1-latest'
             args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'gfx908'
+            alwaysPull true
         }
     }
     stages {

--- a/mlir/utils/jenkins/Jenkinsfile.perf
+++ b/mlir/utils/jenkins/Jenkinsfile.perf
@@ -4,6 +4,7 @@ pipeline {
             image 'rocm/mlir:rocm4.1-latest'
             args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'rocm'
+            alwaysPull true
         }
     }
     stages {

--- a/mlir/utils/jenkins/Jenkinsfile.perf-gfx908
+++ b/mlir/utils/jenkins/Jenkinsfile.perf-gfx908
@@ -4,6 +4,7 @@ pipeline {
             image 'rocm/mlir:rocm4.1-latest'
             args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'test-0'
+            alwaysPull true
         }
     }
     stages {

--- a/mlir/utils/jenkins/Jenkinsfile.upstream
+++ b/mlir/utils/jenkins/Jenkinsfile.upstream
@@ -4,6 +4,7 @@ pipeline {
             image 'rocm/mlir:rocm4.1-latest'
             args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
             label 'rocm'
+            alwaysPull true
         }
     }
     stages {


### PR DESCRIPTION
This protects against the CI being run in outdated Docker images.