### PR TITLE
Pf buildbot

### DIFF
--- a/mlir/utils/buildbot/build-run.sh
+++ b/mlir/utils/buildbot/build-run.sh
@@ -56,17 +56,17 @@ fi
 # Proxy needed on lockhart hosts.
 # Define it here rather than master.cfg to keep it internal.
 case `hostname` in
-    x[10]*) proxy='http://172.23.0.2:3128' ;;
-    *)      proxy='' ;;
+    x[10]*) PROXY='http://172.23.0.2:3128' ;;
+    *)      PROXY='' ;;
 esac
 
-if [ -n "$proxy" ]; then
-    buildproxy="--build-arg http_proxy=${proxy} --build-arg https_proxy=${proxy}"
-    runproxy="-e http_proxy=${proxy} -e https_proxy=${proxy}"
+if [ -n "$PROXY" ]; then
+    BUILDPROXY="--build-arg http_proxy=${PROXY} --build-arg https_proxy=${PROXY}"
+    RUNPROXY="-e http_proxy=${PROXY} -e https_proxy=${PROXY}"
 else
-    buildproxy=''
-    runproxy=''
+    BUILDPROXY=''
+    RUNPROXY=''
 fi
 
-docker build ${buildproxy} -t "${IMAGE_NAME}:latest" .
-docker run -it --net=host --device=/dev/kfd --device=/dev/dri --group-add video --name buildbot --restart always ${runproxy} ${VOLUMES} ${ARGS} "${IMAGE_NAME}:latest" ${CMD}
+docker build ${BUILDPROXY} -t "${IMAGE_NAME}:latest" .
+docker run -it --net=host --device=/dev/kfd --device=/dev/dri --group-add video --name buildbot --restart always ${RUNPROXY} ${VOLUMES} ${ARGS} "${IMAGE_NAME}:latest" ${CMD}

--- a/mlir/utils/buildbot/build-run.sh
+++ b/mlir/utils/buildbot/build-run.sh
@@ -56,9 +56,17 @@ fi
 # Proxy needed on lockhart hosts.
 # Define it here rather than master.cfg to keep it internal.
 case `hostname` in
-    x[10]*) proxy='-e https_proxy=http://172.23.0.2:3128' ;;
+    x[10]*) proxy='http://172.23.0.2:3128' ;;
     *)      proxy='' ;;
 esac
 
-docker build -t "${IMAGE_NAME}:latest" .
-docker run -it --net=host --device=/dev/kfd --device=/dev/dri --group-add video --name buildbot --restart always ${proxy} ${VOLUMES} ${ARGS} "${IMAGE_NAME}:latest" ${CMD}
+if [ -n "$proxy" ]; then
+    buildproxy="--build-arg http_proxy=${proxy} --build-arg https_proxy=${proxy}"
+    runproxy="-e http_proxy=${proxy} -e https_proxy=${proxy}"
+else
+    buildproxy=''
+    runproxy=''
+fi
+
+docker build ${buildproxy} -t "${IMAGE_NAME}:latest" .
+docker run -it --net=host --device=/dev/kfd --device=/dev/dri --group-add video --name buildbot --restart always ${runproxy} ${VOLUMES} ${ARGS} "${IMAGE_NAME}:latest" ${CMD}

--- a/mlir/utils/buildbot/build-run.sh
+++ b/mlir/utils/buildbot/build-run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#===-- build_run.sh ------------------------------------------------------===//
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===----------------------------------------------------------------------===//
+# This script will build and run a docker image, using volumes for data.
+# Arguments:
+#     <path to Dockerfile>
+#     <path containing secrets>
+#     optional: <command to be executed in the container>
+#===----------------------------------------------------------------------===//
+
+set -eu
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+IMAGE_NAME="${1%/}"
+SECRET_STORAGE="$2"
+CMD=
+if [ "$#" -eq 3 ];
+then
+    CMD="$3"
+fi
+
+cd "${DIR}/${IMAGE_NAME}"
+
+# Mount a volume "workertest" to persit across test runs.
+# Use this to keep e.g.  a git checkout or partial build across runs
+if [[ $(docker volume ls | grep workertest | wc -l) == 0 ]] ; then
+    docker volume create workertest
+fi
+
+# Volume to presist the build cache e.g. ccache or sccache.
+# This will speed up local testing.
+if [[ $(docker volume ls | grep workercache | wc -l) == 0 ]] ; then
+    docker volume create workercache
+fi
+
+# Define arguments for mounting the volumes
+# These differ on Windows and Linux
+VOLUMES="-v ${SECRET_STORAGE}:/vol/secrets -v workertest:/vol/test -v workercache:/vol/ccache"
+if [ -n "${OS+x}" ] && [[  "${OS}" == "Windows_NT" ]] ; then
+    VOLUMES="-v ${SECRET_STORAGE}:c:\\volumes\\secrets -v workertest:c:\volumes\\test -v workercache:c:\sccache"
+fi
+
+# Set container arguments, if they are set in the environment:
+ARGS=""
+if [ -n "${BUILDBOT_PORT+x}" ] ; then
+    ARGS+=" -e BUILDBOT_PORT=${BUILDBOT_PORT}"
+fi
+if [ -n "${BUILDBOT_MASTER+x}" ] ; then
+    ARGS+=" -e BUILDBOT_MASTER=${BUILDBOT_MASTER}"
+fi
+
+# Proxy needed on lockhart hosts.
+# Define it here rather than master.cfg to keep it internal.
+case `hostname` in
+    x[10]*) proxy='-e https_proxy=http://172.23.0.2:3128' ;;
+    *)      proxy='' ;;
+esac
+
+docker build -t "${IMAGE_NAME}:latest" .
+docker run -it --net=host --device=/dev/kfd --device=/dev/dri --group-add video --name buildbot --restart always ${proxy} ${VOLUMES} ${ARGS} "${IMAGE_NAME}:latest" ${CMD}

