### PR TITLE
Apply draft patches from upstream D117844 and D118089

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1544,6 +1544,7 @@ private:
   bool validateVccOperand(unsigned Reg) const;
   bool validateVOPLiteral(const MCInst &Inst, const OperandVector &Operands);
   bool validateMAIAccWrite(const MCInst &Inst, const OperandVector &Operands);
+  bool validateMFMA(const MCInst &Inst, const OperandVector &Operands);
   bool validateAGPRLdSt(const MCInst &Inst) const;
   bool validateVGPRAlign(const MCInst &Inst) const;
   bool validateGWS(const MCInst &Inst, const OperandVector &Operands);
@@ -3609,6 +3610,40 @@ bool AMDGPUAsmParser::validateMAIAccWrite(const MCInst &Inst,
   return true;
 }
 
+bool AMDGPUAsmParser::validateMFMA(const MCInst &Inst,
+                                   const OperandVector &Operands) {
+  const unsigned Opc = Inst.getOpcode();
+  const MCInstrDesc &Desc = MII.get(Opc);
+
+  if ((Desc.TSFlags & SIInstrFlags::IsMAI) == 0)
+    return true;
+
+  const int Src2Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src2);
+  if (Src2Idx == -1)
+    return true;
+
+  const MCOperand &Src2 = Inst.getOperand(Src2Idx);
+  if (!Src2.isReg())
+    return true;
+
+  MCRegister Src2Reg = Src2.getReg();
+  MCRegister DstReg = Inst.getOperand(0).getReg();
+  if (Src2Reg == DstReg)
+    return true;
+
+  const MCRegisterInfo *TRI = getContext().getRegisterInfo();
+  if (TRI->getRegClass(Desc.OpInfo[0].RegClass).getSizeInBits() <= 128)
+    return true;
+
+  if (isRegIntersect(Src2Reg, DstReg, TRI)) {
+    Error(getRegLoc(mc2PseudoReg(Src2Reg), Operands),
+          "source 2 operand must not partially overlap with dst");
+    return false;
+  }
+
+  return true;
+}
+
 bool AMDGPUAsmParser::validateDivScale(const MCInst &Inst) {
   switch (Inst.getOpcode()) {
   default:
@@ -4291,6 +4326,9 @@ bool AMDGPUAsmParser::validateInstruction(const MCInst &Inst,
     return false;
   }
   if (!validateMAIAccWrite(Inst, Operands)) {
+    return false;
+  }
+  if (!validateMFMA(Inst, Operands)) {
     return false;
   }
   if (!validateCoherencyBits(Inst, Operands, IDLoc)) {

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -95,7 +95,9 @@ static bool isDGEMM(unsigned Opcode) {
   return Opcode == AMDGPU::V_MFMA_F64_4X4X4F64_e64 ||
          Opcode == AMDGPU::V_MFMA_F64_4X4X4F64_vgprcd_e64 ||
          Opcode == AMDGPU::V_MFMA_F64_16X16X4F64_e64 ||
-         Opcode == AMDGPU::V_MFMA_F64_16X16X4F64_vgprcd_e64;
+         Opcode == AMDGPU::V_MFMA_F64_16X16X4F64_vgprcd_e64 ||
+         Opcode == AMDGPU::V_MFMA_F64_16X16X4F64_mac_e64 ||
+         Opcode == AMDGPU::V_MFMA_F64_16X16X4F64_mac_vgprcd_e64;
 }
 
 static bool isXDL(const GCNSubtarget &ST, const MachineInstr &MI) {
@@ -1477,6 +1479,8 @@ int GCNHazardRecognizer::checkMAIHazards90A(MachineInstr *MI) {
         switch (Opc1) {
         case AMDGPU::V_MFMA_F64_16X16X4F64_e64:
         case AMDGPU::V_MFMA_F64_16X16X4F64_vgprcd_e64:
+        case AMDGPU::V_MFMA_F64_16X16X4F64_mac_e64:
+        case AMDGPU::V_MFMA_F64_16X16X4F64_mac_vgprcd_e64:
           if (!isXDL(ST, *MI))
             NeedWaitStates = DMFMA16x16WritesVGPROverlappedSrcCWaitStates;
           break;
@@ -1509,6 +1513,8 @@ int GCNHazardRecognizer::checkMAIHazards90A(MachineInstr *MI) {
       switch (Opc1) {
       case AMDGPU::V_MFMA_F64_16X16X4F64_e64:
       case AMDGPU::V_MFMA_F64_16X16X4F64_vgprcd_e64:
+      case AMDGPU::V_MFMA_F64_16X16X4F64_mac_e64:
+      case AMDGPU::V_MFMA_F64_16X16X4F64_mac_vgprcd_e64:
         NeedWaitStates = DMFMA16x16WritesVGPROverlappedMFMASrcABWaitStates;
         break;
       case AMDGPU::V_MFMA_F64_4X4X4F64_e64:

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -300,6 +300,13 @@ static bool updateOperand(FoldCandidate &Fold,
   assert(!Fold.needsShrink() && "not handled");
 
   if (Fold.isImm()) {
+    if (Old.isTied()) {
+      int NewMFMAOpc = AMDGPU::getMFMAEarlyClobberOp(MI->getOpcode());
+      if (NewMFMAOpc == -1)
+        return false;
+      MI->setDesc(TII.get(NewMFMAOpc));
+      MI->untieRegOperand(0);
+    }
     Old.ChangeToImmediate(Fold.ImmToFold);
     return true;
   }

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3149,10 +3149,14 @@ MachineInstr *SIInstrInfo::convertToThreeAddress(MachineInstr &MI,
                Opc == AMDGPU::V_FMAC_F16_e32 || Opc == AMDGPU::V_FMAC_F16_e64 ||
                Opc == AMDGPU::V_FMAC_F64_e32 || Opc == AMDGPU::V_FMAC_F64_e64;
   bool IsF64 = Opc == AMDGPU::V_FMAC_F64_e32 || Opc == AMDGPU::V_FMAC_F64_e64;
+  int NewMFMAOpc = -1;
 
   switch (Opc) {
   default:
-    return nullptr;
+    NewMFMAOpc = AMDGPU::getMFMAEarlyClobberOp(Opc);
+    if (NewMFMAOpc == -1)
+      return nullptr;
+    break;
   case AMDGPU::V_MAC_F16_e64:
   case AMDGPU::V_FMAC_F16_e64:
     IsF16 = true;
@@ -3181,6 +3185,19 @@ MachineInstr *SIInstrInfo::convertToThreeAddress(MachineInstr &MI,
   }
   }
 
+  MachineInstrBuilder MIB;
+  MachineBasicBlock &MBB = *MI.getParent();
+
+  if (NewMFMAOpc != -1) {
+    MIB = BuildMI(MBB, MI, MI.getDebugLoc(), get(NewMFMAOpc));
+    for (unsigned I = 0, E = MI.getNumOperands(); I != E; ++I)
+      MIB.add(MI.getOperand(I));
+    updateLiveVariables(LV, MI, *MIB);
+    if (LIS)
+      LIS->ReplaceMachineInstrInMaps(MI, *MIB);
+    return MIB;
+  }
+
   const MachineOperand *Dst = getNamedOperand(MI, AMDGPU::OpName::vdst);
   const MachineOperand *Src0 = getNamedOperand(MI, AMDGPU::OpName::src0);
   const MachineOperand *Src0Mods =
@@ -3191,8 +3208,6 @@ MachineInstr *SIInstrInfo::convertToThreeAddress(MachineInstr &MI,
   const MachineOperand *Src2 = getNamedOperand(MI, AMDGPU::OpName::src2);
   const MachineOperand *Clamp = getNamedOperand(MI, AMDGPU::OpName::clamp);
   const MachineOperand *Omod = getNamedOperand(MI, AMDGPU::OpName::omod);
-  MachineInstrBuilder MIB;
-  MachineBasicBlock &MBB = *MI.getParent();
 
   if (!Src0Mods && !Src1Mods && !Clamp && !Omod && !IsF64 &&
       // If we have an SGPR input, we will violate the constant bus restriction.
@@ -7789,6 +7804,12 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
       Gen = SIEncodingFamily::SDWA10;
       break;
     }
+  }
+
+  if (isMAI(Opcode)) {
+    int MFMAOp = AMDGPU::getMFMAEarlyClobberOp(Opcode);
+    if (MFMAOp != -1)
+      Opcode = MFMAOp;
   }
 
   int MCOp = AMDGPU::getMCOpcode(Opcode, Gen);

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1249,6 +1249,10 @@ namespace AMDGPU {
   LLVM_READONLY
   int getFlatScratchInstSVfromSS(uint16_t Opcode);
 
+  /// \returns earlyclobber version of a MAC MFMA is exists.
+  LLVM_READONLY
+  int getMFMAEarlyClobberOp(uint16_t Opcode);
+
   const uint64_t RSRC_DATA_FORMAT = 0xf00000000000LL;
   const uint64_t RSRC_ELEMENT_SIZE_SHIFT = (32 + 19);
   const uint64_t RSRC_INDEX_STRIDE_SHIFT = (32 + 21);

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -2588,6 +2588,14 @@ def getFlatScratchInstSVfromSS : InstrMapping {
   let ValueCols = [["SV"]];
 }
 
+def getMFMAEarlyClobberOp : InstrMapping {
+  let FilterClass = "MFMATable";
+  let RowFields = ["FMAOp"];
+  let ColFields = ["IsMac"];
+  let KeyCol = ["1"];
+  let ValueCols = [["0"]];
+}
+
 include "SIInstructions.td"
 
 include "DSInstructions.td"

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -388,6 +388,7 @@ class VOPProfileMAI<VOPProfile P, RegisterOperand _SrcRC, RegisterOperand _DstRC
   let HasModifiers = 0;
   let Asm64 = "$vdst, $src0, $src1, $src2$cbsz$abid$blgp";
   let Ins64 = (ins Src0RC64:$src0, Src1RC64:$src1, Src2RC64:$src2, cbsz:$cbsz, abid:$abid, blgp:$blgp);
+  bit NoDstOverlap = !gt(DstVT.Size, 128); // Dst and SrcC cannot partially overlap.
 }
 
 def VOPProfileMAI_F32_F32_X4    : VOPProfileMAI<VOP_V4F32_F32_F32_V4F32,       AISrc_128_f32,  ADst_128>;
@@ -426,6 +427,11 @@ def VOPProfileMAI_F32_V4I16_X32_VCD  : VOPProfileMAI<VOP_V32F32_V4I16_V4I16_V32F
 def VOPProfileMAI_F64_16X16X4F64_VCD : VOPProfileMAI<VOP_V4F64_F64_F64_V4F64,       VISrc_256_f64,  VDst_256,  AVSrc_64>;
 def VOPProfileMAI_F64_4X4X4F64_VCD   : VOPProfileMAI<VOP_F64_F64_F64_F64,           VISrc_64_f64,   VDst_64,   AVSrc_64>;
 
+class MFMATable <bit is_mac, string Name> {
+  bit IsMac = is_mac;
+  string FMAOp = Name;
+}
+
 let Predicates = [HasMAIInsts] in {
 
 let isAsCheapAsAMove = 1, isReMaterializable = 1 in {
@@ -435,13 +441,31 @@ let isAsCheapAsAMove = 1, isReMaterializable = 1 in {
   } // End isMoveImm = 1
 } // End isAsCheapAsAMove = 1, isReMaterializable = 1
 
-multiclass MAIInst<string OpName, string P, SDPatternOperator node> {
+multiclass MAIInst<string OpName, string P, SDPatternOperator node,
+                   bit NoDstOverlap = !cast<VOPProfileMAI>("VOPProfileMAI_" # P).NoDstOverlap> {
   let isConvergent = 1, mayRaiseFPException = 0, ReadsModeReg = 1 in {
     // FP32 denorm mode is respected, rounding mode is not. Exceptions are not supported.
-    defm "" : VOP3Inst<OpName, !cast<VOPProfileMAI>("VOPProfileMAI_" # P), node>;
+    let Constraints = !if(NoDstOverlap, "@earlyclobber $vdst", "") in {
+      defm "" : VOP3Inst<OpName, !cast<VOPProfileMAI>("VOPProfileMAI_" # P), !if(NoDstOverlap, null_frag, node)>,
+                MFMATable<0, NAME # "_e64">;
 
-    let SubtargetPredicate = isGFX90APlus, Mnemonic = OpName in
-    defm _vgprcd : VOP3Inst<OpName # "_vgprcd", !cast<VOPProfileMAI>("VOPProfileMAI_" # P # "_VCD")>;
+      let SubtargetPredicate = isGFX90APlus, Mnemonic = OpName in
+      defm _vgprcd : VOP3Inst<OpName # "_vgprcd", !cast<VOPProfileMAI>("VOPProfileMAI_" # P # "_VCD")>,
+                     MFMATable<0, NAME # "_vgprcd_e64">;
+    }
+
+    foreach _ = BoolToList<NoDstOverlap>.ret in {
+      let Constraints = !if(NoDstOverlap, "$vdst = $src2", ""),
+          isConvertibleToThreeAddress = NoDstOverlap,
+          Mnemonic = OpName in {
+        defm "_mac" : VOP3Inst<OpName # "_mac", !cast<VOPProfileMAI>("VOPProfileMAI_" # P), node>,
+                      MFMATable<1, NAME # "_e64">;
+
+        let SubtargetPredicate = isGFX90APlus in
+        defm _mac_vgprcd : VOP3Inst<OpName # "_mac_vgprcd", !cast<VOPProfileMAI>("VOPProfileMAI_" # P # "_VCD")>,
+                           MFMATable<1, NAME # "_vgprcd_e64">;
+      }
+    }
   } // End isConvergent = 1, mayRaiseFPException = 0, ReadsModeReg = 1
 }
 
@@ -517,6 +541,7 @@ multiclass VOP3P_Real_MAI<bits<7> op> {
   }
 }
 
+let Constraints = "" in {
 multiclass VOP3P_Real_MFMA_gfx90a<bits<7> op> {
   let SubtargetPredicate = isGFX90AOnly,
       AssemblerPredicate = isGFX90AOnly, DecoderNamespace = "GFX90A" in {
@@ -535,6 +560,7 @@ multiclass VOP3P_Real_MFMA<bits<7> op> :
     let AssemblerPredicate = HasMAIInsts;
     let DecoderNamespace = "GFX8";
   }
+}
 }
 
 defm V_PK_MAD_I16 : VOP3P_Real_vi <0x00>;

--- a/external/llvm-project/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.mfma.ll
+++ b/external/llvm-project/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.mfma.ll
@@ -602,14 +602,15 @@ bb:
 
 ; GCN-LABEL: {{^}}test_mfma_f32_32x32x1f32_vecarg:
 ; GFX90A-DAG:      v_mov_b32_e32 [[TWO:v[0-9]+]], 2.0
-; GCN-DAG:         v_mov_b32_e32 [[ONE:v[0-9]+]], 1.0
+; GFX90A-DAG:      v_mov_b32_e32 [[ONE:v[0-9]+]], 1.0
 ; GCN-COUNT-8:     global_load_dwordx4
 ; GFX908-COUNT-16: v_accvgpr_write_b32 a{{[0-9]+}}, v{{[0-9]+}}
-; GFX908-DAG:      v_mov_b32_e32 [[TWO:v[0-9]+]], 2.0
 ; GFX90A-NOT:      v_accvgpr_write
+; GFX908-DAG:      v_mov_b32_e32 [[TWO:v[0-9]+]], 2.0
+; GFX908-DAG:      v_mov_b32_e32 [[ONE:v[0-9]+]], 1.0
 ; GFX908:          v_mfma_f32_32x32x1f32 a[{{[0-9]+:[0-9]+}}], [[ONE]], [[TWO]], a[{{[0-9]+:[0-9]+}}] cbsz:1 abid:2 blgp:3
 ; GFX90A:          v_mfma_f32_32x32x1f32 a[{{[0-9]+:[0-9]+}}], [[ONE]], [[TWO]], a[{{[0-9]+:[0-9]+}}] cbsz:1 abid:2 blgp:3
-; GFX908-COUNT-32: v_accvgpr_read_b32
+; GFX908:          v_accvgpr_read_b32
 ; GFX908-COUNT-8:  global_store_dwordx4
 ; GFX90A-NOT:      v_accvgpr_read_b32
 ; GFX90A-COUNT-5:  global_store_dwordx4 v{{[0-9:]+}}, a[{{[0-9:]+}}], s[{{[0-9:]+}}]

--- a/external/llvm-project/llvm/test/CodeGen/AMDGPU/spill-agpr.ll
+++ b/external/llvm-project/llvm/test/CodeGen/AMDGPU/spill-agpr.ll
@@ -1,37 +1,6 @@
 ; RUN: llc -march=amdgcn -mcpu=gfx908 -verify-machineinstrs < %s | FileCheck -enable-var-scope -check-prefixes=GCN,GFX908 %s
 ; RUN: llc -march=amdgcn -mcpu=gfx90a -verify-machineinstrs < %s | FileCheck -enable-var-scope -check-prefixes=GCN,GFX90A %s
 
-; GCN-LABEL: {{^}}max_24regs_32a_used:
-; GCN-NOT:     s_mov_b32 s{{[0-9]+}}, SCRATCH_RSRC_DWORD0
-; GCN-NOT:     s_mov_b32 s{{[0-9]+}}, SCRATCH_RSRC_DWORD1
-; GCN-DAG:     v_mfma_f32_16x16x1f32
-; GCN-DAG:     v_mfma_f32_16x16x1f32
-; GCN-DAG:     v_accvgpr_read_b32
-; GCN-NOT:     buffer_store_dword
-; GCN-NOT:     buffer_load_dword
-; GFX908-NOT:  v_accvgpr_write_b32
-; GFX90A:      v_accvgpr_write_b32
-; GCN:         ScratchSize: 0
-define amdgpu_kernel void @max_24regs_32a_used(<16 x float> addrspace(1)* %arg, float addrspace(1)* %out) #0 {
-bb:
-  %in.1 = load <16 x float>, <16 x float> addrspace(1)* %arg
-  %mai.1 = tail call <16 x float> @llvm.amdgcn.mfma.f32.16x16x1f32(float 1.0, float 1.0, <16 x float> %in.1, i32 0, i32 0, i32 0)
-  %mai.2 = tail call <16 x float> @llvm.amdgcn.mfma.f32.16x16x1f32(float 1.0, float 1.0, <16 x float> %mai.1, i32 0, i32 0, i32 0)
-  %elt1 = extractelement <16 x float> %mai.2, i32 0
-  %elt2 = extractelement <16 x float> %mai.1, i32 15
-  %elt3 = extractelement <16 x float> %mai.1, i32 14
-  %elt4 = extractelement <16 x float> %mai.2, i32 1
-  store float %elt1, float addrspace(1)* %out
-  %gep1 = getelementptr float, float addrspace(1)* %out, i64 1
-  store float %elt2, float addrspace(1)* %gep1
-  %gep2 = getelementptr float, float addrspace(1)* %out, i64 2
-  store float %elt3, float addrspace(1)* %gep2
-  %gep3 = getelementptr float, float addrspace(1)* %out, i64 3
-  store float %elt4, float addrspace(1)* %gep3
-
-  ret void
-}
-
 ; GCN-LABEL: {{^}}max_12regs_13a_used:
 ; GCN-NOT: s_mov_b32 s{{[0-9]+}}, SCRATCH_RSRC_DWORD0
 ; GCN-NOT: s_mov_b32 s{{[0-9]+}}, SCRATCH_RSRC_DWORD1
@@ -146,7 +115,6 @@ declare <16 x float> @llvm.amdgcn.mfma.f32.16x16x1f32(float, float, <16 x float>
 declare <4 x float> @llvm.amdgcn.mfma.f32.4x4x1f32(float, float, <4 x float>, i32, i32, i32)
 declare <32 x float> @llvm.amdgcn.mfma.f32.32x32x1f32(float, float, <32 x float>, i32, i32, i32)
 
-attributes #0 = { nounwind "amdgpu-num-vgpr"="24" }
 attributes #1 = { nounwind "amdgpu-num-vgpr"="10" }
 attributes #2 = { nounwind "amdgpu-num-vgpr"="12" }
 attributes #3 = { nounwind "amdgpu-num-vgpr"="32" }

--- a/external/llvm-project/llvm/test/MC/AMDGPU/accvgpr-altnames.s
+++ b/external/llvm-project/llvm/test/MC/AMDGPU/accvgpr-altnames.s
@@ -6,5 +6,5 @@ v_accvgpr_read_b32 v2, acc0
 v_accvgpr_write_b32 acc2, -2.0
 // GFX908: v_accvgpr_write_b32 a2, -2.0    ; encoding: [0x02,0x40,0xd9,0xd3,0xf5,0x00,0x00,0x18]
 
-v_mfma_f32_32x32x1f32 acc[0:31], acc0, acc1, acc[1:32]
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[1:32] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_32x32x1f32 acc[0:31], acc0, acc1, acc[32:63]
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[32:63] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x82,0x1c]

--- a/external/llvm-project/llvm/test/MC/AMDGPU/gfx90a_err_pos.s
+++ b/external/llvm-project/llvm/test/MC/AMDGPU/gfx90a_err_pos.s
@@ -7,3 +7,8 @@ ds_gws_init a1 offset:65535 gds
 // CHECK: error: vgpr must be even aligned
 // CHECK-NEXT:{{^}}ds_gws_init a1 offset:65535 gds
 // CHECK-NEXT:{{^}}            ^
+
+v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[2:9]
+// CHECK: error: source 2 operand must not partially overlap with dst
+// CHECK-NEXT:{{^}}v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[2:9]
+// CHECK-NEXT:{{^}}                                              ^

--- a/external/llvm-project/llvm/test/MC/AMDGPU/mai-err.s
+++ b/external/llvm-project/llvm/test/MC/AMDGPU/mai-err.s
@@ -39,19 +39,19 @@ v_accvgpr_write_b32 a0, 65
 v_accvgpr_write_b32 a0, v0
 // GFX900: error: instruction not supported on this GPU
 
-v_mfma_f32_32x32x1f32 v[0:31], v0, v1, a[1:32]
+v_mfma_f32_32x32x1f32 v[0:31], v0, v1, a[0:31]
 // GFX908: error: invalid operand for instruction
 // GFX900: error: instruction not supported on this GPU
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, v1, v[1:32]
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, v[0:31]
 // GFX908: error: invalid operand for instruction
 // GFX900: error: instruction not supported on this GPU
 
-v_mfma_f32_32x32x1f32 a[0:31], s0, v1, a[1:32]
+v_mfma_f32_32x32x1f32 a[0:31], s0, v1, a[0:31]
 // GFX908: error: invalid operand for instruction
 // GFX900: error: instruction not supported on this GPU
 
-v_mfma_f32_32x32x1f32 a[0:31], 1, v1, a[1:32]
+v_mfma_f32_32x32x1f32 a[0:31], 1, v1, a[0:31]
 // GFX908: error: invalid operand for instruction
 // GFX900: error: instruction not supported on this GPU
 
@@ -697,4 +697,12 @@ v_mfma_f32_16x16x8bf16 a[0:3], a0, a1, -2.0
 
 v_mfma_f32_16x16x8bf16 a[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 // GFX908: error: inline constants are not allowed for this operand
+// GFX900: error: instruction not supported on this GPU
+
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[2:33]
+// GFX908: error: source 2 operand must not partially overlap with dst
+// GFX900: error: instruction not supported on this GPU
+
+v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[2:17]
+// GFX908: error: source 2 operand must not partially overlap with dst
 // GFX900: error: instruction not supported on this GPU

--- a/external/llvm-project/llvm/test/MC/AMDGPU/mai-gfx90a.s
+++ b/external/llvm-project/llvm/test/MC/AMDGPU/mai-gfx90a.s
@@ -27,53 +27,53 @@ v_accvgpr_write a2, v255
 v_accvgpr_mov_b32 a1, a2
 // GFX90A: v_accvgpr_mov_b32 a1, a2        ; encoding: [0x02,0xa5,0x02,0x7e]
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[2:33] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[34:65] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x8a,0x04]
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x8a,0xe4]
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[2:33] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[34:65] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x8a,0x14]
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x8a,0xf4]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[2:33] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[34:65] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x8a,0x0c]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x8a,0xec]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[2:33] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[34:65] ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0x8a,0x1c]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc0,0xd3,0x00,0x03,0x8a,0xfc]
 
-v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[2:33] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[34:65] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x8a,0x04]
 
-v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, v1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x8a,0xe4]
 
-v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[2:33] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[34:65] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x8a,0x14]
 
-v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], v0, a1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x8a,0xf4]
 
