### PR TITLE
Fix parser logic for AddDim TransformAttr.

### DIFF
--- a/mlir/test/Dialect/MIOpen/lowering_wrw_atomic_transform.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_wrw_atomic_transform.mlir
@@ -1,4 +1,5 @@
 // RUN: miopen-opt -miopen-affix-params -miopen-lowering %s | FileCheck %s
+// RUN: miopen-opt -miopen-affix-params -miopen-lowering %s | miopen-opt | FileCheck %s
 module  {
   func @miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_0(%arg0: memref<1x32x32x3x3xf32>, %arg1: memref<32x1x32x7x7xf32>, %arg2: memref<32x1x32x9x9xf32>) attributes {kernel = 0 : i32} {
     miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 0 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [2 : i32, 2 : i32, 2 : i32, 2 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = true} : memref<1x32x32x3x3xf32>, memref<32x1x32x7x7xf32>, memref<32x1x32x9x9xf32>

--- a/mlir/test/Dialect/MIOpen/lowering_wrw_atomic_transform_nhwc.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_wrw_atomic_transform_nhwc.mlir
@@ -1,4 +1,5 @@
 // RUN: miopen-opt -miopen-affix-params -miopen-lowering %s | FileCheck %s
+// RUN: miopen-opt -miopen-affix-params -miopen-lowering %s | miopen-opt | FileCheck %s
 module  {
   func @miopen_conv2d_bwd_weight_gkyxc_nghwc_nghwk_0(%arg0: memref<1x32x3x3x32xf32>, %arg1: memref<32x1x7x7x32xf32>, %arg2: memref<32x1x9x9x32xf32>) attributes {kernel = 0 : i32} {
     miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "c", "y", "x", "k"], gemm_id = 0 : i32, input_layout = ["ni", "gi", "hi", "wi", "ci"], num_cu = 120 : i32, output_layout = ["no", "go", "ho", "wo", "ko"], padding = [2 : i32, 2 : i32, 2 : i32, 2 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = true} : memref<1x32x3x3x32xf32>, memref<32x1x7x7x32xf32>, memref<32x1x9x9x32xf32>


### PR DESCRIPTION
Upon studying https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/426 I found the parser logic for `TransformAttr` doesn't consider the case of `AddDim`.