### PR TITLE
Install rocblas in dockerfile as a MIOpen build dependency

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -84,6 +84,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   rocm-dev \
   rocminfo \
   rocprofiler-dev \
+  rocblas \
   libelf1 \
   sudo \
   vim \


### PR DESCRIPTION
This turns out to be another dependency needed for MIOpen build after #281. Tested and proved to pass CI in `test-miopen-driver` branch.