### PR TITLE
[DON'T SQUASH] Device switch support

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -526,6 +526,18 @@ def GPU_LaunchOp : GPU_Op<"launch">,
   let hasCanonicalizer = 1;
 }
 
+def GPU_SetDefaultDeviceOp : GPU_Op<"set_default_device",
+                                    [MemoryEffects<[MemWrite]>]>,
+    Arguments<(ins I32Attr:$devIndex)> {
+  let summary = "Set default GPU for operations after this by index";
+  let description = [{
+    Operation that sets the current default GPU, using a zero-based index
+    into the set of GPUs on the system. The default GPU setting may be
+    thread-local.
+  }];
+  let assemblyFormat = "attr-dict";
+}
+
 def GPU_ReturnOp : GPU_Op<"return", [HasParent<"GPUFuncOp">, NoSideEffect,
                                      Terminator]>,
     Arguments<(ins Variadic<AnyType>:$operands)>, Results<(outs)> {

--- a/external/llvm-project/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
@@ -7,9 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "GPUOpsLowering.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <string>
 
 using namespace mlir;
 

--- a/external/llvm-project/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.h
+++ b/external/llvm-project/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.h
@@ -11,6 +11,8 @@
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
 

--- a/external/llvm-project/mlir/lib/ExecutionEngine/RocmRuntimeWrappers.cpp
+++ b/external/llvm-project/mlir/lib/ExecutionEngine/RocmRuntimeWrappers.cpp
@@ -199,3 +199,7 @@ mgpuMemGetDeviceMemRef1dInt32(int32_t *allocated, int32_t *aligned,
   mgpuMemGetDevicePointer(aligned, &devicePtr);
   return {devicePtr, devicePtr, offset, {size}, {stride}};
 }
+
+extern "C" void mgpuSetDefaultDevice(int32_t device) {
+  HIP_REPORT_IF_ERROR(hipSetDevice(device));
+}

--- a/external/llvm-project/mlir/test/Conversion/GPUCommon/lower-set-default-device-to-gpu-runtime-calls.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUCommon/lower-set-default-device-to-gpu-runtime-calls.mlir
@@ -1,0 +1,11 @@
+// RUN: mlir-opt %s --gpu-to-llvm | FileCheck %s
+
+module attributes {gpu.container_module} {
+  // CHECK-LABEL: func @foo
+  func @foo() {
+    // CHECK-NEXT: %[[ARG:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT: llvm.call @mgpuSetDefaultDevice(%[[ARG]]) : (i32) -> ()
+    gpu.set_default_device { devIndex = 1 : i32 }
+    return
+  }
+}

--- a/external/llvm-project/mlir/test/Dialect/GPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/GPU/ops.mlir
@@ -772,4 +772,11 @@ module attributes {gpu.container_module} {
         gpu.return
       }
    }
+
+   // CHECK-LABEL: func @set_default_device
+   func @set_default_device() {
+     // CHECK-NEXT: gpu.set_default_device {devIndex = 0 : i32}
+     gpu.set_default_device {devIndex = 0 : i32}
+     return
+   }
 }

--- a/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
@@ -90,6 +90,9 @@ BackendUtils::BackendUtils(const std::string &defaultTriple,
 
 BackendUtils::BackendUtils() : BackendUtils("", "", "", true) {}
 
+// TODO(kdrewnia): Assumes that GPU 0 has the same chipset as the GPU that
+// the kernel will be running on
+// This is true in our testing environment, but is not true in general
 void BackendUtils::configTarget(std::string &targetChip,
                                 std::string &features) {
   // Locate rocm_agent_enumerator.

--- a/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/rocm-runtime-wrappers.cpp
@@ -1207,3 +1207,7 @@ extern "C" void mcpuConv2dBwdData(int64_t rank1, void *f_ptr, int64_t rank2,
                            in_w * inputStrides[4]] = acc;
           }
 }
+
+extern "C" void mgpuSetDefaultDevice(int32_t device) {
+  reportErrorIfAny(hipSetDevice(device), "hipSetDevice");
+}


### PR DESCRIPTION
[MLIR][GPU] Add support for selecting the GPU on multi-GPU systems.

This allows GPU dialect users to ensure that the GPU they think they're using is the one that's receiving the runtime mgpu* calls, and allows integration tests to be spread across multiple GPUs on systems that have them.

Add option to mlir-miopen-driver to add device selection in host code
