### PR TITLE
Clean up the use of rocm_agent_enumerator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,6 @@ if( BUILD_FAT_LIBMLIRMIOPEN )
   # compile with MLIR_GPU_TO_HSACO_PASS_ENABLE=1, which is
   # enabled only when MLIR_ENABLE_ROCM_RUNNER turned on
   set(MLIR_ENABLE_ROCM_RUNNER 1 CACHE BOOL "")
-  # Skip linking with HIP so our library is runtime independent
-  set(USE_ROCM_4_4_OR_OLDER 0 CACHE BOOL "Make libMLIRMIOpen runtime independent")
   set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "")
 else()
   set(BUILD_SHARED_LIBS ON CACHE BOOL "")
@@ -94,7 +92,6 @@ else()
   set(LLVM_BUILD_EXAMPLES ON CACHE BOOL "")
   set(MLIR_ROCM_RUNNER_ENABLED 1 CACHE BOOL "")
   set(MLIR_ENABLE_ROCM_RUNNER 1 CACHE BOOL "")
-  set(USE_ROCM_4_4_OR_OLDER 1 CACHE BOOL "Use the rocm_4.4 or older release")
 endif()
 
 # Disable other runners

--- a/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
@@ -20,8 +20,6 @@ include_directories(${CMAKE_SOURCE_DIR}/external/llvm-project/lld/include)
 # Set compile-time flags for ROCm path.
 add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
 
-add_definitions(-D__USE_ROCM_4_4_OR_OLDER__=${USE_ROCM_4_4_OR_OLDER})
-
 set(HIP_PATH "${ROCM_PATH}/hip" CACHE PATH " Path to which HIP has been installed")
 set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
 find_package(HIP)
@@ -88,7 +86,11 @@ add_llvm_library(LLVMROCmBackendUtils
   )
 
 llvm_update_compile_flags(LLVMROCmBackendUtils)
-if (USE_ROCM_4_4_OR_OLDER)
+if ( BUILD_FAT_LIBMLIRMIOPEN )
+  # Skip linking with HIP so our library is runtime independent
+  add_definitions(-D__INCLUDE_HIP__=0)
+else()
+  add_definitions(-D__INCLUDE_HIP__=1)
   target_include_directories(LLVMROCmBackendUtils
     PRIVATE
     "${HIP_PATH}/../include"

--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -99,8 +99,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-venv  && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
-
-# Copy rocm_agent_enumerator. (Refer to MLIR issue#326)
-RUN git clone https://github.com/RadeonOpenCompute/rocminfo.git && \
-    cp rocminfo/rocm_agent_enumerator /opt/rocm/bin && \
-    rm -rf rocminfo


### PR DESCRIPTION
Per conversation with Joseph Greathouse, it'd be problematic if rocm_agent_enumerator might be called a huge number of times in parallel during the build process. This patch reverts the use of "rocm_agent_enumerator -name" in BackendUtils.cpp.