### PR TITLE
[HOTFIX] Teach e2e tests to run single threaded.

### DIFF
--- a/mlir/test/mlir-miopen-e2e-validate.sh.in
+++ b/mlir/test/mlir-miopen-e2e-validate.sh.in
@@ -18,7 +18,7 @@ if [[ "$1" == "--test-only-ops" ]]; then
 fi
 
 declare -i exit_status
-parallel run-conv-integration-test.sh -p=false "$@" \
+parallel -j 1 run-conv-integration-test.sh -p=false "$@" \
     @MLIR_XDLOPS@  @MLIR_POPULATE_VALIDATION@ @MLIR_RANDOM_DATA@ \
     --operation {1} --in_layout {2} --fil_layout {3} --out_layout {4} -t {5} -c \
     '|' perl -e "'$perl_validation_prog'" ::: "${operations[@]}" \

--- a/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
+++ b/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
@@ -145,7 +145,7 @@ function run_tests() {
     # command-line argument
     # The 'awk' invocation prints all lines of output while ensuring indicators of
     # success are present
-    parallel bash -c {} '|' awk \
+    parallel -j 1 bash -c {} '|' awk \
     "'BEGIN { status=2 } /Verifies OK/ { status=status-1 } /ConvMlirIgemm/ { status=status-1 } 1; END { exit(status) }'" \
     <"$TMPFILE"
     exit_status=$?


### PR DESCRIPTION
Empirical e2e testing show GNU parallel with unbounded threads would fail.
Reduce the job count to 1 to make everything work.

Nightly CI run is executed via LLVM lit, and LLVM lit is already using all CPU threads. And with PR #385, GNU parallel is again trying to submit jobs on all CPU threads, potentially ending up with over-subscription and we could bump into some ROCm linux kernel driver-related issues where multiple CPU process trying to submit jobs to GPU.