### PR TITLE
Suppress rocm-smi failures

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -33,7 +33,8 @@ void showEnv() {
     echo "$env.NODE_NAME"
     sh 'cat /etc/os-release'
     sh 'ulimit -a'
-    sh '/opt/rocm/bin/rocm-smi'
+    // Ignore rocm-smi failures in ixt-sjc2-05
+    sh '/opt/rocm/bin/rocm-smi || true'
     sh '/opt/rocm/bin/rocm_agent_enumerator'
     sh 'id'
 }


### PR DESCRIPTION
Using this PR as a test to check whether those below failures are tolerable:

> rocm-smi -a --loglevel debug

```
ERROR: 2 GPU[0]: od volt: RSMI_STATUS_NOT_SUPPORTED: This function is not supported in the current environment.
DEBUG: GPU[0] : Unable to display sclk range
GPU[0] : Unable to display sclk range

ERROR: 2 GPU[0]: od volt: RSMI_STATUS_NOT_SUPPORTED: This function is not supported in the current environment.
DEBUG: GPU[0] : Unable to display mclk range
GPU[0] : Unable to display mclk range

ERROR: 2 GPU[0]: od volt: RSMI_STATUS_NOT_SUPPORTED: This function is not supported in the current environment.
DEBUG: GPU[0] : Unable to display voltage range
GPU[0] : Unable to display voltage range

ERROR: 2 GPU[0]: od volt: RSMI_STATUS_NOT_SUPPORTED: This function is not supported in the current environment.
DEBUG: GPU[0] : Voltage Curve is not supported
GPU[0] : Voltage Curve is not supported
```
