### PR TITLE
Adding i32 support to raw buffer store intrinsics

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -1308,9 +1308,10 @@ def GPU_MubufStoreOp :
 // buffer store
 def GPU_RawbufStoreOp :
     GPU_Op<"raw_buffer_store">,
-    Arguments<(ins AnyTypeOf<[BF16, F16, F32,
+    Arguments<(ins AnyTypeOf<[BF16, F16, F32, I32,
                               VectorOfLengthAndType<[2, 4], [F32]>,
-                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>]>:$value,
+                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                              VectorOfLengthAndType<[2, 4], [I32]>]>:$value,
                    AnyMemRef:$memref,
                    I32:$shift,
                    Variadic<I32>:$indices)> {

--- a/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
@@ -399,3 +399,18 @@ gpu.module @test_module_gpu_mfma_i8 {
     std.return
   }
 }
+
+// -----
+
+gpu.module @test_module_gpu_raw_buffer_store {
+  // CHECK-LABEL: func @gpu_raw_buffer_store_i32
+  builtin.func @gpu_raw_buffer_store_i32(%value : i32, %value2 : vector<2xi32>, %value4 : vector<4xi32>, %shift : i32, %offset : i32, %dst : memref<128xi32>){
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : i32
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset) : i32, memref<128xi32>, i32, i32
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<2xi32>
+      gpu.raw_buffer_store(%value2, %dst, %shift, %offset) : vector<2xi32>, memref<128xi32>, i32, i32
+    // CHECK: rocdl.raw.buffer.store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xi32>
+      gpu.raw_buffer_store(%value4, %dst, %shift, %offset) : vector<4xi32>, memref<128xi32>, i32, i32
+    std.return
+  }
+}

--- a/external/llvm-project/mlir/test/Dialect/GPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/GPU/ops.mlir
@@ -768,6 +768,50 @@ module attributes {gpu.container_module} {
       gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<8xbf16>, memref<128x64x32x16xbf16>, i32, i32, i32, i32, i32
       gpu.return
     }
