### PR TITLE
Fix (or suppress) compiler warnings that show up with check-mlir.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -415,7 +415,7 @@ emitStoreLogic(OpBuilder &b, Location loc, MemRefType destType,
                const Value &dest, const SmallVector<Value, 8> &destLowerIndices,
                const Value &value,
                InMemoryDataOperation memoryOp = InMemoryDataOperation::Set) {
-  auto emitStoreInstruction = [&b, &loc, &memoryOp](
+  auto emitStoreInstruction = [&b, &loc](
                                   const Value &value, MemRefType destType,
                                   Type typeToStore, const Value &dest,
                                   const SmallVector<Value, 8> &destLowerIndices,
@@ -1419,7 +1419,7 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
     auto outputElementType = outputType.getElementType();
 
     // HO/WO dimension for output tensor.
-    int64_t outputHDim, outputWDim;
+    int64_t outputHDim = 0, outputWDim = 0;
 
     // Find Ho/Wo dimension for output tensor. They will be used in
     // transforming input tensor.
@@ -1496,6 +1496,7 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
 
     int64_t gemmM_size, gemmN_size, gemmK_size;
     int64_t gemmMExtra, gemmNExtra, gemmKExtra;
+    gemmM_size = gemmN_size = gemmK_size = 0;
     gemmMExtra = gemmNExtra = gemmKExtra = 0;
     // compute we should use extra padding kernel or not
     // c,k already / g ,so we can skip / g here
@@ -1576,7 +1577,7 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
     // Transform filter tensor.
 
     // Y/X dimension for filter tensor.
-    int64_t filterYDim, filterXDim;
+    int64_t filterYDim = 0, filterXDim = 0;
 
     llvm::SmallVector<int64_t, 2> transformedFilterShape;
 

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -208,6 +208,7 @@ int Conv2dGenerator::getKernelCount() const {
   case miopen::Conv2DBwdWeightOpType:
     return 1;
   }
+  llvm_unreachable("Invalid conv2d operation");
 }
 
 int Conv2dGenerator::getBwdDataKernelCount() const {

--- a/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenOps.cpp
@@ -52,6 +52,7 @@ const char *getNameForConvOpType(const miopen::ConvOpType op) {
   case Conv2DBwdWeightOpType:
     return "conv2d_bwd_weight";
   }
+  llvm_unreachable("Invalid ConvOp type");
 }
 } // namespace miopen
 } // namespace mlir

--- a/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
@@ -38,7 +38,10 @@
 #include "lld/Common/Driver.h"
 
 // TODO: remove this once the rocm_agent_enumerator is ready
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "hip/hip_runtime.h"
+#pragma GCC diagnostic pop
 
 #include <mutex>
 #include <numeric>

--- a/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
@@ -55,6 +55,13 @@ target_link_libraries(rocm-runtime-wrappers
   LLVMSupport
   ${ROCM_RUNTIME_LIBRARY}
 )
+# Suppress some compiler warnings when building with clang.  The first two
+# suppressions regard a GNU extension, the third an incomplete-type warning
+# that apparently works out okay.
+set_source_files_properties(rocm-runtime-wrappers.cpp PROPERTIES
+  COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types;-Wno-return-type-c-linkage")
+set_source_files_properties(BackendUtils.cpp PROPERTIES
+  COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types")
 
 set(LIBS
   lldCommon
@@ -93,4 +100,3 @@ target_include_directories(LLVMROCmBackendUtils
   "${HIP_PATH}/include"
 )
 target_link_libraries(LLVMROCmBackendUtils PRIVATE ${LIBS} ${targets_to_link})
-

--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -19,7 +19,10 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/raw_ostream.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "hip/hip_runtime.h"
+#pragma GCC diagnostic pop
 #include <unordered_map>
 
 namespace {

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -676,7 +676,7 @@ std::string mlir::translateModuleFromMIOpenToHeaderXDLOPS(ModuleOp m) {
       auto filterLayoutAttr = op->getAttrOfType<ArrayAttr>("filter_layout");
       auto inputLayoutAttr = op->getAttrOfType<ArrayAttr>("input_layout");
 
-      size_t dimKF, dimNI, dimCI;
+      size_t dimKF = 0, dimNI = 0, dimCI = 0;
       for (size_t i = 0; i < 5; ++i) {
         auto filterDim = filterLayoutAttr.getValue()[i].dyn_cast<StringAttr>().getValue();
 


### PR DESCRIPTION
Silence some compiler warnings from a HIP include file when compiling
with old g++ (like the 7.5.0 on ixt19).

Remove unused lambda capture.

Fix some compiler warnings about maybe-uninitialised variables and
running off the end of a function.