### PR TITLE
Revert "[AMDGPU] Revert hack on AGPR allocation ordering."

### DIFF
--- a/external/llvm-project/llvm/lib/CodeGen/RegAllocGreedy.cpp
+++ b/external/llvm-project/llvm/lib/CodeGen/RegAllocGreedy.cpp
@@ -312,7 +312,9 @@ void RAGreedy::enqueue(PQueue &CurQueue, const LiveInterval *LI) {
       (Size / SlotIndex::InstrDist) > (2 * RCI.getNumAllocatableRegs(&RC));
 
     if (Stage == RS_Assign && !ForceGlobal && !LI->empty() &&
-        (LIS->intervalIsInOneMBB(*LI))) {
+        (LIS->intervalIsInOneMBB(*LI) ||
+         // HACK: Let AGPR always be allocated in linear instruction order.
+         StringRef("AReg_1024") == TRI->getRegClassName(&RC))) {
       // Allocate original local ranges in linear instruction order. Since they
       // are singly defined, this produces optimal coloring in the absence of
       // global interference and other constraints.


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/llvm-project-mlir#514

Reinstate the temporary hack on AGPR allocation ordering after getting the performance report to undertstand the impact of #514.

http://10.236.106.97:8080/job/MLIR/job/mlir-nightly-all/296/Performance_20report/

The performance degradations in bwd and fwd assert the necessity to have the AGPR hack in the greedy RA.

The performance degradations in wrw could be side effects introduced in #536. And we have a ticket to track improving the performance of it at https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/466