### PR TITLE
Do MIOpen validation tests and MLIR kernels tuning weekly

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -243,7 +243,10 @@ pipeline {
                         stage("Build MIOpen with libMLIRMIOpen") {
                             when { anyOf {
                                     equals expected: true, actual: params.nightly;
-                                    equals expected: true, actual: params.weekly;
+                                    allOf {
+                                        equals expected: true, actual: params.weekly;
+                                        equals expected: true, actual: params.staticLib;
+                                    }
                             }}
                             steps {
                                 dir('MIOpen') {
@@ -271,7 +274,10 @@ pipeline {
                         stage("Stash MIOpen with libMLIRMIOpen") {
                             when { anyOf {
                                     equals expected: true, actual: params.nightly;
-                                    equals expected: true, actual: params.weekly;
+                                    allOf {
+                                        equals expected: true, actual: params.weekly;
+                                        equals expected: true, actual: params.staticLib;
+                                    }
                             }}
                             steps {
                                 stash name:"MIOpen-MLIR-kernels",\
@@ -284,6 +290,7 @@ pipeline {
                         stage("Test MIOpen config with tuning") {
                             when {
                                     equals expected: true, actual: params.weekly;
+                                    equals expected: true, actual: params.staticLib;
                             }
                             environment {
                                 // Make libMIOpen.so accessible to the test driver

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -8,11 +8,7 @@ void buildProject(String target, String cmakeOpts) {
         cmakeArgs: "-DMLIR_MIOPEN_DRIVER_ENABLED=1 $cmakeOpts"
 }
 
-void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
-    git branch: 'develop', poll: false,\
-        url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
-    cmake arguments: "-P install_deps.cmake --minimum ${prefixOpt}",\
-        installation: "InSearchPath"
+void buildMIOpen(String cmakeOpts) {
     sh '[ ! -d build ] || rm -rf build'
     cmakeBuild generator: 'Unix Makefiles',\
         buildDir: 'build',\
@@ -23,6 +19,14 @@ void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
                      ${cmakeOpts}
                      """
     sh 'cd build; make -j $(nproc) MIOpenDriver'
+}
+
+void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
+    git branch: 'develop', poll: false,\
+        url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
+    cmake arguments: "-P install_deps.cmake --minimum ${prefixOpt}",\
+        installation: "InSearchPath"
+    buildMIOpen(cmakeOpts)
 }
 
 void showEnv() {
@@ -53,8 +57,8 @@ void preMergeCheck() {
     sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
 }
 
-void testMIOpenDriver(String dtype, String xdlops, String layout, String direction, String tuning) {
-    echo "Config is (${dtype}, ${layout}, xdlops=${xdlops}, dir=${direction}, tuning=${tuning})"
+void testMIOpenDriver(String dtype, String layout, String direction, String tuning) {
+    echo "Config is (${dtype}, ${layout}, dir=${direction}, tuning=${tuning})"
     sh 'ldconfig'
     dir('MIOpen/build/') {
         sh """
@@ -62,7 +66,6 @@ void testMIOpenDriver(String dtype, String xdlops, String layout, String directi
         --layout ${layout} \
         --direction ${direction} \
         --dtype ${dtype} \
-        ${xdlops == '1' ? '--xdlops' : '--no-xdlops'} \
         ${tuning == '1' ? '--tuning' : '--no-tuning'} \
         < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs"""
     }
@@ -97,6 +100,8 @@ pipeline {
                      description: 'Run extra nightly-only tests')
         booleanParam(name: 'canXdlops', defaultValue: params.canXdlops == false ? false : true,
                      description: 'Can this CI instance use xdlops (no for public server)')
+        booleanParam(name: 'weekly', defaultValue: params.weekly == false ? false : true,
+                     description: 'Run weekly-only jobs')
 
         // Each below control whether to run a individual stage from parallel run
         // They default to true but deverloper can toggle them for debugging purpose
@@ -236,13 +241,10 @@ pipeline {
                             }
                         }
                         stage("Build MIOpen with libMLIRMIOpen") {
-                            when { allOf {
-                                equals expected: true, actual: params.nightly;
-                                anyOf {
-                                    equals expected: true, actual: params.perfTest;
-                                    equals expected: true, actual: params.canXdlops;
-                                } }
-                            }
+                            when { anyOf {
+                                    equals expected: true, actual: params.nightly;
+                                    equals expected: true, actual: params.weekly;
+                            }}
                             steps {
                                 dir('MIOpen') {
                                 getAndBuildMIOpen('--prefix ./MIOpenDeps', '''-DMIOPEN_USE_MLIR=On
@@ -267,12 +269,10 @@ pipeline {
                             }
                         }
                         stage("Stash MIOpen with libMLIRMIOpen") {
-                            when { allOf {
-                                equals expected: true, actual: params.nightly;
-                                anyOf {
-                                equals expected: true, actual: params.perfTest;
-                                equals expected: true, actual: params.canXdlops;
-                            } } }
+                            when { anyOf {
+                                    equals expected: true, actual: params.nightly;
+                                    equals expected: true, actual: params.weekly;
+                            }}
                             steps {
                                 stash name:"MIOpen-MLIR-kernels",\
                                       includes: """
@@ -281,6 +281,29 @@ pipeline {
                                       """
                             }
                         }
+                        stage("Test MIOpen config with tuning") {
+                            when {
+                                    equals expected: true, actual: params.weekly;
+                            }
+                            environment {
+                                // Make libMIOpen.so accessible to the test driver
+                                LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
+                            }
+                            steps {
+                                sh 'ldconfig'
+                                dir('MIOpen/build/') {
+                                    sh 'date --utc +%Y-%m-%d > tuning-date'
+                                    sh """
+                                    bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --tune-all\
+                                       < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs"""
+                                    sh 'ls -l MIOpenUserDB'
+                                }
+                                // Save user database  for nightly jobs
+                                archiveArtifacts artifacts: 'MIOpen/build/MIOpenUserDB/**, MIOpen/build/tuning-date',\
+                                                 onlyIfSuccessful: true
+                            }
+                        }
+ 
                     }
                     post {
                         always {
@@ -354,27 +377,35 @@ pipeline {
         }
         stage("Benchmark and Report Performance") {
             when {
-                        beforeAgent true;
-                        equals expected: true, actual: params.perfTest;
-                        equals expected: true, actual: params.nightly;
-                    }
-                    agent {
-                        docker {
-                            image dockerImage()
-                            args dockerArgs()
-                            label "${params.canXdlops ? 'gfx908' : 'rocm' }"
-                            alwaysPull true
-                        }
-                    }
-                    environment {
-                        // Make libMIOpen.so accessible to the test driver
-                        LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
-                   }
+                beforeAgent true;
+                equals expected: true, actual: params.perfTest;
+                equals expected: true, actual: params.nightly;
+            }
+            agent {
+                docker {
+                    image dockerImage()
+                    args dockerArgs()
+                    label "${params.canXdlops ? 'gfx908' : 'rocm' }"
+                    alwaysPull true
+                }
+            }
+            environment {
+                // Make libMIOpen.so accessible to the test driver
+                LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
+            }
             stages {
                 stage("Copy MIOpen with MLIR kernels") {
                     steps {
                         sh 'rm -rf MIOpen'
                         unstash name: "MIOpen-MLIR-kernels"
+                        //copyArtifacts filter: 'MIOpen/build/MIOpenUserDB,MIOpen/build/tuning-date',\
+                        //                       optional: true,\
+                        //                       flatten: true,\
+                        //                       projectName: "/${JOB_NAME}",\
+                        //                       selector: lastSuccessful(),\
+                        //                       target: 'MIOpen/build/'
+                        //sh 'ls MIOpen/build/MIOpenUserDB'
+                        //sh 'cat MIOpen/build/tuning-date'
                     }
                 }
                 stage("Performance Test: Tuned vs Untuned") {
@@ -419,8 +450,10 @@ pipeline {
         }
         stage("MIOpen Resnet50 Config Test") {
             when { allOf {
-                equals expected: true, actual: params.nightly;
-                equals expected: true, actual: params.canXdlops;
+                anyOf {
+                    equals expected: true, actual: params.nightly;
+                    equals expected: true, actual: params.weekly;
+                }
                 equals expected: true, actual: params.staticLib;
             }}
             matrix {
@@ -433,16 +466,8 @@ pipeline {
                         values 'fp16', 'fp32'
                     }
                     axis {
-                        name 'XDLOPS'
-                        values '1', '0'
-                    }
-                    axis {
                         name 'LAYOUT'
                         values 'NCHW', 'NHWC'
-                    }
-                    axis {
-                        name 'DIRECTION'
-                        values '1', '2', '4'
                     }
                 }
                 stages {
@@ -451,14 +476,14 @@ pipeline {
                             docker {
                                 image dockerImage()
                                 args dockerArgs()
-                                label "${XDLOPS == '1' ? 'gfx908' : 'gfx908'}"
+                                label "${params.canXdlops ? 'gfx908' : 'rocm'}"
                                 alwaysPull true
                             }
                         }
                         stages {
                             stage('Environment') {
                                 steps {
-                                    echo "Config is ($DTYPE, $LAYOUT, xdlops=$XDLOPS, dir=$DIRECTION)"
+                                    echo "Config is ($DTYPE, $LAYOUT)"
                                     showEnv()
                                 }
                             }
@@ -473,7 +498,9 @@ pipeline {
                                     LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
                                 }
                                 steps {
-                                    testMIOpenDriver('$DTYPE', '$XDLOPS', '$LAYOUT', '$DIRECTION', '0')
+                                    testMIOpenDriver('$DTYPE', '$LAYOUT', '1', '0')
+                                    testMIOpenDriver('$DTYPE', '$LAYOUT', '2', '0')
+                                    testMIOpenDriver('$DTYPE', '$LAYOUT', '4', '0')
                                     //testMIOpenDriver('$DTYPE', '$XDLOPS', '$LAYOUT', '$DIRECTION', '1')
                                 }
                             }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
                                 dir('MIOpen/build/') {
                                     sh 'date --utc +%Y-%m-%d > tuning-date'
                                     sh """
-                                    bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --tune-all\
+                                    bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --test-all --tuning\
                                        < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs"""
                                     sh 'ls -l MIOpenUserDB'
                                 }

--- a/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
+++ b/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
-declare -a FIXED_CONFIG_ARGS=()
+declare -a FIXED_CONFIG_ARGS
 declare -g TMPFILE
 declare -ig XDLOPS=0
 declare -ig TUNING=0
+declare -ig TUNEALL=0
 declare -g DTYPE=""
 declare -g DIRECTION=""
 declare -g LAYOUT=""
 declare -g DRIVER="./bin/MIOpenDriver"
 
+declare -a ALL_DTYPES=(fp16 fp32)
+declare -a ALL_DIRECTIONS=(1 2 4)
+declare -a ALL_LAYOUTS=(NCHW NHWC)
+declare -a ALL_CONFIGS=()
+
 function usage() {
     cat <<END
-$0: [-d | --direction] DIR [-t | --dtype] [fp16 | fp32]
-[-l | --layout] LAYOUT [-x | --xdlops] [-X | --no-xdlops (default)]
-[--tuning | --no-tuning (default)] [--driver DRIVER (default bin/MIOpenDriver)]
+$0: [-d | --direction] DIR [-t | --dtype] [fp16 | fp32] [-l | --layout] LAYOUT
+[--tuning | --no-tuning (default)] [--driver DRIVER (default bin/MIOpenDriver)] [--tune-all]
 
 DIR is either 1 (forward (fwd)) 2 (backward data (bwd)), or 
 4 (backward weights (wrw)), other values are currently unsupported 
@@ -35,7 +40,7 @@ function parse_options() {
 
     local parsed_args
     parsed_args=$(getopt -n "$0" -o d:t:l:xXh \
-                         --long direction:,dtype:,layout:,xdlops,no-xdlops,driver:,tuning,no-tuning,help -- "$@")
+                         --long direction:,dtype:,layout:,driver:,tuning,no-tuning,tune-all,help -- "$@")
     local -i valid_args=$?
     if [[ $valid_args -ne 0 ]]; then
         usage
@@ -45,10 +50,9 @@ function parse_options() {
     do
         case "$1" in
             -h | --help ) usage ;;
-            -x | --xdlops ) XDLOPS=1; shift; ;;
-            -X | --no-xdlops ) XDLOPS=0; shift ;;
             --tuning ) TUNING=1; shift; ;;
             --no-tuning ) TUNING=0; shift; ;;
+            --tune-all ) TUNEALL=1; shift; ;;
             -d | --direction ) got_direction=1; DIRECTION="$2"; shift 2 ;;
             -l | --layout ) got_layout=1; LAYOUT="$2"; shift 2 ;;
             -t | --dtype ) got_dtype=1; DTYPE="$2"; shift 2 ;;
@@ -59,13 +63,25 @@ function parse_options() {
     done
 
     # Check required args
-    [[ $got_layout == 1 && $got_direction == 1 && $got_dtype == 1 ]] || usage
+    [[ $got_layout == 1 && $got_direction == 1 && $got_dtype == 1 ]] || [[ $TUNEALL == 1 ]] || usage
 
     # Validate options
-    case "$DTYPE" in
-        fp16 | fp32 ) ;;
-        * ) echo "$0: Invalid dtype $DTYPE"; usage ;;
-    esac
+    if [[ $got_dtype == 1 ]]; then
+        case "$DTYPE" in
+            fp16 | fp32 ) ;;
+            * ) echo "$0: Invalid dtype $DTYPE"; usage ;;
+        esac
+    fi
+}
+
+function get_configs() {
+    local line="#"
+    while IFS= read -r line; do
+        if [[ $line == \#* || $line == "" ]]; then
+            continue
+        fi
+        ALL_CONFIGS+=("$line") 
+    done
 }
 
 function construct_fixed_args() {
@@ -78,8 +94,8 @@ function construct_fixed_args() {
        exit 2
     fi
     case "$DTYPE" in
-        fp16 ) FIXED_CONFIG_ARGS+=("convfp16") ;;
-        fp32 ) FIXED_CONFIG_ARGS+=("conv") ;;
+        fp16 ) FIXED_CONFIG_ARGS=("convfp16") ;;
+        fp32 ) FIXED_CONFIG_ARGS=("conv") ;;
         * ) echo "Can't happen"; exit 3 ;;
     esac
 
@@ -94,14 +110,9 @@ function create_configs() {
        exit 1
     fi
 
-    local line="#"
-    while IFS= read -r line; do
-        if [[ $line == \#* || $line == "" ]]; then
-            continue
-        fi
+    for line in "${ALL_CONFIGS[@]}"; do
         echo "$DRIVER" "${FIXED_CONFIG_ARGS[@]}" "$line" >>"$TMPFILE"
     done
-    cat "$TMPFILE"
 }
 
 function clean_miopen_caches() {
@@ -114,7 +125,7 @@ function setup_environment() {
     export MIOPEN_FIND_MODE=1
     export MIOPEN_DRIVER_USE_GPU_REFERENCE=1
 
-    if [[ $TUNING == 1 ]]; then
+    if [[ $TUNING == 1 || $TUNEALL == 1 ]]; then
         export MIOPEN_FIND_ENFORCE=4
     fi
 
@@ -125,8 +136,12 @@ function setup_environment() {
         4) MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmWrW ;;
         *) echo "$0: Unsupported direction flag $DIRECTION"; exit 2
     esac
-    if [[ $XDLOPS == 1 ]]; then
+    local xdlops
+    xdlops=$(/opt/rocm/bin/rocm_agent_enumerator |grep gfx908)
+
+    if [[ ! -z "$xdlops" ]]; then
        MIOPEN_DEBUG_FIND_ONLY_SOLVER+="Xdlops"
+       XDLOPS=1
     fi
     export MIOPEN_DEBUG_FIND_ONLY_SOLVER
 }
@@ -137,8 +152,6 @@ function run_tests() {
         echo "Test execution preconditions not met"
         exit 3
     fi
-
-    clean_miopen_caches
 
     local exit_status
     # The extra bash -c accounts for parallel trying to pass each line as one
@@ -160,12 +173,35 @@ function run_tests() {
     fi
 }
 
-function main() {
-    parse_options "$@"
+function run_tests_for_a_config() {
     construct_fixed_args
     create_configs
     setup_environment
     run_tests
+}
+
+function tune_all_configs() {
+    for t in ${ALL_DTYPES[@]}; do
+        for d in ${ALL_DIRECTIONS[@]}; do
+            for l in ${ALL_LAYOUTS[@]}; do
+                DTYPE=$t
+                DIRECTION=$d
+                LAYOUT=$l
+                run_tests_for_a_config
+            done
+        done
+    done
+}
+
+function main() {
+    clean_miopen_caches
+    parse_options "$@"
+    get_configs
+    if [[ $TUNEALL == 1 ]]; then
+        tune_all_configs
+    else
+        run_tests_for_a_config
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
- Add a "weekly" parameter to Jenkinsfile. The combination of "staticLib" and "weekly" does:

  Validate MIOpen Resnet50 with tuning and archive the user perfDb.
  Run MIopen tests without tuning.

- Reduce the matrix size of the "Test MIOpen config" to 2x2

- Add a "--tune-all" command line option to miopen_validate.sh which does tuning on all Resnet50 configs.

- Set Xdlops based on GPU type (via rocm_agent_enumerator), thus we can separate MIOpen tests on private CI and public CI.

A successful weekly CI is:
http://ml-ci.amd.com:21096/blue/organizations/jenkins/MLIR%2Ftest_weeklyCI/detail/test_weeklyCI/9/pipeline/276/