### PR TITLE
Adding i8 suport from miopen to gpu conversion

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -481,10 +481,10 @@ def MIOpen_ThreadwiseGemmOp:
 def MIOpen_MFMAV2Op:
     MIOpen_Op<"mfma_v2", [AllTypesMatch<["sourceA", "sourceB"]>,
       AllTypesMatch<["destC", "destD"]>]>,
-    Arguments<(ins AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>]>: $sourceA,
-                   AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>]>: $sourceB,
-                   VectorOfRankAndType<[1], [F32, F16]>: $destC)>,
-    Results<(outs VectorOfRankAndType<[1], [F32, F16]>: $destD)> {
+    Arguments<(ins AnyTypeOf<[I32, F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>]>: $sourceA,
+                   AnyTypeOf<[I32, F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>]>: $sourceB,
+                   VectorOfRankAndType<[1], [I32, F32, F16]>: $destC)>,
+    Results<(outs VectorOfRankAndType<[1], [I32, F32, F16]>: $destD)> {
   let summary = "XDLOPS MFMA V2";
   let description = [{
     The `miopen.mfma_v2` op is an abstraction of XDLOPS.

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -481,8 +481,8 @@ def MIOpen_ThreadwiseGemmOp:
 def MIOpen_MFMAV2Op:
     MIOpen_Op<"mfma_v2", [AllTypesMatch<["sourceA", "sourceB"]>,
       AllTypesMatch<["destC", "destD"]>]>,
-    Arguments<(ins AnyTypeOf<[I32, F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>]>: $sourceA,
-                   AnyTypeOf<[I32, F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>]>: $sourceB,
+    Arguments<(ins AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>, VectorOfLengthAndType<[4], [I8]>]>: $sourceA,
+                   AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>, VectorOfLengthAndType<[4], [I8]>]>: $sourceB,
                    VectorOfRankAndType<[1], [I32, F32, F16]>: $destC)>,
     Results<(outs VectorOfRankAndType<[1], [I32, F32, F16]>: $destD)> {
   let summary = "XDLOPS MFMA V2";

--- a/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
+++ b/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
@@ -445,7 +445,7 @@ struct XdlopsCodeSelection {
         vectorType = VectorType::get({16}, b.getI32Type());
         vectorNumber = 1;
         imms.push_back({0, 0, 0});
-        argType = b.getIntegerType(8);
+        argType = VectorType::get({4}, b.getIntegerType(8));
       } else if (MPerWave == 16 && NPerWave == 16) {
         mfmaInstr = "mfma_i32_16x16x16i8";
         MPerXdlops = 16;
@@ -455,7 +455,7 @@ struct XdlopsCodeSelection {
         vectorType = VectorType::get({4}, b.getI32Type());
         vectorNumber = 1;
         imms.push_back({0, 0, 0});
-        argType = b.getIntegerType(8);
+        argType = VectorType::get({4}, b.getIntegerType(8));
       } else {
         dumpUnsupported(dataType, MPerWave, NPerWave);
       }

--- a/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
+++ b/mlir/include/mlir/Dialect/MIOpen/XdlopsCodeSelection.h
@@ -445,7 +445,7 @@ struct XdlopsCodeSelection {
         vectorType = VectorType::get({16}, b.getI32Type());
         vectorNumber = 1;
         imms.push_back({0, 0, 0});
-        argType = b.getIntegerType(32);
+        argType = b.getIntegerType(8);
       } else if (MPerWave == 16 && NPerWave == 16) {
         mfmaInstr = "mfma_i32_16x16x16i8";
         MPerXdlops = 16;
@@ -455,7 +455,7 @@ struct XdlopsCodeSelection {
         vectorType = VectorType::get({4}, b.getI32Type());
         vectorNumber = 1;
         imms.push_back({0, 0, 0});
-        argType = b.getIntegerType(32);
+        argType = b.getIntegerType(8);
       } else {
         dumpUnsupported(dataType, MPerWave, NPerWave);
       }

--- a/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
+++ b/mlir/lib/Conversion/MIOpenToGPU/MIOpenToGPU.cpp
@@ -125,12 +125,53 @@ struct MIIdRewritePattern : public OpRewritePattern<Tmi> {
 struct MIMFMARewritePattern : public OpRewritePattern<miopen::MFMAV2Op> {
   using OpRewritePattern<miopen::MFMAV2Op>::OpRewritePattern;
 
+  // The below implements the concatenation of 4 i8 to an i32:
+  // a[0] | (a[1] << 8) | (a[2] << 16) | (a[3] << 24)
+  void vector4i8Toi32(const Value &vec4i8, Value &i32vals,
+                      PatternRewriter &b) const {
+    auto loc = vec4i8.getLoc();
+    for (int i = 0; i < 4; ++i) {
+      Value iterOp = b.create<arith::ConstantIndexOp>(loc, i);
+      Value extracted = b.create<vector::ExtractElementOp>(
+          loc, b.getIntegerType(8), vec4i8, iterOp);
+      Value i32A =
+          b.create<arith::ExtUIOp>(loc, extracted, b.getIntegerType(32));
+      Value shiftWidth =
+          b.create<arith::ConstantIntOp>(loc, i * 8, b.getIntegerType(32));
+      Value i32AShifted = b.create<arith::ShLIOp>(loc, i32A, shiftWidth);
+      i32vals = b.create<arith::OrIOp>(loc, i32vals, i32AShifted);
+    }
+  }
+
   LogicalResult matchAndRewrite(miopen::MFMAV2Op op,
                                 PatternRewriter &b) const override {
-    auto gpuMfmaOp = b.create<gpu::MFMAOp>(
-        op.getLoc(), op.getType(), op.sourceA(), op.sourceB(), op.destC());
+    auto loc = op.getLoc();
+    bool isVeci8 = false;
+    if (op.sourceA().getType().isa<VectorType>()) {
+      auto vectorType = op.sourceA().getType().cast<VectorType>();
+      isVeci8 = vectorType.getElementType() == b.getIntegerType(8);
+    }
+
+    gpu::MFMAOp gpuMfmaOp;
+    // Note: For i8 type, gpu.mfma op requires both arguments to be i32 instead
+    // of vector<4xi8>, thus the explicit conversion below
+    if (isVeci8) {
+      Value sourceA =
+          b.create<arith::ConstantIntOp>(loc, 0, b.getIntegerType(32));
+      Value sourceB =
+          b.create<arith::ConstantIntOp>(loc, 0, b.getIntegerType(32));
+      vector4i8Toi32(op.sourceA(), sourceA, b);
+      vector4i8Toi32(op.sourceB(), sourceB, b);
+      gpuMfmaOp = b.create<gpu::MFMAOp>(op.getLoc(), op.getType(), sourceA,
+                                        sourceB, op.destC());
+    } else {
+      gpuMfmaOp = b.create<gpu::MFMAOp>(op.getLoc(), op.getType(), op.sourceA(),
+                                        op.sourceB(), op.destC());
+    }
+
     gpuMfmaOp->setAttr("instr", op->getAttr("instr"));
     gpuMfmaOp->setAttr("imm", op->getAttr("imm"));
+
     op.replaceAllUsesWith(Value(gpuMfmaOp));
     op.erase();
     return success();

--- a/mlir/test/Conversion/MIOpenToGPU/mfma_v2.mlir
+++ b/mlir/test/Conversion/MIOpenToGPU/mfma_v2.mlir
@@ -34,24 +34,23 @@ module {
 
   // ----
 
-  func @mfma_i8_4xi32(%a : i32, %b : i32, %c : vector<4xi32>) attributes {kernel = 0 : i32} {
-    %d0 = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0]}: i32, vector<4xi32>
-    // CHECK: %[[D0:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) {imm = [0, 0, 0], instr = "mfma_i32_32x32x8i8"} : i32, vector<4xi32>
-    %d1 = miopen.mfma_v2(%a, %b, %d0) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0]}: i32, vector<4xi32>
-    // CHECK: %[[D1:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %[[D0]]) {imm = [0, 0, 0], instr = "mfma_i32_32x32x8i8"} : i32, vector<4xi32>
+  func @mfma_i8_4xi32(%a : vector<4xi8>, %b : vector<4xi8>, %c : vector<4xi32>) attributes {kernel = 0 : i32} {
+    %d0 = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0]}: vector<4xi8>, vector<4xi32>
+    // CHECK: %[[D0:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) {imm = [0, 0, 0], instr = "mfma_i32_16x16x16i8"} : i32, vector<4xi32>
+    %d1 = miopen.mfma_v2(%a, %b, %d0) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0]}: vector<4xi8>, vector<4xi32>
+    // CHECK: %[[D1:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %[[D0]]) {imm = [0, 0, 0], instr = "mfma_i32_16x16x16i8"} : i32, vector<4xi32>
 
     return
   }
 
   // ----
 
-  func @mfma_i8_16xi32(%a : i32, %b : i32, %c : vector<16xi32>) attributes {kernel = 0 : i32} {
-    %d0 = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0]}: i32, vector<16xi32>
-    // CHECK: %[[D0:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) {imm = [0, 0, 0], instr = "mfma_i32_16x16x16i8"} : i32, vector<16xi32>
-    %d1 = miopen.mfma_v2(%a, %b, %d0) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0]}: i32, vector<16xi32>
-    // CHECK: %[[D1:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %[[D0]]) {imm = [0, 0, 0], instr = "mfma_i32_16x16x16i8"} : i32, vector<16xi32>
+  func @mfma_i8_16xi32(%a : vector<4xi8>, %b : vector<4xi8>, %c : vector<16xi32>) attributes {kernel = 0 : i32} {
+    %d0 = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0]}: vector<4xi8>, vector<16xi32>
+    // CHECK: %[[D0:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) {imm = [0, 0, 0], instr = "mfma_i32_32x32x8i8"} : i32, vector<16xi32>
+    %d1 = miopen.mfma_v2(%a, %b, %d0) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0]}: vector<4xi8>, vector<16xi32>
+    // CHECK: %[[D1:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %[[D0]]) {imm = [0, 0, 0], instr = "mfma_i32_32x32x8i8"} : i32, vector<16xi32>
 
     return
   }