-v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[2:33] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[34:65] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x8a,0x0c]
 
-v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, v1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x8a,0xec]
 
-v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[2:33] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[34:65] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x8a,0x1c]
 
-v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, a1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x8a,0xfc]
 
 v_mfma_f32_32x32x1f32 a[0:31], v0, v1, -2.0
 // GFX90A: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, -2.0 ; encoding: [0x00,0x80,0xc0,0xd3,0x00,0x03,0xd6,0x03]
@@ -123,53 +123,53 @@ v_mfma_f32_32x32x1f32 a[0:31], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_32x32x1f32 v[0:31], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_32x32x1f32 v[0:31], a0, a1, -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0xd6,0xfb]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[2:17] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[18:33] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[2:17] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[18:33] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[2:17] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[18:33] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[2:17] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[18:33] ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc1,0xd3,0x00,0x03,0x4a,0xfc]
 
-v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[2:17] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[18:33] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[2:17] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[18:33] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[2:17] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[18:33] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[2:17] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[18:33] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x1f32 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x4a,0xfc]
 
 v_mfma_f32_16x16x1f32 a[0:15], v0, v1, -2.0
 // GFX90A: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, -2.0 ; encoding: [0x00,0x80,0xc1,0xd3,0x00,0x03,0xd6,0x03]
