### PR TITLE
Replace all uses of vector tuple ops with variadic arguments

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -264,10 +264,10 @@ def MIOpen_BlockwiseLoadOp:
     MIOpen_Op<"blockwise_load">,
     Arguments<(ins AnyMemRef:$source,
                   VectorOfLengthAndType<[3], [I32]>:$sourceCoordVector)>,
-    Results<(outs TupleOf<[F32, F16, I16,
+    Results<(outs Variadic<AnyTypeOf<[F32, F16, I16,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                             VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$result)> {
+                             VectorOfLengthAndType<[2, 4, 8], [I16]>]>>:$result)> {
   let summary = "Blockwise GPU data load";
   let description = [{
     The `miopen.blockwise_load` op moves data on GPU. Following movements are
@@ -275,17 +275,17 @@ def MIOpen_BlockwiseLoadOp:
     - Global (generic tensor) to register (naive tensor).
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type(operands)  `->` type(results)
+    $source `[` $sourceCoordVector `]` attr-dict `:` type(operands)  `->` type(results)
   }];
 }
 
 // blockwise_store
 def MIOpen_BlockwiseStoreOp:
     MIOpen_Op<"blockwise_store">,
-    Arguments<(ins TupleOf<[F32, F16, I16,
+    Arguments<(ins Variadic<AnyTypeOf<[F32, F16, I16,
                               VectorOfLengthAndType<[2, 4], [F32]>,
                               VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                              VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
+                              VectorOfLengthAndType<[2, 4, 8], [I16]>]>>:$data,
                    AnyMemRef:$dest,
                    VectorOfLengthAndType<[3], [I32]>:$destCoordVector)> {
   let summary = "Blockwise GPU data store";
@@ -295,7 +295,7 @@ def MIOpen_BlockwiseStoreOp:
     - Register (naive tensor) to LDS (naive tensor).
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type(operands)
+    $data `->` $dest `[` $destCoordVector `]`  attr-dict `:` type($data) `->` type($dest) `,` type($destCoordVector)
   }];
 }
 
@@ -326,10 +326,10 @@ def MIOpen_ThreadwiseLoadOp:
     MIOpen_Op<"threadwise_load">,
     Arguments<(ins AnyMemRef:$source,
                    Variadic<I32>:$sourceCoord)>,
-    Results<(outs TupleOf<[F32, F16, I16,
+    Results<(outs Variadic<AnyTypeOf<[F32, F16, I16,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                             VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$result)> {
+                             VectorOfLengthAndType<[2, 4, 8], [I16]>]>>:$result)> {
   let summary = "Threadwise GPU data load";
   let description = [{
     The `miopen.threadwise_load` op moves data on GPU. Following movements are
@@ -337,17 +337,17 @@ def MIOpen_ThreadwiseLoadOp:
     - Global (generic tensor) to register (naive tensor).
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type($source) `,` type($sourceCoord) `->` type($result)
+    $source `[` $sourceCoord `]` attr-dict `:` type($source) `,` type($sourceCoord) `->` type($result)
   }];
 }
 
 // threadwise_store
 def MIOpen_ThreadwiseStoreOp:
-    MIOpen_Op<"threadwise_store">,
-    Arguments<(ins TupleOf<[F32, F16, I16,
+    MIOpen_Op<"threadwise_store", [AttrSizedOperandSegments]>,
+    Arguments<(ins Variadic<AnyTypeOf<[F32, F16, I16,
                               VectorOfLengthAndType<[2, 4], [F32]>,
                               VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                              VectorOfLengthAndType<[2, 4, 8], [I16]>]>:$data,
+                              VectorOfLengthAndType<[2, 4, 8], [I16]>]>>:$data,
                    AnyMemRef:$dest,
                    Variadic<I32>:$destCoord)> {
   let summary = "Threadwise GPU data store";
@@ -357,7 +357,7 @@ def MIOpen_ThreadwiseStoreOp:
     - Register (naive tensor) to LDS (naive tensor).
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type($data) `,` type($dest) `,` type($destCoord)
+    $data `->` $dest `[` $destCoord `]` attr-dict `:` type($data) `->` type($dest) `,` type($destCoord)
   }];
 }
 

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -163,194 +163,194 @@ func @miopen_blockwise_copy(%source : memref<?x?xf32>, %dest : memref<?x?xf32, 3
 
 // f32 tests.
 
-func @miopen_blockwise_load_f32(%source : memref<?x?x?xf32>, %source_coord : vector<3xi32>) -> tuple<f32>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xf32>, vector<3xi32> -> tuple<f32>
-  return %result : tuple<f32>
+func @miopen_blockwise_load_f32(%source : memref<?x?x?xf32>, %source_coord : vector<3xi32>) -> f32  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xf32>, vector<3xi32> -> f32
+  return %result : f32
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_f32
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xf32>, vector<3xi32> -> tuple<f32>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xf32>, vector<3xi32> -> f32
 
-func @miopen_blockwise_load_2xf32(%source : memref<?x?x?xf32>, %source_coord : vector<3xi32>) -> tuple<vector<2xf32>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xf32>, vector<3xi32> -> tuple<vector<2xf32>>
-  return %result : tuple<vector<2xf32>>
+func @miopen_blockwise_load_2xf32(%source : memref<?x?x?xf32>, %source_coord : vector<3xi32>) -> vector<2xf32>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xf32>, vector<3xi32> -> vector<2xf32>
+  return %result : vector<2xf32>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_2xf32
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xf32>, vector<3xi32> -> tuple<vector<2xf32>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xf32>, vector<3xi32> -> vector<2xf32>
 
-func @miopen_blockwise_load_4xf32(%source : memref<?x?x?xf32>, %source_coord : vector<3xi32>) -> tuple<vector<4xf32>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xf32>, vector<3xi32> -> tuple<vector<4xf32>>
-  return %result : tuple<vector<4xf32>>
+func @miopen_blockwise_load_4xf32(%source : memref<?x?x?xf32>, %source_coord : vector<3xi32>) -> vector<4xf32>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xf32>, vector<3xi32> -> vector<4xf32>
+  return %result : vector<4xf32>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_4xf32
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xf32>, vector<3xi32> -> tuple<vector<4xf32>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xf32>, vector<3xi32> -> vector<4xf32>
 
 // f16 tests.
 
-func @miopen_blockwise_load_f16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> tuple<f16>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xf16>, vector<3xi32> -> tuple<f16>
-  return %result : tuple<f16>
+func @miopen_blockwise_load_f16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> f16  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xf16>, vector<3xi32> -> f16
+  return %result : f16
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_f16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xf16>, vector<3xi32> -> tuple<f16>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xf16>, vector<3xi32> -> f16
 
-func @miopen_blockwise_load_2xf16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> tuple<vector<2xf16>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xf16>, vector<3xi32> -> tuple<vector<2xf16>>
-  return %result : tuple<vector<2xf16>>
+func @miopen_blockwise_load_2xf16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> vector<2xf16>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xf16>, vector<3xi32> -> vector<2xf16>
+  return %result : vector<2xf16>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_2xf16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xf16>, vector<3xi32> -> tuple<vector<2xf16>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xf16>, vector<3xi32> -> vector<2xf16>
 
-func @miopen_blockwise_load_4xf16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> tuple<vector<4xf16>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xf16>, vector<3xi32> -> tuple<vector<4xf16>>
-  return %result : tuple<vector<4xf16>>
+func @miopen_blockwise_load_4xf16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> vector<4xf16>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xf16>, vector<3xi32> -> vector<4xf16>
+  return %result : vector<4xf16>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_4xf16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xf16>, vector<3xi32> -> tuple<vector<4xf16>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xf16>, vector<3xi32> -> vector<4xf16>
 
-func @miopen_blockwise_load_8xf16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> tuple<vector<8xf16>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xf16>, vector<3xi32> -> tuple<vector<8xf16>>
-  return %result : tuple<vector<8xf16>>
+func @miopen_blockwise_load_8xf16(%source : memref<?x?x?xf16>, %source_coord : vector<3xi32>) -> vector<8xf16>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xf16>, vector<3xi32> -> vector<8xf16>
+  return %result : vector<8xf16>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_8xf16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xf16>, vector<3xi32> -> tuple<vector<8xf16>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xf16>, vector<3xi32> -> vector<8xf16>
 
 // i16 tests.
 
-func @miopen_blockwise_load_i16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> tuple<i16>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xi16>, vector<3xi32> -> tuple<i16>
-  return %result : tuple<i16>
+func @miopen_blockwise_load_i16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> i16  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xi16>, vector<3xi32> -> i16
+  return %result : i16
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_i16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xi16>, vector<3xi32> -> tuple<i16>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xi16>, vector<3xi32> -> i16
 
-func @miopen_blockwise_load_2xi16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> tuple<vector<2xi16>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xi16>, vector<3xi32> -> tuple<vector<2xi16>>
-  return %result : tuple<vector<2xi16>>
+func @miopen_blockwise_load_2xi16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> vector<2xi16>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xi16>, vector<3xi32> -> vector<2xi16>
+  return %result : vector<2xi16>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_2xi16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xi16>, vector<3xi32> -> tuple<vector<2xi16>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xi16>, vector<3xi32> -> vector<2xi16>
 
-func @miopen_blockwise_load_4xi16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> tuple<vector<4xi16>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xi16>, vector<3xi32> -> tuple<vector<4xi16>>
-  return %result : tuple<vector<4xi16>>
+func @miopen_blockwise_load_4xi16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> vector<4xi16>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xi16>, vector<3xi32> -> vector<4xi16>
+  return %result : vector<4xi16>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_4xi16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xi16>, vector<3xi32> ->  tuple<vector<4xi16>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xi16>, vector<3xi32> -> vector<4xi16>
 
-func @miopen_blockwise_load_8xi16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> tuple<vector<8xi16>>  {
-  %result = miopen.blockwise_load(%source, %source_coord) : memref<?x?x?xi16>, vector<3xi32> -> tuple<vector<8xi16>>
-  return %result : tuple<vector<8xi16>>
+func @miopen_blockwise_load_8xi16(%source : memref<?x?x?xi16>, %source_coord : vector<3xi32>) -> vector<8xi16>  {
+  %result = miopen.blockwise_load %source[%source_coord] : memref<?x?x?xi16>, vector<3xi32> -> vector<8xi16>
+  return %result : vector<8xi16>
 }
 
 // CHECK-LABEL: func @miopen_blockwise_load_8xi16
-//  CHECK: %{{.*}} = miopen.blockwise_load(%{{.*}}, %{{.*}}) : memref<?x?x?xi16>, vector<3xi32> -> tuple<vector<8xi16>>
+//  CHECK: %{{.*}} = miopen.blockwise_load %{{.*}}[%{{.*}}] : memref<?x?x?xi16>, vector<3xi32> -> vector<8xi16>
 
 // --------------------------
 // blockwise_store tests.
 
 // f32 tests.
 
-func @miopen_blockwise_store_f32(%data : tuple<f32>, %dest : memref<?x?x?xf32, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<f32>, memref<?x?x?xf32, 3>, vector<3xi32>
+func @miopen_blockwise_store_f32(%data : f32, %dest : memref<?x?x?xf32, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : f32 -> memref<?x?x?xf32, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_f32
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<f32>, memref<?x?x?xf32, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : f32 -> memref<?x?x?xf32, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_2xf32(%data : tuple<vector<2xf32>>, %dest : memref<?x?x?xf32, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<2xf32>>, memref<?x?x?xf32, 3>, vector<3xi32>
+func @miopen_blockwise_store_2xf32(%data : vector<2xf32>, %dest : memref<?x?x?xf32, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<2xf32> -> memref<?x?x?xf32, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_2xf32
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<2xf32>>, memref<?x?x?xf32, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<2xf32> -> memref<?x?x?xf32, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_4xf32(%data : tuple<vector<4xf32>>, %dest : memref<?x?x?xf32, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<4xf32>>, memref<?x?x?xf32, 3>, vector<3xi32>
+func @miopen_blockwise_store_4xf32(%data : vector<4xf32>, %dest : memref<?x?x?xf32, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<4xf32> -> memref<?x?x?xf32, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_4xf32
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<4xf32>>, memref<?x?x?xf32, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<4xf32> -> memref<?x?x?xf32, 3>, vector<3xi32>
 
 // f16 tests.
 
-func @miopen_blockwise_store_f16(%data : tuple<f16>, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<f16>, memref<?x?x?xf16, 3>, vector<3xi32>
+func @miopen_blockwise_store_f16(%data : f16, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : f16 -> memref<?x?x?xf16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_f16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<f16>, memref<?x?x?xf16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : f16 -> memref<?x?x?xf16, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_2xf16(%data : tuple<vector<2xf16>>, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<2xf16>>, memref<?x?x?xf16, 3>, vector<3xi32>
+func @miopen_blockwise_store_2xf16(%data : vector<2xf16>, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<2xf16> -> memref<?x?x?xf16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_2xf16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<2xf16>>, memref<?x?x?xf16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<2xf16> -> memref<?x?x?xf16, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_4xf16(%data : tuple<vector<4xf16>>, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<4xf16>>, memref<?x?x?xf16, 3>, vector<3xi32>
+func @miopen_blockwise_store_4xf16(%data : vector<4xf16>, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<4xf16> -> memref<?x?x?xf16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_4xf16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<4xf16>>, memref<?x?x?xf16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<4xf16> -> memref<?x?x?xf16, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_8xf16(%data : tuple<vector<8xf16>>, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<8xf16>>, memref<?x?x?xf16, 3>, vector<3xi32>
+func @miopen_blockwise_store_8xf16(%data : vector<8xf16>, %dest : memref<?x?x?xf16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<8xf16> -> memref<?x?x?xf16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_8xf16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<8xf16>>, memref<?x?x?xf16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<8xf16> -> memref<?x?x?xf16, 3>, vector<3xi32>
 
 // i16 tests.
 
-func @miopen_blockwise_store_i16(%data : tuple<i16>, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<i16>, memref<?x?x?xi16, 3>, vector<3xi32>
+func @miopen_blockwise_store_i16(%data : i16, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : i16 -> memref<?x?x?xi16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_i16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<i16>, memref<?x?x?xi16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : i16 -> memref<?x?x?xi16, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_2xi16(%data : tuple<vector<2xi16>>, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<2xi16>>, memref<?x?x?xi16, 3>, vector<3xi32>
+func @miopen_blockwise_store_2xi16(%data : vector<2xi16>, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<2xi16> -> memref<?x?x?xi16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_2xi16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<2xi16>>, memref<?x?x?xi16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<2xi16> -> memref<?x?x?xi16, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_4xi16(%data : tuple<vector<4xi16>>, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<4xi16>>, memref<?x?x?xi16, 3>, vector<3xi32>
+func @miopen_blockwise_store_4xi16(%data : vector<4xi16>, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<4xi16> -> memref<?x?x?xi16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_4xi16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<4xi16>>, memref<?x?x?xi16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<4xi16> -> memref<?x?x?xi16, 3>, vector<3xi32>
 
-func @miopen_blockwise_store_8xi16(%data : tuple<vector<8xi16>>, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
-  miopen.blockwise_store(%data, %dest, %dest_coord) : tuple<vector<8xi16>>, memref<?x?x?xi16, 3>, vector<3xi32>
+func @miopen_blockwise_store_8xi16(%data : vector<8xi16>, %dest : memref<?x?x?xi16, 3>, %dest_coord : vector<3xi32>) {
+  miopen.blockwise_store %data -> %dest[%dest_coord] : vector<8xi16> -> memref<?x?x?xi16, 3>, vector<3xi32>
   return
 }
 
 // CHECK-LABEL: func @miopen_blockwise_store_8xi16
-//  CHECK: miopen.blockwise_store(%{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<8xi16>>, memref<?x?x?xi16, 3>, vector<3xi32>
+//  CHECK: miopen.blockwise_store %{{.*}} -> %{{.*}}[%{{.*}}] : vector<8xi16> -> memref<?x?x?xi16, 3>, vector<3xi32>
 
 // --------------------------
 // threadwise_copy tests.
@@ -478,40 +478,40 @@ func @miopen_threadwise_load(%source_coord : memref<2xi32, 5>,
   %source_coord_x = memref.load %source_coord[%c0] : memref<2xi32, 5>
 
   // check source as vanilla memref, dest as scalar.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32>, i32, i32 -> tuple<f32>
-  %v0 = miopen.threadwise_load(%source, %source_coord_x, %source_coord_y) : memref<?x?xf32>, i32, i32 -> tuple<f32>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x?xf32>, i32, i32 -> f32
+  %v0 = miopen.threadwise_load %source[%source_coord_x, %source_coord_y] : memref<?x?xf32>, i32, i32 -> f32
 
   // check source as vanilla memref, dest as vector.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32>, i32, i32 -> tuple<vector<4xf32>>
-  %v1 = miopen.threadwise_load(%source, %source_coord_x, %source_coord_y) : memref<?x?xf32>, i32, i32 -> tuple<vector<4xf32>>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x?xf32>, i32, i32 -> vector<4xf32>
+  %v1 = miopen.threadwise_load %source[%source_coord_x, %source_coord_y] : memref<?x?xf32>, i32, i32 -> vector<4xf32>
 
   // -----
 
   // check source with embedded affine maps, dest as scalar.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32, #map0>, i32, i32 -> tuple<f32>
-  %v2 = miopen.threadwise_load(%source_with_embedded_affine, %source_coord_x, %source_coord_y) : memref<?x?xf32, #map0>, i32, i32 -> tuple<f32>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x?xf32, #map0>, i32, i32 -> f32
+  %v2 = miopen.threadwise_load %source_with_embedded_affine[%source_coord_x, %source_coord_y] : memref<?x?xf32, #map0>, i32, i32 -> f32
 
   // check source with embedded affine maps, dest as vector.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}}) : memref<?x?xf32, #map0>, i32, i32 -> tuple<vector<4xf32>>
-  %v3 = miopen.threadwise_load(%source_with_embedded_affine, %source_coord_x, %source_coord_y) : memref<?x?xf32, #map0>, i32, i32 -> tuple<vector<4xf32>>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x?xf32, #map0>, i32, i32 -> vector<4xf32>
+  %v3 = miopen.threadwise_load %source_with_embedded_affine[%source_coord_x, %source_coord_y] : memref<?x?xf32, #map0>, i32, i32 -> vector<4xf32>
 
   // -----
 
   // check source with one externally defined affine map, dest as scalar.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
-  %v4 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2] } ] } : memref<?x?x?x?xf32>, i32, i32 -> tuple<f32>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}]
+  %v4 = miopen.threadwise_load %source_with_externally_defined_affine[%source_coord_x, %source_coord_y] { coord_transforms = [ { operand = 0, transforms = [#map2] } ] } : memref<?x?x?x?xf32>, i32, i32 -> f32
 
   // check source with one externally defined affine map, dest as vector.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
-  %v5 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2] } ] } : memref<?x?x?x?xf32>, i32, i32 -> tuple<vector<4xf32>>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}]
+  %v5 = miopen.threadwise_load %source_with_externally_defined_affine[%source_coord_x, %source_coord_y] { coord_transforms = [ { operand = 0, transforms = [#map2] } ] } : memref<?x?x?x?xf32>, i32, i32 -> vector<4xf32>
 
   // check source with multiple externally defined affine maps, dest as scalar.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
-  %v6 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2, #map3] } ] } : memref<?x?x?x?xf32>, i32, i32 -> tuple<f32>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}]
+  %v6 = miopen.threadwise_load %source_with_externally_defined_affine[%source_coord_x, %source_coord_y] { coord_transforms = [ { operand = 0, transforms = [#map2, #map3] } ] } : memref<?x?x?x?xf32>, i32, i32 -> f32
 
   // check source with multiple externally defined affine maps, dest as vector.
-  // CHECK: %{{.*}} = miopen.threadwise_load(%{{.*}}, %{{.*}}, %{{.*}})
-  %v7 = miopen.threadwise_load(%source_with_externally_defined_affine, %source_coord_x, %source_coord_y) { coord_transforms = [ { operand = 0, transforms = [#map2, #map3] } ] } : memref<?x?x?x?xf32>, i32, i32 -> tuple<vector<4xf32>>
+  // CHECK: %{{.*}} = miopen.threadwise_load %{{.*}}[%{{.*}}, %{{.*}}]
+  %v7 = miopen.threadwise_load %source_with_externally_defined_affine[%source_coord_x, %source_coord_y] { coord_transforms = [ { operand = 0, transforms = [#map2, #map3] } ] } : memref<?x?x?x?xf32>, i32, i32 -> vector<4xf32>
 
   return
 }
@@ -520,8 +520,8 @@ func @miopen_threadwise_load(%source_coord : memref<2xi32, 5>,
 // threadwise_store tests.
 
 // CHECK-LABEL: func @miopen_threadwise_store
-func @miopen_threadwise_store(%data_scalar : tuple<f32>,
-                              %data_vector : tuple<vector<4xf32>>,
+func @miopen_threadwise_store(%data_scalar : f32,
+                              %data_vector : vector<4xf32>,
                               %dest_coord : memref<2xi32, 5>,
                               %dest : memref<?x?xf32>,
                               %dest_with_embedded_affine : memref<?x?xf32, #map1>,
@@ -532,40 +532,40 @@ func @miopen_threadwise_store(%data_scalar : tuple<f32>,
   %dest_coord_x = memref.load %dest_coord[%c0] : memref<2xi32, 5>
 
   // check dest as vanilla memrefs, data as scalar.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tuple<f32>, memref<?x?xf32>, i32, i32
-  miopen.threadwise_store(%data_scalar, %dest, %dest_coord_x, %dest_coord_y) : tuple<f32>, memref<?x?xf32>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}] : f32 -> memref<?x?xf32>, i32, i32
+  miopen.threadwise_store %data_scalar -> %dest[%dest_coord_x, %dest_coord_y] : f32 -> memref<?x?xf32>, i32, i32
 
   // check dest as vanilla memrefs, data as vector.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<4xf32>>, memref<?x?xf32>, i32, i32
-  miopen.threadwise_store(%data_vector, %dest, %dest_coord_x, %dest_coord_y) : tuple<vector<4xf32>>, memref<?x?xf32>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}] : vector<4xf32> -> memref<?x?xf32>, i32, i32
+  miopen.threadwise_store %data_vector -> %dest[%dest_coord_x, %dest_coord_y] : vector<4xf32> -> memref<?x?xf32>, i32, i32
 
   // -----
 
   // check dest with embedded affine maps, data as scalar.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tuple<f32>
-  miopen.threadwise_store(%data_scalar, %dest_with_embedded_affine, %dest_coord_x, %dest_coord_y) : tuple<f32>, memref<?x?xf32, #map1>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}] : f32
+  miopen.threadwise_store %data_scalar -> %dest_with_embedded_affine[%dest_coord_x, %dest_coord_y] : f32 -> memref<?x?xf32, #map1>, i32, i32
 
   // check dest with embedded affine maps, data as vector.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tuple<vector<4xf32>>
-  miopen.threadwise_store(%data_vector, %dest_with_embedded_affine, %dest_coord_x, %dest_coord_y) : tuple<vector<4xf32>>, memref<?x?xf32, #map1>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}] : vector<4xf32>
+  miopen.threadwise_store %data_vector -> %dest_with_embedded_affine[%dest_coord_x, %dest_coord_y] : vector<4xf32> -> memref<?x?xf32, #map1>, i32, i32
 
   // -----
 
   // check destination with one externally defined affine map, data as scalar.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
-  miopen.threadwise_store(%data_scalar, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2] } ] } : tuple<f32>, memref<?x?x?x?xf32>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}]
+  miopen.threadwise_store %data_scalar -> %dest_with_externally_defined_affine[%dest_coord_x, %dest_coord_y] { coord_transforms = [ { operand = 1, transforms = [#map2] } ] } : f32 -> memref<?x?x?x?xf32>, i32, i32
 
   // check destination with one externally defined affine map, data as vector.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
-  miopen.threadwise_store(%data_vector, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2] } ] } : tuple<vector<4xf32>>, memref<?x?x?x?xf32>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}]
+  miopen.threadwise_store %data_vector -> %dest_with_externally_defined_affine[%dest_coord_x, %dest_coord_y] { coord_transforms = [ { operand = 1, transforms = [#map2] } ] } : vector<4xf32> -> memref<?x?x?x?xf32>, i32, i32
 
   // check destination with multiple externally defined affine map, data as scalar.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
-  miopen.threadwise_store(%data_scalar, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2, #map3] } ] } : tuple<f32>, memref<?x?x?x?xf32>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}]
+  miopen.threadwise_store %data_scalar -> %dest_with_externally_defined_affine[%dest_coord_x, %dest_coord_y] { coord_transforms = [ { operand = 1, transforms = [#map2, #map3] } ] } : f32 -> memref<?x?x?x?xf32>, i32, i32
 
   // check destination with multiple externally defined affine map, data as vector.
-  // CHECK: miopen.threadwise_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}})
-  miopen.threadwise_store(%data_vector, %dest_with_externally_defined_affine, %dest_coord_x, %dest_coord_y) { coord_transforms = [ { operand = 1, transforms = [#map2, #map3] } ] } : tuple<vector<4xf32>>, memref<?x?x?x?xf32>, i32, i32
+  // CHECK: miopen.threadwise_store %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}]
+  miopen.threadwise_store %data_vector -> %dest_with_externally_defined_affine[%dest_coord_x, %dest_coord_y] { coord_transforms = [ { operand = 1, transforms = [#map2, #map3] } ] } : vector<4xf32> -> memref<?x?x?x?xf32>, i32, i32
 
   return
 }


### PR DESCRIPTION
This commit replaces all cases where we passed a tuple argument to
MIOpen ops, such as threadwise_load or blockwise_store with a variadic
argument. This change allows us to not need to maintain vector.tuple
or vector.tuple_get , which have been removed with upstream.

This PR has the following consequences:

- The print formats of {blockwise,threadwise}_{load,store} have been
changed. Variadic arguments are separated by the rest of the list by
some delimiter other than a comma so that they can be parsed
unambigously. This also makes the printed representations more
human-readable and brings them closer in line with
memref.load/memref.store.
- In threadwise_store, the operand attribute in the coordinate
transformations is no longer 1, but the number of values passed in to
be stored. (For example, `miopen.threadwise_store %1, %2 -> %3[%4]` will
have an operand attribute of 2.) This only affects threadwise_store.
- Calls to computeSliceLengths() now pass nullptr as the type for
irrelevant arguments.

These are the changed discussed in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/306 and would close that issue.

(and so @whchung )