### PR TITLE
Deduplicate various steps in CI files

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -7,6 +7,9 @@ pipeline {
             alwaysPull true
         }
     }
+    environment {
+        PATH="$PATH:/opt/rocm/llvm/bin"
+    }
     stages {
         stage('Environment') {
             steps {
@@ -17,66 +20,37 @@ pipeline {
         stage('Build and Test') {
             steps {
                 checkout scm
-                sh '''
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_PR_E2E_TEST_ENABLED=1 
-                        # if we open sqlite, step4 lowering failed until adding the custom db
-                        # -DMLIR_MIOPEN_SQLITE_ENABLED=1
-
-                    # Build LLVM / MLIR and run tests
-                    cmake --build . --target check-mlir
-                '''
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'check-mlir']],\
+                    cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_ENABLED=1
+                                   -DMLIR_MIOPEN_DRIVER_PR_E2E_TEST_ENABLED=1
+                               '''
             }
         }
         stage('Static Test') {
             steps {
                 sh '''
-                    if [ ! -f ./compile_commands.json ]; then
+                    if [[ ! -f ./compile_commands.json ]]; then
                        ln -s build/compile_commands.json compile_commands.json
                     fi
-
-                    # Set the path to the clang-format executable
-                    PATH=$PATH:/opt/rocm/llvm/bin/
-
-                    python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py
-
-                    # Clean up build directory
-                    rm -rf build
-                '''
+                    '''
+                sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
             }
         }
         stage('Igemm Build') {
             steps {
-                sh '''
-                    mkdir -p build && cd build
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'libMLIRMIOpen']],\
+                    cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'
 
-                    cmake -G "Unix Makefiles" ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DBUILD_SHARED_LIBS=OFF \
-                        -DLLVM_BUILD_LLVM_DYLIB=OFF \
-                        -DBUILD_FAT_LIBMLIRMIOPEN=ON \
-                        -DLLVM_ENABLE_TERMINFO=OFF
-
-                    make -j libMLIRMIOpen
-
-                    # Clean up build directory
-                    rm -rf build
-                '''
+                cmake arguments: '--install . --component libMLIRMIOpen --prefix /opt/rocm',\
+                    installation: 'InSearchPath', workingDir: 'build'
             }
         }
     }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
@@ -7,6 +7,9 @@ pipeline {
             alwaysPull true
         }
     }
