### PR TITLE
Introduce raw buffer load intrinsic and integrate to the lowering process.

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -957,9 +957,9 @@ def GPU_MubufLoadOp :
                              VectorOfLengthAndType<[2, 4, 8], [F16, I16]>]>:$result)> {
   let summary = "AMD GPU Buffer Load";
   let description = [{
-    The `gpu.buffer_load` op is an abstraction of AMD GPU buffer load intrinsics.
-    `vector.transfer_read` is too tightly coupled with masked load which is not
-    supported well on AMD GPU.
+    The `gpu.buffer_load` op is an abstraction of AMD GPU buffer load
+    intrinsics. `vector.transfer_read` is too tightly coupled with LLVM masked
+    load intrinsic, which is not supported well on AMD GPU.
   }];
   let parser = [{ return parseMubufLoadOp(parser, result); }];
   let printer = [{ return ::print(p, *this); }];
@@ -980,16 +980,35 @@ def GPU_MubufStoreOp :
   // we set the address upper bound to 2GB
   let summary = "AMD GPU Buffer Store";
   let description = [{
-    The `gpu.buffer_store` op is an abstraction of AMD GPU buffer store intrinsics.
-    `vector.transfer_write` is too tightly coupled with masked load which is not
-    supported well on AMD GPU.
+    The `gpu.buffer_store` op is an abstraction of AMD GPU buffer store
+    intrinsics. `vector.transfer_write` is too tightly coupled with LLVM masked
+    store intrinsic, which is not supported well on AMD GPU.
   }];
   let parser = [{ return parseMubufStoreOp(parser, result); }];
   let printer = [{ return ::print(p, *this); }];
   let verifier = [{ return ::verify(*this); }];
 }
 
