### PR TITLE
Simplify index diff map computation

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -472,6 +472,7 @@ enum BwdPaddingKernelStatus {
   GemmMNPadStrideTwoXdlopsNHWC,
   GemmMPadStrideTwoXdlopsNHWC
 };
+
 inline void emitStoreLogic(
     BwdPaddingKernelStatus bwdPaddingStatus, OpBuilder &b, Location loc,
     MemRefType destType, Type typeToStore, bool toEmitOOBStoreCheckLogic,
@@ -866,6 +867,24 @@ populateTransformMetadataFromLowerType(OpBuilder &b, ShapedType lowerType,
       "lower_layer_bounds", b.getArrayAttr({lowerShapeAttr}))})});
 }
 
+//===---------------------------------------------------------
+// Determine if the operation provided is a constant, and return its value if it
+// is
+//===---------------------------------------------------------
+inline Optional<int64_t> isConstantValue(Value v) {
+  auto *op = v.getDefiningOp();
+  while (auto cast = dyn_cast<IndexCastOp>(op)) {
+    op = cast.in().getDefiningOp();
+  }
+  if (auto intOp = dyn_cast<ConstantIntOp>(op)) {
+    return intOp.getValue();
+  }
+  if (auto indexOp = dyn_cast<ConstantIndexOp>(op)) {
+    return indexOp.getValue();
+  }
+  return llvm::None;
+}
+
 //===----------------------------------------------------------------------===//
 // Utility function to compute index diff map.
 //===----------------------------------------------------------------------===//
@@ -998,6 +1017,26 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
   // value : lower level updated coordinate on that dimension.
   DenseMap<int64_t, Value> lowerIndicesUpdatedMap;
 
