### PR TITLE
Move Dockerfile to ROCm 5.0

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -2,10 +2,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zhuoran Yin <zhuoran.yin@amd.com>
 
-ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/4.3.1/
+ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/4.5.2/
 ARG ROCM_BUILD_NAME=xenial
 ARG ROCM_BUILD_NUM=main
-ARG ROCM_PATH=/opt/rocm-4.3.1
+ARG ROCM_PATH=/opt/rocm-4.5.2
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -2,10 +2,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zhuoran Yin <zhuoran.yin@amd.com>
 
-ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/4.5.2/
+ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/5.0/
 ARG ROCM_BUILD_NAME=xenial
 ARG ROCM_BUILD_NUM=main
-ARG ROCM_PATH=/opt/rocm-4.5.2
+ARG ROCM_PATH=/opt/rocm-5.0.0
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Per omkar, MI-200 nodes should have a ROCm version >= 4.5
Since we're unlikely to break anyone else with a longer upgrade, go straight to 5.0.

Note that this PR doesn't actually move us over, it just causes the new Docker image to be built.