### PR TITLE
Disable fixed-E2E-tests in weeklies

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -128,6 +128,7 @@ pipeline {
                     when {
                         beforeAgent true;
                         equals expected: true, actual: params.sharedLib;
+                        equals expected: false, actual: params.weekly;
                     }
                     agent {
                         docker {


### PR DESCRIPTION
The fixed-E2E-tests should be run in nightlies or PR.