### PR TITLE
[HOTFIX] set maximum vectorization length to 4 for f16/bf16 types.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -353,7 +353,8 @@ protected:
     if (dataType.isF32()) {
       vectorizationSize = 4;
     } else if (dataType.isF16() || dataType.isBF16()) {
-      vectorizationSize = 8;
+      // FIXME: figure out the best vectorization length for f16 and bf16.
+      vectorizationSize = 4;
     }
     // FIXME: set vectorizationSize be 1 for backward data and backward
     // weight for now.


### PR DESCRIPTION
Fix e2e errors in resnet50 tests.