### PR TITLE
[DO NOT SQUASH] Use LLD from ROCm instead of linking our own copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,12 +75,6 @@ if( BUILD_FAT_LIBMLIRMIOPEN )
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
   set(LLVM_BUILD_LLVM_DYLIB OFF CACHE BOOL "")
   # TODO remove
-  # This is a temporary fix because it is required by AddMLIR.cmake
-  # Otherwise cmake complains that lld is not exported or installed
-  # In reality, the fat library already link with lld and should
-  # not need to export lld
-  set(LLVM_INSTALL_TOOLCHAIN_ONLY OFF CACHE BOOL "")
-  # TODO remove
   # This is a temporary fix because MLIRGPUTransforms has to
   # compile with MLIR_GPU_TO_HSACO_PASS_ENABLE=1, which is
   # enabled only when MLIR_ENABLE_ROCM_RUNNER turned on

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -10,7 +10,7 @@ set(MLIR_ROCM_RUNNER_ENABLED 1 CACHE BOOL "Enable building the mlir ROCm runner"
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
 # LLVM settings
-set(LLVM_ENABLE_PROJECTS "mlir;lld" CACHE STRING "List of default llvm targets")
+set(LLVM_ENABLE_PROJECTS "mlir" CACHE STRING "List of default llvm targets")
 set(LLVM_BUILD_EXAMPLES ON CACHE BOOL "")
 set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")

--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -126,11 +126,6 @@ if(MLIR_ENABLE_ROCM_RUNNER)
       "Building mlir with ROCm support requires the AMDGPU backend")
   endif()
 
-  # Ensure lld is enabled.
-  if (NOT "lld" IN_LIST LLVM_ENABLE_PROJECTS)
-    message(SEND_ERROR "lld is not enabled. Please revise LLVM_ENABLE_PROJECTS")
-  endif()
-
   set(DEFAULT_ROCM_PATH "/opt/rocm" CACHE PATH "Fallback path to search for ROCm installs")
   target_compile_definitions(obj.MLIRGPUTransforms
     PRIVATE
@@ -138,21 +133,9 @@ if(MLIR_ENABLE_ROCM_RUNNER)
     MLIR_GPU_TO_HSACO_PASS_ENABLE=1
   )
 
-  target_include_directories(obj.MLIRGPUTransforms
-    PRIVATE
-    ${MLIR_SOURCE_DIR}/../lld/include
-  )
-
   target_link_libraries(MLIRGPUTransforms
     PRIVATE
-    lldELF
     MLIRExecutionEngine
     MLIRROCDLToLLVMIRTranslation
   )
-
-  # Link lldELF also to libmlir.so. Create an alias that starts with LLVM
-  # because LINK_COMPONENTS elements are implicitly prefixed with LLVM.
-  add_library(LLVMAliasTolldELF ALIAS lldELF)
-  set_property(GLOBAL APPEND PROPERTY MLIR_LLVM_LINK_COMPONENTS AliasTolldELF)
-
 endif()

--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -68,8 +68,6 @@
 
 #include "llvm/Transforms/IPO/Internalize.h"
 
-#include "lld/Common/Driver.h"
-
 #include <iterator>
 #include <memory>
 #include <mutex>
@@ -466,16 +464,15 @@ SerializeToHsacoPass::createHsaco(const SmallVectorImpl<char> &isaBinary) {
   }
   llvm::FileRemover cleanupHsaco(tempHsacoFilename);
 
-  {
-    static std::mutex mutex;
-    const std::lock_guard<std::mutex> lock(mutex);
-    // Invoke lld. Expect a true return value from lld.
-    if (!lld::elf::link({"ld.lld", "-shared", tempIsaBinaryFilename.c_str(),
-                         "-o", tempHsacoFilename.c_str()},
-                        /*canEarlyExit=*/false, llvm::outs(), llvm::errs())) {
-      emitError(loc, "lld invocation error");
-      return {};
-    }
+  std::string theRocmPath = getRocmPath();
+  llvm::SmallString<32> lldPath(std::move(theRocmPath));
+  llvm::sys::path::append(lldPath, "llvm", "bin", "ld.lld");
+  int lldResult = llvm::sys::ExecuteAndWait(
+      lldPath,
+      {"ld.lld", "-shared", tempIsaBinaryFilename, "-o", tempHsacoFilename});
+  if (lldResult != 0) {
+    emitError(loc, "lld invocation error");
+    return {};
   }
 
   // Load the HSA code object.

--- a/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
+++ b/mlir/lib/ExecutionEngine/ROCm/BackendUtils.cpp
@@ -39,9 +39,6 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptionsCommandFlags.h"
 
-// lld headers.
-#include "lld/Common/Driver.h"
-
 // If an old rocm_agent_enumerator that has no "-name" option is used, rely on
 // the hip runtime function to provide GPU GCN Arch names.
 #if __INCLUDE_HIP__

--- a/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
@@ -9,14 +9,6 @@ if (NOT ("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD))
     "Building the mlir rocm runner requires the AMDGPU backend")
 endif()
 
-# Ensure lld is enabled.
-if (NOT "lld" IN_LIST LLVM_ENABLE_PROJECTS)
-  message(SEND_ERROR "lld is not enabled. Please revise LLVM_ENABLE_PROJECTS")
-endif()
-
-# lld header files.
-include_directories(${CMAKE_SOURCE_DIR}/external/llvm-project/lld/include)
-
 # Set compile-time flags for ROCm path.
 add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
 


### PR DESCRIPTION
Discussion with upstream revealed the lld folks don't want us calling them as a library, and discussion here showed that we can use ROCm's lld without much trouble.

This is an import of the equivalent upstream PR https://reviews.llvm.org/D119463 and a removal of lld from the build process here.

I'd like to land this before the upstream update so that this is consistent and agreed on.

