### PR TITLE
Disable pv_with_gpu for E2E tests with random data

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -104,7 +104,8 @@ pipeline {
                             steps {
                                 buildProject('check-mlir',
                                              """-DMLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED=1
-                                             -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=0""")
+                                             -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=0
+                                             -DMLIR_MIOPEN_DRIVER_TEST_GPU_VALIDATION=0""")
                             }
                         }
                     }

--- a/mlir/utils/jenkins/Jenkinsfile.nightly-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.nightly-xdlop
@@ -42,6 +42,7 @@ pipeline {
                     steps: [[args: "clean"], [args: 'check-mlir']],\
                     cmakeArgs: '''-DMLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED=1
                     -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=0
+                    -DMLIR_MIOPEN_DRIVER_TEST_GPU_VALIDATION=0
                     '''
             }
         }


### PR DESCRIPTION
We still want to do cpu validation for E2E tests with random data.