### PR TITLE
Fix the type of random seed from i64 to i32.

### DIFF
--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -499,8 +499,8 @@ mcpuMemset5DFloatRandInt(float *allocated, float *aligned, int64_t offset,
                          int64_t size0, int64_t size1, int64_t size2,
                          int64_t size3, int64_t size4, int64_t stride0,
                          int64_t stride1, int64_t stride2, int64_t stride3,
-                         int64_t stride4, short min, short max, int seed) {
-  if (seed < 0)
+                         int64_t stride4, short min, short max, uint32_t seed) {
+  if (seed == 0)
     std::srand(time(0));
   else
     std::srand(seed);
@@ -521,8 +521,8 @@ extern "C" void mcpuMemset5DFloatRandFloat(
     float *allocated, float *aligned, int64_t offset, int64_t size0,
     int64_t size1, int64_t size2, int64_t size3, int64_t size4, int64_t stride0,
     int64_t stride1, int64_t stride2, int64_t stride3, int64_t stride4,
-    short min, short max, int seed) {
-  if (seed < 0)
+    short min, short max, uint32_t seed) {
+  if (seed == 0)
     std::srand(time(0));
   else
     std::srand(seed);
@@ -640,14 +640,14 @@ extern "C" void mcpuMemset5DHalfRandInt(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int seed) {
+    int64_t stride4, short min, short max, uint32_t seed) {
 
   // Generate tables for converting float to fp16
   unsigned short basetable[512];
   unsigned char shifttable[512];
   generateTables(basetable, shifttable);
 
-  if (seed < 0)
+  if (seed == 0)
     std::srand(time(0));
   else
     std::srand(seed);
@@ -668,14 +668,14 @@ extern "C" void mcpuMemset5DHalfRandFloat(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int seed) {
+    int64_t stride4, short min, short max, uint32_t seed) {
 
   // Generate tables for converting float to fp16
   unsigned short basetable[512];
   unsigned char shifttable[512];
   generateTables(basetable, shifttable);
 
-  if (seed < 0)
+  if (seed == 0)
     std::srand(time(0));
   else
     std::srand(seed);
@@ -809,9 +809,9 @@ extern "C" void mcpuMemset5DBF16RandInt(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int seed) {
+    int64_t stride4, short min, short max, uint32_t seed) {
 
-  if (seed < 0)
+  if (seed == 0)
     std::srand(time(0));
   else
     std::srand(seed);
@@ -832,9 +832,9 @@ extern "C" void mcpuMemset5DBF16RandFloat(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int seed) {
+    int64_t stride4, short min, short max, uint32_t seed) {
 
-  if (seed < 0)
+  if (seed == 0)
     std::srand(time(0));
   else
     std::srand(seed);

--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -499,7 +499,7 @@ mcpuMemset5DFloatRandInt(float *allocated, float *aligned, int64_t offset,
                          int64_t size0, int64_t size1, int64_t size2,
                          int64_t size3, int64_t size4, int64_t stride0,
                          int64_t stride1, int64_t stride2, int64_t stride3,
-                         int64_t stride4, short min, short max, int64_t seed) {
+                         int64_t stride4, short min, short max, int seed) {
   if (seed < 0)
     std::srand(time(0));
   else
@@ -521,7 +521,7 @@ extern "C" void mcpuMemset5DFloatRandFloat(
     float *allocated, float *aligned, int64_t offset, int64_t size0,
     int64_t size1, int64_t size2, int64_t size3, int64_t size4, int64_t stride0,
     int64_t stride1, int64_t stride2, int64_t stride3, int64_t stride4,
-    short min, short max, int64_t seed) {
+    short min, short max, int seed) {
   if (seed < 0)
     std::srand(time(0));
   else
@@ -640,7 +640,7 @@ extern "C" void mcpuMemset5DHalfRandInt(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int64_t seed) {
+    int64_t stride4, short min, short max, int seed) {
 
   // Generate tables for converting float to fp16
   unsigned short basetable[512];
@@ -668,7 +668,7 @@ extern "C" void mcpuMemset5DHalfRandFloat(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int64_t seed) {
+    int64_t stride4, short min, short max, int seed) {
 
   // Generate tables for converting float to fp16
   unsigned short basetable[512];
@@ -809,7 +809,7 @@ extern "C" void mcpuMemset5DBF16RandInt(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int64_t seed) {
+    int64_t stride4, short min, short max, int seed) {
 
   if (seed < 0)
     std::srand(time(0));
@@ -832,7 +832,7 @@ extern "C" void mcpuMemset5DBF16RandFloat(
     unsigned short *allocated, unsigned short *aligned, int64_t offset,
     int64_t size0, int64_t size1, int64_t size2, int64_t size3, int64_t size4,
     int64_t stride0, int64_t stride1, int64_t stride2, int64_t stride3,
-    int64_t stride4, short min, short max, int64_t seed) {
+    int64_t stride4, short min, short max, int seed) {
 
   if (seed < 0)
     std::srand(time(0));

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -286,9 +286,9 @@ static cl::opt<std::string>
 static cl::opt<std::string> randomSeed(
     "rand",
     cl::desc(
-        "A positive integer indicates the seed of random data generator for "
-        "convolution inputs, e.g. -rand 1. If not specifed or -rand none, "
-        "use all ones. Otherwise, use time(0) as the seed."),
+        "A positive integer or zero indicates the seed of random data generator"
+        "for convolution inputs, e.g. -rand 1. If not specifed, or -rand none, "
+        "use all ones. If 0, use time(0) as the seed."),
     cl::value_desc("seed"), cl::init("none"));
 
 static cl::opt<std::string>


### PR DESCRIPTION
Match what's implied in mlir-miopen-driver CPU logic.

This fixes an weird bug that CPU convolution may have different results in different runs, under a fixed random seed value.