### PR TITLE
Fix cmake version to 3.15.1

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -77,10 +77,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN wget --no-check-certificate -qO - http://repo.radeon.com/rocm/rocm.gpg.key 2>/dev/null | apt-key add -
 RUN echo "deb [arch=amd64] $ROCM_DEB_REPO $ROCM_BUILD_NAME $ROCM_BUILD_NUM" > /etc/apt/sources.list.d/rocm.list
 
-# Install latest cmake
+# Install cmake distribution
 RUN wget --no-check-certificate -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
 RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 
+# Note instead of installing the latest, we should always manually bump cmake version when necessary.
+# This make sure that we don't accidentally use newer cmake features incompatible with our client.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   rocm-dev \
   rocminfo \
@@ -91,7 +93,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   vim \
   kmod \
   file \
-  cmake \
+  cmake-data=3.15.1-0kitware1 \
+  cmake=3.15.1-0kitware1 \
   libsqlite3-dev \
   parallel \
   python3-venv  && \


### PR DESCRIPTION
We are always installing the latest cmake. Right now the version got pulled in is `3.20.5` which is way too new compared with `3.15.1`. (The cmake shipped with ubuntu 18.04 is only 3.10.2) I'm afraid that pulling in the newest cmake would make us accidentally use unsupported feature (that cause client to not able to build/ pr not able to upstream).

We should bump cmake version manually and when we all decide this is a good idea.

I have locally tested that:
 - Dockerfile can build and get correct cmake version
 - `ninja check-mlir` continue to function correctly