### PR TITLE
End-to-end impl for fp16 backward weight convolution using atomic add.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h
@@ -118,6 +118,12 @@ public:
   }
   LogicalResult isApplicable() const;
 
+  // Utility function to query if a config requires additional workspace.
+  bool hasWorkspace(OpBuilder &builder) const;
+
+  // Utility function to fetch the size of workspace.
+  int getWorkspaceSize(ModuleOp &module) const;
+
 private:
   template <typename Vector>
   std::vector<int64_t> layoutPermutation(const Vector &src,

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -67,7 +67,8 @@ def MIOpen_Conv2DBwdWeightOp :
     MIOpen_Op<"conv2d_bwd_weight">,
     Arguments<(ins MemRefRankOf<[F32, F16, BF16], [5]>:$filter,
                    MemRefRankOf<[F32, F16, BF16], [5]>:$input,
-                   MemRefRankOf<[F32, F16, BF16], [5]>:$output)> {
+                   MemRefRankOf<[F32, F16, BF16], [5]>:$output,
+                   Variadic<MemRefRankOf<[F32], [5]>>:$workspace)> {
   let summary = "2D convolution backward weight";
   let description = [{
     The `miopen.conv2d_bwd_weight` op computes 2D convolution backward weight.

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -68,7 +68,7 @@ def MIOpen_Conv2DBwdWeightOp :
     Arguments<(ins MemRefRankOf<[F32, F16, BF16], [5]>:$filter,
                    MemRefRankOf<[F32, F16, BF16], [5]>:$input,
                    MemRefRankOf<[F32, F16, BF16], [5]>:$output,
-                   Variadic<MemRefRankOf<[F32], [5]>>:$workspace)> {
+                   Optional<MemRefRankOf<[F32], [5]>>:$workspace)> {
   let summary = "2D convolution backward weight";
   let description = [{
     The `miopen.conv2d_bwd_weight` op computes 2D convolution backward weight.

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -1074,4 +1074,61 @@ public:
   }
 };
 
+// The function is used to compute extra padding sizes.
+// For example, if gemmM size is 3 and gemmMPerBlock is 64,
+// we set gemmMExtra be 64 so (gemmM+gemmMExtra)%gemmMPerBlock=0.
+//
+// Returns:
+// - isOriginalKernelSupport : a bool only used in backward data convolution.
+// - needExtraPad : a bool to indicate whether padding kernel is needed.
+// - gemmM/N/KExtra : additional padding required along Gemm M/N/K dimension.
+//                    They would be all be 0 in case needExtraPad is false.
+template <typename T>
+std::tuple<bool, bool, int64_t, int64_t, int64_t>
+calculatePaddingKernelSize(int64_t gemmMSize, int64_t gemmNSize,
+                           int64_t gemmKSize, ConvolutionContext &convContext,
+                           T populateParams) {
+  bool isOriginalKernelSupport = true;
+  bool needExtraPad = false;
+  int64_t gemmMExtra, gemmNExtra, gemmKExtra;
+  gemmMExtra = gemmNExtra = gemmKExtra = 0;
+
+  auto configParams = populateParams.getTuningParameters(convContext);
+  size_t numOfFailedConfigs = 0;
+  for (auto &params : configParams) {
+    if (gemmMSize % params.gemmMPerBlock == 0 &&
+        gemmKSize % params.gemmKPerBlock == 0 &&
+        gemmNSize % params.gemmNPerBlock == 0) {
+      isOriginalKernelSupport = true;
+      break;
+    }
+    isOriginalKernelSupport = false;
+    numOfFailedConfigs++;
+  }
+
+  auto extraParams = populateParams.getUniversalParameters();
+  if (numOfFailedConfigs == configParams.size()) {
+    needExtraPad = true;
+    int64_t gemmMRemain, gemmKRemain, gemmNRemain;
+
+    gemmMRemain = gemmMSize % extraParams.gemmMPerBlock;
+    if (gemmMRemain != 0)
+      gemmMExtra = extraParams.gemmMPerBlock - gemmMRemain;
+
+    gemmNRemain = gemmNSize % extraParams.gemmNPerBlock;
+    if (gemmNRemain != 0)
+      gemmNExtra = extraParams.gemmNPerBlock - gemmNRemain;
+
+    gemmKRemain = gemmKSize % extraParams.gemmKPerBlock;
+    if (gemmKRemain != 0)
+      gemmKExtra = extraParams.gemmKPerBlock - gemmKRemain;
+
+    // llvm::errs() << "gemmMExtra: " << gemmMExtra << "gemmNExtra: " <<
+    // gemmNExtra << "gemmKExtra: " << gemmKExtra << "\n";
+  }
+
+  return std::make_tuple(isOriginalKernelSupport, needExtraPad, gemmMExtra,
+                         gemmNExtra, gemmKExtra);
+}
+
 #endif // MLIR_DIALECT_MIOPEN_GRIDWISE_GEMM_PARAMS_H

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -115,56 +115,21 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     }
   }
 
-  int64_t gemmM_size, gemmN_size, gemmK_size;
+  int64_t gemmMSize, gemmNSize, gemmKSize;
   int64_t gemmMExtra, gemmNExtra, gemmKExtra;
-  gemmM_size = gemmN_size = gemmK_size = 0;
+  gemmMSize = gemmNSize = gemmKSize = 0;
   gemmMExtra = gemmNExtra = gemmKExtra = 0;
   // FIXME : support forward convolution only right now.
   // compute we should use extra padding kernel or not
   // c,k already / g ,so we can skip / g here
-  gemmM_size = k;
-  gemmK_size = c * y * x;
-  gemmN_size = n * ho * wo;
+  gemmMSize = k;
+  gemmKSize = c * y * x;
+  gemmNSize = n * ho * wo;
 
+  // isOriginalKernelSupport is not used.
+  // Only needExtraPad is used.
+  bool isOriginalKernelSupport = true;
   bool needExtraPad = false;
-
-  auto calculatePaddingKernelSize = [&needExtraPad, gemmM_size, gemmN_size,
-                                     gemmK_size, &gemmMExtra, &gemmNExtra,
-                                     &gemmKExtra,
-                                     &convContext](auto populateParams) {
-    auto config_params = populateParams.getTuningParameters(convContext);
-    unsigned numOfFailedConfigs = 0;
-    for (auto &params : config_params) {
-      if (gemmM_size % params.gemmMPerBlock == 0 &&
-          gemmK_size % params.gemmKPerBlock == 0 &&
-          gemmN_size % params.gemmNPerBlock == 0) {
-        break;
-      } else {
-        numOfFailedConfigs++;
-      }
-    }
-
-    auto extraParams = populateParams.getUniversalParameters();
-    if (numOfFailedConfigs == config_params.size()) {
-      needExtraPad = true;
-      int gemmM_remain, gemmK_remain, gemmN_remain;
-
-      gemmM_remain = gemmM_size % extraParams.gemmMPerBlock;
-      if (gemmM_remain != 0)
-        gemmMExtra = extraParams.gemmMPerBlock - gemmM_remain;
-
-      gemmN_remain = gemmN_size % extraParams.gemmNPerBlock;
-      if (gemmN_remain != 0)
-        gemmNExtra = extraParams.gemmNPerBlock - gemmN_remain;
-
-      gemmK_remain = gemmK_size % extraParams.gemmKPerBlock;
-      if (gemmK_remain != 0)
-        gemmKExtra = extraParams.gemmKPerBlock - gemmK_remain;
-
-      // llvm::errs() << "gemmMExtra: " << gemmMExtra << "gemmNExtra: " <<
-      // gemmNExtra << "gemmKExtra: " << gemmKExtra << "\n";
-    }
-  };
 
   std::string perfConfig;
   if (auto perfConfigAttr =
@@ -195,7 +160,10 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(blockSize));
 
     // Disable kpack in case we need padding kernel.
-    calculatePaddingKernelSize(populateParamsXDL);
+    std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
+             gemmKExtra) =
+        calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize, convContext,
+                                   populateParamsXDL);
     if (needExtraPad) {
       validParams.gemmKPack = 1;
     }

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -162,8 +162,9 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     // Disable kpack in case we need padding kernel.
     std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
              gemmKExtra) =
