### PR TITLE
Reduce parallelism level of jenkins matrix execution

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -314,10 +314,6 @@ pipeline {
                         name 'DIRECTION'
                         values '1', '2', '4'
                     }
-                    axis {
-                        name 'TUNING'
-                        values '1', '0'
-                    }
                 }
                 stages {
                     stage('Test MIOpen') {
@@ -332,7 +328,7 @@ pipeline {
                         stages {
                             stage('Environment') {
                                 steps {
-                                    echo "Config is ($DTYPE, $LAYOUT, xdlops=$XDLOPS, dir=$DIRECTION, tuning=$TUNING)"
+                                    echo "Config is ($DTYPE, $LAYOUT, xdlops=$XDLOPS, dir=$DIRECTION)"
                                     showEnv()
                                 }
                             }
@@ -347,7 +343,8 @@ pipeline {
                                     LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
                                 }
                                 steps {
-                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, $TUNING)
+                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, 0)
+                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, 1)
                                 }
                             }
                         }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -321,7 +321,7 @@ pipeline {
                             docker {
                                 image dockerImage()
                                 args dockerArgs()
-                                label "${XDLOPS == '1' ? 'gfx908' : 'gfx908'} && !single_gpu"
+                                label "${XDLOPS == '1' ? 'gfx908' : 'gfx908'}"
                                 alwaysPull true
                             }
                         }


### PR DESCRIPTION
I noticed that there are too many parallel stages in a matrix execution, which caused a resource contention. See [here](http://10.236.106.97:8080/blue/organizations/jenkins/mlir-nightly-all/detail/mlir-nightly-all/89/pipeline/480). Also, relaxed from the !single_gpu label requirement from MIOpenDriver execution.