### PR TITLE
[DO NOT SQUASH] Add a dump asm option

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/Passes.h
@@ -88,6 +88,12 @@ protected:
       *this, "gpu-binary-annotation",
       llvm::cl::desc("Annotation attribute string for GPU binary"),
       llvm::cl::init(getDefaultGpuBinaryAnnotation())};
+  Option<bool> dumpAsm{
+      *this, "dump-asm",
+      llvm::cl::desc("Whether the final generated instructions or intermediate "
+                     "IR (if stopping early) for a kernel should be dumped to "
+                     "the debug stream"),
+      llvm::cl::init(false)};
 };
 } // namespace gpu
 
@@ -105,7 +111,8 @@ void registerGpuSerializeToHsacoPass();
 std::unique_ptr<Pass> createGpuSerializeToHsacoPass(StringRef triple,
                                                     StringRef arch,
                                                     StringRef features,
-                                                    int optLevel);
+                                                    int optLevel,
+                                                    bool dumpAsm = false);
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -82,7 +82,7 @@ class SerializeToHsacoPass
     : public PassWrapper<SerializeToHsacoPass, gpu::SerializeToBlobPass> {
 public:
   SerializeToHsacoPass(StringRef triple, StringRef arch, StringRef features,
-                       int optLevel);
+                       int optLevel, bool dumpAsm = false);
   SerializeToHsacoPass(const SerializeToHsacoPass &other);
   StringRef getArgument() const override { return "gpu-to-hsaco"; }
   StringRef getDescription() const override {
@@ -149,12 +149,15 @@ static void maybeSetOption(Pass::Option<std::string> &option,
 }
 
 SerializeToHsacoPass::SerializeToHsacoPass(StringRef triple, StringRef arch,
-                                           StringRef features, int optLevel) {
+                                           StringRef features, int optLevel,
+                                           bool dumpAsm) {
   maybeSetOption(this->triple, [&triple] { return triple.str(); });
   maybeSetOption(this->chip, [&arch] { return arch.str(); });
   maybeSetOption(this->features, [&features] { return features.str(); });
   if (this->optLevel.getNumOccurrences() == 0)
     this->optLevel.setValue(optLevel);
+  if (this->dumpAsm.getNumOccurrences() == 0 && dumpAsm)
+    this->dumpAsm.setValue(dumpAsm);
 }
 
 void SerializeToHsacoPass::getDependentDialects(
@@ -516,9 +519,10 @@ void mlir::registerGpuSerializeToHsacoPass() {
 std::unique_ptr<Pass> mlir::createGpuSerializeToHsacoPass(StringRef triple,
                                                           StringRef arch,
                                                           StringRef features,
-                                                          int optLevel) {
+                                                          int optLevel,
+                                                          bool dumpASM) {
   return std::make_unique<SerializeToHsacoPass>(triple, arch, features,
-                                                optLevel);
+                                                optLevel, dumpASM);
 }
 
 #else  // MLIR_GPU_TO_HSACO_PASS_ENABLE

--- a/external/llvm-project/mlir/test/Conversion/GPUToROCm/lower-rocdl-kernel-to-hsaco.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUToROCm/lower-rocdl-kernel-to-hsaco.mlir
@@ -1,6 +1,9 @@
 // RUN: mlir-opt %s --test-gpu-to-hsaco | FileCheck %s
+// RUN: mlir-opt %s --test-gpu-to-hsaco=dump-asm=true 2>&1 |\
+// RUN:   FileCheck %s --check-prefix=CHECK-ASM
 
 // CHECK: gpu.module @foo attributes {gpu.binary = "HSACO"}
+// CHECK-ASM: .globl kernel
 gpu.module @foo {
   llvm.func @kernel(%arg0 : f32, %arg1 : !llvm.ptr<f32>)
     // CHECK: attributes  {gpu.kernel}
@@ -23,3 +26,4 @@ gpu.module @bar {
     llvm.return
   }
 }
+// CHECK-ASM: amdhsa.target:

--- a/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
+++ b/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
@@ -59,6 +59,12 @@ static cl::opt<bool>
                cl::desc("input is in the MLIR LLVM/ROCDL dialect"),
                cl::init(false));
 
+static cl::opt<bool>
+    dumpAsm("dump-asm",
+            cl::desc("Whether to dump the assembly or intermediate "
+                     "IR during GPU kernel convolution"),
+            cl::init(false));
+
 namespace test {
 void registerTestDialect(DialectRegistry &);
 } // namespace test
@@ -89,7 +95,8 @@ static LogicalResult runMLIRPasses(ModuleOp m) {
                                         /*runtime=*/gpu::amd::Runtime::HIP));
   }
   kernelPm.addPass(createGpuSerializeToHsacoPass(
-      utils.getTriple(), utils.getChip(), utils.getFeatures(), optLevel));
+      utils.getTriple(), utils.getChip(), utils.getFeatures(), optLevel,
+      dumpAsm.getValue()));
   auto &funcPm = pm.nest<FuncOp>();
   funcPm.addPass(createGpuAsyncRegionPass());
   funcPm.addPass(createConvertMathToLLVMPass());


### PR DESCRIPTION
[MLIR][GPU] Add a dump-isa pass option to GPU serialization.

The dump-isa pass option allows developers to get the compiled ISA for their kernels, or, if they used an option such as --stop-after, to extract the intermediate IR from the partially-completed compilation process. This simplifies the debugging of compilation issues arising from the serialization of GPU code to binary blobs.

(Rationale: needing to go in and add a call to print the ISA out and then take it back out again before committing was getting to be a pain.)