### PR TITLE
Enable non-xdlops int8 E2E tests

### DIFF
--- a/mlir/test/mlir-miopen-driver/auto_e2e/Int8_tests/lit.local.cfg
+++ b/mlir/test/mlir-miopen-driver/auto_e2e/Int8_tests/lit.local.cfg
@@ -1,2 +1,2 @@
-if not config.enable_miopen_driver_e2e_test or config.no_AMD_GPU or not config.xdlops:
+if not config.enable_miopen_driver_e2e_test or config.no_AMD_GPU :
   config.unsupported = True

--- a/mlir/tools/miopen-gen/miopen-gen.cpp
+++ b/mlir/tools/miopen-gen/miopen-gen.cpp
@@ -1760,8 +1760,8 @@ populateHostHarnessLogic(ModuleOp &module,
   // Run validation
   if (hasValidation) {
     if (validationType == "gpu" &&
-        ((genConfig.xdlops && genConfig.dataTypeStr == "f32") ||
-         genConfig.dataTypeStr == "f16" || genConfig.dataTypeStr == "bf16")) {
+        (genConfig.xdlops || genConfig.dataTypeStr == "f16" ||
+         genConfig.dataTypeStr == "bf16")) {
       // generate generic kernels
       Conv2dGenerator conv2dGenerator(genConfig);
       // use non-xdlops kernels to verify xdlops kernels


### PR DESCRIPTION
I've run fixed E2E tests on lockhart6 and they passed.