### PR TITLE
Update Dockerfile to remove the MIOpen dependency

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -83,7 +83,6 @@ RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 RUN apt-get update && apt-get install -y --no-install-recommends \
   rocm-dev \
   rocminfo \
-  miopen-hip \
   rocprofiler-dev \
   libelf1 \
   sudo \
@@ -96,8 +95,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-venv  && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
-
-# Manually install the latest perfdb from MIOpen/develop branch
-RUN cd ~ && git clone https://github.com/ROCmSoftwarePlatform/MIOpen.git && \
-  cp ~/MIOpen/src/kernels/miopen.db /opt/rocm/miopen/share/miopen/db/miopen.db && \
-  rm -rf MIOpen


### PR DESCRIPTION
Removing the MIOpen dependency as:
 - It is confusing the local test which target to load
 - In the coming milestone, we wouldn't directly interact with perfdb