### PR TITLE
Swizzles part 2

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -1649,12 +1649,6 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
 
     bool needExtraPad = false;
 
-    bool filterLastDimStaysLast = false;
-    // TODO(kderwnia): gemmC -> input sprays results all over the place
-    // so it's not clear whene we can swizzle
-    bool inputLastDimStaysLast = false;
-    bool outputLastDimStaysLast = false;
-
     auto calculatePaddingKernelSize = [&needExtraPad, gemmM_size, gemmN_size,
                                        gemmK_size, &gemmMExtra, &gemmNExtra,
                                        &gemmKExtra](auto populateParams) {
@@ -1844,8 +1838,6 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                            targetGemm2DimAttr.end());
         layoutAttr2.append(sourceProbKDimAttr.begin(),
                            sourceProbKDimAttr.end());
-        filterLastDimStaysLast =
-            (kDim.getValue().getZExtValue() == (filterShape.size() - 1));
       } else {
         layoutAttr0.append(targetGemm0DimAttr.begin(),
                            targetGemm0DimAttr.end());
@@ -1859,9 +1851,6 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                            targetGemm2DimAttr.end());
         layoutAttr2.append(sourceProbCYXDimAttr.begin(),
                            sourceProbCYXDimAttr.end());
-        filterLastDimStaysLast =
-            ((nonKDims[nonKDims.size() - 1].getValue().getZExtValue()) ==
-             (filterShape.size() - 1));
       }
 
       transformedFilterAttrs.push_back(b.getNamedAttr(
@@ -3070,8 +3059,6 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                            targetGemm2DimAttr.end());
         layoutAttr2.append(sourceProbKDimAttr.begin(),
                            sourceProbKDimAttr.end());
-        outputLastDimStaysLast =
-            (kDim.getValue().getZExtValue() == (outputShape.size() - 1));
       } else {
         layoutAttr0.append(targetGemm0DimAttr.begin(),
                            targetGemm0DimAttr.end());
@@ -3085,9 +3072,6 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
                            targetGemm2DimAttr.end());
         layoutAttr2.append(sourceProbNHoWoDimAttr.begin(),
                            sourceProbNHoWoDimAttr.end());
-        outputLastDimStaysLast =
-            nonKDims[nonKDims.size() - 1].getValue().getZExtValue() ==
-            (outputShape.size() - 1);
       }
 
       transformedOutputAttrs.push_back(b.getNamedAttr(
@@ -3377,18 +3361,9 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
     };
 
     // xdlopsV2.
-    if (isXdlops) {
+    if (isXdlops)
       gridwiseGemmAttrs.push_back(
           b.getNamedAttr("xdlopsV2", b.getBoolAttr(true)));
-      llvm::SmallVector<bool, 3> shouldSwizzleVals = {filterLastDimStaysLast,
-                                                      inputLastDimStaysLast,
-                                                      outputLastDimStaysLast};
-      bool shouldSwizzleOut =
-          shouldSwizzleVals[fields.gridwiseGemmArgumentPosition[2]];
-
-      gridwiseGemmAttrs.push_back(
-          b.getNamedAttr("swizzleOut", b.getBoolAttr(shouldSwizzleOut)));
-    }
 
     if (convOpType == miopen::ConvOpType::Conv2DBwdDataOpType) {
       gridwiseGemmAttrs.push_back(b.getNamedAttr(
@@ -4953,13 +4928,9 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
     };
 
     // xdlopsV2.
-    if (isXdlops) {
+    if (isXdlops)
       gridwiseGemmAttrs.push_back(
           b.getNamedAttr("xdlopsV2", b.getBoolAttr(true)));
-      bool shouldSwizzleOutput = (nameToDims["wi"] == 4);
-      gridwiseGemmAttrs.push_back(
-          b.getNamedAttr("swizzleOut", b.getBoolAttr(shouldSwizzleOutput)));
-    }
 
     gridwiseGemmAttrs.push_back(b.getNamedAttr(
         "kernel_algorithm", b.getStringAttr("backward_data_v4r1")));
@@ -6892,9 +6863,7 @@ struct GridwiseGemmV2RewritePattern
         b.create<RemUIOp>(loc, laneId_xdlops_gemm, num_threads_blk_ConstantOp);
 
     constexpr int64_t swizzleGroup = 4;
-    bool swizzleOutAttr = op->getAttr("swizzleOut").cast<BoolAttr>().getValue();
     bool enableOutSwizzles =
-        swizzleOutAttr &&
         (M2 == swizzleGroup && (m % swizzleGroup == 0) &&
          (n % swizzleGroup == 0) && (MPerWave % swizzleGroup == 0) &&
          (NPerWave % swizzleGroup == 0));

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -7360,7 +7360,7 @@ struct GridwiseGemmV2RewritePattern
                  b.create<RemUIOp>(loc, m_thread_data_on_global, M2TimesM1Op),
                  M2ConstantOp),
              // m_thread_data_on_global % M2
-             b.create<DivUIOp>(loc, m_thread_data_on_global, M2ConstantOp),
+             b.create<RemUIOp>(loc, m_thread_data_on_global, M2ConstantOp),
              // n_thread_data_on_global / N1
              b.create<DivUIOp>(loc, n_thread_data_on_global, N1ConstantOp),
              // n_thread-data_on_global % N1

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -9253,8 +9253,10 @@ struct ThreadwiseCopyV2RewritePattern
     computeSliceLengths(sliceLengths, composedSourceTransform,
                         composedDestTransform, coordTransformsAttr, boundAttr,
                         sourceType, destType);
-    sliceLengths[upperVectorDim] /= dataPerCopy;
-    assert(sliceLengths[upperVectorDim] != 0);
+    if (upperVectorDim >= 0) {
+      sliceLengths[upperVectorDim] /= dataPerCopy;
+      assert(sliceLengths[upperVectorDim] != 0);
+    }
 
     // llvm::errs() << "slice lengths: ";
     // for (unsigned i = 0; i < sliceLengths.size(); ++i)

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -24,7 +24,6 @@
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Vector/VectorOps.h"
-#include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -56,7 +55,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
-#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <iterator>
 
@@ -649,6 +647,7 @@ inline void emitStoreLogic(
     SmallVector<Value, 8> destLowerIndicesUpdated;
     for (unsigned iter = 1; iter <= 5; ++iter)
       destLowerIndicesUpdated.push_back(ifWithinBoundsOp.getResults()[iter]);
+
     emitStoreInstruction(value, destType, typeToStore, dest,
                          destLowerIndicesUpdated,
                          /*oob=*/ifWithinBoundsOp.getResults()[0]);
@@ -7174,6 +7173,8 @@ struct GridwiseGemmV2RewritePattern
                                                       group_size_ConstantOp),
                              group_size_ConstantOp);
       } else {
+        // Original C++ logic.
+        //     index_t col = col_blk * mfma_type.n + blk_td + n_i * NPerXdlops;
         threadMtxColInBlock = blk_td_xdlops_gemm;
       }
       int64_t thread_mtx_on_blk_col_const =
