### PR TITLE
[DO NOT SQUASH] Make the BF16 conversion ops elementwise

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -20,6 +20,7 @@ include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/DataLayoutInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/VectorInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // GPU Dialect operations.
@@ -1246,9 +1247,11 @@ def GPU_MFMAOp:
 }
 
 def GPU_BFConvertOp :
-    GPU_Op<"bf_convert">,
-    Arguments<(ins F32:$in)>,
-    Results<(outs I16:$out)> {
+    GPU_Op<"bf_convert", [NoSideEffect,
+    DeclareOpInterfaceMethods<VectorUnrollOpInterface>] #
+    ElementwiseMappable.traits>,
+    Arguments<(ins TypesLike<F32, "f32-like">:$in)>,
+    Results<(outs TypesLike<I16, "i16-like">:$out)> {
   let summary = "from fp32 to bf16";
   let description = [{
     The 'gpu.bf_convert' op converts an fp32 value to bf16 value. Stored as i16 for usage compatibility.

--- a/external/llvm-project/mlir/include/mlir/IR/OpBase.td
+++ b/external/llvm-project/mlir/include/mlir/IR/OpBase.td
@@ -828,25 +828,26 @@ class NestedTupleOf<list<Type> allowedTypes> :
 //===----------------------------------------------------------------------===//
 // Common type constraints
 //===----------------------------------------------------------------------===//
+// Type constraint for types that are "like" some type or set of types T, that is
+// they're either a T, a vector of Ts, or a tensor of Ts
+class TypesLike<Type allowedType, string name> : TypeConstraint<Or<[
+  allowedType.predicate, VectorOf<[allowedType]>.predicate,
+  TensorOf<[allowedType]>.predicate]>,
+  name>;
+
+
 
 // Type constraint for bool-like types: bools, vectors of bools, tensors of
 // bools.
-def BoolLike : TypeConstraint<Or<[I1.predicate, VectorOf<[I1]>.predicate,
-                                  TensorOf<[I1]>.predicate]>,
-    "bool-like">;
+def BoolLike : TypesLike<I1, "bool-like">;
 
 // Type constraint for signless-integer-like types: signless integers, indices,
 // vectors of signless integers or indices, tensors of signless integers.
-def SignlessIntegerLike : TypeConstraint<Or<[
-        AnySignlessIntegerOrIndex.predicate,
-        VectorOf<[AnySignlessIntegerOrIndex]>.predicate,
-        TensorOf<[AnySignlessIntegerOrIndex]>.predicate]>,
+def SignlessIntegerLike : TypesLike<AnySignlessIntegerOrIndex,
     "signless-integer-like">;
 
 // Type constraint for float-like types: floats, vectors or tensors thereof.
-def FloatLike : TypeConstraint<Or<[AnyFloat.predicate,
-        VectorOf<[AnyFloat]>.predicate, TensorOf<[AnyFloat]>.predicate]>,
-    "floating-point-like">;
+def FloatLike : TypesLike<AnyFloat, "floating-point-like">;
 
 // Type constraint for signless-integer-like or float-like types.
 def SignlessIntegerOrFloatLike : TypeConstraint<Or<[

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -25,11 +25,14 @@
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/GPU/Passes.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -890,36 +893,47 @@ struct BFOpLowering : ConvertToLLVMPattern {
     auto adaptor = gpu::BFConvertOpAdaptor(operands);
     auto loc = bfOp.getLoc();
 
-    Type castedI32Type = rewriter.getIntegerType(32);
-    Type castedI16Type = rewriter.getIntegerType(16);
-    Type llvmI32Type = typeConverter->convertType(castedI32Type);
-    Type llvmI16Type = typeConverter->convertType(castedI16Type);
+    Type srcType = adaptor.in().getType();
+    Type destType = bfOp.out().getType();
+    Type bitcastType = rewriter.getI32Type();
+    if (auto srcShaped = srcType.dyn_cast<ShapedType>())
+      bitcastType = srcShaped.clone(bitcastType);
+    Type llvmBitcastType = typeConverter->convertType(bitcastType);
+    Type llvmDestType = typeConverter->convertType(destType);
+
+    auto getI32ConstAttr = [&bitcastType,
+                            &rewriter](int32_t value) -> Attribute {
+      Attribute scalar = rewriter.getI32IntegerAttr(value);
+      if (LLVM::isCompatibleVectorType(bitcastType))
+        return SplatElementsAttr::get(bitcastType.cast<ShapedType>(), scalar);
+      return scalar;
+    };
     // a = bitcast f32 value to i32
     // b = (a + 32767) << 16
     // c = ((a << 16) & 1)
     // d = b + c
     // truncate (d << 16) to i16 and return this i16
-    auto bitcastop =
-        rewriter.create<LLVM::BitcastOp>(loc, llvmI32Type, adaptor.in());
-    auto constantSixteen = rewriter.create<LLVM::ConstantOp>(
-        loc, llvmI32Type, rewriter.getIntegerAttr(castedI32Type, 16));
-    auto ShiftValue = rewriter.create<LLVM::LShrOp>(loc, llvmI32Type, bitcastop,
-                                                    constantSixteen);
+    Value bitcastop =
+        rewriter.create<LLVM::BitcastOp>(loc, llvmBitcastType, adaptor.in());
+    Value constantSixteen = rewriter.create<LLVM::ConstantOp>(
+        loc, llvmBitcastType, getI32ConstAttr(16));
+    Value shiftValue = rewriter.create<LLVM::LShrOp>(
+        loc, llvmBitcastType, bitcastop, constantSixteen);
 
-    auto constantOne = rewriter.create<LLVM::ConstantOp>(
-        loc, llvmI32Type, rewriter.getIntegerAttr(castedI32Type, 1));
-    auto andValue = rewriter.create<LLVM::AndOp>(loc, ShiftValue, constantOne);
+    Value constantOne = rewriter.create<LLVM::ConstantOp>(loc, llvmBitcastType,
+                                                          getI32ConstAttr(1));
+    Value andValue = rewriter.create<LLVM::AndOp>(loc, shiftValue, constantOne);
 
-    auto constantBig = rewriter.create<LLVM::ConstantOp>(
-        loc, llvmI32Type, rewriter.getIntegerAttr(castedI32Type, 32767));
-    auto addBigValue =
+    Value constantBig = rewriter.create<LLVM::ConstantOp>(
+        loc, llvmBitcastType, getI32ConstAttr(32767));
+    Value addBigValue =
         rewriter.create<LLVM::AddOp>(loc, bitcastop, constantBig);
-    auto addValue = rewriter.create<LLVM::AddOp>(loc, andValue, addBigValue);
+    Value addValue = rewriter.create<LLVM::AddOp>(loc, andValue, addBigValue);
 
-    auto ShiftBeforeTruncValue = rewriter.create<LLVM::LShrOp>(
-        loc, llvmI32Type, addValue, constantSixteen);
-    auto truncValue =
-        rewriter.create<LLVM::TruncOp>(loc, llvmI16Type, ShiftBeforeTruncValue);
+    Value shiftBeforeTruncValue = rewriter.create<LLVM::LShrOp>(
+        loc, bitcastType, addValue, constantSixteen);
+    Value truncValue = rewriter.create<LLVM::TruncOp>(loc, llvmDestType,
+                                                      shiftBeforeTruncValue);
     rewriter.replaceOp(op, {truncValue});
     return success();
   }

--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -734,20 +734,9 @@ inline Value createTypeConversionOp(OpBuilder &b, Location loc, Value source,
                destElemType == b.getF16Type()) {
       result = b.create<arith::TruncFOp>(loc, source, destType);
     } else if (destElemType == b.getIntegerType(16)) {
-      if (sourceElemType == sourceType) {
-        result = b.create<miopen::DataConvertOp>(loc, destType, source);
-      } else {
-        result = createZeroConstantFloatOp(b, loc, destType);
-        int64_t numElements = destType.cast<VectorType>().getNumElements();
-        for (int64_t i = 0; i < numElements; ++i) {
-          Value extracted = b.create<vector::ExtractElementOp>(
-              loc, source, b.create<ConstantIndexOp>(loc, i));
-          Value converted =
-              b.create<miopen::DataConvertOp>(loc, destElemType, extracted);
-          result = b.create<vector::InsertElementOp>(
-              loc, converted, result, b.create<ConstantIndexOp>(loc, i));
-        }
-      }
+      result = b.create<miopen::DataConvertOp>(loc, destType, source);
+    } else {
+      llvm_unreachable("Only fp32, fp16, or bf16 targets for data conversion");
     }
   }
   return result;

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
@@ -28,6 +28,7 @@
 #include "mlir/Support/TypeID.h"
 
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/VectorInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 
 #include "llvm/ADT/DenseMap.h"

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -15,6 +15,7 @@
 
 include "mlir/Dialect/MIOpen/MIOpenAttrDefs.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/VectorInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
 
 // Base class for MIOpen dialect ops.
@@ -518,9 +519,11 @@ def MIOpen_XdlopsGemmV2Op:
 }
 
 def MIOpen_DataConvertOp :
-    MIOpen_Op<"data_convert">,
-    Arguments<(ins F32:$in)>,
-    Results<(outs I16:$out)> {
+    MIOpen_Op<"data_convert", [NoSideEffect,
+    DeclareOpInterfaceMethods<VectorUnrollOpInterface>] #
+    ElementwiseMappable.traits>,
+    Arguments<(ins TypesLike<F32, "f32-like">:$in)>,
+    Results<(outs TypesLike<I16, "i16-like">:$out)> {
   let summary = "data type conversion";
   let description = [{
     The `miopen.data_convert` op will convert f32 to bf16, but we use i16 to replace bf16 here.

--- a/mlir/test/Dialect/GPU/cast.mlir
+++ b/mlir/test/Dialect/GPU/cast.mlir
@@ -6,10 +6,20 @@ module attributes {gpu.container_module} {
 // CHECK: llvm.bitcast
 // CHECK: llvm.mlir.constant
 // CHECK: llvm.lshr
-    gpu.func @cast() {
+    gpu.func @cast() -> i16 {
       %0 = arith.constant 3.2 : f32
-      gpu.bf_convert %0  : f32 to i16
-      gpu.return
+      %1 = gpu.bf_convert %0  : f32 to i16
+      gpu.return %1 : i16
+    }
+// CHECK-LABEL: llvm.func @cast_vector
+// CHECK: llvm.mlir.constant
+// CHECK: llvm.bitcast
+// CHECK: llvm.mlir.constant
+// CHECK: llvm.lshr
+    gpu.func @cast_vector() -> vector<4xi16> {
+      %0 = arith.constant dense<3.2> : vector<4xf32>
+      %1 = gpu.bf_convert %0 : vector<4xf32> to vector<4xi16>
+      gpu.return %1 : vector<4xi16>
     }
   }
 }


### PR DESCRIPTION
- Abstract out the TLike interfaces in OpBase.td (this'll get submitted upstream)
- Make both miopen.data_convert and gpu.bf_convert take vector arguments
- Push the vector arguments through to LLVM so so the optimizer has opportunities to be clever and so I don't have to add the elementwise op unrolling pass to GPUToROCDL

This is a minor PR that cleans up the annoyance living at [issue #379](https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/379) and makes the data op conversion code more uniform.