### PR TITLE
Fix side effects caused by #498.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -567,15 +567,6 @@ protected:
     return (gemmSize.gemmM / param->gemmMPerBlock) *
            (gemmSize.gemmN / param->gemmNPerBlock) * gemmSize.gemmG;
   }
-
-  mlir::LogicalResult isValidGemm(InitParams *param, GemmSize &gemmSize) {
-    if (!(gemmSize.gemmM % param->gemmMPerBlock == 0 &&
-          gemmSize.gemmN % param->gemmNPerBlock == 0 &&
-          gemmSize.gemmK % param->gemmKPerBlock == 0)) {
-      return mlir::failure();
-    }
-    return mlir::success();
-  }
 };
 
 struct InitParamsNonXDL : InitParams, Serializable<InitParamsNonXDL> {
@@ -792,6 +783,15 @@ public:
   }
 
   InitParams getUniversalParameters() { return universal_Parameters; }
+
+  LogicalResult isValidGemm(InitParamsNonXDL *param, GemmSize &gemmSize) {
+    if (!(gemmSize.gemmM % param->gemmMPerBlock == 0 &&
+          gemmSize.gemmN % param->gemmNPerBlock == 0 &&
+          gemmSize.gemmK % param->gemmKPerBlock == 0)) {
+      return mlir::failure();
+    }
+    return mlir::success();
+  }
 };
 
 class PopulateParamsXDL : public PopulateParamsBase {
@@ -1020,6 +1020,15 @@ public:
   }
 
   InitParams getUniversalParameters() { return universal_Parameters; }
+
+  LogicalResult isValidGemm(InitParamsXDL *param, GemmSize &gemmSize) {
+    if (!(gemmSize.gemmM % param->gemmMPerBlock == 0 &&
+          gemmSize.gemmN % param->gemmNPerBlock == 0 &&
+          gemmSize.gemmK % (param->gemmKPerBlock * param->gemmKPack) == 0)) {
+      return mlir::failure();
+    }
+    return mlir::success();
+  }
 };
 
 #endif // MLIR_DIALECT_MIOPEN_GRIDWISE_GEMM_PARAMS_H

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -939,6 +939,7 @@ private:
                    << "\n";
       return failure();
     } else if ((dataType.isF16() || dataType.isBF16()) &&
+               (param.gemmKPack != 1) &&
                ((param.gemmKPack < 4) || (param.gemmKPack > 8))) {
       llvm::errs() << "Invalid KPACK tuning parameter: " << param.gemmKPack
                    << "\n";


### PR DESCRIPTION
Fix side effects caused by #498 . 2 issues identified:

- For `f16` type, we should still allow `KPACK` be 1. We really just don't want to see `KPACK` be set as 2, which is too narrow for XDLOPS `f16` instructions.
- When `KPACK` is larger than 1, we need to check if `GemmK` dimension can be divided by `KPerBlock * KPACK`.

All 3 failing configs raised in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/427 are fixed in this PR. This should unblock the CI.