### PR TITLE
fix backward data issue

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -3920,7 +3920,7 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                                            b.getStringAttr("wi")}))};
         auto isInputHipBoundCheck = [&]() {
           if (wTildaSlice > wo || hTildaSlice > ho)
-              return true;
+            return true;
           // if pad = 0 , not need oob check
           if (leftPadH == 0 && rightPadH == 0 && leftPadW == 0 &&
               rightPadW == 0)

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -3919,6 +3919,8 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                            b.getArrayAttr({b.getStringAttr("hi"),
                                            b.getStringAttr("wi")}))};
         auto isInputHipBoundCheck = [&]() {
+          if (wTildaSlice > wo || hTildaSlice > ho)
+              return true;
           // if pad = 0 , not need oob check
           if (leftPadH == 0 && rightPadH == 0 && leftPadW == 0 &&
               rightPadW == 0)
@@ -3931,10 +3933,10 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
         };
         if (isInputHipBoundCheck()) {
           llvm::SmallVector<IntegerAttr, 2> padDim;
-          if (leftPadH || rightPadH) {
+          if (leftPadH || rightPadH || hTildaSlice > ho) {
             inputOobCheckDims.insert(currentKeyToDim["hi"]);
           }
-          if (leftPadW || rightPadW) {
+          if (leftPadW || rightPadW || wTildaSlice > wo) {
             inputOobCheckDims.insert(currentKeyToDim["wi"]);
           }
         }

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -3919,12 +3919,10 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                            b.getArrayAttr({b.getStringAttr("hi"),
                                            b.getStringAttr("wi")}))};
         auto isInputHipBoundCheck = [&]() {
-          // FIXME:  wTildaSlice > wo will let padding kernel fail,
-          // we need to fix the padding kernel in next step
-          // but this logic(wTildaSlice > wo) is correct
-          // when using padding kernel, don't add hi,wi at this moment
-          // if stride =1 and wTildaSlice > wo , don't do additional check
-          // or the padding kernel will fail due to it only check dim no
+          // FIXME:  wTildaSlice > wo will let stride2 backwaed data kernel
+          // fail, so when (wTildaSlice > wo),  h and w dim check is must but if
+          // stride =1 and wTildaSlice > wo , don't do additional check or the
+          // padding kernel will fail due compiler issue
           if ((wTildaSlice > wo && strideW > 1) ||
               (hTildaSlice > ho && strideH > 1))
             return true;

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -357,6 +357,39 @@ static void correctParameters() {
       }
     }
   }
+
+  // adjust the padding size
+  auto getOutputDim = [](int64_t inputLen, int64_t filLen, int leftPadLen,
+                         int rightPadLen, int strideLen, int dilLen) {
+    return (inputLen + leftPadLen + rightPadLen - (filLen - 1) * dilLen - 1) /
+               strideLen +
+           1;
+  };
+
+  int hi = inputHeight.getValue();
+  int y = filterHeight.getValue();
+  int in_left_pad_h = paddingHeightLeft.getValue();
+  int conv_stride_h = strideHeight.getValue();
+  int conv_dilation_h = dilationHeight.getValue();
+  int ho = getOutputDim(hi, y, in_left_pad_h, paddingHeightRight.getValue(),
+                        conv_stride_h, conv_dilation_h);
+  int hi_padded = 1 + (y - 1) * conv_dilation_h + (ho - 1) * conv_stride_h;
+  int in_right_pad_h =
+      hi_padded > (hi + in_left_pad_h) ? hi_padded - (hi + in_left_pad_h) : 0;
+  paddingHeightRight.setValue(in_right_pad_h);
+
+  int wi = inputWidth.getValue();
+  int x = filterWidth.getValue();
+  int in_left_pad_w = paddingWidthLeft.getValue();
+  int conv_stride_w = strideWidth.getValue();
+  int conv_dilation_w = dilationWidth.getValue();
+  int wo = getOutputDim(wi, x, in_left_pad_w, paddingWidthRight.getValue(),
+                        conv_stride_w, conv_dilation_w);
+
+  int wi_padded = 1 + (x - 1) * conv_dilation_w + (wo - 1) * conv_stride_w;
+  int in_right_pad_w =
+      wi_padded > (wi + in_left_pad_w) ? wi_padded - (wi + in_left_pad_w) : 0;
+  paddingWidthRight.setValue(in_right_pad_w);
 }
 
 static void verifyLayout() {

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -359,6 +359,10 @@ static void correctParameters() {
   }
 
   // adjust the padding size
+  // getOutputDim can give us correct output size
+  // output size = input size+ padding size
+  // then -(filter size-1) * dilation size -1
+  // ,/ stride size and add 1
   auto getOutputDim = [](int64_t inputLen, int64_t filLen, int leftPadLen,
                          int rightPadLen, int strideLen, int dilLen) {
     return (inputLen + leftPadLen + rightPadLen - (filLen - 1) * dilLen - 1) /
@@ -374,6 +378,11 @@ static void correctParameters() {
   int ho = getOutputDim(hi, y, in_left_pad_h, paddingHeightRight.getValue(),
                         conv_stride_h, conv_dilation_h);
   int hi_padded = 1 + (y - 1) * conv_dilation_h + (ho - 1) * conv_stride_h;
+  // we got correct output size via getOutputDim, before adjusting size
+  // we have original output size from user , but we need to check the padding
+  // size so we use output size to calculate original input size add pad size,
+  // hi_padded if hi_padded is equal to hi + in_left_pad_h , no adjusting but if
+  // not equal, need extra padding hi_padded - (hi + in_left_pad_h)
   int in_right_pad_h =
       hi_padded > (hi + in_left_pad_h) ? hi_padded - (hi + in_left_pad_h) : 0;
   paddingHeightRight.setValue(in_right_pad_h);


### PR DESCRIPTION
this PR fix backward data stride=2 issues
 ./bin/mlir-miopen-driver -pv -c -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=64 --padding_h=1 --padding_w=1 -in_channels=64 -out_channels=64 -in_h=51 -in_w=51 -fil_h=3 -fil_w=3 -p=false   --conv_stride_h=2   --conv_stride_w=2  --operation=conv2d_bwd_data  |./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void


 ./bin/mlir-miopen-driver -pv -c -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=64 --padding_h=0 --padding_w=0 -in_channels=64 -out_channels=64 -in_h=51 -in_w=51 -fil_h=3 -fil_w=3 -p=false --conv_stride_h=2 --conv_stride_w=2 --operation=conv2d_bwd_data -x2|./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./lib/libmlir_runner_utils.so --entry-point-result=void



sometimes the htilda >hout  or wtilda >wout
is this cases we need to add out of boundary check