+  auto addToOriginal = [&b, loc](Value original, Value diff) -> Value {
+    auto mbDiffConst = isConstantValue(diff);
+    if (mbDiffConst.hasValue()) {
+      int64_t diff = mbDiffConst.getValue();
+      if (diff == 0) {
+        if (original.getType() == b.getIndexType()) {
+          return b.create<IndexCastOp>(loc, original, b.getI32Type());
+        }
+        return original;
+      }
+      auto mbOriginalConst = isConstantValue(original);
+      if (mbOriginalConst.hasValue()) {
+        return b.create<ConstantIntOp>(loc, diff + mbOriginalConst.getValue(),
+                                       32);
+      }
+    }
+    return b.create<AddIOp>(
+        loc, b.create<IndexCastOp>(loc, original, b.getI32Type()), diff);
+  };
+
   // Iterate through all transformations specified in g.
   for (auto &mapping : layoutArrayAttr) {
     DictionaryAttr g = mapping.template cast<DictionaryAttr>();
@@ -1017,21 +1056,27 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
       for (unsigned iter = 0; iter < e.size(); ++iter) {
         int64_t coefficient = e[iter].template cast<IntegerAttr>().getInt();
         int64_t upperDim = p[iter].template cast<IntegerAttr>().getInt();
-        lowerDiff = b.create<AddIOp>(
-            loc, lowerDiff,
-            b.create<MulIOp>(
-                loc,
-                b.create<ConstantIntOp>(loc, coefficient, b.getIntegerType(32)),
-                upperIndicesDiff[upperDim]));
+        auto mbUpperDiff = isConstantValue(upperIndicesDiff[upperDim]);
+        auto mbLowerDiff = isConstantValue(lowerDiff);
+        if (mbUpperDiff.hasValue() && mbLowerDiff.hasValue()) {
+          lowerDiff = b.create<ConstantIntOp>(
+              loc,
+              mbLowerDiff.getValue() + coefficient * mbUpperDiff.getValue(),
+              /*bitwidth=*/32);
+        } else {
+          lowerDiff = b.create<AddIOp>(
+              loc, lowerDiff,
+              b.create<MulIOp>(loc,
+                               b.create<ConstantIntOp>(loc, coefficient,
+                                                       b.getIntegerType(32)),
+                               upperIndicesDiff[upperDim]));
+        }
       }
 
       int64_t lowerDim = q[0].template cast<IntegerAttr>().getInt();
       lowerIndicesDiffMap[lowerDim] = lowerDiff;
-      lowerIndicesUpdatedMap[lowerDim] = b.create<AddIOp>(
-          loc,
-          b.create<IndexCastOp>(loc, lowerIndicesOriginal[lowerDim],
-                                b.getIntegerType(32)),
-          lowerDiff);
+      lowerIndicesUpdatedMap[lowerDim] =
+          addToOriginal(lowerIndicesOriginal[lowerDim], lowerDiff);
     } else if (transformation.getValue() == "UnMerge") {
       auto e = g.get("parameters").template cast<ArrayAttr>();
       assert(e.size() == p.size());
@@ -1041,21 +1086,26 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
       for (unsigned iter = 1; iter < e.size(); ++iter) {
         int64_t coefficient = e[iter].template cast<IntegerAttr>().getInt();
         int64_t upperDim = p[iter].template cast<IntegerAttr>().getInt();
-        lowerDiff = b.create<AddIOp>(
-            loc, upperIndicesDiff[upperDim],
-            b.create<MulIOp>(
-                loc,
-                b.create<ConstantIntOp>(loc, coefficient, b.getIntegerType(32)),
-                lowerDiff));
+        auto mbUpperDiff = isConstantValue(upperIndicesDiff[upperDim]);
+        auto mbLowerDiff = isConstantValue(lowerDiff);
+        if (mbUpperDiff.hasValue() && mbLowerDiff.hasValue()) {
+          lowerDiff = b.create<ConstantIntOp>(
+              loc,
+              mbLowerDiff.getValue() + coefficient * mbUpperDiff.getValue(),
+              /*bitwidth=*/32);
+        } else {
+          lowerDiff = b.create<AddIOp>(
+              loc, lowerDiff,
+              b.create<MulIOp>(loc,
+                               b.create<ConstantIntOp>(loc, coefficient,
+                                                       b.getIntegerType(32)),
+                               upperIndicesDiff[upperDim]));
+        }
       }
-
       int64_t lowerDim = q[0].template cast<IntegerAttr>().getInt();
       lowerIndicesDiffMap[lowerDim] = lowerDiff;
-      lowerIndicesUpdatedMap[lowerDim] = b.create<AddIOp>(
-          loc,
-          b.create<IndexCastOp>(loc, lowerIndicesOriginal[lowerDim],
-                                b.getIntegerType(32)),
-          lowerDiff);
+      lowerIndicesUpdatedMap[lowerDim] =
+          addToOriginal(lowerIndicesOriginal[lowerDim], lowerDiff);
     } else if ((transformation.getValue() == "PassThrough") ||
                (transformation.getValue() == "Pad") ||
                (transformation.getValue() == "Slice")) {
@@ -1066,11 +1116,8 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
         Value upperDiff = upperIndicesDiff[upperDim];
         Value lowerDiff = upperDiff;
         lowerIndicesDiffMap[lowerDim] = lowerDiff;
-        lowerIndicesUpdatedMap[lowerDim] = b.create<AddIOp>(
-            loc,
-            b.create<IndexCastOp>(loc, lowerIndicesOriginal[lowerDim],
-                                  b.getIntegerType(32)),
-            lowerDiff);
+        lowerIndicesUpdatedMap[lowerDim] =
+            addToOriginal(lowerIndicesOriginal[lowerDim], lowerDiff);
       }
     } else if ((transformation.getValue() == "Merge") ||
                (transformation.getValue() == "Unfold")) {
@@ -1084,10 +1131,10 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
                                 .getValue();
 
       SmallVector<Value, 8> lowerDiffModified;
-      auto upperDiffOp = upperIndicesDiff[upperDim].getDefiningOp();
-      if (auto v = dyn_cast<ConstantIntOp>(upperDiffOp)) {
+      auto mbUpperDiffVal = isConstantValue(upperIndicesDiff[upperDim]);
+      if (mbUpperDiffVal.hasValue()) {
         // In case upper level diff is a constant, use constantFold.
-        int64_t upperDiff = v.getValue();
+        int64_t upperDiff = mbUpperDiffVal.getValue();
 
         // Populate an upper diff vector with all indices 0, other than
         // upperDim dimension set as upperDiff.
@@ -1154,11 +1201,8 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
       SmallVector<Value, 8> lowerIndicesModified;
       for (unsigned iter = 0; iter < q.size(); ++iter) {
         int64_t lowerDim = q[iter].template cast<IntegerAttr>().getInt();
-        lowerIndicesModified.push_back(b.create<AddIOp>(
-            loc,
-            b.create<IndexCastOp>(loc, lowerIndicesOriginal[lowerDim],
-                                  b.getIntegerType(32)),
-            lowerDiffs[iter]));
+        lowerIndicesModified.push_back(
+            addToOriginal(lowerIndicesOriginal[lowerDim], lowerDiffs[iter]));
       }
       assert(lowerIndicesModified.size() == q.size());
 
@@ -1166,13 +1210,12 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
       // For Unfold it's not needed.
       if (transformation.getValue() == "Merge") {
         // Get lower layer bounds.
-        SmallVector<Value, 8> lowerLayerBounds;
+        SmallVector<int64_t, 8> lowerLayerBounds;
         for (unsigned iter = 0; iter < q.size(); ++iter) {
           int64_t lowerDim = q[iter].template cast<IntegerAttr>().getInt();
           int64_t v =
               lowerLayerShape[lowerDim].template cast<IntegerAttr>().getInt();
-          auto cv = b.create<ConstantIntOp>(loc, v, b.getIntegerType(32));
-          lowerLayerBounds.push_back(cv);
+          lowerLayerBounds.push_back(v);
         }
         assert(lowerLayerBounds.size() == lowerIndicesModified.size());
 
@@ -1190,67 +1233,56 @@ computeIndexDiffMap(OpBuilder &b, Location loc,
 
         // We only implement carry logic. Borrow logic would never happen as
         // upper index diffs would always be positive in the current algorithm.
-
-        // setup carryOp for the first iteration
-        Value carryOp = b.create<ConstantIntOp>(loc, 0, b.getIntegerType(1));
-        for (int64_t iter = q.size() - 1; iter >= 0; --iter) {
+        Value overflowOp = b.create<ConstantIntOp>(loc, 0, 32);
+        for (ssize_t iter = q.size() - 1; iter >= 0; --iter) {
           int64_t lowerDim = q[iter].template cast<IntegerAttr>().getInt();
+          int64_t upperBound = lowerLayerBounds[iter];
+          // If the overflow is statically 0, nothing gets added
+          Value diff =
+              addToOriginal(lowerDiffsCarryChecked[lowerDim], overflowOp);
+          Value index =
+              addToOriginal(lowerIndicesCarryChecked[lowerDim], overflowOp);
 
-          // carry logic.
-          auto ifCarryOp = b.create<scf::IfOp>(
-              loc, TypeRange{b.getIntegerType(32), b.getIntegerType(32)},
-              carryOp, /*withElseRegion=*/true);
-          auto ifCarryThenBuilder = ifCarryOp.getThenBodyBuilder();
-          auto carriedLowerDiff = ifCarryThenBuilder.create<AddIOp>(
-              loc, lowerDiffsCarryChecked[lowerDim], oneConstantI32Op);
-          auto carriedLowerIndice = ifCarryThenBuilder.create<AddIOp>(
-              loc, lowerIndicesCarryChecked[lowerDim], oneConstantI32Op);
-          ifCarryThenBuilder.create<scf::YieldOp>(
-              loc, ValueRange{carriedLowerDiff.getResult(),
-                              carriedLowerIndice.getResult()});
-          auto ifCarryElseBuilder = ifCarryOp.getElseBodyBuilder();
-          carriedLowerDiff = ifCarryElseBuilder.create<AddIOp>(
-              loc, lowerDiffsCarryChecked[lowerDim], zeroConstantI32Op);
-          carriedLowerIndice = ifCarryElseBuilder.create<AddIOp>(
-              loc, lowerIndicesCarryChecked[lowerDim], zeroConstantI32Op);
-          ifCarryElseBuilder.create<scf::YieldOp>(
-              loc, ValueRange{carriedLowerDiff.getResult(),
-                              carriedLowerIndice.getResult()});
-          auto carriedLowerDiffResult = ifCarryOp.results()[0];
-          auto carriedLowerIndiceResult = ifCarryOp.results()[1];
+          auto mbConstantDiff = isConstantValue(diff);
+          auto mbConstantIndex = isConstantValue(index);
 
-          // set carry flag for the next digit.
-          carryOp = b.create<CmpIOp>(loc, CmpIPredicate::sge,
-                                     carriedLowerIndiceResult,
-                                     lowerLayerBounds[iter]);
+          // If we get lucky, everything is constant and so we have a constant
+          // result
+          if (mbConstantIndex.hasValue() && mbConstantDiff.hasValue()) {
+            int64_t index = mbConstantIndex.getValue();
+            int64_t diff = mbConstantDiff.getValue();
+            if (index < upperBound) {
+              overflowOp = b.create<ConstantIntOp>(loc, 0, 32);
+              lowerIndicesCarryChecked[lowerDim] =
+                  b.create<ConstantIntOp>(loc, index, 32);
+              lowerDiffsCarryChecked[lowerDim] =
+                  b.create<ConstantIntOp>(loc, diff, 32);
+            } else {
+              int64_t carry = index / upperBound;
+              int64_t newIndex = index % upperBound;
+              int64_t newDiff = diff - (carry * upperBound);
+              overflowOp = b.create<ConstantIntOp>(loc, carry, 32);
+              lowerIndicesCarryChecked[lowerDim] =
+                  b.create<ConstantIntOp>(loc, newIndex, 32);
+              lowerDiffsCarryChecked[lowerDim] =
+                  b.create<ConstantIntOp>(loc, newDiff, 32);
+            }
+            continue;
+          }
 
-          // overflow logic.
-          auto ifOverflowOp = b.create<scf::IfOp>(
-              loc, TypeRange{b.getIntegerType(32), b.getIntegerType(32)},
-              carryOp, /*withElseRegion=*/true);
-          auto ifOverflowThenBuilder = ifOverflowOp.getThenBodyBuilder();
-          auto updatedLowerDiff = ifOverflowThenBuilder.create<SubIOp>(
-              loc, carriedLowerDiffResult, lowerLayerBounds[iter]);
-          auto updatedLowerIndice = ifOverflowThenBuilder.create<SubIOp>(
-              loc, carriedLowerIndiceResult, lowerLayerBounds[iter]);
-          ifOverflowThenBuilder.create<scf::YieldOp>(
-              loc, ValueRange{updatedLowerDiff.getResult(),
-                              updatedLowerIndice.getResult()});
-          auto ifOverflowElseBuilder = ifOverflowOp.getElseBodyBuilder();
-          updatedLowerDiff = ifOverflowElseBuilder.create<SubIOp>(
-              loc, carriedLowerDiffResult, zeroConstantI32Op);
-          updatedLowerIndice = ifOverflowElseBuilder.create<SubIOp>(
-              loc, carriedLowerIndiceResult, zeroConstantI32Op);
-          ifOverflowElseBuilder.create<scf::YieldOp>(
-              loc, ValueRange{updatedLowerDiff.getResult(),
-                              updatedLowerIndice.getResult()});
+          Value upperBoundOp = b.create<ConstantIntOp>(loc, upperBound, 32);
+          Value carry = b.create<UnsignedDivIOp>(loc, index, upperBoundOp);
+          Value newIndex = b.create<UnsignedRemIOp>(loc, index, upperBoundOp);
+          // If the merge is, as is typical, near the end of the transformations
+          // this computation should get hit by the dead code eleminator
+          Value newDiff = b.create<SubIOp>(
+              loc, diff, b.create<MulIOp>(loc, carry, upperBoundOp));
 
-          // updatedResult is by default of i32 type.
-          Value updatedLowerDiffResult = ifOverflowOp.results()[0];
-          Value updatedLowerIndiceResult = ifOverflowOp.results()[1];
-          lowerDiffsCarryChecked[lowerDim] = updatedLowerDiffResult;
-          lowerIndicesCarryChecked[lowerDim] = updatedLowerIndiceResult;
+          overflowOp = carry;
+          lowerDiffsCarryChecked[lowerDim] = newDiff;
+          lowerIndicesCarryChecked[lowerDim] = newIndex;
         }
+
         assert(lowerDiffsCarryChecked.size() == lowerIndicesModified.size());
         assert(lowerIndicesCarryChecked.size() == lowerIndicesModified.size());
         lowerDiffs.clear();


### PR DESCRIPTION
1. Constant fold more of the computation if possible.
This both simplifies the generated IR and enables further
optimizations, such as

2. Refactor carry application in Merge/Unfold operations.
Instead of a bunch of if statements, use remainders and integer
divisions to perform the carry logic. While in more complex cases,
such as the padding-1 kernel in the PR E2E tests, this ultimately
optimizes to the same ISA (at least, looking at the store logic),
it has the advantage of being correct when the overflow in a merge in
more than 1. In addition, this patch removed a lot of store address
computation logic from the stores in

-fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk -batchsize=1 -in_channels=64 -in_h=2 -in_w=2 -out_channels=64 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --conv_stride_h=1 --conv_stride_w=1 --padding_h=0 --padding_w=0 -t f32 --operation conv2d -x2 -pv -c

where the generated ISA now has a bunch of buffer_store_dword
instructions with constant offsets, which demonstrates the potential
value of this change.