### PR TITLE
Fix MIOpen benchmark python error (object of type NoneType has no len)

### DIFF
--- a/mlir/utils/jenkins/MIOpenDriver.py
+++ b/mlir/utils/jenkins/MIOpenDriver.py
@@ -270,7 +270,7 @@ def runConfigWithMIOpenDriver(commandLine):
     print("Running MIOpen Benchmark: ", commandLine)
     profilerCommand = ROCPROF + ' --stats ' + MIOpenDriverCommand
     # invoke rocprof + MIOpenDriver.
-    p1 = subprocess.Popen(profilerCommand.split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    p1 = subprocess.Popen(profilerCommand.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     # get output.
     try:
         outs, errs = p1.communicate(timeout=180)


### PR DESCRIPTION
Nightlies are failing due to an issue with performance testing.  
```
Running MLIR Benchmark:  ConvConiguration(dtype='f16', direction='wrw', layout='NCHW',
                n=256, c=64, hi=56, wi=56, k=64, y=3, x=3,
                convStrideH=1, convStrideW=1, paddingH=1, paddingW=1,
                dilationH=1, dilationW=1, group=1, xdlops=True)
rm: cannot remove 'results.stats.csv': No such file or directory
Running MIOpen Benchmark:  ['conv', '-F', '1', '-f', 'NCHW', '-I', 'NCHW', '-O', 'NCHW', '-n', '256', '-c', '1024', '-H', '14', '-W', '14', '-k', '2048', '-y', '1', '-x', '1', '-p', '0', '-q', '0', '-u', '2', '-v', '2', '-l', '1', '-j', '1', '-m', 'conv', '-g', '1', '-t', '1']
Traceback (most recent call last):
  File "../mlir/utils/jenkins/MIOpenDriver.py", line 354, in <module>
    generatePerformanceResults(configs, xdlops)
  File "../mlir/utils/jenkins/MIOpenDriver.py", line 331, in generatePerformanceResults
    miopen_df = pd.DataFrame(benchmarkMIOpen(testVector.split(sep=' '), xdlops) for testVector in configs)
  File "/home/jeffp/.local/lib/python3.6/site-packages/pandas/core/frame.py", line 502, in __init__
    data = list(data)
  File "../mlir/utils/jenkins/MIOpenDriver.py", line 331, in <genexpr>
    miopen_df = pd.DataFrame(benchmarkMIOpen(testVector.split(sep=' '), xdlops) for testVector in configs)
  File "../mlir/utils/jenkins/MIOpenDriver.py", line 296, in benchmarkMIOpen
    runConfigWithMIOpenDriver(commandLine)
  File "../mlir/utils/jenkins/MIOpenDriver.py", line 277, in runConfigWithMIOpenDriver
    if len(errs) > 0:
TypeError: object of type 'NoneType' has no len()
```
@yiqian1 suggested the following fix.  Local tests show successful runs.  

