### PR TITLE
Improve utility kernels perf

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Passes.td
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.td
@@ -24,7 +24,7 @@ def MIOpenApplyImplPass : Pass<"miopen-apply-impl", "ModuleOp"> {
 def MIOpenOpsStep1Pass : Pass<"miopen-lowering", "ModuleOp"> {
   let summary = "expand convolution into coordinate transformations and gridwise gemm";
   let constructor = "mlir::miopen::createLowerMIOpenOpsStep1Pass()";
-  let dependentDialects = ["miopen::MIOpenDialect", "memref::MemRefDialect", "AffineDialect"];
+  let dependentDialects = ["miopen::MIOpenDialect", "memref::MemRefDialect", "AffineDialect", "scf::SCFDialect"];
 }
 
 def MIOpenOpsAffixTuningParametersPass : Pass<"miopen-affix-params", "::mlir::FuncOp"> {

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/UtilityParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/UtilityParams.h
@@ -1,0 +1,26 @@
+//===- GridwiseGemmParams.h - MLIR tuning parameter generation --------*-===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines parameters for utility kernels.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_MIOPEN_UTILITY_PARAMS_H
+#define MLIR_DIALECT_MIOPEN_UTILITY_PARAMS_H
+
+namespace mlir {
+namespace miopen {
+
+/// Default grid size and block size for utility kernels used in the lowering
+/// process.
+constexpr int64_t kUtilityKernelGridSize = 512;
+constexpr int64_t kUtilityKernelBlockSize = 64;
+
+} // end namespace miopen
+} // end namespace mlir
+#endif // MLIR_DIALECT_MIOPEN_UTILITY_PARAMS_H

--- a/mlir/include/mlir/Dialect/MIOpen/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/builderUtils.h
@@ -16,15 +16,16 @@ Value createConstantFloatOp(OpBuilder &b, Location loc, Type type,
 Value createConstantIntOp(OpBuilder &b, Location loc, Type type, Type elemType,
                           int64_t value);
 
-// Utility function to emit constant zero op. Can return scalars or vectors.
+/// Utility function to emit constant zero op. Can return scalars or vectors.
 Value createZeroConstantOp(OpBuilder &b, Location loc, Type type);
 
-// Utility function to emit type conversion ops.
+/// Utility function to emit type conversion ops.
 Value createTypeConversionOp(OpBuilder &b, Location loc, Value source,
                              Type destType);
 
-// Utility function to collapse an multi-dimensional memref to 1D.
+/// Utility function to collapse an multi-dimensional memref to 1D.
 Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source);
+
 } // namespace miopen
 } // namespace mlir
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Dialect/MIOpen/MIOpen.h"
 #include "mlir/Dialect/MIOpen/Passes.h"
 #include "mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h"
