### PR TITLE
Use unsigned operator in index calculate

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -109,9 +109,9 @@ inline bool overrideLoadStoreHack(const DictionaryAttr &transformSpec) {
 template <typename T>
 inline std::tuple<Type, TupleType, int, int, int>
 computeLoadStoreTypeInfo(OpBuilder &b, T &gop, Type elementType,
-                         const SmallVector<int64_t, 3> &dims, bool isMatrixA) {
-  int64_t loadLength = 1;
-  int64_t storeLength = 1;
+                         const SmallVector<uint64_t, 3> &dims, bool isMatrixA) {
+  uint64_t loadLength = 1;
+  uint64_t storeLength = 1;
   int vectorDim = dims.size() - 1;
   if (isMatrixA) {
     loadLength = gop->getAttr("matrix_a_source_data_per_read")
@@ -153,14 +153,14 @@ computeLoadStoreTypeInfo(OpBuilder &b, T &gop, Type elementType,
 // threadwise_copy_v2 to determine the bounds of load/store loops.
 //===----------------------------------------------------------------------===//
 inline void
-computeSliceLengths(SmallVector<int64_t, 2> &sliceLengths,
+computeSliceLengths(SmallVector<uint64_t, 2> &sliceLengths,
                     const Optional<AffineMap> &composedSourceTransform,
                     const Optional<AffineMap> &composedDestTransform,
                     const ArrayAttr &coordTransformsAttr,
                     const Optional<ArrayAttr> &boundAttr, Type sourceType,
                     Type destType) {
   auto populateSliceLengthsWithTypeShape =
-      [](SmallVector<int64_t, 2> &sliceLengths, Type type) {
+      [](SmallVector<uint64_t, 2> &sliceLengths, Type type) {
         assert(type.isa<MemRefType>() || type.isa<VectorType>());
         if (type.isa<MemRefType>()) {
           // Use the shape of memref as initial slice lengths.
@@ -4814,7 +4814,7 @@ static void affixThreadwiseCopyAttributes(miopen::ThreadwiseCopyOp top,
 template <typename T, typename U>
 void affixBlockwiseCopyAttributes(
     T &bop, U &gop, OpBuilder &b,
-    const SmallVector<int64_t, 3> &blockwiseCopyBounds, int vectorDim,
+    const SmallVector<uint64_t, 3> &blockwiseCopyBounds, int vectorDim,
     int blockwiseLoadLength, int blockwiseStoreLength) {
   bop->setAttr("block_size", gop->getAttr("block_size"));
 
@@ -5069,12 +5069,12 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     auto NBlockWorkConstantOp = b.create<ConstantIndexOp>(loc, NBlockWork);
     auto GStridOp = b.create<ConstantIndexOp>(loc, GStride);
     auto block_work_id_g =
-        b.create<SignedDivIOp>(loc, bid, GStridOp); // id_g of coordinate
-    auto block_work_rem = b.create<SignedRemIOp>(loc, bid, GStridOp);
+        b.create<UnsignedDivIOp>(loc, bid, GStridOp); // id_g of coordinate
+    auto block_work_rem = b.create<UnsignedRemIOp>(loc, bid, GStridOp);
     auto block_work_id_m =
-        b.create<SignedDivIOp>(loc, block_work_rem, NBlockWorkConstantOp);
+        b.create<UnsignedDivIOp>(loc, block_work_rem, NBlockWorkConstantOp);
     auto block_work_id_n =
-        b.create<SignedRemIOp>(loc, block_work_rem, NBlockWorkConstantOp);
+        b.create<UnsignedRemIOp>(loc, block_work_rem, NBlockWorkConstantOp);
     auto MPerBlockConstantOp = b.create<ConstantIndexOp>(loc, MPerBlock);
     auto NPerBlockConstantOp = b.create<ConstantIndexOp>(loc, NPerBlock);
     auto m_block_data_on_global =
@@ -5093,11 +5093,11 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     // llvm::errs() << "matrix_b_source_data_per_read: " << matrix_b_source_data_per_read << "\n";
 
     // Compute ThreadSliceLengths for Matrix A.
-    int64_t GemmABlockCopyNumberDataPerThread =
+    uint64_t GemmABlockCopyNumberDataPerThread =
         MPerBlock * KPerBlock / BlockSize;
 
-    int64_t GemmABlockCopyThreadSliceLengths_GemmK;
-    int64_t GemmABlockCopyThreadSliceLengths_GemmM;
+    uint64_t GemmABlockCopyThreadSliceLengths_GemmK;
+    uint64_t GemmABlockCopyThreadSliceLengths_GemmM;
     switch (matrix_a_source_vector_read_dim) {
     case GemmK:
       GemmABlockCopyThreadSliceLengths_GemmK = matrix_a_source_data_per_read;
@@ -5131,11 +5131,11 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     // llvm::errs() << GemmABlockCopyClusterLengths_GemmM << "\n";
 
     // Compute ThreadSliceLengths for Matrix B.
-    int64_t GemmBBlockCopyNumberDataPerThread =
+    uint64_t GemmBBlockCopyNumberDataPerThread =
         NPerBlock * KPerBlock / BlockSize;
 
-    int64_t GemmBBlockCopyThreadSliceLengths_GemmK;
-    int64_t GemmBBlockCopyThreadSliceLengths_GemmN;
+    uint64_t GemmBBlockCopyThreadSliceLengths_GemmK;
+    uint64_t GemmBBlockCopyThreadSliceLengths_GemmN;
     assert(matrix_b_source_vector_read_dim != GemmG);
     switch (matrix_b_source_vector_read_dim) {
     case GemmK:
@@ -5162,7 +5162,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     // Compute ThreadClusterLengths for Matrix B.
     // int64_t GemmBBlockCopyClusterLengths_GemmK =
     //    KPerBlock / GemmBBlockCopyThreadSliceLengths_GemmK;
-    int64_t GemmBBlockCopyClusterLengths_GemmN =
+    uint64_t GemmBBlockCopyClusterLengths_GemmN =
         NPerBlock / GemmBBlockCopyThreadSliceLengths_GemmN;
 
     // llvm::errs() << "thread cluster lengths for Matrix B\n";
@@ -5183,9 +5183,9 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     auto GemmABlockCopyThreadSliceLengths_GemmMConstantOp =
         b.create<ConstantIndexOp>(loc, GemmABlockCopyThreadSliceLengths_GemmM);
 
-    auto GemmABlockCopyThreadClusterId_Y = b.create<SignedRemIOp>(
+    auto GemmABlockCopyThreadClusterId_Y = b.create<UnsignedRemIOp>(
         loc, tid, GemmABlockCopyClusterLengths_GemmKConstantOp);
-    auto GemmABlockCopyThreadClusterId_X = b.create<SignedDivIOp>(
+    auto GemmABlockCopyThreadClusterId_X = b.create<UnsignedDivIOp>(
         loc, tid, GemmABlockCopyClusterLengths_GemmKConstantOp);
     auto GemmAThreadDataIdBegin_Y =
         b.create<MulIOp>(loc, GemmABlockCopyThreadClusterId_Y,
@@ -5217,9 +5217,9 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     auto GemmBBlockCopyThreadSliceLengths_GemmNConstantOp =
         b.create<ConstantIndexOp>(loc, GemmBBlockCopyThreadSliceLengths_GemmN);
 
-    auto GemmBBlockCopyThreadClusterId_Y = b.create<SignedDivIOp>(
+    auto GemmBBlockCopyThreadClusterId_Y = b.create<UnsignedDivIOp>(
         loc, tid, GemmBBlockCopyClusterLengths_GemmNConstantOp);
-    auto GemmBBlockCopyThreadClusterId_X = b.create<SignedRemIOp>(
+    auto GemmBBlockCopyThreadClusterId_X = b.create<UnsignedRemIOp>(
         loc, tid, GemmBBlockCopyClusterLengths_GemmNConstantOp);
     auto GemmBThreadDataIdBegin_Y =
         b.create<MulIOp>(loc, GemmBBlockCopyThreadClusterId_Y,
@@ -5312,7 +5312,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
         b.create<miopen::GpuAllocOp>(loc, threadCRegisterMemRefType);
 
     // Determine vector / scalar load type for Matrix A / B.
-    SmallVector<int64_t, 3> blockwiseCopyABounds = {
+    SmallVector<uint64_t, 3> blockwiseCopyABounds = {
         1, GemmABlockCopyThreadSliceLengths_GemmK,
         GemmABlockCopyThreadSliceLengths_GemmM};
     Type blockwiseLoadAType;
@@ -5340,7 +5340,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     // llvm::errs() << "load size: " << blockwiseLoadAVectorLength << "\n";
     // llvm::errs() << "store size: " << blockwiseStoreAVectorLength << "\n";
 
-    SmallVector<int64_t, 3> blockwiseCopyBBounds = {
+    SmallVector<uint64_t, 3> blockwiseCopyBBounds = {
         1, GemmBBlockCopyThreadSliceLengths_GemmK,
         GemmBBlockCopyThreadSliceLengths_GemmN};
     Type blockwiseLoadBType;
@@ -5438,18 +5438,18 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
     auto ThreadPerLevel0ClusterConstantOp =
         b.create<ConstantIndexOp>(loc, ThreadPerLevel0Cluster);
     auto level1_id =
-        b.create<SignedDivIOp>(loc, tid, ThreadPerLevel0ClusterConstantOp);
+        b.create<UnsignedDivIOp>(loc, tid, ThreadPerLevel0ClusterConstantOp);
     auto level1_m_id =
-        b.create<SignedDivIOp>(loc, level1_id, NLevel1ClusterConstantOp);
+        b.create<UnsignedDivIOp>(loc, level1_id, NLevel1ClusterConstantOp);
     auto level1_n_id =
-        b.create<SignedRemIOp>(loc, level1_id, NLevel1ClusterConstantOp);
+        b.create<UnsignedRemIOp>(loc, level1_id, NLevel1ClusterConstantOp);
 
     auto level0_id =
-        b.create<SignedRemIOp>(loc, tid, ThreadPerLevel0ClusterConstantOp);
+        b.create<UnsignedRemIOp>(loc, tid, ThreadPerLevel0ClusterConstantOp);
     auto level0_m_id =
-        b.create<SignedDivIOp>(loc, level0_id, NLevel0ClusterConstantOp);
+        b.create<UnsignedDivIOp>(loc, level0_id, NLevel0ClusterConstantOp);
     auto level0_n_id =
-        b.create<SignedRemIOp>(loc, level0_id, NLevel0ClusterConstantOp);
+        b.create<UnsignedRemIOp>(loc, level0_id, NLevel0ClusterConstantOp);
 
     int64_t MPerLevel0Cluster = MPerThread * MLevel0Cluster;
     int64_t NPerLevel0Cluster = NPerThread * NLevel0Cluster;
@@ -5820,13 +5820,13 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<miopen::GridwiseGemm
 
     // g index
     matrixCThreadwiseCopySourceAndDestCoords.push_back(GemmDataIdBegin_G_i32);
-    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<SignedDivIOp>(
+    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<UnsignedDivIOp>(
         loc, m_thread_data_on_global_i32, M1ConstantI32Op));
-    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<SignedRemIOp>(
+    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<UnsignedRemIOp>(
         loc, m_thread_data_on_global_i32, M1ConstantI32Op));
-    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<SignedDivIOp>(
+    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<UnsignedDivIOp>(
         loc, n_thread_data_on_global_i32, N1ConstantI32Op));
-    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<SignedRemIOp>(
+    matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<UnsignedRemIOp>(
         loc, n_thread_data_on_global_i32, N1ConstantI32Op));
 
     auto threadwiseCopyCMatrixOp = b.create<miopen::ThreadwiseCopyOp>(
@@ -6125,12 +6125,12 @@ struct GridwiseGemmV2RewritePattern
 
     // Result block_work_desc is <NBlockWorkd, MBlockWork>
 
-    auto block_work_id_g = b.create<SignedDivIOp>(loc, bid, GStridOp);
-    auto block_work_rem = b.create<SignedRemIOp>(loc, bid, GStridOp);
+    auto block_work_id_g = b.create<UnsignedDivIOp>(loc, bid, GStridOp);
+    auto block_work_rem = b.create<UnsignedRemIOp>(loc, bid, GStridOp);
     auto block_work_id_m =
-        b.create<SignedRemIOp>(loc, block_work_rem, MBlockWorkConstantOp);
+        b.create<UnsignedRemIOp>(loc, block_work_rem, MBlockWorkConstantOp);
     auto block_work_id_n =
-        b.create<SignedDivIOp>(loc, block_work_rem, MBlockWorkConstantOp);
+        b.create<UnsignedDivIOp>(loc, block_work_rem, MBlockWorkConstantOp);
 
     auto m_block_data_on_global =
         b.create<MulIOp>(loc, block_work_id_m, MPerBlockConstantOp);
@@ -6147,11 +6147,11 @@ struct GridwiseGemmV2RewritePattern
     // Logic to prepare parameters for blockwise_copy.
 
     // Compute ThreadSliceLengths for Matrix A.
-    int64_t GemmABlockCopyNumberDataPerThread =
+    uint64_t GemmABlockCopyNumberDataPerThread =
         MPerBlock * KPerBlock / BlockSize;
 
-    int64_t GemmABlockCopyThreadSliceLengths_GemmK;
-    int64_t GemmABlockCopyThreadSliceLengths_GemmM;
+    uint64_t GemmABlockCopyThreadSliceLengths_GemmK;
+    uint64_t GemmABlockCopyThreadSliceLengths_GemmM;
     switch (matrix_a_source_vector_read_dim) {
     case GemmK:
       GemmABlockCopyThreadSliceLengths_GemmK = matrix_a_source_data_per_read;
@@ -6175,7 +6175,7 @@ struct GridwiseGemmV2RewritePattern
     // llvm::errs() << GemmABlockCopyThreadSliceLengths_GemmM << "\n";
 
     // Compute ThreadClusterLengths for Matrix A.
-    int64_t GemmABlockCopyClusterLengths_GemmK =
+    uint64_t GemmABlockCopyClusterLengths_GemmK =
         KPerBlock / GemmABlockCopyThreadSliceLengths_GemmK;
     // int64_t GemmABlockCopyClusterLengths_GemmM =
     //    MPerBlock / GemmABlockCopyThreadSliceLengths_GemmM;
@@ -6185,11 +6185,11 @@ struct GridwiseGemmV2RewritePattern
     // llvm::errs() << GemmABlockCopyClusterLengths_GemmM << "\n";
 
     // Compute ThreadSliceLengths for Matrix B.
-    int64_t GemmBBlockCopyNumberDataPerThread =
+    uint64_t GemmBBlockCopyNumberDataPerThread =
         NPerBlock * KPerBlock / BlockSize;
 
-    int64_t GemmBBlockCopyThreadSliceLengths_GemmK;
-    int64_t GemmBBlockCopyThreadSliceLengths_GemmN;
+    uint64_t GemmBBlockCopyThreadSliceLengths_GemmK;
+    uint64_t GemmBBlockCopyThreadSliceLengths_GemmN;
     switch (matrix_b_source_vector_read_dim) {
     case GemmK:
       GemmBBlockCopyThreadSliceLengths_GemmK = matrix_b_source_data_per_read;
@@ -6215,7 +6215,7 @@ struct GridwiseGemmV2RewritePattern
     // Compute ThreadClusterLengths for Matrix B.
     // int64_t GemmBBlockCopyClusterLengths_GemmK =
     //    KPerBlock / GemmBBlockCopyThreadSliceLengths_GemmK;
-    int64_t GemmBBlockCopyClusterLengths_GemmN =
+    uint64_t GemmBBlockCopyClusterLengths_GemmN =
         NPerBlock / GemmBBlockCopyThreadSliceLengths_GemmN;
 
     // llvm::errs() << "thread cluster lengths for Matrix B\n";
@@ -6232,9 +6232,9 @@ struct GridwiseGemmV2RewritePattern
     auto GemmABlockCopyThreadSliceLengths_GemmMConstantOp =
         b.create<ConstantIndexOp>(loc, GemmABlockCopyThreadSliceLengths_GemmM);
 
-    auto GemmABlockCopyThreadClusterId_Y = b.create<SignedRemIOp>(
+    auto GemmABlockCopyThreadClusterId_Y = b.create<UnsignedRemIOp>(
         loc, tid, GemmABlockCopyClusterLengths_GemmKConstantOp);
-    auto GemmABlockCopyThreadClusterId_X = b.create<SignedDivIOp>(
+    auto GemmABlockCopyThreadClusterId_X = b.create<UnsignedDivIOp>(
         loc, tid, GemmABlockCopyClusterLengths_GemmKConstantOp);
     auto GemmAThreadDataIdBegin_Y =
         b.create<MulIOp>(loc, GemmABlockCopyThreadClusterId_Y,
@@ -6266,9 +6266,9 @@ struct GridwiseGemmV2RewritePattern
     auto GemmBBlockCopyThreadSliceLengths_GemmNConstantOp =
         b.create<ConstantIndexOp>(loc, GemmBBlockCopyThreadSliceLengths_GemmN);
 
-    auto GemmBBlockCopyThreadClusterId_Y = b.create<SignedDivIOp>(
+    auto GemmBBlockCopyThreadClusterId_Y = b.create<UnsignedDivIOp>(
         loc, tid, GemmBBlockCopyClusterLengths_GemmNConstantOp);
-    auto GemmBBlockCopyThreadClusterId_X = b.create<SignedRemIOp>(
+    auto GemmBBlockCopyThreadClusterId_X = b.create<UnsignedRemIOp>(
         loc, tid, GemmBBlockCopyClusterLengths_GemmNConstantOp);
     auto GemmBThreadDataIdBegin_Y =
         b.create<MulIOp>(loc, GemmBBlockCopyThreadClusterId_Y,
@@ -6347,7 +6347,7 @@ struct GridwiseGemmV2RewritePattern
     // -----
 
     // Determine vector / scalar load type for Matrix A / B.
-    SmallVector<int64_t, 3> blockwiseCopyABounds = {
+    SmallVector<uint64_t, 3> blockwiseCopyABounds = {
         1, GemmABlockCopyThreadSliceLengths_GemmK,
         GemmABlockCopyThreadSliceLengths_GemmM};
     Type blockwiseLoadAType;
@@ -6360,7 +6360,7 @@ struct GridwiseGemmV2RewritePattern
         computeLoadStoreTypeInfo(b, op, elementType, blockwiseCopyABounds,
                                  true);
 
-    SmallVector<int64_t, 3> blockwiseCopyBBounds = {
+    SmallVector<uint64_t, 3> blockwiseCopyBBounds = {
         1, GemmBBlockCopyThreadSliceLengths_GemmK,
         GemmBBlockCopyThreadSliceLengths_GemmN};
     Type blockwiseLoadBType;
@@ -6512,9 +6512,9 @@ struct GridwiseGemmV2RewritePattern
     // const index_t waveId_n = waveId % GemmNWaves;
     // mMyWaveOffsetA = waveId_m * GemmMPerWave;
     // mMyWaveOffsetB = waveId_n * GemmNPerWave;
-    auto waveId = b.create<SignedDivIOp>(loc, tid, waveSizeConstantOp);
-    auto waveId_m = b.create<SignedDivIOp>(loc, waveId, NWavesConstantOp);
-    auto waveId_n = b.create<SignedRemIOp>(loc, waveId, NWavesConstantOp);
+    auto waveId = b.create<UnsignedDivIOp>(loc, tid, waveSizeConstantOp);
+    auto waveId_m = b.create<UnsignedDivIOp>(loc, waveId, NWavesConstantOp);
+    auto waveId_n = b.create<UnsignedRemIOp>(loc, waveId, NWavesConstantOp);
 
     Value mMyWaveOffsetA, mMyWaveOffsetB;
     mMyWaveOffsetA = b.create<MulIOp>(loc, waveId_m, MPerWaveConstantOp);
@@ -6891,33 +6891,33 @@ struct GridwiseGemmV2RewritePattern
       // }
       //
       auto xdlops_i_xdlops_gemm =
-          b.create<SignedDivIOp>(loc, iv, NumBlksPerXdlopsConstantOp);
+          b.create<UnsignedDivIOp>(loc, iv, NumBlksPerXdlopsConstantOp);
       auto j_xdlops_gemm =
-          b.create<SignedRemIOp>(loc, iv, NumBlksPerXdlopsConstantOp);
+          b.create<UnsignedRemIOp>(loc, iv, NumBlksPerXdlopsConstantOp);
       auto m_i_xdlops_gemm =
-          b.create<SignedDivIOp>(loc, xdlops_i_xdlops_gemm, NRepeatsConstantOp);
+          b.create<UnsignedDivIOp>(loc, xdlops_i_xdlops_gemm, NRepeatsConstantOp);
       auto n_i_xdlops_gemm =
-          b.create<SignedRemIOp>(loc, xdlops_i_xdlops_gemm, NRepeatsConstantOp);
+          b.create<UnsignedRemIOp>(loc, xdlops_i_xdlops_gemm, NRepeatsConstantOp);
 
       auto laneId_xdlops_gemm =
-          b.create<SignedRemIOp>(loc, tid, wave_size_ConstantOp);
-      auto blk_id_xdlops_gemm = b.create<SignedDivIOp>(
+          b.create<UnsignedRemIOp>(loc, tid, wave_size_ConstantOp);
+      auto blk_id_xdlops_gemm = b.create<UnsignedDivIOp>(
           loc, laneId_xdlops_gemm, num_threads_blk_ConstantOp);
-      auto blk_td_xdlops_gemm = b.create<SignedRemIOp>(
+      auto blk_td_xdlops_gemm = b.create<UnsignedRemIOp>(
           loc, laneId_xdlops_gemm, num_threads_blk_ConstantOp);
       Value col_blk_xdlops_gemm, row_blk_xdlops_gemm;
       bool IsABroadcast = (NPerXdlops >= MPerXdlops);
       if (IsABroadcast) {
         // IsABroadcast
-        col_blk_xdlops_gemm = b.create<SignedRemIOp>(
+        col_blk_xdlops_gemm = b.create<UnsignedRemIOp>(
             loc, j_xdlops_gemm, num_output_blks_ConstantOp);
-        row_blk_xdlops_gemm = b.create<SignedDivIOp>(
+        row_blk_xdlops_gemm = b.create<UnsignedDivIOp>(
             loc, j_xdlops_gemm, num_output_blks_ConstantOp);
       } else {
         // !IsABroadcast
-        col_blk_xdlops_gemm = b.create<SignedDivIOp>(
+        col_blk_xdlops_gemm = b.create<UnsignedDivIOp>(
             loc, j_xdlops_gemm, num_output_blks_ConstantOp);
-        row_blk_xdlops_gemm = b.create<SignedRemIOp>(
+        row_blk_xdlops_gemm = b.create<UnsignedRemIOp>(
             loc, j_xdlops_gemm, num_output_blks_ConstantOp);
       }
 
@@ -6965,10 +6965,10 @@ struct GridwiseGemmV2RewritePattern
       // }
 
       auto xdlops_i_blockwise_gemm =
-          b.create<SignedDivIOp>(loc, iv, NumBlksConstantOp);
-      auto m_blockwise_gemm = b.create<SignedDivIOp>(
+          b.create<UnsignedDivIOp>(loc, iv, NumBlksConstantOp);
+      auto m_blockwise_gemm = b.create<UnsignedDivIOp>(
           loc, xdlops_i_blockwise_gemm, NRepeatsConstantOp);
-      auto n_blockwise_gemm = b.create<SignedRemIOp>(
+      auto n_blockwise_gemm = b.create<UnsignedRemIOp>(
           loc, xdlops_i_blockwise_gemm, NRepeatsConstantOp);
 
       // Original C++ logic.
@@ -6979,7 +6979,7 @@ struct GridwiseGemmV2RewritePattern
           b.create<AddIOp>(
               loc,
               b.create<MulIOp>(
-                  loc, b.create<SignedRemIOp>(loc, waveId, NWavesConstantOp),
+                  loc, b.create<UnsignedRemIOp>(loc, waveId, NWavesConstantOp),
                   NPerWaveConstantOp),
               b.create<MulIOp>(loc, n_blockwise_gemm, NPerXdlopsConstantOp)),
           thread_mtx_on_blk_col);
@@ -6994,7 +6994,7 @@ struct GridwiseGemmV2RewritePattern
           b.create<AddIOp>(
               loc,
               b.create<MulIOp>(
-                  loc, b.create<SignedDivIOp>(loc, waveId, NWavesConstantOp),
+                  loc, b.create<UnsignedDivIOp>(loc, waveId, NWavesConstantOp),
                   MPerWaveConstantOp),
               b.create<MulIOp>(loc, m_blockwise_gemm, MPerXdlopsConstantOp)),
           thread_mtx_on_blk_row);
@@ -7025,18 +7025,18 @@ struct GridwiseGemmV2RewritePattern
       // g
       matrixCThreadwiseCopySourceAndDestCoords.push_back(GemmDataIdBegin_G_i32);
       // m_thread_data_on_global / (M2 * M1)
-      matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<SignedDivIOp>(
+      matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<UnsignedDivIOp>(
           loc, m_thread_data_on_global_i32, M2TimesM1I32Op));
 
       // m_thread_data_on_global % (M2 * M1) / M2
-      matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<SignedDivIOp>(
+      matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<UnsignedDivIOp>(
           loc,
-          b.create<SignedRemIOp>(loc, m_thread_data_on_global_i32,
+          b.create<UnsignedRemIOp>(loc, m_thread_data_on_global_i32,
                                  M2TimesM1I32Op),
           M2ConstantI32Op));
 
       // m_thread_data_on_global % M2
-      matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<SignedRemIOp>(
+      matrixCThreadwiseCopySourceAndDestCoords.push_back(b.create<UnsignedRemIOp>(
           loc, m_thread_data_on_global_i32, M2ConstantI32Op));
 
       // n_thread_data_on_global
@@ -7769,7 +7769,7 @@ struct ThreadwiseCopyRewritePattern
         boundAttr = op->getAttr("bound").template cast<ArrayAttr>();
 
       // Figure out the bounds of load/store loops.
-      SmallVector<int64_t, 2> sliceLengths;
+      SmallVector<uint64_t, 2> sliceLengths;
 
       computeSliceLengths(sliceLengths, composedSourceTransform,
                           composedDestTransform, coordTransformsAttr, boundAttr,
@@ -8015,7 +8015,7 @@ struct ThreadwiseLoadRewritePattern
       boundAttr = op->getAttr("bound").template cast<ArrayAttr>();
 
     // Figure out the bounds of load/store loops.
-    SmallVector<int64_t, 2> sliceLengths;
+    SmallVector<uint64_t, 2> sliceLengths;
 
     computeSliceLengths(sliceLengths, composedSourceTransform,
                         /*composedDestTransform=*/Optional<AffineMap>{},
@@ -8275,7 +8275,7 @@ struct ThreadwiseStoreRewritePattern
       boundAttr = op->getAttr("bound").template cast<ArrayAttr>();
 
     // Figure out the bounds of load/store loops.
-    SmallVector<int64_t, 2> sliceLengths;
+    SmallVector<uint64_t, 2> sliceLengths;
 
     computeSliceLengths(sliceLengths,
                         /*composedSourceTransform=*/Optional<AffineMap>{},
@@ -8531,7 +8531,7 @@ struct ThreadwiseCopyV2RewritePattern
       boundAttr = op->getAttr("bound").template cast<ArrayAttr>();
 
     // Figure out the bounds of load/store loops.
-    SmallVector<int64_t, 2> sliceLengths;
+    SmallVector<uint64_t, 2> sliceLengths;
 
     computeSliceLengths(sliceLengths, composedSourceTransform,
                         composedDestTransform, coordTransformsAttr, boundAttr,
@@ -9040,7 +9040,7 @@ struct XdlopsGemmV2RewritePattern
     // K * KRepeats; constexpr index_t BStride = K * KRepeats;
 
     auto tid = b.create<miopen::WorkitemIdOp>(loc, b.getIndexType());
-    auto laneId = b.create<SignedRemIOp>(
+    auto laneId = b.create<UnsignedRemIOp>(
         loc, tid, b.create<ConstantIndexOp>(loc, wave_size));
 
     // TBD. FloatA / FloatB could be vectorized via KPack tuning parameter.
@@ -9215,8 +9215,8 @@ struct XdlopsGemmV2RewritePattern
       //     const index_t blk_td = laneId % mfma_type.num_threads_blk;
 
       auto NumThreadsBlkConstantOp = b.create<ConstantIndexOp>(loc, num_threads_blk);
-      auto blk_id = b.create<SignedDivIOp>(loc, laneId, NumThreadsBlkConstantOp);
-      auto blk_td = b.create<SignedRemIOp>(loc, laneId, NumThreadsBlkConstantOp);
+      auto blk_id = b.create<UnsignedDivIOp>(loc, laneId, NumThreadsBlkConstantOp);
+      auto blk_td = b.create<UnsignedRemIOp>(loc, laneId, NumThreadsBlkConstantOp);
 
       // Original C++ logic.
       //     // load into registers


### PR DESCRIPTION
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/294

Replace the signed div and rem generated in miopen lowering.
There are few leftover in Affine lowering, raised a separate issue https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/341

Will rebase after llvm tip is merged.