@@ -315,53 +315,53 @@ v_mfma_f32_4x4x1f32 a[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_4x4x1f32 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_4x4x1f32 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc2,0xd3,0x00,0x03,0xd6,0xfb]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[2:17] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[18:33] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[2:17] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[18:33] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[2:17] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[18:33] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[2:17] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[18:33] ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc4,0xd3,0x00,0x03,0x4a,0xfc]
 
-v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[2:17] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[18:33] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[2:17] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[18:33] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[2:17] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[18:33] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[2:17] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[18:33] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2f32 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x4a,0xfc]
 
 v_mfma_f32_32x32x2f32 a[0:15], v0, v1, -2.0
 // GFX90A: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, -2.0 ; encoding: [0x00,0x80,0xc4,0xd3,0x00,0x03,0xd6,0x03]
@@ -507,53 +507,53 @@ v_mfma_f32_16x16x4f32 a[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_16x16x4f32 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_16x16x4f32 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc5,0xd3,0x00,0x03,0xd6,0xfb]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[2:33] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[34:65] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x8a,0x04]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x8a,0xe4]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[2:33] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[34:65] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x8a,0x14]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x8a,0xf4]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[2:33] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[34:65] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x8a,0x0c]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x8a,0xec]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[2:33] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[34:65] ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0x8a,0x1c]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc8,0xd3,0x00,0x05,0x8a,0xfc]
 
