### PR TITLE
Make MIOpen test non-xdlops on gfx906 only

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -223,7 +223,7 @@ pipeline {
                         docker {
                             image dockerImage()
                             args dockerArgs()
-                            label "${params.canXdlops ? 'gfx908' : 'rocm' }"
+                            label "${params.canXdlops ? 'gfx908' : 'gfx906' }"
                             alwaysPull true
                         }
                     }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -422,7 +422,7 @@ pipeline {
                             docker {
                                 image dockerImage()
                                 args dockerArgs()
-                                label "${params.canXdlops ? 'gfx908' : 'rocm'}"
+                                label "${params.canXdlops ? 'gfx908' : 'gfx906'}"
                                 alwaysPull true
                             }
                         }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -85,7 +85,7 @@ pipeline {
                         docker {
                             image dockerImage()
                             args dockerArgs()
-                            label "rocm"
+                            label "gfx906"
                             alwaysPull true
                         }
                     }


### PR DESCRIPTION
This implements the step1 of https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/389

Refer to [here ](http://ml-ci.amd.com:21096/label/gfx906/) for list of gfx906 machines.