### PR TITLE
Miopen dialect opt step 22 : Force index type be 32-bits wide.

### DIFF
--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -2301,7 +2301,7 @@ static LogicalResult runMLIRPasses(ModuleOp &module,
     } else if (pipeline == "rocdl") {
       // Set up the lowering pipeline which goes down to ROCDL dialect.
       populateDefaultLoweringPipeline(pm);
-      pm.addPass(createLowerGpuOpsToROCDLOpsPass());
+      pm.addPass(createLowerGpuOpsToROCDLOpsPass(/*indexBitWidth=*/32));
     }
   } else {
     auto errorHandler = [&](const Twine &msg) {

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -265,7 +265,7 @@ extern "C" MiirStatus miirLowerBin(MiirHandle mlirHandle) {
   // Passes for lowering ROCDL dialect
   pm.addPass(createGpuKernelOutliningPass());
   pm.addPass(createStripDebugInfoPass());
-  pm.addPass(createLowerGpuOpsToROCDLOpsPass());
+  pm.addPass(createLowerGpuOpsToROCDLOpsPass(/*indexBitWidth=*/32));
   pm.addPass(createConvertGPUKernelToBlobPass(
       [&utils](Operation *m, llvm::LLVMContext &llvmContext,
                llvm::StringRef name) {

--- a/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
+++ b/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
@@ -57,7 +57,7 @@ static LogicalResult runMLIRPasses(ModuleOp m) {
   pm.addPass(createGpuKernelOutliningPass());
   auto &kernelPm = pm.nest<gpu::GPUModuleOp>();
   kernelPm.addPass(createStripDebugInfoPass());
-  kernelPm.addPass(createLowerGpuOpsToROCDLOpsPass());
+  kernelPm.addPass(createLowerGpuOpsToROCDLOpsPass(/*indexBitWidth=*/32));
   kernelPm.addPass(createConvertGPUKernelToBlobPass(
       [&utils](Operation *m, llvm::LLVMContext &llvmContext,
                llvm::StringRef name) {


### PR DESCRIPTION
Instead of hacking dataLayout string, use this trick converting MLIR dialects to LLVM-level dialect.

Ensure index type is 32-bits wide to reduce meaningless 32<->64 bit conversions ahead of load/store instructions.

For the config generated by `mlir-miopen-driver -p`:
Before: 521592 ns.
After: 407833 ns.