-v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[2:33] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[34:65] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x8a,0x04]
 
-v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x8a,0xe4]
 
-v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[2:33] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[34:65] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x8a,0x14]
 
-v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], v[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x8a,0xf4]
 
-v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[2:33] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[34:65] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x8a,0x0c]
 
-v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x8a,0xec]
 
-v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[2:33] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[34:65] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x05,0x8a,0x1c]
 
-v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0x8a,0xfc]
 
 v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x80,0xc8,0xd3,0x00,0x05,0xd6,0x03]
@@ -603,53 +603,53 @@ v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_32x32x4f16 v[0:31], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x05,0xd6,0xfb]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xc9,0xd3,0x00,0x05,0x4a,0xfc]
 
-v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4f16 v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x05,0x4a,0xfc]
 
 v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x80,0xc9,0xd3,0x00,0x05,0xd6,0x03]
@@ -795,53 +795,53 @@ v_mfma_f32_4x4x4f16 a[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_4x4x4f16 v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_4x4x4f16 v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xca,0xd3,0x00,0x05,0xd6,0xfb]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xcc,0xd3,0x00,0x05,0x4a,0xfc]
 
-v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8f16 v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x05,0x4a,0xfc]
 
 v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x80,0xcc,0xd3,0x00,0x05,0xd6,0x03]
