### PR TITLE
Improve backtraces in CI and developer testing time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
-project(miopen-mlir)
-cmake_minimum_required(VERSION 3.13.4)
+project(miopen-mlir CXX C)
+cmake_minimum_required(VERSION 3.15.1)
+
+# Adapted from https://blog.kitware.com/cmake-and-the-default-build-type/
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 # Set policy CMP0057 to support IN_LIST operators
 cmake_policy(SET CMP0057 NEW)

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ void buildProject(String target, String cmakeOpts) {
     sh 'python -m pip install pathlib2'
     cmakeBuild generator: 'Ninja',\
         buildDir: 'build',\
-        buildType: 'Release',\
+        buildType: 'RelWithDebInfo',\
         installation: 'InSearchPath',\
         steps: [[args: target]],\
         cmakeArgs: "-DMLIR_MIOPEN_DRIVER_ENABLED=1 $cmakeOpts"
@@ -59,9 +59,6 @@ pipeline {
                             label "${params.canXdlops ? 'gfx908' : 'rocm' } && !single_gpu"
                             alwaysPull true
                         }
-                    }
-                    environment {
-                        PATH="$PATH:/opt/rocm/llvm/bin"
                     }
                     stages {
                         stage('Environment') {
@@ -131,7 +128,7 @@ pipeline {
                         }
                     }
                     environment {
-                        PATH="$PATH:/opt/rocm/llvm/bin"
+                        PATH="/opt/rocm/llvm/bin:$PATH"
                     }
                     stages {
                         stage("Igemm build") {
@@ -193,7 +190,7 @@ pipeline {
                         }
                     }
                     environment {
-                        PATH="$PATH:/opt/rocm/llvm/bin"
+                        PATH="/opt/rocm/llvm/bin:$PATH"
                     }
                     stages {
                         stage("Environment") {
@@ -205,7 +202,7 @@ pipeline {
                             steps {
                                 dir('MIOpen') {
                                     sh 'mkdir MIOpenInstallDir'
-                                    getAndBuildMIOpen('--prefix ./MIOpenDeps', 
+                                    getAndBuildMIOpen('--prefix ./MIOpenDeps',
                                                       '''-DMIOPEN_BACKEND=HIP
                                     -DCMAKE_PREFIX_PATH="${WORKSPACE}/MIOpen/MIOpenDeps"
                                     -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/MIOpen/MIOpenInstallDir
@@ -248,7 +245,7 @@ pipeline {
                                     reportFiles: 'MLIR_Performance_Changes.html,MLIR_vs_MIOpen.html',
                                     reportName: 'Performance report'
                                 ])
-                                
+
                                 plot csvFileName: 'plot-nightly-perf-results-000001.csv',\
                                     csvSeries: [[file: 'build/mlir_vs_miopen_perf_means.csv', displayTableFlag: false]],\
                                     title: 'Test performance summary',\


### PR DESCRIPTION
- Set the default build type to Release
- Set the CI to include debug info in its builds
- Link llvm-symbolizer-10 to llvm-symbolizer
- On builds where MIOpen is built, put the llvm-symbolizer from
  RoCM clang in the front of the path so it gets picked up.

(Note, this Docker change doesn't break anything if not applied, so it
can be packaged with other changes)