### PR TITLE
[HOTFIX] Fix static fat lib linker issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,17 @@ endif()
 if( BUILD_FAT_LIBMLIRMIOPEN )
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
   set(LLVM_BUILD_LLVM_DYLIB OFF CACHE BOOL "")
-  set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")
+  # TODO remove
+  # This is a temporary fix because it is required by AddMLIR.cmake
+  # Otherwise cmake complains that lld is not exported or installed
+  # In reality, the fat library already link with lld and should
+  # not need to export lld
+  set(LLVM_INSTALL_TOOLCHAIN_ONLY OFF CACHE BOOL "")
+  # TODO remove
+  # This is a temporary fix because MLIRGPUTransforms has to
+  # compile with MLIR_GPU_TO_HSACO_PASS_ENABLE=1, which is
+  # enabled only when MLIR_ENABLE_ROCM_RUNNER turned on
+  set(MLIR_ENABLE_ROCM_RUNNER 1 CACHE BOOL "")
   # Skip linking with HIP so our library is runtime independent
   set(USE_ROCM_4_4_OR_OLDER 0 CACHE BOOL "Make libMLIRMIOpen runtime independent")
   set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "")

--- a/mlir/tools/mlir-miopen-lib/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-lib/CMakeLists.txt
@@ -16,6 +16,9 @@ set(LIBS
   MLIRShape
   MLIRTransforms
   MLIRSupport
+  MLIRGPUTransforms
+  MLIRTargetLLVMIRExport
+  MLIRToLLVMIRTranslationRegistration
   MLIRIR
   MLIRTargetMIOpenCppTranslation
 )


### PR DESCRIPTION
This PR fixed the following linker error from #391

```
../lib/libMIOpen.so.1.0: undefined reference to `mlir::createGpuSerializeToHsacoPass(llvm::StringRef, llvm::StringRef, llvm::StringRef)'

clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
```

The linker error existing because we missed a number of dependencies in building `libMLIRMIOpen` target.

However, we should revert the two cmake variable changes because the fat library should not be dependent on either.

~~Can validate linker issue is gone however doesn't have enough time to validate through MIOpen functionality.~~

Can validate linker issue is gone and MIOpen is functional correctly.

