### PR TITLE
Fix and parallelize MIOpen tests.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile.miopen-test
+++ b/mlir/utils/jenkins/Jenkinsfile.miopen-test
@@ -1,18 +1,78 @@
 pipeline {
     agent none
     stages {
+        // Workaround Durable Tasks bug, hopefully
+        stage("Library build") {
+            agent {
+                docker {
+                    image 'rocm/mlir:rocm4.1-latest'
+                    args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
+                    label "rocm"
+                    alwaysPull true
+                }
+            }
+            stages {
+                stage('Build libMLIRMIOpen') {
+                    steps {
+                        checkout scm
+                        cmakeBuild generator: 'Ninja',\
+                            buildDir: 'build',\
+                            installation: 'InSearchPath',\
+                            buildType: 'Release',\
+                            steps: [[args: 'libMLIRMIOpen']],\
+                            cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'
+                        cmake arguments: '--install . --component libMLIRMIOpen',\
+                            installation: 'InSearchPath', workingDir: 'build'
+
+                    }
+                }
+                stage('Build MIOpenDriver') {
+                    steps {
+                        dir('MIOpen') {
+                            git branch: 'develop', poll: false,\
+                                url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
+                            cmake arguments: "-P install_deps.cmake --minimum",\
+                                installation: "InSearchPath"
+                            cmakeBuild generator: 'Unix Makefiles',\
+                                buildDir: 'build',\
+                                buildType: 'Release',\
+                                installation: 'InSearchPath',\
+                                cmakeArgs: '''-DMIOPEN_USE_MLIR=On
+                                -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+                                -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+                                -DBUILD_DEV=On
+                                -DMIOPEN_TEST_FLAGS=\'--verbose --disable-verification-cache\'
+                                '''
+                            sh 'cd build; make -j $(nproc) MIOpenDriver'
+                        }
+                        stash name:"MIOpen-test-requisites",\
+                                includes: """MIOpen/src/kernels/**,\
+MIOpen/build/bin/MIOpenDriver,\
+MIOpen/build/lib/*,\
+mlir/utils/jenkins/miopen-tests/**\
+"""
+
+                    }
+                }
+            }
+            post {
+                always {
+                    cleanWs()
+                }
+            }
+        }
         stage("Resnet50 configs nightly tests") {
-            // Note: the builds are reused between cases on each node
-            // It may be possible to move build steps out to execute once
-            // but this could cause issues with target-specific code
-            // when we run the non-xdlops tests on a gfx900
             matrix {
                 agent {
                     docker {
-                        image 'rocm/mlir:miopen_test'
+                        image 'rocm/mlir:latest'
                         args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
-                        label "${XDLOPS == '1' ? 'gfx908 && multi_gpu' : 'gfx908 && multi_gpu'}"
+                        label "${XDLOPS == '1' ? 'gfx908' : 'gfx908'} && multi_gpu"
+                        alwaysPull true
                     }
+                }
+                options {
+                    skipDefaultCheckout()
                 }
                 axes {
                     axis {
@@ -33,11 +93,6 @@ pipeline {
                     }
                 }
                 stages {
-                    stage('Install parallel (temp until dockerfile updated)') {
-                        steps {
-                            sh 'apt-get update 2>&1 >/dev/null && apt-get install -y --no-install-recommends parallel 2>&1 >/dev/null'
-                        }
-                    }
                     stage('Environment') {
                         steps {
                             echo "Config is ($DTYPE, $LAYOUT, xdlops=$XDLOPS, dir=$DIRECTION)"
@@ -45,46 +100,9 @@ pipeline {
                             sh '/opt/rocm/bin/rocm-smi'
                         }
                     }
-                    stage('Build libMLIRMIOpen') {
+                    stage("Copy MIOpen test environment") {
                         steps {
-                            checkout scm
-                            cmakeBuild generator: 'Unix Makefiles',\
-                               buildDir: 'build',\
-                               sourceDir: 'llvm',\
-                               installation: 'InDocker',\
-                               buildType: 'Release',\
-                               cmakeArgs: '''-DLLVM_ENABLE_PROJECTS="mlir;lld"
-                    -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
-                    -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
-                    -DBUILD_SHARED_LIBS=OFF
-                    -DLLVM_BUILD_LLVM_DYLIB=OFF
-                    -DLLVM_ENABLE_TERMINFO=OFF
-                    -DCMAKE_INSTALL_PREFIX=/opt/rocm
-                    -DBUILD_FAT_LIBMLIRMIOPEN=ON
-                    '''
-                            sh 'cd build; make -j $(nproc) libMLIRMIOpen'
-                            cmake arguments: '--install . --component libMLIRMIOpen',\
-                                installation: 'InSearchPath', workingDir: 'build'
-
-                        }
-                    }
-                    stage('Build MIOpenDriver') {
-                        steps {
-                            dir('MIOpen') {
-                                git branch: 'develop', poll: false, url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
-                                cmakeBuild buildDir: 'build',\
-                                   buildType: 'Release',\
-                                   installation: 'InDocker',\
-                                   cmakeArgs: '''-DMIOPEN_USE_MLIR=On
--DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
--DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
--DBUILD_DEV=On
--DMIOPEN_TEST_FLAGS=\'--verbose --disable-verification-cache\'
---log-level=WARNING
--DCMAKE_RULE_MESSAGES=OFF
-'''
-                                sh 'cd build; make -j $(nproc) MIOpenDriver'
-                            }
+                            unstash name: "MIOpen-test-requisites"
                         }
                     }
                     stage("Test MIOpen config") {


### PR DESCRIPTION
- Switch the MIOpen tests to the mlir docker image, making them build
successfully
- Use stash and unstash to build the MIOpen library once and then run
the tests several times