-        calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize, convContext,
-                                   populateParamsXDL);
+        calculatePaddingKernelSize(
+            gemmMSize, gemmNSize, gemmKSize, convContext.getOpType(),
+            convContext.getDataType(), populateParamsXDL);
     if (needExtraPad) {
       validParams.gemmKPack = 1;
     }

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -643,14 +643,16 @@ LogicalResult backwardData(Conv2DBwdDataOp op, PatternRewriter &b) {
     PopulateParams populateParams;
     std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
              gemmKExtra) =
-        calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize, convContext,
-                                   populateParams);
+        calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
+                                   convContext.getOpType(),
+                                   convContext.getDataType(), populateParams);
   } else { // xdlops
     PopulateParamsXDL populateParamsXDL;
     std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
              gemmKExtra) =
-        calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize, convContext,
-                                   populateParamsXDL);
+        calculatePaddingKernelSize(
+            gemmMSize, gemmNSize, gemmKSize, convContext.getOpType(),
+            convContext.getDataType(), populateParamsXDL);
   }
 
   LogicalResult supportedPaddingKernel = isSupportedBackwardDataPaddingKernel(
@@ -1156,13 +1158,15 @@ template <typename T> struct Conv2DRewritePattern : public OpRewritePattern<T> {
       std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
                gemmKExtra) =
           calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
-                                     convContext, populateParams);
+                                     convContext.getOpType(),
+                                     convContext.getDataType(), populateParams);
     } else { // xdlops
       PopulateParamsXDL populateParamsXDL;
       std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
                gemmKExtra) =