-// buffer store
+// raw buffer load
+def GPU_RawMubufLoadOp :
+    GPU_Op<"raw_buffer_load">,
+    Arguments<(ins AnyMemRef:$memref,
+                   Variadic<I32>:$indices)>,
+    Results<(outs AnyTypeOf<[I16, F16, F32,
+                             VectorOfLengthAndType<[2, 4], [F32]>,
+                             VectorOfLengthAndType<[2, 4, 8], [F16, I16]>]>:$result)> {
+  let summary = "AMD GPU Raw Buffer Load";
+  let description = [{
+    The `gpu.raw_buffer_load` op is an abstraction of AMD GPU raw buffer load
+    intrinsics. `vector.transfer_read` is too tightly coupled with LLVM masked
+    load intrinsic, which is not supported well on AMD GPU.
+  }];
+  let parser = [{ return parseRawMubufLoadOp(parser, result); }];
+  let printer = [{ return ::print(p, *this); }];
+  let verifier = [{ return ::verify(*this); }];
+}
+
+// raw buffer store
 def GPU_RawbufStoreOp :
     GPU_Op<"raw_buffer_store">,
     Arguments<(ins AnyTypeOf<[I16, F16, F32,
@@ -1001,10 +1020,10 @@ def GPU_RawbufStoreOp :
   // the destination address will add the shift, if it's zero , just store
   // but if the value is 0x7fffffff, it will do oob store because
   // we set the address upper bound to 2GB
-  let summary = "AMD GPU Buffer Store";
+  let summary = "AMD GPU Raw Buffer Store";
   let description = [{
-    The `gpu.raw_buffer_store` op is an abstraction of AMD GPU Raw buffer store intrinsics.
-    `vector.transfer_write` is too tightly coupled with masked load which is not
+    The `gpu.raw_buffer_store` op is an abstraction of AMD GPU raw buffer store intrinsics.
+    `vector.transfer_write` is too tightly coupled with masked store which is not
     supported well on AMD GPU.
   }];
   let parser = [{ return parseRawbufStoreOp(parser, result); }];

--- a/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -993,10 +993,14 @@ def GPU_MubufStoreOp :
 def GPU_RawMubufLoadOp :
     GPU_Op<"raw_buffer_load">,
     Arguments<(ins AnyMemRef:$memref,
+                   I32:$shift,
                    Variadic<I32>:$indices)>,
     Results<(outs AnyTypeOf<[I16, F16, F32,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, I16]>]>:$result)> {
+  // The destination address will add the shift operand, if it's zero, just
+  // load normally. But if the value is 0x7fffffff, it will do OOB load because
+  // we set the address upper bound to 2GB.
   let summary = "AMD GPU Raw Buffer Load";
   let description = [{
     The `gpu.raw_buffer_load` op is an abstraction of AMD GPU raw buffer load
@@ -1017,9 +1021,9 @@ def GPU_RawbufStoreOp :
                    AnyMemRef:$memref,
                    I32:$shift,
                    Variadic<I32>:$indices)> {
-  // the destination address will add the shift, if it's zero , just store
-  // but if the value is 0x7fffffff, it will do oob store because
-  // we set the address upper bound to 2GB
+  // The destination address will add the shift operand, if it's zero, just
+  // store normally. But if the value is 0x7fffffff, it will do OOB store
+  // because we set the address upper bound to 2GB.
   let summary = "AMD GPU Raw Buffer Store";
   let description = [{
     The `gpu.raw_buffer_store` op is an abstraction of AMD GPU raw buffer store intrinsics.

--- a/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -990,7 +990,7 @@ def GPU_MubufStoreOp :
 }
 
 // raw buffer load
-def GPU_RawMubufLoadOp :
+def GPU_RawbufLoadOp :
     GPU_Op<"raw_buffer_load">,
     Arguments<(ins AnyMemRef:$memref,
                    I32:$shift,
@@ -1007,7 +1007,7 @@ def GPU_RawMubufLoadOp :
     intrinsics. `vector.transfer_read` is too tightly coupled with LLVM masked
     load intrinsic, which is not supported well on AMD GPU.
   }];
-  let parser = [{ return parseRawMubufLoadOp(parser, result); }];
+  let parser = [{ return parseRawbufLoadOp(parser, result); }];
   let printer = [{ return ::print(p, *this); }];
   let verifier = [{ return ::verify(*this); }];
 }

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -445,7 +445,7 @@ struct MubufStoreOpLowering : ConvertToLLVMPattern {
 
 struct RawbufLoadOpLowering : ConvertToLLVMPattern {
   explicit RawbufLoadOpLowering(MLIRContext *context,
-                               LLVMTypeConverter &typeConverter)
+                                LLVMTypeConverter &typeConverter)
       : ConvertToLLVMPattern(gpu::RawbufLoadOp::getOperationName(), context,
                              typeConverter) {}
 
@@ -565,7 +565,8 @@ struct RawbufLoadOpLowering : ConvertToLLVMPattern {
             typeConverter->convertType(interimResultType);
 
         Value interimLoad = rewriter.create<ROCDL::RawbufLoadOp>(
-            loc, interimLLVMResultType, rsrc, voffset_shift, vindex, zeroglcslc);
+            loc, interimLLVMResultType, rsrc, voffset_shift, vindex,
+            zeroglcslc);
 
         rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, LLVMResultType,
                                                      interimLoad);
@@ -1103,7 +1104,7 @@ void mlir::populateGpuToROCDLConversionPatterns(
   patterns.insert<MubufStoreOpLowering>(converter.getDialect()->getContext(),
                                         converter);
   patterns.insert<RawbufLoadOpLowering>(converter.getDialect()->getContext(),
-                                         converter);
+                                        converter);
   patterns.insert<RawbufStoreOpLowering>(converter.getDialect()->getContext(),
                                          converter);
   patterns.insert<AtomicFAddOpLowering>(converter.getDialect()->getContext(),

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1003,6 +1003,38 @@ static void print(OpAsmPrinter &p, gpu::MubufStoreOp op) {
 static LogicalResult verify(gpu::MubufStoreOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
+// RawMubufLoadOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseRawMubufLoadOp(OpAsmParser &parser,
+                                    OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 5> ops;
+  SmallVector<Type, 5> types;
+
+  auto ret = parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+             parser.parseOptionalAttrDict(result.attributes) ||
+             parser.parseColonTypeList(types) ||
+             parser.resolveOperand(ops[0], types[0], result.operands) ||
+             parser.addTypeToList(types[1], result.types);
+
+  // resolve source coorindates.
+  for (unsigned i = 1; i < ops.size(); ++i) {
+    ret &= succeeded(parser.resolveOperand(
+        ops[i], parser.getBuilder().getIntegerType(32), result.operands));
+  }
+
+  return failure(ret);
+}
+
+static void print(OpAsmPrinter &p, gpu::RawMubufLoadOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.memref().getType() << ", " << op.getResult().getType();
+}
+
+static LogicalResult verify(gpu::RawMubufLoadOp op) { return success(); }
+
+//===----------------------------------------------------------------------===//
 // RawbufStoreOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1006,10 +1006,10 @@ static void print(OpAsmPrinter &p, gpu::MubufStoreOp op) {
 static LogicalResult verify(gpu::MubufStoreOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
-// RawMubufLoadOp
+// RawbufLoadOp
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseRawMubufLoadOp(OpAsmParser &parser,
+static ParseResult parseRawbufLoadOp(OpAsmParser &parser,
                                        OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 5> ops;
   SmallVector<Type, 5> types;
@@ -1033,13 +1033,13 @@ static ParseResult parseRawMubufLoadOp(OpAsmParser &parser,
   return failure(ret);
 }
 
-static void print(OpAsmPrinter &p, gpu::RawMubufLoadOp op) {
+static void print(OpAsmPrinter &p, gpu::RawbufLoadOp op) {
   p << op.getOperationName() << "(" << op.getOperands() << ")";
   p.printOptionalAttrDict(op.getAttrs());
   p << " : " << op.memref().getType() << ", " << op.getResult().getType();
 }
 
-static LogicalResult verify(gpu::RawMubufLoadOp op) { return success(); }
+static LogicalResult verify(gpu::RawbufLoadOp op) { return success(); }
 
 //===----------------------------------------------------------------------===//
 // RawbufStoreOp

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1010,7 +1010,7 @@ static LogicalResult verify(gpu::MubufStoreOp op) { return success(); }
 //===----------------------------------------------------------------------===//
 
 static ParseResult parseRawbufLoadOp(OpAsmParser &parser,
-                                       OperationState &result) {
+                                     OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 5> ops;
   SmallVector<Type, 5> types;
 

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1051,8 +1051,11 @@ static ParseResult parseRawbufStoreOp(OpAsmParser &parser,
              parser.parseOptionalAttrDict(result.attributes) ||
              parser.parseColonTypeList(types) ||
              parser.resolveOperand(ops[0], types[0], result.operands) ||
-             parser.resolveOperand(ops[1], types[1], result.operands) ||
-             parser.resolveOperand(ops[2], types[2], result.operands);
+             parser.resolveOperand(ops[1], types[1], result.operands);
+
+  // resolve shift operand.
+  ret &= succeeded(parser.resolveOperand(
+      ops[2], parser.getBuilder().getIntegerType(32), result.operands));
 
   // resolve source coorindates.
   for (unsigned i = 3; i < ops.size(); ++i) {

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1007,7 +1007,7 @@ static LogicalResult verify(gpu::MubufStoreOp op) { return success(); }
 //===----------------------------------------------------------------------===//
 
 static ParseResult parseRawMubufLoadOp(OpAsmParser &parser,
-                                    OperationState &result) {
+                                       OperationState &result) {
   SmallVector<OpAsmParser::OperandType, 5> ops;
   SmallVector<Type, 5> types;
 
@@ -1018,7 +1018,8 @@ static ParseResult parseRawMubufLoadOp(OpAsmParser &parser,
              parser.addTypeToList(types[1], result.types);
 
   // resolve shift operand.
-  ret &= succeeded(parser.resolveOperand(ops[1], parser.getBuilder().getIntegerType(32), result.operands));
+  ret &= succeeded(parser.resolveOperand(
+      ops[1], parser.getBuilder().getIntegerType(32), result.operands));
 
   // resolve source coorindates.
   for (unsigned i = 2; i < ops.size(); ++i) {

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1017,8 +1017,11 @@ static ParseResult parseRawMubufLoadOp(OpAsmParser &parser,
              parser.resolveOperand(ops[0], types[0], result.operands) ||
              parser.addTypeToList(types[1], result.types);
 
+  // resolve shift operand.
+  ret &= succeeded(parser.resolveOperand(ops[1], parser.getBuilder().getIntegerType(32), result.operands));
+
   // resolve source coorindates.
-  for (unsigned i = 1; i < ops.size(); ++i) {
+  for (unsigned i = 2; i < ops.size(); ++i) {
     ret &= succeeded(parser.resolveOperand(
         ops[i], parser.getBuilder().getIntegerType(32), result.operands));
   }

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -981,8 +981,11 @@ static ParseResult parseMubufStoreOp(OpAsmParser &parser,
              parser.parseOptionalAttrDict(result.attributes) ||
              parser.parseColonTypeList(types) ||
              parser.resolveOperand(ops[0], types[0], result.operands) ||
-             parser.resolveOperand(ops[1], types[1], result.operands) ||
-             parser.resolveOperand(ops[2], types[2], result.operands);
+             parser.resolveOperand(ops[1], types[1], result.operands);
+
+  // resolve shift operand.
+  ret &= succeeded(parser.resolveOperand(
+      ops[2], parser.getBuilder().getIntegerType(32), result.operands));
 
   // resolve source coorindates.
   for (unsigned i = 3; i < ops.size(); ++i) {

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -124,12 +124,14 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
         "in_channels", "in_h",         "in_w",      "out_layout",
         "out_type",    "out_channels", "out_h",     "out_w",
         "fil_layout",  "fil_type",     "fil_w",     "fil_h"};
-    if (!std::all_of(
-        validKeys.cbegin(), validKeys.cend(),
-        [&argMap](const std::string &key) { return argMap.count(key) > 0; })) {
-          return false;
+    if (!std::all_of(validKeys.cbegin(), validKeys.cend(),
+                     [&argMap](const std::string &key) {
+                       return argMap.count(key) > 0;
+                     })) {
+      return false;
     }
-    bool noMixedTypes = argMap["in_type"] == argMap["out_type"] && argMap["fil_type"] == argMap["out_type"];
+    bool noMixedTypes = argMap["in_type"] == argMap["out_type"] &&
+                        argMap["fil_type"] == argMap["out_type"];
     return noMixedTypes;
   };
 

--- a/mlir/test/Conversion/GPUToROCDL/mubuf_store.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/mubuf_store.mlir
@@ -6,42 +6,42 @@ gpu.module @mubuf_store {
   // CHECK-LABEL: func @buffer_store_f32_to_rank_1
   func @buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_f32_to_rank_4
   func @buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_2xf32_to_rank_1
   func @buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_2xf32_to_rank_4
   func @buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_4xf32_to_rank_1
   func @buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_4xf32_to_rank_4
   func @buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
     return
   }
 
@@ -50,14 +50,14 @@ gpu.module @mubuf_store {
   // CHECK-LABEL: func @buffer_store_f16_to_rank_1
   func @buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_f16_to_rank_4
   func @buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>
     return
   }
 
@@ -65,7 +65,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xf16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>
     return
   }
 
@@ -73,7 +73,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xf16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>
     return
   }
 
@@ -81,7 +81,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xf16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>
     return
   }
 
@@ -89,7 +89,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xf16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>
     return
   }
 
@@ -97,7 +97,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xf16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>
     return
   }
 
@@ -105,7 +105,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xf16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>
     return
   }
 
@@ -114,14 +114,14 @@ gpu.module @mubuf_store {
   // CHECK-LABEL: func @buffer_store_i16_to_rank_1
   func @buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<i16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_i16_to_rank_4
   func @buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<i16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>
     return
   }
 
@@ -129,7 +129,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xi16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>
     return
   }
 
@@ -137,7 +137,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xi16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>
     return
   }
 
@@ -145,7 +145,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xi16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>
     return
   }
 
@@ -153,7 +153,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xi16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>
     return
   }
 
@@ -161,7 +161,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xi16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>
     return
   }
 
@@ -169,7 +169,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xi16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>
     return
   }
 }

--- a/mlir/test/Conversion/GPUToROCDL/rawbuf_load.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/rawbuf_load.mlir
@@ -1,0 +1,175 @@
+// RUN: mlir-opt %s -convert-gpu-to-rocdl='index-bitwidth=32' | FileCheck %s
+
+gpu.module @mubuf_load {
+  // f32 tests.
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_f32
+  func @raw_buffer_load_from_rank_1_to_f32(%src : memref<128xf32>, %shift : i32, %offset0 : i32) -> f32 {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf32>, f32
+    return %result : f32
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_f32
+  func @raw_buffer_load_from_rank_4_to_f32(%src : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f32 {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, f32
+    return %result : f32
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_2xf32
+  func @raw_buffer_load_from_rank_1_to_2xf32(%src : memref<128xf32>, %shift : i32, %offset0 : i32) -> vector<2xf32> {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf32>, vector<2xf32>
+    return %result : vector<2xf32>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_2xf32
+  func @raw_buffer_load_from_rank_4_to_2xf32(%src : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf32> {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<2xf32>
+    return %result : vector<2xf32>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_4xf32
+  func @raw_buffer_load_from_rank_4_to_4xf32(%src : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf32> {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<4xf32>
+    return %result : vector<4xf32>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_4xf32
+  func @raw_buffer_load_from_rank_1_to_4xf32(%src : memref<128xf32>, %shift : i32, %offset0 : i32) -> vector<4xf32> {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf32>, vector<4xf32>
+    return %result : vector<4xf32>
+  }
+
+  // f16 tests.
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_f16
+  func @raw_buffer_load_from_rank_1_to_f16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> f16 {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f16
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf16>, f16
+    return %result : f16
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_f16
+  func @raw_buffer_load_from_rank_4_to_f16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f16 {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f16
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, f16
+    return %result : f16
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_2xf16
+  func @raw_buffer_load_from_rank_1_to_2xf16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> vector<2xf16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : f32 to vector<2xf16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf16>, vector<2xf16>
+    return %result : vector<2xf16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_2xf16
+  func @raw_buffer_load_from_rank_4_to_2xf16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : f32 to vector<2xf16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<2xf16>
+    return %result : vector<2xf16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_4xf16
+  func @raw_buffer_load_from_rank_1_to_4xf16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> vector<4xf16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<2xf32> to vector<4xf16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf16>, vector<4xf16>
+    return %result : vector<4xf16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_4xf16
+  func @raw_buffer_load_from_rank_4_to_4xf16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<2xf32> to vector<4xf16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<4xf16>
+    return %result : vector<4xf16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_8xf16
+  func @raw_buffer_load_from_rank_1_to_8xf16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> vector<8xf16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<4xf32> to vector<8xf16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf16>, vector<8xf16>
+    return %result : vector<8xf16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_8xf16
+  func @raw_buffer_load_from_rank_4_to_8xf16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<8xf16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<4xf32> to vector<8xf16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<8xf16>
+    return %result : vector<8xf16>
+  }
+
+  // i16 (bf16) tests.
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_i16
+  func @raw_buffer_load_from_rank_1_to_i16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> i16 {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i16
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, i16
+    return %result : i16
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_i16
+  func @raw_buffer_load_from_rank_4_to_i16(%src : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> i16 {
+    // CHECK: rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i16
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, i16
+    return %result : i16
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_2xi16
+  func @raw_buffer_load_from_rank_1_to_2xi16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> vector<2xi16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : f32 to vector<2xi16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, vector<2xi16>
+    return %result : vector<2xi16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_2xi16
+  func @raw_buffer_load_from_rank_4_to_2xi16(%src : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xi16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : f32 to vector<2xi16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<2xi16>
+    return %result : vector<2xi16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_4xi16
+  func @raw_buffer_load_from_rank_1_to_4xi16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> vector<4xi16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<2xf32> to vector<4xi16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, vector<4xi16>
+    return %result : vector<4xi16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_4xi16
+  func @raw_buffer_load_from_rank_4_to_4xi16(%src : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xi16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<2xf32> to vector<4xi16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<4xi16>
+    return %result : vector<4xi16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_1_to_8xi16
+  func @raw_buffer_load_from_rank_1_to_8xi16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> vector<8xi16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<4xf32> to vector<8xi16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, vector<8xi16>
+    return %result : vector<8xi16>
+  }
+
+  // CHECK-LABEL: func @raw_buffer_load_from_rank_4_to_8xi16
+  func @raw_buffer_load_from_rank_4_to_8xi16(%src : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<8xi16> {
+    // CHECK: [[LOAD:%[a-zA-Z_0-9]+]] = rocdl.raw.buffer.load %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    // CHECK-NEXT: llvm.bitcast [[LOAD]] : vector<4xf32> to vector<8xi16>
+    %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<8xi16>
+    return %result : vector<8xi16>
+  }
+}

--- a/mlir/test/Conversion/GPUToROCDL/rawbuf_store.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/rawbuf_store.mlir
@@ -1,175 +1,175 @@
 // RUN: mlir-opt %s -convert-gpu-to-rocdl='index-bitwidth=32' | FileCheck %s
 
-gpu.module @mubuf_store {
+gpu.module @rawbuf_store {
   // f32 tests.
 
-  // CHECK-LABEL: func @buffer_store_f32_to_rank_1
-  func @buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-    // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>
+  // CHECK-LABEL: func @raw_buffer_store_f32_to_rank_1
+  func @raw_buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_f32_to_rank_4
-  func @buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
+  // CHECK-LABEL: func @raw_buffer_store_f32_to_rank_4
+  func @raw_buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_2xf32_to_rank_1
-  func @buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-    // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>
+  // CHECK-LABEL: func @raw_buffer_store_2xf32_to_rank_1
+  func @raw_buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_2xf32_to_rank_4
-  func @buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
+  // CHECK-LABEL: func @raw_buffer_store_2xf32_to_rank_4
+  func @raw_buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_4xf32_to_rank_1
-  func @buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-    // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>
+  // CHECK-LABEL: func @raw_buffer_store_4xf32_to_rank_1
+  func @raw_buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_4xf32_to_rank_4
-  func @buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
+  // CHECK-LABEL: func @raw_buffer_store_4xf32_to_rank_4
+  func @raw_buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
     return
   }
 
   // f16 tests.
 
-  // CHECK-LABEL: func @buffer_store_f16_to_rank_1
-  func @buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-    // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>
+  // CHECK-LABEL: func @raw_buffer_store_f16_to_rank_1
+  func @raw_buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f16
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_f16_to_rank_4
-  func @buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>
+  // CHECK-LABEL: func @raw_buffer_store_f16_to_rank_4
+  func @raw_buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f16
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_2xf16_to_rank_1
-  func @buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_2xf16_to_rank_1
+  func @raw_buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xf16> to f32
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_2xf16_to_rank_4
-  func @buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_2xf16_to_rank_4
+  func @raw_buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xf16> to f32
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_4xf16_to_rank_1
-  func @buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_4xf16_to_rank_1
+  func @raw_buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xf16> to vector<2xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_4xf16_to_rank_4
-  func @buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_4xf16_to_rank_4
+  func @raw_buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xf16> to vector<2xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_8xf16_to_rank_1
-  func @buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_8xf16_to_rank_1
+  func @raw_buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xf16> to vector<4xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_8xf16_to_rank_4
-  func @buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_8xf16_to_rank_4
+  func @raw_buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xf16> to vector<4xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>
     return
   }
 
   // i16 (bf16) tests.
 
-  // CHECK-LABEL: func @buffer_store_i16_to_rank_1
-  func @buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-    // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<i16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>
+  // CHECK-LABEL: func @raw_buffer_store_i16_to_rank_1
+  func @raw_buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i16
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_i16_to_rank_4
-  func @buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-    // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<i16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>
+  // CHECK-LABEL: func @raw_buffer_store_i16_to_rank_4
+  func @raw_buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i16
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_2xi16_to_rank_1
-  func @buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_2xi16_to_rank_1
+  func @raw_buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xi16> to f32
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_2xi16_to_rank_4
-  func @buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_2xi16_to_rank_4
+  func @raw_buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xi16> to f32
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_4xi16_to_rank_1
-  func @buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_4xi16_to_rank_1
+  func @raw_buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xi16> to vector<2xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_4xi16_to_rank_4
-  func @buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_4xi16_to_rank_4
+  func @raw_buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xi16> to vector<2xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_8xi16_to_rank_1
-  func @buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_8xi16_to_rank_1
+  func @raw_buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xi16> to vector<4xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>
     return
   }
 
-  // CHECK-LABEL: func @buffer_store_8xi16_to_rank_4
-  func @buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+  // CHECK-LABEL: func @raw_buffer_store_8xi16_to_rank_4
+  func @raw_buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xi16> to vector<4xf32>
-    // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>
+    // CHECK-NEXT: rocdl.raw.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
+    gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>
     return
   }
 }

--- a/mlir/test/Conversion/GPUToROCDL/rawbuf_store.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/rawbuf_store.mlir
@@ -6,42 +6,42 @@ gpu.module @mubuf_store {
   // CHECK-LABEL: func @buffer_store_f32_to_rank_1
   func @buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_f32_to_rank_4
   func @buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_2xf32_to_rank_1
   func @buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_2xf32_to_rank_4
   func @buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_4xf32_to_rank_1
   func @buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_4xf32_to_rank_4
   func @buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: rocdl.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
     return
   }
 
@@ -50,14 +50,14 @@ gpu.module @mubuf_store {
   // CHECK-LABEL: func @buffer_store_f16_to_rank_1
   func @buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_f16_to_rank_4
   func @buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>
     return
   }
 
@@ -65,7 +65,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xf16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>
     return
   }
 
@@ -73,7 +73,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xf16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>
     return
   }
 
@@ -81,7 +81,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xf16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>
     return
   }
 
@@ -89,7 +89,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xf16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>
     return
   }
 
@@ -97,7 +97,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xf16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>
     return
   }
 
@@ -105,7 +105,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xf16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>
     return
   }
 
@@ -114,14 +114,14 @@ gpu.module @mubuf_store {
   // CHECK-LABEL: func @buffer_store_i16_to_rank_1
   func @buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<i16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>
     return
   }
 
   // CHECK-LABEL: func @buffer_store_i16_to_rank_4
   func @buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<i16>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>
     return
   }
 
@@ -129,7 +129,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xi16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>
     return
   }
 
@@ -137,7 +137,7 @@ gpu.module @mubuf_store {
   func @buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<2xi16> to f32
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f32
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>
     return
   }
 
@@ -145,7 +145,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xi16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>
     return
   }
 
@@ -153,7 +153,7 @@ gpu.module @mubuf_store {
   func @buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<4xi16> to vector<2xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>
     return
   }
 
@@ -161,7 +161,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xi16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>
     return
   }
 
@@ -169,7 +169,7 @@ gpu.module @mubuf_store {
   func @buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
     // CHECK: [[BITCAST:%[a-zA-Z_0-9]+]] = llvm.bitcast %{{.*}} : vector<8xi16> to vector<4xf32>
     // CHECK-NEXT: rocdl.buffer.store [[BITCAST]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xf32>
-    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>, i32
+    gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>
     return
   }
 }

--- a/mlir/test/Dialect/GPU/ops.mlir
+++ b/mlir/test/Dialect/GPU/ops.mlir
@@ -707,42 +707,42 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL: gpu.func @raw_buffer_store_f32_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128xf32>
     gpu.func @raw_buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_f32_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128x64x32x16xf32>
     gpu.func @raw_buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_2xf32_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128xf32>
     gpu.func @raw_buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_2xf32_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128x64x32x16xf32>
     gpu.func @raw_buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_4xf32_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128xf32>
     gpu.func @raw_buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_4xf32_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128x64x32x16xf32>
     gpu.func @raw_buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
       gpu.return
     }
 
@@ -751,56 +751,56 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL: gpu.func @raw_buffer_store_f16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : f16, memref<128xf16>
     gpu.func @raw_buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_f16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f16, memref<128x64x32x16xf16>
     gpu.func @raw_buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_2xf16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf16>, memref<128xf16>
     gpu.func @raw_buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_2xf16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf16>, memref<128x64x32x16xf16>
     gpu.func @raw_buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_4xf16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf16>, memref<128xf16>
     gpu.func @raw_buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_4xf16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf16>, memref<128x64x32x16xf16>
     gpu.func @raw_buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_8xf16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xf16>, memref<128xf16>
     gpu.func @raw_buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_8xf16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<8xf16>, memref<128x64x32x16xf16>
     gpu.func @raw_buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>
       gpu.return
     }
 
@@ -809,56 +809,56 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL: gpu.func @raw_buffer_store_i16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : i16, memref<128xi16>
     gpu.func @raw_buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_i16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : i16, memref<128x64x32x16xi16>
     gpu.func @raw_buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_2xi16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi16>, memref<128xi16>
     gpu.func @raw_buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_2xi16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi16>, memref<128x64x32x16xi16>
     gpu.func @raw_buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_4xi16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi16>, memref<128xi16>
     gpu.func @raw_buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_4xi16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi16>, memref<128x64x32x16xi16>
     gpu.func @raw_buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_8xi16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xi16>, memref<128xi16>
     gpu.func @raw_buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @raw_buffer_store_8xi16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<8xi16>, memref<128x64x32x16xi16>
     gpu.func @raw_buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>, i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>
       gpu.return
     }
   }

--- a/mlir/test/Dialect/GPU/ops.mlir
+++ b/mlir/test/Dialect/GPU/ops.mlir
@@ -390,42 +390,42 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL: gpu.func @buffer_store_f32_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128xf32>
     gpu.func @buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_f32_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128x64x32x16xf32>
     gpu.func @buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_2xf32_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128xf32>
     gpu.func @buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_2xf32_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128x64x32x16xf32>
     gpu.func @buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_4xf32_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128xf32>
     gpu.func @buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_4xf32_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128x64x32x16xf32>
     gpu.func @buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>
       gpu.return
     }
 
