### PR TITLE
Suppress CMake warnings and remove redundant project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
-project(miopen-mlir CXX C)
 cmake_minimum_required(VERSION 3.15.1)
+
+# Allow VERSION for projects, as expected in CMake 3.0+
+cmake_policy(SET CMP0048 NEW)
+project(miopen-mlir VERSION 0.202108 LANGUAGES CXX C)
+
+# New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
 
 # Adapted from https://blog.kitware.com/cmake-and-the-default-build-type/
 set(default_build_type "Release")

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.13.4)  # fixme: double-check versions
-
-project(mlir-miopen)
-
 message(STATUS "LLVM_INCLUDE_DIRS: ${LLVM_INCLUDE_DIRS}")
 message(STATUS "MLIR_INCLUDE_DIRS: ${MLIR_INCLUDE_DIRS}")
 message(STATUS "LLVM_BUILD_LIBRARY_DIR: ${LLVM_BUILD_LIBRARY_DIR}")
@@ -26,8 +22,8 @@ append_if(C_SUPPORTS_WERROR_IMPLICIT_FUNCTION_DECLARATION "-Werror=implicit-func
 
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_BINARY_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/mlir/include)
+include_directories(${PROJECT_BINARY_DIR}/mlir/include)
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 


### PR DESCRIPTION
This removes the warnings about Ninja's depfiles generator that our project (and LLVM) produce on CMake 3.20+. It also undoes the implicit reset of that policy change caused by a second project() command in the MLIR CMakeFiles.txt.

Not having two calls to project() might, if we're lucky, also address some of the compile_commands.json issues we've been having.