### PR TITLE
[DO NOT SQUASH] Warnings cleanup

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/GPUOps.td
@@ -771,7 +771,7 @@ def GPU_LDSBarrierOp : GPU_Op<"lds_barrier"> {
   let description = [{
     The "lds_barrier" op synchronizes all LDS activities of a workgroup.
   }];
-  let parser = [{ return success(); }];
+  let assemblyFormat = "attr-dict";
 }
 
 def GPU_GPUModuleOp : GPU_Op<"module", [

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -57,7 +57,7 @@ void mlirGetKernelInfo(MlirModule module, int *size, void *data) {
     for (int i = 0; i < argSize; i++)
       argData[i + 1] = info[i];
     char *nameData = (char *)(argData + argSize + 1);
-    for (int i = 0; i < kernelName.size(); i++) {
+    for (size_t i = 0, e = kernelName.size(); i < e; ++i) {
       nameData[i] = kernelName[i];
     }
   }

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -62,8 +62,7 @@ public:
   matchAndRewrite(migraphx::ConvolutionOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     auto operands = adaptor.getOperands();
-    auto loc = op->getLoc();
-    auto context = op->getContext();
+    Location loc = op->getLoc();
     auto input_t = operands[0];
     auto filter_t = operands[1];
     auto results = op->getResults();

--- a/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
+++ b/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
@@ -326,7 +326,6 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     auto operands = adaptor.getOperands();
     auto loc = top->getLoc();
-    auto context = top->getContext();
 
     SmallVector<int64_t> NCHW2NHWC{0, 2, 3, 1};
     SmallVector<int64_t> NHWC2NCHW{0, 3, 1, 2};

--- a/mlir/lib/Dialect/MIOpen/Transforms/ApplyImpl.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ApplyImpl.cpp
@@ -45,7 +45,6 @@ struct MIOpenApplyImplPass
       SymbolTable symbolTable(mod);
       auto *ctx = mod.getContext();
       OpBuilder b(ctx);
-      auto loc = mod.getLoc();
 
       SmallVector<gpu::GPUModuleOp, 8> gpuMods;
       miopenMod->walk([&](gpu::GPUModuleOp gpuMod) {


### PR DESCRIPTION
This one's exactly what it says it is.

`skip-ci` has been applied so that we can get to merging it after some of the more substantial stuff goes in - we only have so many CI nodes at the moment, after all.