### PR TITLE
Include constants, in any operand position, in frontOps.

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -377,7 +377,7 @@ public:
           Operation *op = convOp;
           while (true) {
             // Special loop for constant operands.
-            for (const auto& opnd : op->getOperands()) {
+            for (const auto &opnd : op->getOperands()) {
               Operation *usedOp = opnd.getDefiningOp();
               if (usedOp) {
                 if (detail::isConstantLike(usedOp) && usedOp->hasOneUse()) {


### PR DESCRIPTION
We already follow first-operand element-wise-op chains back from the conv2d that is the basis for the partition.  This commit adds a special case to include constant operands in any position.