### PR TITLE
Adopt correct configuration parameters passed via --conv-config

### DIFF
--- a/mlir/test/mlir-miopen-driver/populate_conv_config.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_conv_config.mlir
@@ -1,0 +1,87 @@
+// RUN: mlir-miopen-driver --conv-config "--x2 1 --operation conv2d_bwd_weight  --kernel_id 0 --num_cu 120 --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --groupsize 1 --fil_layout GNCHW --fil_type fp32 --in_layout NGCHW --out_layout NGCHW --in_type fp32 --out_type fp32 --batchsize 256 --in_channels 1024 --out_channels 2048 --in_h 14 --in_w 14 --fil_h 1 --fil_w 1 --out_h 8 --out_w 8 --dilation_h 2 --dilation_w 2 --conv_stride_h 2 --conv_stride_w 2 --padding_h 1 --padding_w 1 --kernel_name mlir_gen_igemm_conv2d_v4r4_wrw_xdlops" -pv | FileCheck %s --check-prefix=PV
+
+//PV: [[FIL1:%.*]] = alloc() : memref<1x2048x1024x1x1xf32>
+//PV: [[FIL2:%.*]] = alloc() : memref<1x2048x1024x1x1xf32>
+//PV: call @verify_results([[FIL2]], [[FIL1]])
+//PV: %{{.*}} = memref_cast %{{.*}} : memref<256x1x2048x8x8xf32> to memref<*xf32>
+//PV-NEXT: [[S1:%.*]] = constant 2 : i32
+//PV-NEXT: [[S2:%.*]] = constant 2 : i32
+//PV-NEXT: [[P1:%.*]] = constant 1 : i32
+//PV-NEXT: [[P2:%.*]] = constant 1 : i32
+//PV-NEXT: [[P3:%.*]] = constant 1 : i32
+//PV-NEXT: [[P4:%.*]] = constant 1 : i32
+//PV-NEXT: [[D1:%.*]] = constant 2 : i32
+//PV-NEXT: [[D2:%.*]] = constant 2 : i32
+//PV: [[G:%.*]] = constant 103 : i8
+//PV: [[K:%.*]] = constant 107 : i8
+//PV: [[C:%.*]] = constant 99 : i8
+//PV: [[Y:%.*]] = constant 121 : i8
+//PV: [[X:%.*]] = constant 120 : i8
+//PV: [[N:%.*]] = constant 110 : i8
+//PV: [[H:%.*]] = constant 104 : i8
+//PV: [[W:%.*]] = constant 119 : i8
+//PV: store [[G]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[K]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[C]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[Y]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[X]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[N]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[G]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[C]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[H]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[W]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[N]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[G]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[K]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[H]], %{{.*}} : memref<5xi8>
+//PV-NEXT: store [[W]], %{{.*}} : memref<5xi8>
+//PV: call @mcpuConv2dBwdWeight(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, [[S1]], [[S2]], [[P1]], [[P2]], [[P3]], [[P4]], [[D1]], [[D2]]) : {{.*}}
+
+// RUN: mlir-miopen-driver --conv-config "--x2 1 --operation conv2d_bwd_weight  --kernel_id 0 --num_cu 120 --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --groupsize 1 --fil_layout GNCHW --fil_type fp32 --in_layout NGCHW --out_layout NGCHW --in_type fp32 --out_type fp32 --batchsize 256 --in_channels 1024 --out_channels 2048 --in_h 14 --in_w 14 --fil_h 1 --fil_w 1 --out_h 8 --out_w 8 --dilation_h 2 --dilation_w 2 --conv_stride_h 2 --conv_stride_w 2 --padding_h 1 --padding_w 1 --kernel_name mlir_gen_igemm_conv2d_v4r4_wrw_xdlops" -pv_with_gpu | FileCheck %s --check-prefix=PVGPU
+
+//PVGPU: miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2) {arch = "gfx908", dilations = [2 : i32, 2 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 0 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [1 : i32, 1 : i32, 1 : i32, 1 : i32], strides = [2 : i32, 2 : i32], xdlopsV2 = true} : memref<1x2048x1024x1x1xf32>, memref<256x1x1024x14x14xf32>, memref<256x1x2048x8x8xf32>
+//PVGPU: miopen.conv2d_bwd_weight(%{{.*}}, %{{.*}}, %{{.*}}) {arch = "gfx908", dilations = [2 : i32, 2 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 0 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [1 : i32, 1 : i32, 1 : i32, 1 : i32], strides = [2 : i32, 2 : i32]} : memref<1x2048x1024x1x1xf32>, memref<256x1x1024x14x14xf32>, memref<256x1x2048x8x8xf32>
+
+// RUN: mlir-miopen-driver --conv-config "--x2 1 --operation conv2d_bwd_weight  --kernel_id 0 --num_cu 120 --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --groupsize 1 --fil_layout GNCHW --fil_type fp32 --in_layout NGCHW --out_layout NGCHW --in_type fp32 --out_type fp32 --batchsize 256 --in_channels 1024 --out_channels 2048 --in_h 14 --in_w 14 --fil_h 1 --fil_w 1 --out_h 8 --out_w 8 --dilation_h 2 --dilation_w 2 --conv_stride_h 2 --conv_stride_w 2 --padding_h 1 --padding_w 1 --kernel_name mlir_gen_igemm_conv2d_v4r4_wrw_xdlops" -prc | FileCheck %s --check-prefix=PRC
+
+//PRC:[[FIL:%.*]] = memref_cast %{{.*}} : memref<1x2048x1024x1x1xf32> to memref<*xf32>
+//PRC-NEXT: call @print_memref_f32([[FIL]]) : (memref<*xf32>) -> ()
+//PRC: %{{.*}} = memref_cast %{{.*}} : memref<256x1x2048x8x8xf32> to memref<*xf32>
+//PRC-NEXT: [[S1:%.*]] = constant 2 : i32
+//PRC-NEXT: [[S2:%.*]] = constant 2 : i32
+//PRC-NEXT: [[P1:%.*]] = constant 1 : i32
+//PRC-NEXT: [[P2:%.*]] = constant 1 : i32
+//PRC-NEXT: [[P3:%.*]] = constant 1 : i32
+//PRC-NEXT: [[P4:%.*]] = constant 1 : i32
+//PRC-NEXT: [[D1:%.*]] = constant 2 : i32
+//PRC-NEXT: [[D2:%.*]] = constant 2 : i32
+//PRC: [[G:%.*]] = constant 103 : i8
+//PRC: [[K:%.*]] = constant 107 : i8
+//PRC: [[C:%.*]] = constant 99 : i8
+//PRC: [[Y:%.*]] = constant 121 : i8
+//PRC: [[X:%.*]] = constant 120 : i8
+//PRC: [[N:%.*]] = constant 110 : i8
+//PRC: [[H:%.*]] = constant 104 : i8
+//PRC: [[W:%.*]] = constant 119 : i8
+//PRC: store [[G]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[K]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[C]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[Y]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[X]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[N]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[G]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[C]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[H]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[W]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[N]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[G]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[K]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[H]], %{{.*}} : memref<5xi8>
+//PRC-NEXT: store [[W]], %{{.*}} : memref<5xi8>
+//PRC: call @mcpuConv2dBwdWeight(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, [[S1]], [[S2]], [[P1]], [[P2]], [[P3]], [[P4]], [[D1]], [[D2]]) : {{.*}}
+
+// RUN:  mlir-miopen-driver --conv-config "--x2 1 --operation conv2d_bwd_weight  --kernel_id 0 --num_cu 120 --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --groupsize 1 --fil_layout GNCHW --fil_type fp32 --in_layout NGCHW --out_layout NGCHW --in_type fp32 --out_type fp32 --batchsize 256 --in_channels 1024 --out_channels 2048 --in_h 14 --in_w 14 --fil_h 1 --fil_w 1 --out_h 8 --out_w 8 --dilation_h 2 --dilation_w 2 --conv_stride_h 2 --conv_stride_w 2 --padding_h 1 --padding_w 1 --kernel_name mlir_gen_igemm_conv2d_v4r4_wrw_xdlops" -ph -pr  | FileCheck %s --check-prefix=PH
+
+//PH: [[FIL:%.*]] = memref_cast %{{.*}} : memref<1x2048x1024x1x1xf32> to memref<*xf32>
+//PH-NEXT: call @print_memref_f32([[FIL]]) : (memref<*xf32>) -> ()
+


### PR DESCRIPTION
In mlir-miopen-driver.cpp, replace accesses to command line options with accesses to genConfig, such that correct configurations are used no matter how the configurations are passed in (via command line options or --conv-config).