### PR TITLE
Change `template cast` to `cast`.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/AffineMapHelper.h
@@ -38,12 +38,11 @@ inline AffineMap composeTransforms(ArrayRef<AffineMap> affineMaps) {
 
 inline AffineMap composeTransforms(ArrayAttr affineMaps) {
   int64_t iter = affineMaps.size() - 1;
-  AffineMap transform =
-      affineMaps[iter].template cast<AffineMapAttr>().getValue();
+  AffineMap transform = affineMaps[iter].cast<AffineMapAttr>().getValue();
   --iter;
   while (iter >= 0) {
-    transform = transform.compose(
-        affineMaps[iter].template cast<AffineMapAttr>().getValue());
+    transform =
+        transform.compose(affineMaps[iter].cast<AffineMapAttr>().getValue());
     --iter;
   }
   return transform;
@@ -57,7 +56,7 @@ inline bool hasPadding(AffineExpr expr) {
   bool ret = false;
   auto hasMinusConstant = [](AffineExpr expr) -> bool {
     if (expr.getKind() == AffineExprKind::Constant) {
-      auto constantExpr = expr.template cast<AffineConstantExpr>();
+      auto constantExpr = expr.cast<AffineConstantExpr>();
       if (constantExpr.getValue() < 0)
         return true;
     }
@@ -69,7 +68,7 @@ inline bool hasPadding(AffineExpr expr) {
 
     tmp.walk([&ret](AffineExpr expr_sub) {
       if (expr_sub.getKind() == AffineExprKind::Constant) {
-        auto constantSubExpr = expr_sub.template cast<AffineConstantExpr>();
+        auto constantSubExpr = expr_sub.cast<AffineConstantExpr>();
         if (constantSubExpr.getValue() < 0)
           ret = true;
       }

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -97,8 +97,8 @@ def MIOpen_TransformOp :
    [{
      $_state.addOperands({input});
      if (populateBounds) {
-       MemRefType lowerMemRefType = input.getType().template cast<MemRefType>();
-       MemRefType upperMemRefType = output.template cast<MemRefType>();
+       MemRefType lowerMemRefType = input.getType().cast<MemRefType>();
+       MemRefType upperMemRefType = output.cast<MemRefType>();
        $_state.addAttribute("lower_layer_bounds", buildMemRefShapeAttr($_builder, lowerMemRefType));
        $_state.addAttribute("upper_layer_bounds", buildMemRefShapeAttr($_builder, upperMemRefType));
      }

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/ConvContext.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/ConvContext.h
@@ -122,7 +122,7 @@ template <typename T> static miopen::ConvOpType ObtainConvDirection(T &op) {
 }
 
 template <typename T> static mlir::Type obtainDataType(T &op) {
-  return op.input().getType().template cast<MemRefType>().getElementType();
+  return op.input().getType().cast<MemRefType>().getElementType();
 }
 
 static inline void

--- a/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
@@ -92,47 +92,37 @@ LogicalResult backwardWeightAtomicAdd(T op, PatternRewriter &b,
   auto paddingAttr = op->template getAttrOfType<ArrayAttr>("padding");
 
   // Get shape of filter tensor.
-  auto filterType = op.filter().getType().template cast<MemRefType>();
+  auto filterType = op.filter().getType().cast<MemRefType>();
   auto filterShape = filterType.getShape();
   auto filterElementType = filterType.getElementType();
 
   // Get shape of input tensor.
-  auto inputType = op.input().getType().template cast<MemRefType>();
+  auto inputType = op.input().getType().cast<MemRefType>();
   auto inputShape = inputType.getShape();
   auto inputElementType = inputType.getElementType();
 
   // Get shape of output tensor.
-  auto outputType = op.output().getType().template cast<MemRefType>();
+  auto outputType = op.output().getType().cast<MemRefType>();
   auto outputShape = outputType.getShape();
   auto outputElementType = outputType.getElementType();
 
   // Obtain convolution parameters: padding / dialtion / stride.
-  auto leftPadH =
-      paddingAttr.getValue()[0].template cast<IntegerAttr>().getInt();
-  auto leftPadW =
-      paddingAttr.getValue()[2].template cast<IntegerAttr>().getInt();
-  auto rightPadH =
-      paddingAttr.getValue()[1].template cast<IntegerAttr>().getInt();
-  auto rightPadW =
-      paddingAttr.getValue()[3].template cast<IntegerAttr>().getInt();
+  auto leftPadH = paddingAttr.getValue()[0].cast<IntegerAttr>().getInt();
+  auto leftPadW = paddingAttr.getValue()[2].cast<IntegerAttr>().getInt();
+  auto rightPadH = paddingAttr.getValue()[1].cast<IntegerAttr>().getInt();
+  auto rightPadW = paddingAttr.getValue()[3].cast<IntegerAttr>().getInt();
 
-  auto dilationH =
-      dilationsAttr.getValue()[0].template cast<IntegerAttr>().getInt();
-  auto dilationW =
-      dilationsAttr.getValue()[1].template cast<IntegerAttr>().getInt();
-  auto strideH =
-      stridesAttr.getValue()[0].template cast<IntegerAttr>().getInt();
-  auto strideW =
-      stridesAttr.getValue()[1].template cast<IntegerAttr>().getInt();
+  auto dilationH = dilationsAttr.getValue()[0].cast<IntegerAttr>().getInt();
+  auto dilationW = dilationsAttr.getValue()[1].cast<IntegerAttr>().getInt();
+  auto strideH = stridesAttr.getValue()[0].cast<IntegerAttr>().getInt();
+  auto strideW = stridesAttr.getValue()[1].cast<IntegerAttr>().getInt();
   // get y, x, ho, wo, hi, wi
   int64_t g, n, k, c, y, x, ho, wo, hi, wi;
   g = n = k = c = y = x = ho = wo = hi = wi = 0;
   for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
-    auto filterAttr =
-        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto outputAttr =
-        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
+    auto filterAttr = filterLayoutAttr.getValue()[i].cast<StringAttr>();
+    auto inputAttr = inputLayoutAttr.getValue()[i].cast<StringAttr>();
+    auto outputAttr = outputLayoutAttr.getValue()[i].cast<StringAttr>();
 
     if (filterAttr.getValue() == "g") {
       g = filterShape[i];
@@ -176,8 +166,7 @@ LogicalResult backwardWeightAtomicAdd(T op, PatternRewriter &b,
     // key to dim
     std::map<StringRef, int> filterKeyToDim;
     for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
-      if (auto strAttr =
-              filterLayoutAttr.getValue()[i].template cast<StringAttr>()) {
+      if (auto strAttr = filterLayoutAttr.getValue()[i].cast<StringAttr>()) {
         filterKeyToDim[strAttr.getValue()] = i;
       }
     }
@@ -393,8 +382,7 @@ LogicalResult backwardWeightAtomicAdd(T op, PatternRewriter &b,
     // key to dim
     std::map<StringRef, int> currentKeyToDim;
     for (unsigned i = 0; i < inputLayoutAttr.size(); ++i) {
-      if (auto strAttr =
-              inputLayoutAttr.getValue()[i].template cast<StringAttr>()) {
+      if (auto strAttr = inputLayoutAttr.getValue()[i].cast<StringAttr>()) {
         currentKeyToDim[strAttr.getValue()] = i;
       }
     }
@@ -762,8 +750,7 @@ LogicalResult backwardWeightAtomicAdd(T op, PatternRewriter &b,
     // key to dim
     std::map<StringRef, int> currentKeyToDim;
     for (unsigned i = 0; i < outputLayoutAttr.size(); ++i) {
-      if (auto strAttr =
-              outputLayoutAttr.getValue()[i].template cast<StringAttr>()) {
+      if (auto strAttr = outputLayoutAttr.getValue()[i].cast<StringAttr>()) {
         currentKeyToDim[strAttr.getValue()] = i;
       }
     }


### PR DESCRIPTION
It seems we should be able to use `cast` instead of `template cast` in most of the places according to:

https://llvm.org/docs/ProgrammersManual.html#the-isa-cast-and-dyn-cast-templates

This PR is a preparatory task for us to re-examine the codes and figure out duplicated places where common logic are worthwhile extracted.