### PR TITLE
Dump asm as in upstream

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/Passes.h
@@ -88,12 +88,6 @@ protected:
       *this, "gpu-binary-annotation",
       llvm::cl::desc("Annotation attribute string for GPU binary"),
       llvm::cl::init(getDefaultGpuBinaryAnnotation())};
-  Option<bool> dumpAsm{
-      *this, "dump-asm",
-      llvm::cl::desc("Whether the final generated instructions or intermediate "
-                     "IR (if stopping early) for a kernel should be dumped to "
-                     "the debug stream"),
-      llvm::cl::init(false)};
 };
 } // namespace gpu
 
@@ -111,8 +105,7 @@ void registerGpuSerializeToHsacoPass();
 std::unique_ptr<Pass> createGpuSerializeToHsacoPass(StringRef triple,
                                                     StringRef arch,
                                                     StringRef features,
-                                                    int optLevel,
-                                                    bool dumpAsm = false);
+                                                    int optLevel);
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToBlob.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToBlob.cpp
@@ -24,6 +24,8 @@
 #include "llvm/Target/TargetMachine.h"
 #include <string>
 
+#define DEBUG_TYPE "serialize-to-blob"
+
 using namespace mlir;
 
 std::string gpu::getDefaultGpuBinaryAnnotation() { return "gpu.binary"; }
@@ -78,6 +80,12 @@ void gpu::SerializeToBlobPass::runOnOperation() {
     return signalPassFailure();
 
   std::string targetISA = std::move(maybeTargetISA.getValue());
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "ISA for module: " << getOperation().getNameAttr() << "\n";
+    llvm::dbgs() << targetISA << "\n";
+    llvm::dbgs().flush();
+  });
 
   // Serialize the target ISA.
   std::unique_ptr<std::vector<char>> blob = serializeISA(targetISA);

--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToBlob.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToBlob.cpp
@@ -20,18 +20,11 @@
 #include "llvm/ADT/None.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
-
-#include <mutex>
 #include <string>
 
 using namespace mlir;
-
-// Ensure multiple threads don't try to simultaneously dump the assembly for
-// separate modules
-static std::mutex dumpAsmLock;
 
 std::string gpu::getDefaultGpuBinaryAnnotation() { return "gpu.binary"; }
 
