### PR TITLE
[AMDGPU] Disable d16 loads/stores to high register halves on gfx90a

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -1343,7 +1343,8 @@ def HasPackedD16VMem : Predicate<"!Subtarget->hasUnpackedD16VMem()">,
 
 def D16PreservesUnusedBits :
   Predicate<"Subtarget->d16PreservesUnusedBits()">,
-  AssemblerPredicate<(all_of FeatureGFX9Insts, (not FeatureSRAMECC))>;
+  AssemblerPredicate<(all_of FeatureGFX9Insts, (not FeatureSRAMECC),
+    (not FeatureGFX90AInsts))>;
 
 def LDSRequiresM0Init : Predicate<"Subtarget->ldsRequiresM0Init()">;
 def NotLDSRequiresM0Init : Predicate<"!Subtarget->ldsRequiresM0Init()">;

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -597,7 +597,9 @@ public:
   }
 
   bool d16PreservesUnusedBits() const {
-    return hasD16LoadStore() && !TargetID.isSramEccOnOrAny();
+    // gff90a's d16 loads don't preserve unused bits
+    return hasD16LoadStore() && !TargetID.isSramEccOnOrAny() &&
+           !hasGFX90AInsts();
   }
 
   bool hasD16Images() const {


### PR DESCRIPTION
Testing reveals that, on gfx90a, *_load_short_d16_hi does note
preserve the low-order bits of the destination register, even with
SramECC disabled. To prevent the generation of semantically incorrect
code, disable D16PreservesUnesedBits on this target.

(A more specific test may be needed to account for future gfx90*
targets, but checking for gfx90a instructions was what was in the
existing code)

Internal note: This patch causes the PR E2E tests to pass on Lockhart, resolving https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/363, and I'll be sending it upstream shortly.