### PR TITLE
Completely remove mlir cpp backend from API

### DIFF
--- a/mlir/tools/mlir-miopen-lib/Miir.h
+++ b/mlir/tools/mlir-miopen-lib/Miir.h
@@ -53,29 +53,6 @@ extern "C" MiirHandle miirCreateHandle(const char *options);
  */
 extern "C" int miirGetKernelCount(MiirHandle handle);
 
-/*! @brief Lower the MLIR module to c++ code
- *  @param handle   MLIR handle
- */
-extern "C" MiirStatus miirLowerCpp(MiirHandle handle);
-
-/*! @brief Populate Conv2d implicitgemm host code for MIOpen
- *  @param handle   MLIR handle
- *  @return         Source string
- */
-extern "C" const char *miirGenIgemmSource(MiirHandle handle);
-
-/*! @brief Populate Conv2d implicitgemm header code for MIOpen
- *  @param handle   MLIR handle
- *  @return         Header string
- */
-extern "C" const char *miirGenIgemmHeader(MiirHandle handle);
-
-/*! @brief Populate Conv2d implicitgemm compilation flags for MIOpen
- *  @param handle   MLIR handle
- *  @return         Compilation flags string
- */
-extern "C" const char *miirGenIgemmCflags(MiirHandle handle);
-
 /*! @brief Lower the MLIR module to be able to obtain tuning parameters
  *  @param handle MLIR handle
  */

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
@@ -17,7 +17,7 @@ static cl::opt<std::string> args(
 static cl::opt<std::string>
     option("option", cl::desc("Code gen options: source/header/cflags"),
            cl::value_desc("Igemm convolution option string"),
-           cl::init("source"));
+           cl::init("tuningparams"));
 
 int main(int argc, char **argv) {
   // Parse pass names in main to ensure static initialization completed.
@@ -29,24 +29,7 @@ int main(int argc, char **argv) {
 
   MiirHandle handle = miirCreateHandle(args.getValue().c_str());
 
-  // Cpp backend source/header/cflags generation
-  if ((option.getValue() == "source") || (option.getValue() == "header") ||
-      (option.getValue() == "cflags")) {
-    status = miirLowerCpp(handle);
-    if (status == MIIR_SUCCESS) {
-      if (option.getValue() == "source") {
-        std::string source = miirGenIgemmSource(handle);
-        std::cout << source << std::endl;
-      } else if (option.getValue() == "header") {
-        std::string header = miirGenIgemmHeader(handle);
-        std::cout << header << std::endl;
-      } else if (option.getValue() == "cflags") {
-        std::string cflags = miirGenIgemmCflags(handle);
-        std::cout << cflags << std::endl;
-      }
-    }
-    // Bin backend binary generation
-  } else if (option.getValue() == "tuningparams") {
+  if (option.getValue() == "tuningparams") {
     status = miirLowerTuningParams(handle);
     if (status != MIIR_SUCCESS) {
       return status;

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -213,55 +213,6 @@ extern "C" MiirStatus miirGetExecutionDims(MiirHandle mlirHandle,
   return MIIR_INVALID_MODULE;
 }
 
-extern "C" MiirStatus miirLowerCpp(MiirHandle mlirHandle) {
-  const std::lock_guard<std::mutex> lock(mutex);
-  MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
-  if (handle == nullptr)
-    return MIIR_INVALID_PARAM;
-
-  ModuleOp module = handle->getModule();
-
-  PassManager pm(module.getContext(), PassManager::Nesting::Implicit);
-  pm.addPass(
-      mlir::miopen::createAffixTuningParametersPass(0, 0, handle->perfConfig));
-  pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
-  LogicalResult result = pm.run(module);
-  return (result.succeeded()) ? MIIR_SUCCESS : MIIR_BUILD_FAILURE;
-}
-
-extern "C" const char *miirGenIgemmSource(MiirHandle mlirHandle) {
-  const std::lock_guard<std::mutex> lock(mutex);
-  MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
-  if (handle == nullptr)
-    return "";
-
-  handle->genTxt = "";
-  // TBD: FIXME.
-  return (handle->genTxt).c_str();
-}
-
-extern "C" const char *miirGenIgemmHeader(MiirHandle mlirHandle) {
-  const std::lock_guard<std::mutex> lock(mutex);
-  MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
-  if (handle == nullptr)
-    return "";
-
-  handle->genTxt = "";
-  // TBD: FIXME.
-  return (handle->genTxt).c_str();
-}
-
-extern "C" const char *miirGenIgemmCflags(MiirHandle mlirHandle) {
-  const std::lock_guard<std::mutex> lock(mutex);
-  MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
-  if (handle == nullptr)
-    return "";
-
-  handle->genTxt = "";
-  // TBD: FIXME.
-  return (handle->genTxt).c_str();
-}
-
 extern "C" MiirStatus miirLowerTuningParams(MiirHandle mlirHandle) {
   const std::lock_guard<std::mutex> lock(mutex);
   miirLazyInit();


### PR DESCRIPTION
This is the final PR for https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/141

I removed the cpp backend calls from:
 - The Miir.h API
 - Test code from `mlir-miopen-lib-test`
 - Implementation code from `mlir-miopen-lib.cpp`
