### PR TITLE
Use std::call_once to get rid of compile-time warning.

### DIFF
--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -34,10 +34,11 @@ struct MiirHandle_s {
       return registry;
     };
     static MLIRContext context(getRegistry());
-    static bool once = []() {
+    static std::once_flag once;
+    std::call_once(once, []() {
       context.loadDialect<miopen::MIOpenDialect, StandardOpsDialect>();
       return true;
-    }();
+    });
     return context;
   }
   MiirHandle_s() {
@@ -62,7 +63,8 @@ struct MiirHandle_s {
 // condition of one thread doing intialization and another doing
 // lowering.
 bool miirLazyInit() {
-  static const bool once = []() {
+  static bool once;
+  std::call_once(once, []() {
     llvm::InitializeAllTargets();
     llvm::InitializeAllTargetInfos();
     llvm::InitializeAllTargetMCs();
@@ -76,7 +78,7 @@ bool miirLazyInit() {
     LLVMInitializeAMDGPUAsmPrinter();
     mlir::initializeLLVMPasses();
     return true;
-  }();
+  });
   return once;
 }
 

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -37,7 +37,6 @@ struct MiirHandle_s {
     static std::once_flag once;
     std::call_once(once, []() {
       context.loadDialect<miopen::MIOpenDialect, StandardOpsDialect>();
-      return true;
     });
     return context;
   }
@@ -62,8 +61,8 @@ struct MiirHandle_s {
 // With this guarantee, we are protected from the possible race
 // condition of one thread doing intialization and another doing
 // lowering.
-bool miirLazyInit() {
-  static bool once;
+void miirLazyInit() {
+  static std::once_flag once;
   std::call_once(once, []() {
     llvm::InitializeAllTargets();
     llvm::InitializeAllTargetInfos();
@@ -77,9 +76,7 @@ bool miirLazyInit() {
     LLVMInitializeAMDGPUTargetMC();
     LLVMInitializeAMDGPUAsmPrinter();
     mlir::initializeLLVMPasses();
-    return true;
   });
-  return once;
 }
 
 LogicalResult MIOpenEnabled(const Conv2dGenerator::Config& conf) {


### PR DESCRIPTION
This change is potentially big so I'm asking you guys to help review it.