### PR TITLE
Don't corrupt the heap when passed a 3D layout.

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -175,11 +175,11 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
 
     // MIOpen has NCHW as layout string for all three tensors
     config.inputLayout = translateLayout(
-        argMap["in_layout"], std::string("NGCHW"), std::string("ngchw"));
+        argMap["in_layout"], std::string("NGCDHW"), std::string("ngcdhw"));
     config.filterLayout = translateLayout(
-        argMap["fil_layout"], std::string("GNCHW"), std::string("gkcyx"));
+        argMap["fil_layout"], std::string("GNCDHW"), std::string("gkczyx"));
     config.outputLayout = translateLayout(
-        argMap["out_layout"], std::string("NGCHW"), std::string("ngkhw"));
+        argMap["out_layout"], std::string("NGCDHW"), std::string("ngkdhw"));
 
     // Determine tensor dimensions.
     return parseConvDims(strToLong("batchsize"), strToLong("groupsize"),
@@ -227,8 +227,13 @@ Conv2dGenerator::parseConvDims(int64_t batchSize, int64_t groupSize,
     return true;
   };
 
+  size_t layoutLen = config.filterLayout.length();
+  if (layoutLen != config.inputLayout.length() ||
+      layoutLen != config.outputLayout.length()) {
+    return failure();
+  }
   // Determine dimensions.
-  for (size_t i = 0; i < 5; ++i) {
+  for (size_t i = 0; i < layoutLen; ++i) {
     if (!convertLayout(config.filterLayout[i], filterKeys, filterVals,
                        config.filterDimension) ||
         !convertLayout(config.inputLayout[i], inputKeys, inputVals,

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -129,6 +129,16 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
         [&argMap](const std::string &key) { return argMap.count(key) > 0; })) {
           return false;
     }
+    static const std::vector<std::string> layoutArgs = {
+        "fil_layout", "in_layout", "out_layout"};
+
+    if (!std::all_of(layoutArgs.cbegin(), layoutArgs.cend(),
+                     [&argMap](const std::string &key) {
+                       return argMap[key].length() == 5;
+                     })) {
+      return false;
+    }
+
     bool noMixedTypes = argMap["in_type"] == argMap["out_type"] && argMap["fil_type"] == argMap["out_type"];
     return noMixedTypes;
   };
@@ -175,11 +185,11 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
 
     // MIOpen has NCHW as layout string for all three tensors
     config.inputLayout = translateLayout(
-        argMap["in_layout"], std::string("NGCDHW"), std::string("ngcdhw"));
+        argMap["in_layout"], std::string("NGCHW"), std::string("ngchw"));
     config.filterLayout = translateLayout(
-        argMap["fil_layout"], std::string("GNCDHW"), std::string("gkczyx"));
+        argMap["fil_layout"], std::string("GNCHW"), std::string("gkcyx"));
     config.outputLayout = translateLayout(
-        argMap["out_layout"], std::string("NGCDHW"), std::string("ngkdhw"));
+        argMap["out_layout"], std::string("NGCHW"), std::string("ngkhw"));
 
     // Determine tensor dimensions.
     return parseConvDims(strToLong("batchsize"), strToLong("groupsize"),


### PR DESCRIPTION
The layout-permuting code would write off the end of arrays if a
layout of length 6 (that is, a 3D convolution) was passed in. This
would cause crashes later in program execution. This commit adds the
support needed to reject 3D layout cleanly.