### PR TITLE
[ROCm 5.1] Backport #451 to ROCm 5.1 release branch

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -223,7 +223,7 @@ pipeline {
                         docker {
                             image dockerImage()
                             args dockerArgs()
-                            label "${params.canXdlops ? 'gfx908' : 'rocm' }"
+                            label "${params.canXdlops ? 'gfx908' : 'gfx906' }"
                             alwaysPull true
                         }
                     }
@@ -422,7 +422,7 @@ pipeline {
                             docker {
                                 image dockerImage()
                                 args dockerArgs()
-                                label "${params.canXdlops ? 'gfx908' : 'rocm'}"
+                                label "${params.canXdlops ? 'gfx908' : 'gfx906'}"
                                 alwaysPull true
                             }
                         }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -85,7 +85,7 @@ pipeline {
                         docker {
                             image dockerImage()
                             args dockerArgs()
-                            label "rocm"
+                            label "gfx906"
                             alwaysPull true
                         }
                     }


### PR DESCRIPTION
Refer to #451. I cherry-picked #451 to the tip of `release/rocm-5.1`.

This make sure that when we execute our CI to execute MIOpen tests on ROCm 5.1 release, gfx900 won't be picked. CI is kicked out to run the entire set of CI tests.

Note that since I'm targeting to backport to the release branch, I need 2 approvals to merge.