-
 }

--- a/mlir/test/Conversion/MIOpenToGPU/mfma_v2.mlir
+++ b/mlir/test/Conversion/MIOpenToGPU/mfma_v2.mlir
@@ -31,4 +31,27 @@ module {
 
     return
   }
+
+  // ----
+
+  func @mfma_i8_4xi32(%a : i32, %b : i32, %c : vector<4xi32>) attributes {kernel = 0 : i32} {
+    %d0 = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0]}: i32, vector<4xi32>
+    // CHECK: %[[D0:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) {imm = [0, 0, 0], instr = "mfma_i32_32x32x8i8"} : i32, vector<4xi32>
+    %d1 = miopen.mfma_v2(%a, %b, %d0) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0]}: i32, vector<4xi32>
+    // CHECK: %[[D1:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %[[D0]]) {imm = [0, 0, 0], instr = "mfma_i32_32x32x8i8"} : i32, vector<4xi32>
+
+    return
+  }
+
+  // ----
+
+  func @mfma_i8_16xi32(%a : i32, %b : i32, %c : vector<16xi32>) attributes {kernel = 0 : i32} {
+    %d0 = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0]}: i32, vector<16xi32>
+    // CHECK: %[[D0:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %{{.*}}) {imm = [0, 0, 0], instr = "mfma_i32_16x16x16i8"} : i32, vector<16xi32>
+    %d1 = miopen.mfma_v2(%a, %b, %d0) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0]}: i32, vector<16xi32>
+    // CHECK: %[[D1:.*]] = gpu.mfma(%{{.*}}, %{{.*}}, %[[D0]]) {imm = [0, 0, 0], instr = "mfma_i32_16x16x16i8"} : i32, vector<16xi32>
+
+    return
+  }
+
 }

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -638,6 +638,22 @@ func @miopen_mfma_v2_f16(%a : vector<4xf16>, %b : vector<4xf16>, %c : vector<32x
 // CHECK-LABEL: func @miopen_mfma_v2_f16
 //   CHECK: miopen.mfma_v2
 
+func @miopen_mfma_v2_i8_4xi32(%a : i32, %b : i32, %c : vector<4xi32>) -> vector<4xi32> {
+  %d = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0] } : i32, vector<4xi32>
+  return %d : vector<4xi32>
+}
+
+// CHECK-LABEL: func @miopen_mfma_v2_i8_4xi32
+//   CHECK: miopen.mfma_v2
+
+func @miopen_mfma_v2_i8_16xi32(%a : i32, %b : i32, %c : vector<16xi32>) -> vector<16xi32> {
+  %d = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0] } : i32, vector<16xi32>
+  return %d : vector<16xi32>
+}
+
+// CHECK-LABEL: func @miopen_mfma_v2_i8_16xi32
+//   CHECK: miopen.mfma_v2
+
 func @miopen_mfma_v2_bf16(%a : vector<2xbf16>, %b : vector<2xbf16>, %c : vector<32xf32>) -> vector<32xf32> {
   %d = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_f32_32x32x2bf16", imm = [1, 0, 0] } : vector<2xbf16>, vector<32xf32>
   return %d : vector<32xf32>

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -638,16 +638,16 @@ func @miopen_mfma_v2_f16(%a : vector<4xf16>, %b : vector<4xf16>, %c : vector<32x
 // CHECK-LABEL: func @miopen_mfma_v2_f16
 //   CHECK: miopen.mfma_v2
 
-func @miopen_mfma_v2_i8_4xi32(%a : i32, %b : i32, %c : vector<4xi32>) -> vector<4xi32> {
-  %d = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0] } : i32, vector<4xi32>
+func @miopen_mfma_v2_i8_4xi32(%a : vector<4xi8>, %b : vector<4xi8>, %c : vector<4xi32>) -> vector<4xi32> {
+  %d = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0] } : vector<4xi8>, vector<4xi32>
   return %d : vector<4xi32>
 }
 
 // CHECK-LABEL: func @miopen_mfma_v2_i8_4xi32
 //   CHECK: miopen.mfma_v2
 
