### PR TITLE
Enabled nonxdlops perfconfig passthrough

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -27,6 +27,7 @@ class Conv2dGenerator {
 public:
   struct Config {
     std::string arch;
+    std::string perfConfig;
     int num_cu;
     bool xdlops;
     miopen::ConvOpType operation;
@@ -51,7 +52,8 @@ public:
     int filterWidth;
   };
 
-  Conv2dGenerator(const std::string &arch = "", int num_cu = 0,
+  Conv2dGenerator(const std::string &arch = "",
+                  const std::string &perfConfig = "", int num_cu = 0,
                   bool xdlops = false,
                   const miopen::ConvOpType operation = miopen::Conv2DOpType,
                   const std::string &dataTypeStr = "f32",

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -47,7 +47,8 @@ std::unique_ptr<Pass> createTestAffineTransformPass();
 /// Create a pass to affix tuning parameters to gridwise gemm ops.
 std::unique_ptr<Pass>
 createAffixTuningParametersPass(int64_t blockSizeOverride = 0,
-                                int64_t gridSizeOverride = 0);
+                                int64_t gridSizeOverride = 0,
+                                std::string perfConfig = "");
 
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/MIOpen/Passes.h.inc"

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -715,6 +715,7 @@ private:
 public:
   LogicalResult paramsFromCtx(ConvolutionContext &ctx,
                               int64_t blockSizeOverride,
+                              const std::string &perfConfig,
                               InitParamsNonXDL &validParams,
                               DerivedParams &gemmADerivedParam,
                               DerivedParams &gemmBDerivedParam,

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -15,14 +15,15 @@
 using namespace mlir;
 
 Conv2dGenerator::Conv2dGenerator(
-    const std::string &arch, int num_cu, bool xdlops,
-    const miopen::ConvOpType operation, const std::string &dataTypeStr,
-    int dilationHeight, int dilationWidth, int strideHeight, int strideWidth,
-    int paddingHeightLeft, int paddingHeightRight, int paddingWidthLeft,
-    int paddingWidthRight, const std::string &filterLayout,
-    const std::string &inputLayout, const std::string &outputLayout,
-    const std::string &kernelName)
+    const std::string &arch, const std::string &perfConfig, int num_cu,
+    bool xdlops, const miopen::ConvOpType operation,
+    const std::string &dataTypeStr, int dilationHeight, int dilationWidth,
+    int strideHeight, int strideWidth, int paddingHeightLeft,
+    int paddingHeightRight, int paddingWidthLeft, int paddingWidthRight,
+    const std::string &filterLayout, const std::string &inputLayout,
+    const std::string &outputLayout, const std::string &kernelName)
     : config{arch,
+             perfConfig,
              num_cu,
              xdlops,
              operation,
@@ -169,6 +170,7 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
     };
 
     strToStr("arch", config.arch);
+    strToStr("perf_config", config.perfConfig);
     strToInt("num_cu", config.num_cu);
     strToInt("x2", config.xdlops);
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -16,9 +16,10 @@ using namespace mlir;
 namespace {
 struct AffixTuningParameters : public MIOpenOpsAffixTuningParametersPassBase<AffixTuningParameters> {
 public:
-  AffixTuningParameters(int64_t blockSizeOverride, int64_t gridSizeOverride)
+  AffixTuningParameters(int64_t blockSizeOverride, int64_t gridSizeOverride,
+                        std::string perfConfig)
       : blockSizeOverride(blockSizeOverride),
-        gridSizeOverride(gridSizeOverride) {}
+        gridSizeOverride(gridSizeOverride), perfConfig(perfConfig) {}
   void runOnFunction() override;
 
 private:
@@ -35,6 +36,7 @@ private:
   //   coherent tuning parameters with the pre-set block size.
   int64_t blockSizeOverride;
   int64_t gridSizeOverride;
+  std::string perfConfig;
 
   // Actual implementation.
   template <typename T> void affixTuningParametersImpl(T &op);
@@ -190,8 +192,9 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
 
     PopulateParams populateParams;
     LogicalResult status = populateParams.paramsFromCtx(
-        convContext, blockSizeOverride, validParams, gemmADerivedParam,
-        gemmBDerivedParam, blockGemmDerivedParam, gemmCDstPerWrite, gridSize);
+        convContext, blockSizeOverride, perfConfig, validParams,
+        gemmADerivedParam, gemmBDerivedParam, blockGemmDerivedParam,
+        gemmCDstPerWrite, gridSize);
 
     if (failed(status)) {
       signalPassFailure();
@@ -255,7 +258,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
 
 std::unique_ptr<Pass>
 mlir::miopen::createAffixTuningParametersPass(int64_t blockSizeOverride,
-                                              int64_t gridSizeOverride) {
+                                              int64_t gridSizeOverride,
+                                              std::string perfConfig) {
   return std::make_unique<AffixTuningParameters>(blockSizeOverride,
-                                                 gridSizeOverride);
+                                                 gridSizeOverride, perfConfig);
 }

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
@@ -930,7 +930,7 @@ void mlir::translateModuleFromMIOpenToCFlags(ModuleOp m, std::string &cflags) {
       int64_t gridSize;
       PopulateParams populateParams;
       (void)populateParams.paramsFromCtx(
-          ctx, 0, validParams, gemmADerivedParam, gemmBDerivedParam,
+          ctx, 0, "", validParams, gemmADerivedParam, gemmBDerivedParam,
           blockGemmDerivedParam, gemmCDstPerWrite, gridSize);
 
       std::map<std::string, int> parameters;

--- a/mlir/test/mlir-miopen-lib/perf_config.mlir
+++ b/mlir/test/mlir-miopen-lib/perf_config.mlir
@@ -1,0 +1,9 @@
+// RUN: mlir-miopen-lib-test --args " --operation conv2d --arch amdgcn-amd-amdhsa:gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1 --perf_config 64,32,32,4,2,2" --option bin | FileCheck %s --check-prefix=BIN
+// RUN: mlir-miopen-driver --conv-config " --operation conv2d --arch amdgcn-amd-amdhsa:gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1 --perf_config 64,32,32,4,2,2" -c -target=tuning | FileCheck %s --check-prefix=Tuning
+
+// BIN: ELF
+// Tuning: block_size = 64
+// Tuning: m_per_block = 32
+// Tuning: m_per_thread = 2
+// Tuning: n_per_block = 32
+// Tuning: n_per_thread = 2

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -65,6 +65,11 @@ static cl::opt<std::string>
          cl::desc("amdgpu architecture, eg: gfx803, gfx900, gfx906, gfx908"),
          cl::value_desc("GFX architecture string"), cl::init("gfx906"));
 
+static cl::opt<std::string>
+    perfConfig("perf_config",
+               cl::desc("performance config data used for tuning"),
+               cl::value_desc("Serialized tuning parameters"), cl::init(""));
+
 static cl::opt<int>
     num_cu("num_cu",
            cl::desc("Number of compute units, valid combinations include: "
@@ -2436,12 +2441,18 @@ static LogicalResult populateKernelLaunchLogic(
   return success();
 }
 
-static void populateDefaultLoweringPipeline(PassManager &pm) {
-  // Passes for lowering MIOpen dialect.
+static void populateTuningPipeline(PassManager &pm,
+                                   const std::string &perfConfig) {
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
   pm.addPass(mlir::miopen::createAffineTransformPass());
-  pm.addPass(
-      mlir::miopen::createAffixTuningParametersPass(blockSize, gridSize));
+  pm.addPass(mlir::miopen::createAffixTuningParametersPass(blockSize, gridSize,
+                                                           perfConfig));
+}
+
+static void populateDefaultLoweringPipeline(PassManager &pm,
+                                            const std::string &perfConfig) {
+  // Passes for lowering MIOpen dialect.
+  populateTuningPipeline(pm, perfConfig);
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep2Pass());
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep3Pass());
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep4Pass());
@@ -2456,7 +2467,8 @@ static void populateDefaultLoweringPipeline(PassManager &pm) {
 }
 
 static LogicalResult runMLIRPasses(ModuleOp &module,
-                                   mlir::PassPipelineCLParser &passPipeline) {
+                                   mlir::PassPipelineCLParser &passPipeline,
+                                   const std::string &perfConfig) {
   PassManager pm(module.getContext(), PassManager::Nesting::Implicit);
   applyPassManagerCLOptions(pm);
 
@@ -2464,12 +2476,16 @@ static LogicalResult runMLIRPasses(ModuleOp &module,
   bool toUseBuiltinPipeline = loweringWithBuiltinPipeline.getValue();
   if (toUseBuiltinPipeline) {
     StringRef pipeline = loweringTargetDialect.getValue();
-    if (pipeline == "gpu") {
+    if (pipeline == "tuning") {
+      // Set up the default lowering pipeline which goes down to affix tuning
+      // parameters
+      populateTuningPipeline(pm, perfConfig);
+    } else if (pipeline == "gpu") {
       // Set up the default lowering pipeline which goes down to GPU dialect.
-      populateDefaultLoweringPipeline(pm);
+      populateDefaultLoweringPipeline(pm, perfConfig);
     } else if (pipeline == "rocdl") {
       // Set up the lowering pipeline which goes down to ROCDL dialect.
-      populateDefaultLoweringPipeline(pm);
+      populateDefaultLoweringPipeline(pm, perfConfig);
       pm.addPass(createLowerGpuOpsToROCDLOpsPass(/*indexBitWidth=*/32));
     }
   } else {
@@ -2542,8 +2558,8 @@ int main(int argc, char **argv) {
   }
 
   Conv2dGenerator conv2dGenerator(
-      arch.getValue(), num_cu.getValue(), xdlopsV2.getValue(),
-      operation.getValue(), tensorDataType.getValue(),
+      arch.getValue(), perfConfig.getValue(), num_cu.getValue(),
+      xdlopsV2.getValue(), operation.getValue(), tensorDataType.getValue(),
       dilationHeight.getValue(), dilationWidth.getValue(),
       strideHeight.getValue(), strideWidth.getValue(),
       paddingHeightLeft.getValue(), paddingHeightRight.getValue(),
@@ -2655,8 +2671,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  // Apply passes.
-  if (failed(runMLIRPasses(module, passPipeline))) {
+  // Run MLIR passes with passed in tuning parameters
+  if (failed(runMLIRPasses(module, passPipeline, genConfig.perfConfig))) {
     llvm::errs() << "Lowering failed.\n";
     exit(1);
   }

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -38,6 +38,7 @@ struct MiirHandle_s {
   MLIRContext context;
   mlir::OwningModuleRef module;
   std::string arch;
+  std::string perfConfig;
   std::string genTxt;
   int kernelCount;
 };
@@ -104,6 +105,7 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
   }
 
   handle->arch = config.arch;
+  handle->perfConfig = config.perfConfig;
   handle->kernelCount = conv2dGenerator.getKernelCount();
 
   ModuleOp module = handle->getModule();
@@ -256,7 +258,8 @@ extern "C" MiirStatus miirLowerTuningParams(MiirHandle mlirHandle) {
   // Passes for lowering MIOpen dialect.
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
   pm.addPass(mlir::miopen::createAffineTransformPass());
-  pm.addPass(mlir::miopen::createAffixTuningParametersPass(0, 0));
+  pm.addPass(
+      mlir::miopen::createAffixTuningParametersPass(0, 0, handle->perfConfig));
 
   auto status = pm.run(module);
 
@@ -289,7 +292,8 @@ extern "C" MiirStatus miirLowerBin(MiirHandle mlirHandle) {
   // Passes for lowering MIOpen dialect.
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
   pm.addPass(mlir::miopen::createAffineTransformPass());
-  pm.addPass(mlir::miopen::createAffixTuningParametersPass(0, 0));
+  pm.addPass(
+      mlir::miopen::createAffixTuningParametersPass(0, 0, handle->perfConfig));
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep2Pass());
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep3Pass());
   pm.addPass(mlir::miopen::createLowerMIOpenOpsStep4Pass());


### PR DESCRIPTION
This is the first step in implementing the following feature: https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/88

* Added plumbing code for perfConfig to pass through mlir-miopen-driver
  and mlir-miopen-lib
* PerfConfig is deserialized in GridwiseGemmParams
* Added test to make sure tuning parameters are overriden from the
  command line options