### PR TITLE
Fixing MIOpenDriver test setup

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile.miopen-test
+++ b/mlir/utils/jenkins/Jenkinsfile.miopen-test
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     stages {
-        // Workaround Durable Tasks bug, hopefully
         stage("Library build") {
             agent {
                 docker {
@@ -46,12 +45,10 @@ pipeline {
                             sh 'cd build; make -j $(nproc) MIOpenDriver'
                         }
                         stash name:"MIOpen-test-requisites",\
-                                includes: """MIOpen/src/kernels/**,\
-MIOpen/build/bin/MIOpenDriver,\
-MIOpen/build/lib/*,\
-mlir/utils/jenkins/miopen-tests/**\
-"""
-
+                            includes: """
+                            MIOpen/build/**,\
+                            mlir/utils/jenkins/miopen-tests/**\
+                            """
                     }
                 }
             }
@@ -67,7 +64,7 @@ mlir/utils/jenkins/miopen-tests/**\
                     docker {
                         image 'rocm/mlir:latest'
                         args '--user "$(id -u):$(id -g)" --device=/dev/kfd --device=/dev/dri --group-add video -u 0'
-                        label "${XDLOPS == '1' ? 'gfx908' : 'gfx908'} && multi_gpu"
+                        label 'gfx908'
                         alwaysPull true
                     }
                 }
@@ -89,7 +86,7 @@ mlir/utils/jenkins/miopen-tests/**\
                     }
                     axis {
                         name 'DIRECTION'
-                        values '1', '4'
+                        values '1', '2', '4'
                     }
                 }
                 stages {
@@ -106,15 +103,21 @@ mlir/utils/jenkins/miopen-tests/**\
                         }
                     }
                     stage("Test MIOpen config") {
+                        environment {
+                            // Make libMIOpen.so accessible to the test driver
+                            LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${WORKSPACE}/MIOpen/build/lib"
+                        }
                         steps {
                             echo "Config is ($DTYPE, $LAYOUT, xdlops=$XDLOPS, dir=$DIRECTION)"
+                            sh 'ldconfig'
                             dir('MIOpen/build/') {
                                 sh """
-bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh \
---layout $LAYOUT \
---direction $DIRECTION \
---dtype $DTYPE \
-${XDLOPS == '1' ? '--xdlops' : '--no-xdlops'} <${WORKSPACE}/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs"""
+                                bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh \
+                                --layout $LAYOUT \
+                                --direction $DIRECTION \
+                                --dtype $DTYPE \
+                                ${XDLOPS == '1' ? '--xdlops' : '--no-xdlops'} \
+                                < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs"""
                             }
                         }
                     }

--- a/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
+++ b/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
@@ -113,6 +113,7 @@ function setup_environment() {
     declare -xg MIOPEN_DEBUG_FIND_ONLY_SOLVER
     case "$DIRECTION" in
         1) MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmFwd ;;
+        2) MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmBwd ;;
         4) MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmWrW ;;
         *) echo "$0: Unsupported direction flag $DIRECTION"; exit 2
     esac


### PR DESCRIPTION
This PR fixed https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/195.

Changes:
 - Move to test on machine with label of gfx908
 - Add bwd direction
 - Add ldconfig such that the test driver is able to find the shared library

Branch is passing with the jenkins page [here](http://10.236.106.97:8080/blue/organizations/jenkins/MLIR-MIOpen-Resnet50-nightly/detail/MLIR-MIOpen-Resnet50-nightly/132/pipeline/1216). All MIOpen resnet50 configs finish to run in ~30 mins.

Once the PR is merged, I will modify the jenkins job such that it targets our `miopen-dialect branch.