@@ -987,53 +987,53 @@ v_mfma_f32_16x16x16f16 a[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_16x16x16f16 v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_16x16x16f16 v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcd,0xd3,0x00,0x05,0xd6,0xfb]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[2:33] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[34:65] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x8a,0x04]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x8a,0xe4]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[2:33] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[34:65] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x8a,0x14]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x8a,0xf4]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[2:33] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[34:65] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x8a,0x0c]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x8a,0xec]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[2:33] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[34:65] ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x8a,0x1c]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd0,0xd3,0x00,0x03,0x8a,0xfc]
 
-v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[2:33] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[34:65] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x8a,0x04]
 
-v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, v1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x8a,0xe4]
 
-v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[2:33] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[34:65] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x8a,0x14]
 
-v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], v0, a1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x8a,0xf4]
 
-v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[2:33] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[34:65] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x8a,0x0c]
 
-v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, v1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x8a,0xec]
 
-v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[2:33]
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[2:33] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[34:65]
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[34:65] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x8a,0x1c]
 
-v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, a1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x8a,0xfc]
 
 v_mfma_i32_32x32x4i8 a[0:31], v0, v1, 2
 // GFX90A: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, 2 ; encoding: [0x00,0x80,0xd0,0xd3,0x00,0x03,0x0a,0x02]
@@ -1083,53 +1083,53 @@ v_mfma_i32_32x32x4i8 a[0:31], a0, a1, 2 cbsz:3 abid:2 blgp:7
 v_mfma_i32_32x32x4i8 v[0:31], a0, a1, 2 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_i32_32x32x4i8 v[0:31], a0, a1, 2 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x0a,0xfa]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[2:17] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[18:33] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[2:17] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[18:33] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[2:17] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[18:33] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[2:17] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[18:33] ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd1,0xd3,0x00,0x03,0x4a,0xfc]
 
-v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[2:17] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[18:33] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[2:17] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[18:33] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[2:17] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[18:33] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[2:17]
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[2:17] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[18:33]
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[18:33] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_16x16x4i8 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x4a,0xfc]
 
 v_mfma_i32_16x16x4i8 a[0:15], v0, v1, 2
 // GFX90A: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, 2 ; encoding: [0x00,0x80,0xd1,0xd3,0x00,0x03,0x0a,0x02]
@@ -1275,53 +1275,53 @@ v_mfma_i32_4x4x4i8 a[0:3], a0, a1, 2 cbsz:3 abid:2 blgp:7
 v_mfma_i32_4x4x4i8 v[0:3], a0, a1, 2 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_i32_4x4x4i8 v[0:3], a0, a1, 2 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd2,0xd3,0x00,0x03,0x0a,0xfa]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[2:17] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[18:33] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[2:17] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[18:33] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[2:17] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[18:33] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[2:17] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[18:33] ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xd4,0xd3,0x00,0x03,0x4a,0xfc]
 
-v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[2:17] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[18:33] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[2:17] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[18:33] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[2:17] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[18:33] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[2:17]
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[2:17] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[18:33]
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[18:33] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_i32_32x32x8i8 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x4a,0xfc]
 
 v_mfma_i32_32x32x8i8 a[0:15], v0, v1, 2
 // GFX90A: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, 2 ; encoding: [0x00,0x80,0xd4,0xd3,0x00,0x03,0x0a,0x02]
@@ -1467,53 +1467,53 @@ v_mfma_i32_16x16x16i8 a[0:3], a0, a1, 2 cbsz:3 abid:2 blgp:7
 v_mfma_i32_16x16x16i8 v[0:3], a0, a1, 2 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_i32_16x16x16i8 v[0:3], a0, a1, 2 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd5,0xd3,0x00,0x03,0x0a,0xfa]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[2:33] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[34:65] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x8a,0x04]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x8a,0xe4]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[2:33] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[34:65] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x8a,0x14]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x8a,0xf4]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[2:33] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[34:65] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x8a,0x0c]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x8a,0xec]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[2:33] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[34:65] ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0x8a,0x1c]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe8,0xd3,0x00,0x03,0x8a,0xfc]
 
-v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[2:33] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[34:65] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x8a,0x04]
 
-v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, v1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x8a,0xe4]
 
-v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[2:33] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[34:65] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x8a,0x14]
 
-v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], v0, a1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x8a,0xf4]
 
-v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[2:33] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[34:65] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x8a,0x0c]
 
-v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, v1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x8a,0xec]
 
-v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[2:33]
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[2:33] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[34:65]
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[34:65] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x8a,0x1c]
 
-v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x8a,0xfc]
 
 v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, -2.0
 // GFX90A: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, -2.0 ; encoding: [0x00,0x80,0xe8,0xd3,0x00,0x03,0xd6,0x03]
@@ -1563,53 +1563,53 @@ v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_32x32x2bf16 v[0:31], a0, a1, -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0xd6,0xfb]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[2:17] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[18:33] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[2:17] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[18:33] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[2:17] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[18:33] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[2:17] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[18:33] ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe9,0xd3,0x00,0x03,0x4a,0xfc]
 
-v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[2:17] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[18:33] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[2:17] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[18:33] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[2:17] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[18:33] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[2:17]
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[2:17] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[18:33]
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[18:33] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x2bf16 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x4a,0xfc]
 
 v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, -2.0
 // GFX90A: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, -2.0 ; encoding: [0x00,0x80,0xe9,0xd3,0x00,0x03,0xd6,0x03]
@@ -1755,53 +1755,53 @@ v_mfma_f32_4x4x2bf16 a[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_4x4x2bf16 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_4x4x2bf16 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xeb,0xd3,0x00,0x03,0xd6,0xfb]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[2:17] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[18:33] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[2:17] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[18:33] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[2:17] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[18:33] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[2:17] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[18:33] ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xec,0xd3,0x00,0x03,0x4a,0xfc]
 
-v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[2:17] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x0a,0x04]
+v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[18:33] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x4a,0x04]
 
-v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x0a,0xe4]
+v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x4a,0xe4]
 
-v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[2:17] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x0a,0x14]
+v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[18:33] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x4a,0x14]
 
-v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x0a,0xf4]
+v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], v0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x4a,0xf4]
 
-v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[2:17] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x0a,0x0c]
+v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[18:33] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x4a,0x0c]
 
-v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x0a,0xec]
+v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, v1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x4a,0xec]
 
-v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[2:17]
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[2:17] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x0a,0x1c]
+v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[18:33]
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[18:33] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x4a,0x1c]
 
-v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x0a,0xfc]
+v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16 v[0:15], a0, a1, v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x4a,0xfc]
 
 v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, -2.0
 // GFX90A: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, -2.0 ; encoding: [0x00,0x80,0xec,0xd3,0x00,0x03,0xd6,0x03]
@@ -1947,53 +1947,53 @@ v_mfma_f32_16x16x8bf16 a[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_16x16x8bf16 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_16x16x8bf16 v[0:3], a0, a1, -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xed,0xd3,0x00,0x03,0xd6,0xfb]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[2:33] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[34:65] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x8a,0x04]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x8a,0xe4]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[2:33] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[34:65] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x8a,0x14]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x8a,0xf4]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[2:33] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[34:65] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x8a,0x0c]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], v[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x8a,0xec]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[2:33] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[34:65] ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0x8a,0x1c]
 