-func @miopen_mfma_v2_i8_16xi32(%a : i32, %b : i32, %c : vector<16xi32>) -> vector<16xi32> {
-  %d = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0] } : i32, vector<16xi32>
+func @miopen_mfma_v2_i8_16xi32(%a : vector<4xi8>, %b : vector<4xi8>, %c : vector<16xi32>) -> vector<16xi32> {
+  %d = miopen.mfma_v2(%a, %b, %c) { instr = "mfma_i32_16x16x16i8", imm = [0, 0, 0] } : vector<4xi8>, vector<16xi32>
   return %d : vector<16xi32>
 }
 


### PR DESCRIPTION
This PR adds support from miopen to gpu conversion, and make sure that gpu.mfma accepts argument like i32.

Note: the vector<4xi8> to i32 conversion will behave like a typecast and not incur any additional overhead.

### Example

For such MLIR prototype:
```mlir
module {
  func @mfma_i8_4xi32(%a : vector<4xi8>, %b : vector<4xi8>, %result : memref<16xi32>) attributes {kernel = 0 : i32} {
    %vec = arith.constant dense<0> : vector<16xi32>
    %d0 = miopen.mfma_v2(%a, %b, %vec) { instr = "mfma_i32_32x32x8i8", imm = [0, 0, 0]}: vector<4xi8>, vector<16xi32>

    // Make sure that compiler don't optimize the above away
    %c0 = constant 0 : index
    %v0 = vector.extractelement %d0[%c0 : index] : vector<16xi32>
    memref.store %v0, %result[%c0] : memref<16xi32>
    return }
}
```

