### PR TITLE
Enable xdlops perfconfig passthrough

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -550,6 +550,14 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
   }
 };
 
+template <typename T> std::string genDebugForParams(T params) {
+  std::ostringstream os;
+  os << "DB load succeed: ";
+  params.visit(params, [&os](auto &arg) { os << arg << ","; });
+  os << "\n";
+  return os.str();
+}
+
 // block gemm tuning params that sepcific the layout of thread-wise gemm in a
 // workgroup
 struct DerivedBlockGemmParams {
@@ -880,6 +888,7 @@ private:
 public:
   LogicalResult paramsFromCtx(ConvolutionContext &ctx,
                               int64_t blockSizeOverride,
+                              const std::string &perfConfig,
                               InitParamsXDL &validParams,
                               DerivedParams &gemmADerivedParam,
                               DerivedParams &gemmBDerivedParam,

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -145,8 +145,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     int64_t gridSize = 0;
 
     LogicalResult status = populateParamsXDL.paramsFromCtx(
-        convContext, blockSizeOverride, validParams, gemmADerivedParam,
-        gemmBDerivedParam, blockSize, gridSize);
+        convContext, blockSizeOverride, perfConfig, validParams,
+        gemmADerivedParam, gemmBDerivedParam, blockSize, gridSize);
 
     if (failed(status)) {
       signalPassFailure();

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -825,9 +825,9 @@ std::string mlir::translateModuleFromMIOpenToCFlagsXDLOPS(ModuleOp m) {
       DerivedParams gemmBDerivedParam;
       int64_t blockSize = 0;
       int64_t gridSize = 0;
-      (void)populateParams.paramsFromCtx(ctx, 0, validParams, gemmADerivedParam,
-                                         gemmBDerivedParam, blockSize,
-                                         gridSize);
+      (void)populateParams.paramsFromCtx(ctx, 0, "", validParams,
+                                         gemmADerivedParam, gemmBDerivedParam,
+                                         blockSize, gridSize);
 
       parameters["CK_PARAM_TUNABLE_BLOCK_SIZE"] = blockSize;
       parameters["CK_PARAM_DEPENDENT_GRID_SIZE"] = gridSize;

--- a/mlir/test/mlir-miopen-lib/perf_config.mlir
+++ b/mlir/test/mlir-miopen-lib/perf_config.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-miopen-lib-test --args " --operation conv2d --arch amdgcn-amd-amdhsa:gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1 --perf_config 64,32,32,4,2,2" --option bin | FileCheck %s --check-prefix=BIN
 // RUN: mlir-miopen-driver --conv-config " --operation conv2d --arch amdgcn-amd-amdhsa:gfx906 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1 --perf_config 64,32,32,4,2,2" -c -target=tuning | FileCheck %s --check-prefix=Tuning
+// RUN: mlir-miopen-driver --conv-config " --operation conv2d --arch amdgcn-amd-amdhsa:gfx908 --num_cu 64 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1 --perf_config 8,64,8,8,64,0,false,false --x2 1" -c -target=tuning | FileCheck %s --check-prefix=Tuning-xdlops
 
 // BIN: ELF
 // Tuning: block_size = 64
@@ -7,3 +8,8 @@
 // Tuning: m_per_thread = 2
 // Tuning: n_per_block = 32
 // Tuning: n_per_thread = 2
+// Tuning-xdlops: k_per_block = 8
+// Tuning-xdlops: m_per_block = 8
+// Tuning-xdlops: m_per_wave = 8
+// Tuning-xdlops: n_per_block = 64
+// Tuning-xdlops: n_per_wave = 64


### PR DESCRIPTION
This is the second step to implementing the following feature: https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/88. 

For previous PR to nonxdlops please see https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/pull/325.

* Added plumbing code for perfConfig to pass through mlir-miopen-driver
  and mlir-miopen-lib
* PerfConfig is deserialized in GridwiseGemmParams
* Added test to make sure tuning parameters are overridden from the
  command line options