### PR TITLE
Show more comparison results in the performance report

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -273,7 +273,7 @@ pipeline {
                                 sh 'sed -i "/ROCmSoftwarePlatform\\/llvm-project-mlir/d" ./requirements.txt'
                                 cmake arguments: "-P install_deps.cmake --minimum --prefix ${WORKSPACE}/MIOpenDeps",\
                                     installation: "InSearchPath"
-                                buildMIOpen('''-DMIOPEN_USE_MLIR=On
+                                buildMIOpen('''-DMIOPEN_USE_MLIR=ON
                                         -DMIOPEN_BACKEND=HIP
                                         -DCMAKE_PREFIX_PATH="${WORKSPACE}/MIOpenDeps"
                                         -DMIOPEN_USER_DB_PATH=${WORKSPACE}/MIOpen/build/MIOpenUserDB
@@ -349,68 +349,7 @@ pipeline {
                         }
                     }
                 }
-                stage("Build for Performance Test") {
-                    when {
-                        beforeAgent true;
-                        allOf{
-                            equals expected: true, actual: params.perfTest;
-                            equals expected: true, actual: params.nightly;
-                    } }
-                    agent {
-                        docker {
-                            image dockerImage()
-                            args dockerArgs()
-                            label "${params.canXdlops ? 'gfx908' : 'rocm' }"
-                            alwaysPull true
-                        }
-                    }
-                    environment {
-                        PATH="/opt/rocm/llvm/bin:$PATH"
-                        HOME="${WORKSPACE}"
-                    }
-                    stages {
-                        stage("Environment") {
-                            steps {
-                                showEnv()
-                            }
-                        }
-                        stage("Build MIOpen with HIP") {
-                           steps {
-                               dir('MIOpen') {
-                                   getAndBuildMIOpen("--prefix ${WORKSPACE}/MIOpen/MIOpenDeps",
-                                                     '''-DMIOPEN_BACKEND=HIP -DMIOPEN_USE_MLIR=Off
-                                   -DCMAKE_PREFIX_PATH="${WORKSPACE}/MIOpen/MIOpenDeps"
-                                   -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/MIOpen/build/MIOpenInstallDir
-                                   ''')
-                                   sh 'cd build; make -j $(nproc)'
-                                   sh 'cd build; make install'
-                               }
-                               stash name:"MIOpen-kernels",\
-                                   includes: "MIOpen/build/**"
-                           }
-                        }
-                        stage("Build MLIR") {
-                            steps {
-                                buildProject('miopen-gen mlir-miopen-driver mlir-rocm-runner ci-performance-scripts', '')
-                            }
-                        }
-                        stage("Test MLIR vs MIOpen") {
-                            steps {
-                                dir('build') {
-                                    sh 'date --utc +%Y-%m-%d > perf-run-date'
-                                    // Run MLIR perf benchmarks
-                                    sh 'python3 ./bin/MIOpenDriver.py'
-                                }
-                                stash name:"Perf-report", includes:"build/mlir_vs_miopen_perf.csv"
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            cleanWs()
-                        }
-                    }
-                }
+
             }
         }
         stage("MIOpen Resnet50 Config Test") {
@@ -510,6 +449,11 @@ pipeline {
                 HOME="${WORKSPACE}"
             }
             stages {
+                stage("Environment") {
+                    steps {
+                        showEnv()
+                    }
+                }
                 stage("Copy MIOpen with MLIR kernels") {
                     steps {
                         sh 'rm -rf MIOpen'
@@ -534,6 +478,34 @@ pipeline {
                         }
                     }
                 }
+                stage("Build MIOpen with HIP") {
+                    steps {
+                        sh 'rm -rf MIOpen'
+                        dir('MIOpen') {
+                            getAndBuildMIOpen("--prefix ${WORKSPACE}/MIOpen/MIOpenDeps",
+                                '''-DMIOPEN_BACKEND=HIP -DMIOPEN_USE_MLIR=OFF
+                                   -DCMAKE_PREFIX_PATH="${WORKSPACE}/MIOpen/MIOpenDeps"
+                                   -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/MIOpen/build/MIOpenInstallDir
+                                   ''')
+                            sh 'cd build; make -j $(nproc)'
+                            sh 'cd build; make install'
+                        }
+                    }
+                }
+                stage("Build MLIR") {
+                    steps {
+                        buildProject('miopen-gen mlir-miopen-driver mlir-rocm-runner ci-performance-scripts', '')
+                    }
+                }
+                stage("Test MLIR vs MIOpen") {
+                    steps {
+                        dir('build') {
+                            sh 'date --utc +%Y-%m-%d > perf-run-date'
+                            // Run MLIR perf benchmarks
+                            sh 'python3 ./bin/MIOpenDriver.py'
+                        }
+                    }
+                }
                 stage("Copy earlier performance results") {
                     steps {
                         copyArtifacts filter: 'build/*.csv,build/perf-run-date',\
@@ -544,10 +516,8 @@ pipeline {
                                                target: 'build/oldData'
                     }
                 }
-
                 stage("Create performance reports") {
                     steps {
-                        unstash name: "Perf-report"
                         dir('build') {
                             sh 'ls -l'
                             sh 'python3 ./bin/createPerformanceReports.py'

--- a/mlir/utils/jenkins/MIOpenDriver.py
+++ b/mlir/utils/jenkins/MIOpenDriver.py
@@ -312,9 +312,9 @@ def generatePerformanceResults(configs, xdlops):
 
     df = mlir_df.merge(miopen_df, on=ConvConfiguration.TABLE_COLUMNS[:-1],
                            suffixes=('', ' (MIOpen)'))
-    df.rename(columns={'TFlops': 'MLIR TFlops', 'TFlops (MIOpen)': 'MIOpen TFlops'}, inplace=True)
+    df.rename(columns={'TFlops': 'MLIR TFlops', 'TFlops (MIOpen)': 'MIOpen TFlops (no MLIR Kernels)'}, inplace=True)
 
-    df['MLIR/MIOpen'] = df['MLIR TFlops'] / df['MIOpen TFlops']
+    df['MLIR/MIOpen'] = df['MLIR TFlops'] / df['MIOpen TFlops (no MLIR Kernels)']
     df.to_csv(reportUtils.PERF_REPORT_FILE, index=False)
 
 def getSolverName(testVector, xdlops):

--- a/mlir/utils/jenkins/createPerformanceReports.py
+++ b/mlir/utils/jenkins/createPerformanceReports.py
@@ -14,7 +14,7 @@ def printAllPerformance():
     try:
         df = pd.read_csv(reportUtils.PERF_REPORT_FILE)
         perfReportFound = True
-        COLUMNS_TO_AVERAGE = ['MLIR TFlops', 'MIOpen TFlops', 'MLIR/MIOpen']
+        COLUMNS_TO_AVERAGE = ['MLIR TFlops', 'MIOpen TFlops (no MLIR Kernels)', 'MLIR/MIOpen']
     except FileNotFoundError:
         print('Perf report not found.')
         return
@@ -36,15 +36,16 @@ def printAllPerformance():
         df['MIOpen TFlops (Tuned MLIR Kernels)'] = tuned_df['TFlops']
         df['MIOpen TFlops (Untuned MLIR Kernels)'] = untuned_df['TFlops']
         df['Tuned/Untuned'] = df['MIOpen TFlops (Tuned MLIR Kernels)']/df['MIOpen TFlops (Untuned MLIR Kernels)']
+        df['Tuned/MIOpen'] = df['MIOpen TFlops (Tuned MLIR Kernels)']/df['MIOpen TFlops (no MLIR Kernels)'] 
         df.to_csv(reportUtils.PERF_REPORT_FILE, index=False)
-        COLUMNS_TO_AVERAGE = ['MLIR TFlops', 'MIOpen TFlops', 'MLIR/MIOpen',
-                              'MIOpen TFlops (Tuned MLIR Kernels)', 'MIOpen TFlops (Untuned MLIR Kernels)', 'Tuned/Untuned']
+        COLUMNS_TO_AVERAGE = ['MLIR TFlops', 'MIOpen TFlops (no MLIR Kernels)', 'MLIR/MIOpen',
+                              'MIOpen TFlops (Tuned MLIR Kernels)', 'MIOpen TFlops (Untuned MLIR Kernels)', 'Tuned/Untuned', 'Tuned/MIOpen']
 
     plotMean = df[COLUMNS_TO_AVERAGE].agg(reportUtils.geoMean)
     plotMean.name = "Geo. mean"
     plotMean = pd.DataFrame(plotMean).T
 
-    plotMean[['MLIR TFlops', 'MIOpen TFlops']]\
+    plotMean[['MLIR TFlops', 'MIOpen TFlops (no MLIR Kernels)']]\
         .to_csv(reportUtils.PERF_PLOT_REPORT_FILE, index=False)
 
     means = df.groupby(["Direction", "DataType"])[COLUMNS_TO_AVERAGE]\
@@ -53,7 +54,7 @@ def printAllPerformance():
     means.to_csv(reportUtils.PERF_STATS_REPORT_FILE)
 
     with open("MLIR_vs_MIOpen.html", 'w') as htmlOutput:
-        reportUtils.htmlReport(df, means, "MLIR vs. MIOpen performance", ["MLIR/MIOpen", "Tuned/Untuned"], htmlOutput)
+        reportUtils.htmlReport(df, means, "MLIR vs. MIOpen performance", ["MLIR/MIOpen", "Tuned/Untuned", "Tuned/MIOpen"], htmlOutput)
 
 # Main function.
 if __name__ == '__main__':

--- a/mlir/utils/jenkins/perfRegressionReport.py
+++ b/mlir/utils/jenkins/perfRegressionReport.py
@@ -10,8 +10,8 @@ import pandas as pd
 
 def loadMlirData(filename: str):
     df = pd.read_csv(filename, sep=',', header=0, index_col=False)
-    COLUMNS_DROPPED = ['MIOpen TFlops', 'MLIR/MIOpen', 'MIOpen TFlops (Tuned MLIR Kernels)', 
-                       'MIOpen TFlops (Untuned MLIR Kernels)', 'Tuned/Untuned']
+    COLUMNS_DROPPED = ['MIOpen TFlops (no MLIR Kernels)', 'MLIR/MIOpen', 'MIOpen TFlops (Tuned MLIR Kernels)',
+                       'MIOpen TFlops (Untuned MLIR Kernels)', 'Tuned/Untuned', 'Tuned/MIOpen']
     df.drop(columns=COLUMNS_DROPPED, inplace=True, errors='ignore')
     return df
 
@@ -31,6 +31,9 @@ def computePerfStats(oldDf: pd.DataFrame, newDf: pd.DataFrame, oldLabel: str, ne
             file=sys.stderr)
         return computePerfStats(newDf.copy(), newDf, "forced copy", newLabel)
 
+    if (oldLabel == newLabel):
+        oldLabel += "_old"
+        newLabel += "_new"
     oldLabel = f"MLIR TFlops ({oldLabel})"
     newLabel = f"MLIR TFlops ({newLabel})"
     data.rename(columns={'MLIR TFlops_old': oldLabel,

--- a/mlir/utils/jenkins/reportUtils.py
+++ b/mlir/utils/jenkins/reportUtils.py
@@ -41,7 +41,7 @@ def setCommonStyles(styler: 'pd.io.formats.style.Styler', speedupCols: list):
         {'selector': 'tbody tr:nth-child(odd)', 'props': [('background-color', '#e0e0e0')]},
         {'selector': 'tbody tr:nth-child(even)', 'props': [('background-color', '#eeeeee')]},
         {'selector': 'table', 'props': [('background-color', '#dddddd'), ('border-collapse', 'collapse')]},
-        {'selector': 'th, td', 'props': [('padding', '0.5em'), ('text-align', 'center')]}])
+        {'selector': 'th, td', 'props': [('padding', '0.5em'), ('text-align', 'center'), ('max-width', '150px')]}])
     styler.set_precision(ROUND_DIGITS)
     styler.set_na_rep("FAILED")
     for col in speedupCols:


### PR DESCRIPTION
Add MIOpen with tuned MLIR kernels vs. MIOpen without MLIR kernels in the performance report.
Combine two perfTest stages into one to avoid potential impact of different nodes on performance.