@@ -85,12 +78,6 @@ void gpu::SerializeToBlobPass::runOnOperation() {
     return signalPassFailure();
 
   std::string targetISA = std::move(maybeTargetISA.getValue());
-
-  if (dumpAsm.getValue()) {
-    const std::lock_guard<std::mutex> lock(dumpAsmLock);
-    llvm::dbgs() << targetISA << "\n";
-    llvm::dbgs().flush();
-  }
 
   // Serialize the target ISA.
   std::unique_ptr<std::vector<char>> blob = serializeISA(targetISA);

--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -82,7 +82,7 @@ class SerializeToHsacoPass
     : public PassWrapper<SerializeToHsacoPass, gpu::SerializeToBlobPass> {
 public:
   SerializeToHsacoPass(StringRef triple, StringRef arch, StringRef features,
-                       int optLevel, bool dumpAsm = false);
+                       int optLevel);
   SerializeToHsacoPass(const SerializeToHsacoPass &other);
   StringRef getArgument() const override { return "gpu-to-hsaco"; }
   StringRef getDescription() const override {
@@ -149,15 +149,12 @@ static void maybeSetOption(Pass::Option<std::string> &option,
 }
 
 SerializeToHsacoPass::SerializeToHsacoPass(StringRef triple, StringRef arch,
-                                           StringRef features, int optLevel,
-                                           bool dumpAsm) {
+                                           StringRef features, int optLevel) {
   maybeSetOption(this->triple, [&triple] { return triple.str(); });
   maybeSetOption(this->chip, [&arch] { return arch.str(); });
   maybeSetOption(this->features, [&features] { return features.str(); });
   if (this->optLevel.getNumOccurrences() == 0)
     this->optLevel.setValue(optLevel);
-  if (this->dumpAsm.getNumOccurrences() == 0 && dumpAsm)
-    this->dumpAsm.setValue(dumpAsm);
 }
 
 void SerializeToHsacoPass::getDependentDialects(
@@ -519,10 +516,9 @@ void mlir::registerGpuSerializeToHsacoPass() {
 std::unique_ptr<Pass> mlir::createGpuSerializeToHsacoPass(StringRef triple,
                                                           StringRef arch,
                                                           StringRef features,
-                                                          int optLevel,
-                                                          bool dumpASM) {
+                                                          int optLevel) {
   return std::make_unique<SerializeToHsacoPass>(triple, arch, features,
-                                                optLevel, dumpASM);
+                                                optLevel);
 }
 
 #else  // MLIR_GPU_TO_HSACO_PASS_ENABLE

--- a/external/llvm-project/mlir/test/Conversion/GPUToROCm/lower-rocdl-kernel-to-hsaco.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUToROCm/lower-rocdl-kernel-to-hsaco.mlir
@@ -1,9 +1,6 @@
 // RUN: mlir-opt %s --test-gpu-to-hsaco | FileCheck %s
-// RUN: mlir-opt %s --test-gpu-to-hsaco=dump-asm=true 2>&1 |\
-// RUN:   FileCheck %s --check-prefix=CHECK-ASM
 
 // CHECK: gpu.module @foo attributes {gpu.binary = "HSACO"}
-// CHECK-ASM: .globl kernel
 gpu.module @foo {
   llvm.func @kernel(%arg0 : f32, %arg1 : !llvm.ptr<f32>)
     // CHECK: attributes  {gpu.kernel}
@@ -26,4 +23,3 @@ gpu.module @bar {
     llvm.return
   }
 }
-// CHECK-ASM: amdhsa.target:

--- a/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
+++ b/mlir/tools/mlir-rocm-runner/mlir-rocm-runner.cpp
@@ -59,12 +59,6 @@ static cl::opt<bool>
                cl::desc("input is in the MLIR LLVM/ROCDL dialect"),
                cl::init(false));
 
-static cl::opt<bool>
-    dumpAsm("dump-asm",
-            cl::desc("Whether to dump the assembly or intermediate "
-                     "IR during GPU kernel convolution"),
-            cl::init(false));
-
 namespace test {
 void registerTestDialect(DialectRegistry &);
 } // namespace test
@@ -95,8 +89,7 @@ static LogicalResult runMLIRPasses(ModuleOp m) {
                                         /*runtime=*/gpu::amd::Runtime::HIP));
   }
   kernelPm.addPass(createGpuSerializeToHsacoPass(
-      utils.getTriple(), utils.getChip(), utils.getFeatures(), optLevel,
-      dumpAsm.getValue()));
+      utils.getTriple(), utils.getChip(), utils.getFeatures(), optLevel));
   auto &funcPm = pm.nest<FuncOp>();
   funcPm.addPass(createGpuAsyncRegionPass());
   funcPm.addPass(createConvertMathToLLVMPass());


### PR DESCRIPTION
This is a commit to harmonize the assembly dumping infrastructure with how the upstream folks wanted it rewritten.

See below for new commit message there:

[MLIR][GPU] Add debug output to enable dumping GPU assembly

- Set the DEBUG_TYPE of SerializeToBlob to serialize-to-blob
- Add debug output to print the assembly or PTX for GPU modules before
  they are assembled and linked

Note that, as SerializeToBlob is a superclass of SerializeToCubin and
SerializeToHsaco, --debug-only=serialize-to-blom will dump the
intermediate compiler result for both of these passes.

In addition, if LLVM options such as --stop-after are used to control
the GPU kernel compilation process, the debug output will contain the
appropriate intermediate IR.

Differential Revision: https://reviews.llvm.org/D117519