### PR TITLE
Adding xdlopsgemm and blockwisegemm i8 implementation

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -442,8 +442,14 @@ def MIOpen_BlockwiseGemmV2Op:
                    ArgTransforms<2>:$transforms,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
-                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
-                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
+                   MemRefOf<[F32, F16, BF16, I8, 
+                             VectorOfLengthAndType<[2, 4], [F32]>, 
+                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, 
+                             VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
+                   MemRefOf<[F32, F16, BF16, I8, 
+                             VectorOfLengthAndType<[2, 4], [F32]>, 
+                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, 
+                             VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
                    Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
     Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>: $vectorDs)> {
   let summary = "Blockwise GEMM XDLOPS version";
@@ -481,8 +487,14 @@ def MIOpen_ThreadwiseGemmOp:
 def MIOpen_MFMAV2Op:
     MIOpen_Op<"mfma_v2", [AllTypesMatch<["sourceA", "sourceB"]>,
       AllTypesMatch<["destC", "destD"]>]>,
-    Arguments<(ins AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>, VectorOfLengthAndType<[4], [I8]>]>: $sourceA,
-                   AnyTypeOf<[F32, VectorOfLengthAndType<[4], [F16]>, VectorOfLengthAndType<[2], [BF16]>, VectorOfLengthAndType<[4], [I8]>]>: $sourceB,
+    Arguments<(ins AnyTypeOf<[F32, 
+                              VectorOfLengthAndType<[4], [F16]>, 
+                              VectorOfLengthAndType<[2], [BF16]>, 
+                              VectorOfLengthAndType<[4], [I8]>]>: $sourceA,
+                   AnyTypeOf<[F32, 
+                              VectorOfLengthAndType<[4], [F16]>, 
+                              VectorOfLengthAndType<[2], [BF16]>, 
+                              VectorOfLengthAndType<[4], [I8]>]>: $sourceB,
                    VectorOfRankAndType<[1], [I32, F32, F16]>: $destC)>,
     Results<(outs VectorOfRankAndType<[1], [I32, F32, F16]>: $destD)> {
   let summary = "XDLOPS MFMA V2";
@@ -502,8 +514,14 @@ def MIOpen_XdlopsGemmV2Op:
                    ArgTransforms<2>:$transforms,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
-                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
-                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
+                   MemRefOf<[F32, F16, BF16, I8, 
+                             VectorOfLengthAndType<[2, 4], [F32]>, 
+                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, 
+                             VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
+                   MemRefOf<[F32, F16, BF16, I8, 
+                             VectorOfLengthAndType<[2, 4], [F32]>, 
+                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, 
+                             VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
                    Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
     Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorDs)> {
   let summary = "XDLOPS GEMM V2";

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -437,15 +437,15 @@ def MIOpen_BlockwiseGemmOp:
 // blockwise_gemm_v2
 def MIOpen_BlockwiseGemmV2Op:
     MIOpen_Op<"blockwise_gemm_v2">,
-    Arguments<(ins MemRefOf<[F32, F16, BF16]>:$matrixA,
-                   MemRefOf<[F32, F16, BF16]>:$matrixB,
+    Arguments<(ins MemRefOf<[F32, F16, BF16, I8]>:$matrixA,
+                   MemRefOf<[F32, F16, BF16, I8]>:$matrixB,
                    ArgTransforms<2>:$transforms,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
-                   MemRefOf<[F32, F16, BF16, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>]>:$bufferA,
-                   MemRefOf<[F32, F16, BF16, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>]>:$bufferB,
-                   Variadic<VectorOfRankAndType<[1], [F32, F16]>>:$vectorCs)>,
-    Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16]>>: $vectorDs)> {
+                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
+                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
+                   Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
+    Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>: $vectorDs)> {
   let summary = "Blockwise GEMM XDLOPS version";
   let description = [{
     The `miopen.block_gemm` op does GEMM at workgroup (block) level.
@@ -497,15 +497,15 @@ def MIOpen_MFMAV2Op:
 // xdlops_gemm_V2
 def MIOpen_XdlopsGemmV2Op:
     MIOpen_Op<"xdlops_gemm_v2">,
-    Arguments<(ins MemRefOf<[F32, F16, BF16]>:$matrixA,
-                   MemRefOf<[F32, F16, BF16]>:$matrixB,
+    Arguments<(ins MemRefOf<[F32, F16, BF16, I8]>:$matrixA,
+                   MemRefOf<[F32, F16, BF16, I8]>:$matrixB,
                    ArgTransforms<2>:$transforms,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
-                   MemRefOf<[F32, F16, BF16, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>]>:$bufferA,
-                   MemRefOf<[F32, F16, BF16, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>]>:$bufferB,
-                   Variadic<VectorOfRankAndType<[1], [F32, F16]>>:$vectorCs)>,
-    Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16]>>:$vectorDs)> {
+                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
+                   MemRefOf<[F32, F16, BF16, I8, VectorOfLengthAndType<[2, 4], [F32]>, VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>, VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
+                   Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
+    Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorDs)> {
   let summary = "XDLOPS GEMM V2";
   let description = [{
     The `miopen.xdlops_gemm_v2` op is an abstraction of doing GEMM based on XDLOPS.

--- a/mlir/include/mlir/Dialect/MIOpen/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/builderUtils.h
@@ -8,9 +8,9 @@
 
 namespace mlir {
 namespace miopen {
-Value createConstantFloatOp(OpBuilder &b, Location loc, Type elementType,
-                            float value);
-Value createZeroConstantFloatOp(OpBuilder &b, Location loc, Type type);
+// Utility function to emit constant zero op. Can return scalars or vectors.
+Value createZeroConstantOp(OpBuilder &b, Location loc, Type type);
+
 } // namespace miopen
 } // namespace mlir
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
@@ -309,8 +309,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     }
 
     // Prepare some useful constants.
-    Value zeroConstantFloatOp =
-        createZeroConstantFloatOp(b, loc, accumulatorType);
+    Value zeroConstantFloatOp = createZeroConstantOp(b, loc, accumulatorType);
     auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
 
     ArrayRef<int64_t> aShape, bShape, cShape;
@@ -2112,7 +2111,7 @@ struct GridwiseGemmV2RewritePattern
     // Logic to allocate 0-initialized vectors for C.
     SmallVector<Value, 4> vectorCs;
     SmallVector<Type, 4> vectorCTypes;
-    auto vectorZeroConst = createZeroConstantFloatOp(b, loc, vectorType);
+    auto vectorZeroConst = createZeroConstantOp(b, loc, vectorType);
     std::fill_n(std::back_inserter(vectorCs), vectorNumber, vectorZeroConst);
     std::fill_n(std::back_inserter(vectorCTypes), vectorNumber, vectorType);
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
@@ -150,8 +150,7 @@ Value emitLoadLogic(OpBuilder &b, Location loc, MemRefType sourceType,
         Type elementType = loadedVectorType.getElementType();
         int64_t vectorLength = loadedVectorType.getShape()[0];
 
-        Value loadedVector =
-            createZeroConstantFloatOp(b, loc, loadedVectorType);
+        Value loadedVector = createZeroConstantOp(b, loc, loadedVectorType);
 
         SmallVector<Value, 8> srcLowerIndicesUpdated;
         srcLowerIndicesUpdated.append(srcLowerIndices.begin(),
@@ -188,7 +187,7 @@ Value emitLoadLogic(OpBuilder &b, Location loc, MemRefType sourceType,
                                   srcLowerIndices.end());
 
     // Emit a useful constant 0f for later use.
-    Value zeroOp = createZeroConstantFloatOp(b, loc, loadedType);
+    Value zeroOp = createZeroConstantOp(b, loc, loadedType);
 
     // Walkthrough all lower level indices where the dimension has
     // padding, check if the result lies within boundaries.
@@ -1606,7 +1605,7 @@ struct ThreadwiseCopyV2RewritePattern
       // Load from source.
       Value loadedValue;
       if (dataPerCopy > 1) {
-        loadedValue = createZeroConstantFloatOp(b, loc, typeToLoad);
+        loadedValue = createZeroConstantOp(b, loc, typeToLoad);
         for (int64_t i = 0; i < dataPerCopy; ++i) {
           Value index = b.create<ConstantIndexOp>(loc, i);
           Value extracted = b.create<vector::ExtractElementOp>(
@@ -2010,7 +2009,7 @@ struct ThreadwiseStoreRewritePattern
       if (dstDataPerWrite > 1) {
         assert(typeToStore.isa<VectorType>());
 
-        valueToStore = createZeroConstantFloatOp(b, loc, typeToStore);
+        valueToStore = createZeroConstantOp(b, loc, typeToStore);
         for (int64_t iter = 0; iter < dstDataPerWrite; ++iter) {
           int64_t decomposedInputsIndex = inputsIndex + iter * vectorDimStride;
           // llvm::errs() << "decomposedInputsIndex: " << decomposedInputsIndex
@@ -2785,7 +2784,7 @@ struct XdlopsGemmV2RewritePattern : public OpRewritePattern<XdlopsGemmV2Op> {
               ? argType.template cast<VectorType>().getShape()[0]
               : 1;
       if (argTypeVectorLength > 1) {
-        Value zeroOp = createZeroConstantFloatOp(innerLoopb, loc, dataType);
+        Value zeroOp = createZeroConstantOp(innerLoopb, loc, dataType);
 
         Value offset;
         if (KPack > 1) {

--- a/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
@@ -22,3 +22,23 @@ func @miopen_blockwise_gemm_v2_two_results(%matrixA : memref<512xf32, 3>, %matri
   } : memref<512xf32, 3>, memref<512xf32, #map, 3>, index, index, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, vector<32xf32>, vector<32xf32> -> vector<32xf32>, vector<32xf32>
   return %vectorD0, %vectorD1 : vector<32xf32>, vector<32xf32>
 }
+
+func @miopen_blockwise_gemm_v2_one_result(%matrixA : memref<1024xi8, 3>, %matrixB : memref<1024xi8, #map, 3>, %bufferA : memref<2xvector<4xi8>, 5>, %bufferB : memref<2xvector<4xi8>, 5>) -> (vector<16xi32>) {
+  %c0 = arith.constant 0 : index
+  %c0i = arith.constant 0 : i32
+  %vectorC0 = splat %c0i : vector<16xi32>
+  // CHECK:  miopen.xdlops_gemm_v2
+  %vectorD0 = miopen.blockwise_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+    block_size = 256 : i32,
+    k = 2 : i32,
+    kpack = 8 : i32,
+    m = 64 : i32,
+    m_per_wave = 32 : i32,
+    m_waves = 2 : i32,
+    n = 64 : i32,
+    n_per_wave = 32 : i32,
+    n_waves = 2 : i32,
+    transforms = [[], []]
+  } : memref<1024xi8, 3>, memref<1024xi8, #map, 3>, index, index, memref<2xvector<4xi8>, 5>, memref<2xvector<4xi8>, 5>, vector<16xi32> -> vector<16xi32>
+  return %vectorD0 : vector<16xi32>
+}

--- a/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
@@ -23,3 +23,24 @@ func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<512xf32, 3>, %matrixB 
   } : memref<512xf32, 3>, memref<512xf32, #map, 3>, index, index, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, vector<32xf32>, vector<32xf32> -> vector<32xf32>, vector<32xf32>
   return %vectorD0, %vectorD1 : vector<32xf32>, vector<32xf32>
 }
+
+func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<1024xi8, 3>, %matrixB : memref<1024xi8, #map, 3>, %bufferA : memref<2xvector<4xi8>, 5>, %bufferB : memref<2xvector<4xi8>, 5>) -> vector<16xi32> {
+  %c0 = arith.constant 0 : index
+  %c0i = arith.constant 0 : i32
+  %vectorC0 = splat %c0i : vector<16xi32>
+  // CHECK: miopen.mfma_v2
+  // CHECK-NOT: miopen.mfma_v2
+  %vectorD0 = miopen.xdlops_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+    block_size = 256 : i32, // m_waves * n_waves * 64
+    k = 2 : i32,
+    kpack = 8 : i32,
+    m_per_wave = 32 : i32, // xdlops requires 32x32
+    n_per_wave = 32 : i32, // xdlops requires 32x32
+    m = 64 : i32, // m_waves * m/wave
+    n = 64 : i32, // n_waves * n/wave
+    m_waves = 2 : i32,
+    n_waves = 2 : i32,
+    transforms = [[], []]
+  } : memref<1024xi8, 3>, memref<1024xi8, #map, 3>, index, index, memref<2xvector<4xi8>, 5>, memref<2xvector<4xi8>, 5>, vector<16xi32> -> vector<16xi32>
+  return %vectorD0 : vector<16xi32>
+}


### PR DESCRIPTION
I did the following in this PR:
 - Added i8 definition for xdlops gemm and blockwise gemm op
 - Amended builderUtils to take i8 into account
 - Added unit tests for both amended ops

Sending the i8 PRs in reasonable smaller chunks so that it is easier to review. I'm hoping to get feedback such as to address issues early.

Going forward I plan on to work on following areas:
 - bottom up, next PR: continue to work on i8 conversion of step4 ops including:
   - ThreadwiseCopyV2
   - ThreadwiseStore
   - ThreadwiseLoad
   - InWarpTransposeOp  
 - top down, next PR: Start from a set of tuning parameters and lower from gridwisegemm -> blockwise level ops 