### PR TITLE
Restore the --gpu-to-hsaco option because it's used in integration te…

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -508,10 +508,8 @@ void mlir::registerGpuSerializeToHsacoPass() {
         LLVMInitializeAMDGPUTargetInfo();
         LLVMInitializeAMDGPUTargetMC();
 
-        // Known-bad values for constructor arguments since the instance of the
-        // pass that's registered here will never be used directly
-        return std::make_unique<SerializeToHsacoPass>(
-            "", "[GARBAGE]", "+veryfake,-cantsurface", -1);
+        return std::make_unique<SerializeToHsacoPass>("amdgcn-amd-amdhsa", "",
+                                                      "", 2);
       });
 }
 

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/gpu-to-hsaco.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/gpu-to-hsaco.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-opt %s \
 // RUN:   -gpu-kernel-outlining \
-// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco)' \
+// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco{chip=%chip})' \
 // RUN:   -gpu-to-llvm \
 // RUN: | mlir-cpu-runner \
 // RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/lit.local.cfg
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/lit.local.cfg
@@ -1,2 +1,23 @@
+import subprocess
+
 if not config.enable_rocm_runner:
   config.unsupported = True
+
+# Need to specify the chip sub-option to the gpu-to-hsaco pass, and also check
+# that we have a gpu at all.  Use rocm_agent_enumerator to find the chip and
+# use %chip to insert it, and if no chip is found, mark the test unsupported.
+# Even though the tests here use mlir-cpu-runner, they still call mgpu
+# functions.
+config.chip = 'gfx000'
+if config.rocm_path:
+   try:
+       p = subprocess.run([config.rocm_path + "/bin/rocm_agent_enumerator"],
+                          check=True, stdout=subprocess.PIPE)
+       agents = [x for x in p.stdout.split() if x != b'gfx000']
+       if agents:
+           config.chip = agents[0].decode('utf-8')
+       else:
+           config.unsupported = True
+   except subprocess.CalledProcessError:
+       config.unsupported = True
+config.substitutions.append(('%chip', config.chip))

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/two-modules.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/two-modules.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-opt %s \
 // RUN:   -gpu-kernel-outlining \
-// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco)' \
+// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco{chip=%chip})' \
 // RUN:   -gpu-to-llvm \
 // RUN: | mlir-cpu-runner \
 // RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/vecadd.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/vecadd.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s \
 // RUN:   -convert-scf-to-std \
 // RUN:   -gpu-kernel-outlining \
-// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco)' \
+// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco{chip=%chip})' \
 // RUN:   -gpu-to-llvm \
 // RUN: | mlir-cpu-runner \
 // RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/vector-transferops.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/vector-transferops.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s \
 // RUN:   -convert-scf-to-std \
 // RUN:   -gpu-kernel-outlining \
-// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco)' \
+// RUN:   -pass-pipeline='gpu.module(strip-debuginfo,convert-gpu-to-rocdl,gpu-to-hsaco{chip=%chip})' \
 // RUN:   -gpu-to-llvm \
 // RUN: | mlir-cpu-runner \
 // RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \


### PR DESCRIPTION
…sts.

Update the tests to derive the chip in the lit config and specify it as
sub-option, replacing the old use of the default.