### PR TITLE
Add argument validations to MIOpen driver.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -38,7 +38,6 @@ public:
 
     int kernelId;
 
-    int outputSize;
     SmallVector<int64_t, 5> filterDimension;
     SmallVector<int64_t, 5> inputDimension;
     SmallVector<int64_t, 5> outputDimension;

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -124,9 +124,13 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
         "in_channels", "in_h",         "in_w",      "out_layout",
         "out_type",    "out_channels", "out_h",     "out_w",
         "fil_layout",  "fil_type",     "fil_w",     "fil_h"};
-    return std::all_of(
+    if (!std::all_of(
         validKeys.cbegin(), validKeys.cend(),
-        [&argMap](const std::string &key) { return argMap.count(key) > 0; });
+        [&argMap](const std::string &key) { return argMap.count(key) > 0; })) {
+          return false;
+    }
+    bool noMixedTypes = argMap["in_type"] == argMap["out_type"] && argMap["fil_type"] == argMap["out_type"];
+    return noMixedTypes;
   };
 
   // Proceed only if we have a valid argMap. Otherwise leave the handle to be


### PR DESCRIPTION
Add a general validation that prevents mixed data types.
Also, ensure MIOpen does not try to generate kernels for:
- bf16
- Layouts other than NCHW or NHWC (since they haven't been tested)

Finally, clean up convolution config by removing an unesed variable.

This commit is the MLIR side of a move to move more of the applicability
checks for the MLIR solver to MLIR from MIOpen.