### PR TITLE
Disable certain tests that use miopen-driver when it isn't built

### DIFF
--- a/mlir/test/Dialect/MIOpen/lowering_affine_transform_padding_check.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_affine_transform_padding_check.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: miopen-driver
 // RUN: mlir-miopen-driver --operation conv2d -t f32 -x2 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 28 --in_w 28 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 -miopen-lowering -miopen-affine-transform -miopen-test-affine-transform | FileCheck %s --check-prefix=CHECK0
 // RUN: mlir-miopen-driver --operation conv2d -t f32 -x2 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 128 --in_h 28 --in_w 28 --out_channels 128 --fil_w 3 --fil_h 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 1 --padding_w 1 -miopen-lowering -miopen-affine-transform -miopen-test-affine-transform | FileCheck %s --check-prefix=CHECK1
 

--- a/mlir/test/Dialect/MIOpen/lowering_affix_params.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_affix_params.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: miopen-driver
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s
 // RUN: mlir-miopen-driver -p --operation=conv2d_dummy -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s
 

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -44,6 +44,8 @@ config.enable_rocm_runner = @MLIR_ROCM_RUNNER_ENABLED@
 config.spirv_wrapper_library_dir = "@MLIR_SPIRV_WRAPPER_LIBRARY_DIR@"
 config.enable_spirv_cpu_runner = @MLIR_SPIRV_CPU_RUNNER_ENABLED@
 config.enable_miopen_driver = @MLIR_MIOPEN_DRIVER_ENABLED@
+if config.enable_miopen_driver:
+    config.available_features.add('miopen-driver')
 config.enable_miopen_driver_e2e_test = @MLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED@
 config.enable_miopen_driver_misc_e2e_test = @MLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED@
 config.enable_miopen_driver_pr_e2e_test = @MLIR_MIOPEN_DRIVER_PR_E2E_TEST_ENABLED@

--- a/mlir/test/mlir-miopen-lib/lit.local.cfg
+++ b/mlir/test/mlir-miopen-lib/lit.local.cfg
@@ -1,0 +1,2 @@
+if not config.enable_miopen_driver:
+  config.unsupported = True


### PR DESCRIPTION
(This arises from wanting to break #220 into smaller pieces to work out what went wrong)