### PR TITLE
[DO NOT SQUASH] Extend tuning parameters with kpack turned off

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -1268,9 +1268,10 @@ def GPU_MubufLoadOp :
     GPU_Op<"buffer_load">,
     Arguments<(ins AnyMemRef:$memref,
                    Variadic<I32>:$indices)>,
-    Results<(outs AnyTypeOf<[BF16, F16, F32,
+    Results<(outs AnyTypeOf<[BF16, F16, F32, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
-                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>]>:$result)> {
+                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$result)> {
   let summary = "AMD GPU Buffer Load";
   let description = [{
     The `gpu.buffer_load` op is an abstraction of AMD GPU buffer load intrinsics.
@@ -1285,9 +1286,10 @@ def GPU_MubufLoadOp :
 // buffer store
 def GPU_MubufStoreOp :
     GPU_Op<"buffer_store">,
-    Arguments<(ins AnyTypeOf<[BF16, F16, F32,
+    Arguments<(ins AnyTypeOf<[BF16, F16, F32, I32,
                               VectorOfLengthAndType<[2, 4], [F32]>,
-                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>]>:$value,
+                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                              VectorOfLengthAndType<[2, 4], [I32]>]>:$value,
                    AnyMemRef:$memref,
                    I32:$shift,
                    Variadic<I32>:$indices)> {

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -320,7 +320,6 @@ struct MubufLoadOpLowering : ConvertToLLVMPattern {
             VectorType::get(interimShape, rewriter.getF32Type());
       Type interimLLVMResultType =
           typeConverter->convertType(interimResultType);
-      interimResultType.dump();
 
       Value interimLoad = rewriter.create<ROCDL::MubufLoadOp>(
           loc, interimLLVMResultType, rsrc, vindex, voffset, slc, glc);

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -522,7 +522,7 @@ def MIOpen_BufferLoadOp :
               VectorOfLengthAndType<[2, 4], [F32]>,
               VectorOfLengthAndType<[2, 4, 8], [F16]>,
               VectorOfLengthAndType<[2, 4, 8], [BF16]>,
-              VectorOfLengthAndType<[4], [I8]>,
+              VectorOfLengthAndType<[2, 4, 8, 16], [I8]>,
               VectorOfLengthAndType<[2, 4], [I32]>]>:$result)> {
   let summary = "Load data from a global buffer";
 

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -366,12 +366,12 @@ protected:
     // in the algorithm.
     int64_t vectorizationSize = 1;
     auto dataType = ctx.getDataType();
-    if (dataType.isF32()) {
-      vectorizationSize = 4;
-    } else if (dataType.isF16() || dataType.isBF16()) {
-      // FIXME: figure out the best vectorization length for f16 and bf16.
-      vectorizationSize = 4;
-    }
+    unsigned dataWidth = dataType.getIntOrFloatBitWidth();
+    // 128 is the upper limit we support in vectorized load/store, which could
+    // be 4 fp32, 8 fp16, or 16 int8
+    const auto highestPotentialVectorizationLen = 128;
+    vectorizationSize = highestPotentialVectorizationLen / dataWidth;
+
     // FIXME: set vectorizationSize be 1 for backward data and backward
     // weight for now.
     // The logic for deciding vectorization size and dimension for
@@ -621,7 +621,6 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
 
 template <typename T> std::string genDebugForParams(T params) {
   std::ostringstream os;
-  os << "DB load succeed: ";
   params.visit(params, [&os](auto &arg) { os << arg << ","; });
   os << "\n";
   return os.str();
@@ -819,9 +818,9 @@ private:
       // TODO remove
       {64, 64, 1, 32, 32, 1, false, false},
 
-      {64, 64, 1, 32, 32, 16, false, false},
-      {64, 64, 2, 32, 32, 16, false, false},
-      {64, 64, 4, 32, 32, 16, false, false},
+      {64, 64, 2, 32, 32, 1, false, false},
+      {64, 64, 4, 32, 32, 1, false, false},
+      {64, 64, 16, 32, 32, 16, false, false},
 
       // TODO Amend all kPack to be 16 for i8
       {16, 16, 16, 16, 16, 1, false, false},
@@ -873,6 +872,26 @@ private:
     return calculateInputDerivedParams(param, blockSize, ctx, false, derived);
   }
 
+  LogicalResult isKpackValid(InitParamsXDL *param,
+                             const DerivedParams &gemmADerived,
+                             const DerivedParams &gemmBDerived) {
+    if (isKpackValid(param, gemmADerived).failed()) {
+      return failure();
+    }
+    if (isKpackValid(param, gemmBDerived).failed()) {
+      return failure();
+    }
+    return success();
+  }
+
+  LogicalResult isKpackValid(InitParamsXDL *param,
+                             const DerivedParams &derived) {
+    if (param->gemmKPack > derived.srcDataPerRead) {
+      return failure();
+    }
+    return success();
+  }
+
   LogicalResult calculateLdsNumberOfByte(InitParamsXDL &param,
                                          const ConvolutionContext &ctx,
                                          DerivedParams gemmADerived,
@@ -917,8 +936,8 @@ private:
       // limited selection below
       // clang-format off
       validWaveGemmSize = {
-        std::make_tuple(32, 32, 1),
-        std::make_tuple(16, 16, 1)};
+        std::make_tuple(32, 32, 2),
+        std::make_tuple(16, 16, 4)};
       // clang-format on
     } else {
       // clang-format off
@@ -966,8 +985,8 @@ private:
     if ((param.gemmNPerBlock % param.gemmNPerWave) != 0)
       return failure();
 
-    if ((param.gemmKPerBlock % param.gemmKPack) != 0)
-      return failure();
+    // Note KPerBlock and KPack are independent tuning parameters.
+    // There's no need to check if they are divide exactly
 
     // Reject invalid KPACK values.
     // For fp32: reject anything wider than 4.

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -369,7 +369,7 @@ protected:
     unsigned dataWidth = dataType.getIntOrFloatBitWidth();
     // 128 is the upper limit we support in vectorized load/store, which could
     // be 4 fp32, 8 fp16, or 16 int8
-    const auto highestPotentialVectorizationLen = 128;
+    const size_t highestPotentialVectorizationLen = 128;
     vectorizationSize = highestPotentialVectorizationLen / dataWidth;
 
     // FIXME: set vectorizationSize be 1 for backward data and backward

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -815,15 +815,18 @@ private:
   // clang-format off
   llvm::SmallVector<InitParamsXDL, 4> initParametersForwardI8 = {
       // M/block N/block K/block M/wave N/wave kPack aCopyMore bCopyMore
-      // TODO remove
-      {64, 64, 1, 32, 32, 1, false, false},
-
-      {64, 64, 2, 32, 32, 1, false, false},
+      // TODO enable kpack
+      // The 32 x 32 xdlops k/block must be divisible by 2
+      {64, 64, 8, 32, 32, 1, false, false},
       {64, 64, 4, 32, 32, 1, false, false},
-      {64, 64, 16, 32, 32, 16, false, false},
-
-      // TODO Amend all kPack to be 16 for i8
-      {16, 16, 16, 16, 16, 1, false, false},
+      {64, 64, 2, 32, 32, 1, false, false},
+      {32, 32, 8, 32, 32, 1, false, false},
+      {32, 32, 4, 32, 32, 1, false, false},
+      {32, 32, 2, 32, 32, 1, false, false},
+      // The 16 x 16 xdlops k/block must be divisible by 4
+      {32, 32, 8, 16, 16, 1, false, false},
+      {32, 32, 4, 16, 16, 1, false, false},
+      {16, 16, 8, 16, 16, 1, false, false},
       {16, 16, 4, 16, 16, 1, false, false},
   };
   // clang-format on
@@ -870,26 +873,6 @@ private:
       InitParamsXDL *param, ConvolutionContext &ctx, DerivedParams &derived) {
     int64_t blockSize = obtainBlockSize(*param, waveSize);
     return calculateInputDerivedParams(param, blockSize, ctx, false, derived);
-  }
-
-  LogicalResult isKpackValid(InitParamsXDL *param,
-                             const DerivedParams &gemmADerived,
-                             const DerivedParams &gemmBDerived) {
-    if (isKpackValid(param, gemmADerived).failed()) {
-      return failure();
-    }
-    if (isKpackValid(param, gemmBDerived).failed()) {
-      return failure();
-    }
-    return success();
-  }
-
-  LogicalResult isKpackValid(InitParamsXDL *param,
-                             const DerivedParams &derived) {
-    if (param->gemmKPack > derived.srcDataPerRead) {
-      return failure();
-    }
-    return success();
   }
 
   LogicalResult calculateLdsNumberOfByte(InitParamsXDL &param,

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -968,8 +968,10 @@ private:
     if ((param.gemmNPerBlock % param.gemmNPerWave) != 0)
       return failure();
 
-    // Note KPerBlock and KPack are independent tuning parameters.
+    // TODO Remove. Note KPerBlock and KPack are independent tuning parameters.
     // There's no need to check if they are divide exactly
+    if ((param.gemmKPerBlock % param.gemmKPack) != 0)
+      return failure();
 
     // Reject invalid KPACK values.
     // For fp32: reject anything wider than 4.

--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
@@ -254,7 +254,7 @@ struct BufferLoadRewritePattern : public OpRewritePattern<BufferLoadOp> {
         oobDims.push_back(pair.index());
     bool toEmitOobChecks = !oobDims.empty();
 
-    auto emitLoadInstruction = [&b, loc, loadedType, sourceType,
+    auto emitLoadInstruction = [&b, loc, loadedType,
                                 source](ValueRange loadCoords) -> Value {
       Value loadedValue;
 

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -268,12 +268,6 @@ LogicalResult PopulateParamsXDL::populateDerived(
     return failure();
   }
 
-  res = isKpackValid(&params, gemmADerivedParam, gemmBDerivedParam);
-  if (failed(res)) {
-    LLVM_DEBUG(llvm::dbgs() << "Incoherent kpack tuning parameter.\n");
-    return failure();
-  }
-
   std::size_t ldsSize = 0;
   res = calculateLdsNumberOfByte(params, ctx, gemmADerivedParam,
                                  gemmBDerivedParam, ldsSize);

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -268,6 +268,12 @@ LogicalResult PopulateParamsXDL::populateDerived(
     return failure();
   }
 
+  res = isKpackValid(&params, gemmADerivedParam, gemmBDerivedParam);
+  if (failed(res)) {
+    LLVM_DEBUG(llvm::dbgs() << "Incoherent kpack tuning parameter.\n");
+    return failure();
+  }
+
   std::size_t ldsSize = 0;
   res = calculateLdsNumberOfByte(params, ctx, gemmADerivedParam,
                                  gemmBDerivedParam, ldsSize);


### PR DESCRIPTION
This fix https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/465, as well as a number of issues listed below:

- Amend vectorization size decision to be dependent on data width only
- Amended valid k/wave as both xdlops for int8 are reduction ops and needs k/wave to be at least 2/4
- Extended support of i8 type to MIOpen::buffer_load
- Extended support of i32 type to MubufStore
- Corrected lowering pattern of MubufLoad and MubufStore to incorporate i8
- Make Buffer load lowering to emit scalar load when the load is too narrow or too wide

Refer to full nightly pass [here](http://rocmhead.amd.com:8080/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-539/10/pipeline/).