@@ -7202,8 +7203,6 @@ struct GridwiseGemmV2RewritePattern
       auto thread_mtx_on_blk_row = b.create<AddIOp>(
           loc, threadMtxRowInBlock,
           b.create<ConstantIndexOp>(loc, thread_mtx_on_blk_row_const));
-
-      // xdlop output space is, logically, a space of
 
       // compute c_thread_mtx_index_row, c_thread_mtx_index_col.
       // compute c_thread_mtx_index_row_i32, c_thread_mtx_index_col_i32.
@@ -9335,6 +9334,7 @@ struct ThreadwiseCopyV2RewritePattern
       emitStoreLogic(bwdPaddingStatus, b, loc, destType, destElementType,
                      toEmitOOBStoreCheckLogic, oobStoreCheckDims, op.dest(),
                      destLowerIndices, convertedScalarValue, dataOpration);
+
       // increase IVs
       bool toIncreaseNextDigit = true;
       int iter = loopIVsPerAccessOrder.size() - 1;

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.td
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.td
@@ -59,7 +59,7 @@ def MIOpenCopyOptPass : Pass<"miopen-copy-opt", "ModuleOp"> {
 def MIOpenOpsStep3Pass : Pass<"miopen-lowering-step3", "ModuleOp"> {
   let summary = "expand blockwise copy into threadwise copy, blockwise gemm into threadwise gemm";
   let constructor = "mlir::miopen::createLowerMIOpenOpsStep3Pass()";
-  let dependentDialects = ["miopen::MIOpenDialect", "scf::SCFDialect", "vector::VectorDialect", "AffineDialect", "memref::MemRefDialect"];
+  let dependentDialects = ["gpu::GPUDialect", "miopen::MIOpenDialect", "scf::SCFDialect", "vector::VectorDialect", "AffineDialect", "memref::MemRefDialect"];
 }
 
 def MIOpenOpsStep4Pass : Pass<"miopen-lowering-step4", "ModuleOp"> {

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -471,14 +471,14 @@ protected:
       }
       break;
     case mlir::miopen::Conv2DBwdWeightOpType:
-      if (dimIndexVal["ci"].first == 4) {
+      if (dimIndexVal["k"].first == 4) {
         out.gemmVectorDim = 1;
         out.destVectorDim = 4;
       } else {
-        // The need to skip padding renders vectorization impossible
-        // in the general case
-        out.gemmVectorDim = -1;
-        out.destVectorDim = -1;
+        out.gemmVectorDim = 2;
+        // Backward weight computations fold the {c, y, x} dimensions
+        // into N using the native order
+        out.destVectorDim = 4;
       }
       break;
     case mlir::miopen::Conv2DBwdDataOpType:

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -454,7 +454,8 @@ protected:
       vectorizationSize = 1;
     }
 
-    if ((cVectorLength > 0) && (dataPerThread % vectorizationSize == 0)) {
+    if ((cVectorLength > 0) && (dataPerThread % vectorizationSize == 0)
+        && (cVectorLength % vectorizationSize == 0)) {
       out.dataPerCopy = gcd(dataPerThread, vectorizationSize);
     } else {
       out.dataPerCopy = 1;

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -20,10 +20,12 @@
 #include "mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h"
 #include "mlir/Dialect/MIOpen/utility/math.h"
 #include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/YAMLTraits.h"
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 
@@ -97,6 +99,13 @@ struct DerivedParams {
   DerivedParams()
       : srcVectorReadDim(GemmG), srcDataPerRead(1), dstDataPerWrite(1),
         clusterLenGemmPos1(0), clusterLenGemmPos2(0) {}
+};
+
+struct DerivedOutParams {
+  int64_t gemmVectorDim;
+  int64_t destVectorDim;
+  int64_t dataPerCopy;
+  DerivedOutParams() : gemmVectorDim(-1), destVectorDim(-1), dataPerCopy(1) {}
 };
 
 class PopulateParamsBase {
@@ -366,6 +375,7 @@ protected:
         opType == mlir::miopen::ConvOpType::Conv2DBwdWeightOpType) {
       vectorizationSize = 1;
     }
+
     // srcDataPerRead bounded by size of threadwise copy
     if ((vectorizableLength > 0) && (vectorizableLength % 4 == 0)) {
       derived.srcDataPerRead = gcd(vectorizationSize, dataPerThreadCopy);
@@ -413,6 +423,70 @@ protected:
       return mlir::failure();
 
     return mlir::success();
+  }
+
+  mlir::LogicalResult calculateOutputDerivedParams(InitParams *params,
+                                                   int64_t blockSize,
+                                                   ConvolutionContext &ctx,
+                                                   DerivedOutParams &out) {
+    int64_t cVectorLength = 0;
+    ConvOpType op = ctx.getOpType();
+
+    obtainGemmCVecLen(ctx, cVectorLength);
+    int64_t dataPerThread =
+        (params->gemmMPerBlock * params->gemmNPerBlock) / blockSize;
+    if (!(dataPerThread > 0)) {
+      return failure();
+    }
+
+    // TODO: Allow vectorization group size of 2
+    int64_t vectorizationSize = 4;
+    if (ConvOpType::Conv2DBwdDataOpType == op) {
+      vectorizationSize = 1;
+    }
+
+    // Shrink vectorization size to get some vectorization where we wouldn't
+    // have any
+    if ((vectorizationSize > 2) && (dataPerThread % vectorizationSize != 0)) {
+      vectorizationSize = 2;
+    }
+
+    if ((cVectorLength > 0) && (dataPerThread % vectorizationSize == 0)) {
+      out.dataPerCopy = gcd(dataPerThread, vectorizationSize);
+    } else {
+      out.dataPerCopy = 1;
+    }
+
+    auto &dimIndexVal = ctx.dimIndexVal;
+    // Find dimensions in which the copy will take place
+    switch (op) {
+    case mlir::miopen::Conv2DOpType:
+      if (dimIndexVal["ko"].first == 4) {
+        out.gemmVectorDim = 1;
+        out.destVectorDim = 4;
+      } else {
+        out.gemmVectorDim = 2;
+        // This relies on assumptions about how we load our data for GEMM
+        out.destVectorDim = dimIndexVal["wo"].first;
+      }
+      break;
+    case mlir::miopen::Conv2DBwdWeightOpType:
+      if (dimIndexVal["ci"].first == 4) {
+        out.gemmVectorDim = 1;
+        out.destVectorDim = 4;
+      } else {
+        // The need to skip padding renders vectorization impossible
+        // in the general case
+        out.gemmVectorDim = -1;
+        out.destVectorDim = -1;
+      }
+      break;
+    case mlir::miopen::Conv2DBwdDataOpType:
+      out.gemmVectorDim = -1;
+      out.destVectorDim = -1;
+      break;
+    }
+    return success();
   }
 
   static void obtainGemmSize(ConvolutionContext &ctx, GemmSize &gemmSize) {
@@ -618,30 +692,10 @@ private:
                                        derived);
   }
 
-  int64_t calculateGemmCDestDataPerWrite(const InitParamsNonXDL &param,
-                                         ConvolutionContext &ctx) {
-    int64_t outputVecLen = 0;
-    if ((ctx.opType == miopen::ConvOpType::Conv2DOpType) &&
-        (ctx.dimIndexVal["ko"].first == 4)) {
-      // gemmM vectorizable. However, there is no parameters for vectorizing
-      // gemmM dimension for matrix C. Do nothing here.
-    } else if ((ctx.opType == miopen::ConvOpType::Conv2DBwdDataOpType) &&
-               (ctx.dimIndexVal["ci"].first == 4)) {
-      // gemmM vectorizable. However, there is no parameters for vectorizing
-      // gemmM dimension for matrix C. Do nothing here.
-    } else {
-      obtainGemmCVecLen(ctx, outputVecLen);
-    }
-
-    outputVecLen = gcd(outputVecLen, param.gemmNPerThread);
-
-    if ((outputVecLen > 0) && (outputVecLen % 4 == 0)) {
-      return 4;
-    } else if ((outputVecLen > 0) && (outputVecLen % 2 == 0)) {
-      return 2;
-    }
-
-    return 1;
+  LogicalResult calculateGemmCBlockwiseCopyParams(InitParamsNonXDL *params,
+                                                  ConvolutionContext &ctx,
+                                                  DerivedOutParams &out) {
+    return calculateOutputDerivedParams(params, params->blockSize, ctx, out);
   }
 
   LogicalResult
@@ -706,30 +760,28 @@ private:
     return success();
   }
 
-  LogicalResult populateDerived(ConvolutionContext &ctx,
-                                InitParamsNonXDL &validParams,
-                                GemmSize &gemmSize,
-                                DerivedParams &gemmADerivedParam,
-                                DerivedParams &gemmBDerivedParam,
-                                DerivedBlockGemmParams &blockGemmDerivedParam,
-                                int64_t &gemmCDstPerWrite, int64_t &gridSize);
+  LogicalResult
+  populateDerived(ConvolutionContext &ctx, InitParamsNonXDL &validParams,
+                  GemmSize &gemmSize, DerivedParams &gemmADerivedParam,
+                  DerivedParams &gemmBDerivedParam,
+                  DerivedBlockGemmParams &blockGemmDerivedParam,
+                  DerivedOutParams &gemmCDerivedParam, int64_t &gridSize);
 
   LogicalResult populatePaddingKernelDerived(
       ConvolutionContext &ctx, InitParamsNonXDL &validParams,
       GemmSize &gemmSize, DerivedParams &gemmADerivedParam,
       DerivedParams &gemmBDerivedParam,
-      DerivedBlockGemmParams &blockGemmDerivedParam, int64_t &gemmCDstPerWrite,
-      int64_t &gridSize);
+      DerivedBlockGemmParams &blockGemmDerivedParam,
+      DerivedOutParams &gemmCDerivedParam, int64_t &gridSize);
 
 public:
-  LogicalResult paramsFromCtx(ConvolutionContext &ctx,
-                              int64_t blockSizeOverride,
-                              const std::string &perfConfig,
-                              InitParamsNonXDL &validParams,
-                              DerivedParams &gemmADerivedParam,
-                              DerivedParams &gemmBDerivedParam,
-                              DerivedBlockGemmParams &blockGemmDerivedParam,
-                              int64_t &gemmCDstPerWrite, int64_t &gridSize);
+  LogicalResult
+  paramsFromCtx(ConvolutionContext &ctx, int64_t blockSizeOverride,
+                const std::string &perfConfig, InitParamsNonXDL &validParams,
+                DerivedParams &gemmADerivedParam,
+                DerivedParams &gemmBDerivedParam,
+                DerivedBlockGemmParams &blockGemmDerivedParam,
+                DerivedOutParams &gemmCDerivedParam, int64_t &gridSize);
 
   llvm::SmallVector<InitParamsNonXDL, 8> getTuningParameters() {
     return initParameters;
@@ -863,12 +915,14 @@ private:
                                 InitParamsXDL &validParams, GemmSize &gemmSize,
                                 DerivedParams &gemmADerivedParam,
                                 DerivedParams &gemmBDerivedParam,
+                                DerivedOutParams &gemmCDerivedParam,
                                 int64_t &blockSize, int64_t &gridSize);
 
   LogicalResult populatePaddingKernelDerived(
       ConvolutionContext &ctx, InitParamsXDL &validParams, GemmSize &gemmSize,
       DerivedParams &gemmADerivedParam, DerivedParams &gemmBDerivedParam,
-      int64_t &blockSize, int64_t &gridSize);
+      DerivedOutParams &gemmCDerivedParam, int64_t &blockSize,
+      int64_t &gridSize);
 
   LogicalResult isValidGridGemmXdlops(GemmSize &gemmSize) {
     auto gemmM = gemmSize.gemmM;
@@ -893,6 +947,7 @@ public:
                               InitParamsXDL &validParams,
                               DerivedParams &gemmADerivedParam,
                               DerivedParams &gemmBDerivedParam,
+                              DerivedOutParams &gemmCDerivedParam,
                               int64_t &blockSize, int64_t &gridSize);
 
   llvm::SmallVector<InitParamsXDL, 4> getTuningParameters() {

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -445,12 +445,6 @@ protected:
       vectorizationSize = 1;
     }
 
