### PR TITLE
Add gemmSizes checks to quickly reject an invalid configuration

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -14,6 +14,7 @@
 #define MLIR_DIALECT_MIOPEN_CONV2DGENERATOR_H_
 
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
+#include "mlir/Dialect/MIOpen/utility/BackwardDataValidation.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -113,6 +114,9 @@ public:
   }
   LogicalResult isApplicable() const;
 
+  int64_t getBwdDataNumberOfGemm() const;
+  std::tuple<int64_t, int64_t, int64_t> getBwdDataGemmSizes(int64_t) const;
+
 private:
   template <typename Vector>
   std::vector<int64_t> layoutPermutation(const Vector &src,
@@ -128,6 +132,7 @@ private:
   int getBwdDataKernelCount() const;
   LogicalResult hasValidDimension() const;
   LogicalResult hasValidChip() const;
+  LogicalResult hasValidGemmSizes() const;
 
   // Generator config
   Config config;

--- a/mlir/include/mlir/Dialect/MIOpen/utility/BackwardDataValidation.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/BackwardDataValidation.h
@@ -1,0 +1,84 @@
+//===- Conv2dGenerator.h - MLIR to C++ option parsing ---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares mlir Conv2dGenerator class
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BACKWARD_DATA_VALIDATION_H
+#define BACKWARD_DATA_VALIDATION_H
+
+#include "math.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+
+inline std::tuple<int64_t, int64_t, int64_t> calculateBwdDataGemmSizes(
+    int64_t y, int64_t x, int64_t c, int64_t n, int64_t k, int64_t ho,
+    int64_t wo, int64_t hi, int64_t wi, int strideH, int strideW, int dilationH,
+    int dilationW, int leftPadH, int leftPadW, int64_t gemmId) {
+  auto gcdStrideDilationH = math_util::gcd(strideH, dilationH);
+  auto gcdStrideDilationW = math_util::gcd(strideW, dilationW);
+
+  auto yTilda = strideH / gcdStrideDilationH;
+  auto xTilda = strideW / gcdStrideDilationW;
+
+  auto hTilda =
+      ho + math_util::integer_divide_ceil(dilationH * (y - 1), strideH);
+  auto wTilda =
+      wo + math_util::integer_divide_ceil(dilationW * (x - 1), strideW);
+
+  auto iHTildaLeft = math_util::integer_divide_floor(
+      std::max(0, leftPadH - dilationH * (yTilda - 1)), strideH);
+  auto iWTildaLeft = math_util::integer_divide_floor(
+      std::max(0, leftPadW - dilationW * (xTilda - 1)), strideW);
+
+  auto iHTildaRight = std::min(
+      hTilda, math_util::integer_divide_ceil(leftPadH + hi - 1, strideH) + 1);
+  auto iWTildaRight = std::min(
+      wTilda, math_util::integer_divide_ceil(leftPadW + wi - 1, strideW) + 1);
+
+  auto hTildaSlice = iHTildaRight - iHTildaLeft;
+  auto wTildaSlice = iWTildaRight - iWTildaLeft;
+
+  auto iYTilda = gemmId / xTilda;
+  auto iXTilda = gemmId % xTilda;
+
+  auto yDotSlice = math_util::integer_divide_ceil(y - iYTilda, yTilda);
+  auto xDotSlice = math_util::integer_divide_ceil(x - iXTilda, xTilda);
+
+  auto gemmM = c;
+  auto gemmN = n * hTildaSlice * wTildaSlice;
+  auto gemmK = k * yDotSlice * xDotSlice;
+  return std::make_tuple(gemmM, gemmN, gemmK);
+}
+
+inline LogicalResult isValidGridGemmXdlops(int64_t gemmM, int64_t gemmN,
+                                           int64_t gemmK, int64_t waveSize) {
+  if (gemmM % 16 != 0 && gemmN % 64 != 0) {
+    return failure();
+  }
+
+  if ((gemmM * gemmN) % 256 == 0 && (gemmK * gemmM) % waveSize == 0 &&
+      (gemmK * gemmN) % waveSize == 0 && gemmN % 16 == 0 && gemmM % 4 == 0 &&
+      gemmK % 4 == 0) {
+    return success();
+  }
+  return failure();
+}
+
+inline LogicalResult isValidGemmNonXdlops(int64_t gemmM, int64_t gemmN,
+                                          int64_t gemmK) {
+  if (gemmM % 32 == 0 && gemmN % 32 == 0 && gemmK % 4 == 0)
+    return success();
+  else
+    return failure();
+}
+
+} // namespace mlir
+#endif // BACKWARD_DATA_VALIDATION_H

