### PR TITLE
Add timing information to lit test

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -54,6 +54,13 @@ if(MLIR_MIOPEN_DRIVER_TEST_GPU_VALIDATION)
   set(MLIR_POPULATE_VALIDATION "-pv_with_gpu")
 endif()
 
+# Sets execution options for lit test
+set(LIT_EXE_OPTION "")
+# Enables time tracking of individual tests
+if(MLIR_MIOPEN_DRIVER_TIMING_TEST_ENABLED)
+  set(LIT_EXE_OPTION "--time-tests")
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
@@ -109,6 +116,7 @@ endif()
 add_lit_testsuite(check-mlir-miopen "Running the MLIR-MIOpen regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${MLIR_TEST_DEPENDS}
+  ARGS ${LIT_EXE_OPTION}
   )
 set_target_properties(check-mlir-miopen PROPERTIES FOLDER "Tests")
 

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -208,6 +208,7 @@ pipeline {
                                              -DMLIR_MIOPEN_DRIVER_RANDOM_DATA_SEED=1
                                              -DMLIR_MIOPEN_DRIVER_MISC_E2E_TEST_ENABLED=0
                                              -DMLIR_MIOPEN_DRIVER_TEST_GPU_VALIDATION=0
+                                             -DMLIR_MIOPEN_DRIVER_TIMING_TEST_ENABLED=1
                                              -DCMAKE_EXPORT_COMPILE_COMMANDS=1""")
                             }
                         }


### PR DESCRIPTION
Shows individual test wall time as below, enabled for random test.

[3165/3166] Running the MLIR-MIOpen regression tests
                                                                                                                                             -- Testing: 136 tests, 56 workers --
 83% [========================================================================================================================================================================================================================================================------------------------------------------------] ETA: 00:00:04
 88% [=======================================================================================================================================================================================================================================================================---------------------------------] ETA: 00:00:10
Slowest Tests:
--------------------------------------------------------------------------
158.56s: MLIR :: mlir-miopen-driver/auto_e2e/conv2d_host_validation_f32_fwd.mlir
143.65s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nchw_f16.mlir
143.38s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nchw_f32.mlir
143.10s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nhwc_f32.mlir
139.12s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nhwc_f16.mlir
120.89s: MLIR :: mlir-miopen-driver/auto_e2e/conv2d_host_validation_f16_fwd.mlir
102.45s: MLIR :: mlir-miopen-driver/auto_e2e/Resnext101/fwd_nchw.mlir
102.18s: MLIR :: mlir-miopen-driver/auto_e2e/Resnext101/wrw_nchw.mlir
102.17s: MLIR :: mlir-miopen-driver/auto_e2e/Resnext101/bwd_nhwc.mlir
101.14s: MLIR :: mlir-miopen-driver/auto_e2e/Resnext101/bwd_nchw.mlir
100.65s: MLIR :: mlir-miopen-driver/auto_e2e/Resnext101/wrw_nhwc.mlir
98.82s: MLIR :: mlir-miopen-driver/auto_e2e/Resnext101/fwd_nhwc.mlir
90.79s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nchw_f16_bwd.mlir
88.79s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nchw_f32_bwd.mlir
87.91s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nhwc_f16_bwd.mlir
82.84s: MLIR :: mlir-miopen-driver/auto_e2e/Resnet50/Resnet50_nhwc_f32_bwd.mlir
60.06s: MLIR :: mlir-miopen-driver/auto_e2e/padding_kernel_gemmK.mlir
49.11s: MLIR :: mlir-miopen-driver/auto_e2e/conv2d_host_validation_f16_bwd.mlir
47.29s: MLIR :: mlir-miopen-driver/auto_e2e/padding_kernel_gemmN.mlir
36.37s: MLIR :: mlir-miopen-driver/auto_e2e/conv2d_host_validation_f32_bwd.mlir

Tests Times:
--------------------------------------------------------------------------
[   Range   ] :: [               Percentage               ] :: [ Count ]
--------------------------------------------------------------------------
[150s,160s) :: [                                        ] :: [  1/136]
[140s,150s) :: [*                                       ] :: [  4/136]
[130s,140s) :: [                                        ] :: [  0/136]
[120s,130s) :: [                                        ] :: [  1/136]
[110s,120s) :: [                                        ] :: [  0/136]
[100s,110s) :: [*                                       ] :: [  5/136]
[ 90s,100s) :: [                                        ] :: [  2/136]
[ 80s, 90s) :: [                                        ] :: [  3/136]
[ 70s, 80s) :: [                                        ] :: [  0/136]
[ 60s, 70s) :: [                                        ] :: [  1/136]
[ 50s, 60s) :: [                                        ] :: [  0/136]
[ 40s, 50s) :: [                                        ] :: [  2/136]
[ 30s, 40s) :: [                                        ] :: [  2/136]
[ 20s, 30s) :: [*                                       ] :: [  6/136]
[ 10s, 20s) :: [***                                     ] :: [ 13/136]
[  0s, 10s) :: [****************************            ] :: [ 96/136]
--------------------------------------------------------------------------

Testing Time: 158.86s
  Unsupported      :  11
  Passed           : 122
  Expectedly Failed:   3