+    environment {
+        PATH="$PATH:/opt/rocm/llvm/bin"
+    }
     stages {
         stage('Environment') {
             steps {
@@ -17,29 +20,15 @@ pipeline {
         stage('Build and Test') {
             steps {
                 checkout scm
-                sh '''
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_PR_E2E_TEST_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_XDLOPS_TEST_ENABLED=1
-                        # if we open sqlite, step4 lowering failed until adding the custom db
-                        # -DMLIR_MIOPEN_SQLITE_ENABLED=1
-
-                    # Build LLVM / MLIR and run tests
-                    cmake --build . --target check-mlir
-                '''
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'check-mlir']],\
+                    cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_ENABLED=1
+                               -DMLIR_MIOPEN_DRIVER_PR_E2E_TEST_ENABLED=1
+                               -DMLIR_MIOPEN_DRIVER_XDLOPS_TEST_ENABLED=1
+                               '''
             }
         }
         stage('Static Test') {
@@ -48,36 +37,21 @@ pipeline {
                     if [ ! -f ./compile_commands.json ]; then
                        ln -s build/compile_commands.json compile_commands.json
                     fi
-
-                    # Set the path to the clang-format executable
-                    PATH=$PATH:/opt/rocm/llvm/bin/
-
-                    python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py
-
-                    # Clean up build directory
-                    rm -rf build
-                '''
+                    '''
+                sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
             }
         }
         stage('Igemm Build') {
             steps {
-                sh '''
-                    mkdir -p build && cd build
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'libMLIRMIOpen']],\
+                    cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'
 
-                    cmake -G "Unix Makefiles" ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DBUILD_SHARED_LIBS=OFF \
-                        -DLLVM_BUILD_LLVM_DYLIB=OFF \
-                        -DBUILD_FAT_LIBMLIRMIOPEN=ON \
-                        -DLLVM_ENABLE_TERMINFO=OFF
-
-                    make -j libMLIRMIOpen
-
-                    # Clean up build directory
-                    rm -rf build
-                '''
+                cmake arguments: '--install . --component libMLIRMIOpen --prefix /opt/rocm',\
+                    installation: 'InSearchPath', workingDir: 'build'
             }
         }
     }

--- a/mlir/utils/jenkins/Jenkinsfile.miopen-test
+++ b/mlir/utils/jenkins/Jenkinsfile.miopen-test
@@ -1,18 +1,78 @@
 pipeline {
     agent none
     stages {
+        // Workaround Durable Tasks bug, hopefully
+        stage("Library build") {
+            agent {
+                docker {
+                    image 'rocm/mlir:rocm4.1-latest'
+                    args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
+                    label "rocm"
+                    alwaysPull true
+                }
+            }
+            stages {
+                stage('Build libMLIRMIOpen') {
+                    steps {
+                        checkout scm
+                        cmakeBuild generator: 'Ninja',\
+                            buildDir: 'build',\
+                            installation: 'InSearchPath',\
+                            buildType: 'Release',\
+                            steps: [[args: 'libMLIRMIOpen']],\
+                            cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'
+                        cmake arguments: '--install . --component libMLIRMIOpen',\
+                            installation: 'InSearchPath', workingDir: 'build'
+
+                    }
+                }
+                stage('Build MIOpenDriver') {
+                    steps {
+                        dir('MIOpen') {
+                            git branch: 'develop', poll: false,\
+                                url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
+                            cmake arguments: "-P install_deps.cmake --minimum",\
+                                installation: "InSearchPath"
+                            cmakeBuild generator: 'Ninja',\
+                                buildDir: 'build',\
+                                buildType: 'Release',\
+                                installation: 'InSearchPath',\
+                                steps: [[args: "MIOpenDriver"]],\
+                                cmakeArgs: '''-DMIOPEN_USE_MLIR=On
+                                -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+                                 -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+                                 -DBUILD_DEV=On
+                                -DMIOPEN_TEST_FLAGS=\'--verbose --disable-verification-cache\'
+                                '''
+                        }
+                        stash name:"MIOpen-test-requisites",\
+                                includes: """MIOpen/src/kernels/**,\
+MIOpen/build/bin/MIOpenDriver,\
+MIOpen/build/lib/*,\
+mlir/utils/jenkins/miopen-tests/**\
+"""
+
+                    }
+                }
+            }
+            post {
+                always {
+                    cleanWs()
+                }
+            }
+        }
         stage("Resnet50 configs nightly tests") {
-            // Note: the builds are reused between cases on each node
-            // It may be possible to move build steps out to execute once
-            // but this could cause issues with target-specific code
-            // when we run the non-xdlops tests on a gfx900
             matrix {
                 agent {
                     docker {
-                        image 'rocm/mlir:miopen_test'
+                        image 'rocm/mlir:latest'
                         args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
-                        label "${XDLOPS == '1' ? 'gfx908 && multi_gpu' : 'gfx908 && multi_gpu'}"
+                        label "${XDLOPS == '1' ? 'gfx908' : 'gfx908'} && multi_gpu"
+                        alwaysPull true
                     }
+                }
+                options {
+                    skipDefaultCheckout()
                 }
                 axes {
                     axis {
@@ -33,11 +93,6 @@ pipeline {
                     }
                 }
                 stages {
-                    stage('Install parallel (temp until dockerfile updated)') {
-                        steps {
-                            sh 'apt-get update 2>&1 >/dev/null && apt-get install -y --no-install-recommends parallel 2>&1 >/dev/null'
-                        }
-                    }
                     stage('Environment') {
                         steps {
                             echo "Config is ($DTYPE, $LAYOUT, xdlops=$XDLOPS, dir=$DIRECTION)"
@@ -45,46 +100,9 @@ pipeline {
                             sh '/opt/rocm/bin/rocm-smi'
                         }
                     }
-                    stage('Build libMLIRMIOpen') {
+                    stage("Copy MIOpen test environment") {
                         steps {
-                            checkout scm
-                            cmakeBuild generator: 'Unix Makefiles',\
-                               buildDir: 'build',\
-                               sourceDir: 'llvm',\
-                               installation: 'InDocker',\
-                               buildType: 'Release',\
-                               cmakeArgs: '''-DLLVM_ENABLE_PROJECTS="mlir;lld"
-                    -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
-                    -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
-                    -DBUILD_SHARED_LIBS=OFF
-                    -DLLVM_BUILD_LLVM_DYLIB=OFF
-                    -DLLVM_ENABLE_TERMINFO=OFF
-                    -DCMAKE_INSTALL_PREFIX=/opt/rocm
-                    -DBUILD_FAT_LIBMLIRMIOPEN=ON
-                    '''
-                            sh 'cd build; make -j $(nproc) libMLIRMIOpen'
-                            cmake arguments: '--install . --component libMLIRMIOpen',\
-                                installation: 'InSearchPath', workingDir: 'build'
-
-                        }
-                    }
-                    stage('Build MIOpenDriver') {
-                        steps {
-                            dir('MIOpen') {
-                                git branch: 'develop', poll: false, url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
-                                cmakeBuild buildDir: 'build',\
-                                   buildType: 'Release',\
-                                   installation: 'InDocker',\
-                                   cmakeArgs: '''-DMIOPEN_USE_MLIR=On
--DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
--DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
--DBUILD_DEV=On
--DMIOPEN_TEST_FLAGS=\'--verbose --disable-verification-cache\'
---log-level=WARNING
--DCMAKE_RULE_MESSAGES=OFF
-'''
-                                sh 'cd build; make -j $(nproc) MIOpenDriver'
-                            }
+                            unstash name: "MIOpen-test-requisites"
                         }
                     }
                     stage("Test MIOpen config") {

--- a/mlir/utils/jenkins/Jenkinsfile.nightly
+++ b/mlir/utils/jenkins/Jenkinsfile.nightly
@@ -7,6 +7,9 @@ pipeline {
             alwaysPull true
         }
     }
+    environment {
+        PATH="$PATH:/opt/rocm/llvm/bin"
+    }
     stages {
         stage('Environment') {
             steps {
@@ -17,59 +20,31 @@ pipeline {
         stage('Build and Test') {
             steps {
                 checkout scm
-                sh '''
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED=1 \
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'check-mlir']],\
+                    cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_ENABLED=1
+                        -DMLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED=1
                         -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=1
