### PR TITLE
Introduce three toggels for each parallel stage

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -91,15 +91,29 @@ void postProcessPerfRes() {
 pipeline {
     agent none
     parameters {
+        // Below should be set statically by Jenkins job
         booleanParam(name: 'nightly', defaultValue: params.nightly ?: false,
                      description: 'Run extra nightly-only tests')
         booleanParam(name: 'canXdlops', defaultValue: params.canXdlops ?: true,
                      description: 'Can this CI instance use xdlops (no for public server)')
+
+        // Each below control whether to run a individual stage from parallel run
+        // They default to true but deverloper can toggle them for debugging purpose
+        booleanParam(name: 'sharedLib', defaultValue: params.sharedLib ?: true,
+                     description: 'Run the shared library stage')
+        booleanParam(name: 'staticLib', defaultValue: params.staticLib ?: true,
+                     description: 'Run the static library stage')
+        booleanParam(name: 'perfTest', defaultValue: params.perfTest ?: true,
+                     description: 'Run the performance testing stage')
     }
     stages {
         stage("Builds and tests") {
             parallel {
                 stage("Shared library") {
+                    when {
+                        beforeAgent true;
+                        equals expected: true, actual: params.sharedLib;
+                    }
                     agent {
                         docker {
                             image dockerImage()
@@ -156,7 +170,11 @@ pipeline {
                     }
                 }
 
-                stage("Implicit GEMM") {
+                stage("Static Library") {
+                    when {
+                        beforeAgent true;
+                        equals expected: true, actual: params.staticLib;
+                    }
                     agent {
                         docker {
                             image dockerImage()
@@ -217,6 +235,7 @@ pipeline {
                 stage("Performance testing") {
                     when {
                         beforeAgent true;
+                        equals expected: true, actual: params.perfTest;
                         equals expected: true, actual: params.nightly;
                     }
                     agent {
@@ -290,8 +309,9 @@ pipeline {
 
         stage("MIOpen resnet50 config test") {
             when { allOf {
-                equals expected: true, actual: params.nightly
-                equals expected: true, actual: params.canXdlops
+                equals expected: true, actual: params.nightly;
+                equals expected: true, actual: params.canXdlops;
+                equals expected: true, actual: params.staticLib;
             }}
             matrix {
                 options {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -99,11 +99,11 @@ pipeline {
 
         // Each below control whether to run a individual stage from parallel run
         // They default to true but deverloper can toggle them for debugging purpose
-        booleanParam(name: 'sharedLib', defaultValue: params.sharedLib ?: true,
+        booleanParam(name: 'sharedLib', defaultValue: true,
                      description: 'Run the shared library stage')
-        booleanParam(name: 'staticLib', defaultValue: params.staticLib ?: true,
+        booleanParam(name: 'staticLib', defaultValue: true,
                      description: 'Run the static library stage')
-        booleanParam(name: 'perfTest', defaultValue: params.perfTest ?: true,
+        booleanParam(name: 'perfTest', defaultValue: true,
                      description: 'Run the performance testing stage')
     }
     stages {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -363,8 +363,8 @@ pipeline {
                                     LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
                                 }
                                 steps {
-                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, '0')
-                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, '1')
+                                    testMIOpenDriver('$DTYPE', '$XDLOPS', '$LAYOUT', '$DIRECTION', '0')
+                                    testMIOpenDriver('$DTYPE', '$XDLOPS', '$LAYOUT', '$DIRECTION', '1')
                                 }
                             }
                         }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -363,8 +363,8 @@ pipeline {
                                     LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
                                 }
                                 steps {
-                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, 0)
-                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, 1)
+                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, '0')
+                                    testMIOpenDriver($DTYPE, $XDLOPS, $LAYOUT, $DIRECTION, '1')
                                 }
                             }
                         }


### PR DESCRIPTION
This is a temporary measure to fix https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/336. But I expect this to be useful on PR execution as well. (A PR developer can have more confidence if he can validate the PR against MIOpenDriver matrix stages, without the need to wait till nightly testing).

There has been multiple days our nightly CI can't do a full execution. I figure creating new toggles could at least allow me to run only the interesting MIOpen tuning stage, for example, without having to wait for the long random e2e task to finish.