### PR TITLE
Adding i8 suport from gpu to rocdl conversion

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -1233,10 +1233,10 @@ def GPU_SubgroupMmaElementwiseOp : GPU_Op<"subgroup_mma_elementwise",
 def GPU_MFMAOp:
     GPU_Op<"mfma", [AllTypesMatch<["sourceA", "sourceB"]>,
                         AllTypesMatch<["destC", "destD"]>]>,
-    Arguments<(ins AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [I16]>, VectorOfLengthAndType<[4], [I16]>]>: $sourceA,
-                   AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [I16]>, VectorOfLengthAndType<[4], [I16]>]>: $sourceB,
-                   VectorOfRankAndType<[1], [F32, F16]>: $destC)>,
-    Results<(outs VectorOfRankAndType<[1], [F32, F16]>: $destD)> {
+    Arguments<(ins AnyTypeOf<[I32, F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [I16]>, VectorOfLengthAndType<[4], [I16]>]>: $sourceA,
+                   AnyTypeOf<[I32, F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [I16]>, VectorOfLengthAndType<[4], [I16]>]>: $sourceB,
+                   VectorOfRankAndType<[1], [I32, F32, F16]>: $destC)>,
+    Results<(outs VectorOfRankAndType<[1], [I32, F32, F16]>: $destD)> {
   let summary = "XDLOPS MFMA";
   let description = [{
     The `gpu.mfma` op is an abstraction of XDLOPS.

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -875,6 +875,17 @@ struct MFMAOpLowering : ConvertToLLVMPattern {
             op, adaptor.destC().getType(),
             ValueRange{adaptor.sourceA(), adaptor.sourceB(), adaptor.destC(),
                        immValues[0], immValues[1], immValues[2]});
+    } else if (mfmaInstr.endswith("i8")) {
+      if (mfmaInstr == "mfma_i32_32x32x8i8")
+        rewriter.replaceOpWithNewOp<ROCDL::mfma_i32_32x32x8i8>(
+            op, adaptor.destC().getType(),
+            ValueRange{adaptor.sourceA(), adaptor.sourceB(), adaptor.destC(),
+                       immValues[0], immValues[1], immValues[2]});
+      else if (mfmaInstr == "mfma_i32_16x16x16i8")
+        rewriter.replaceOpWithNewOp<ROCDL::mfma_i32_16x16x16i8>(
+            op, adaptor.destC().getType(),
+            ValueRange{adaptor.sourceA(), adaptor.sourceB(), adaptor.destC(),
+                       immValues[0], immValues[1], immValues[2]});
     }
 
     return success();

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -886,6 +886,9 @@ struct MFMAOpLowering : ConvertToLLVMPattern {
             op, adaptor.destC().getType(),
             ValueRange{adaptor.sourceA(), adaptor.sourceB(), adaptor.destC(),
                        immValues[0], immValues[1], immValues[2]});
+      else {
+        return failure();
+      }
     }
 
     return success();

--- a/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s -convert-gpu-to-rocdl -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -convert-gpu-to-rocdl='index-bitwidth=32' -split-input-file | FileCheck --check-prefix=CHECK32 %s
 
-gpu.module @test_module {
+gpu.module @test_module_index_op {
   // CHECK-LABEL: func @gpu_index_ops()
   // CHECK32-LABEL: func @gpu_index_ops()
   builtin.func @gpu_index_ops()
@@ -58,7 +58,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_index_comp {
   // CHECK-LABEL: func @gpu_index_comp
   // CHECK32-LABEL: func @gpu_index_comp
   builtin.func @gpu_index_comp(%idx : index) -> index {
@@ -73,7 +73,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_sync {
   // CHECK-LABEL: func @gpu_sync()
   builtin.func @gpu_sync() {
     // CHECK: rocdl.barrier
@@ -84,7 +84,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_fabs {
   // CHECK: llvm.func @__ocml_fabs_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_fabs_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_fabs
@@ -99,7 +99,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_ceil {
   // CHECK: llvm.func @__ocml_ceil_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_ceil_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_ceil
@@ -114,7 +114,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_floor {
   // CHECK: llvm.func @__ocml_floor_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_floor_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_floor
@@ -129,7 +129,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_cos {
   // CHECK: llvm.func @__ocml_cos_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_cos_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_cos
@@ -144,7 +144,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_exp {
   // CHECK: llvm.func @__ocml_exp_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_exp_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_exp
@@ -161,7 +161,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_exp2 {
   // CHECK: llvm.func @__ocml_exp2_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_exp2_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_exp2
@@ -179,7 +179,7 @@ gpu.module @test_module {
 // -----
 
 // Test that we handled properly operation with SymbolTable other than module op
-gpu.module @test_module {
+gpu.module @test_module_gpu_exp3 {
   "test.symbol_scope"() ({
     // CHECK: test.symbol_scope
     // CHECK: llvm.func @__ocml_exp_f32(f32) -> f32
@@ -200,7 +200,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_expm1 {
   // CHECK: llvm.func @__ocml_expm1_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_expm1_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_expm1
@@ -217,7 +217,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_log {
   // CHECK: llvm.func @__ocml_log_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_log_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_log
@@ -232,7 +232,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_log1p {
   // CHECK: llvm.func @__ocml_log1p_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_log1p_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_log1p
@@ -247,7 +247,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_log10 {
   // CHECK: llvm.func @__ocml_log10_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_log10_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_log10
@@ -262,7 +262,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_log2 {
   // CHECK: llvm.func @__ocml_log2_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_log2_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_log2
@@ -277,7 +277,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_sqrt {
   // CHECK: llvm.func @__ocml_rsqrt_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_rsqrt_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_rsqrt
@@ -297,7 +297,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_sqrt2 {
   // CHECK: llvm.func @__ocml_sqrt_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_sqrt_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_sqrt
@@ -317,7 +317,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_tanh {
   // CHECK: llvm.func @__ocml_tanh_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_tanh_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_tanh
@@ -332,7 +332,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_atan {
   // CHECK: llvm.func @__ocml_atan_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_atan_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_atan
@@ -347,7 +347,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_atan2 {
   // CHECK: llvm.func @__ocml_atan2_f32(f32, f32) -> f32
   // CHECK: llvm.func @__ocml_atan2_f64(f64, f64) -> f64
   // CHECK-LABEL: func @gpu_atan2
@@ -362,7 +362,7 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_gpu_pow {
   // CHECK: llvm.func @__ocml_pow_f32(f32, f32) -> f32
   // CHECK: llvm.func @__ocml_pow_f64(f64, f64) -> f64
   // CHECK-LABEL: func @gpu_pow
@@ -377,12 +377,25 @@ gpu.module @test_module {
 
 // -----
 
-gpu.module @test_module {
+gpu.module @test_module_kernel {
   // CHECK-LABEL: @kernel_func
   // CHECK: attributes
   // CHECK: gpu.kernel
   // CHECK: rocdl.kernel
   gpu.func @kernel_func() kernel {
     gpu.return
+  }
+}
+
+// -----
+
+gpu.module @test_module_gpu_mfma {
+  // CHECK-LABEL: func @gpu_mfma_i8
+  builtin.func @gpu_mfma_i8(%arg_i32 : i32, %arg_vi32x4 : vector<4xi32>, %arg_vi32x16 : vector<16xi32>){
+    // CHECK: rocdl.mfma.i32.32x32x8i8 %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} :
+    %result16xi32 = gpu.mfma(%arg_i32, %arg_i32, %arg_vi32x16) {instr = "mfma_i32_32x32x8i8"} : i32, vector<16xi32>
+    // CHECK: rocdl.mfma.i32.16x16x16i8 %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} :
+    %result4xi32 = gpu.mfma(%arg_i32, %arg_i32, %arg_vi32x4) {instr = "mfma_i32_16x16x16i8" } : i32, vector<4xi32>
+    std.return
   }
 }

--- a/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
@@ -277,7 +277,7 @@ gpu.module @test_module_gpu_log2 {
 
 // -----
 
-gpu.module @test_module_gpu_sqrt {
+gpu.module @test_module_gpu_rsqrt {
   // CHECK: llvm.func @__ocml_rsqrt_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_rsqrt_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_rsqrt
@@ -297,7 +297,7 @@ gpu.module @test_module_gpu_sqrt {
 
 // -----
 
-gpu.module @test_module_gpu_sqrt2 {
+gpu.module @test_module_gpu_sqrt {
   // CHECK: llvm.func @__ocml_sqrt_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_sqrt_f64(f64) -> f64
   // CHECK-LABEL: func @gpu_sqrt
@@ -389,7 +389,7 @@ gpu.module @test_module_kernel {
 
 // -----
 
-gpu.module @test_module_gpu_mfma {
+gpu.module @test_module_gpu_mfma_i8 {
   // CHECK-LABEL: func @gpu_mfma_i8
   builtin.func @gpu_mfma_i8(%arg_i32 : i32, %arg_vi32x4 : vector<4xi32>, %arg_vi32x16 : vector<16xi32>){
     // CHECK: rocdl.mfma.i32.32x32x8i8 %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} :

--- a/external/llvm-project/mlir/test/Dialect/GPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/GPU/ops.mlir
@@ -251,6 +251,26 @@ module attributes {gpu.container_module} {
 
       gpu.return
     }
+
+    // CHECK-LABEL: gpu.func @mfma_i8_4xi32
+    // CHECK:       gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) : i32, vector<4xi32> 
+    // CHECK-NEXT:  gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) : i32, vector<4xi32>
+    gpu.func @mfma_i8_4xi32(%a : i32, %b : i32, %c : vector<4xi32>) {
+      gpu.mfma(%a, %b, %c) : i32, vector<4xi32> 
+      %d = gpu.mfma(%a, %b, %c) : i32, vector<4xi32> 
+
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @mfma_i8_16xi32
+    // CHECK:       gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) : i32, vector<16xi32> 
+    // CHECK-NEXT:  gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) : i32, vector<16xi32>
+    gpu.func @mfma_i8_16xi32(%a : i32, %b : i32, %c : vector<16xi32>) {
+      gpu.mfma(%a, %b, %c) : i32, vector<16xi32> 
+      %d = gpu.mfma(%a, %b, %c) : i32, vector<16xi32> 
+
+      gpu.return
+    }
   }
 
   gpu.module @mubuf_load {


### PR DESCRIPTION
This PR implements https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/411. It looks like ROCDL->LLVM conversion is already done so the only thing necessary left is GPU->ROCDL conversion.

### Background: all i8 xdlops

```llvm
llvm.amdgcn.mfma.i32.32x32x4i8
llvm.amdgcn.mfma.i32.16x16x4i8
llvm.amdgcn.mfma.i32.4x4x4i8
llvm.amdgcn.mfma.i32.32x32x8i8
llvm.amdgcn.mfma.i32.16x16x16i8
```

Among the only useful ones are the last two with reduction (Others may be deprecated in future hardware, thanks for tips from @zjing14)
```llvm
llvm.amdgcn.mfma.i32.32x32x8i8
llvm.amdgcn.mfma.i32.16x16x16i8
```

I worked in the following components in this PR:
 - GPU ops tablegen: Added i8 support to gpu.mfma op
 - LowerGpuOpsToROCDLOps: Added i8 support to two mfma instructions
 - Unit tests including:
   - gpu to rocdl lowering
   - gpu.mfma parsing tests

Note: all components touched are in `./external` repo and are upstream-able.