### PR TITLE
#152 (Partition TOSA at conv2d) and #162 (Element-wise attribute for TOSA ops)

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOpBase.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOpBase.td
@@ -192,4 +192,9 @@ class Tosa_Op<string mnemonic, list<OpTrait> traits = []> :
     Op<Tosa_Dialect, mnemonic, !listconcat(traits, [TosaOpInterface])> {
 }
 
+//===----------------------------------------------------------------------===//
+// TOSA element-wise ops.  The Elementwise trait requires identical shapes.
+//===----------------------------------------------------------------------===//
+def AbstractElementwise : NativeOpTrait<"tosa::AbstractElementwise">;
+
 #endif // TOSA_OP_BASE

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOpTraits.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOpTraits.h
@@ -1,0 +1,33 @@
+//===- TosaOpTraits.h - MLIR TOSA operation traits --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares C++ classes for operation traits in the TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TOSA_IR_TOSAOPTRAITS_H_
+#define MLIR_DIALECT_TOSA_IR_TOSAOPTRAITS_H_
+
+#include "mlir/IR/OpDefinition.h"
+
+namespace mlir {
+namespace OpTrait {
+namespace tosa {
+
+// A trait for ops that are elementwise in the abstract, and thus can
+// be fused.  The existing Elementwise trait requires identical shapes
+// for any non-scalar operands and results, but this one doesn't.
+template <typename ConcreteType>
+struct AbstractElementwise
+    : public TraitBase<ConcreteType, AbstractElementwise> {};
+
+} // namespace tosa
+} // namespace OpTrait
+} // namespace mlir
+
+#endif // MLIR_DIALECT_TOSA_IR_TOSAOPTRAITS_H_

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Traits.h"
+#include "mlir/Dialect/Tosa/IR/TosaOpTraits.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
@@ -15,8 +15,8 @@
 
 #include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Traits.h"
 #include "mlir/Dialect/Tosa/IR/TosaOpTraits.h"
+#include "mlir/Dialect/Traits.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the operation set for the TOSA dialect as defined in
-// the TOSA specfication (https://developer.mlplatform.org/w/tosa/). 
+// the TOSA specfication (https://developer.mlplatform.org/w/tosa/).
 //
 //===----------------------------------------------------------------------===//
 