-    // Shrink vectorization size to get some vectorization where we wouldn't
-    // have any
-    if ((vectorizationSize > 2) && (dataPerThread % vectorizationSize != 0)) {
-      vectorizationSize = 2;
-    }
-
     if ((cVectorLength > 0) && (dataPerThread % vectorizationSize == 0)) {
       out.dataPerCopy = gcd(dataPerThread, vectorizationSize);
     } else {

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -454,8 +454,8 @@ protected:
       vectorizationSize = 1;
     }
 
-    if ((cVectorLength > 0) && (dataPerThread % vectorizationSize == 0)
-        && (cVectorLength % vectorizationSize == 0)) {
+    if ((cVectorLength > 0) && (dataPerThread % vectorizationSize == 0) &&
+        (cVectorLength % vectorizationSize == 0)) {
       out.dataPerCopy = gcd(dataPerThread, vectorizationSize);
     } else {
       out.dataPerCopy = 1;

--- a/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
@@ -999,9 +999,14 @@ LogicalResult backwardWeightAtomicAdd(T op, PatternRewriter &b,
 
   // xdlopsV2.
   auto xdlopsV2Attr = op->template getAttrOfType<BoolAttr>("xdlopsV2");
-  if (xdlopsV2Attr && xdlopsV2Attr.getValue() == true)
+  if (xdlopsV2Attr && xdlopsV2Attr.getValue() == true) {
     gridwiseGemmAttrs.push_back(
         b.getNamedAttr("xdlopsV2", b.getBoolAttr(true)));
+    // TODO(kdrewnia): Work out when this is applicable
+    // I'm calling it a day now
+    gridwiseGemmAttrs.push_back(
+        b.getNamedAttr("swizzleOut", b.getBoolAttr(false)));
+  }
 
   gridwiseGemmAttrs.push_back(b.getNamedAttr(
       "kernel_algorithm", b.getStringAttr("backward_weight_v4r4")));

--- a/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
@@ -81,6 +81,14 @@ LogicalResult backwardWeightAtomicAdd(T op, PatternRewriter &b,
   auto archAttr = op->template getAttrOfType<StringAttr>("arch");
   auto numCuAttr = op->template getAttrOfType<IntegerAttr>("num_cu");
 
+  // TODO(kdrewnia) We can't use vector stores since this operation
+  // transforms KYXC outputs to KCYX ones. Until we stop doing the twist,
+  // we can't vectorize the writes
+  if (auto gemmVectorization =
+          op->template getAttrOfType<IntegerAttr>("matrix_c_data_per_copy")) {
+    op->setAttr("matrix_c_data_per_copy", b.getI32IntegerAttr(1));
+  }
+
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");
   auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");

--- a/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/BackwardWeightV4R4Helper.h
@@ -999,14 +999,9 @@ LogicalResult backwardWeightAtomicAdd(T op, PatternRewriter &b,
 
   // xdlopsV2.
   auto xdlopsV2Attr = op->template getAttrOfType<BoolAttr>("xdlopsV2");
-  if (xdlopsV2Attr && xdlopsV2Attr.getValue() == true) {
+  if (xdlopsV2Attr && xdlopsV2Attr.getValue() == true)
     gridwiseGemmAttrs.push_back(
         b.getNamedAttr("xdlopsV2", b.getBoolAttr(true)));
-    // TODO(kdrewnia): Work out when this is applicable
-    // I'm calling it a day now
-    gridwiseGemmAttrs.push_back(
-        b.getNamedAttr("swizzleOut", b.getBoolAttr(false)));
-  }
 
   gridwiseGemmAttrs.push_back(b.getNamedAttr(
       "kernel_algorithm", b.getStringAttr("backward_weight_v4r4")));

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -66,12 +66,14 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     InitParamsXDL validParams;
     DerivedParams gemmADerivedParam;
     DerivedParams gemmBDerivedParam;
+    DerivedOutParams gemmCDerivedParam;
     int64_t blockSize = 0;
     int64_t gridSize = 0;
 
     LogicalResult status = populateParamsXDL.paramsFromCtx(
         convContext, blockSizeOverride, perfConfig, validParams,
-        gemmADerivedParam, gemmBDerivedParam, blockSize, gridSize);
+        gemmADerivedParam, gemmBDerivedParam, gemmCDerivedParam, blockSize,
+        gridSize);
 
     if (failed(status)) {
       signalPassFailure();
@@ -107,19 +109,25 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("matrix_b_source_vector_read_dim",
                 b.getI32IntegerAttr(gemmBDerivedParam.srcVectorReadDim));
 
+    op->setAttr("matrix_c_data_per_copy",
+                b.getI32IntegerAttr(gemmCDerivedParam.dataPerCopy));
+    op->setAttr("matrix_c_source_vector_read_dim",
+                b.getI32IntegerAttr(gemmCDerivedParam.gemmVectorDim));
+    op->setAttr("matrix_c_dest_vector_write_dim",
+                b.getI32IntegerAttr(gemmCDerivedParam.destVectorDim));
   } else {
     InitParamsNonXDL validParams;
     DerivedParams gemmADerivedParam;
     DerivedParams gemmBDerivedParam;
     DerivedBlockGemmParams blockGemmDerivedParam;
-    int64_t gemmCDstPerWrite;
+    DerivedOutParams gemmCDerivedParam;
     int64_t gridSize;
 
     PopulateParams populateParams;
     LogicalResult status = populateParams.paramsFromCtx(
         convContext, blockSizeOverride, perfConfig, validParams,
         gemmADerivedParam, gemmBDerivedParam, blockGemmDerivedParam,
-        gemmCDstPerWrite, gridSize);
+        gemmCDerivedParam, gridSize);
 
     if (failed(status)) {
       signalPassFailure();
@@ -169,16 +177,14 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
                 b.getI32IntegerAttr(blockGemmDerivedParam.gemmMLevel1Cluster));
     op->setAttr("n_level1_cluster",
                 b.getI32IntegerAttr(blockGemmDerivedParam.gemmNLevel1Cluster));
-  }
 
-  // Derived parameters for gemmC.
-  // TODO: Pending fix from
-  // https://github.com/whchung/llvm-project/pull/26/files#r444968168
-  // op->setAttr("matrix_c_dest_data_per_write",
-  //           b.getI32IntegerAttr(gemmCDstPerWrite));
-  op->setAttr("matrix_c_dest_data_per_write", b.getI32IntegerAttr(1));
-  op->setAttr("matrix_c_source_dest_vector_read_write_dim",
-              b.getI32IntegerAttr(4));
+    op->setAttr("matrix_c_data_per_copy",
+                b.getI32IntegerAttr(gemmCDerivedParam.dataPerCopy));
+    op->setAttr("matrix_c_source_vector_read_dim",
+                b.getI32IntegerAttr(gemmCDerivedParam.gemmVectorDim));
+    op->setAttr("matrix_c_dest_vector_write_dim",
+                b.getI32IntegerAttr(gemmCDerivedParam.destVectorDim));
+  }
 }
 
 std::unique_ptr<Pass>

--- a/mlir/test/Dialect/MIOpen/lowering_threadwise_copy_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_threadwise_copy_v2.mlir
@@ -7,6 +7,14 @@
 #map8 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 8 + d2 * 4 + d3, d4)>
 #map9 = affine_map<(d0, d1, d2) -> (d2 floordiv 196, d0, d1, (d2 mod 196) floordiv 14, (d2 mod 196) mod 14)>
 
+#map10 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1 * 4 + d5)>
+#map11 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1 * 8 + d2 * 4 + d3, d4 * 4 + d5)>
+#map12 = affine_map<(d0, d1, d2) -> (d2 floordiv 256, d0, d1, (d2 mod 256) floordiv 16, d2 mod 16)>
+
+#map13 = affine_map<(d0, d1, d2, d3, d4) -> (d1 * 4 + d3)>
+#map14 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 8 + d2 * 4 + d3, d4)>
+#map15 = affine_map<(d0, d1, d2) -> (d2 floordiv 256, d0, (d2 mod 256) floordiv 16, d2 mod 16, d1)>
+
 // CHECK-LABEL: func @miopen_threadwise_copy_v2
 func @miopen_threadwise_copy_v2(%source : vector<32xf32>,
                                 %dest1D : memref<32xf32>,
@@ -26,6 +34,7 @@ func @miopen_threadwise_copy_v2(%source : vector<32xf32>,
     source_data_per_read = 1,
     dest_data_per_write = 1,
     vector_read_write_dim = 0,
+    upper_vector_read_dim = 4,
     bound = [1 : i32, 8 : i32, 4 : i32],
     coord_transforms = [
       {
@@ -180,3 +189,221 @@ func @miopen_threadwise_copy_v2(%source : vector<32xf32>,
 
   return
 }
+
+// CHECK-LABEL: @miopen_threadwise_copy_v2_vectorized_nchw
+func @miopen_threadwise_copy_v2_vectorized_nchw(%source_offset : i32,
+                                %source : vector<32xf32>,
+                                %dest5D : memref<128x1x1024x16x16xf32>) {
+  %c0_i32 = constant 0 : i32
+
+  // A usecase of threadwise_copy_v2 that should be vectorized
+  // This threadwise_copy takes the extra n dimension split used in swizzling
+  // and has dimensions that are an even multiple of 4 to prevent OOB checks
+  // CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %c0_i32, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>,
+  miopen.threadwise_copy_v2 %source[%source_offset,
+    %c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] ->
+    %dest5D[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] {
+      bound = [1 : i32, 4 : i32, 1 : i32, 1 : i32, 1 : i32, 4 : i32],
+      coord_transforms = [
+        {metadata = [{
+            layout = [
+              {
+                lower_layer_dimensions = [0 : i32], lower_layer_names = ["raw"],
+                parameters = [16 : i32, 4 : i32, 4 : i32, 4 : i32, 4 : i32, 1 : i32],
+                transformation = "Embed",
+                upper_layer_dimensions = [0 : i32, 1 : i32, 2 : i32, 3 : i32, 4 : i32, 5 : i32],
+                upper_layer_names = ["dim0", "m3", "dim2", "dim3", "dim4", "n1"]
+              }],
+            lower_layer_bounds = [16 : i32], lower_layer_layout = ["raw"],
+            map = [#map10],
+            upper_layer_bounds = [1 : i32, 4 : i32, 1 : i32, 1 : i32, 1 : i32, 4 : i32],
+            upper_layer_layout = ["dim0", "m3", "dim2", "dim3", "dim4", "n1"]}],
+            operand = 0 : i32, transforms = [#map10]
+        },
+        {domain = [1 : i32, 128 : i32, 2 : i32, 4 : i32, 8192 : i32, 4 : i32],
+        metadata = [{
+          layout = [
+            {
+              lower_layer_dimensions = [0 : i32],
+              lower_layer_names = ["gemmG"],
+              transformation = "PassThrough",
+              upper_layer_dimensions = [0 : i32],
+              upper_layer_names = ["g"]
+            },
+            {
+              lower_layer_dimensions = [1 : i32],
+              lower_layer_names = ["gemmM"],
+              parameters = [8 : i32, 4 : i32, 1 : i32],
+              transformation = "Embed",
+              upper_layer_dimensions = [1 : i32, 2 : i32, 3 : i32],
+              upper_layer_names = ["m0", "m1", "m2"]
+            },
+            {
+              lower_layer_dimensions = [2 : i32],
+              lower_layer_names = ["gemmN"],
+              parameters = [4 : i32, 1 : i32],
+              transformation = "Embed",
+              upper_layer_dimensions = [4 : i32, 5 : i32],
+              upper_layer_names = ["n0", "n1"]}],
+              lower_layer_bounds = [1 : i32, 1024 : i32, 32768 : i32],
+              lower_layer_layout = ["gemmG", "gemmM", "gemmN"],
+              map = [#map11],
+              upper_layer_bounds = [1 : i32, 128 : i32, 2 : i32, 4 : i32, 8192 : i32, 4 : i32],
+              upper_layer_layout = ["g", "m0", "m1", "m2", "n0", "n1"]
+            },
+            {
+              extraPad = false, gemmMExtra = 0 : i32, gemmNExtra = 0 : i32,
+              gridwise_gemm_argument_position = 2 : i32,
+              layout = [
+                {
+                  lower_layer_dimensions = [1 : i32],
+                  lower_layer_names = ["go"],
+                  transformation = "PassThrough",
+                  upper_layer_dimensions = [0 : i32],
+                  upper_layer_names = ["gemmG"]
+                },
+                {
+                  lower_layer_dimensions = [2 : i32],
+                  lower_layer_names = ["ko"],
+                  transformation = "PassThrough",
+                  upper_layer_dimensions = [1 : i32],
+                  upper_layer_names = ["gemmM"]
+                },
+                {
+                  lower_layer_dimensions = [0 : i32, 3 : i32, 4 : i32],
+                  lower_layer_names = ["no", "ho", "wo"],
+                  transformation = "Merge",
+                  upper_layer_dimensions = [2 : i32],
+                  upper_layer_names = ["gemmN"]
+                  }
+              ],
+              lower_layer_bounds = [128 : i32, 1 : i32, 1024 : i32, 16 : i32, 16 : i32],
+              lower_layer_layout = ["no", "go", "ko", "ho", "wo"],
+              lowest_layer = true,
+              map = [#map12],
+              upper_layer_bounds = [1 : i32, 1024 : i32, 32768 : i32],
+              upper_layer_layout = ["gemmG", "gemmM", "gemmN"]
+            }
+          ],
+          operand = 1 : i32, transforms = [#map11, #map12]
+        }
+      ],
+      dest_data_per_write = 4 : i32,
+      dim_access_order = [0 : i32, 1 : i32, 2 : i32, 3 : i32, 4 : i32, 5 : i32],
+      source_data_per_read = 4 : i32, vector_read_write_dim = 4 : i32,
+      upper_vector_read_dim = 5 : i32}
+      : vector<32xf32>, i32,
+      i32, i32, i32, i32, i32, i32 ->
+      memref<128x1x1024x16x16xf32>, i32, i32, i32, i32, i32, i32
+
+  return
+}
+
+// CHECK-LABEL: @miopen_threadwise_copy_v2_vectorized_nhwc
+func @miopen_threadwise_copy_v2_vectorized_nhwc(%source_offset : i32,
+                                %source : vector<32xf32>,
+                                %dest5D : memref<128x1x16x16x1024xf32>) {
+  %c0_i32 = constant 0 : i32
+
+  // A usecase of threadwise_copy_v2 that should be vectorized
+  // This threadwise_copy takes the extra n dimension split used in swizzling
+  // and has dimensions that are an even multiple of 4 to prevent OOB checks
+  // CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %c0_i32, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xf32>,
+  miopen.threadwise_copy_v2 %source[%source_offset,
+    %c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] ->
+    %dest5D[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] {
+      bound = [1 : i32, 4 : i32, 1 : i32, 4 : i32, 1 : i32],
+      coord_transforms = [
+        {metadata = [{
+            layout = [
+              {
+                lower_layer_dimensions = [0 : i32], lower_layer_names = ["raw"],
+                parameters = [16 : i32, 4 : i32, 4 : i32, 1 : i32, 1 : i32],
+                transformation = "Embed",
+                upper_layer_dimensions = [0 : i32, 1 : i32, 2 : i32, 3 : i32, 4 : i32],
+                upper_layer_names = ["dim0", "m3", "dim2", "m2", "dim4"]
+              }],
+            lower_layer_bounds = [16 : i32], lower_layer_layout = ["raw"],
+            map = [#map13],
+            upper_layer_bounds = [1 : i32, 4 : i32, 1 : i32, 4 : i32, 1 : i32],
+            upper_layer_layout = ["dim0", "m3", "dim2", "m2", "dim4"]}],
+            operand = 0 : i32, transforms = [#map13]
+        },
+        {domain = [1 : i32, 128 : i32, 2 : i32, 4 : i32, 32768 : i32],
+        metadata = [{
+          layout = [
+            {
+              lower_layer_dimensions = [0 : i32],
+              lower_layer_names = ["gemmG"],
+              transformation = "PassThrough",
+              upper_layer_dimensions = [0 : i32],
+              upper_layer_names = ["g"]
+            },
+            {
+              lower_layer_dimensions = [1 : i32],
+              lower_layer_names = ["gemmM"],
+              parameters = [8 : i32, 4 : i32, 1 : i32],
+              transformation = "Embed",
+              upper_layer_dimensions = [1 : i32, 2 : i32, 3 : i32],
+              upper_layer_names = ["m0", "m1", "m2"]
+            },
+            {
+              lower_layer_dimensions = [2 : i32],
+              lower_layer_names = ["gemmN"],
+              transformation = "PassThrough",
+              upper_layer_dimensions = [4 : i32],
+              upper_layer_names = ["n"]}],
+              lower_layer_bounds = [1 : i32, 1024 : i32, 32768 : i32],
+              lower_layer_layout = ["gemmG", "gemmM", "gemmN"],
+              map = [#map14],
+              upper_layer_bounds = [1 : i32, 128 : i32, 2 : i32, 4 : i32, 32768 : i32],
+              upper_layer_layout = ["g", "m0", "m1", "m2", "n"]
+            },
+            {
+              extraPad = false, gemmMExtra = 0 : i32, gemmNExtra = 0 : i32,
+              gridwise_gemm_argument_position = 2 : i32,
+              layout = [
+                {
+                  lower_layer_dimensions = [1 : i32],
+                  lower_layer_names = ["go"],
+                  transformation = "PassThrough",
+                  upper_layer_dimensions = [0 : i32],
+                  upper_layer_names = ["gemmG"]
+                },
+                {
+                  lower_layer_dimensions = [4 : i32],
+                  lower_layer_names = ["ko"],
+                  transformation = "PassThrough",
+                  upper_layer_dimensions = [1 : i32],
+                  upper_layer_names = ["gemmM"]
+                },
+                {
+                  lower_layer_dimensions = [0 : i32, 2 : i32, 3 : i32],
+                  lower_layer_names = ["no", "ho", "wo"],
+                  transformation = "Merge",
+                  upper_layer_dimensions = [2 : i32],
+                  upper_layer_names = ["gemmN"]
+                  }
+              ],
+              lower_layer_bounds = [128 : i32, 1 : i32, 16 : i32, 16 : i32, 1024 : i32],
+              lower_layer_layout = ["no", "go", "ho", "wo", "ko"],
+              lowest_layer = true,
+              map = [#map15],
+              upper_layer_bounds = [1 : i32, 1024 : i32, 32768 : i32],
+              upper_layer_layout = ["gemmG", "gemmM", "gemmN"]
+            }
+          ],
+          operand = 1 : i32, transforms = [#map14, #map15]
+        }
+      ],
+      dest_data_per_write = 4 : i32,
+      dim_access_order = [0 : i32, 1 : i32, 2 : i32, 3 : i32, 4 : i32],
+      source_data_per_read = 4 : i32, vector_read_write_dim = 4 : i32,
+      upper_vector_read_dim = 3 : i32}
+      : vector<32xf32>, i32,
+      i32, i32, i32, i32, i32 ->
+      memref<128x1x16x16x1024xf32>, i32, i32, i32, i32, i32
+
+  return
+}
+

--- a/mlir/test/mlir-miopen-driver/tuning_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/tuning_xdlops.mlir
@@ -1,9 +1,13 @@
-// Check the naming of tuning parameters for xdlops
+// Check the naming of tuning parameters for xdlops and matrix c vectorization values
 
 // RUN: mlir-miopen-driver -p -x2 -miopen-affix-params -miopen-lowering -miopen-affine-transform | FileCheck %s --check-prefix=STEP1
 // RUN: mlir-miopen-driver -p -x2 -miopen-affix-params -miopen-lowering -miopen-affine-transform -miopen-lowering-step2 | FileCheck %s --check-prefix=STEP2
+// RUN: mlir-miopen-driver -p --fil_layout=kyxc --in_layout=nhwc --out_layout=nhwk -x2 -miopen-affix-params -miopen-lowering -miopen-affine-transform | FileCheck %s --check-prefix=NHWC
 
 // STEP1: m_per_wave
+// STEP1: matrix_c_data_per_copy = 4
+// STEP1: matrix_c_dest_vector_write_dim = 4
+// STEP1: matrix_c_source_vector_read_dim = 2
 // STEP1: n_per_wave
 // STEP1-NOT: m_per_thread
 // STEP1-NOT: n_per_thread
@@ -12,3 +16,7 @@
 // STEP2: n_per_wave
 // STEP2-NOT: m_per_thread
 // STEP2-NOT: n_per_thread
+
+// NHWC: matrix_c_data_per_copy = 4
+// NHWC: matrix_c_dest_vector_write_dim = 4
+// NHWC: matrix_c_source_vector_read_dim = 1


### PR DESCRIPTION
Enable vector stores in matrix C store back to memory when using xdlops.

Use swizzles to transpose multiplication results in order to enable this vector store in the NKHW case.

TODO items:

- Applying similar transformations to non-xdlops
- Changing the backward weight atomic add code to not move dimensions around in order to enable vector writes in those kernels

(This is currently skip-ci due to dependencies on #437 and #425 but is ready for review)