### PR TITLE
Revert "Add reboot in post build action"

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -92,10 +92,6 @@ void postProcessPerfRes() {
     archiveArtifacts artifacts: 'build/mlir_*.csv,build/perf-run-date', onlyIfSuccessful: true
 }
 
-def reboot(){
-    build job: 'reboot-slaves', propagate: false , parameters: [string(name: 'server', value: "${env.NODE_NAME}"),]
-}
-
 pipeline {
     agent none
     parameters {
@@ -171,7 +167,6 @@ pipeline {
                      post {
                         always {
                             cleanWs()
-                            reboot()
                         }
                     }
                 }
@@ -213,7 +208,6 @@ pipeline {
                     post {
                         always {
                             cleanWs()
-                            reboot()
                         }
                     }
                 }
@@ -336,7 +330,6 @@ pipeline {
                     post {
                         always {
                             cleanWs()
-                            reboot()
                         }
                     }
                 }
@@ -399,7 +392,6 @@ pipeline {
                     post {
                         always {
                             cleanWs()
-                            reboot()
                         }
                     }
                 }
@@ -475,7 +467,6 @@ pipeline {
                         post {
                             always {
                                 cleanWs()
-                                reboot()
                             }
                         }
                     }
@@ -552,7 +543,6 @@ pipeline {
             post {
                 always {
                     cleanWs()
-                    reboot()
                 }
              }
         }


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/llvm-project-mlir#448, that caused a race condition in jenkins execution.

This occasionally result in below:

```jenkinsfile
16:25:10  Scheduling project: reboot-slaves
16:25:18  Starting building: reboot-slaves #15
16:31:26  [Pipeline] }
16:31:26  [Pipeline] // withEnv
16:31:26  [Pipeline] }
16:31:48  $ docker stop --time=1 c62c82e9816dc530b83b6c28d24ddb1e19dfaa4e866458feac8cb862aebd1a91
16:31:48  $ docker rm -f c62c82e9816dc530b83b6c28d24ddb1e19dfaa4e866458feac8cb862aebd1a91
```

We should instead make sure the docker stop happen before the reboot. Reverting now and explore a better approach afterwards.