### PR TITLE
Fix pattern rewrite paradigm to allow error to propagate

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -1784,22 +1784,18 @@ void LowerMIOpenOpsStep1Pass::runOnOperation() {
   MLIRContext *ctx = &getContext();
 
   ConversionTarget target(*ctx);
-  target.addIllegalOp<miopen::Conv2DOp>();
-  target.addIllegalOp<miopen::Conv2DBwdDataOp>();
-  target.addIllegalOp<miopen::Conv2DBwdWeightOp>();
-
-  target.addLegalOp<miopen::TransformOp>();
-  target.addLegalOp<miopen::GridwiseGemmOp>();
-  target.addLegalOp<miopen::GridwiseGemmV2Op>();
+  target.addIllegalOp<miopen::Conv2DOp, miopen::Conv2DBwdDataOp,
+                      miopen::Conv2DBwdWeightOp>();
+  target.addLegalOp<miopen::TransformOp, miopen::GridwiseGemmOp,
+                    miopen::GridwiseGemmV2Op>();
   // Below are required legalize for the lowering of Conv2DBwdWeightOp
-  target.addLegalDialect<arith::ArithmeticDialect>();
-  target.addLegalDialect<memref::MemRefDialect>();
-  target.addLegalDialect<AffineDialect>();
+  target.addLegalDialect<arith::ArithmeticDialect, memref::MemRefDialect,
+                         AffineDialect>();
 
   RewritePatternSet patterns(ctx);
-  patterns.add<Conv2DRewritePattern<Conv2DOp>>(ctx);
-  patterns.add<Conv2DRewritePattern<Conv2DBwdDataOp>>(ctx);
-  patterns.add<Conv2DRewritePattern<Conv2DBwdWeightOp>>(ctx);
+  patterns.add<Conv2DRewritePattern<Conv2DOp>,
+               Conv2DRewritePattern<Conv2DBwdDataOp>,
+               Conv2DRewritePattern<Conv2DBwdWeightOp>>(ctx);
 
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(patterns)))) {

--- a/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
@@ -2645,16 +2645,12 @@ struct GridwiseGemmV2RewritePattern
 void LowerMIOpenOpsStep2Pass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   ConversionTarget target(*ctx);
-  target.addIllegalOp<miopen::GridwiseGemmOp>();
-  target.addIllegalOp<miopen::GridwiseGemmV2Op>();
-
-  target.addLegalDialect<arith::ArithmeticDialect>();
-  target.addLegalDialect<miopen::MIOpenDialect>();
-  target.addLegalDialect<AffineDialect>();
+  target.addIllegalOp<miopen::GridwiseGemmOp, miopen::GridwiseGemmV2Op>();
+  target.addLegalDialect<arith::ArithmeticDialect, miopen::MIOpenDialect,
+                         AffineDialect>();
 
   RewritePatternSet patterns(ctx);
-  patterns.add<GridwiseGemmRewritePattern>(ctx);
-  patterns.add<GridwiseGemmV2RewritePattern>(ctx);
+  patterns.add<GridwiseGemmRewritePattern, GridwiseGemmV2RewritePattern>(ctx);
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(patterns)))) {
     signalPassFailure();

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -47,10 +47,13 @@ private:
     static MLIRContext context(getRegistry());
     static std::once_flag once;
     std::call_once(once, []() {
-      // FIXME: A conv op would ignore this context and instead use the
-      // context from the UnknownLoc
+      // Turn off all diagnotic printing on op and stacktrace
+      // Note: This is not necessary with below handler
       context.printOpOnDiagnostic(false);
       context.printStackTraceOnDiagnostic(false);
+      // Register a handler that swallows all diagnostic print
+      DiagnosticEngine &engine = context.getDiagEngine();
+      engine.registerHandler([](Diagnostic &diag) {});
       context.loadDialect<miopen::MIOpenDialect, StandardOpsDialect>();
     });
     return context;

--- a/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-lib/mlir-miopen-lib.cpp
@@ -47,6 +47,10 @@ private:
     static MLIRContext context(getRegistry());
     static std::once_flag once;
     std::call_once(once, []() {
+      // FIXME: A conv op would ignore this context and instead use the
+      // context from the UnknownLoc
+      context.printOpOnDiagnostic(false);
+      context.printStackTraceOnDiagnostic(false);
       context.loadDialect<miopen::MIOpenDialect, StandardOpsDialect>();
     });
     return context;


### PR DESCRIPTION
I have tested this locally and confirm it will fix https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1449. This PR is an urgency blocker, please review ASAP.

I corrected the common paradigm for pattern rewriting in this PR.

`applyPatternsAndFoldGreedily()`
 - This is inappropriate rewriting pattern for our case
 - It applies to lowering patterns that needs to be repeatedly applied and check whether it converged
 - It ignored any lowering failure from any lowering pattern
 - From API end, it won't be able to generate an error code even if the lowering pattern failed

Instead

`applyPartialConversion()`
 - Allow us to setup a success metric beforehand
 - Make sure target IR was what we expected