@@ -434,56 +434,56 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL: gpu.func @buffer_store_f16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : f16, memref<128xf16>
     gpu.func @buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_f16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f16, memref<128x64x32x16xf16>
     gpu.func @buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_2xf16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf16>, memref<128xf16>
     gpu.func @buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_2xf16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf16>, memref<128x64x32x16xf16>
     gpu.func @buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_4xf16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf16>, memref<128xf16>
     gpu.func @buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_4xf16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf16>, memref<128x64x32x16xf16>
     gpu.func @buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_8xf16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xf16>, memref<128xf16>
     gpu.func @buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_8xf16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<8xf16>, memref<128x64x32x16xf16>
     gpu.func @buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>
       gpu.return
     }
 
@@ -492,56 +492,56 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL: gpu.func @buffer_store_i16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : i16, memref<128xi16>
     gpu.func @buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_i16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : i16, memref<128x64x32x16xi16>
     gpu.func @buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_2xi16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi16>, memref<128xi16>
     gpu.func @buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_2xi16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi16>, memref<128x64x32x16xi16>
     gpu.func @buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_4xi16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi16>, memref<128xi16>
     gpu.func @buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_4xi16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi16>, memref<128x64x32x16xi16>
     gpu.func @buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_8xi16_to_rank_1
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xi16>, memref<128xi16>
     gpu.func @buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>
       gpu.return
     }
 
     // CHECK-LABEL: gpu.func @buffer_store_8xi16_to_rank_4
     //   CHECK: gpu.buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<8xi16>, memref<128x64x32x16xi16>
     gpu.func @buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
