### PR TITLE
Fix a build error in mixr_cobj wrt mlirBlockCreate API usage.

### DIFF
--- a/mlir/test/CAPI/mixr_cobj.cpp
+++ b/mlir/test/CAPI/mixr_cobj.cpp
@@ -62,9 +62,11 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
   MlirType bias0Type = mlirRankedTensorTypeGet(
       1, bias0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
   MlirType funcBodyArgTypes[] = {inType, filter0Type, bias0Type};
+  MlirLocation funcBodyLocations[] = {location, location, location};
   MlirRegion funcBodyRegion = mlirRegionCreate();
-  MlirBlock funcBody = mlirBlockCreate(
-      sizeof(funcBodyArgTypes) / sizeof(MlirType), funcBodyArgTypes);
+  MlirBlock funcBody =
+      mlirBlockCreate(sizeof(funcBodyArgTypes) / sizeof(MlirType),
+                      funcBodyArgTypes, funcBodyLocations);
   mlirRegionAppendOwnedBlock(funcBodyRegion, funcBody);
 
   //-------------- func op


### PR DESCRIPTION
This fixes mlir-mixr-full-test target.

And this unblocks https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1443