### PR TITLE
Port over mlir-lsp-server

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(MLIR_TEST_DEPENDS
   FileCheck count not
   miopen-opt
   miopen-translate
+  miopen-lsp-server
   mlir-mixr-capi-test
   mlir-tosa-miir-test
   mlir-opt

--- a/mlir/tools/CMakeLists.txt
+++ b/mlir/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 #add_subdirectory(mlir-cuda-runner)
 #add_subdirectory(mlir-cpu-runner)
+add_subdirectory(miopen-lsp-server)
 add_subdirectory(miopen-opt)
 #add_subdirectory(mlir-reduce)
 add_subdirectory(mlir-rocm-runner)

--- a/mlir/tools/miopen-lsp-server/CMakeLists.txt
+++ b/mlir/tools/miopen-lsp-server/CMakeLists.txt
@@ -1,0 +1,53 @@
+set(LLVM_OPTIONAL_SOURCES
+  null.cpp
+)
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  AsmParser
+  )
+
+if(MLIR_INCLUDE_TESTS)
+  set(test_libs
+    MLIRAffineTransformsTestPasses
+    MLIRShapeTestPasses
+    MLIRSPIRVTestPasses
+    MLIRTestAnalysis
+    MLIRTestDialect
+    MLIRTestIR
+    MLIRTestPass
+    MLIRTestReducer
+    MLIRTestRewrite
+    MLIRTestTransforms
+    )
+endif()
+
+set(LIBS
+  ${dialect_libs}
+  ${conversion_libs}
+  ${test_libs}
+  MLIRLoopAnalysis
+  MLIRAnalysis
+  MLIRDialect
+  MLIRLspServerLib
+  MLIRParser
+  MLIRPass
+  MLIRTransforms
+  MLIRTransformUtils
+  MLIRSupport
+  MLIRIR
+  )
+
+add_llvm_tool(miopen-lsp-server
+  miopen-lsp-server.cpp
+
+  DEPENDS
+  ${LIBS}
+  )
+target_link_libraries(miopen-lsp-server PRIVATE ${LIBS})
+llvm_update_compile_flags(miopen-lsp-server)
+
+mlir_check_all_link_libraries(miopen-lsp-server)

--- a/mlir/tools/miopen-lsp-server/miopen-lsp-server.cpp
+++ b/mlir/tools/miopen-lsp-server/miopen-lsp-server.cpp
@@ -1,0 +1,22 @@
+//===- miopen-lsp-server.cpp - MLIR Language Server with MIOpen dialects ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------===//
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitMIOpenDialects.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+using namespace mlir;
+
+int main(int argc, char **argv) {
+  DialectRegistry registry;
+  registerAllDialects(registry);
+  registerMIOpenDialects(registry);
+  return failed(MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
This'll give us tab-complete for op names in VS Code and probably more stuff down the line.