### PR TITLE
Replace the `operation` string in Conv2dGenerator with an enum.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -25,12 +25,11 @@ namespace mlir {
 
 class Conv2dGenerator {
 public:
-  enum Op { Fwd, Dummy, BwdData, BwdWeight };
   struct Config {
     std::string arch;
     int num_cu;
     bool xdlops;
-    Op operation;
+    miopen::ConvOpType operation;
     std::string dataTypeStr;
     int dilationHeight, dilationWidth;
     int strideHeight, strideWidth;
@@ -53,7 +52,8 @@ public:
   };
 
   Conv2dGenerator(const std::string &arch = "", int num_cu = 0,
-                  bool xdlops = false, const Op operation = Fwd,
+                  bool xdlops = false,
+                  const miopen::ConvOpType operation = miopen::Conv2DOpType,
                   const std::string &dataTypeStr = "f32",
                   int dilationHeight = 1, int dilationWidth = 1,
                   int strideHeight = 1, int strideWidth = 1,
@@ -75,8 +75,8 @@ public:
 
   void flipXdlops();
 
-  static Optional<Op> getOpForName(const StringRef name);
-  static const char *getNameForOp(const Op);
+  static Optional<miopen::ConvOpType> getOpForName(const StringRef name);
+  static const char *getNameForOp(const miopen::ConvOpType);
 
   LogicalResult parseConvConfig(const char *arguments);
 

--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -17,14 +17,20 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
 namespace mlir {
+
 class Conv2dGenerator {
 public:
+  enum Op { Fwd, Dummy, BwdData, BwdWeight };
   struct Config {
     std::string arch;
     int num_cu;
     bool xdlops;
-    std::string operation;
+    Op operation;
     std::string dataTypeStr;
     int dilationHeight, dilationWidth;
     int strideHeight, strideWidth;
@@ -47,7 +53,7 @@ public:
   };
 
   Conv2dGenerator(const std::string &arch = "", int num_cu = 0,
-                  bool xdlops = false, const std::string &operation = "conv2d",
+                  bool xdlops = false, const Op operation = Fwd,
                   const std::string &dataTypeStr = "f32",
                   int dilationHeight = 1, int dilationWidth = 1,
                   int strideHeight = 1, int strideWidth = 1,
@@ -68,6 +74,9 @@ public:
   void setDataType(std::string dataTypeStr);
 
   void flipXdlops();
+
+  static Optional<Op> getOpForName(const StringRef name);
+  static const char *getNameForOp(const Op);
 
   LogicalResult parseConvConfig(const char *arguments);
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.h
@@ -21,11 +21,17 @@
 
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringRef.h"
+
 namespace mlir {
 
 namespace miopen {
 
 enum ConvOpType { Conv2DOpType, Conv2DBwdDataOpType, Conv2DBwdWeightOpType };
+
+llvm::Optional<ConvOpType> getConvOpTypeForName(llvm::StringRef name);
+const char *getNameForConvOpType(const ConvOpType);
 } // end namespace miopen
 
 #include "mlir/Dialect/MIOpen/MIOpenOpsDialect.h.inc"

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -71,18 +71,6 @@ def MIOpen_Conv2DBwdWeightOp :
   }];
 }
 
-def MIOpen_Conv2DDummyOp :
-    MIOpen_Op<"conv2d_dummy">,
-    Arguments<(ins MemRefRankOf<[F32, F16, I16], [5]>:$filter,
-                   MemRefRankOf<[F32, F16, I16], [5]>:$input,
-                   MemRefRankOf<[F32, F16, I16], [5]>:$output)> {
-  let summary = "Dummy op for 2D convolution";
-  let description = [{
-    The `miopen.conv2d_dummy` op is an empty op which takes the same operands as a regular 2D conv op.
-  }];
-}
-
-
 def MIOpen_TransformOp :
     MIOpen_Op<"transform">,
     Arguments<(ins AnyMemRef:$input)>,

--- a/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
+++ b/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
@@ -155,16 +155,6 @@ struct MIMFMARewritePattern : public OpRewritePattern<miopen::MFMAV2Op> {
   }
 };
 
-struct MIDummyRewritePattern : public OpRewritePattern<miopen::Conv2DDummyOp> {
-  using OpRewritePattern<miopen::Conv2DDummyOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(miopen::Conv2DDummyOp op,
-                                PatternRewriter &b) const override {
-    op.erase();
-    return success();
-  }
-};
-
 } // namespace
 
 void LowerMIOpenOpsToGPUPass::runOnOperation() {
@@ -273,7 +263,6 @@ void LowerMIOpenOpsToGPUPass::runOnOperation() {
     patterns.insert<MIOpRewritePattern<ReturnOp, gpu::ReturnOp>>(&getContext());
 
     patterns.insert<MIMFMARewritePattern>(&getContext());
-    patterns.insert<MIDummyRewritePattern>(&getContext());
     if (failed(applyPatternsAndFoldGreedily(gpuMod, std::move(patterns))))
       signalPassFailure();
   });

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -117,31 +117,6 @@ Type Conv2dGenerator::getDataType(OpBuilder &builder) const {
   return dataType;
 }
 
-Optional<miopen::ConvOpType>
-Conv2dGenerator::getOpForName(const StringRef name) {
-  if (name == "conv2d") {
-    return miopen::Conv2DOpType;
-  }
-  if (name == "conv2d_bwd_data") {
-    return miopen::Conv2DBwdDataOpType;
-  }
-  if (name == "conv2d_bwd_weight") {
-    return miopen::Conv2DBwdWeightOpType;
-  }
-  return llvm::None;
-}
-
-const char *Conv2dGenerator::getNameForOp(const miopen::ConvOpType op) {
-  switch (op) {
-  case miopen::Conv2DOpType:
-    return "conv2d";
-  case miopen::Conv2DBwdDataOpType:
-    return "conv2d_bwd_data";
-  case miopen::Conv2DBwdWeightOpType:
-    return "conv2d_bwd_weight";
-  }
-}
-
 LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
   std::map<std::string, std::string> argMap;
   strToTokens(arguments, argMap);
@@ -198,7 +173,7 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
     strToInt("x2", config.xdlops);
 
     // conv settings
-    auto const op = getOpForName(argMap["operation"]);
+    auto const op = miopen::getConvOpTypeForName(argMap["operation"]);
     if (!op.hasValue()) {
       return failure();
     }
@@ -291,7 +266,7 @@ Conv2dGenerator::parseConvDims(int64_t batchSize, int64_t groupSize,
   if (config.kernelName.empty()) {
     int id = std::max(config.kernelId, 0);
     config.kernelName = std::string("miopen_") +
-                        getNameForOp(config.operation) + "_" +
+                        miopen::getNameForConvOpType(config.operation) + "_" +
                         config.filterLayout + "_" + config.inputLayout + "_" +
                         config.outputLayout + "_" + std::to_string(id);
   }

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -179,29 +179,6 @@ static LogicalResult verify(Conv2DBwdWeightOp op) {
 }
 
 //===----------------------------------------------------------------------===//
-// Conv2DDummyOp
-//===----------------------------------------------------------------------===//
-
-static ParseResult parseConv2DDummyOp(OpAsmParser &parser,
-                                      OperationState &result) {
-  SmallVector<OpAsmParser::OperandType, 3> ops;
-  SmallVector<Type, 3> types;
-  return failure(
-      parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
-      parser.parseOptionalAttrDict(result.attributes) ||
-      parser.parseColonTypeList(types) ||
-      parser.resolveOperands(ops, types, parser.getNameLoc(), result.operands));
-}
-
-static void print(OpAsmPrinter &p, Conv2DDummyOp op) {
-  p << op.getOperationName() << "(" << op.getOperands() << ")";
-  p.printOptionalAttrDict(op.getAttrs());
-  p << " : " << op.getOperandTypes();
-}
-
-static LogicalResult verify(Conv2DDummyOp op) { return success(); }
-
-//===----------------------------------------------------------------------===//
 // TransformOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -27,6 +27,33 @@ namespace {
 
 } // namespace
 
+namespace mlir {
+namespace miopen {
+Optional<ConvOpType> getConvOpTypeForName(const StringRef name) {
+  if (name == "conv2d") {
+    return Conv2DOpType;
+  }
+  if (name == "conv2d_bwd_data") {
+    return Conv2DBwdDataOpType;
+  }
+  if (name == "conv2d_bwd_weight") {
+    return Conv2DBwdWeightOpType;
+  }
+  return llvm::None;
+}
+
+const char *getNameForConvOpType(const miopen::ConvOpType op) {
+  switch (op) {
+  case Conv2DOpType:
+    return "conv2d";
+  case Conv2DBwdDataOpType:
+    return "conv2d_bwd_data";
+  case Conv2DBwdWeightOpType:
+    return "conv2d_bwd_weight";
+  }
+}
+} // namespace miopen
+} // namespace mlir
 //===----------------------------------------------------------------------===//
 // MIOpenDialect
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -122,13 +122,6 @@ void AffixTuningParameters::runOnFunction() {
 
   func.walk(
       [&](miopen::GridwiseGemmV2Op op) { affixTuningParametersImpl(op); });
-
-  func.walk([&](miopen::Conv2DDummyOp op) {
-    OpBuilder b(op.getContext());
-    // Set attributes for the dummy conv2d op.
-    getFunction()->setAttr("block_size", b.getI32IntegerAttr(1));
-    getFunction()->setAttr("grid_size", b.getI32IntegerAttr(1));
-  });
 }
 
 template <typename T>

--- a/mlir/test/Dialect/MIOpen/lowering_affix_params.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_affix_params.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: miopen-driver
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s
-// RUN: mlir-miopen-driver -p --operation=conv2d_dummy -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s
+// RUN: mlir-miopen-driver -p --operation=conv2d -miopen-lowering -miopen-affine-transform -miopen-affix-params | FileCheck %s
 
 // CHECK: module {{.*}}
 // CHECK-NEXT: func @{{.*}}(%{{.*}}: memref<{{.*}}>, %{{.*}}: memref<{{.*}}>, %arg2: memref<{{.*}}>) attributes {block_size = {{.*}} : i32, grid_size = {{.*}} : i32, kernel = 0 : i32}

--- a/mlir/test/Dialect/MIOpen/ops.mlir
+++ b/mlir/test/Dialect/MIOpen/ops.mlir
@@ -87,34 +87,6 @@ func @miopen_conv2d_bwd_weight_f16(%filter : memref<?x?x?x?x?xf16>, %input : mem
 // CHECK-LABEL: func @miopen_conv2d_bwd_weight_f16
 // CHECK-NEXT: miopen.conv2d_bwd_weight
 
-func @miopen_conv2d_dummy(%filter : memref<?x?x?x?x?xf32>, %input : memref<?x?x?x?x?xf32>, %output : memref<?x?x?x?x?xf32>) {
-  miopen.conv2d_dummy(%filter, %input, %output) {
-    filter_layout = ["g", "k", "c", "y", "x"],
-    input_layout = ["n", "gi", "c", "hi", "wi"],
-    output_layout = ["n", "go", "k", "ho", "wo"],
-    dilations = [1, 1],
-    strides = [1, 1],
-    padding = [0, 0, 0, 0]
-  } : memref<?x?x?x?x?xf32>, memref<?x?x?x?x?xf32>, memref<?x?x?x?x?xf32>
-  return
-}
-// CHECK-LABEL: func @miopen_conv2d_dummy
-// CHECK-NEXT: miopen.conv2d_dummy
-
-func @miopen_conv2d_dummy_f16(%filter : memref<?x?x?x?x?xf16>, %input : memref<?x?x?x?x?xf16>, %output : memref<?x?x?x?x?xf16>) {
-  miopen.conv2d_dummy(%filter, %input, %output) {
-    filter_layout = ["g", "k", "c", "y", "x"],
-    input_layout = ["n", "gi", "c", "hi", "wi"],
-    output_layout = ["n", "go", "k", "ho", "wo"],
-    dilations = [1, 1],
-    strides = [1, 1],
-    padding = [0, 0, 0, 0]
-  } : memref<?x?x?x?x?xf16>, memref<?x?x?x?x?xf16>, memref<?x?x?x?x?xf16>
-  return
-}
-// CHECK-LABEL: func @miopen_conv2d_dummy_f16
-// CHECK-NEXT: miopen.conv2d_dummy
-
 // test 1-1 dimension mappings.
 func @miopen_transform_1_to_1(%memref: memref<?x?x?x?x?xf32>) {
   %transformed_memref = miopen.transform(%memref) {

--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -17,7 +17,7 @@
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 // RUN: mlir-miopen-driver -p -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
-// RUN: mlir-miopen-driver -p --operation conv2d_dummy -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p --operation conv2d -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 
 // fp16 tests.
 
@@ -35,7 +35,7 @@
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -t f16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 // RUN: mlir-miopen-driver -p -t f16 -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
-// RUN: mlir-miopen-driver -p -t f16 --operation conv2d_dummy -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p -t f16 --operation conv2d -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 
 // bf16(i16) tests.
 
@@ -53,4 +53,4 @@
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip
 // RUN: mlir-miopen-driver -p -t bf16 -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-lowering-step5 -convert-miopen-to-gpu -convert-gpu-to-rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
 // RUN: mlir-miopen-driver -p -t bf16 -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
-// RUN: mlir-miopen-driver -p -t bf16 --operation conv2d_dummy -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900
+// RUN: mlir-miopen-driver -p -t bf16 --operation conv2d -c -target=rocdl | mlir-translate -mlir-to-rocdlir | opt -O3 -S -strip | llc -mcpu=gfx900


### PR DESCRIPTION
This guards against "spoooky action at a distance" crashes from
unexpected values for the convolution operation.