-                        # if we open sqlite, step4 lowering failed until adding the custom db
-                        # -DMLIR_MIOPEN_SQLITE_ENABLED=1
-
-                    # Build LLVM / MLIR and run tests
-                    cmake --build . --target check-mlir
-
-                    # Clean up build directory
-                    rm -rf build
-                '''
+                    '''
+                dir("build") {
+                    deleteDir
+                }
             }
         }
         stage('Test Random E2E') {
             steps {
-                sh '''
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED=1 \
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'check-mlir']],\
+                    cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_ENABLED=1
+                        -DMLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED=1
                         -DMLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED=1
-
-                    # Build LLVM / MLIR and run E2E tests
-                    cmake --build . --target check-mlir
-
-                    # Clean up build directory
-                    rm -rf build
-                '''
+                    '''
             }
         }
     }

--- a/mlir/utils/jenkins/Jenkinsfile.nightly-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.nightly-xdlop
@@ -7,6 +7,9 @@ pipeline {
             alwaysPull true
         }
     }
+    environment {
+        PATH="$PATH:/opt/rocm/llvm/bin"
+    }
     stages {
         stage('Environment') {
             steps {
@@ -17,49 +20,28 @@ pipeline {
         stage('Build and Test XDLop E2E') {
             steps {
                 checkout scm
-                sh '''
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=1 \
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'check-mlir']],\
+                    cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_ENABLED=1
+                        -DMLIR_MIOPEN_DRIVER_E2E_TEST_ENABLED=1
+                        -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=1
                         -DMLIR_MIOPEN_DRIVER_XDLOPS_TEST_ENABLED=1
-                        # if we open sqlite, step4 lowering failed until adding the custom db
-                        # -DMLIR_MIOPEN_SQLITE_ENABLED=1
-
-                    # Build LLVM / MLIR and run tests
-                    cmake --build . --target check-mlir
-
-                '''
+                    '''
             }
         }
         stage('Test Random XDLop E2E') {
             steps {
-                sh '''
-                    cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    cmake -DMLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED=1 \
-                          -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=0 .
-
-                    # Build LLVM / MLIR and run E2E tests
-                    cmake --build . --target check-mlir
-
-                    # Clean up build directory
-                    rm -rf build
-                '''
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: "clean"], [args: 'check-mlir']],\
+                    cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED=1
+                    -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=0
+                    '''
             }
         }
     }

--- a/mlir/utils/jenkins/Jenkinsfile.perf
+++ b/mlir/utils/jenkins/Jenkinsfile.perf
@@ -17,29 +17,12 @@ pipeline {
         stage('Build and Test') {
             steps {
                 checkout scm
-                sh '''
-                    # make build directory
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    # config MLIR on ROCm, with MIOpen dialect
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_ENABLED=1
-                        # if we open sqlite, step4 lowering failed until adding the custom db
-                        # -DMLIR_MIOPEN_SQLITE_ENABLED=1
-
-                    # build LLVM / MLIR and run tests
-                    cmake --build . --target check-mlir
-                '''
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'check-mlir']],\
+                    cmakeArgs: '-DMLIR_MIOPEN_DRIVER_ENABLED=1'
             }
         }
         stage('Benchmark') {

--- a/mlir/utils/jenkins/Jenkinsfile.perf-gfx908
+++ b/mlir/utils/jenkins/Jenkinsfile.perf-gfx908
@@ -7,6 +7,9 @@ pipeline {
             alwaysPull true
         }
     }
+    environment {
+        PATH="$PATH:/opt/rocm/llvm/bin"
+    }
     stages {
         stage('Environment') {
             steps {
@@ -17,37 +20,20 @@ pipeline {
         stage('Build and Test FP32') {
             steps {
                 checkout scm
-                sh '''
-                    # make build directory
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
+                // config MLIR on ROCm, with MIOpen dialect
+                // with custom perf db for:
+                // - gfx908
+                // - fp32
+                // - resnet50 configs.
 
