### PR TITLE
Backport patch to MLIR build system that fixes standalone tests

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -15,6 +15,11 @@ llvm_canonicalize_cmake_booleans(
   MLIR_VULKAN_RUNNER_ENABLED
   )
 
+# Passed to lit.site.cfg.py.so that the out of tree Standalone dialect test
+# can find MLIR's CMake configuration
+set(MLIR_CMAKE_CONFIG_DIR
+  "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir")
+
 # Passed to lit.site.cfg.py.in to set up the path where to find the libraries
 # for linalg integration tests.
 set(MLIR_DIALECT_LINALG_INTEGRATION_TEST_LIB_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})

--- a/mlir/test/Examples/standalone/lit.local.cfg
+++ b/mlir/test/Examples/standalone/lit.local.cfg
@@ -1,3 +1,5 @@
 config.substitutions.append(("%cmake", config.host_cmake))
 config.substitutions.append(("%host_cxx", config.host_cxx))
 config.substitutions.append(("%host_cc", config.host_cc))
+config.substitutions.append(
+    ("%mlir_cmake_config_dir", config.mlir_cmake_config_dir))

--- a/mlir/test/Examples/standalone/test.toy
+++ b/mlir/test/Examples/standalone/test.toy
@@ -1,4 +1,4 @@
-# RUN: %cmake %mlir_src_root/examples/standalone -DCMAKE_CXX_COMPILER=%host_cxx -DCMAKE_C_COMPILER=%host_cc -DMLIR_DIR=%llvm_lib_dir/cmake/mlir ; %cmake --build . --target check-standalone | tee %t | FileCheck %s
+# RUN: %cmake %mlir_src_root/examples/standalone -DCMAKE_CXX_COMPILER=%host_cxx -DCMAKE_C_COMPILER=%host_cc -DMLIR_DIR=%mlir_cmake_config_dir ; %cmake --build . --target check-standalone | tee %t | FileCheck %s
 
 # CHECK: Passed: 3
 # UNSUPPORTED: windows, android

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -33,6 +33,7 @@ config.mlir_src_root = "@MLIR_SOURCE_DIR@"
 config.mlir_obj_root = "@MLIR_BINARY_DIR@"
 config.mlir_runner_utils_dir = "@MLIR_RUNNER_UTILS_DIR@"
 config.mlir_tools_dir = "@MLIR_TOOLS_DIR@"
+config.mlir_cmake_config_dir = "@MLIR_CMAKE_CONFIG_DIR@"
 config.linalg_test_lib_dir = "@MLIR_DIALECT_LINALG_INTEGRATION_TEST_LIB_DIR@"
 config.build_examples = @LLVM_BUILD_EXAMPLES@
 config.run_cuda_tests = @MLIR_CUDA_CONVERSIONS_ENABLED@


### PR DESCRIPTION
This patch is submitted to LLVM at https://reviews.llvm.org/D103276, but I'd like to apply it to our copy now.

-- Original commit below --
[MLIR] Fix Standalone dialect test to work in out-of-tree builds

When LLVM and MLIR are built as subprojects (via add_subdirectory),
the CMake configuration that indicates where the MLIR libraries are is
not necessarily in the same cmake/ directory as LLVM's configuration.
This patch removes that the assumption about where MLIRConfig.cmake is
located.

(As an additional none, the %llvm_lib_dir substitution was never
defined, and so find_package(MLIR) in the build was succeeding for
other reasons.)