--- a/mlir/include/mlir/Dialect/MIOpen/utility/math.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/math.h
@@ -22,7 +22,7 @@ template <typename T> T gcd(T x, T y) {
 }
 
 template <typename X, typename... Ys> auto gcd(X x, Ys... ys) {
-  return gcd(x, ys...);
+  return gcd(x, gcd(ys...));
 }
 
 // least common multiple

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -21,8 +21,8 @@ LogicalResult PopulateParams::populateDerived(
   }
 
   if (ctx.opType == miopen::ConvOpType::Conv2DBwdDataOpType &&
-      !(gemmSize.gemmM % 32 == 0 && gemmSize.gemmN % 32 == 0 &&
-        gemmSize.gemmK % 4 == 0)) {
+      failed(isValidGemmNonXdlops(gemmSize.gemmM, gemmSize.gemmN,
+                                  gemmSize.gemmK))) {
     LLVM_DEBUG(llvm::dbgs() << "Invalid gemm sizes for backward data.\n");
     return failure();
   }
@@ -229,7 +229,8 @@ LogicalResult PopulateParamsXDL::populateDerived(
   }
 
   if (ctx.opType == miopen::ConvOpType::Conv2DBwdDataOpType &&
-      failed(isValidGridGemmXdlops(gemmSize))) {
+      failed(isValidGridGemmXdlops(gemmSize.gemmM, gemmSize.gemmN,
+                                   gemmSize.gemmK, waveSize))) {
     LLVM_DEBUG(llvm::dbgs()
                << "Invalid XDLops gemm sizes for backward data.\n");
     return failure();

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -94,7 +94,6 @@ LogicalResult MIOpenEnabled(const Conv2dGenerator::Config& conf) {
   bool noBF16 = conf.dataTypeStr != "bf16";
   return LogicalResult::success(layoutSupported && noBF16);
 }
-
 } // namespace
 
 typedef void *MiirHandle;
@@ -112,13 +111,13 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
     return nullptr;
   }
 
-  MiirHandle_s *handle = new MiirHandle_s;
-  OpBuilder builder(&(handle->getContext()));
-
   const auto &config = conv2dGenerator.getConfig();
   if (failed(MIOpenEnabled(config))) {
     return nullptr;
   }
+
+  MiirHandle_s *handle = new MiirHandle_s;
+  OpBuilder builder(&(handle->getContext()));
 
   handle->triple = config.triple;
   handle->chip = config.chip;
@@ -265,11 +264,12 @@ extern "C" const char *miirGenIgemmCflags(MiirHandle mlirHandle) {
 
 extern "C" MiirStatus miirLowerTuningParams(MiirHandle mlirHandle) {
   const std::lock_guard<std::mutex> lock(mutex);
-  miirLazyInit();
 
   MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
   if (handle == nullptr)
     return MIIR_INVALID_PARAM;
+
+  miirLazyInit();
 
   ModuleOp module = handle->getModule();
 
@@ -289,11 +289,12 @@ extern "C" MiirStatus miirLowerTuningParams(MiirHandle mlirHandle) {
 
 extern "C" MiirStatus miirLowerBin(MiirHandle mlirHandle) {
   const std::lock_guard<std::mutex> lock(mutex);
-  miirLazyInit();
 
   MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
   if (handle == nullptr)
     return MIIR_INVALID_PARAM;
+
+  miirLazyInit();
 
   ModuleOp module = handle->getModule();
 


### PR DESCRIPTION
Check gemm sizes for backward data convolutions in miirCreateHandle() so that a configuration with invalid gemm sizes will be rejected without going through the lowering pass. The motivation was to regain the performance loss of the function IsApplicable() in MIOpen's MLIR solvers as described in [this ticket](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1062).

This patch regains most (meaning >90%) of the performance of IsApplicable(). For example, for an invalid configuration, the original IsApplication() took 12us, the current IsApplication() takes 3700us, and with the changes in this PR, IsApplication() would take 180us. Although it’s much faster than the current IsApplication(), it’s still 15x slower than the original one. This is due to the overhead of passing the configuration to MLIR library and extracting necessary data for analysis. 