### PR TITLE
Fix various compiler warnings

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -5167,7 +5167,8 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
           GemmABlockCopyThreadSliceLengths_GemmM;
       break;
     case GemmG:
-      llvm_unreachable("Group matrix unimplemented");
+      llvm_unreachable("Vector loads/stores aren't possible in the G dimension "
+                       "and should not haven been attempted");
     }
 
     // llvm::errs() << "thread slice lengths for Matrix A\n";
@@ -5205,7 +5206,8 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
           GemmBBlockCopyThreadSliceLengths_GemmN;
       break;
     case GemmG:
-      llvm_unreachable("Group matrix unimplemented");
+      llvm_unreachable("Vector loads/stores aren't possible in the G dimension "
+                       "and should not haven been attempted");
     }
 
     // llvm::errs() << "thread slice lengths for Matrix B\n";
@@ -6219,7 +6221,8 @@ struct GridwiseGemmV2RewritePattern
           GemmABlockCopyThreadSliceLengths_GemmM;
       break;
     case GemmG:
-      llvm_unreachable("Group matrix not supported");
+      llvm_unreachable("Vector loads/stores aren't possible in the G dimension "
+                       "and should not haven been attempted");
     }
 
     // llvm::errs() << "thread slice lengths for Matrix A\n";
@@ -6256,7 +6259,8 @@ struct GridwiseGemmV2RewritePattern
           GemmBBlockCopyThreadSliceLengths_GemmN;
       break;
     case GemmG:
-      llvm_unreachable("Group matrix not supported");
+      llvm_unreachable("Vector loads/stores aren't possible in the G dimension "
+                       "and should not haven been attempted");
     }
 
     // llvm::errs() << "thread slice lengths for Matrix B\n";

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
 #include "mlir/Dialect/MIOpen/Tuning/ConvContext.h"
 #include "mlir/Dialect/MIOpen/Tuning/Serializable.h"
-#include "mlir/Dialect/MIOpen/utility/BackwardDataPaddingKernel.h"
 #include "mlir/Dialect/MIOpen/utility/math.hpp"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/Support/CommandLine.h"

--- a/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
+++ b/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
@@ -15,6 +15,7 @@
 #define MLIR_XDLOPS_CODE_SELECTION_H
 
 #include "mlir/Dialect/GPU/GPUDialect.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <stdint.h>
 
 using namespace mlir;
@@ -184,6 +185,7 @@ struct XdlopsCodeSelection {
         llvm::errs() << "dataType: ";
         dataType.dump();
         llvm::errs() << "\n";
+        llvm_unreachable("Can't meaningfully continue xdlop generation");
       }
     } else if (dataType == b.getF16Type()) {
       if (MPerWave == 128 && NPerWave == 64) {
@@ -312,6 +314,7 @@ struct XdlopsCodeSelection {
         llvm::errs() << "dataType: ";
         dataType.dump();
         llvm::errs() << "\n";
+        llvm_unreachable("Can't meaningfully continue xdlop generation");
       }
     } else if (dataType == b.getIntegerType(16)) {
       if (MPerWave == 128 && NPerWave == 64) {
@@ -440,7 +443,10 @@ struct XdlopsCodeSelection {
         llvm::errs() << "dataType: ";
         dataType.dump();
         llvm::errs() << "\n";
+        llvm_unreachable("Can't meaningfully continue xdlop generation");
       }
+    } else {
+      llvm_unreachable("XDLOPs for unsupported data types should be rejected");
     }
 
     // Obtain properties of MFMA instructions.
@@ -658,7 +664,7 @@ struct XdlopsCodeSelection {
       cycles = 8;
       k_base = 2;
     } else {
-      llvm::errs() << "Unsupported case as mfmaInstr not selected!\n";
+      llvm_unreachable("Unsupported case as mfmaInstr not selected!\n");
     }
 
     // Populate result.

--- a/mlir/include/mlir/Dialect/MIOpen/utility/BackwardDataPaddingKernel.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/BackwardDataPaddingKernel.h
@@ -281,9 +281,6 @@ inline Value padInput(int64_t gemmMExtra, int64_t gemmNExtra,
     paddingInputShape.push_back(transformedShape[1]);
     paddingInputShape.push_back(transformedShape[2]);
 
-    StringAttr gemmKDim;
-    IntegerAttr gemmKDimName;
-
     llvm::SmallVector<NamedAttribute, 3> sourceGemmDim0Attr{
         b.getNamedAttr("transformation", b.getStringAttr("PassThrough")),
         b.getNamedAttr("lower_layer_dimensions", b.getArrayAttr({GemmDim0})),

--- a/mlir/include/mlir/Dialect/MIOpen/utility/math.hpp
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/math.hpp
@@ -1,13 +1,15 @@
 #ifndef MATH_HPP
 #define MATH_HPP
 
+#include <cstdlib>
+
 namespace math {
 // greatest common divisor, aka highest common factor
 template <typename T> T gcd(T x, T y) {
   assert(!(x == 0 && y == 0));
 
   if (x < 0 || y < 0) {
-    return gcd(abs(x), abs(y));
+    return gcd(std::abs(x), std::abs(y));
   } else if (x == y || x == 0) {
     return y;
   } else if (y == 0) {

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -36,6 +36,11 @@ Conv2dGenerator::Conv2dGenerator(
              inputLayout,
              outputLayout,
              kernelName,
+             -1,
+             {},
+             {},
+             {},
+             -1,
              -1} {}
 
 namespace {

--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -390,7 +390,8 @@ short randomIntegerValue(short min, short max) {
 float randomFloatValue(short min, short max) {
   if (min == max)
     return (float)min;
-  return (max - min) * (float)(std::rand()) / RAND_MAX + (float)min;
+  return (float)((max - min) * (double)(std::rand()) / (double)RAND_MAX) +
+         (float)min;
 }
 
 // 3D float memref utility routines.

--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -388,10 +388,12 @@ short randomIntegerValue(short min, short max) {
 }
 
 float randomFloatValue(short min, short max) {
+  float minAsF = static_cast<float>(min);
   if (min == max)
-    return (float)min;
-  return (float)((max - min) * (double)(std::rand()) / (double)RAND_MAX) +
-         (float)min;
+    return minAsF;
+  return static_cast<float>((max - min) * static_cast<double>(std::rand()) /
+                            static_cast<double>(RAND_MAX)) +
+         minAsF;
 }
 
 // 3D float memref utility routines.


### PR DESCRIPTION
- Remove unused variables and class members in conv generator
- Change several if/else if/... blocks to switch/case to remove
- warnings about potentially uninitialized variables and to give us a
- warning if we add a case in the future
- Turn some can't happen cases into llvm_unreachable() so they crash
- the compiler if they do, in fact, happen, instead of plowing ahead
- with an error message
- Fix random utilities by:
  - Using an abs() that won't truncate
  - Performing certain calculations with doubles since RAND_MAX is not
    representable by a float on 64-bit platforms

The remaining pile of warnings that's our responsibility is in
rocm-runtime-wrappers.cpp , which has extern "C" functions that export
templated types that probably shouldn't be extern "C" (the non 1D
StridedMemRefType<>s) - it's not clear what to do about those.