-v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], a[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe3,0xd3,0x00,0x05,0x8a,0xfc]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[2:33] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[34:65] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x8a,0x04]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x8a,0xe4]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[2:33] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[34:65] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x8a,0x14]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], v[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x8a,0xf4]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[2:33] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[34:65] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x8a,0x0c]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], v[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x8a,0xec]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[2:33]
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[2:33] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[34:65]
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[34:65] ; encoding: [0x00,0x00,0xe3,0xd3,0x00,0x05,0x8a,0x1c]
 
-v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[2:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], v[34:65] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0x8a,0xfc]
 
 v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f32_32x32x4bf16_1k a[0:31], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x80,0xe3,0xd3,0x00,0x05,0xd6,0x03]
@@ -2043,53 +2043,53 @@ v_mfma_f32_32x32x4bf16_1k a[0:31], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_32x32x4bf16_1k v[0:31], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe3,0xd3,0x00,0x05,0xd6,0xfb]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe4,0xd3,0x00,0x05,0x4a,0xfc]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xe4,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_16x16x4bf16_1k v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe4,0xd3,0x00,0x05,0x4a,0xfc]
 
 v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f32_16x16x4bf16_1k a[0:15], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x80,0xe4,0xd3,0x00,0x05,0xd6,0x03]
@@ -2235,53 +2235,53 @@ v_mfma_f32_4x4x4bf16_1k a[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_4x4x4bf16_1k v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_4x4x4bf16_1k v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe5,0xd3,0x00,0x05,0xd6,0xfb]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[2:17] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[18:33] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], v[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[2:17] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[18:33] ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], a[0:1], a[2:3], a[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xe6,0xd3,0x00,0x05,0x4a,0xfc]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x4a,0x04]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x4a,0xe4]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x0a,0x14]
+v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x4a,0x14]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], v[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x4a,0xf4]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[2:17] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[18:33] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x4a,0x0c]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x0a,0xec]
+v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], v[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x4a,0xec]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[2:17]
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[2:17] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x0a,0x1c]
+v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[18:33]
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[18:33] ; encoding: [0x00,0x00,0xe6,0xd3,0x00,0x05,0x4a,0x1c]
 
-v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[2:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x0a,0xfc]
+v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f32_32x32x8bf16_1k v[0:15], a[0:1], a[2:3], v[18:33] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe6,0xd3,0x00,0x05,0x4a,0xfc]
 
 v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f32_32x32x8bf16_1k a[0:15], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x80,0xe6,0xd3,0x00,0x05,0xd6,0x03]
@@ -2427,11 +2427,11 @@ v_mfma_f32_16x16x16bf16_1k a[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 v_mfma_f32_16x16x16bf16_1k v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f32_16x16x16bf16_1k v[0:3], a[0:1], a[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe7,0xd3,0x00,0x05,0xd6,0xfb]
 
-v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[2:9]
-// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[2:9] ; encoding: [0x00,0x00,0xee,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[10:17]
+// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[10:17] ; encoding: [0x00,0x00,0xee,0xd3,0x00,0x05,0x2a,0x04]
 
-v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[2:9] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[2:9] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xee,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[10:17] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], v[10:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xee,0xd3,0x00,0x05,0x2a,0xe4]
 
 v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f64_16x16x4f64 v[0:7], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x00,0xee,0xd3,0x00,0x05,0xd6,0x03]
@@ -2451,11 +2451,11 @@ v_mfma_f64_4x4x4f64 v[0:1], v[0:1], v[2:3], -2.0
 v_mfma_f64_4x4x4f64 v[0:1], v[0:1], v[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f64_4x4x4f64 v[0:1], v[0:1], v[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xef,0xd3,0x00,0x05,0xd6,0xe3]
 
-v_mfma_f64_16x16x4f64 v[0:7], a[0:1], v[2:3], v[2:9]
-// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], a[0:1], v[2:3], v[2:9] ; encoding: [0x00,0x00,0xee,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f64_16x16x4f64 v[0:7], a[0:1], v[2:3], v[10:17]
+// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], a[0:1], v[2:3], v[10:17] ; encoding: [0x00,0x00,0xee,0xd3,0x00,0x05,0x2a,0x0c]
 
-v_mfma_f64_16x16x4f64 v[0:7], v[0:1], a[2:3], v[2:9] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], v[0:1], a[2:3], v[2:9] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xee,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f64_16x16x4f64 v[0:7], v[0:1], a[2:3], v[10:17] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f64_16x16x4f64 v[0:7], v[0:1], a[2:3], v[10:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xee,0xd3,0x00,0x05,0x2a,0xf4]
 
 v_mfma_f64_16x16x4f64 v[0:7], a[0:1], a[2:3], -2.0
 // GFX90A: v_mfma_f64_16x16x4f64 v[0:7], a[0:1], a[2:3], -2.0 ; encoding: [0x00,0x00,0xee,0xd3,0x00,0x05,0xd6,0x1b]
@@ -2469,11 +2469,11 @@ v_mfma_f64_4x4x4f64 v[0:1], v[0:1], a[2:3], v[2:3] cbsz:3 abid:2 blgp:7
 v_mfma_f64_4x4x4f64 v[0:1], a[0:1], a[2:3], -2.0
 // GFX90A: v_mfma_f64_4x4x4f64 v[0:1], a[0:1], a[2:3], -2.0 ; encoding: [0x00,0x00,0xef,0xd3,0x00,0x05,0xd6,0x1b]
 
-v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[2:9]
-// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[2:9] ; encoding: [0x00,0x80,0xee,0xd3,0x00,0x05,0x0a,0x04]
+v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[10:17]
+// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[10:17] ; encoding: [0x00,0x80,0xee,0xd3,0x00,0x05,0x2a,0x04]
 
-v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[2:9] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[2:9] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xee,0xd3,0x00,0x05,0x0a,0xe4]
+v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[10:17] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], a[10:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xee,0xd3,0x00,0x05,0x2a,0xe4]
 
 v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], -2.0
 // GFX90A: v_mfma_f64_16x16x4f64 a[0:7], v[0:1], v[2:3], -2.0 ; encoding: [0x00,0x80,0xee,0xd3,0x00,0x05,0xd6,0x03]
@@ -2496,11 +2496,11 @@ v_mfma_f64_4x4x4f64 a[0:1], v[0:1], v[2:3], 0
 v_mfma_f64_4x4x4f64 a[0:1], v[0:1], v[2:3], -2.0 cbsz:3 abid:2 blgp:7
 // GFX90A: v_mfma_f64_4x4x4f64 a[0:1], v[0:1], v[2:3], -2.0 cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xef,0xd3,0x00,0x05,0xd6,0xe3]
 
-v_mfma_f64_16x16x4f64 a[0:7], a[0:1], v[2:3], a[2:9]
-// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], a[0:1], v[2:3], a[2:9] ; encoding: [0x00,0x80,0xee,0xd3,0x00,0x05,0x0a,0x0c]
+v_mfma_f64_16x16x4f64 a[0:7], a[0:1], v[2:3], a[10:17]
+// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], a[0:1], v[2:3], a[10:17] ; encoding: [0x00,0x80,0xee,0xd3,0x00,0x05,0x2a,0x0c]
 
