### PR TITLE
Add LD library path for nightly performance tests; Increase timeout threshold

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -200,10 +200,7 @@ pipeline {
                                 dir('MIOpen') {
                                     getAndBuildMIOpen('''-DMIOPEN_BACKEND=HIP
                                     -DCMAKE_PREFIX_PATH="/opt/rocm/hip;/opt/rocm/;/usr/local"
-                                    -DCMAKE_INSTALL_PREFIX=/opt/rocm/
                                     ''')
-                                    // Temporary workaround for MIOpen breakage
-                                    sh 'cd build; make install'
                                 }
                             }
                         }
@@ -213,7 +210,12 @@ pipeline {
                             }
                         }
                         stage('Performance Test') {
+                            environment {
+                                // Make libMIOpen.so accessible to the test driver
+                                LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
+                            }
                             steps {
+                                sh 'ldconfig'
                                 dir('build') {
                                     // Run MLIR perf benchmarks
                                     sh 'python3 ./llvm/MIOpenDriver.py'

--- a/mlir/utils/jenkins/Jenkinsfile.nightly-perf
+++ b/mlir/utils/jenkins/Jenkinsfile.nightly-perf
@@ -17,7 +17,7 @@ pipeline {
                 sh '/opt/rocm/bin/rocm-smi'
             }
         }
-        stage('Build MIOpen') {
+        stage('Build MIOpenDriver') {
             steps {
                 dir('MIOpen') {
                     git branch: 'develop', poll: false,\
@@ -30,12 +30,9 @@ pipeline {
                                 cmakeArgs: '''
                                  -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
                                  -DMIOPEN_BACKEND=HIP
-                                 -DCMAKE_PREFIX_PATH="/opt/rocm/hip;/opt/rocm/;/usr/local" \
-                                 -DCMAKE_INSTALL_PREFIX=/opt/rocm/ ..
+                                 -DCMAKE_PREFIX_PATH="/opt/rocm/hip;/opt/rocm/;/usr/local" ..
                                 '''
                     sh 'cd build; make -j $(nproc) MIOpenDriver'
-                    //A temporary workaround for MIOpenDriver seg fault
-                    sh 'cd build; make install'
                 }
             }
         }
@@ -50,11 +47,15 @@ pipeline {
             }
         }
         stage('Performance Test') {
+            environment {
+               LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${WORKSPACE}/MIOpen/build/lib"
+            }
             steps {
                 cmake arguments: '--build . --target MIOpenDriver.py',\
                     installation: 'InSearchPath', workingDir: 'build'
 
                 // Run MLIR perf benchmarks
+                sh 'ldconfig'
                 dir('build') {
                     sh 'python3 ./llvm/MIOpenDriver.py'
                 }

--- a/mlir/utils/jenkins/MIOpenDriver.py
+++ b/mlir/utils/jenkins/MIOpenDriver.py
@@ -216,7 +216,7 @@ def runConfigWithMIOpenDriver(commandLine):
     p1 = subprocess.Popen(profilerCommand.split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
     # get output.
     try:
-        outs, errs = p1.communicate(timeout=30)
+        outs, errs = p1.communicate(timeout=180)
     except TimeoutExpired:
         p1.kill()
         outs, errs = p1.communicate()


### PR DESCRIPTION
This seems to solve the MIOpenDriver crashes I saw before. 

Performance tests on gfx908 passed. http://rocmhead.amd.com:8080/job/test-perf/