### PR TITLE
Make the build order of miopen-gen be deterministic.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -389,7 +389,7 @@ pipeline {
                         }
                         stage("Build MLIR") {
                             steps {
-                                buildProject('mlir-miopen-driver mlir-rocm-runner ci-performance-scripts', '')
+                                buildProject('miopen-gen mlir-miopen-driver mlir-rocm-runner ci-performance-scripts', '')
                             }
                         }
                         stage("Test MLIR vs MIOpen") {


### PR DESCRIPTION
Since PR #461, miopen-gen has become a required tool. Make it be built
explicitly in "Build MLIR" stage to prevent non-determinisim.