### PR TITLE
Use intrinsic instead of inline asm for lds barrier

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -106,18 +106,11 @@ def ROCDL_BarrierOp : ROCDL_Op<"barrier"> {
 def ROCDL_LDSBarrierOp : ROCDL_Op<"lds_barrier"> {
   string llvmBuilder = [{
     llvm::LLVMContext &llvmContext = builder.getContext();
-    llvm::FunctionType *function_type = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(llvmContext), // return type.
-        false);                             // no variadic arguments.
-    llvm::Value *inlineAsm = llvm::InlineAsm::get(
-        function_type,                       // FunctionType *Ty,
-        "s_waitcnt lgkmcnt(0) \n s_barrier", // const std::string &AsmString,
-        "",                                  // const std::string &Constraints,
-        true,                                // bool hasSideEffects,
-        false,                               // bool isAlignStack,
-        llvm::InlineAsm::AD_ATT              // AsmDialect asmDialect
-        );
-    builder.CreateCall(function_type, inlineAsm);
+    //    builder.CreateFence(llvm::AtomicOrdering::Release,
+    //                       llvmContext.getOrInsertSyncScopeID("workgroup"));
+    auto lgkm0 = llvm::ConstantInt::get(llvmContext, llvm::APInt(32, 49279, true)); // 49279 :i32
+    createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_s_waitcnt, lgkm0);
+    createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_s_barrier);
   }];
   let assemblyFormat = "attr-dict";
 }

--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -104,12 +104,11 @@ def ROCDL_BarrierOp : ROCDL_Op<"barrier"> {
 }
 
 def ROCDL_LDSBarrierOp : ROCDL_Op<"lds_barrier"> {
+  // Guarantees LDS update until this point are all completed.
   string llvmBuilder = [{
     llvm::LLVMContext &llvmContext = builder.getContext();
-    //    builder.CreateFence(llvm::AtomicOrdering::Release,
-    //                       llvmContext.getOrInsertSyncScopeID("workgroup"));
-    auto lgkm0 = llvm::ConstantInt::get(llvmContext, llvm::APInt(32, 49279, true)); // 49279 :i32
-    createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_s_waitcnt, lgkm0);
+    builder.CreateFence(llvm::AtomicOrdering::Release,
+                       llvmContext.getOrInsertSyncScopeID("workgroup"));
     createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_s_barrier);
   }];
   let assemblyFormat = "attr-dict";

--- a/external/llvm-project/mlir/test/Target/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/rocdl.mlir
@@ -45,7 +45,7 @@ llvm.func @rocdl.barrier() {
 }
 
 llvm.func @rocdl.lds_barrier() {
-  // CHECK:      call void @llvm.amdgcn.s.waitcnt(i32 49279)
+  // CHECK:      fence syncscope("workgroup") release
   // CHECK-NEXT: call void @llvm.amdgcn.s.barrier()
   rocdl.lds_barrier
   llvm.return

--- a/external/llvm-project/mlir/test/Target/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/rocdl.mlir
@@ -45,7 +45,8 @@ llvm.func @rocdl.barrier() {
 }
 
 llvm.func @rocdl.lds_barrier() {
-  // CHECK: call void asm sideeffect "s_waitcnt lgkmcnt(0) \0A s_barrier", ""()
+  // CHECK:      call void @llvm.amdgcn.s.waitcnt(i32 49279)
+  // CHECK-NEXT: call void @llvm.amdgcn.s.barrier()
   rocdl.lds_barrier
   llvm.return
 }


### PR DESCRIPTION
Let's see how it works,
- compare the performance as is.
- We can build llvm (tip) separately, can we run tests with it?