-v_mfma_f64_16x16x4f64 a[0:7], v[0:1], a[2:3], a[2:9] cbsz:3 abid:2 blgp:7
-// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], v[0:1], a[2:3], a[2:9] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xee,0xd3,0x00,0x05,0x0a,0xf4]
+v_mfma_f64_16x16x4f64 a[0:7], v[0:1], a[2:3], a[10:17] cbsz:3 abid:2 blgp:7
+// GFX90A: v_mfma_f64_16x16x4f64 a[0:7], v[0:1], a[2:3], a[10:17] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x93,0xee,0xd3,0x00,0x05,0x2a,0xf4]
 
 v_mfma_f64_16x16x4f64 a[0:7], a[0:1], a[2:3], -2.0
 // GFX90A: v_mfma_f64_16x16x4f64 a[0:7], a[0:1], a[2:3], -2.0 ; encoding: [0x00,0x80,0xee,0xd3,0x00,0x05,0xd6,0x1b]

--- a/external/llvm-project/llvm/test/MC/AMDGPU/mai.s
+++ b/external/llvm-project/llvm/test/MC/AMDGPU/mai.s
@@ -43,53 +43,59 @@ v_accvgpr_write a2, shared_base
 v_accvgpr_write a2, pops_exiting_wave_id
 // NOGFX908: error: source operand must be either a VGPR or an inline constant
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[1:32]
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[1:32] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[0:31]
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[0:31] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x02,0x04]
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[33:64]
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[33:64] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x86,0x04]
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[1:32]
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[1:32] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x86,0xe4]
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[33:64]
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[33:64] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x86,0x14]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[1:32]
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[1:32] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], v0, a1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x86,0xf4]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[33:64]
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[33:64] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x86,0x0c]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[1:32]
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[1:32] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, v1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x86,0xec]
 
-v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[33:64]
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[33:64] ; encoding: [0x00,0x00,0xc0,0xd3,0x00,0x03,0x86,0x1c]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[1:16]
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[1:16] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x1f32 a[0:31], a0, a1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc0,0xd3,0x00,0x03,0x86,0xfc]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[17:32]
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[17:32] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[1:16]
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[1:16] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[17:32]
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[17:32] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[1:16]
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[1:16] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[17:32]
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[17:32] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[1:16]
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[1:16] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[17:32]
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[17:32] ; encoding: [0x00,0x00,0xc1,0xd3,0x00,0x03,0x46,0x1c]
+
+v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x1f32 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc1,0xd3,0x00,0x03,0x46,0xfc]
+
+v_mfma_f32_4x4x1f32 a[0:3], v0, v1, a[1:4]
+// GFX908: v_mfma_f32_4x4x1f32 a[0:3], v0, v1, a[1:4] ; encoding: [0x00,0x00,0xc2,0xd3,0x00,0x03,0x06,0x04]
 
 v_mfma_f32_4x4x1f32 a[0:3], v0, v1, a[1:4]
 // GFX908: v_mfma_f32_4x4x1f32 a[0:3], v0, v1, a[1:4] ; encoding: [0x00,0x00,0xc2,0xd3,0x00,0x03,0x06,0x04]
@@ -115,29 +121,29 @@ v_mfma_f32_4x4x1f32 a[0:3], a0, a1, a[1:4]
 v_mfma_f32_4x4x1f32 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7
 // GFX908: v_mfma_f32_4x4x1f32 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc2,0xd3,0x00,0x03,0x06,0xfc]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[1:16]
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[1:16] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[17:32]
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[17:32] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[1:16]
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[1:16] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[17:32]
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[17:32] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[1:16]
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[1:16] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[17:32]
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[17:32] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[1:16]
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[1:16] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[17:32]
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[17:32] ; encoding: [0x00,0x00,0xc4,0xd3,0x00,0x03,0x46,0x1c]
 
-v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2f32 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc4,0xd3,0x00,0x03,0x46,0xfc]
 
 v_mfma_f32_16x16x4f32 a[0:3], v0, v1, a[1:4]
 // GFX908: v_mfma_f32_16x16x4f32 a[0:3], v0, v1, a[1:4] ; encoding: [0x00,0x00,0xc5,0xd3,0x00,0x03,0x06,0x04]
@@ -163,53 +169,53 @@ v_mfma_f32_16x16x4f32 a[0:3], a0, a1, a[1:4]
 v_mfma_f32_16x16x4f32 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7
 // GFX908: v_mfma_f32_16x16x4f32 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc5,0xd3,0x00,0x03,0x06,0xfc]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[1:32]
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[1:32] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[33:64]
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[33:64] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x86,0x04]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], v[1:2], a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x86,0xe4]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[1:32]
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[1:32] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[33:64]
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[33:64] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x86,0x14]
 
-v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], v[0:1], a[1:2], a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x86,0xf4]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[1:32]
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[1:32] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[33:64]
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[33:64] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x86,0x0c]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], v[1:2], a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x86,0xec]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[1:32]
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[1:32] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[33:64]
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[33:64] ; encoding: [0x00,0x00,0xc8,0xd3,0x00,0x03,0x86,0x1c]
 
-v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4f16 a[0:31], a[0:1], a[1:2], a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc8,0xd3,0x00,0x03,0x86,0xfc]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[1:16]
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[1:16] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[17:32]
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[17:32] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[1:16]
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[1:16] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[17:32]
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[17:32] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], v[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[1:16]
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[1:16] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[17:32]
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[17:32] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[1:16]
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[1:16] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[17:32]
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[17:32] ; encoding: [0x00,0x00,0xc9,0xd3,0x00,0x03,0x46,0x1c]
 
-v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x4f16 a[0:15], a[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xc9,0xd3,0x00,0x03,0x46,0xfc]
 
 v_mfma_f32_4x4x4f16 a[0:3], v[0:1], v[1:2], a[1:4]
 // GFX908: v_mfma_f32_4x4x4f16 a[0:3], v[0:1], v[1:2], a[1:4] ; encoding: [0x00,0x00,0xca,0xd3,0x00,0x03,0x06,0x04]
@@ -235,29 +241,29 @@ v_mfma_f32_4x4x4f16 a[0:3], a[0:1], a[1:2], a[1:4]
 v_mfma_f32_4x4x4f16 a[0:3], a[0:1], a[1:2], a[1:4] cbsz:3 abid:2 blgp:7
 // GFX908: v_mfma_f32_4x4x4f16 a[0:3], a[0:1], a[1:2], a[1:4] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xca,0xd3,0x00,0x03,0x06,0xfc]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[1:16]
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[1:16] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[17:32]
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[17:32] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[1:16]
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[1:16] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[17:32]
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[17:32] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], v[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[1:16]
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[1:16] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[17:32]
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[17:32] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], v[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[1:16]
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[1:16] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[17:32]
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[17:32] ; encoding: [0x00,0x00,0xcc,0xd3,0x00,0x03,0x46,0x1c]
 
-v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x8f16 a[0:15], a[0:1], a[1:2], a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcc,0xd3,0x00,0x03,0x46,0xfc]
 
 v_mfma_f32_16x16x16f16 a[0:3], v[0:1], v[1:2], a[1:4]
 // GFX908: v_mfma_f32_16x16x16f16 a[0:3], v[0:1], v[1:2], a[1:4] ; encoding: [0x00,0x00,0xcd,0xd3,0x00,0x03,0x06,0x04]
