### PR TITLE
Add a 'render' group in Dockerfile, because some CI hosts have /dev/k…

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -65,6 +65,9 @@ RUN ln -s /usr/bin/clang-10 /usr/bin/clang;\
 
 # --------------------- Section 2: MIOpen dialect setups -----------------
 
+# Need "render" group because some CI hosts have /dev/kfd under it.
+RUN groupadd -g 109 render
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   apt-utils \
   apt-transport-https \


### PR DESCRIPTION
…fd under that group instead of 'video'.