+
+    // i32 tests.
+
+    // CHECK-LABEL: gpu.func @buffer_store_i32_to_rank_1
+    //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : i32, memref<128xi32>, i32, i32
+    gpu.func @buffer_store_i32_to_rank_1(%value : i32, %dst : memref<128xi32>, %shift : i32, %offset0 : i32) {
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : i32, memref<128xi32>, i32, i32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_store_i32_to_rank_4
+    //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : i32, memref<128x64x32x16xi32>, i32, i32, i32, i32, i32
+    gpu.func @buffer_store_i32_to_rank_4(%value : i32, %dst : memref<128x64x32x16xi32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : i32, memref<128x64x32x16xi32>, i32, i32, i32, i32, i32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_store_2xi32_to_rank_1
+    //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi32>, memref<128xi32>, i32, i32
+    gpu.func @buffer_store_2xi32_to_rank_1(%value : vector<2xi32>, %dst : memref<128xi32>, %shift : i32, %offset0 : i32) {
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<2xi32>, memref<128xi32>, i32, i32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_store_2xi32_to_rank_4
+    //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<2xi32>, memref<128x64x32x16xi32>, i32, i32, i32, i32, i32
+    gpu.func @buffer_store_2xi32_to_rank_4(%value : vector<2xi32>, %dst : memref<128x64x32x16xi32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<2xi32>, memref<128x64x32x16xi32>, i32, i32, i32, i32, i32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_store_4xi32_to_rank_1
+    //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi32>, memref<128xi32>, i32, i32
+    gpu.func @buffer_store_4xi32_to_rank_1(%value : vector<4xi32>, %dst : memref<128xi32>, %shift : i32, %offset0 : i32) {
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0) : vector<4xi32>, memref<128xi32>, i32, i32
+      gpu.return
+    }
+
+    // CHECK-LABEL: gpu.func @buffer_store_4xi32_to_rank_4
+    //   CHECK: gpu.raw_buffer_store(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : vector<4xi32>, memref<128x64x32x16xi32>, i32, i32, i32, i32, i32
+    gpu.func @buffer_store_4xi32_to_rank_4(%value : vector<4xi32>, %dst : memref<128x64x32x16xi32>, %shift : i32, %offset0 : i32, %offset1 : i32, %offset2 : i32, %offset3 : i32) {
+      gpu.raw_buffer_store(%value, %dst, %shift, %offset0, %offset1, %offset2, %offset3) : vector<4xi32>, memref<128x64x32x16xi32>, i32, i32, i32, i32, i32
+      gpu.return
+    }
   }
 
   gpu.module @atomic_fadd {

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -185,5 +185,29 @@ llvm.func @rocdl.mubuf(%rsrc : vector<4xi32>, %vindex : i32,
   llvm.return
 }
 
+llvm.func @rocdl.rawbufi32(%rsrc : vector<4xi32>,
+                        %offset : i32, %soffset : i32,
+                        %vdata1 : vector<1xi32>,
+                        %vdata2 : vector<2xi32>, 
+                        %vdata4 : vector<4xi32>) {
+  // CHECK-LABEL: rocdl.rawbufi32
+  %aux = llvm.mlir.constant(0 : i32) : i32
+  // CHECK: call <1 x i32> @llvm.amdgcn.raw.buffer.load.v1i32(<4 x i32> %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 {{.*}})
+  %r1 = rocdl.raw.buffer.load %rsrc, %offset, %soffset, %aux : vector<1xi32>
+  // CHECK: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 {{.*}})
+  %r2 = rocdl.raw.buffer.load %rsrc, %offset, %soffset, %aux : vector<2xi32>
+  // CHECK: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 {{.*}})
+  %r4 = rocdl.raw.buffer.load %rsrc, %offset, %soffset, %aux : vector<4xi32>
+
+  // CHECK: call void @llvm.amdgcn.raw.buffer.store.v1i32(<1 x i32> %{{.*}}, <4 x i32> %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 {{.*}})
+  rocdl.raw.buffer.store %vdata1, %rsrc, %offset, %soffset, %aux : vector<1xi32>
+  // CHECK: call void @llvm.amdgcn.raw.buffer.store.v2i32(<2 x i32> %{{.*}}, <4 x i32> %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 {{.*}})
+  rocdl.raw.buffer.store %vdata2, %rsrc, %offset, %soffset, %aux : vector<2xi32>
+  // CHECK: call void @llvm.amdgcn.raw.buffer.store.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i32 %{{.*}}, i32 %{{.*}}, i32 {{.*}})
+  rocdl.raw.buffer.store %vdata4, %rsrc, %offset, %soffset, %aux : vector<4xi32>
+
+  llvm.return
+}
+
 // CHECK-DAG: attributes #[[$KERNEL_ATTRS]] = { "amdgpu-flat-work-group-size"="1, 256" "amdgpu-implicitarg-num-bytes"="56" }
 // CHECK-DAG: attributes #[[$KERNEL_WORKGROUP_ATTRS]] = { "amdgpu-flat-work-group-size"="1, 1024"


### PR DESCRIPTION
This is the last op missing for i8 threadwise copy result: Since xdlops populate i32 vector, its lowered result requires raw buffer store on i32 vector types. I added i32 type lowering on raw buffer store from gpu->rocdl->llvm. The existing implementation is robust enough to handle the additional type. I updated tablegen and unit test to make sure this new type will continue be tracked.

With this change I'm able to do end-to-end lowering with:
```bash
./bin/miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step{2,3,4,5} -convert-miopen-to-gpu -convert-gpu-to-rocdl ./conv_op.mlir &> rocdl_wrong.mlir | ./bin/miopen-translate -gpu-module-to-rocdlir |  /opt/rocm/llvm/bin/opt -passes='default<O3>,strip' -S | /opt/rocm/llvm/bin/llc -mcpu=gfx908
```

Next steps:
 - Exercise more configs with different problem sizes
 - Exercise more tuning parameters
 - Add and fix end-to-end test when infrastructure from @yiqian1 is ready