### PR TITLE
[DO NOT SQUASH] Run generic LLVM optimizations when serializing (on AMD)

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/Passes.h
@@ -15,6 +15,8 @@
 
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/IR/LegacyPassManager.h"
 
 namespace llvm {
 class TargetMachine;
@@ -62,6 +64,15 @@ private:
   virtual std::unique_ptr<llvm::Module>
   translateToLLVMIR(llvm::LLVMContext &llvmContext);
 
+  /// Translates the module to ISA
+  virtual Optional<std::string>
+  translateToISA(llvm::Module &llvmModule, llvm::TargetMachine &targetMachine);
+
+  /// Hook allowing the application of optimizations before codegen
+  /// By default, does nothing
+  virtual LogicalResult optimizeLlvm(llvm::Module &llvmModule,
+                                     llvm::TargetMachine &targetMachine);
+
   /// Serializes the target ISA to binary form.
   virtual std::unique_ptr<std::vector<char>>
   serializeISA(const std::string &isa) = 0;
@@ -91,8 +102,10 @@ void registerGpuSerializeToCubinPass();
 /// Register pass to serialize GPU kernel functions to a HSAco binary
 /// annotation.
 void registerGpuSerializeToHsacoPass();
-std::unique_ptr<Pass> createGpuSerializeToHsacoPass(
-    StringRef triple, StringRef arch, StringRef features);
+std::unique_ptr<Pass> createGpuSerializeToHsacoPass(StringRef triple,
+                                                    StringRef arch,
+                                                    StringRef features,
+                                                    int optLevel);
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -13,6 +13,7 @@ if (MLIR_ENABLE_ROCM_CONVERSIONS)
     AMDGPUCodeGen
     AMDGPUDesc
     AMDGPUInfo
+    target
   )
 endif()
 
@@ -159,6 +160,7 @@ if(MLIR_ENABLE_ROCM_RUNNER)
   target_link_libraries(MLIRGPUTransforms
     PRIVATE
     lldELF
+    MLIRExecutionEngine
     MLIRROCDLToLLVMIRTranslation
   )
 

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -322,7 +322,7 @@ extern "C" MiirStatus miirLowerBin(MiirHandle mlirHandle) {
   pm.addPass(createStripDebugInfoPass());
   pm.addPass(createLowerGpuOpsToROCDLOpsPass(/*indexBitWidth=*/32));
   pm.addPass(createGpuSerializeToHsacoPass(
-      utils.getTriple(), utils.getChip(), utils.getFeatures()));
+      utils.getTriple(), utils.getChip(), utils.getFeatures(), /*optLevel=*/3));
 
   auto status = pm.run(module);
 


### PR DESCRIPTION
This is the resubmission of #394. Now that the essential parts of the fixes have been moved into #396 , this is a much less urgent PR.