+#include "mlir/Dialect/MIOpen/Tuning/UtilityParams.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Types.h"
@@ -163,11 +164,13 @@ void AffixTuningParameters::affixBackwardWeightUtilityKernels(
       case 0:
       case 2:
         // Set grid_size and block_size for utility kernels.
-        op->setAttr("grid_size", b.getI32IntegerAttr(512));
-        op->setAttr("block_size", b.getI32IntegerAttr(64));
+        op->setAttr("grid_size", b.getI32IntegerAttr(kUtilityKernelGridSize));
+        op->setAttr("block_size", b.getI32IntegerAttr(kUtilityKernelBlockSize));
         // Set attributes on the function.
-        getOperation()->setAttr("grid_size", b.getI32IntegerAttr(512));
-        getOperation()->setAttr("block_size", b.getI32IntegerAttr(64));
+        getOperation()->setAttr("grid_size",
+                                b.getI32IntegerAttr(kUtilityKernelGridSize));
+        getOperation()->setAttr("block_size",
+                                b.getI32IntegerAttr(kUtilityKernelBlockSize));
         break;
       case 1:
         break;

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -162,13 +162,12 @@ void AffixTuningParameters::affixBackwardWeightUtilityKernels(
       switch (gemmId) {
       case 0:
       case 2:
-        // Override grid_size and block_size be 1 for utility kernels.
-        // FIXME. Use better sizes for speedups.
-        op->setAttr("grid_size", b.getI32IntegerAttr(1));
-        op->setAttr("block_size", b.getI32IntegerAttr(1));
+        // Set grid_size and block_size for utility kernels.
+        op->setAttr("grid_size", b.getI32IntegerAttr(512));
+        op->setAttr("block_size", b.getI32IntegerAttr(64));
         // Set attributes on the function.
-        getOperation()->setAttr("block_size", b.getI32IntegerAttr(1));
-        getOperation()->setAttr("grid_size", b.getI32IntegerAttr(1));
+        getOperation()->setAttr("grid_size", b.getI32IntegerAttr(512));
+        getOperation()->setAttr("block_size", b.getI32IntegerAttr(64));
         break;
       case 1:
         break;

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/MIOpen/MIOpen.h"
 #include "mlir/Dialect/MIOpen/Passes.h"
 #include "mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h"
+#include "mlir/Dialect/MIOpen/Tuning/UtilityParams.h"
 #include "mlir/Dialect/MIOpen/utility/builderUtils.h"
 #include "mlir/Dialect/MIOpen/utility/loweringUtils.h"
 
@@ -209,11 +210,11 @@ LogicalResult zeroInit(Conv2DBwdWeightOp op, PatternRewriter &b) {
   //     collapsedOutput[i] = 0;
 
   auto workgroupId = b.create<WorkgroupIdOp>(loc, b.getIndexType());
-  auto workgroupDim = b.create<ConstantIndexOp>(loc, 64);
+  auto workgroupDim = b.create<ConstantIndexOp>(loc, kUtilityKernelBlockSize);
   auto workitemId = b.create<WorkitemIdOp>(loc, b.getIndexType());
   auto offset = b.create<AddIOp>(
       loc, b.create<MulIOp>(loc, workgroupId, workgroupDim), workitemId);
-  auto gridDim = b.create<ConstantIndexOp>(loc, 512);
+  auto gridDim = b.create<ConstantIndexOp>(loc, kUtilityKernelGridSize);
   auto stride = b.create<MulIOp>(loc, workgroupDim, gridDim);
 
   auto loop = b.create<scf::ForOp>(
@@ -251,11 +252,11 @@ LogicalResult elementwiseConversion(Conv2DBwdWeightOp op, PatternRewriter &b) {
   //     collapsedFilter[i] = convert(collapsedWorkspace[i]);
 
   auto workgroupId = b.create<WorkgroupIdOp>(loc, b.getIndexType());
-  auto workgroupDim = b.create<ConstantIndexOp>(loc, 64);
+  auto workgroupDim = b.create<ConstantIndexOp>(loc, kUtilityKernelBlockSize);
   auto workitemId = b.create<WorkitemIdOp>(loc, b.getIndexType());
   auto offset = b.create<AddIOp>(
       loc, b.create<MulIOp>(loc, workgroupId, workgroupDim), workitemId);
-  auto gridDim = b.create<ConstantIndexOp>(loc, 512);
+  auto gridDim = b.create<ConstantIndexOp>(loc, kUtilityKernelGridSize);
   auto stride = b.create<MulIOp>(loc, workgroupDim, gridDim);
 
   auto loop = b.create<scf::ForOp>(

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -179,9 +179,8 @@ void affixGridwiseGemmAttributes(Operation *convOp, Operation *gop,
   }
 }
 
-template <typename T>
 void createElementwiseLoop(OpBuilder &b, Location loc, int64_t bound,
-                           T emitBodyFunc) {
+                           function_ref<void(Value)> emitBodyFunc) {
   // Pseudo code:
   // size_t offset = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
   // size_t stride = hipBlockDim_x * hipGridDim_x;

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -35,6 +35,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
+using namespace mlir::arith;
 using namespace mlir::miopen;
 //===----------------------------------------------------------------------===//
 // Conv2D (forward, backward) lowering.
@@ -200,9 +201,27 @@ LogicalResult zeroInit(Conv2DBwdWeightOp op, PatternRewriter &b) {
   auto collapsedOutput = createCollapseShapeOp(b, loc, output);
   ArrayRef<int64_t> collapsedOutputShape =
       collapsedOutput.getType().cast<MemRefType>().getShape();
-  auto loop = b.create<AffineForOp>(loc, 0, collapsedOutputShape[0]);
+
+  // Pseudo code:
+  // size_t offset = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+  // size_t stride = hipBlockDim_x * hipGridDim_x;
+  // for (size_t i = offset; i < sizeof(collapsedOutput); i+= stride)
+  //     collapsedOutput[i] = 0;
+
+  auto workgroupId = b.create<WorkgroupIdOp>(loc, b.getIndexType());
+  auto workgroupDim = b.create<ConstantIndexOp>(loc, 64);
+  auto workitemId = b.create<WorkitemIdOp>(loc, b.getIndexType());
+  auto offset = b.create<AddIOp>(
+      loc, b.create<MulIOp>(loc, workgroupId, workgroupDim), workitemId);
+  auto gridDim = b.create<ConstantIndexOp>(loc, 512);
+  auto stride = b.create<MulIOp>(loc, workgroupDim, gridDim);
+
+  auto loop = b.create<scf::ForOp>(
+      loc, offset, b.create<ConstantIndexOp>(loc, collapsedOutputShape[0]),
+      stride);
   b.setInsertionPointToStart(loop.getBody());
-  b.create<AffineStoreOp>(loc, zeroOp, collapsedOutput, loop.getInductionVar());
+  b.create<memref::StoreOp>(loc, zeroOp, collapsedOutput,
+                            loop.getInductionVar());
 
   b.eraseOp(op);
   return success();
@@ -224,13 +243,30 @@ LogicalResult elementwiseConversion(Conv2DBwdWeightOp op, PatternRewriter &b) {
       collapsedWorkspace.getType().cast<MemRefType>().getShape();
   assert((collapsedFilterShape[0] == collapsedWorkspaceShape[0]) &&
          "Filter tensor and workspace size mismatch");
-  auto loop = b.create<AffineForOp>(loc, 0, collapsedWorkspaceShape[0]);
-  auto iv = loop.getInductionVar();
+
+  // Pseudo code:
+  // size_t offset = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+  // size_t stride = hipBlockDim_x * hipGridDim_x;
+  // for (size_t i = offset; i < sizeof(collapsedOutput); i+= stride)
+  //     collapsedFilter[i] = convert(collapsedWorkspace[i]);
+
+  auto workgroupId = b.create<WorkgroupIdOp>(loc, b.getIndexType());
+  auto workgroupDim = b.create<ConstantIndexOp>(loc, 64);
+  auto workitemId = b.create<WorkitemIdOp>(loc, b.getIndexType());
+  auto offset = b.create<AddIOp>(
+      loc, b.create<MulIOp>(loc, workgroupId, workgroupDim), workitemId);
+  auto gridDim = b.create<ConstantIndexOp>(loc, 512);
+  auto stride = b.create<MulIOp>(loc, workgroupDim, gridDim);
+
+  auto loop = b.create<scf::ForOp>(
+      loc, offset, b.create<ConstantIndexOp>(loc, collapsedWorkspaceShape[0]),
+      stride);
   b.setInsertionPointToStart(loop.getBody());
-  auto loadedValue = b.create<AffineLoadOp>(loc, collapsedWorkspace, iv);
+  auto iv = loop.getInductionVar();
+  auto loadedValue = b.create<memref::LoadOp>(loc, collapsedWorkspace, iv);
   auto convertedValue =
       createTypeConversionOp(b, loc, loadedValue, filterDataType);
-  b.create<AffineStoreOp>(loc, convertedValue, collapsedFilter, iv);
+  b.create<memref::StoreOp>(loc, convertedValue, collapsedFilter, iv);
 
   b.eraseOp(op);
   return success();
@@ -1787,10 +1823,11 @@ void LowerMIOpenOpsStep1Pass::runOnOperation() {
   target.addIllegalOp<miopen::Conv2DOp, miopen::Conv2DBwdDataOp,
                       miopen::Conv2DBwdWeightOp>();
   target.addLegalOp<miopen::TransformOp, miopen::GridwiseGemmOp,
-                    miopen::GridwiseGemmV2Op>();
+                    miopen::GridwiseGemmV2Op, miopen::WorkgroupIdOp,
+                    miopen::WorkitemIdOp>();
   // Below are required legalize for the lowering of Conv2DBwdWeightOp
   target.addLegalDialect<arith::ArithmeticDialect, memref::MemRefDialect,
-                         AffineDialect>();
+                         AffineDialect, scf::SCFDialect>();
 
   RewritePatternSet patterns(ctx);
   patterns.add<Conv2DRewritePattern<Conv2DOp>,

--- a/mlir/test/mlir-miopen-lib/populate_bww.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_bww.mlir
@@ -25,7 +25,7 @@
 // KERNELCOUNT2: Kernel count=2
 // BIN2: ELF
 // BIN2: ELF
-// TUNING2_0: globalSize=1, localSize=1
+// TUNING2_0: globalSize=32768, localSize=64
 // TUNING2_1: globalSize{{.*}}localSize{{.*}}
 // DRIVER2: miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 0 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = true} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 // DRIVER2: miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 1 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = true} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
@@ -45,9 +45,9 @@
 // BIN3: ELF
 // BIN3: ELF
 // BIN3: ELF
-// TUNING3_0: globalSize=1, localSize=1
+// TUNING3_0: globalSize=32768, localSize=64
 // TUNING3_1: globalSize{{.*}}localSize{{.*}}
-// TUNING3_2: globalSize=1, localSize=1
+// TUNING3_2: globalSize=32768, localSize=64
 // DRIVER3: miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2, %arg3) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 0 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = true} : memref<1x1024x1024x1x1xf16>, memref<64x1x1024x14x14xf16>, memref<64x1x1024x14x14xf16>, memref<1x1024x1024x1x1xf32>
 // DRIVER3: miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2, %arg3) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 1 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = true} : memref<1x1024x1024x1x1xf16>, memref<64x1x1024x14x14xf16>, memref<64x1x1024x14x14xf16>, memref<1x1024x1024x1x1xf32>
 // DRIVER3: miopen.conv2d_bwd_weight(%arg0, %arg1, %arg2, %arg3) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], gemm_id = 2 : i32, input_layout = ["ni", "gi", "ci", "hi", "wi"], num_cu = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = true} : memref<1x1024x1024x1x1xf16>, memref<64x1x1024x14x14xf16>, memref<64x1x1024x14x14xf16>, memref<1x1024x1024x1x1xf32>


### PR DESCRIPTION
The utility kernels for backward weight convolutions were naive and performed badly. Use a better grid size / block size to increase parallelism in this PR.

Benchmark commmand:
```
./bin/miopen-gen --x2 --operation conv2d_bwd_weight -t f16 --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --groupsize 1 -ph | ./bin/mlir-miopen-driver -c | rocprof --stats ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./external/llvm-project/llvm/lib/libmlir_runner_utils.so --entry-point-result=void
```

This is a backward weight convolution which uses XDLOPS, in fp16, no padding along Gemm M/N/K. Therefore a 0-init kernel and a conversion kernel will be used.

at tip of `miopen-dialect`:

```
# cat results.stats.csv
"Name","Calls","TotalDurationNs","AverageNs","Percentage"
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_0.kd",1,290640047,290640047,51.83518016940135
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_2.kd",1,264794271,264794271,47.2256280123375
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_1.kd",1,5266052,5266052,0.9391918182611508
```

With this PR:
```
# cat results.stats.csv
"Name","Calls","TotalDurationNs","AverageNs","Percentage"
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_1.kd",1,5289100,5289100,99.4823779017496
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_2.kd",1,20960,20960,0.3942354352953568
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_0.kd",1,6560,6560,0.12338666295503534
```

`miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_1.kd` which is the actual backward convolution, originally takes only about 0.94% of execution time, now takes up 99.48%. It means the execution time of other 2 utility kernels have been greatly reduced via this PR.

This PR only covers backward weight convolution. I'll update backward data in #546 directly.