### PR TITLE
Miopen dialect opt step 24: Remove the undesirable LDS barrier within MFMA code emission hot loop.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -7731,10 +7731,6 @@ struct XdlopsGemmV2RewritePattern
             ValueRange{loopKiv});
       }
 
-      // FIXME: See if it's possible to get rid of the this barrier.
-      // LDS barrier.
-      loopKb.create<miopen::LDSBarrierOp>(loc);
-
       SmallVector<Value, 4> mfmas;
       for (int64_t i = 0; i < vectorNumber; ++i) {
         auto vectorC = loopK.getRegionIterArgs()[i];


### PR DESCRIPTION
After #226 / #255 is merged, taking this PR would produce correct results and we could eliminate the undesirable LDS barrier within MFMA code emission hot loop.