### PR TITLE
Fix remaining MI-200 failures with broad workaround

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -750,7 +750,10 @@ public:
   Align getStackAlignment() const { return Align(16); }
 
   bool enableMachineScheduler() const override {
-    return true;
+    // XXX(kdrewnia): Don't merge this initially, and don't merge without
+    // discussion of cleaner hammers. This will get past the MI-200 test
+    // failures on fp16 xdlops at the cost of performance everywhere
+    return false;
   }
 
   bool useAA() const override;


### PR DESCRIPTION
This change disables the instruction scheduler in the compiler backend, which """fixes""" the remaining fp16 xdlops issues we're having. See https://ontrack-internal.amd.com/browse/SWDEV-318900 for more info and **don't merge this**.