The IR for conversion:
```mlir 
      %1 = llvm.mlir.constant(0 : i32) : i32                                                                                                                                                                                                                                       
      %2 = llvm.mlir.constant(1 : index) : i64                                                                                                                                                                                                                                     
      %3 = llvm.mlir.constant(8 : i32) : i32
      %4 = llvm.mlir.constant(2 : index) : i64
      %5 = llvm.mlir.constant(16 : i32) : i32
      %6 = llvm.mlir.constant(3 : index) : i64
      %7 = llvm.mlir.constant(24 : i32) : i32
      %8 = llvm.mlir.constant(0 : index) : i64
      llvm.br ^bb1
    ^bb1:  // pred: ^bb0
      %9 = llvm.extractelement %arg0[%8 : i64] : vector<4xi8>
      %10 = llvm.zext %9 : i8 to i32
      %11 = llvm.shl %10, %1  : i32
      %12 = llvm.extractelement %arg0[%2 : i64] : vector<4xi8>
      %13 = llvm.zext %12 : i8 to i32
      %14 = llvm.shl %13, %3  : i32
      %15 = llvm.or %11, %14  : i32
      ...
      %42 = rocdl.mfma.i32.32x32x8i8 %23, %38, %0, %39, %40, %41 : (i32, i32, vector<16xi32>, i32, i32, i32) -> vector<16xi32>
```


The ISA would be:
```assembly
mfma_i8_4xi32:                                                                                                                                                                                                                                                       
        s_load_dwordx2 s[0:1], s[4:5], 0x0
        s_load_dwordx2 s[2:3], s[4:5], 0x10
        v_accvgpr_write_b32 a0, 0
        v_accvgpr_write_b32 a1, 0
        v_accvgpr_write_b32 a2, 0
        s_waitcnt lgkmcnt(0)
        v_mov_b32_e32 v0, s0
        v_accvgpr_write_b32 a3, 0
        ...
        v_accvgpr_write_b32 a15, 0
        v_mov_b32_e32 v1, s1
        s_nop 1
        v_mfma_i32_32x32x8i8 a[0:15], v0, v1, a[0:15]
```