-      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>, i32
+      gpu.buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>
       gpu.return
     }
   }

--- a/mlir/test/Dialect/GPU/ops.mlir
+++ b/mlir/test/Dialect/GPU/ops.mlir
@@ -546,6 +546,161 @@ module attributes {gpu.container_module} {
     }
   }
 
+  gpu.module @rawbuf_load {
+    // f32 tests.
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_f32
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf32>, f32
+    gpu.func @buffer_load_from_rank_1_to_f32(%src : memref<128xf32>, %offset0 : i32) -> f32 {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf32>, f32
+      gpu.return %result : f32
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_f32
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf32>, f32
+    gpu.func @buffer_load_from_rank_4_to_f32(%src : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f32 {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, f32
+      gpu.return %result : f32
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_2xf32
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf32>, vector<2xf32>
+    gpu.func @buffer_load_from_rank_1_to_2xf32(%src : memref<128xf32>, %offset0 : i32) -> vector<2xf32> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf32>, vector<2xf32>
+      gpu.return %result : vector<2xf32>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_2xf32
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf32>, vector<2xf32>
+    gpu.func @buffer_load_from_rank_4_to_2xf32(%src : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf32> {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<2xf32>
+      gpu.return %result : vector<2xf32>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_4xf32
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf32>, vector<4xf32>
+    gpu.func @buffer_load_from_rank_1_to_4xf32(%src : memref<128xf32>, %offset0 : i32) -> vector<4xf32> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf32>, vector<4xf32>
+      gpu.return %result : vector<4xf32>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_4xf32
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf32>, vector<4xf32>
+    gpu.func @buffer_load_from_rank_4_to_4xf32(%src : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf32> {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<4xf32>
+      gpu.return %result : vector<4xf32>
+    }
+
+    // f16 tests.
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_f16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, f16
+    gpu.func @buffer_load_from_rank_1_to_f16(%src : memref<128xf16>, %offset0 : i32) -> f16 {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, f16
+      gpu.return %result : f16
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_f16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, f16
+    gpu.func @buffer_load_from_rank_4_to_f16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f16 {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, f16
+      gpu.return %result : f16
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_2xf16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, vector<2xf16>
+    gpu.func @buffer_load_from_rank_1_to_2xf16(%src : memref<128xf16>, %offset0 : i32) -> vector<2xf16> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, vector<2xf16>
+      gpu.return %result : vector<2xf16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_2xf16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, vector<2xf16>
+    gpu.func @buffer_load_from_rank_4_to_2xf16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf16> {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<2xf16>
+      gpu.return %result : vector<2xf16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_4xf16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, vector<4xf16>
+    gpu.func @buffer_load_from_rank_1_to_4xf16(%src : memref<128xf16>, %offset0 : i32) -> vector<4xf16> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, vector<4xf16>
+      gpu.return %result : vector<4xf16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_4xf16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, vector<4xf16>
+    gpu.func @buffer_load_from_rank_4_to_4xf16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf16> {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<4xf16>
+      gpu.return %result : vector<4xf16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_8xf16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, vector<8xf16>
+    gpu.func @buffer_load_from_rank_1_to_8xf16(%src : memref<128xf16>, %offset0 : i32) -> vector<8xf16> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, vector<8xf16>
+      gpu.return %result : vector<8xf16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_8xf16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, vector<8xf16>
+    gpu.func @buffer_load_from_rank_4_to_8xf16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<8xf16> {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<8xf16>
+      gpu.return %result : vector<8xf16>
+    }
+
+    // i16 tests.
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_i16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, i16
+    gpu.func @buffer_load_from_rank_1_to_i16(%src : memref<128xi16>, %offset0 : i32) -> i16 {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, i16
+      gpu.return %result : i16
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_i16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xi16>, i16
+    gpu.func @buffer_load_from_rank_4_to_i16(%src : memref<128x64x32x16xi16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> i16 {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, i16
+      gpu.return %result : i16
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_2xi16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, vector<2xi16>
+    gpu.func @buffer_load_from_rank_1_to_2xi16(%src : memref<128xi16>, %offset0 : i32) -> vector<2xi16> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, vector<2xi16>
+      gpu.return %result : vector<2xi16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_2xi16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xi16>, vector<2xi16>
+    gpu.func @buffer_load_from_rank_4_to_2xi16(%src : memref<128x64x32x16xi16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xi16> {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<2xi16>
+      gpu.return %result : vector<2xi16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_4xi16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, vector<4xi16>
+    gpu.func @buffer_load_from_rank_1_to_4xi16(%src : memref<128xi16>, %offset0 : i32) -> vector<4xi16> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, vector<4xi16>
+      gpu.return %result : vector<4xi16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_4xi16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xi16>, vector<4xi16>
+    gpu.func @buffer_load_from_rank_4_to_4xi16(%src : memref<128x64x32x16xi16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xi16> {
+      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<4xi16>
+      gpu.return %result : vector<4xi16>
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_8xi16
+    //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, vector<8xi16>
+    gpu.func @buffer_load_from_rank_1_to_8xi16(%src : memref<128xi16>, %offset0 : i32) -> vector<8xi16> {
+      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, vector<8xi16>
+      gpu.return %result : vector<8xi16>
+    }
+  }
+
   gpu.module @rawbuf_store {
     // f32 tests.
 

--- a/mlir/test/Dialect/GPU/ops.mlir
+++ b/mlir/test/Dialect/GPU/ops.mlir
@@ -549,154 +549,154 @@ module attributes {gpu.container_module} {
   gpu.module @rawbuf_load {
     // f32 tests.
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_f32
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_f32
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf32>, f32
-    gpu.func @buffer_load_from_rank_1_to_f32(%src : memref<128xf32>, %offset0 : i32) -> f32 {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf32>, f32
+    gpu.func @raw_buffer_load_from_rank_1_to_f32(%src : memref<128xf32>, %shift : i32, %offset0 : i32) -> f32 {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf32>, f32
       gpu.return %result : f32
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_f32
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_f32
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf32>, f32
-    gpu.func @buffer_load_from_rank_4_to_f32(%src : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f32 {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, f32
+    gpu.func @raw_buffer_load_from_rank_4_to_f32(%src : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f32 {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, f32
       gpu.return %result : f32
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_2xf32
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_2xf32
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf32>, vector<2xf32>
-    gpu.func @buffer_load_from_rank_1_to_2xf32(%src : memref<128xf32>, %offset0 : i32) -> vector<2xf32> {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf32>, vector<2xf32>
+    gpu.func @raw_buffer_load_from_rank_1_to_2xf32(%src : memref<128xf32>, %shift : i32, %offset0 : i32) -> vector<2xf32> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf32>, vector<2xf32>
       gpu.return %result : vector<2xf32>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_2xf32
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_2xf32
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf32>, vector<2xf32>
-    gpu.func @buffer_load_from_rank_4_to_2xf32(%src : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf32> {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<2xf32>
+    gpu.func @raw_buffer_load_from_rank_4_to_2xf32(%src : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf32> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<2xf32>
       gpu.return %result : vector<2xf32>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_4xf32
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_4xf32
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf32>, vector<4xf32>
-    gpu.func @buffer_load_from_rank_1_to_4xf32(%src : memref<128xf32>, %offset0 : i32) -> vector<4xf32> {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf32>, vector<4xf32>
+    gpu.func @raw_buffer_load_from_rank_1_to_4xf32(%src : memref<128xf32>, %shift : i32, %offset0 : i32) -> vector<4xf32> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf32>, vector<4xf32>
       gpu.return %result : vector<4xf32>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_4xf32
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_4xf32
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf32>, vector<4xf32>
-    gpu.func @buffer_load_from_rank_4_to_4xf32(%src : memref<128x64x32x16xf32>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf32> {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<4xf32>
+    gpu.func @raw_buffer_load_from_rank_4_to_4xf32(%src : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf32> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf32>, vector<4xf32>
       gpu.return %result : vector<4xf32>
     }
 
     // f16 tests.
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_f16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_f16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, f16
-    gpu.func @buffer_load_from_rank_1_to_f16(%src : memref<128xf16>, %offset0 : i32) -> f16 {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, f16
+    gpu.func @raw_buffer_load_from_rank_1_to_f16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> f16 {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf16>, f16
       gpu.return %result : f16
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_f16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_f16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, f16
-    gpu.func @buffer_load_from_rank_4_to_f16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f16 {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, f16
+    gpu.func @raw_buffer_load_from_rank_4_to_f16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> f16 {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, f16
       gpu.return %result : f16
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_2xf16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_2xf16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, vector<2xf16>
-    gpu.func @buffer_load_from_rank_1_to_2xf16(%src : memref<128xf16>, %offset0 : i32) -> vector<2xf16> {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, vector<2xf16>
+    gpu.func @raw_buffer_load_from_rank_1_to_2xf16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> vector<2xf16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf16>, vector<2xf16>
       gpu.return %result : vector<2xf16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_2xf16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_2xf16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, vector<2xf16>
-    gpu.func @buffer_load_from_rank_4_to_2xf16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf16> {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<2xf16>
+    gpu.func @raw_buffer_load_from_rank_4_to_2xf16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xf16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<2xf16>
       gpu.return %result : vector<2xf16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_4xf16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_4xf16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, vector<4xf16>
-    gpu.func @buffer_load_from_rank_1_to_4xf16(%src : memref<128xf16>, %offset0 : i32) -> vector<4xf16> {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, vector<4xf16>
+    gpu.func @raw_buffer_load_from_rank_1_to_4xf16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> vector<4xf16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xf16>, vector<4xf16>
       gpu.return %result : vector<4xf16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_4xf16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_4xf16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, vector<4xf16>
-    gpu.func @buffer_load_from_rank_4_to_4xf16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf16> {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<4xf16>
+    gpu.func @raw_buffer_load_from_rank_4_to_4xf16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xf16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<4xf16>
       gpu.return %result : vector<4xf16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_8xf16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_8xf16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xf16>, vector<8xf16>
-    gpu.func @buffer_load_from_rank_1_to_8xf16(%src : memref<128xf16>, %offset0 : i32) -> vector<8xf16> {
+    gpu.func @raw_buffer_load_from_rank_1_to_8xf16(%src : memref<128xf16>, %shift : i32, %offset0 : i32) -> vector<8xf16> {
       %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xf16>, vector<8xf16>
       gpu.return %result : vector<8xf16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_8xf16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_8xf16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xf16>, vector<8xf16>
-    gpu.func @buffer_load_from_rank_4_to_8xf16(%src : memref<128x64x32x16xf16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<8xf16> {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<8xf16>
+    gpu.func @raw_buffer_load_from_rank_4_to_8xf16(%src : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<8xf16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xf16>, vector<8xf16>
       gpu.return %result : vector<8xf16>
     }
 
     // i16 tests.
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_i16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_i16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, i16
-    gpu.func @buffer_load_from_rank_1_to_i16(%src : memref<128xi16>, %offset0 : i32) -> i16 {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, i16
+    gpu.func @raw_buffer_load_from_rank_1_to_i16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> i16 {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, i16
       gpu.return %result : i16
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_i16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_i16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xi16>, i16
-    gpu.func @buffer_load_from_rank_4_to_i16(%src : memref<128x64x32x16xi16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> i16 {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, i16
+    gpu.func @raw_buffer_load_from_rank_4_to_i16(%src : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> i16 {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, i16
       gpu.return %result : i16
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_2xi16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_2xi16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, vector<2xi16>
-    gpu.func @buffer_load_from_rank_1_to_2xi16(%src : memref<128xi16>, %offset0 : i32) -> vector<2xi16> {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, vector<2xi16>
+    gpu.func @raw_buffer_load_from_rank_1_to_2xi16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> vector<2xi16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, vector<2xi16>
       gpu.return %result : vector<2xi16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_2xi16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_2xi16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xi16>, vector<2xi16>
-    gpu.func @buffer_load_from_rank_4_to_2xi16(%src : memref<128x64x32x16xi16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xi16> {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<2xi16>
+    gpu.func @raw_buffer_load_from_rank_4_to_2xi16(%src : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<2xi16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<2xi16>
       gpu.return %result : vector<2xi16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_4xi16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_4xi16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, vector<4xi16>
-    gpu.func @buffer_load_from_rank_1_to_4xi16(%src : memref<128xi16>, %offset0 : i32) -> vector<4xi16> {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, vector<4xi16>
+    gpu.func @raw_buffer_load_from_rank_1_to_4xi16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> vector<4xi16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, vector<4xi16>
       gpu.return %result : vector<4xi16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_4_to_4xi16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_4_to_4xi16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : memref<128x64x32x16xi16>, vector<4xi16>
-    gpu.func @buffer_load_from_rank_4_to_4xi16(%src : memref<128x64x32x16xi16>, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xi16> {
-      %result = gpu.raw_buffer_load(%src, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<4xi16>
+    gpu.func @raw_buffer_load_from_rank_4_to_4xi16(%src : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) -> vector<4xi16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0, %offset1, %offset2, %offset3) : memref<128x64x32x16xi16>, vector<4xi16>
       gpu.return %result : vector<4xi16>
     }
 
-    // CHECK-LABEL: gpu.func @buffer_load_from_rank_1_to_8xi16
+    // CHECK-LABEL: gpu.func @raw_buffer_load_from_rank_1_to_8xi16
     //   CHECK: gpu.raw_buffer_load(%{{.*}}, %{{.*}}) : memref<128xi16>, vector<8xi16>
-    gpu.func @buffer_load_from_rank_1_to_8xi16(%src : memref<128xi16>, %offset0 : i32) -> vector<8xi16> {
-      %result = gpu.raw_buffer_load(%src, %offset0) : memref<128xi16>, vector<8xi16>
+    gpu.func @raw_buffer_load_from_rank_1_to_8xi16(%src : memref<128xi16>, %shift : i32, %offset0 : i32) -> vector<8xi16> {
+      %result = gpu.raw_buffer_load(%src, %shift, %offset0) : memref<128xi16>, vector<8xi16>
       gpu.return %result : vector<8xi16>
     }
   }
@@ -704,160 +704,160 @@ module attributes {gpu.container_module} {
   gpu.module @rawbuf_store {
     // f32 tests.
 
-    // CHECK-LABEL: gpu.func @buffer_store_f32_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_f32_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128xf32>
-    gpu.func @buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_f32_to_rank_1(%value : f32, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f32, memref<128xf32>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_f32_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_f32_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f32, memref<128x64x32x16xf32>
-    gpu.func @buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f32, memref<128x64x32x16xf32>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_2xf32_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_2xf32_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128xf32>
-    gpu.func @buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_2xf32_to_rank_1(%value : vector<2xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf32>, memref<128xf32>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_2xf32_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_2xf32_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf32>, memref<128x64x32x16xf32>
-    gpu.func @buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_2xf32_to_rank_4(%value : vector<2xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf32>, memref<128x64x32x16xf32>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_4xf32_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_4xf32_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128xf32>
-    gpu.func @buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_4xf32_to_rank_1(%value : vector<4xf32>, %dst : memref<128xf32>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf32>, memref<128xf32>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_4xf32_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_4xf32_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>, memref<128x64x32x16xf32>
-    gpu.func @buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf32>, memref<128x64x32x16xf32>, i32
       gpu.return
     }
 
     // f16 tests.
 
-    // CHECK-LABEL: gpu.func @buffer_store_f16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_f16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : f16, memref<128xf16>
-    gpu.func @buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_f16_to_rank_1(%value : f16, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : f16, memref<128xf16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_f16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_f16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : f16, memref<128x64x32x16xf16>
-    gpu.func @buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_f16_to_rank_4(%value : f16, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : f16, memref<128x64x32x16xf16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_2xf16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_2xf16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf16>, memref<128xf16>
-    gpu.func @buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_2xf16_to_rank_1(%value : vector<2xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xf16>, memref<128xf16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_2xf16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_2xf16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xf16>, memref<128x64x32x16xf16>
-    gpu.func @buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_2xf16_to_rank_4(%value : vector<2xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xf16>, memref<128x64x32x16xf16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_4xf16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_4xf16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf16>, memref<128xf16>
-    gpu.func @buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_4xf16_to_rank_1(%value : vector<4xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xf16>, memref<128xf16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_4xf16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_4xf16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf16>, memref<128x64x32x16xf16>
-    gpu.func @buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_4xf16_to_rank_4(%value : vector<4xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xf16>, memref<128x64x32x16xf16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_8xf16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_8xf16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xf16>, memref<128xf16>
-    gpu.func @buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_8xf16_to_rank_1(%value : vector<8xf16>, %dst : memref<128xf16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xf16>, memref<128xf16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_8xf16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_8xf16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<8xf16>, memref<128x64x32x16xf16>
-    gpu.func @buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_8xf16_to_rank_4(%value : vector<8xf16>, %dst : memref<128x64x32x16xf16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xf16>, memref<128x64x32x16xf16>, i32
       gpu.return
     }
 
     // i16 tests.
 
-    // CHECK-LABEL: gpu.func @buffer_store_i16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_i16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : i16, memref<128xi16>
-    gpu.func @buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_i16_to_rank_1(%value : i16, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : i16, memref<128xi16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_i16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_i16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : i16, memref<128x64x32x16xi16>
-    gpu.func @buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_i16_to_rank_4(%value : i16, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i16, memref<128x64x32x16xi16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_2xi16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_2xi16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi16>, memref<128xi16>
-    gpu.func @buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_2xi16_to_rank_1(%value : vector<2xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xi16>, memref<128xi16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_2xi16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_2xi16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi16>, memref<128x64x32x16xi16>
-    gpu.func @buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_2xi16_to_rank_4(%value : vector<2xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi16>, memref<128x64x32x16xi16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_4xi16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_4xi16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi16>, memref<128xi16>
-    gpu.func @buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_4xi16_to_rank_1(%value : vector<4xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xi16>, memref<128xi16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_4xi16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_4xi16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi16>, memref<128x64x32x16xi16>
-    gpu.func @buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_4xi16_to_rank_4(%value : vector<4xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi16>, memref<128x64x32x16xi16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_8xi16_to_rank_1
+    // CHECK-LABEL: gpu.func @raw_buffer_store_8xi16_to_rank_1
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<8xi16>, memref<128xi16>
-    gpu.func @buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
+    gpu.func @raw_buffer_store_8xi16_to_rank_1(%value : vector<8xi16>, %dst : memref<128xi16>, %shift : i32, %offset0 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<8xi16>, memref<128xi16>, i32
       gpu.return
     }
 
-    // CHECK-LABEL: gpu.func @buffer_store_8xi16_to_rank_4
+    // CHECK-LABEL: gpu.func @raw_buffer_store_8xi16_to_rank_4
     //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<8xi16>, memref<128x64x32x16xi16>
-    gpu.func @buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+    gpu.func @raw_buffer_store_8xi16_to_rank_4(%value : vector<8xi16>, %dst : memref<128x64x32x16xi16>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xi16>, memref<128x64x32x16xi16>, i32
       gpu.return
     }

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -65,17 +65,18 @@ bool miirLazyInit() {
   return once;
 }
 
-LogicalResult MIOpenEnabled(const Conv2dGenerator::Config& conf) {
-  const std::string& inLayout = conf.inputLayout;
-  const std::string& filLayout = conf.filterLayout;
-  const std::string& outLayout = conf.outputLayout;
+LogicalResult MIOpenEnabled(const Conv2dGenerator::Config &conf) {
+  const std::string &inLayout = conf.inputLayout;
+  const std::string &filLayout = conf.filterLayout;
+  const std::string &outLayout = conf.outputLayout;
 
-  const static std::set<std::tuple<std::string, std::string, std::string>> supportedLayouts = {
-    {"ngchw", "gkcyx", "ngkhw"},
-    {"nhwgc", "gkyxc", "nhwgk"}
-  };
+  const static std::set<std::tuple<std::string, std::string, std::string>>
+      supportedLayouts = {{"ngchw", "gkcyx", "ngkhw"},
+                          {"nhwgc", "gkyxc", "nhwgk"}};
 
-  bool layoutSupported = supportedLayouts.count(std::make_tuple(inLayout, filLayout, outLayout)) > 0;
+  bool layoutSupported =
+      supportedLayouts.count(std::make_tuple(inLayout, filLayout, outLayout)) >
+      0;
   bool noBF16 = conf.dataTypeStr != "bf16";
   return LogicalResult::success(layoutSupported && noBF16);
 }
@@ -98,7 +99,7 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
     handle = new MiirHandle_s;
     OpBuilder builder(&(handle->context));
 
-    const auto& config = conv2dGenerator.getConfig();
+    const auto &config = conv2dGenerator.getConfig();
     if (failed(MIOpenEnabled(config))) {
       return nullptr;
     }


### PR DESCRIPTION
Up until now we are using buffer load intrinsic when it comes to vector loads. In PR #248 we started to use raw buffer store intrinsic provided by LLVM AMDGPU, but NOT raw buffer load intrinsic.

@asleepzzz identified while working on https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/138 that it's highly likely we need to switch to raw buffer load intrinsic.

Therefore, in this PR, introduce raw buffer load intrinsic and integrate to the lowering process.

- Fix undesirable `i32` type specification in the syntax of `gpu.buffer_store` and `gpu.raw_buffer_store` ops for shift operand.
- Fix `rawbuf_store.mlir` to REALLY test `gpu.raw_buffer_store` and its lowering to `rocdl.raw.buffer.store`.
- Introduce `gpu.raw_buffer_load`.
- Introduce conversion from `gpu.raw_buffer_load` to `rocdl.raw_buffer_load`.
- Implement unit test to test the conversion process.
- Integrate into `emitLoadInstruction`.