### PR TITLE
Disable ROCm runner build when we build a static library.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -251,7 +251,7 @@ pipeline {
                             steps {
                                 checkout scm
                                 buildProject('libMLIRMIOpen',
-                                             '-DBUILD_FAT_LIBMLIRMIOPEN=ON')
+                                             '-DBUILD_FAT_LIBMLIRMIOPEN=1 -DMLIR_ENABLE_ROCM_RUNNER=0')
                                 cmake arguments: "--install . --component libMLIRMIOpen --prefix ${WORKSPACE}/MIOpenDeps",\
                                 installation: 'InSearchPath', workingDir: 'build'
                             }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -103,7 +103,7 @@ pipeline {
                             steps {
                                 checkout scm
                                 buildProject('libMLIRMIOpen',
-                                             '-DBUILD_FAT_LIBMLIRMIOPEN=ON')
+                                             '-DBUILD_FAT_LIBMLIRMIOPEN=1 -DMLIR_ENABLE_ROCM_RUNNER=0')
                                 cmake arguments: "--install . --component libMLIRMIOpen --prefix ${WORKSPACE}/MIOpenDeps",\
                                 installation: 'InSearchPath', workingDir: 'build'
                             }


### PR DESCRIPTION
Supply -DMLIR_ENABLE_ROCM_RUNNER=0 when we build libMLIRMIOpen.
This will eliminate the dependency to a working ROCm installation with a
working ROCm-compatible GPU installed.

This change is recommended by @jerryyin reviewing an MIOpen PR: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1443