### PR TITLE
Allow vector loads in backward weight convolutions.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -372,13 +372,11 @@ protected:
       // FIXME: figure out the best vectorization length for f16 and bf16.
       vectorizationSize = 4;
     }
-    // FIXME: set vectorizationSize be 1 for backward data and backward
-    // weight for now.
+    // FIXME: set vectorizationSize be 1 for backward data for now.
     // The logic for deciding vectorization size and dimension for
-    // backward data and backward weight has to be reviewed.
+    // backward data has to be reviewed.
     auto opType = ctx.opType;
-    if (opType == mlir::miopen::ConvOpType::BwdData ||
-        opType == mlir::miopen::ConvOpType::BwdWeight) {
+    if (opType == mlir::miopen::ConvOpType::BwdData) {
       vectorizationSize = 1;
     }
 


### PR DESCRIPTION
This PR enables vector loads for backward weight convolution.

Combined with #548 and #551, the speed of backward weight convolution would be improved even further.

Benchmark commmand:
```
./bin/miopen-gen --x2 --operation conv2d_bwd_weight -t f16 --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --groupsize 1 -ph | ./bin/mlir-miopen-driver -c | rocprof --stats ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./external/llvm-project/llvm/lib/libmlir_runner_utils.so --entry-point-result=void
```

With PR #548 + #551:

```
# cat results.stats.csv
"Name","Calls","TotalDurationNs","AverageNs","Percentage"
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_1.kd",1,1035033,1035033,97.36602720705754
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_2.kd",1,20640,20640,1.9416142302261548
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_0.kd",1,7360,7360,0.6923585627163032
```
Total time: `1063033`.

With PR #548 + #551 + this PR:
```
# cat results.stats.csv
"Name","Calls","TotalDurationNs","AverageNs","Percentage"
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_1.kd",1,955680,955680,97.16935090287946
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_2.kd",1,20480,20480,2.082316577192126
"miopen_conv2d_bwd_weight_gkcyx_ngchw_ngkhw_0.kd",1,7360,7360,0.7483325199284203
```
Total time: `983520`. About 7.5% improvement.