-                    # config MLIR on ROCm, with MIOpen dialect
-                    # with custom perf db for:
-                    # - gfx908
-                    # - fp32
-                    # - resnet50 configs.
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1 \
-                        -DMLIR_MIOPEN_DRIVER_ENABLED=1 \
-                        -DMLIR_MIOPEN_SQLITE_ENABLED=1 \
-                        -DMIOPEN_SYSTEM_DB_PATH=`readlink -f ../mlir/utils/jenkins/perfdb/miopen_1.0.0.udb.resnet50_fp32_1013`
-
-
-                    # build MLIR tools needed for performance benchmarking.
-                    # due to customized perf db, tuning-related tests may not
-                    # pass.
-                    cmake --build . --target mlir-miopen-driver
-                    cmake --build . --target mlir-rocm-runner
-                '''
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'mlir-miopen-driver mlir-rocm-runner']],\
+                    cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_ENABLED=1
+                        -DMIOPEN_SYSTEM_DB_PATH=${WORKSPACE}/mlir/utils/jenkins/perfdb/miopen_1.0.0.udb.resnet50_fp32_1013
+                    '''
             }
         }
         stage('Benchmark FP32') {

--- a/mlir/utils/jenkins/Jenkinsfile.upstream
+++ b/mlir/utils/jenkins/Jenkinsfile.upstream
@@ -7,6 +7,9 @@ pipeline {
             alwaysPull true
         }
     }
+    environment {
+        PATH="$PATH:/opt/rocm/llvm/bin"
+    }
     stages {
         stage('Environment') {
             steps {
@@ -17,26 +20,23 @@ pipeline {
         stage('Build and Test') {
             steps {
                 git 'https://github.com/llvm/llvm-project'
-                sh '''
-                    # make build directory
-                    mkdir -p build && cd build
-                    # Set the path to llvm-symbolizer
-                    PATH=$PATH:/opt/rocm-4.1.1/llvm/bin/
-
-                    # config MLIR on ROCm
-                    cmake -G Ninja ../llvm \
-                        -DLLVM_ENABLE_PROJECTS="mlir;lld" \
-                        -DLLVM_BUILD_EXAMPLES=ON \
-                        -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DLLVM_ENABLE_ASSERTIONS=ON \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DLLVM_BUILD_LLVM_DYLIB=ON \
-                        -DMLIR_ROCM_RUNNER_ENABLED=1
-
-                    # build LLVM / MLR and run tests
-                    cmake --build . --target check-mlir
-                '''
+                cmakeBuild generator: 'Ninja',\
+                    buildDir: 'build',\
+                    sourceDir: 'llvm',\
+                    buildType: 'Release',\
+                    installation: 'InSearchPath',\
+                    steps: [[args: 'check-mlir']],\
+                    // Reminder to keep these up to date with our cmake
+                    cmakeArgs: '''
+                    -DLLVM_ENABLE_PROJECTS="mlir;lld"
+                    -DLLVM_BUILD_EXAMPLES=ON
+                    -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU"
+                    -DCMAKE_BUILD_TYPE=Release
+                    -DLLVM_ENABLE_ASSERTIONS=ON
+                    -DBUILD_SHARED_LIBS=ON
+                    -DLLVM_BUILD_LLVM_DYLIB=ON
+                    -DMLIR_ROCM_RUNNER_ENABLED=1
+                    '''
             }
         }
     }


### PR DESCRIPTION
(Note, this is blocked by #240 landing and so is skip-ci for now)
 
- Use the newly-defined top-level CMakeLists.txt to reduce the number
 of redundant build flags.

 - Replace many shell scripts that call cmake and a build tool with
 calls to the cmake plugin.

  - Similarly, move PATH changes into the Jenkins configuration

Many of these CI files still contain similar steps (like various
compile/test combinations). I have a separate PR that creates one big
Jenkinsfile, but I'd like to land this first so that we know the
general structure of the changes I've made is solid before we
consolidate them into one file.