-          calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
-                                     convContext, populateParamsXDL);
+          calculatePaddingKernelSize(
+              gemmMSize, gemmNSize, gemmKSize, convContext.getOpType(),
+              convContext.getDataType(), populateParamsXDL);
     }
 
     if (ConvOpType::BwdWeight == convOpType && isXdlops &&

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -206,7 +206,7 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   bool hasWorkspace =
       (filterType.getElementType() == b.getF16Type() && isXdlops);
   if (hasWorkspace) {
-    assert(op.workspace().size());
+    assert(op.workspace());
   }
 
   // Get shape of input tensor.
@@ -301,7 +301,7 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
     addKBlockWrap.passThrough({"k", "c", "y", "x"});
 
     TransformMapAttr addKBlockTransformAttr = addKBlockTransform.get();
-    Value filterTensorInUse = (hasWorkspace) ? op.workspace()[0] : op.filter();
+    Value filterTensorInUse = (hasWorkspace) ? op.workspace() : op.filter();
     Value withKBlock = b.create<miopen::TransformOp>(loc, filterTensorInUse,
                                                      addKBlockTransformAttr);
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -206,7 +206,7 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   bool hasWorkspace =
       (filterType.getElementType() == b.getF16Type() && isXdlops);
   if (hasWorkspace) {
-    assert(op.workspace());
+    assert(op.workspace() && "Op has no workspace");
   }
 
   // Get shape of input tensor.

--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
@@ -1466,7 +1466,7 @@ struct ThreadwiseCopyV2RewritePattern
 
     auto sourceType = op.source().getType().cast<VectorType>();
     auto destType = op.dest().getType().cast<MemRefType>();
-    InMemoryDataOperation dataOpration = op.dataOperation();
+    InMemoryDataOperation dataOperation = op.dataOperation();
     Value sourceOffsetOp =
         b.create<ConstantIndexOp>(loc, op.sourceOffset().getZExtValue());
 
@@ -1635,7 +1635,8 @@ struct ThreadwiseCopyV2RewritePattern
       // Store to dest.
       emitStoreLogic(op.paddingInfo().getBwdPaddingInfo(), b, loc, destType,
                      typeToStore, toEmitOOBStoreCheckLogic, oobStoreCheckDims,
-                     op.dest(), destLowerIndices, convertedValue, dataOpration);
+                     op.dest(), destLowerIndices, convertedValue,
+                     dataOperation);
       // increase IVs
       bool toIncreaseNextDigit = true;
       int iter = loopIVs.size() - 1;

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -407,7 +407,7 @@ LogicalResult PopulateParamsXDL::paramsFromCtx(
 #endif // MLIR_ENABLE_SQLITE
 
   LogicalResult res = failure();
-  for (auto &params : getTuningParameters(ctx)) {
+  for (auto &params : getTuningParameters(ctx.getOpType(), ctx.getDataType())) {
     blockSize = obtainBlockSize(params, waveSize);
     // We have an override on the blockSize, only loop through the
     // initParameters with the same blockSize
@@ -432,7 +432,8 @@ LogicalResult PopulateParamsXDL::paramsFromCtx(
                             << " PARAMETERS!\n");
 
       LLVM_DEBUG(llvm::dbgs() << "BUT PADDING KERNEL CAN EXECUTE IT\n");
-      for (auto &params : getTuningParameters(ctx)) {
+      for (auto &params :
+           getTuningParameters(ctx.getOpType(), ctx.getDataType())) {
         res = populatePaddingKernelDerived(
             ctx, params, gemmSize, gemmADerivedParam, gemmBDerivedParam,
             gemmCDerivedParam, blockSize, gridSize);

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -279,8 +279,10 @@ LogicalResult PopulateParamsXDL::populateDerived(
 
   // parameters derivable from tunable parameters.
   int64_t nKBlocks = 1;
-  if (ctx.opType == miopen::ConvOpType::BwdWeight && ctx.getDataType().isF32())
+  if (ctx.opType == miopen::ConvOpType::BwdWeight &&
+      (ctx.getDataType().isF32() || ctx.getDataType().isF16())) {
     nKBlocks = getKBlocks(ctx);
+  }
   gridSize = obtainGridSize(gemmSize, &params) * nKBlocks;
 
   res =

--- a/mlir/test/mlir-miopen-lib/workspace.mlir
+++ b/mlir/test/mlir-miopen-lib/workspace.mlir
@@ -1,0 +1,45 @@
+/////////////////////////////////////
+// No-padding along Gemm M/N/K cases.
+/////////////////////////////////////
+
+// Forward convolution
+// RUN: mlir-miopen-lib-test --args " --x2 0 --operation conv2d --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 0 --operation conv2d --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+
+// Backward data convolution
+// RUN: mlir-miopen-lib-test --args " --x2 0 --operation conv2d_bwd_data --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 0 --operation conv2d_bwd_data --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d_bwd_data --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d_bwd_data --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+
+// Backward weight convolution
+// RUN: mlir-miopen-lib-test --args " --x2 0 --operation conv2d_bwd_weight --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 0 --operation conv2d_bwd_weight --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d_bwd_weight --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp32 --fil_type fp32 --out_type fp32 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+// fp16+XDLOPS+backward weight. This would require a workspace.
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d_bwd_weight --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_NONZERO
+
+/////////////////////////////////////
+// Padding along Gemm M/N/K cases.
+/////////////////////////////////////
+
+// Forward convolution
+// Omitted here. Existing logic would never trigger a kernel which requires a workspace.
+// Test cases above are already sufficient.
+
+// Backward data convolution
+// Omitted here. Existing logic would never trigger a kernel which requires a workspace.
+// Test cases above are already sufficient.
+
+// Backward weight convolution
+// For cases which involves padding along Gemm M/N/K dimension, a kernel which requires a workspace would not be generated.
+// fp16+XDLOPS+backward weight, but with padding along GemmK dimension, this would NOT require a workspace.
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d_bwd_weight --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 20 --in_channels 3 --out_channels 6 --in_h 32 --in_w 32 --out_h 16 --out_w 16 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 3 --padding_w 3 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+
+// fp16+XDLOPS+backward weight, but with padding along GemmN dimension, this would NOT require a workspace.
+// RUN: mlir-miopen-lib-test --args " --x2 1 --operation conv2d_bwd_weight --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --num_cu 120 --in_type fp16 --fil_type fp16 --out_type fp16 --fil_layout GNCHW --in_layout NGCHW --out_layout NGCHW --batchsize 256 --in_channels 3 --out_channels 64 --in_h 224 --in_w 224 --out_h 112 --out_w 112 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 3 --padding_w 3 --kernel_name conv2d_nchw_kcyx_nkhw --groupsize 1" --option workspace | FileCheck %s --check-prefix=WORKSPACE_ZERO
+
+// WORKSPACE_ZERO: Workspace=0
+// WORKSPACE_NONZERO: Workspace=4194304

--- a/mlir/tools/mlir-miopen-lib/Miir.h
+++ b/mlir/tools/mlir-miopen-lib/Miir.h
@@ -53,6 +53,14 @@ extern "C" MiirHandle miirCreateHandle(const char *options);
  */
 extern "C" int miirGetKernelCount(MiirHandle handle);
 
+/*! @brief Return the size of workspace required in bytes
+  + *         Currently the function will return 0 for most of cases.
+  + *         For fp16 backward weight convolutions, a workspace is required.
+  + *  @param handle MLIR handle
+  + *  @return       Size of workspace required in bytes
+  + */
+extern "C" int miirGetWorkspaceSize(MiirHandle handle);
+
 /*! @brief Lower the MLIR module to be able to obtain tuning parameters
  *  @param handle MLIR handle
  */

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib-test.cpp
@@ -43,6 +43,8 @@ int main(int argc, char **argv) {
     std::cout << "ExecutionDims - globalSize=" << globalSize
               << ", localSize=" << localSize << std::endl;
 
+  } else if (option.getValue() == "workspace") {
+    std::cout << "Workspace=" << miirGetWorkspaceSize(handle) << std::endl;
   } else if (option.getValue() == "bin") {
     int count = miirGetKernelCount(handle);
 

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -35,6 +35,7 @@ struct MiirHandle_s {
   std::string features;
   std::string genTxt;
   int kernelCount = 0;
+  int workspace = 0;
 
 private:
   MLIRContext &getContext() {
@@ -122,6 +123,7 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
   handle->kernelCount = conv2dGenerator.getKernelCount();
 
   ModuleOp module = handle->getModule();
+  handle->workspace = conv2dGenerator.getWorkspaceSize(module);
 
   if (failed(conv2dGenerator.genConvModule(module, config.kernelId))) {
     return nullptr;
@@ -135,6 +137,14 @@ extern "C" int miirGetKernelCount(MiirHandle mlirHandle) {
     return -1;
 
   return handle->kernelCount;
+}
+
+extern "C" int miirGetWorkspaceSize(MiirHandle mlirHandle) {
+  MiirHandle_s *handle = static_cast<MiirHandle_s *>(mlirHandle);
+  if (handle == nullptr)
+    return 0;
+
+  return handle->workspace;
 }
 
 extern "C" MiirStatus miirDestroyHandle(MiirHandle mlirHandle) {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -22,7 +22,7 @@ void buildMIOpen(String cmakeOpts) {
 }
 
 void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
-    git branch: 'develop', poll: false,\
+    git branch: 'mlir-workspace', poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
     cmake arguments: "-P install_deps.cmake --minimum ${prefixOpt}",\
         installation: "InSearchPath"
@@ -266,7 +266,7 @@ pipeline {
                             }}
                             steps {
                                 dir('MIOpen') {
-                                git branch: 'develop', poll: false,\
+                                git branch: 'mlir-workspace', poll: false,\
                                     url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
                                 sh 'sed -i "/ROCmSoftwarePlatform\\/llvm-project-mlir/d" ./requirements.txt'
                                 cmake arguments: "-P install_deps.cmake --minimum --prefix ${WORKSPACE}/MIOpenDeps",\

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -23,6 +23,7 @@ void buildMIOpen(String cmakeOpts) {
 void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
     git branch: 'mlir-workspace', poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
+    sh 'sed -i "/ROCmSoftwarePlatform\\/llvm-project-mlir/d" ./requirements.txt'
     cmake arguments: "-P install_deps.cmake --minimum ${prefixOpt}",\
         installation: "InSearchPath"
     buildMIOpen(cmakeOpts)

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -21,7 +21,7 @@ void buildMIOpen(String cmakeOpts) {
 }
 
 void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
-    git branch: 'develop', poll: false,\
+    git branch: 'mlir-workspace', poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
     cmake arguments: "-P install_deps.cmake --minimum ${prefixOpt}",\
         installation: "InSearchPath"


### PR DESCRIPTION
Rebased with the tip.

Using atomic adds under the following conditions:
- backward weight convolution
- fp16
- XDLOPS
- do not use padding along Gemm M/N/K dimension

If all conditions are met, an extra workspace is required to hold the result in fp32 data type. An `Miir` interface is added to let clients query how large the workspace should be.

`miopen-gen` is modified to automatically change the kernel signature when such an extra workspace is needed.

Utility functions inside `Conv2dGenerator` are modified to compute if a config requires a workspace. Notice there are hard-coded tuning paremeters in the current implementation which is very not ideal.

Added test cases to check various configs on whether a workspace is needed.

Empirical performance tests show 3.5X performance improvements on supported resnet50 fp16 backward weight convolution configs.