@@ -283,53 +289,53 @@ v_mfma_f32_16x16x16f16 a[0:3], a[0:1], a[1:2], a[1:4]
 v_mfma_f32_16x16x16f16 a[0:3], a[0:1], a[1:2], a[1:4] cbsz:3 abid:2 blgp:7
 // GFX908: v_mfma_f32_16x16x16f16 a[0:3], a[0:1], a[1:2], a[1:4] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xcd,0xd3,0x00,0x03,0x06,0xfc]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[1:32]
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[1:32] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[33:64]
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[33:64] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x86,0x04]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, v1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x86,0xe4]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[1:32]
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[1:32] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[33:64]
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[33:64] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x86,0x14]
 
-v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], v0, a1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x86,0xf4]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[1:32]
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[1:32] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[33:64]
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[33:64] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x86,0x0c]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, v1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x86,0xec]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[1:32]
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[1:32] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[33:64]
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[33:64] ; encoding: [0x00,0x00,0xd0,0xd3,0x00,0x03,0x86,0x1c]
 
-v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x4i8 a[0:31], a0, a1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd0,0xd3,0x00,0x03,0x86,0xfc]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[1:16]
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[1:16] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[17:32]
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[17:32] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[1:16]
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[1:16] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[17:32]
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[17:32] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[1:16]
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[1:16] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[17:32]
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[17:32] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[1:16]
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[1:16] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[17:32]
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[17:32] ; encoding: [0x00,0x00,0xd1,0xd3,0x00,0x03,0x46,0x1c]
 
-v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_16x16x4i8 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd1,0xd3,0x00,0x03,0x46,0xfc]
 
 v_mfma_i32_4x4x4i8 a[0:3], v0, v1, a[1:4]
 // GFX908: v_mfma_i32_4x4x4i8 a[0:3], v0, v1, a[1:4] ; encoding: [0x00,0x00,0xd2,0xd3,0x00,0x03,0x06,0x04]
@@ -355,29 +361,29 @@ v_mfma_i32_4x4x4i8 a[0:3], a0, a1, a[1:4]
 v_mfma_i32_4x4x4i8 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7
 // GFX908: v_mfma_i32_4x4x4i8 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd2,0xd3,0x00,0x03,0x06,0xfc]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[1:16]
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[1:16] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[17:32]
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[17:32] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[1:16]
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[1:16] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[17:32]
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[17:32] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[1:16]
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[1:16] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[17:32]
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[17:32] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[1:16]
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[1:16] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[17:32]
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[17:32] ; encoding: [0x00,0x00,0xd4,0xd3,0x00,0x03,0x46,0x1c]
 
-v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_i32_32x32x8i8 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd4,0xd3,0x00,0x03,0x46,0xfc]
 
 v_mfma_i32_16x16x16i8 a[0:3], v0, v1, a[1:4]
 // GFX908: v_mfma_i32_16x16x16i8 a[0:3], v0, v1, a[1:4] ; encoding: [0x00,0x00,0xd5,0xd3,0x00,0x03,0x06,0x04]
@@ -403,53 +409,53 @@ v_mfma_i32_16x16x16i8 a[0:3], a0, a1, a[1:4]
 v_mfma_i32_16x16x16i8 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7
 // GFX908: v_mfma_i32_16x16x16i8 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xd5,0xd3,0x00,0x03,0x06,0xfc]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[1:32]
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[1:32] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[33:64]
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[33:64] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x86,0x04]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, v1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x86,0xe4]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[1:32]
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[1:32] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[33:64]
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[33:64] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x86,0x14]
 
-v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], v0, a1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x86,0xf4]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[1:32]
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[1:32] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[33:64]
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[33:64] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x86,0x0c]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, v1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x86,0xec]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[1:32]
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[1:32] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[33:64]
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[33:64] ; encoding: [0x00,0x00,0xe8,0xd3,0x00,0x03,0x86,0x1c]
 
-v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[1:32] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[1:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[33:64] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x2bf16 a[0:31], a0, a1, a[33:64] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe8,0xd3,0x00,0x03,0x86,0xfc]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[1:16]
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[1:16] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[17:32]
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[17:32] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[1:16]
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[1:16] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[17:32]
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[17:32] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[1:16]
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[1:16] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[17:32]
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[17:32] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[1:16]
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[1:16] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[17:32]
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[17:32] ; encoding: [0x00,0x00,0xe9,0xd3,0x00,0x03,0x46,0x1c]
 
-v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_16x16x2bf16 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xe9,0xd3,0x00,0x03,0x46,0xfc]
 
 v_mfma_f32_4x4x2bf16 a[0:3], v0, v1, a[1:4]
 // GFX908: v_mfma_f32_4x4x2bf16 a[0:3], v0, v1, a[1:4] ; encoding: [0x00,0x00,0xeb,0xd3,0x00,0x03,0x06,0x04]
@@ -475,29 +481,29 @@ v_mfma_f32_4x4x2bf16 a[0:3], a0, a1, a[1:4]
 v_mfma_f32_4x4x2bf16 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7
 // GFX908: v_mfma_f32_4x4x2bf16 a[0:3], a0, a1, a[1:4] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xeb,0xd3,0x00,0x03,0x06,0xfc]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[1:16]
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[1:16] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x06,0x04]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[17:32]
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[17:32] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x46,0x04]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x06,0xe4]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x46,0xe4]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[1:16]
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[1:16] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x06,0x14]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[17:32]
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[17:32] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x46,0x14]
 
-v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x06,0xf4]
+v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], v0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x46,0xf4]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[1:16]
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[1:16] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x06,0x0c]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[17:32]
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[17:32] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x46,0x0c]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x06,0xec]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, v1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x46,0xec]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[1:16]
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[1:16] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x06,0x1c]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[17:32]
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[17:32] ; encoding: [0x00,0x00,0xec,0xd3,0x00,0x03,0x46,0x1c]
 
-v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7
-// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[1:16] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x06,0xfc]
+v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7
+// GFX908: v_mfma_f32_32x32x4bf16 a[0:15], a0, a1, a[17:32] cbsz:3 abid:2 blgp:7 ; encoding: [0x00,0x13,0xec,0xd3,0x00,0x03,0x46,0xfc]
 
 v_mfma_f32_16x16x8bf16 a[0:3], v0, v1, a[1:4]
 // GFX908: v_mfma_f32_16x16x8bf16 a[0:3], v0, v1, a[1:4] ; encoding: [0x00,0x00,0xed,0xd3,0x00,0x03,0x06,0x04]

--- a/external/llvm-project/llvm/test/MC/AMDGPU/misaligned-vgpr-tuples-err.s
+++ b/external/llvm-project/llvm/test/MC/AMDGPU/misaligned-vgpr-tuples-err.s
@@ -18,8 +18,8 @@ v_mfma_f32_32x32x8f16 a[0:15], a[1:2], v[0:1], a[0:15]
 v_mfma_i32_4x4x4i8 a[1:4], a0, v1, 2
 // GFX90A: error: invalid register class: vgpr tuples must be 64 bit aligned
 
-v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[1:16]
+v_mfma_f32_16x16x1f32 a[0:15], a0, v1, a[17:32]
 // GFX90A: error: invalid register class: vgpr tuples must be 64 bit aligned
 
-v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[1:32]
+v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[33:64]
 // GFX90A: error: invalid register class: vgpr tuples must be 64 bit aligned


### PR DESCRIPTION
These fixed the MI-200 nightly failures (see [issue #400](https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/400) and aren't a terrible evil hack.

I'm leaving this draft just in case more changes to the patches happen upstream.