### PR TITLE
Packport LLVM patch to silence a bunch of CMake warnings on 3.20

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -2,6 +2,12 @@
 
 cmake_minimum_required(VERSION 3.13.4)
 
+# CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
+# New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
 set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 
 if(NOT DEFINED LLVM_VERSION_MAJOR)


### PR DESCRIPTION
[cmake] Configure policy CMP0116

Using `cmake` >=3.20 results in many warnings about this new policy. This change silences the warnings by explicitly declaring use of the "OLD" behavior.

This policy currently affects only one place: the `tablegen()` function in `TableGen.cmake`.

Differential Revision: https://reviews.llvm.org/D101083