--- a/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
@@ -1,0 +1,71 @@
+#===-- Dockerfile --------------------------------------------------------===//
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===----------------------------------------------------------------------===//
+# Docker image used for the mlir-rocm-mi200 builder
+#
+# Environment variables configurable at runtime:
+#    BUILDBOT_MASTER - server host to connect to
+#    BUILDBOT_PORT   - server port to connect to
+#===----------------------------------------------------------------------===//
+
+# Use the rocm/mlir image as base
+FROM rocm/mlir:rocm5.0-latest
+
+RUN apt-get update; \
+    apt-get install -y dumb-init; \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 ;\
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 ;\
+    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-10 100
+
+# LTS releases often bundle obsolete pip versions that cannot access newest
+# Linux binary wheels. This pinned version is not special: it was just current
+# at the time this was added. Refer to compatibility table:
+# https://github.com/pypa/manylinux
+RUN python3 -m pip install --upgrade pip
+
+# Refer to mlir/lib/Bindings/Python/requirements.txt. Listed explicitly here
+# and version pinned for consistency as this is a bot.
+RUN python3 -m pip install numpy pybind11 PyYAML
+
+# Install build bot (server was at 2.8.5-dev at time of writing).
+RUN pip3 install buildbot-worker
+
+# Workaround permissions issues when writing to named volumes
+# https://github.com/docker/compose/issues/3270#issuecomment-206214034
+RUN mkdir -p /vol/test /vol/ccache /vol/worker ; \
+    chmod -R 777 /vol
+
+# Volume to mount secrets into the container.
+VOLUME /vol/secrets
+# Volume to store data for local, manual testing of the container.
+VOLUME /vol/test
+# Volume to store ccache.
+VOLUME /vol/ccache
+ENV CCACHE_DIR=/vol/ccache
+# Volume for worker working directory.
+VOLUME /vol/worker
+
+# Create user account, some tests fail if run as root.
+RUN useradd buildbot --create-home
+WORKDIR /vol/worker
+
+# copy startup script
+COPY run.sh /home/buildbot/
+RUN chmod a+rx /home/buildbot/run.sh
+
+USER buildbot
+ENV WORKER_NAME="mlir-rocm-mi200"
+
+# Allow the server port of this agent to be configurable during deployment.
+# This way we can connect the same image to production and integration.
+# Ports:
+#   9990 - production
+#   9994 - integration
+#   9989 - testing
+ENV BUILDBOT_PORT="9989"
+ENV BUILDBOT_MASTER="localhost"
+
+CMD /home/buildbot/run.sh

--- a/mlir/utils/buildbot/mlir-rocm-mi200/run.sh
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#===-- run.sh -------------------------------------------------------------===//
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===----------------------------------------------------------------------===//
+# This script will start the buildbot worker
+#
+#===----------------------------------------------------------------------===//
+
+set -eu
+
+# Read the worker password from a mounted file.
+WORKER_PASSWORD=$(cat /vol/secrets/token)
+
+# Set up buildbot host and maintainer info.
+mkdir -p "${WORKER_NAME}/info/"
+echo "dl.mlse.buildbot@amd.com" > "${WORKER_NAME}/info/admin"
+
+# generate the host information of this worker
+(
+  uname -a ; \
+  cat /proc/cpuinfo | grep "model name" | head -n1 | cut -d " " -f 3- ;\
+  echo "number of cores: $(nproc)" ;\
+  rocm-smi --showdriverversion --showid --showmeminfo all ;\
+  lsb_release -d | cut -f 2- ; \
+  clang --version | head -n1 ; \
+  ld.lld-10 --version ; \
+  cmake --version | head -n1 ; \
+) > ${WORKER_NAME}/info/host
+
+#echo "Full rocm-smi output:"
+#rocm-smi -a
+
+echo "Host information:"
+cat ${WORKER_NAME}/info/host
+
+# create the folder structure
+echo "creating worker ${WORKER_NAME} at port ${BUILDBOT_PORT}..."
+buildbot-worker create-worker --keepalive=200 "${WORKER_NAME}" \
+  ${BUILDBOT_MASTER}:${BUILDBOT_PORT} "${WORKER_NAME}" "${WORKER_PASSWORD}"
+
+# start the worker, based on
+# https://hub.docker.com/r/buildbot/buildbot-worker/dockerfile
+echo "starting worker..."
+/usr/bin/dumb-init twistd --pidfile= --nodaemon -l - --python="${WORKER_NAME}/buildbot.tac"

--- a/mlir/utils/buildbot/mlir-rocm-mi200/token
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/token
@@ -1,0 +1,1 @@
+rocmmlir22


### PR DESCRIPTION
Gather the buildbot setup files under mlir/utils/buildbot so they don't get lost.  They're adapted from files in llvm-zorg/buildbot/google/docker, but don't quite fit there.

Start the buildbot on the intended worker host with
```
git clone https://github.com/ROCmSoftwarePlatform/llvm-project-mlir.git
cd ./llvm-project-mlir/mlir/utils/buildbot
export BUILDBOT_PORT=9994
export BUILDBOT_MASTER=lab.llvm.org
./build-run.sh mlir-rocm-mi200 `pwd`/mlir-rocm-mi200
```
build-run.sh is in this review.  It will build a docker image based on rocm/mlir:rocm5.0-latest using the Dockerfile here, culminating in running run.sh to start the buildbot worker in a docker container.  The worker will connect to the master and listen for commands;  the worker password is in the file named token.  The container will persist, keeping its data in a couple of docker volumes, and will try to restart if the system is rebooted.