### PR TITLE
Add some missing initialize-all pieces to mlir-rocm-runner

### DIFF
--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -53,9 +53,11 @@ struct MiirHandle_s {
 // lowering.
 bool miirLazyInit() {
   static const bool once = []() {
+    llvm::InitializeAllTargets();
     llvm::InitializeAllTargetInfos();
     llvm::InitializeAllTargetMCs();
     llvm::InitializeAllAsmParsers();
+    llvm::InitializeAllAsmPrinters();
 
     // Initialize LLVM AMDGPU backend.
     LLVMInitializeAMDGPUTarget();

--- a/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
+++ b/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
@@ -87,9 +87,11 @@ static LogicalResult runMLIRPasses(ModuleOp m) {
 int main(int argc, char **argv) {
   registerPassManagerCLOptions();
   llvm::InitLLVM y(argc, argv);
+  llvm::InitializeAllTargets();
   llvm::InitializeAllTargetInfos();
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmParsers();
+  llvm::InitializeAllAsmPrinters();
 
   // Initialize LLVM AMDGPU backend.
   LLVMInitializeAMDGPUTarget();


### PR DESCRIPTION
Short story:  Without this small change, mlir-rocm-runner on an mlir file that doesn't include gpu-dialect ops will crash.  No existing mlir-rocm-runner test has a problem, but some experimental stuff I was doing triggered it.

Long story:  JitRunnerMain() sets up to run on the host, which is X86.  mlir-rocm-runner arranges to override that in its MLIR-pass setup.  In between, some other setup happens, including building an X86 Target object.  If these missing parts aren't done, it will fail and crash.  When gpu-dialect ops are present, the "other setup" brings in some linker modules that, among other things, finish the X86 setup, and thus the X86 Target object builds cleanly.  These changes make up for cases without gpu-dialect ops.

Yeah, I really want to do the GPU ops, but I haven't managed that part yet.  Meanwhile, let's not crash.