@@ -58,7 +58,7 @@ def Tosa_ArgMaxOp : Tosa_Op<"argmax", [
 //===----------------------------------------------------------------------===//
 def Tosa_AvgPool2dOp : Tosa_Op<"avg_pool2d", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>, 
+                              ["inferReturnTypeComponents"]>,
     NoSideEffect]> {
   let summary = "Performs max pooling on the input.";
 
@@ -315,7 +315,7 @@ def Tosa_TransposeConv2DOp : Tosa_Op<"transpose_conv2d", [
 def Tosa_ClampOp : Tosa_Op<"clamp", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Computes clamp(features, min, max).";
 
   let description = [{
@@ -343,7 +343,7 @@ def Tosa_ClampOp : Tosa_Op<"clamp", [
 def Tosa_ReluNOp : Tosa_Op<"reluN", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Computes rectified linear: `max(features, N)`.";
 
   let description = [{
@@ -367,7 +367,7 @@ def Tosa_ReluNOp : Tosa_Op<"reluN", [
 def Tosa_SigmoidOp : Tosa_Op<"sigmoid", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Computes elementwise sigmoid of input.";
 
   let description = [{
@@ -393,7 +393,7 @@ def Tosa_SigmoidOp : Tosa_Op<"sigmoid", [
 def Tosa_TanhOp : Tosa_Op<"tanh", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Computes elementwise hyperbolic tangent of input";
 
   let description = [{
@@ -424,7 +424,7 @@ def Tosa_TanhOp : Tosa_Op<"tanh", [
 def Tosa_AddOp : Tosa_Op<"add", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect, Commutative]> {
+    ResultsBroadcastableShape, NoSideEffect, Commutative, AbstractElementwise]> {
   let summary = "Elementwise addition operator";
 
   let description = [{
@@ -448,7 +448,7 @@ def Tosa_AddOp : Tosa_Op<"add", [
 def Tosa_ArithmeticRightShiftOp : Tosa_Op<"arithmetic_right_shift", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise Arithmetic Right Shift";
 
   let description = [{
@@ -473,12 +473,12 @@ def Tosa_ArithmeticRightShiftOp : Tosa_Op<"arithmetic_right_shift", [
 def Tosa_BitwiseAndOp : Tosa_Op<"bitwise_and", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect, Commutative]> {
+    ResultsBroadcastableShape, NoSideEffect, Commutative, AbstractElementwise]> {
   let summary = "Bitwise AND operator";
 
   let description = [{
     Elementwise bitwise AND of input1 and input2. Axis of size 1
-    will be broadcast as necessary. 
+    will be broadcast as necessary.
   }];
 
   let arguments = (ins
@@ -497,7 +497,7 @@ def Tosa_BitwiseAndOp : Tosa_Op<"bitwise_and", [
 def Tosa_BitwiseOrOp : Tosa_Op<"bitwise_or", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect, Commutative]> {
+    ResultsBroadcastableShape, NoSideEffect, Commutative, AbstractElementwise]> {
   let summary = "Bitwise OR operator";
 
   let description = [{
@@ -521,7 +521,7 @@ def Tosa_BitwiseOrOp : Tosa_Op<"bitwise_or", [
 def Tosa_BitwiseXorOp : Tosa_Op<"bitwise_xor", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect, Commutative]> {
+    ResultsBroadcastableShape, NoSideEffect, Commutative, AbstractElementwise]> {
   let summary = "Bitwise XOR operator";
 
   let description = [{
@@ -545,7 +545,7 @@ def Tosa_BitwiseXorOp : Tosa_Op<"bitwise_xor", [
 def Tosa_DivOp : Tosa_Op<"div", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Integer divide operator";
 
   let description = [{
@@ -569,7 +569,7 @@ def Tosa_DivOp : Tosa_Op<"div", [
 def Tosa_LogicalAndOp : Tosa_Op<"logical_and", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, Commutative, NoSideEffect]> {
+    ResultsBroadcastableShape, Commutative, NoSideEffect, AbstractElementwise]> {
   let summary = "Returns the truth value of x AND y element-wise.";
 
   let description = [{
@@ -593,7 +593,7 @@ def Tosa_LogicalAndOp : Tosa_Op<"logical_and", [
 def Tosa_LogicalLeftShiftOp : Tosa_Op<"logical_left_shift", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise Logical Left Shift";
 
   let description = [{
@@ -617,7 +617,7 @@ def Tosa_LogicalLeftShiftOp : Tosa_Op<"logical_left_shift", [
 def Tosa_LogicalRightShiftOp : Tosa_Op<"logical_right_shift", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise Logical Right Shift";
 
   let description = [{
@@ -641,7 +641,7 @@ def Tosa_LogicalRightShiftOp : Tosa_Op<"logical_right_shift", [
 def Tosa_LogicalOrOp : Tosa_Op<"logical_or", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, Commutative, NoSideEffect]> {
+    ResultsBroadcastableShape, Commutative, NoSideEffect, AbstractElementwise]> {
   let summary = "Returns the truth value of x OR y element-wise.";
 
   let description = [{
@@ -665,7 +665,7 @@ def Tosa_LogicalOrOp : Tosa_Op<"logical_or", [
 def Tosa_LogicalXorOp : Tosa_Op<"logical_xor", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, Commutative, NoSideEffect]> {
+    ResultsBroadcastableShape, Commutative, NoSideEffect, AbstractElementwise]> {
   let summary = "Returns the truth value of x XOR y element-wise.";
 
   let description = [{
@@ -689,7 +689,7 @@ def Tosa_LogicalXorOp : Tosa_Op<"logical_xor", [
 def Tosa_MaximumOp : Tosa_Op<"maximum", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect, Commutative]> {
+    ResultsBroadcastableShape, NoSideEffect, Commutative, AbstractElementwise]> {
   let summary = "Elementwise Maximum";
 
   let description = [{
@@ -713,7 +713,7 @@ def Tosa_MaximumOp : Tosa_Op<"maximum", [
 def Tosa_MinimumOp : Tosa_Op<"minimum", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect, Commutative]> {
+    ResultsBroadcastableShape, NoSideEffect, Commutative, AbstractElementwise]> {
   let summary = "Elementwise Minimum";
 
   let description = [{
@@ -737,7 +737,7 @@ def Tosa_MinimumOp : Tosa_Op<"minimum", [
 def Tosa_MulOp : Tosa_Op<"mul", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect, Commutative]> {
+    ResultsBroadcastableShape, NoSideEffect, Commutative, AbstractElementwise]> {
   let summary = "Multiplication operator";
 
   let description = [{
@@ -762,7 +762,7 @@ def Tosa_MulOp : Tosa_Op<"mul", [
 def Tosa_PowOp : Tosa_Op<"pow", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Computes the power of one value to another.";
 
   let description = [{
@@ -786,7 +786,7 @@ def Tosa_PowOp : Tosa_Op<"pow", [
 def Tosa_SubOp : Tosa_Op<"sub", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise subtraction operator";
 
   let description = [{
@@ -853,7 +853,7 @@ def Tosa_TableOp : Tosa_Op<"table", [
 def Tosa_AbsOp : Tosa_Op<"abs", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise abs op";
 
   let description = [{
@@ -875,7 +875,7 @@ def Tosa_AbsOp : Tosa_Op<"abs", [
 def Tosa_BitwiseNotOp : Tosa_Op<"bitwise_not", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Bitwise NOT operator";
 
   let description = [{
@@ -897,7 +897,7 @@ def Tosa_BitwiseNotOp : Tosa_Op<"bitwise_not", [
 def Tosa_CeilOp : Tosa_Op<"ceil", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise ceil op";
 
   let description = [{
@@ -919,7 +919,7 @@ def Tosa_CeilOp : Tosa_Op<"ceil", [
 def Tosa_ClzOp : Tosa_Op<"clz", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise count leading zero op";
 
   let description = [{
@@ -941,7 +941,7 @@ def Tosa_ClzOp : Tosa_Op<"clz", [
 def Tosa_ExpOp : Tosa_Op<"exp", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise exp op";
 
   let description = [{
@@ -963,7 +963,7 @@ def Tosa_ExpOp : Tosa_Op<"exp", [
 def Tosa_FloorOp : Tosa_Op<"floor", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise floor op";
 
   let description = [{
@@ -985,7 +985,7 @@ def Tosa_FloorOp : Tosa_Op<"floor", [
 def Tosa_LogOp : Tosa_Op<"log", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise log op";
 
   let description = [{
@@ -1007,7 +1007,7 @@ def Tosa_LogOp : Tosa_Op<"log", [
 def Tosa_LogicalNotOp : Tosa_Op<"logical_not", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Returns the truth value of NOT x element-wise.";
 
   let description = [{
@@ -1029,7 +1029,7 @@ def Tosa_LogicalNotOp : Tosa_Op<"logical_not", [
 def Tosa_NegateOp : Tosa_Op<"negate", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise negate op";
 
   let description = [{
@@ -1054,7 +1054,7 @@ def Tosa_NegateOp : Tosa_Op<"negate", [
 def Tosa_ReciprocalOp : Tosa_Op<"reciprocal", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise reciprocal op";
 
   let description = [{
@@ -1077,7 +1077,7 @@ def Tosa_ReciprocalOp : Tosa_Op<"reciprocal", [
 def Tosa_RsqrtOp : Tosa_Op<"rsqrt", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    NoSideEffect]> {
+    NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise 1/sqrt op";
 
   let description = [{
@@ -1105,7 +1105,8 @@ def Tosa_RsqrtOp : Tosa_Op<"rsqrt", [
 //===----------------------------------------------------------------------===//
 def Tosa_SelectOp : Tosa_Op<"select", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>, NoSideEffect]> {
+                              ["inferReturnTypeComponents"]>,
+                              NoSideEffect, AbstractElementwise]> {
   let summary = "Elementwise select operator";
 
   let description = [{
@@ -1134,7 +1135,7 @@ def Tosa_SelectOp : Tosa_Op<"select", [
 def Tosa_EqualOp : Tosa_Op<"equal", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, Commutative, NoSideEffect]> {
+    ResultsBroadcastableShape, Commutative, NoSideEffect, AbstractElementwise]> {
   let summary = "Returns the truth value of (x == y) element-wise.";
 
   let description = [{
@@ -1157,7 +1158,7 @@ def Tosa_EqualOp : Tosa_Op<"equal", [
 def Tosa_GreaterOp : Tosa_Op<"greater", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Returns the truth value of (x > y) element-wise.";
 
   let description = [{
@@ -1180,7 +1181,7 @@ def Tosa_GreaterOp : Tosa_Op<"greater", [
 def Tosa_GreaterEqualOp : Tosa_Op<"greater_equal", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>,
-    ResultsBroadcastableShape, NoSideEffect]> {
+    ResultsBroadcastableShape, NoSideEffect, AbstractElementwise]> {
   let summary = "Returns the truth value of (x >= y) element-wise.";
 
   let description = [{
@@ -1367,7 +1368,7 @@ def Tosa_ConcatOp : Tosa_Op<"concat", [
   let summary = "Concatenates tensors along one dimension.";
 
   let description = [{
-    Concatenate a variadic amount of tensors along a given axis. No data 
+    Concatenate a variadic amount of tensors along a given axis. No data
     conversion happens during a concat operation.
   }];
 
@@ -1493,7 +1494,7 @@ def Tosa_SliceOp: Tosa_Op<"slice", [
 //===----------------------------------------------------------------------===//
 def Tosa_TileOp: Tosa_Op<"tile", [
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>, 
+                              ["inferReturnTypeComponents"]>,
       NoSideEffect]> {
   let summary = "Tile operator";
 
@@ -1517,7 +1518,7 @@ def Tosa_TileOp: Tosa_Op<"tile", [
 //===----------------------------------------------------------------------===//
 def Tosa_TransposeOp : Tosa_Op<"transpose", [
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>, 
+                              ["inferReturnTypeComponents"]>,
       NoSideEffect]> {
   let summary = "Transpose operator";
 
@@ -1547,7 +1548,7 @@ def Tosa_TransposeOp : Tosa_Op<"transpose", [
 //===----------------------------------------------------------------------===//
 def Tosa_GatherOp : Tosa_Op<"gather", [
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>, 
+                              ["inferReturnTypeComponents"]>,
       NoSideEffect]> {
   let summary = "Gather operation,";
 
@@ -1679,7 +1680,7 @@ def Tosa_CastOp: Tosa_Op<"cast", [NoSideEffect,
 //===----------------------------------------------------------------------===//
 // Operator: rescale
 //===----------------------------------------------------------------------===//
-def Tosa_RescaleOp: Tosa_Op<"rescale", [NoSideEffect, 
+def Tosa_RescaleOp: Tosa_Op<"rescale", [NoSideEffect,
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>]> {
   let summary = "Tosa rescale operator";

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the operation set for the TOSA dialect as defined in
-// the TOSA specfication (https://developer.mlplatform.org/w/tosa/).
+// the TOSA specification (https://developer.mlplatform.org/w/tosa/). 
 //
 //===----------------------------------------------------------------------===//
 
@@ -58,7 +58,7 @@ def Tosa_ArgMaxOp : Tosa_Op<"argmax", [
 //===----------------------------------------------------------------------===//
 def Tosa_AvgPool2dOp : Tosa_Op<"avg_pool2d", [
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>,
+                              ["inferReturnTypeComponents"]>, 
     NoSideEffect]> {
   let summary = "Performs max pooling on the input.";
 
@@ -478,7 +478,7 @@ def Tosa_BitwiseAndOp : Tosa_Op<"bitwise_and", [
 
   let description = [{
     Elementwise bitwise AND of input1 and input2. Axis of size 1
-    will be broadcast as necessary.
+    will be broadcast as necessary. 
   }];
 
   let arguments = (ins
@@ -1368,7 +1368,7 @@ def Tosa_ConcatOp : Tosa_Op<"concat", [
   let summary = "Concatenates tensors along one dimension.";
 
   let description = [{
-    Concatenate a variadic amount of tensors along a given axis. No data
+    Concatenate a variadic amount of tensors along a given axis. No data 
     conversion happens during a concat operation.
   }];
 
@@ -1494,7 +1494,7 @@ def Tosa_SliceOp: Tosa_Op<"slice", [
 //===----------------------------------------------------------------------===//
 def Tosa_TileOp: Tosa_Op<"tile", [
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>,
+                              ["inferReturnTypeComponents"]>, 
       NoSideEffect]> {
   let summary = "Tile operator";
 
@@ -1518,7 +1518,7 @@ def Tosa_TileOp: Tosa_Op<"tile", [
 //===----------------------------------------------------------------------===//
 def Tosa_TransposeOp : Tosa_Op<"transpose", [
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>,
+                              ["inferReturnTypeComponents"]>, 
       NoSideEffect]> {
   let summary = "Transpose operator";
 
@@ -1548,7 +1548,7 @@ def Tosa_TransposeOp : Tosa_Op<"transpose", [
 //===----------------------------------------------------------------------===//
 def Tosa_GatherOp : Tosa_Op<"gather", [
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>,
+                              ["inferReturnTypeComponents"]>, 
       NoSideEffect]> {
   let summary = "Gather operation,";
 
@@ -1680,7 +1680,7 @@ def Tosa_CastOp: Tosa_Op<"cast", [NoSideEffect,
 //===----------------------------------------------------------------------===//
 // Operator: rescale
 //===----------------------------------------------------------------------===//
-def Tosa_RescaleOp: Tosa_Op<"rescale", [NoSideEffect,
+def Tosa_RescaleOp: Tosa_Op<"rescale", [NoSideEffect, 
       DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
                               ["inferReturnTypeComponents"]>]> {
   let summary = "Tosa rescale operator";

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
@@ -22,6 +22,9 @@ namespace tosa {
 std::unique_ptr<Pass> createTosaInferShapesPass();
 std::unique_ptr<Pass> createTosaMakeBroadcastablePass();
 std::unique_ptr<Pass> createTosaTestQuantUtilAPIPass();
+std::unique_ptr<Pass> createTosaPartitionPass();
+std::unique_ptr<Pass> createPostPartitionCollapsePass();
+void registerTosaPartitionPipelinePass();
 
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/Tosa/Transforms/Passes.h.inc"

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -43,4 +43,29 @@ def TosaMakeBroadcastable : FunctionPass<"tosa-make-broadcastable"> {
   let constructor = "createTosaMakeBroadcastablePass()";
 }
 
+def TosaPartition : FunctionPass<"tosa-partition"> {
+  let summary = "Outline TOSA Conv2D ops and adjacent element-wise ops";
+  let description = [{
+    Outline kernels of tosa::Conv2D and surrounding elementwise ops.
+  }];
+
+  let constructor = "createTosaPartitionPass()";
+
+  let options = [
+    Option<"nofront", "nofront", "bool", /*default=*/"false",
+           "Don't gather ops ahead of Conv2D">
+  ];
+  let dependentDialects = ["tosa::TosaDialect"];
+}
+
+def PostPartitionCollapse : Pass<"tosa-collapse", "ModuleOp"> {
+  let summary = "After --tosa-partition, merge identical functions";
+  let description = [{
+    Replace calls to identical functions with calls to the first one,
+    allowing the others to be dead-coded.
+  }];
+
+  let constructor = "createPostPartitionCollapsePass()";
+}
+
 #endif // MLIR_DIALECT_TOSA_TRANSFORMS_PASSES

--- a/external/llvm-project/mlir/include/mlir/InitAllPasses.h
+++ b/external/llvm-project/mlir/include/mlir/InitAllPasses.h
@@ -66,6 +66,7 @@ inline void registerAllPasses() {
   registerStandardPasses();
   tensor::registerTensorPasses();
   tosa::registerTosaOptPasses();
+  tosa::registerTosaPartitionPipelinePass();
 }
 
 } // namespace mlir

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRTosaTransforms
   TosaInferShapes.cpp
   TosaMakeBroadcastable.cpp
+  TosaPartition.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa/Transforms
@@ -9,6 +10,7 @@ add_mlir_dialect_library(MLIRTosaTransforms
   MLIRTosaPassIncGen
 
   LINK_LIBS PUBLIC
+  MLIRTransforms
   MLIRPass
   MLIRTosa
   )

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -1,0 +1,424 @@
+//===- TosaPartition.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Replace conv2d followed by elementwise with call to function containing them.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Dialect/Tosa/Transforms/PassDetail.h"
+#include "mlir/Dialect/Tosa/Transforms/Passes.h"
+#include "mlir/Dialect/Tosa/Utils/QuantUtils.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include <algorithm>
+#include <deque>
+#include <iostream>
+
+using llvm::SmallVector;
+
+using namespace mlir;
+
+namespace {
+
+// Tosa ops can broadcast values along axes, which allows for
+// element-wise operations without fully-matching dimensions.  The
+// Elementwise trait is strict about matching dimensions, but the
+// AbstractElementwise trait is specific to applicable Tosa ops.  In
+// practice, broadcastable and same-type Tosa ops are also element-wise.
+bool isElementwiseOp(Operation *op) {
+  return op->hasTrait<OpTrait::Elementwise>() ||
+         op->hasTrait<OpTrait::tosa::AbstractElementwise>() ||
+         op->hasTrait<OpTrait::ResultsBroadcastableShape>() ||
+         op->hasTrait<OpTrait::SameOperandsAndResultType>();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Inspired by / adapted from outlineIfOp() in SCF/Transforms/Utils.cpp.
+// Given a convolution op and its fuse-able trailing (second) and leading
+// (front) ops, remove them into a separate function.
+void outlineConvPartOps(Operation *convOp, SetVector<Operation *> &secondOps,
+                        ArrayRef<Operation *> frontOps, ArrayRef<Value> params,
+                        ArrayRef<Value> returnVals, StringRef partFnName) {
+  OpBuilder b(convOp);
+  Location loc = convOp->getLoc();
+  MLIRContext *ctx = convOp->getContext();
+
+  // Insert outlined function before current function.
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(convOp->getParentOfType<FuncOp>());
+
+  // Make FuncOp from convOp's operand types and secondOp's result type.
+  ValueRange values(params);
+  ValueRange results(returnVals);
+  FunctionType type =
+      FunctionType::get(ctx, values.getTypes(), results.getTypes());
+  SmallVector<NamedAttribute, 1> kernelAttrs{
+      b.getNamedAttr("kernel", b.getUnitAttr()),
+  };
+  auto outlinedFunc = b.create<FuncOp>(loc, partFnName, type,
+                                       ArrayRef<NamedAttribute>(kernelAttrs));
+  outlinedFunc->setAttr("sym_visibility", StringAttr::get(ctx, "private"));
+
+  // Clone convOp and secondOps into the body of the new function.
+  b.setInsertionPointToStart(outlinedFunc.addEntryBlock());
+  BlockAndValueMapping bvm;
+  for (auto it : llvm::zip(values, outlinedFunc.getArguments()))
+    bvm.map(std::get<0>(it), std::get<1>(it));
+
+  for (auto *op : llvm::reverse(frontOps)) {
+    b.clone(*op, bvm);
+  }
+
+  b.clone(*convOp, bvm);
+
+  // Since secondOps is a SetVector, it's in the order that the ops were
+  // seen in the main function, which is safe to iterate through.
+  Operation *lastOp = convOp;
+  for (auto *op : secondOps) {
+    assert(llvm::all_of(op->getOperands(),
+                        [&](Value v) { return bvm.lookupOrNull(v); }));
+    b.clone(*op, bvm);
+    lastOp = op;
+  }
+
+  // Make ReturnOp from secondOps' results.
+  SmallVector<Value> returnOperands;
+  for (auto op : returnVals) {
+    returnOperands.push_back(bvm.lookup(op));
+  }
+  // Can't also supply return types, because it'll see a mismatch
+  // in numbers where there isn't one.
+  b.create<ReturnOp>(loc, returnOperands);
+
+  // Replace convOp and secondOps with CallOp to new function.
+  b.setInsertionPointAfter(lastOp);
+  CallOp callOp = b.create<CallOp>(loc, outlinedFunc, values);
+
+  for (auto it : llvm::zip(returnVals, callOp->getResults())) {
+    std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
+  }
+
+  // Erase the ops we outlined, which should be safe now.
+  for (auto &op : llvm::make_early_inc_range(llvm::reverse(secondOps))) {
+    assert(op->use_empty() && "expected 'op' to have no uses");
+    op->erase();
+  }
+  assert(convOp->use_empty() && "expected 'op' to have no uses");
+  convOp->erase();
+  for (auto &op : llvm::make_early_inc_range(frontOps)) {
+    assert(op->use_empty() && "expected 'op' to have no uses");
+    op->erase();
+  }
+}
+
+// Can't just use an equality test on attributes, because the sym_name
+// attribute will always be different.  Here we get NamedAttrLists,
+// which are implicitly sorted, and walk down them in parallel, ignoring
+// sym_name.  If they're equivalent, then all the attributes will pair
+// up.
+bool areAttributesEffectivelyEqual(Operation *lhs, Operation *rhs) {
+  NamedAttrList lhsAttrs(lhs->getAttrs());
+  NamedAttrList rhsAttrs(rhs->getAttrs());
+
+  const auto *lhsIterator = lhsAttrs.begin();
+  const auto *rhsIterator = rhsAttrs.begin();
+
+  while (lhsIterator != lhsAttrs.end() && rhsIterator != rhsAttrs.end()) {
+    NamedAttribute lhsAttr = *lhsIterator;
+    NamedAttribute rhsAttr = *rhsIterator;
+
+    // Skip names, which always differ.
+    if (lhsAttr.first == "sym_name")
+      lhsAttr = *(++lhsIterator);
+    if (rhsAttr.first == "sym_name")
+      rhsAttr = *(++rhsIterator);
+
+    if (lhsAttr != rhsAttr)
+      return false;
+
+    ++lhsIterator;
+    ++rhsIterator;
+  }
+
+  return (lhsIterator == lhsAttrs.end() && rhsIterator == rhsAttrs.end());
+}
+
+// OperationEquivalence::isEquivalentTo() doesn't do what I want because
+// the attributes it compares also include the function names, which will
+// always be different.  Another approach would be to temporarily modify
+// the functions to remove the names (and anything else unimportant).
+bool isFunctionallyEquivalentTo(Operation *lhs, Operation *rhs) {
+  if (lhs == rhs)
+    return true;
+
+  // Compare the operation name.
+  if (lhs->getName() != rhs->getName())
+    return false;
+  // Check operand counts.
+  if (lhs->getNumOperands() != rhs->getNumOperands())
+    return false;
+  SmallVector<Type> lhsOperandTypes(lhs->getOperandTypes().begin(),
+                                    lhs->getOperandTypes().end());
+  SmallVector<Type> rhsOperandTypes(rhs->getOperandTypes().begin(),
+                                    rhs->getOperandTypes().end());
+  if (lhsOperandTypes.size() != rhsOperandTypes.size())
+    return false;
+  for (auto it : llvm::zip(lhsOperandTypes, rhsOperandTypes)) {
+    if (std::get<0>(it) != std::get<1>(it))
+      return false;
+  }
+  // Compare attributes.
+  if (!areAttributesEffectivelyEqual(lhs, rhs))
+    return false;
+  // Compare result types.
+  SmallVector<Type> lhsResultTypes(lhs->getResultTypes());
+  SmallVector<Type> rhsResultTypes(rhs->getResultTypes());
+  if (lhsResultTypes.size() != rhsResultTypes.size())
+    return false;
+  switch (lhsResultTypes.size()) {
+  case 0:
+    break;
+  case 1:
+    // Compare the single result type.
+    if (lhsResultTypes.front() != rhsResultTypes.front())
+      return false;
+    break;
+  default:
+    // Use the type buffer for the comparison, as we can guarantee it is the
+    // same for any given range of result types. This takes advantage of the
+    // fact the result types >1 are stored in a TupleType and uniqued.
+    if (lhsResultTypes.data() != rhsResultTypes.data())
+      return false;
+    break;
+  }
+
+  auto isExternFunc = [](Operation *op) {
+    FuncOp f = dyn_cast<FuncOp>(op);
+    return isa<FuncOp>(op) &&
+           (f->getRegions().size() != 1 || f->getRegions()[0].empty());
+  };
+  if (isExternFunc(lhs) || isExternFunc(rhs)) {
+    return false;
+  }
+
+  // TODO: Allow commutative operations to have different ordering.
+  for (auto itRegion : llvm::zip(lhs->getRegions(), rhs->getRegions())) {
+    for (auto itOperation : llvm::zip(std::get<0>(itRegion).getOps(),
+                                      std::get<1>(itRegion).getOps())) {
+      if (!isFunctionallyEquivalentTo(&std::get<0>(itOperation),
+                                      &std::get<1>(itOperation))) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Inspired by / adapted from TestSCFIfUtilsPass in
+// test/lib/Transforms/TestSCFUtils.cpp.
+class TosaPartitionPass : public TosaPartitionBase<TosaPartitionPass> {
+public:
+  void runOnFunction() override {
+    int count = 0;
+    FuncOp func = getFunction();
+
+    auto callback = [&](tosa::Conv2DOp convOp) {
+      auto strCount = std::string("_outlined_part_") + std::to_string(count++);
+
+      // Given a Conv2DOp, gather all the element-wise ops that are reachable
+      // from its results, contiguously.
+      //
+      // The ops after the Conv2D are "second" ops.
+      // inputNodes gathers what will become the parameters of the outlined
+      // function;  initially it's the Conv2D's arguments, and it accumulates
+      // arguments to other ops that don't come from inside the outlined
+      // function.
+      // resultNodes will become the results of the outlined function.  It
+      // starts with Conv2D's result(s) and gains the results of each new
+      // secondOp.  When all a resultNode's users can be determined to lie
+      // within the outlined function, it's removed from the set.
+      //
+      // These are SetVectors because we test with contains() a lot, but still
+      // want to preserve order.
+      SetVector<Operation *> secondOps;
+      SetVector<Value> inputNodes(convOp->getOperands().begin(),
+                                  convOp->getOperands().end());
+      SetVector<Value> resultNodes(convOp->getResults().begin(),
+                                   convOp->getResults().end());
+
+      // Grab a useful set of leading ops, like we do for trailing.
+      // Let's limit it to only first arguments, with single uses.
+      SmallVector<Operation *> frontOps;
+      if (!nofront) {
+        Operation *op = convOp;
+        while (true) {
+          if (op->getNumOperands() < 1)
+            break;
+          Operation *usedOp = op->getOpOperand(0).get().getDefiningOp();
+          if (!usedOp)
+            break;
+          if (!isElementwiseOp(usedOp) || !usedOp->hasOneUse())
+            break;
+          // Remove the first operand from the function inputs, if present.
+          // Add usedOp's operands to the function inputs.
+          inputNodes.remove(op->getOpOperand(0).get());
+          inputNodes.insert(usedOp->getOperands().begin(),
+                            usedOp->getOperands().end());
+          frontOps.push_back(usedOp);
+          op = usedOp;
+        }
+      }
+
+      DominanceInfo domInfo(func);
+      std::deque<Operation *> worklist; // cuz I want to pull from the front.
+
+      worklist.push_back(convOp);
+      while (!worklist.empty()) {
+        Operation *op = worklist.front();
+        worklist.pop_front();
+        for (auto *userOp : op->getUsers()) {
+          if (isElementwiseOp(userOp) /* && userOp->hasOneUse() */) {
+            bool skip = false;
+            // First criterion is that the op is element-wise.  Second criterion
+            // is that the op dominates all the users of the accumulated results
+            // of the outlined function.  In other words, we can't take an op
+            // that comes "after" a user of the result from the eventual call,
+            // because the call needs to dominate all its users.
+            for (const Value &val : resultNodes) {
+              for (auto *user : val.getDefiningOp()->getUsers()) {
+                if (user != userOp &&
+                    !domInfo.properlyDominates(userOp, user)) {
+                  skip = true;
+                }
+              }
+            }
+
+            // userOp is acceptable.  Keep it as a secondOp, put it on the
+            // worklist.  Add its operands to inputNodes unless they come
+            // from other secondOps (indicated by being in resultNodes).
+            // If all the users of any resultNode are in secondOps, there's
+            // no need to return it so remove from resultNodes.  Finally,
+            // add all userOp's results to resultNodes.
+            if (!skip) {
+              secondOps.insert(userOp);
+              worklist.push_back(userOp);
+              for (Value opnd : userOp->getOperands()) {
+                if (!resultNodes.contains(opnd)) {
+                  inputNodes.insert(opnd);
+                }
+              }
+              for (const Value &val : resultNodes) {
+                if (llvm::all_of(val.getUsers(), [&](Operation *u) {
+                      return secondOps.contains(u);
+                    })) {
+                  resultNodes.remove(val);
+                }
+              }
+              for (auto res : userOp->getResults()) {
+                resultNodes.insert(res);
+              }
+            }
+          }
+        }
+      }
+
+      if (!secondOps.empty() || !frontOps.empty()) {
+        // Make the outlined function from the ops we've gathered.
+        outlineConvPartOps(convOp, secondOps, frontOps,
+                           inputNodes.getArrayRef(), resultNodes.getArrayRef(),
+                           std::string(func.sym_name()) + strCount);
+        // Outlining will erase nodes and thus perturb the walk, so
+        // signal interrupted to exit it and restart.
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    };
+
+    // Walk until we've outlined all the Conv2D ops we can.
+    while (func.walk(callback).wasInterrupted()) {
+    }
+
+    // Count on the SymbolDCE pass to clean up the dead functions.
+  }
+};
+
+// Replace calls to identical functions with calls to the first one,
+// allowing the others to be dead-coded.
+struct PostPartitionCollapsePass
+    : public PostPartitionCollapseBase<PostPartitionCollapsePass> {
+  void runOnOperation() override;
+};
+
+void PostPartitionCollapsePass::runOnOperation() {
+  ModuleOp module = getOperation();
+  // For all FuncOps, make a mapping to replace those that are identical to
+  // another.
+  SmallVector<Operation *> opsSeen;
+  DenseMap<StringRef, StringRef> replacements;
+  for (auto f : module.getOps<FuncOp>()) {
+    bool replaced = false;
+    for (Operation *o : opsSeen) {
+      if (isFunctionallyEquivalentTo(f, o)) {
+        replacements[f.sym_name()] = dyn_cast<FuncOp>(o).sym_name();
+        replaced = true;
+      }
+    }
+    if (!replaced) {
+      opsSeen.push_back(f);
+    }
+  }
+  // Then walk all the CallOps and remap callees where appropriate.
+  module.walk([&](CallOp call) {
+    if (replacements.find(call.getCallee()) != replacements.end()) {
+      call.calleeAttr(FlatSymbolRefAttr::get(module->getContext(),
+                                             replacements[call.getCallee()]));
+    }
+  });
+}
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::tosa::createTosaPartitionPass() {
+  return std::make_unique<TosaPartitionPass>();
+}
+
+std::unique_ptr<Pass> mlir::tosa::createPostPartitionCollapsePass() {
+  return std::make_unique<PostPartitionCollapsePass>();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+static void tosaPartitionPipeline(OpPassManager &pm) {
+  pm.addPass(std::make_unique<TosaPartitionPass>());
+  pm.addPass(std::make_unique<PostPartitionCollapsePass>());
+  pm.addPass(mlir::createSymbolDCEPass());
+}
+
+namespace mlir {
+namespace tosa {
+void registerTosaPartitionPipelinePass() {
+  PassPipelineRegistration<>("tosa-partition-pipeline",
+                             "Partition around Conv2D ops and clean up after",
+                             tosaPartitionPipeline);
+}
+} // namespace tosa
+} // namespace mlir

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
@@ -1,0 +1,46 @@
+// RUN: mlir-opt %s --tosa-to-linalg-on-tensors --tosa-to-standard --linalg-detensorize \
+// RUN:   -tensor-constant-bufferize -std-bufferize -linalg-bufferize -tensor-bufferize \
+// RUN:   -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
+// RUN:   --tosa-to-standard -lower-affine -convert-linalg-to-llvm --convert-scf-to-std \
+// RUN:   --convert-math-to-llvm --convert-std-to-llvm --reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: > %t1
+//
+// RUN  cat %t1 | FileCheck %s
+// CHECK:  Unranked Memref
+// CHECK-SAME:  sizes = [1, 10, 10, 2] strides = [200, 20, 2, 1]
+// CHECK-NEXT:  [[[[0.458882,     0.344086],
+// CHECK-NEXT:     [0.336863,     0.469958],
+// CHECK-NEXT:     [0.214844,     0.595831],
+// CHECK-NEXT:     [0.0928252,     0.721703],
+//
+// RUN: mlir-opt %s --tosa-partition-pipeline --tosa-to-linalg-on-tensors --tosa-to-standard --linalg-detensorize \
+// RUN:   -tensor-constant-bufferize -std-bufferize -linalg-bufferize -tensor-bufferize \
+// RUN:   -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
+// RUN:   --tosa-to-standard -lower-affine -convert-linalg-to-llvm --convert-scf-to-std \
+// RUN:   --convert-math-to-llvm --convert-std-to-llvm --reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: > %t2
+//
+// RUN: diff --ignore-matching-lines='Unranked Memref' %t1 %t2
+
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 808 : i32}}  {
+  func private @print_memref_f32(memref<*xf32>)
+  func private @printNewline()
+  func @main() {
+    %0 = "tosa.const"() {value = dense<[[[[-1.747810e-01], [0.356973231], [-0.166753888]], [[-0.298198819], [0.110798746], [-0.314905882]], [[-0.267817706], [0.318314373], [0.329790294]]], [[[-0.236702681], [-0.0709462166], [-0.192342982]], [[0.138438225], [-0.217499733], [0.0627906919]], [[0.0631466805], [-2.780110e-01], [0.357007563]]]]> : tensor<2x3x3x1xf32>} : () -> tensor<2x3x3x1xf32>
+    %1 = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
+    %2 = "tosa.const"() {value = dense<[[[[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]]]]> : tensor<1x10x10x1xf32>} : () -> tensor<1x10x10x1xf32>
+    %4 = "tosa.conv2d"(%2, %0, %1) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<1x10x10x1xf32>, tensor<2x3x3x1xf32>, tensor<2xf32>) -> tensor<1x10x10x2xf32>
+    %5 = "tosa.clamp"(%4) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<1x10x10x2xf32>) -> tensor<1x10x10x2xf32>
+    %8 = memref.buffer_cast %5 : memref<1x10x10x2xf32>
+    %9 = memref.cast %8 : memref<1x10x10x2xf32> to memref<*xf32>
+    call @print_memref_f32(%9) : (memref<*xf32>) -> ()
+    call @printNewline() : () -> ()
+    return
+  }
+}

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
@@ -1,0 +1,73 @@
+// RUN: mlir-opt --split-input-file --tosa-partition-pipeline %s -verify-each=0 -o -| FileCheck %s
+
+// CHECK-LABEL: func private @test_fusion_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.abs
+// CHECK: return
+// CHECK: func @test_fusion
+// CHECK: call @test_fusion_outlined_part_0
+func @test_fusion(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %1 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion2_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.negate
+// CHECK: return
+// CHECK: func @test_fusion2
+// CHECK: call @test_fusion2_outlined_part_0
+func @test_fusion2(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.negate"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %1 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion3_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.abs
+// CHECK: tosa.negate
+// CHECK: return
+// CHECK: func @test_fusion3
+// CHECK: call @test_fusion3_outlined_part_0
+func @test_fusion3(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.negate"(%1) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %2 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion4_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.abs
+// +++pf:  This test used to absorb the tosa.add, too, but doesn't now.
+// CHECK: return
+// CHECK: func @test_fusion4
+// CHECK: call @test_fusion4_outlined_part_0
+func @test_fusion4(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.add"(%0, %1) {} : (tensor<128x128x30x30xf32>, tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %2 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion5_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.abs
+// CHECK: tosa.add
+// CHECK: return
+// CHECK: func @test_fusion5
+// CHECK: tosa.conv2d
+// CHECK: call @test_fusion5_outlined_part_0
+func @test_fusion5(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>, %arg3: tensor<128x8x32x32xf32>, %arg4: tensor<128x8x3x3xf32>, %arg5: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.conv2d"(%arg3, %arg4, %arg5) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %3 = "tosa.add"(%2, %1) {} : (tensor<128x128x30x30xf32>, tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %3 : tensor<128x128x30x30xf32>
+}

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/gpu-to-hsaco.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/gpu-to-hsaco.mlir
@@ -11,10 +11,10 @@
 func @other_func(%arg0 : f32, %arg1 : memref<?xf32>) {
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %block_dim = dim %arg1, %c0 : memref<?xf32>
+  %block_dim = memref.dim %arg1, %c0 : memref<?xf32>
   gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
              threads(%tx, %ty, %tz) in (%block_x = %block_dim, %block_y = %c1, %block_z = %c1) {
-    store %arg0, %arg1[%tx] : memref<?xf32>
+    memref.store %arg0, %arg1[%tx] : memref<?xf32>
     gpu.terminator
   }
   return
@@ -22,12 +22,12 @@ func @other_func(%arg0 : f32, %arg1 : memref<?xf32>) {
 
 // CHECK: [1, 1, 1, 1, 1]
 func @main() {
-  %arg0 = alloc() : memref<5xf32>
+  %arg0 = memref.alloc() : memref<5xf32>
   %21 = constant 5 : i32
-  %22 = memref_cast %arg0 : memref<5xf32> to memref<?xf32>
-  %cast = memref_cast %22 : memref<?xf32> to memref<*xf32>
+  %22 = memref.cast %arg0 : memref<5xf32> to memref<?xf32>
+  %cast = memref.cast %22 : memref<?xf32> to memref<*xf32>
   gpu.host_register %cast : memref<*xf32>
-  %23 = memref_cast %22 : memref<?xf32> to memref<*xf32>
+  %23 = memref.cast %22 : memref<?xf32> to memref<*xf32>
   call @print_memref_f32(%23) : (memref<*xf32>) -> ()
   %24 = constant 1.0 : f32
   %25 = call @mgpuMemGetDeviceMemRef1dFloat(%22) : (memref<?xf32>) -> (memref<?xf32>)

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/two-modules.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/two-modules.mlir
@@ -10,24 +10,24 @@
 
 // CHECK: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 func @main() {
-  %arg = alloc() : memref<13xi32>
-  %dst = memref_cast %arg : memref<13xi32> to memref<?xi32>
+  %arg = memref.alloc() : memref<13xi32>
+  %dst = memref.cast %arg : memref<13xi32> to memref<?xi32>
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %sx = dim %dst, %c0 : memref<?xi32>
-  %cast_dst = memref_cast %dst : memref<?xi32> to memref<*xi32>
+  %sx = memref.dim %dst, %c0 : memref<?xi32>
+  %cast_dst = memref.cast %dst : memref<?xi32> to memref<*xi32>
   gpu.host_register %cast_dst : memref<*xi32>
   %dst_device = call @mgpuMemGetDeviceMemRef1dInt32(%dst) : (memref<?xi32>) -> (memref<?xi32>)
   gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
              threads(%tx, %ty, %tz) in (%block_x = %sx, %block_y = %c1, %block_z = %c1) {
     %t0 = index_cast %tx : index to i32
-    store %t0, %dst_device[%tx] : memref<?xi32>
+    memref.store %t0, %dst_device[%tx] : memref<?xi32>
     gpu.terminator
   }
   gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
              threads(%tx, %ty, %tz) in (%block_x = %sx, %block_y = %c1, %block_z = %c1) {
     %t0 = index_cast %tx : index to i32
-    store %t0, %dst_device[%tx] : memref<?xi32>
+    memref.store %t0, %dst_device[%tx] : memref<?xi32>
     gpu.terminator
   }
   call @print_memref_i32(%cast_dst) : (memref<*xi32>) -> ()

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/vecadd.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/vecadd.mlir
@@ -12,13 +12,13 @@
 func @vecadd(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>, %arg2 : memref<?xf32>) {
   %c0 = constant 0 : index
   %c1 = constant 1 : index
-  %block_dim = dim %arg0, %c0 : memref<?xf32>
+  %block_dim = memref.dim %arg0, %c0 : memref<?xf32>
   gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
              threads(%tx, %ty, %tz) in (%block_x = %block_dim, %block_y = %c1, %block_z = %c1) {
-    %a = load %arg0[%tx] : memref<?xf32>
-    %b = load %arg1[%tx] : memref<?xf32>
+    %a = memref.load %arg0[%tx] : memref<?xf32>
+    %b = memref.load %arg1[%tx] : memref<?xf32>
     %c = addf %a, %b : f32
-    store %c, %arg2[%tx] : memref<?xf32>
+    memref.store %c, %arg2[%tx] : memref<?xf32>
     gpu.terminator
   }
   return
@@ -30,19 +30,19 @@ func @main() {
   %c1 = constant 1 : index
   %c5 = constant 5 : index
   %cf1dot23 = constant 1.23 : f32
-  %0 = alloc() : memref<5xf32>
-  %1 = alloc() : memref<5xf32>
-  %2 = alloc() : memref<5xf32>
-  %3 = memref_cast %0 : memref<5xf32> to memref<?xf32>
-  %4 = memref_cast %1 : memref<5xf32> to memref<?xf32>
-  %5 = memref_cast %2 : memref<5xf32> to memref<?xf32>
+  %0 = memref.alloc() : memref<5xf32>
+  %1 = memref.alloc() : memref<5xf32>
+  %2 = memref.alloc() : memref<5xf32>
+  %3 = memref.cast %0 : memref<5xf32> to memref<?xf32>
+  %4 = memref.cast %1 : memref<5xf32> to memref<?xf32>
+  %5 = memref.cast %2 : memref<5xf32> to memref<?xf32>
   scf.for %i = %c0 to %c5 step %c1 {
-    store %cf1dot23, %3[%i] : memref<?xf32>
-    store %cf1dot23, %4[%i] : memref<?xf32>
+    memref.store %cf1dot23, %3[%i] : memref<?xf32>
+    memref.store %cf1dot23, %4[%i] : memref<?xf32>
   }
-  %6 = memref_cast %3 : memref<?xf32> to memref<*xf32>
-  %7 = memref_cast %4 : memref<?xf32> to memref<*xf32>
-  %8 = memref_cast %5 : memref<?xf32> to memref<*xf32>
+  %6 = memref.cast %3 : memref<?xf32> to memref<*xf32>
+  %7 = memref.cast %4 : memref<?xf32> to memref<*xf32>
+  %8 = memref.cast %5 : memref<?xf32> to memref<*xf32>
   gpu.host_register %6 : memref<*xf32>
   gpu.host_register %7 : memref<*xf32>
   gpu.host_register %8 : memref<*xf32>

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/vector-transferops.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/vector-transferops.mlir
@@ -59,19 +59,19 @@ func @main() {
   %cf1 = constant 1.0 : f32
   %cf1dot23 = constant 1.23 : f32
 
-  %arg0 = alloc() : memref<4xf32>
-  %arg1 = alloc() : memref<4xf32>
+  %arg0 = memref.alloc() : memref<4xf32>
+  %arg1 = memref.alloc() : memref<4xf32>
 
-  %22 = memref_cast %arg0 : memref<4xf32> to memref<?xf32>
-  %23 = memref_cast %arg1 : memref<4xf32> to memref<?xf32>
+  %22 = memref.cast %arg0 : memref<4xf32> to memref<?xf32>
+  %23 = memref.cast %arg1 : memref<4xf32> to memref<?xf32>
 
   scf.for %i = %c0 to %c4 step %c1 {
-    store %cf1dot23, %22[%i] : memref<?xf32>
-    store %cf1dot23, %23[%i] : memref<?xf32>
+    memref.store %cf1dot23, %22[%i] : memref<?xf32>
+    memref.store %cf1dot23, %23[%i] : memref<?xf32>
   }
 
-  %cast0 = memref_cast %22 : memref<?xf32> to memref<*xf32>
-  %cast1 = memref_cast %23 : memref<?xf32> to memref<*xf32>
+  %cast0 = memref.cast %22 : memref<?xf32> to memref<*xf32>
+  %cast1 = memref.cast %23 : memref<?xf32> to memref<*xf32>
 
   gpu.host_register %cast0 : memref<*xf32>
   gpu.host_register %cast1 : memref<*xf32>


### PR DESCRIPTION
Look for tosa::Conv2D ops followed and/or preceded by element-wise ops, and pull them out into separate functions with a "kernel" attribute for later fusion.  Requires the invention of an element-wise attribute.

Also update some integration  tests for the external/llvm-project update.