### PR TITLE
Get AMD GCN Arch names from rocm_agent_enumerator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(MLIR_ENABLE_SQLITE "${MLIR_MIOPEN_SQLITE_ENABLED}")
 set(LLVM_ENABLE_ZLIB "OFF" CACHE STRING "")
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
 
+set(USE_ROCM_4_4_OR_OLDER 0 CACHE BOOL "Use the rocm_4.4 or older release")
 # LLVM settings that have an effect on the MLIR dialect
 set(LLVM_TARGETS_TO_BUILD "X86;AMDGPU" CACHE STRING "")
 

--- a/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
+++ b/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
@@ -56,8 +56,7 @@ private:
                             const std::string &features);
   LogicalResult createHsaco(const Blob &isaBlob, StringRef name,
                             Blob &hsacoBlob);
-  void configTargetChip(std::string &targetChip);
-  void configTargetFeatures(std::string &features);
+  void configTargetChip(std::string &targetChip, std::string &features);
 };
 } // namespace mlir
 

--- a/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
+++ b/mlir/include/mlir/ExecutionEngine/ROCm/BackendUitls.h
@@ -56,7 +56,7 @@ private:
                             const std::string &features);
   LogicalResult createHsaco(const Blob &isaBlob, StringRef name,
                             Blob &hsacoBlob);
-  void configTargetChip(std::string &targetChip, std::string &features);
+  void configTarget(std::string &targetChip, std::string &features);
 };
 } // namespace mlir
 

--- a/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
@@ -39,7 +39,7 @@
 
 // If an old rocm_agent_enumerator that has no "-name" option is used, rely on
 // the hip runtime function to provide GPU GCN Arch names.
-#if ROCM_4_4_OR_OLDER
+#if __USE_ROCM_4_4_OR_OLDER__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #include "hip/hip_runtime.h"
@@ -55,7 +55,7 @@ static constexpr const char kRunnerProgram[] = "mlir-rocm-runner";
 static constexpr const char kRocmAgentEnumerator[] = "rocm_agent_enumerator";
 static constexpr const char kTargetTriple[] = "amdgcn-amd-amdhsa";
 
-#if ROCM_4_4_OR_OLDER
+#if __USE_ROCM_4_4_OR_OLDER__
 namespace {
 void getGpuGCNArchName(hipDevice_t device, std::string &gcnArchName) {
   hipDeviceProp_t props;
@@ -271,7 +271,7 @@ void BackendUtils::configTarget(std::string &targetChip,
 
   // Invoke rocm_agent_enumerator.
   std::string errorMessage;
-#if ROCM_4_4_OR_OLDER
+#if __USE_ROCM_4_4_OR_OLDER__
   SmallVector<StringRef, 1> args{rocmAgentEnumerator.get()};
 #else
   SmallVector<StringRef, 2> args{rocmAgentEnumerator.get(), "-name"};
@@ -285,7 +285,7 @@ void BackendUtils::configTarget(std::string &targetChip,
     llvm::WithColor::warning(llvm::errs(), kRunnerProgram)
         << kRocmAgentEnumerator << " invocation error: " << errorMessage
         << ", set target as " << chip << "\n";
-#if ROCM_4_4_OR_OLDER
+#if __USE_ROCM_4_4_OR_OLDER__
     llvm::WithColor::warning(llvm::errs(), kRunnerProgram)
         << "suggest to use a newer ROCm release and compile with "
            "-DUSE_ROCM_4_4_OR_OLDER=0\n";
@@ -301,7 +301,7 @@ void BackendUtils::configTarget(std::string &targetChip,
         << "\n";
     return;
   }
-#if ROCM_4_4_OR_OLDER
+#if __USE_ROCM_4_4_OR_OLDER__
   for (llvm::line_iterator lines(*gfxArchList); !lines.is_at_end(); ++lines) {
     // Skip the line with content "gfx000".
     if (*lines == "gfx000")

--- a/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
@@ -17,6 +17,11 @@ endif()
 # lld header files.
 include_directories(${CMAKE_SOURCE_DIR}/external/llvm-project/lld/include)
 
+# Set compile-time flags for ROCm path.
+add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
+
+add_definitions(-DROCM_4_4_OR_OLDER=${USE_ROCM_4_4_OR_OLDER})
+
 set(HIP_PATH "${ROCM_PATH}/hip" CACHE PATH " Path to which HIP has been installed")
 set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
 find_package(HIP)
@@ -25,9 +30,6 @@ if (NOT HIP_FOUND)
 else()
   message(STATUS "ROCm HIP version: ${HIP_VERSION}")
 endif()
-
-# Set compile-time flags for ROCm path.
-add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
 
 # Locate HIP runtime library.
 find_library(ROCM_RUNTIME_LIBRARY amdhip64
@@ -44,6 +46,7 @@ add_definitions(-D__HIP_PLATFORM_HCC__)
 add_llvm_library(rocm-runtime-wrappers SHARED
   rocm-runtime-wrappers.cpp
 )
+
 target_include_directories(rocm-runtime-wrappers
   PRIVATE
   "${HIP_PATH}/../include"
@@ -94,9 +97,11 @@ add_llvm_library(LLVMROCmBackendUtils
   )
 
 llvm_update_compile_flags(LLVMROCmBackendUtils)
-target_include_directories(LLVMROCmBackendUtils
-  PRIVATE
-  "${HIP_PATH}/../include"
-  "${HIP_PATH}/include"
-)
+if ( USE_ROCM_4_4_OR_OLDER )
+  target_include_directories(LLVMROCmBackendUtils
+    PRIVATE
+    "${HIP_PATH}/../include"
+    "${HIP_PATH}/include"
+  )
+endif()
 target_link_libraries(LLVMROCmBackendUtils PRIVATE ${LIBS} ${targets_to_link})

--- a/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories(${CMAKE_SOURCE_DIR}/external/llvm-project/lld/include)
 # Set compile-time flags for ROCm path.
 add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
 
-add_definitions(-DROCM_4_4_OR_OLDER=${USE_ROCM_4_4_OR_OLDER})
+add_definitions(-D__USE_ROCM_4_4_OR_OLDER__=${USE_ROCM_4_4_OR_OLDER})
 
 set(HIP_PATH "${ROCM_PATH}/hip" CACHE PATH " Path to which HIP has been installed")
 set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
@@ -97,7 +97,7 @@ add_llvm_library(LLVMROCmBackendUtils
   )
 
 llvm_update_compile_flags(LLVMROCmBackendUtils)
-if ( USE_ROCM_4_4_OR_OLDER )
+if (USE_ROCM_4_4_OR_OLDER)
   target_include_directories(LLVMROCmBackendUtils
     PRIVATE
     "${HIP_PATH}/../include"


### PR DESCRIPTION
Replace a HIP runtime function with rocm_agent_enumerator to get architecture names in order to make BackendUtils HIP-independent. 