### PR TITLE
Fix CI for PRs after the OOT transition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,18 @@ set(MLIR_MIOPEN_DRIVER_TEST_GPU_VALIDATION 1 CACHE BOOL "Enable E2E tests with G
 set(MLIR_MIOPEN_SQLITE_ENABLED 0 CACHE BOOL "Enable SQLite integration")
 set(MLIR_ENABLE_SQLITE "${MLIR_MIOPEN_SQLITE_ENABLED}")
 
+# LLVM settings that have an effect on the MLIR dialect
+set(LLVM_TARGETS_TO_BUILD "X86;AMDGPU" CACHE STRING "")
+
+# Build the ROCm conversions and run according tests if the AMDGPU backend
+# is available
+if ("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
+  set(MLIR_ROCM_CONVERSIONS_ENABLED 1)
+else()
+  set(MLIR_ROCM_CONVERSIONS_ENABLED 0)
+endif()
+add_definitions(-DMLIR_ROCM_CONVERSIONS_ENABLED=${MLIR_ROCM_CONVERSIONS_ENABLED})
+
 # Pointers to: 1) external LLVM bins/libs, and 2) MIOpen Dialect bins/libs
 set(LLVM_EXTERNAL_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/bin" CACHE PATH "")
 set(LLVM_EXTERNAL_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/lib" CACHE PATH "")

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -7,15 +7,6 @@ set(CMAKE_BUILD_TYPE Release CACHE INTERNAL "")
 set(MLIR_CMAKE_CONFIG_DIR
    "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir")
 
-# Build the ROCm conversions and run according tests if the AMDGPU backend
-# is available
-if ("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
-  set(MLIR_ROCM_CONVERSIONS_ENABLED 1)
-else()
-  set(MLIR_ROCM_CONVERSIONS_ENABLED 0)
-endif()
-add_definitions(-DMLIR_ROCM_CONVERSIONS_ENABLED=${MLIR_ROCM_CONVERSIONS_ENABLED})
-
 # MLIR settings
 set(MLIR_ROCM_RUNNER_ENABLED 1 CACHE BOOL "Enable building the mlir ROCm runner")
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
@@ -23,7 +14,6 @@ set(MLIR_TABLEGEN_EXE mlir-tblgen)
 # LLVM settings
 set(LLVM_ENABLE_PROJECTS "mlir;lld" CACHE STRING "List of default llvm targets")
 set(LLVM_BUILD_EXAMPLES ON CACHE BOOL "")
-set(LLVM_TARGETS_TO_BUILD "X86;AMDGPU" CACHE STRING "")
 set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
 set(LLVM_ENABLE_ASSERTIONS ON CACHE BOOL "")

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -97,6 +97,8 @@ pipeline {
                                   ln -s build/compile_commands.json compile_commands.json
                                 fi
                                 '''
+                                // Before premerge-checks, reset all mods from the OOT patcher tool
+                                sh 'git checkout external/llvm-project && git clean -fd external/llvm-project'
                                 sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
                             }
                         }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -50,10 +50,10 @@ pipeline {
         }
         stage('Igemm Build') {
             steps {
+                sh 'rm -rf build'
                 cmakeBuild generator: 'Ninja',\
                     buildDir: 'build',\
                     buildType: 'Release',\
-                    cleanBuild: true,\
                     installation: 'InSearchPath',\
                     steps: [[args: 'libMLIRMIOpen']],\
                     cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -53,6 +53,7 @@ pipeline {
                 cmakeBuild generator: 'Ninja',\
                     buildDir: 'build',\
                     buildType: 'Release',\
+                    cleanBuild: true,\
                     installation: 'InSearchPath',\
                     steps: [[args: 'libMLIRMIOpen']],\
                     cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -43,6 +43,8 @@ pipeline {
                        ln -s build/compile_commands.json compile_commands.json
                     fi
                     '''
+                // Before premerge-checks, reset all mods from the OOT patcher tool
+                sh 'git checkout external/llvm-project && git clean -fd external/llvm-project'
                 sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
             }
         }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
@@ -50,10 +50,10 @@ pipeline {
         }
         stage('Igemm Build') {
             steps {
+                sh 'rm -rf build'
                 cmakeBuild generator: 'Ninja',\
                     buildDir: 'build',\
                     buildType: 'Release',\
-                    cleanBuild: true,\
                     installation: 'InSearchPath',\
                     steps: [[args: 'libMLIRMIOpen']],\
                     cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'

--- a/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
@@ -53,6 +53,7 @@ pipeline {
                 cmakeBuild generator: 'Ninja',\
                     buildDir: 'build',\
                     buildType: 'Release',\
+                    cleanBuild: true,\
                     installation: 'InSearchPath',\
                     steps: [[args: 'libMLIRMIOpen']],\
                     cmakeArgs: '-DBUILD_FAT_LIBMLIRMIOPEN=ON'

--- a/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream-xdlop
@@ -43,6 +43,8 @@ pipeline {
                        ln -s ./build/compile_commands.json compile_commands.json
                     fi
                     '''
+                // Before premerge-checks, reset all mods from the OOT patcher tool
+                sh 'git checkout external/llvm-project && git clean -fd external/llvm-project'
                 sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
             }
         }

--- a/mlir/utils/jenkins/static-checks/premerge-checks.py
+++ b/mlir/utils/jenkins/static-checks/premerge-checks.py
@@ -87,7 +87,7 @@ def run_clang_tidy(base_commit, ignore_config):
     diff = remove_ignored(diff.splitlines(keepends=True), open(ignore_config, 'r'))
   else:
     ignore = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, [])
-  p = subprocess.Popen(['./clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py', '-p0', '-quiet'],
+  p = subprocess.Popen(['./external/llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py', '-p0', '-quiet'],
                        stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
   a = ''.join(diff)
   out = p.communicate(input=a.encode())[0].decode()


### PR DESCRIPTION
We're seeing CI errors like the following with all PRs (post-OOT):
```
+ python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py

The following files would be modified but have unstaged changes:

M	external/llvm-project/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp

M	external/llvm-project/mlir/lib/Dialect/Vector/VectorOps.cpp

Please commit, stage, or stash them first.

script returned exit code 1
```