### PR TITLE
Remove ThreadLocalCache from MLIRContext and StorageUniquer, to avoid data races

### DIFF
--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -24,7 +24,6 @@
 #include "mlir/IR/Location.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Types.h"
-#include "mlir/Support/ThreadLocalCache.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
@@ -267,10 +266,6 @@ public:
   llvm::StringMap<PointerUnion<Dialect *, MLIRContext *>,
                   llvm::BumpPtrAllocator &>
       identifiers;
-  /// A thread local cache of identifiers to reduce lock contention.
-  ThreadLocalCache<llvm::StringMap<
-      llvm::StringMapEntry<PointerUnion<Dialect *, MLIRContext *>> *>>
-      localIdentifierCache;
 
   /// An allocator used for AbstractAttribute and AbstractType objects.
   llvm::BumpPtrAllocator abstractDialectSymbolAllocator;
@@ -736,26 +731,18 @@ Identifier Identifier::get(StringRef str, MLIRContext *context) {
     return Identifier(&*insertedIt.first);
   }
 
-  // Check for an existing instance in the local cache.
-  auto *&localEntry = (*impl.localIdentifierCache)[str];
-  if (localEntry)
-    return Identifier(localEntry);
-
   // Check for an existing identifier in read-only mode.
   {
     llvm::sys::SmartScopedReader<true> contextLock(impl.identifierMutex);
     auto it = impl.identifiers.find(str);
-    if (it != impl.identifiers.end()) {
-      localEntry = &*it;
-      return Identifier(localEntry);
-    }
+    if (it != impl.identifiers.end())
+      return Identifier(&*it);
   }
 
   // Acquire a writer-lock so that we can safely create the new instance.
   llvm::sys::SmartScopedWriter<true> contextLock(impl.identifierMutex);
   auto it = impl.identifiers.insert({str, getDialectOrContext()}).first;
-  localEntry = &*it;
-  return Identifier(localEntry);
+  return Identifier(&*it);
 }
 
 Dialect *Identifier::getDialect() {

--- a/mlir/lib/Support/StorageUniquer.cpp
+++ b/mlir/lib/Support/StorageUniquer.cpp
@@ -127,24 +127,18 @@ public:
     if (!threadingIsEnabled)
       return getOrCreateUnsafe(shard, lookupKey, ctorFn);
 
-    // Check for a instance of this object in the local cache.
-    auto localIt = localCache->insert_as({hashValue}, lookupKey);
-    BaseStorage *&localInst = localIt.first->storage;
-    if (localInst)
-      return localInst;
-
     // Check for an existing instance in read-only mode.
     {
       llvm::sys::SmartScopedReader<true> typeLock(shard.mutex);
       auto it = shard.instances.find_as(lookupKey);
       if (it != shard.instances.end())
-        return localInst = it->storage;
+        return it->storage;
     }
 
     // Acquire a writer-lock so that we can safely create the new storage
     // instance.
     llvm::sys::SmartScopedWriter<true> typeLock(shard.mutex);
-    return localInst = getOrCreateUnsafe(shard, lookupKey, ctorFn);
+    return getOrCreateUnsafe(shard, lookupKey, ctorFn);
   }
   /// Run a mutation function on the provided storage object in a thread-safe
   /// way.


### PR DESCRIPTION
…  while destroying.  MLIRContext's ThreadLocalCache is removed in a main-line patch from June which we don't have yet.  Thread support is reworked too extensively to patch here and may solve the StorageUniquer situation;  we'll revisit when we're up-to-date.  More discussion at issue #278.

In other words, this is a short-term patch to avoid intermittent crashes;  part of it is already in the main line and part may be superseded by the main line.