### PR TITLE
MLIR#468: use miopen.transform instead of memref.expand_shape in TosaToMIOpen

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
@@ -260,10 +260,9 @@ public:
   void addDim(StringRef name, uint32_t dim, int64_t size);
 
   void expand(StringRef name, uint32_t dim, int64_t size);
-  void expand(ArrayRef<StringRef> names,
-              ArrayRef<uint32_t> dims,
+  void expand(ArrayRef<StringRef> names, ArrayRef<uint32_t> dims,
               ArrayRef<int64_t> sizes);
-  
+
   void slice(ArrayRef<StringRef> upperNames, ArrayRef<StringRef> lowerNames,
              ArrayRef<int64_t> begins, ArrayRef<int64_t> ends);
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
@@ -111,8 +111,8 @@ public:
   // The names live as long as the CoordTransformBuilder
   void getEndNames(SmallVectorImpl<StringRef> &names);
 
-  SmallString<8> startName(uint32_t dim);
-  SmallString<8> endName(uint32_t dim);
+  StringRef startName(uint32_t dim);
+  StringRef endName(uint32_t dim);
   uint32_t startIndex(StringRef name);
   uint32_t endIndex(StringRef name);
 
@@ -259,6 +259,11 @@ public:
   // Defines a dimension that is not mapped to any coordinates in the output
   void addDim(StringRef name, uint32_t dim, int64_t size);
 
+  void expand(StringRef name, uint32_t dim, int64_t size);
+  void expand(ArrayRef<StringRef> names,
+              ArrayRef<uint32_t> dims,
+              ArrayRef<int64_t> sizes);
+  
   void slice(ArrayRef<StringRef> upperNames, ArrayRef<StringRef> lowerNames,
              ArrayRef<int64_t> begins, ArrayRef<int64_t> ends);
 

--- a/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
+++ b/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
@@ -67,22 +67,22 @@ static bool isConstantZero(Value v) {
 
 static Value expandMemRef(ConversionPatternRewriter &rw, Operation *op,
                           Value operand, int idx = 4) {
-    auto loc = op->getLoc();
-    auto oprType = operand.getType().template cast<ShapedType>();
-    if (!oprType.hasStaticShape()) {
-      (void)rw.notifyMatchFailure(
-          op, "tosa to miopen conversion expects statically shaped tensors");
-      return Value();
-    }
-    auto shape = oprType.getShape();
+  auto loc = op->getLoc();
+  auto oprType = operand.getType().template cast<ShapedType>();
+  if (!oprType.hasStaticShape()) {
+    (void)rw.notifyMatchFailure(
+        op, "tosa to miopen conversion expects statically shaped tensors");
+    return Value();
+  }
+  auto shape = oprType.getShape();
 
-    SmallVector<StringRef, 8> names { "a", "b", "c", "d", "e", "f", "h", "i"};
-    names.resize(shape.size());
-    miopen::BottomUpCTBuilder transform(rw, names, shape);
-    transform.expand("g", idx, 1);
+  SmallVector<StringRef, 8> names{"a", "b", "c", "d", "e", "f", "h", "i"};
+  names.resize(shape.size());
+  miopen::BottomUpCTBuilder transform(rw, names, shape);
+  transform.expand("g", idx, 1);
 
-    return rw.create<miopen::TransformOp>(loc, operand, transform.get());
-} 
+  return rw.create<miopen::TransformOp>(loc, operand, transform.get());
+}
 
 static LogicalResult
 makeMIOpenConv2D(ConversionPatternRewriter &rw, Operation *op, Value input,

--- a/mlir/lib/Dialect/MIOpen/CoordTransformBuilder.cpp
+++ b/mlir/lib/Dialect/MIOpen/CoordTransformBuilder.cpp
@@ -547,7 +547,7 @@ void BottomUpCTBuilder::expand(ArrayRef<StringRef> names,
     ptDims.push_back(dim++);
   }
   passThrough(ptNames, ptDims, ptNames);
-  for (auto tuple : llvm::zip(names, dims, sizes)) { 
+  for (auto tuple : llvm::zip(names, dims, sizes)) {
     addDim(std::get<0>(tuple), std::get<1>(tuple), std::get<2>(tuple));
   }
 }

--- a/mlir/lib/Dialect/MIOpen/CoordTransformBuilder.cpp
+++ b/mlir/lib/Dialect/MIOpen/CoordTransformBuilder.cpp
@@ -177,11 +177,11 @@ void CoordTransformsBuilder::getEndNames(SmallVectorImpl<StringRef> &names) {
   }
 }
 
-SmallString<8> CoordTransformsBuilder::startName(uint32_t dim) {
+StringRef CoordTransformsBuilder::startName(uint32_t dim) {
   return startNames[dim];
 }
 
-SmallString<8> CoordTransformsBuilder::endName(uint32_t dim) {
+StringRef CoordTransformsBuilder::endName(uint32_t dim) {
   assert(endNames.count(dim) == 1 &&
          "Dimension not defined in ending dimension space");
   return endNames[dim];
@@ -521,6 +521,35 @@ int64_t BottomUpCTBuilder::paddingSign() const {
 void BottomUpCTBuilder::addDim(StringRef name, uint32_t dim, int64_t size) {
   defineDim(name, dim, size);
   addTransform(TransformType::AddDim, {size}, {}, {}, {name}, {dim});
+}
+
+void BottomUpCTBuilder::expand(StringRef name, uint32_t dim, int64_t size) {
+  SmallVector<StringRef, 8> names;
+  SmallVector<uint32_t, 8> dims;
+  for (uint32_t i = 0; i < nStartDims(); ++i) {
+    names.push_back(startName(i));
+    dims.push_back(i + (i >= dim ? 1 : 0));
+  }
+  passThrough(names, dims, names);
+  addDim(name, dim, size);
+}
+
+void BottomUpCTBuilder::expand(ArrayRef<StringRef> names,
+                               ArrayRef<uint32_t> dims,
+                               ArrayRef<int64_t> sizes) {
+  SmallVector<StringRef, 8> ptNames;
+  SmallVector<uint32_t, 8> ptDims;
+  uint32_t dim = 0;
+  for (uint32_t i = 0; i < nStartDims(); ++i) {
+    ptNames.push_back(startName(i));
+    while (std::find(dims.begin(), dims.end(), dim) != dims.end())
+      dim++;
+    ptDims.push_back(dim++);
+  }
+  passThrough(ptNames, ptDims, ptNames);
+  for (auto tuple : llvm::zip(names, dims, sizes)) { 
+    addDim(std::get<0>(tuple), std::get<1>(tuple), std::get<2>(tuple));
+  }
 }
 
 void BottomUpCTBuilder::slice(ArrayRef<StringRef> upperNames,

--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -80,7 +80,7 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
 
   typedef SmallVector<miopen::TransformOp, 4> TransformList;
 
-  Value bwTraceTo(Value inp, TransformList *transforms=nullptr) const {
+  Value bwTraceTo(Value inp, TransformList *transforms = nullptr) const {
     if (auto bt = inp.getDefiningOp<miopen::TransformOp>()) {
       if (transforms)
         transforms->push_back(bt);
@@ -275,8 +275,8 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
         assert(!twinpV1);
         twinpV1 = twinp_t;
       } else if (auto twinp_t =
-                 traceToThreadwiseCopy<miopen::ThreadwiseCopyV2Op>(
-                     inp, transforms)) {
+                     traceToThreadwiseCopy<miopen::ThreadwiseCopyV2Op>(
+                         inp, transforms)) {
         assert(!twinpV2);
         twinpV2 = twinp_t;
       }

--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -78,14 +78,17 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
     return Value();
   }
 
-  Value backtraceToAlloc(Value inp) const {
-    if (auto bt = inp.getDefiningOp<miopen::TransformOp>())
-      return backtraceToAlloc(bt->getOperand(0));
-    if (auto bt = inp.getDefiningOp<memref::ExpandShapeOp>())
-      return backtraceToAlloc(bt->getOperand(0));
-    if (auto bt = inp.getDefiningOp<memref::AllocOp>())
-      return inp;
+  typedef SmallVector<miopen::TransformOp, 4> TransformList;
+
+  Value bwTraceTo(Value inp, TransformList *transforms=nullptr) const {
+    if (auto bt = inp.getDefiningOp<miopen::TransformOp>()) {
+      if (transforms)
+        transforms->push_back(bt);
+      return bwTraceTo(bt->getOperand(0), transforms);
+    }
     if (auto bt = inp.getDefiningOp<miopen::GpuAllocOp>())
+      return inp;
+    if (auto bt = inp.getDefiningOp<memref::AllocOp>())
       return inp;
     return Value();
   }
@@ -93,16 +96,21 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
   Value makeThreadwiseCopy(PatternRewriter &b, Operation *miTWCopy,
                            Value inp) const {
     // 0. capture reg alloc for miTWCopy output regs
+    TransformList transforms;
     auto twinp = miTWCopy->getOperand(0);
-    auto miTransform = twinp.getDefiningOp<miopen::TransformOp>();
-    auto miTransformInp = miTransform->getOperand(0);
-    auto miAlloc = miTransformInp.getDefiningOp<miopen::GpuAllocOp>();
+    // auto miTransform = twinp.getDefiningOp<miopen::TransformOp>();
+    // auto miTransformInp = miTransform->getOperand(0);
+    // auto miAlloc = miTransformInp.getDefiningOp<miopen::GpuAllocOp>();
+    auto miAlloc = bwTraceTo(twinp, &transforms);
 
     // 1. clone reg alloc + transform
     BlockAndValueMapping cloningMap;
-    auto nAlloc = b.clone(*miAlloc, cloningMap);
-    cloningMap.map(miTransform->getOperand(0), nAlloc->getResult(0));
-    auto nTransform = b.clone(*miTransform, cloningMap);
+    auto nAlloc = b.clone(*miAlloc.getDefiningOp(), cloningMap);
+    Operation *nTransform = nAlloc;
+    for (auto transform : llvm::reverse(transforms)) {
+      cloningMap.map(transform->getOperand(0), nTransform->getResult(0));
+      nTransform = b.clone(*transform, cloningMap);
+    }
 
     // 2. clone twcopy for <addend> -> regs
     cloningMap.map(miTWCopy->getOperand(0), inp);
@@ -142,10 +150,6 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
       if (auto miTransform = transform.getDefiningOp<miopen::TransformOp>()) {
         cloningMap.map(miTransform->getOperand(0), ret);
         tcopy = b.clone(*miTransform, cloningMap);
-      } else if (auto laReshape =
-                     transform.getDefiningOp<memref::ExpandShapeOp>()) {
-        cloningMap.map(laReshape->getOperand(0), ret);
-        tcopy = b.clone(*laReshape, cloningMap);
       } else {
         assert(0);
       }
@@ -169,7 +173,7 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
       if (auto op = dyn_cast<linalg::GenericOp>(use.getOwner())) {
         // reader
       } else if (!nextVal) {
-        nextVal = getOpResult<memref::ExpandShapeOp>(use);
+        nextVal = getOpResult<miopen::TransformOp>(use);
         transforms.push_back(nextVal);
       }
       cnt++;
@@ -200,7 +204,7 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
                              Operation *twcopy) const {
     auto ctx = laGeneric.getContext();
     auto loc = laGeneric.getLoc();
-    Value twout = backtraceToAlloc(twcopy->getOperand(1));
+    Value twout = bwTraceTo(twcopy->getOperand(1));
     auto regType = laIn.getType().template cast<MemRefType>();
     auto laOut = b.create<miopen::GpuAllocOp>(loc, regType);
 
@@ -265,16 +269,22 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
         return fail;
       }
       // first trace to back to regs, then forward to twcopy
+      SmallVector<Value, 5> transforms_l;
       if (auto twinp_t = traceToThreadwiseCopy<miopen::ThreadwiseCopyOp>(
-              inp, transforms)) {
+              inp, transforms_l)) {
         // 1.2. Only one input should trace to twcopy
         assert(!twinpV1);
         twinpV1 = twinp_t;
-      } else if (auto twinp_t =
-                     traceToThreadwiseCopy<miopen::ThreadwiseCopyV2Op>(
-                         inp, transforms)) {
-        assert(!twinpV2);
-        twinpV2 = twinp_t;
+        transforms = transforms_l;
+      } else {
+        transforms_l.clear();
+        if (auto twinp_t =
+            traceToThreadwiseCopy<miopen::ThreadwiseCopyV2Op>(
+                inp, transforms)) {
+          assert(!twinpV2);
+          twinpV2 = twinp_t;
+          transforms = transforms_l;
+        }
       }
     }
 
@@ -305,7 +315,7 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
 
         // 2.6. Reset output on threadwise_copy
         auto mrReshape =
-            transforms.front().getDefiningOp<memref::ExpandShapeOp>();
+            transforms.front().getDefiningOp<miopen::TransformOp>();
         mrReshape->setOperand(0, out);
 
         return success();
@@ -373,7 +383,7 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
 
         // 2.6. Reset twcopy output to point to old laGeneric output
         auto mrReshape =
-            transforms.front().getDefiningOp<memref::ExpandShapeOp>();
+            transforms.front().getDefiningOp<miopen::TransformOp>();
         mrReshape->setOperand(0, out);
       }
     }

--- a/mlir/lib/Dialect/MIOpen/Transforms/CopyOpt.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/CopyOpt.cpp
@@ -70,8 +70,8 @@ template <typename T> struct MICORewritePattern : public OpRewritePattern<T> {
         }
         if (!writer)
           return fail;
-      } else if (auto mrop = dyn_cast<memref::ExpandShapeOp>(use.getOwner())) {
-        // 1.1 Input of memref.expand_shape
+      } else if (auto mrop = dyn_cast<miopen::TransformOp>(use.getOwner())) {
+        // 1.1 Input of miopen.transform
         if (writer)
           return fail;
         Value mrval = mrop;


### PR DESCRIPTION
Since the conversion of tosa.conv2d will generate an miopen.conv2d which requires 5D tensor parameters, we need to expand the shape of the tosa.conv2d parameters by adding a 'G; dimension of size 1. Currently this is accomplished with a memref.expand_shape operation but this causes problems if we need to insert an miopen.transform<broadcast> for bias-add. The chain of miopen.transforms cannot be broken by memref operations (as currently implemented).

This change will apply only to tosa.conv2d and tosa.matmul operation parameters.

See: https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/468