### PR TITLE
Make the merging of identical kernels part of the outlining process,

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -58,7 +58,7 @@ def TosaMakeBroadcastable : FunctionPass<"tosa-make-broadcastable"> {
   let constructor = "createTosaMakeBroadcastablePass()";
 }
 
-def TosaPartition : FunctionPass<"tosa-partition"> {
+def TosaPartition : Pass<"tosa-partition", "ModuleOp"> {
   let summary = "Outline TOSA Conv2D ops and adjacent element-wise ops";
   let description = [{
     Outline kernels of tosa::Conv2D and surrounding elementwise ops.
@@ -71,16 +71,6 @@ def TosaPartition : FunctionPass<"tosa-partition"> {
            "Don't gather ops ahead of Conv2D">
   ];
   let dependentDialects = ["tosa::TosaDialect"];
-}
-
-def PostPartitionCollapse : Pass<"tosa-collapse", "ModuleOp"> {
-  let summary = "After --tosa-partition, merge identical functions";
-  let description = [{
-    Replace calls to identical functions with calls to the first one,
-    allowing the others to be dead-coded.
-  }];
-
-  let constructor = "createPostPartitionCollapsePass()";
 }
 
 #endif // MLIR_DIALECT_TOSA_TRANSFORMS_PASSES

--- a/external/llvm-project/mlir/include/mlir/InitAllPasses.h
+++ b/external/llvm-project/mlir/include/mlir/InitAllPasses.h
@@ -70,7 +70,6 @@ inline void registerAllPasses() {
   registerStandardPasses();
   tensor::registerTensorPasses();
   tosa::registerTosaOptPasses();
-  tosa::registerTosaPartitionPipelinePass();
 }
 
 } // namespace mlir

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -52,62 +52,264 @@ bool isElementwiseOp(Operation *op) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Inspired by / adapted from outlineIfOp() in SCF/Transforms/Utils.cpp.
+// Inspired by / adapted from outlineIfOp() in SCF/Transforms/Utils.cpp
+// and mergeIdenticalBlocks() in Utils/RegionUtils.cpp.
+
+struct OutliningCandidate {
+  OutliningCandidate(Operation *_convOp, ArrayRef<Operation *> &_secondOps,
+                     ArrayRef<Operation *> &_frontOps, ArrayRef<Value> &_params,
+                     ArrayRef<Value> &_returnVals, StringRef _partFnName);
+
+  unsigned addOp(Operation *op, unsigned orderIt);
+
+  Operation *convOp;
+  SmallVector<Operation *> secondOps;
+  SmallVector<Operation *> frontOps;
+  SmallVector<Value> params;
+  SmallVector<Value> returnVals;
+  std::string partFnName;
+  llvm::hash_code hash;
+  FuncOp function;
+
+  /// Return the order index for the given value that is within the block of
+  /// this data.
+  unsigned getOrderOf(Value value) const;
+
+  /// A map of result producing operations to their relative orders within this
+  /// block. The order of an operation is the number of defined values that are
+  /// produced within the block before this operation.
+  DenseMap<Operation *, unsigned> opOrderIndex;
+};
+
+unsigned OutliningCandidate::addOp(Operation *op, unsigned orderIt) {
+  if (unsigned numResults = op->getNumResults()) {
+    opOrderIndex.try_emplace(op, orderIt);
+    orderIt += numResults;
+  }
+
+  auto opHash = OperationEquivalence::computeHash(
+      op, OperationEquivalence::ignoreHashValue,
+      OperationEquivalence::ignoreHashValue,
+      OperationEquivalence::IgnoreLocations);
+  hash = llvm::hash_combine(hash, opHash);
+
+  return orderIt;
+}
+
+OutliningCandidate::OutliningCandidate(Operation *convOp_,
+                                       ArrayRef<Operation *> &secondOps_,
+                                       ArrayRef<Operation *> &frontOps_,
+                                       ArrayRef<Value> &params_,
+                                       ArrayRef<Value> &returnVals_,
+                                       StringRef partFnName_)
+    : convOp(convOp_), partFnName(partFnName_), hash(0), function(nullptr) {
+  // We'll need to grab the cloned ops to avoid use-after-free.
+  for (auto *op : secondOps_) {
+    secondOps.push_back(op);
+  }
+  for (auto *op : frontOps_) {
+    frontOps.push_back(op);
+  }
+  for (auto val : params_) {
+    params.push_back(val);
+  }
+  for (auto val : returnVals_) {
+    returnVals.push_back(val);
+  }
+
+  unsigned orderIt = params.size();
+  for (auto *op : frontOps) {
+    orderIt = addOp(op, orderIt);
+  }
+  orderIt = addOp(convOp, orderIt);
+  for (auto *op : secondOps) {
+    orderIt = addOp(op, orderIt);
+  }
+}
+
+unsigned OutliningCandidate::getOrderOf(Value value) const {
+  // Arguments use the argument number as the order index.
+  if (BlockArgument arg = value.dyn_cast<BlockArgument>())
+    return arg.getArgNumber();
+  for (unsigned i = 0; i < params.size(); i++) {
+    if (params[i] == value)
+      return i;
+  }
+
+  // Otherwise, the result order is offset from the parent op's order.
+  auto *definingOp = value.getDefiningOp();
+  if (definingOp) {
+    auto opOrderIt = opOrderIndex.find(definingOp);
+    // Candidate arguments will have a definingOp that won't be in opOrderIndex.
+    assert(opOrderIt != opOrderIndex.end() && "expected op to have an order");
+    return opOrderIt->second + value.cast<OpResult>().getResultNumber();
+  }
+
+  return 0;
+}
+
+bool opsMatch(Operation *lhs, Operation *rhs, OutliningCandidate &one,
+              OutliningCandidate &two) {
+  // Check that the operations are equivalent.
+  if (!OperationEquivalence::isEquivalentTo(
+          lhs, rhs, OperationEquivalence::ignoreValueEquivalence,
+          OperationEquivalence::ignoreValueEquivalence,
+          OperationEquivalence::Flags::IgnoreLocations))
+    return false;
+
+  // Compare the operands of the two operations. If the operand is within
+  // the block, it must refer to the same operation.
+  auto lhsOperands = lhs->getOperands(), rhsOperands = rhs->getOperands();
+  if (lhs->getNumOperands() != rhs->getNumOperands()) {
+    return false;
+  }
+  for (int operand : llvm::seq<int>(0, lhs->getNumOperands())) {
+    Value lhsOperand = lhsOperands[operand];
+    Value rhsOperand = rhsOperands[operand];
+    if (lhsOperand == rhsOperand)
+      continue;
+    // Check that the types of the operands match.
+    if (lhsOperand.getType() != rhsOperand.getType())
+      return false;
+
+    // Otherwise, these operands must have the same logical order within the
+    // parent block.
+    if (one.getOrderOf(lhsOperand) != two.getOrderOf(rhsOperand)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool outliningCandidatesEquivalent(OutliningCandidate &one,
+                                   OutliningCandidate &two) {
+  if (one.hash != two.hash) {
+    return false;
+  }
+
+  if (one.params.size() != two.params.size()) {
+    return false;
+  }
+  for (unsigned i = 0; i < one.params.size(); i++) {
+    if (one.params[i].getType() != two.params[i].getType()) {
+      return false;
+    }
+  }
+
+  for (auto ops : llvm::zip(one.frontOps, two.frontOps)) {
+    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
+      return false;
+    }
+  }
+  if (!opsMatch(one.convOp, two.convOp, one, two)) {
+    return false;
+  }
+  for (auto ops : llvm::zip(one.secondOps, two.secondOps)) {
+    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+OutliningCandidate *
+findOutliningCandidate(OutliningCandidate &newCandidate,
+                       std::vector<OutliningCandidate> &candidates) {
+  for (auto &candidate : candidates) {
+    if (outliningCandidatesEquivalent(candidate, newCandidate)) {
+      return &candidate;
+    }
+  }
+  return nullptr;
+}
+
 // Given a convolution op and its fuse-able trailing (second) and leading
 // (front) ops, remove them into a separate function.
-void outlineConvPartOps(Operation *convOp, SetVector<Operation *> &secondOps,
+void outlineConvPartOps(Operation *convOp, ArrayRef<Operation *> secondOps,
                         ArrayRef<Operation *> frontOps, ArrayRef<Value> params,
-                        ArrayRef<Value> returnVals, StringRef partFnName) {
+                        ArrayRef<Value> returnVals, StringRef partFnName,
+                        std::vector<OutliningCandidate> &candidates) {
+  ValueRange values(params);
+  Operation *lastOp = secondOps[secondOps.size() - 1];
   OpBuilder b(convOp);
   Location loc = convOp->getLoc();
-  MLIRContext *ctx = convOp->getContext();
+  FuncOp outlinedFunc;
 
-  // Insert outlined function before current function.
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPoint(convOp->getParentOfType<FuncOp>());
+  // ------------------------------------------------------------
+  // Merging part.
 
-  // Make FuncOp from convOp's operand types and secondOp's result type.
-  ValueRange values(params);
-  ValueRange results(returnVals);
-  FunctionType type =
-      FunctionType::get(ctx, values.getTypes(), results.getTypes());
-  SmallVector<NamedAttribute, 1> kernelAttrs{
-      b.getNamedAttr("kernel", b.getUnitAttr()),
-  };
-  auto outlinedFunc = b.create<FuncOp>(loc, partFnName, type,
-                                       ArrayRef<NamedAttribute>(kernelAttrs));
-  outlinedFunc->setAttr("sym_visibility", StringAttr::get(ctx, "private"));
+  OutliningCandidate newCandidate(convOp, secondOps, frontOps, params,
+                                  returnVals, partFnName);
 
-  // Clone convOp and secondOps into the body of the new function.
-  b.setInsertionPointToStart(outlinedFunc.addEntryBlock());
-  BlockAndValueMapping bvm;
-  for (auto it : llvm::zip(values, outlinedFunc.getArguments()))
-    bvm.map(std::get<0>(it), std::get<1>(it));
+  if (OutliningCandidate *found =
+          findOutliningCandidate(newCandidate, candidates)) {
+    // Matches one we already have.
+    outlinedFunc = found->function;
+  } else {
+    // ------------------------------------------------------------
+    // Construction part.
 
-  for (auto *op : llvm::reverse(frontOps)) {
-    b.clone(*op, bvm);
+    // Insert outlined function before current function.
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(convOp->getParentOfType<FuncOp>());
+
+    // Make FuncOp from convOp's operand types and secondOp's result type.
+    MLIRContext *ctx = convOp->getContext();
+    ValueRange results(returnVals);
+    FunctionType type =
+        FunctionType::get(ctx, values.getTypes(), results.getTypes());
+    SmallVector<NamedAttribute, 1> kernelAttrs{
+        b.getNamedAttr("kernel", b.getUnitAttr()),
+    };
+    outlinedFunc = b.create<FuncOp>(loc, partFnName, type,
+                                    ArrayRef<NamedAttribute>(kernelAttrs));
+    outlinedFunc->setAttr("sym_visibility", StringAttr::get(ctx, "private"));
+    newCandidate.function = outlinedFunc;
+
+    // Clone frontOps, convOp, and secondOps into the body of the new function,
+    // while also updating the comparison details for future candidates.
+    b.setInsertionPointToStart(outlinedFunc.addEntryBlock());
+    BlockAndValueMapping bvm;
+    for (auto it : llvm::zip(values, outlinedFunc.getArguments()))
+      bvm.map(std::get<0>(it), std::get<1>(it));
+
+    newCandidate.frontOps.clear();
+    for (auto *op : llvm::reverse(frontOps)) {
+      newCandidate.frontOps.push_back(b.clone(*op, bvm));
+      newCandidate.opOrderIndex[newCandidate.frontOps.back()] =
+          newCandidate.opOrderIndex[op];
+    }
+    std::reverse(newCandidate.frontOps.begin(), newCandidate.frontOps.end());
+
+    newCandidate.convOp = b.clone(*convOp, bvm);
+    newCandidate.opOrderIndex[newCandidate.convOp] =
+        newCandidate.opOrderIndex[convOp];
+
+    newCandidate.secondOps.clear();
+    for (auto *op : secondOps) {
+      // All operands should already be in bvm.
+      assert(llvm::all_of(op->getOperands(),
+                          [&](Value v) { return bvm.lookupOrNull(v); }));
+      newCandidate.secondOps.push_back(b.clone(*op, bvm));
+      newCandidate.opOrderIndex[newCandidate.secondOps.back()] =
+          newCandidate.opOrderIndex[op];
+    }
+
+    // Make ReturnOp from secondOps' results.
+    SmallVector<Value> returnOperands;
+    for (auto op : returnVals) {
+      returnOperands.push_back(bvm.lookup(op));
+    }
+    // Can't also supply return types, because it'll see a mismatch
+    // in numbers where there isn't one.
+    b.create<ReturnOp>(loc, returnOperands);
+
+    candidates.push_back(newCandidate);
   }
 
-  b.clone(*convOp, bvm);
-
-  // Since secondOps is a SetVector, it's in the order that the ops were
-  // seen in the main function, which is safe to iterate through.
-  Operation *lastOp = convOp;
-  for (auto *op : secondOps) {
-    assert(llvm::all_of(op->getOperands(),
-                        [&](Value v) { return bvm.lookupOrNull(v); }));
-    b.clone(*op, bvm);
-    lastOp = op;
-  }
-
-  // Make ReturnOp from secondOps' results.
-  SmallVector<Value> returnOperands;
-  for (auto op : returnVals) {
-    returnOperands.push_back(bvm.lookup(op));
-  }
-  // Can't also supply return types, because it'll see a mismatch
-  // in numbers where there isn't one.
-  b.create<ReturnOp>(loc, returnOperands);
+  // ------------------------------------------------------------
+  // Replacement part.
 
   // Replace convOp and secondOps with CallOp to new function.
   b.setInsertionPointAfter(lastOp);
@@ -130,295 +332,142 @@ void outlineConvPartOps(Operation *convOp, SetVector<Operation *> &secondOps,
   }
 }
 
-// Can't just use an equality test on attributes, because the sym_name
-// attribute will always be different.  Here we get NamedAttrLists,
-// which are implicitly sorted, and walk down them in parallel, ignoring
-// sym_name.  If they're equivalent, then all the attributes will pair
-// up.
-bool areAttributesEffectivelyEqual(Operation *lhs, Operation *rhs) {
-  NamedAttrList lhsAttrs(lhs->getAttrs());
-  NamedAttrList rhsAttrs(rhs->getAttrs());
-
-  const auto *lhsIterator = lhsAttrs.begin();
-  const auto *rhsIterator = rhsAttrs.begin();
-
-  while (lhsIterator != lhsAttrs.end() && rhsIterator != rhsAttrs.end()) {
-    NamedAttribute lhsAttr = *lhsIterator;
-    NamedAttribute rhsAttr = *rhsIterator;
-
-    // Skip names, which always differ.
-    if (lhsAttr.getName() == "sym_name")
-      lhsAttr = *(++lhsIterator);
-    if (rhsAttr.getName() == "sym_name")
-      rhsAttr = *(++rhsIterator);
-
-    if (lhsAttr != rhsAttr)
-      return false;
-
-    ++lhsIterator;
-    ++rhsIterator;
-  }
-
-  return (lhsIterator == lhsAttrs.end() && rhsIterator == rhsAttrs.end());
-}
-
-// OperationEquivalence::isEquivalentTo() doesn't do what I want because
-// the attributes it compares also include the function names, which will
-// always be different.  Another approach would be to temporarily modify
-// the functions to remove the names (and anything else unimportant).
-bool isFunctionallyEquivalentTo(Operation *lhs, Operation *rhs) {
-  if (lhs == rhs)
-    return true;
-
-  // Compare the operation name.
-  if (lhs->getName() != rhs->getName())
-    return false;
-  // Check operand counts.
-  if (lhs->getNumOperands() != rhs->getNumOperands())
-    return false;
-  SmallVector<Type> lhsOperandTypes(lhs->getOperandTypes().begin(),
-                                    lhs->getOperandTypes().end());
-  SmallVector<Type> rhsOperandTypes(rhs->getOperandTypes().begin(),
-                                    rhs->getOperandTypes().end());
-  if (lhsOperandTypes.size() != rhsOperandTypes.size())
-    return false;
-  for (auto it : llvm::zip(lhsOperandTypes, rhsOperandTypes)) {
-    if (std::get<0>(it) != std::get<1>(it))
-      return false;
-  }
-  // Compare attributes.
-  if (!areAttributesEffectivelyEqual(lhs, rhs))
-    return false;
-  // Compare result types.
-  SmallVector<Type> lhsResultTypes(lhs->getResultTypes());
-  SmallVector<Type> rhsResultTypes(rhs->getResultTypes());
-  if (lhsResultTypes.size() != rhsResultTypes.size())
-    return false;
-  switch (lhsResultTypes.size()) {
-  case 0:
-    break;
-  case 1:
-    // Compare the single result type.
-    if (lhsResultTypes.front() != rhsResultTypes.front())
-      return false;
-    break;
-  default:
-    // Use the type buffer for the comparison, as we can guarantee it is the
-    // same for any given range of result types. This takes advantage of the
-    // fact the result types >1 are stored in a TupleType and uniqued.
-    if (lhsResultTypes.data() != rhsResultTypes.data())
-      return false;
-    break;
-  }
-
-  auto isExternFunc = [](Operation *op) {
-    FuncOp f = dyn_cast<FuncOp>(op);
-    return isa<FuncOp>(op) &&
-           (f->getRegions().size() != 1 || f->getRegions()[0].empty());
-  };
-  if (isExternFunc(lhs) || isExternFunc(rhs)) {
-    return false;
-  }
-
-  // TODO: Allow commutative operations to have different ordering.
-  for (auto itRegion : llvm::zip(lhs->getRegions(), rhs->getRegions())) {
-    for (auto itOperation : llvm::zip(std::get<0>(itRegion).getOps(),
-                                      std::get<1>(itRegion).getOps())) {
-      if (!isFunctionallyEquivalentTo(&std::get<0>(itOperation),
-                                      &std::get<1>(itOperation))) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 // Inspired by / adapted from TestSCFIfUtilsPass in
 // test/lib/Transforms/TestSCFUtils.cpp.
 class TosaPartitionPass : public TosaPartitionBase<TosaPartitionPass> {
 public:
-  void runOnFunction() override {
-    int count = 0;
-    FuncOp func = getFunction();
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    auto funcOps = module.getOps<FuncOp>();
+    for (auto func : llvm::make_early_inc_range(funcOps)) {
+      int count = 0;
+      // (Problems with node mismatches and unexpected uses if we have the
+      // candidates list at module level.)
+      std::vector<OutliningCandidate> candidates;
+      auto callback = [&](tosa::Conv2DOp convOp) {
+        auto strCount =
+            std::string("_outlined_part_") + std::to_string(count++);
 
-    auto callback = [&](tosa::Conv2DOp convOp) {
-      auto strCount = std::string("_outlined_part_") + std::to_string(count++);
+        // Given a Conv2DOp, gather all the element-wise ops that are reachable
+        // from its results, contiguously.
+        //
+        // The ops after the Conv2D are "second" ops.
+        // inputNodes gathers what will become the parameters of the outlined
+        // function;  initially it's the Conv2D's arguments, and it accumulates
+        // arguments to other ops that don't come from inside the outlined
+        // function.
+        // resultNodes will become the results of the outlined function.  It
+        // starts with Conv2D's result(s) and gains the results of each new
+        // secondOp.  When all a resultNode's users can be determined to lie
+        // within the outlined function, it's removed from the set.
+        //
+        // These are SetVectors because we test with contains() a lot, but still
+        // want to preserve order.
+        SetVector<Operation *> secondOps;
+        SetVector<Value> inputNodes(convOp->getOperands().begin(),
+                                    convOp->getOperands().end());
+        SetVector<Value> resultNodes(convOp->getResults().begin(),
+                                     convOp->getResults().end());
 
-      // Given a Conv2DOp, gather all the element-wise ops that are reachable
-      // from its results, contiguously.
-      //
-      // The ops after the Conv2D are "second" ops.
-      // inputNodes gathers what will become the parameters of the outlined
-      // function;  initially it's the Conv2D's arguments, and it accumulates
-      // arguments to other ops that don't come from inside the outlined
-      // function.
-      // resultNodes will become the results of the outlined function.  It
-      // starts with Conv2D's result(s) and gains the results of each new
-      // secondOp.  When all a resultNode's users can be determined to lie
-      // within the outlined function, it's removed from the set.
-      //
-      // These are SetVectors because we test with contains() a lot, but still
-      // want to preserve order.
-      SetVector<Operation *> secondOps;
-      SetVector<Value> inputNodes(convOp->getOperands().begin(),
-                                  convOp->getOperands().end());
-      SetVector<Value> resultNodes(convOp->getResults().begin(),
-                                   convOp->getResults().end());
-
-      // Grab a useful set of leading ops, like we do for trailing.
-      // Let's limit it to only first arguments, with single uses.
-      SmallVector<Operation *> frontOps;
-      if (!nofront) {
-        Operation *op = convOp;
-        while (true) {
-          if (op->getNumOperands() < 1)
-            break;
-          Operation *usedOp = op->getOpOperand(0).get().getDefiningOp();
-          if (!usedOp)
-            break;
-          if (!isElementwiseOp(usedOp) || !usedOp->hasOneUse())
-            break;
-          // Remove the first operand from the function inputs, if present.
-          // Add usedOp's operands to the function inputs.
-          inputNodes.remove(op->getOpOperand(0).get());
-          inputNodes.insert(usedOp->getOperands().begin(),
-                            usedOp->getOperands().end());
-          frontOps.push_back(usedOp);
-          op = usedOp;
+        // Grab a useful set of leading ops, like we do for trailing.
+        // Let's limit it to only first arguments, with single uses.
+        SmallVector<Operation *> frontOps;
+        if (!nofront) {
+          Operation *op = convOp;
+          while (true) {
+            if (op->getNumOperands() < 1)
+              break;
+            Operation *usedOp = op->getOpOperand(0).get().getDefiningOp();
+            if (!usedOp)
+              break;
+            if (!isElementwiseOp(usedOp) || !usedOp->hasOneUse())
+              break;
+            // Remove the first operand from the function inputs, if present.
+            // Add usedOp's operands to the function inputs.
+            inputNodes.remove(op->getOpOperand(0).get());
+            inputNodes.insert(usedOp->getOperands().begin(),
+                              usedOp->getOperands().end());
+            frontOps.push_back(usedOp);
+            op = usedOp;
+          }
         }
-      }
 
-      DominanceInfo domInfo(func);
-      std::deque<Operation *> worklist; // cuz I want to pull from the front.
+        DominanceInfo domInfo(func);
+        std::deque<Operation *> worklist; // cuz I want to pull from the front.
 
-      worklist.push_back(convOp);
-      while (!worklist.empty()) {
-        Operation *op = worklist.front();
-        worklist.pop_front();
-        for (auto *userOp : op->getUsers()) {
-          if (isElementwiseOp(userOp) /* && userOp->hasOneUse() */) {
-            bool skip = false;
-            // First criterion is that the op is element-wise.  Second criterion
-            // is that the op dominates all the users of the accumulated results
-            // of the outlined function.  In other words, we can't take an op
-            // that comes "after" a user of the result from the eventual call,
-            // because the call needs to dominate all its users.
-            for (const Value &val : resultNodes) {
-              for (auto *user : val.getDefiningOp()->getUsers()) {
-                if (user != userOp &&
-                    !domInfo.properlyDominates(userOp, user)) {
-                  skip = true;
-                }
-              }
-            }
-
-            // userOp is acceptable.  Keep it as a secondOp, put it on the
-            // worklist.  Add its operands to inputNodes unless they come
-            // from other secondOps (indicated by being in resultNodes).
-            // If all the users of any resultNode are in secondOps, there's
-            // no need to return it so remove from resultNodes.  Finally,
-            // add all userOp's results to resultNodes.
-            if (!skip) {
-              secondOps.insert(userOp);
-              worklist.push_back(userOp);
-              for (Value opnd : userOp->getOperands()) {
-                if (!resultNodes.contains(opnd)) {
-                  inputNodes.insert(opnd);
-                }
-              }
+        worklist.push_back(convOp);
+        while (!worklist.empty()) {
+          Operation *op = worklist.front();
+          worklist.pop_front();
+          for (auto *userOp : op->getUsers()) {
+            if (isElementwiseOp(userOp)) {
+              bool skip = false;
+              // First criterion is that the op is element-wise.  Second
+              // criterion is that the op dominates all the users of the
+              // accumulated results of the outlined function.  In other words,
+              // we can't take an op that comes "after" a user of the result
+              // from the eventual call, because the call needs to dominate all
+              // its users.
               for (const Value &val : resultNodes) {
-                if (llvm::all_of(val.getUsers(), [&](Operation *u) {
-                      return secondOps.contains(u);
-                    })) {
-                  resultNodes.remove(val);
+                for (auto *user : val.getDefiningOp()->getUsers()) {
+                  if (user != userOp &&
+                      !domInfo.properlyDominates(userOp, user)) {
+                    skip = true;
+                  }
                 }
               }
-              for (auto res : userOp->getResults()) {
-                resultNodes.insert(res);
+
+              // userOp is acceptable.  Keep it as a secondOp, put it on the
+              // worklist.  Add its operands to inputNodes unless they come
+              // from other secondOps (indicated by being in resultNodes).
+              // If all the users of any resultNode are in secondOps, there's
+              // no need to return it so remove from resultNodes.  Finally,
+              // add all userOp's results to resultNodes.
+              if (!skip) {
+                secondOps.insert(userOp);
+                worklist.push_back(userOp);
+                for (Value opnd : userOp->getOperands()) {
+                  if (!resultNodes.contains(opnd)) {
+                    inputNodes.insert(opnd);
+                  }
+                }
+                for (const Value &val : resultNodes) {
+                  if (llvm::all_of(val.getUsers(), [&](Operation *u) {
+                        return secondOps.contains(u);
+                      })) {
+                    resultNodes.remove(val);
+                  }
+                }
+                for (auto res : userOp->getResults()) {
+                  resultNodes.insert(res);
+                }
               }
             }
           }
         }
-      }
 
-      if (!secondOps.empty() || !frontOps.empty()) {
-        // Make the outlined function from the ops we've gathered.
-        outlineConvPartOps(convOp, secondOps, frontOps,
-                           inputNodes.getArrayRef(), resultNodes.getArrayRef(),
-                           std::string(func.sym_name()) + strCount);
-        // Outlining will erase nodes and thus perturb the walk, so
-        // signal interrupted to exit it and restart.
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    };
+        if (!secondOps.empty() || !frontOps.empty()) {
+          // Make the outlined function from the ops we've gathered.
+          outlineConvPartOps(
+              convOp, secondOps.getArrayRef(), frontOps,
+              inputNodes.getArrayRef(), resultNodes.getArrayRef(),
+              std::string(func.sym_name()) + strCount, candidates);
+          // Outlining will erase nodes and thus perturb the walk, so
+          // signal interrupted to exit it and restart.
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      };
 
-    // Walk until we've outlined all the Conv2D ops we can.
-    while (func.walk(callback).wasInterrupted()) {
+      // Walk until we've outlined all the Conv2D ops we can.
+      while (func.walk(callback).wasInterrupted()) {
+      }
     }
-
-    // Count on the SymbolDCE pass to clean up the dead functions.
   }
 };
-
-// Replace calls to identical functions with calls to the first one,
-// allowing the others to be dead-coded.
-struct PostPartitionCollapsePass
-    : public PostPartitionCollapseBase<PostPartitionCollapsePass> {
-  void runOnOperation() override;
-};
-
-void PostPartitionCollapsePass::runOnOperation() {
-  ModuleOp module = getOperation();
-  // For all FuncOps, make a mapping to replace those that are identical to
-  // another.
-  SmallVector<Operation *> opsSeen;
-  DenseMap<StringRef, StringRef> replacements;
-  for (auto f : module.getOps<FuncOp>()) {
-    bool replaced = false;
-    for (Operation *o : opsSeen) {
-      if (isFunctionallyEquivalentTo(f, o)) {
-        replacements[f.sym_name()] = dyn_cast<FuncOp>(o).sym_name();
-        replaced = true;
-      }
-    }
-    if (!replaced) {
-      opsSeen.push_back(f);
-    }
-  }
-  // Then walk all the CallOps and remap callees where appropriate.
-  module.walk([&](CallOp call) {
-    if (replacements.find(call.getCallee()) != replacements.end()) {
-      call.calleeAttr(FlatSymbolRefAttr::get(module->getContext(),
-                                             replacements[call.getCallee()]));
-    }
-  });
-}
 
 } // namespace
 
 std::unique_ptr<Pass> mlir::tosa::createTosaPartitionPass() {
   return std::make_unique<TosaPartitionPass>();
 }
-
-std::unique_ptr<Pass> mlir::tosa::createPostPartitionCollapsePass() {
-  return std::make_unique<PostPartitionCollapsePass>();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-static void tosaPartitionPipeline(OpPassManager &pm) {
-  pm.addPass(std::make_unique<TosaPartitionPass>());
-  pm.addPass(std::make_unique<PostPartitionCollapsePass>());
-  pm.addPass(mlir::createSymbolDCEPass());
-}
-
-namespace mlir {
-namespace tosa {
-void registerTosaPartitionPipelinePass() {
-  PassPipelineRegistration<>("tosa-partition-pipeline",
-                             "Partition around Conv2D ops and clean up after",
-                             tosaPartitionPipeline);
-}
-} // namespace tosa
-} // namespace mlir

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
@@ -16,9 +16,9 @@
 // CHECK-NEXT:     [0.214844,     0.595831],
 // CHECK-NEXT:     [0.0928252,     0.721703],
 //
-// RUN: mlir-opt %s --tosa-partition-pipeline --tosa-to-linalg --tosa-to-standard --linalg-detensorize \
-// RUN:   -tensor-constant-bufferize -std-bufferize -linalg-bufferize -tensor-bufferize \
-// RUN:   -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
+// RUN: mlir-opt %s --tosa-partition --tosa-to-linalg --tosa-to-standard \
+// RUN:   --linalg-detensorize -tensor-constant-bufferize -std-bufferize -linalg-bufferize \
+// RUN:   -tensor-bufferize -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
 // RUN:   --tosa-to-standard -lower-affine -convert-linalg-to-llvm --convert-scf-to-std \
 // RUN:   --convert-math-to-llvm --convert-std-to-llvm --reconcile-unrealized-casts \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --split-input-file --tosa-partition-pipeline %s -verify-each=0 -o -| FileCheck %s
+// RUN: mlir-opt --split-input-file --tosa-partition %s -verify-each=0 -o -| FileCheck %s
 
 // CHECK-LABEL: func private @test_fusion_outlined_part_0
 // CHECK: tosa.conv2d


### PR DESCRIPTION
rather than a separate pass after the partition pass.

That makes the separate pass, and the follow-up symbolDCE pass,
unnecessary, and thus makes the partition-pipeline pass also
unnecessary.  It uses some of the logic of mergeIdenticalBlocks() but
different code, since it isn't manipulating Blocks.

Change --tosa-partition from function-level to module-level pass,
because it creates FuncOps.  There were possibilities for race
conditions there.  In conjunction, move candidates list from module- to
function-level to avoid some trouble with shared nodes.

The one catch is that we no longer catch identical kernel functions that
originate in different primary functions, since we have only a
function-level view instead of a module-level view when merging.