### PR TITLE
Fix OOB check dimensions for filters. Get rid of associated hacks.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -4649,7 +4649,7 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
             /*populateBounds=*/true);
 
         // if the config do not do padding kernel,
-	// gemmCPad = gemm
+        // gemmCPad = gemm
         Value gemmCPad =
             padOutput(gemmMExtra, gemmNExtra, gemmKExtra, gemm, b, loc,
                       outputOobCheckDims, nameToDims, transformedShape,


### PR DESCRIPTION
This PR address issues raised in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/181

cases under:

- `mlir/tests/mlir-miopen-driver/auto_e2e/padding_kernel_gemmK.mlir`
- `mlir/tests/mlir-miopen-driver/auto_e2e/padding_kernel_gemmN.mlir`

can pass with index diff maps introduced in #226 now.

Get rid of hot fix introduced in #261 .
