### PR TITLE
Enable int8 from step 1 to step 3 lowering

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -35,9 +35,9 @@ class ArgTransforms<int n> : Confined<ArgTransformsAttr, [ArrayCount<n>]>;
 
 def MIOpen_Conv2DOp :
     MIOpen_Op<"conv2d">,
-    Arguments<(ins MemRefRankOf<[F32, F16, BF16], [5]>:$filter,
-                   MemRefRankOf<[F32, F16, BF16], [5]>:$input,
-                   MemRefRankOf<[F32, F16, BF16], [5]>:$output)> {
+    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [5]>:$filter,
+                   MemRefRankOf<[F32, F16, BF16, I8], [5]>:$input,
+                   MemRefRankOf<[F32, F16, BF16, I8], [5]>:$output)> {
   let summary = "2D convolution forward";
   let description = [{
     The `miopen.conv2d` op computes 2D convolution forward.
@@ -152,9 +152,9 @@ def MIOpen_GridwiseGemmOp :
 // gridwise_gemm_v2
 def MIOpen_GridwiseGemmV2Op :
     MIOpen_Op<"gridwise_gemm_v2">,
-    Arguments<(ins MemRefRankOf<[F32, F16, BF16], [3, 4]>:$a,
-                   MemRefRankOf<[F32, F16, BF16], [3, 4]>:$b,
-                   MemRefRankOf<[F32, F16, BF16], [3, 4]>:$c,
+    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [3, 4]>:$a,
+                   MemRefRankOf<[F32, F16, BF16, I8], [3, 4]>:$b,
+                   MemRefRankOf<[F32, F16, BF16, I8], [3, 4]>:$c,
                    BoolArrayAttr:$aOobDims,
                    BoolArrayAttr:$bOobDims,
                    BoolArrayAttr:$cOobDims,
@@ -268,10 +268,11 @@ def MIOpen_BlockwiseLoadOp:
                   MIOpen_PaddingInfoAttr:$paddingInfo,
                   BoolArrayAttr:$oobDims,
                   Variadic<Index>:$sourceCoord)>,
-    Results<(outs Variadic<AnyTypeOf<[F32, F16, BF16,
+    Results<(outs Variadic<AnyTypeOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                             VectorOfLengthAndType<[2, 4, 8], [BF16]>]>>:$result)> {
+                             VectorOfLengthAndType<[2, 4, 8], [BF16]>,
+                             VectorOfLengthAndType<[4], [I8]>]>>:$result)> {
   let summary = "Blockwise GPU data load";
   let description = [{
     The `miopen.blockwise_load` op moves data on GPU. Following movements are
@@ -290,10 +291,11 @@ def MIOpen_BlockwiseStoreOp:
     Arguments<(ins AnyMemRef:$dest,
                   IndexArrayAttr:$bounds,
                   ArgTransforms<1>:$transforms,
-                  Variadic<AnyTypeOf<[F32, F16, BF16,
+                  Variadic<AnyTypeOf<[F32, F16, BF16, I8,
                               VectorOfLengthAndType<[2, 4], [F32]>,
                               VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                              VectorOfLengthAndType<[2, 4, 8], [BF16]>]>>:$data,
+                              VectorOfLengthAndType<[2, 4, 8], [BF16]>,
+                              VectorOfLengthAndType<[4], [I8]>]>>:$data,
                    Variadic<Index>:$destCoord)> {
   let summary = "Blockwise GPU data store";
   let description = [{
@@ -344,10 +346,11 @@ def MIOpen_ThreadwiseLoadOp:
                    MIOpen_PaddingInfoAttr:$paddingInfo,
                    BoolArrayAttr:$oobDims,
                    Variadic<Index>:$sourceCoord)>,
-    Results<(outs Variadic<AnyTypeOf<[F32, F16, BF16,
+    Results<(outs Variadic<AnyTypeOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                             VectorOfLengthAndType<[2, 4, 8], [BF16]>]>>:$result)> {
+                             VectorOfLengthAndType<[2, 4, 8], [BF16]>,
+                             VectorOfLengthAndType<[4], [I8]>]>>:$result)> {
   let summary = "Threadwise GPU data load";
   let description = [{
     The `miopen.threadwise_load` op moves data on GPU. Following movements are
@@ -367,10 +370,11 @@ def MIOpen_ThreadwiseStoreOp:
     Arguments<(ins AnyMemRef:$dest,
                    IndexArrayAttr:$bounds,
                    ArgTransforms<1>:$transforms,
-                   Variadic<AnyTypeOf<[F32, F16, BF16,
+                   Variadic<AnyTypeOf<[F32, F16, BF16, I8,
                               VectorOfLengthAndType<[2, 4], [F32]>,
                               VectorOfLengthAndType<[2, 4, 8], [F16]>,
-                              VectorOfLengthAndType<[2, 4, 8], [BF16]>]>>:$data,
+                              VectorOfLengthAndType<[2, 4, 8], [BF16]>,
+                              VectorOfLengthAndType<[4], [I8]>]>>:$data,
                    Variadic<Index>:$destCoord)> {
   let summary = "Threadwise GPU data store";
   let description = [{
@@ -387,7 +391,7 @@ def MIOpen_ThreadwiseStoreOp:
 // threadwise_copy_v2
 def MIOpen_ThreadwiseCopyV2Op:
     MIOpen_Op<"threadwise_copy_v2", [AttrSizedOperandSegments]>,
-    Arguments<(ins VectorOfRankAndType<[1], [F32, F16]>:$source,
+    Arguments<(ins VectorOfRankAndType<[1], [F32, F16, I32]>:$source,
                    AnyMemRef:$dest,
                    IndexArrayAttr:$bounds,
                    ArgTransforms<2>:$transforms,

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -37,7 +37,7 @@ def MIOpen_Conv2DOp :
     MIOpen_Op<"conv2d">,
     Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [5]>:$filter,
                    MemRefRankOf<[F32, F16, BF16, I8], [5]>:$input,
-                   MemRefRankOf<[F32, F16, BF16, I8], [5]>:$output)> {
+                   MemRefRankOf<[F32, F16, BF16, I32], [5]>:$output)> {
   let summary = "2D convolution forward";
   let description = [{
     The `miopen.conv2d` op computes 2D convolution forward.
@@ -154,7 +154,7 @@ def MIOpen_GridwiseGemmV2Op :
     MIOpen_Op<"gridwise_gemm_v2">,
     Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [3, 4]>:$a,
                    MemRefRankOf<[F32, F16, BF16, I8], [3, 4]>:$b,
-                   MemRefRankOf<[F32, F16, BF16, I8], [3, 4]>:$c,
+                   MemRefRankOf<[F32, F16, BF16, I32], [3, 4]>:$c,
                    BoolArrayAttr:$aOobDims,
                    BoolArrayAttr:$bOobDims,
                    BoolArrayAttr:$cOobDims,

--- a/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1318,7 +1318,7 @@ struct GridwiseGemmV2RewritePattern
     auto loc = op.getLoc();
 
     // Obtain data type.
-    auto elementType = op.c().getType().cast<MemRefType>().getElementType();
+    auto elementType = op.b().getType().cast<MemRefType>().getElementType();
 
     // Prepare some useful constants.
     auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);

--- a/mlir/lib/Dialect/MIOpen/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/MIOpen/utility/builderUtils.cpp
@@ -33,6 +33,19 @@ Value createConstantI8Op(OpBuilder &b, Location loc, Type type,
   return retValue;
 }
 
+Value createConstantI32Op(OpBuilder &b, Location loc, Type type,
+                          Type elementType, int32_t value) {
+  Value retValue;
+  if (auto vecType = type.dyn_cast<VectorType>()) {
+    retValue =
+        b.create<ConstantOp>(loc, SplatElementsAttr::get(vecType, value));
+  } else {
+    retValue = b.create<ConstantOp>(loc, b.getI8IntegerAttr(value), type);
+  }
+
+  return retValue;
+}
+
 Value createConstantFloatOp(OpBuilder &b, Location loc, Type type,
                             Type elementType, float value) {
   auto semantics = static_cast<APFloat::Semantics>(-1);
@@ -72,6 +85,8 @@ Value createZeroConstantOp(OpBuilder &b, Location loc, Type type) {
 
   if (elementType == b.getIntegerType(8)) {
     return createConstantI8Op(b, loc, type, elementType, 0);
+  } else if (elementType == b.getIntegerType(32)) {
+    return createConstantI32Op(b, loc, type, elementType, 0);
   } else {
     return createConstantFloatOp(b, loc, type, elementType, 0.0);
   }

--- a/mlir/test/Dialect/MIOpen/lowering_top_level.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_top_level.mlir
@@ -91,7 +91,7 @@ func @miopen_conv2d_f16(%filter : memref<1x128x8x3x3xf16>, %input : memref<128x1
 // CHECK-NEXT:  %[[OUT:.*]] = miopen.transform %arg2 by [#[[$MAP_OUTPUT_FWD]]]
 // CHECK-NEXT:  miopen.gridwise_gemm(%[[FILTER]], %[[IN3]], %[[OUT]])
 
-func @miopen_conv2d_i8(%filter : memref<1x128x8x3x3xi8>, %input : memref<128x1x8x32x32xi8>, %output : memref<128x1x128x30x30xi8>) {
+func @miopen_conv2d_i8(%filter : memref<1x128x8x3x3xi8>, %input : memref<128x1x8x32x32xi8>, %output : memref<128x1x128x30x30xi32>) {
   miopen.conv2d(%filter, %input, %output) {
     arch = "gfx908",
     num_cu = 120,
@@ -102,7 +102,7 @@ func @miopen_conv2d_i8(%filter : memref<1x128x8x3x3xi8>, %input : memref<128x1x8
     strides = [1, 1],
     padding = [0, 0, 0 ,0],
     xdlopsV2 = true
-  } : memref<1x128x8x3x3xi8>, memref<128x1x8x32x32xi8>, memref<128x1x128x30x30xi8>
+  } : memref<1x128x8x3x3xi8>, memref<128x1x8x32x32xi8>, memref<128x1x128x30x30xi32>
   return
 }
 // CHECK-LABEL: func {{@miopen_conv2d_i8.*%arg0.*%arg1.*%arg2}}

--- a/mlir/test/Dialect/MIOpen/lowering_top_level.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_top_level.mlir
@@ -91,6 +91,30 @@ func @miopen_conv2d_f16(%filter : memref<1x128x8x3x3xf16>, %input : memref<128x1
 // CHECK-NEXT:  %[[OUT:.*]] = miopen.transform %arg2 by [#[[$MAP_OUTPUT_FWD]]]
 // CHECK-NEXT:  miopen.gridwise_gemm(%[[FILTER]], %[[IN3]], %[[OUT]])
 
+func @miopen_conv2d_i8(%filter : memref<1x128x8x3x3xi8>, %input : memref<128x1x8x32x32xi8>, %output : memref<128x1x128x30x30xi8>) {
+  miopen.conv2d(%filter, %input, %output) {
+    arch = "gfx908",
+    num_cu = 120,
+    filter_layout = ["g", "k", "c", "y", "x"],
+    input_layout = ["ni", "gi", "ci", "hi", "wi"],
+    output_layout = ["no", "go", "ko", "ho", "wo"],
+    dilations = [1, 1],
+    strides = [1, 1],
+    padding = [0, 0, 0 ,0],
+    xdlopsV2 = true
+  } : memref<1x128x8x3x3xi8>, memref<128x1x8x32x32xi8>, memref<128x1x128x30x30xi8>
+  return
+}
+// CHECK-LABEL: func {{@miopen_conv2d_i8.*%arg0.*%arg1.*%arg2}}
+// CHECK-NOT:   miopen.conv2d
+// CHECK-NEXT:  %[[FILTER:.*]] = miopen.transform %arg0 by [#[[$MAP_FILTER_FWD]]]
+// CHECK-NEXT:  %[[IN1:.*]] = miopen.transform %arg1 by [#[[$MAP_INPUT1_FWD]]]
+// CHECK-NEXT:  %[[IN2:.*]] = miopen.transform %[[IN1]] by [#[[$MAP_INPUT2_FWD]]]
+// CHECK-NEXT:  %[[IN3:.*]] = miopen.transform %[[IN2]] by [#[[$MAP_INPUT3_FWD]]]
+// CHECK-NEXT:  %[[OUT:.*]] = miopen.transform %arg2 by [#[[$MAP_OUTPUT_FWD]]]
+// CHECK-NEXT:  miopen.gridwise_gemm_v2(%[[FILTER]], %[[IN3]], %[[OUT]])
+
+
 func @miopen_conv2d_bwd_data(%filter: memref<1x1024x1024x1x1xf32>, %input: memref<128x1x1024x14x14xf32>, %output: memref<128x1x1024x14x14xf32>) attributes {kernel = 0 : i32} {
 miopen.conv2d_bwd_data(%filter, %input, %output) {
     arch = "gfx908",


### PR DESCRIPTION
This PR enables conv op lowering from step 1 to step 3, with a caveats that tuning parameters needs to be re-defined for i8, existing tuning parameters are for testing only. It has been a surprisingly easy PR. After this is merged, the only left is to make sure lowering step 4 work with i8 type.

With this PR we support the below with a manually written conv op with i8 type
```bash
 ./bin/miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 ./conv_op.mlir
```
Once @yiqian1 finished her changes on conv2d generator, I can add more tests into mlir sanity on int8 using `miopen-gen`