### PR TITLE
Refactor how dimension names / sizes are fetched in tuning and lowering pipeline.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
@@ -46,6 +46,7 @@
 //===----------------------------------------------------------------------===//
 //  MIOpen Dialect
 //===----------------------------------------------------------------------===//
+#include "mlir/Dialect/MIOpen/MIOpenOpTraits.h"
 #include "mlir/Dialect/MIOpen/MIOpenOpsDialect.h.inc"
 #include "mlir/Dialect/MIOpen/MIOpenTypes.h.inc"
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOpTraits.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOpTraits.h
@@ -1,0 +1,31 @@
+//===- MIOpenOpTraits.h - MLIR MIOpen dialect operation traits --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares C++ classes for some of operation traits in the MIOpen
+// dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_MIOPEN_OPTRAITS_H_
+#define MLIR_DIALECT_MIOPEN_OPTRAITS_H_
+
+#include "mlir/IR/OpDefinition.h"
+
+namespace mlir {
+namespace OpTrait {
+namespace miopen {
+
+/// An operation trait for convolution ops.
+template <typename ConcreteType>
+class ConvolutionOp : public TraitBase<ConcreteType, ConvolutionOp> {};
+
+} // namespace miopen
+} // namespace OpTrait
+} // namespace mlir
+
+#endif // MLIR_DIALECT_MIOPEN_OPTRAITS_H_

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -27,6 +27,8 @@ class MIOpen_Op<string mnemonic, list<Trait> traits = []> :
   }];
 }
 
+def ConvolutionOp : NativeOpTrait<"miopen::ConvolutionOp">;
+
 def TransformMapArrayAttr : TypedArrayAttrBase<MIOpen_TransformMapAttr,
   "Coordinate transforms array attribute, giving the sequence of transform maps applicable to a value, uppermost to lowermost"> {}
 
@@ -36,7 +38,7 @@ def ArgTransformsAttr : TypedArrayAttrBase<TransformMapArrayAttr,
 class ArgTransforms<int n> : Confined<ArgTransformsAttr, [ArrayCount<n>]>;
 
 def MIOpen_Conv2DOp :
-    MIOpen_Op<"conv2d">,
+    MIOpen_Op<"conv2d", [ConvolutionOp]>,
     Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [5]>:$filter,
                    MemRefRankOf<[F32, F16, BF16, I8], [5]>:$input,
                    MemRefRankOf<[F32, F16, BF16, I32], [5]>:$output)> {
@@ -51,7 +53,7 @@ def MIOpen_Conv2DOp :
 }
 
 def MIOpen_Conv2DBwdDataOp :
-    MIOpen_Op<"conv2d_bwd_data">,
+    MIOpen_Op<"conv2d_bwd_data", [ConvolutionOp]>,
     Arguments<(ins MemRefRankOf<[F32, F16, BF16], [5]>:$filter,
                    MemRefRankOf<[F32, F16, BF16], [5]>:$input,
                    MemRefRankOf<[F32, F16, BF16], [5]>:$output)> {
@@ -66,7 +68,7 @@ def MIOpen_Conv2DBwdDataOp :
 }
 
 def MIOpen_Conv2DBwdWeightOp :
-    MIOpen_Op<"conv2d_bwd_weight">,
+    MIOpen_Op<"conv2d_bwd_weight", [ConvolutionOp]>,
     Arguments<(ins MemRefRankOf<[F32, F16, BF16], [5]>:$filter,
                    MemRefRankOf<[F32, F16, BF16], [5]>:$input,
                    MemRefRankOf<[F32, F16, BF16], [5]>:$output,

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -59,6 +59,67 @@ inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo) {
 std::tuple<Value, ArrayAttr> untransform(OpBuilder &b, Value transformed,
                                          ArrayAttr existing = nullptr);
 
+template <typename T>
+inline std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                  int64_t, int64_t>
+fetchDimensions(T &op) {
+  auto filterLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("filter_layout");
+  auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
+  auto outputLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("output_layout");
+
+  // Get shape of filter tensor.
+  auto filterType = op.filter().getType().template cast<MemRefType>();
+  auto filterShape = filterType.getShape();
+
+  // Get shape of input tensor.
+  auto inputType = op.input().getType().template cast<MemRefType>();
+  auto inputShape = inputType.getShape();
+
+  // Get shape of output tensor.
+  auto outputType = op.output().getType().template cast<MemRefType>();
+  auto outputShape = outputType.getShape();
+
+  // get y, x, ho, wo, hi, wi, k, c, n
+  int64_t y, x, ho, wo, hi, wi, k, c, n;
+  y = x = ho = wo = hi = wi = k = c = n = 0;
+
+  for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
+    auto filterAttr =
+        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
+    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
+    auto outputAttr =
+        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
+
+    if (filterAttr.getValue() == "y") {
+      y = filterShape[i];
+    } else if (filterAttr.getValue() == "x") {
+      x = filterShape[i];
+    } else if (filterAttr.getValue() == "k") {
+      k = filterShape[i];
+    } else if (filterAttr.getValue() == "c") {
+      c = filterShape[i];
+    }
+
+    if (inputAttr.getValue() == "hi") {
+      hi = inputShape[i];
+    } else if (inputAttr.getValue() == "wi") {
+      wi = inputShape[i];
+    } else if (inputAttr.getValue() == "ni") {
+      n = inputShape[i];
+    }
+
+    if (outputAttr.getValue() == "ho") {
+      ho = outputShape[i];
+    } else if (outputAttr.getValue() == "wo") {
+      wo = outputShape[i];
+    }
+  }
+
+  return std::make_tuple(y, x, ho, wo, hi, wi, k, c, n);
+}
+
 } // end namespace miopen
 } // end namespace mlir
 #endif

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -60,6 +60,32 @@ std::tuple<Value, ArrayAttr> untransform(OpBuilder &b, Value transformed,
                                          ArrayAttr existing = nullptr);
 
 template <typename T>
+inline std::tuple<llvm::SmallVector<StringRef, 5>,
+                  llvm::SmallVector<StringRef, 5>,
+                  llvm::SmallVector<StringRef, 5>>
+fetchDimensionNames(T &op) {
+  auto filterLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("filter_layout");
+  auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
+  auto outputLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("output_layout");
+
+  llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
+  for (size_t i = 0; i < filterLayoutAttr.size(); ++i) {
+    auto filterAttr =
+        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
+    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
+    auto outputAttr =
+        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
+
+    filterNames.push_back(filterAttr.getValue());
+    inputNames.push_back(inputAttr.getValue());
+    outputNames.push_back(outputAttr.getValue());
+  }
+  return std::make_tuple(filterNames, inputNames, outputNames);
+}
+
+template <typename T>
 inline std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
                   int64_t, int64_t>
 fetchDimensions(T &op) {

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -59,8 +59,15 @@ inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo) {
 std::tuple<Value, ArrayAttr> untransform(OpBuilder &b, Value transformed,
                                          ArrayAttr existing = nullptr);
 
-std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
-           int64_t, int64_t>
+/// Given a convolution `op`, obtain the maps which contains the mapping between
+/// dimension names and dimension sizes for filter, input, and output memrefs.
+/// `op` shall possess ConvolutionOp trait.
+/// The return value would be a tuple which contains 3 maps.
+/// The first one is the map for filter memref.
+/// The second one is the map for input memref.
+/// The third one is the map for the output memref.
+std::tuple<llvm::StringMap<int64_t>, llvm::StringMap<int64_t>,
+           llvm::StringMap<int64_t>>
 fetchDimensions(Operation *op);
 
 } // end namespace miopen

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -59,66 +59,9 @@ inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo) {
 std::tuple<Value, ArrayAttr> untransform(OpBuilder &b, Value transformed,
                                          ArrayAttr existing = nullptr);
 
-template <typename T>
-inline std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
-                  int64_t, int64_t>
-fetchDimensions(T &op) {
-  auto filterLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("filter_layout");
-  auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
-  auto outputLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("output_layout");
-
-  // Get shape of filter tensor.
-  auto filterType = op.filter().getType().template cast<MemRefType>();
-  auto filterShape = filterType.getShape();
-
-  // Get shape of input tensor.
-  auto inputType = op.input().getType().template cast<MemRefType>();
-  auto inputShape = inputType.getShape();
-
-  // Get shape of output tensor.
-  auto outputType = op.output().getType().template cast<MemRefType>();
-  auto outputShape = outputType.getShape();
-
-  // get y, x, ho, wo, hi, wi, k, c, n
-  int64_t y, x, ho, wo, hi, wi, k, c, n;
-  y = x = ho = wo = hi = wi = k = c = n = 0;
-
-  for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
-    auto filterAttr =
-        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto outputAttr =
-        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
-
-    if (filterAttr.getValue() == "y") {
-      y = filterShape[i];
-    } else if (filterAttr.getValue() == "x") {
-      x = filterShape[i];
-    } else if (filterAttr.getValue() == "k") {
-      k = filterShape[i];
-    } else if (filterAttr.getValue() == "c") {
-      c = filterShape[i];
-    }
-
-    if (inputAttr.getValue() == "hi") {
-      hi = inputShape[i];
-    } else if (inputAttr.getValue() == "wi") {
-      wi = inputShape[i];
-    } else if (inputAttr.getValue() == "ni") {
-      n = inputShape[i];
-    }
-
-    if (outputAttr.getValue() == "ho") {
-      ho = outputShape[i];
-    } else if (outputAttr.getValue() == "wo") {
-      wo = outputShape[i];
-    }
-  }
-
-  return std::make_tuple(y, x, ho, wo, hi, wi, k, c, n);
-}
+std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+           int64_t, int64_t>
+fetchDimensions(Operation *op);
 
 } // end namespace miopen
 } // end namespace mlir

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -60,32 +60,6 @@ std::tuple<Value, ArrayAttr> untransform(OpBuilder &b, Value transformed,
                                          ArrayAttr existing = nullptr);
 
 template <typename T>
-inline std::tuple<llvm::SmallVector<StringRef, 5>,
-                  llvm::SmallVector<StringRef, 5>,
-                  llvm::SmallVector<StringRef, 5>>
-fetchDimensionNames(T &op) {
-  auto filterLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("filter_layout");
-  auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
-  auto outputLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("output_layout");
-
-  llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
-  for (size_t i = 0; i < filterLayoutAttr.size(); ++i) {
-    auto filterAttr =
-        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto outputAttr =
-        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
-
-    filterNames.push_back(filterAttr.getValue());
-    inputNames.push_back(inputAttr.getValue());
-    outputNames.push_back(outputAttr.getValue());
-  }
-  return std::make_tuple(filterNames, inputNames, outputNames);
-}
-
-template <typename T>
 inline std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
                   int64_t, int64_t>
 fetchDimensions(T &op) {

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -67,14 +67,14 @@ void AffixTuningParameters::affixBackwardWeightUtilityKernels(
 
     ConvolutionContext convContext = populateConvContext(op);
 
-    // get y, x, ho, wo, hi, wi, k, c, n
-    int64_t y, x, ho, wo, hi, wi, k, c, n;
-    std::tie(y, x, ho, wo, hi, wi, k, c, n) = fetchDimensions(op);
+    // Fetch convolution dimensions.
+    llvm::StringMap<int64_t> filterDim, inputDim, outputDim;
+    std::tie(filterDim, inputDim, outputDim) = fetchDimensions(op);
 
     int64_t gemmMSize, gemmNSize, gemmKSize;
-    gemmMSize = k;
-    gemmKSize = n * ho * wo;
-    gemmNSize = c * y * x;
+    gemmMSize = filterDim["k"];
+    gemmKSize = outputDim["n"] * outputDim["ho"] * outputDim["wo"];
+    gemmNSize = filterDim["c"] * filterDim["y"] * filterDim["x"];
 
     int64_t gemmMExtra, gemmNExtra, gemmKExtra;
     gemmMExtra = gemmNExtra = gemmKExtra = 0;
@@ -120,17 +120,17 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
 
   ConvolutionContext convContext = populateConvContext(op);
 
-  // get y, x, ho, wo, hi, wi, k, c, n
-  int64_t y, x, ho, wo, hi, wi, k, c, n;
-  std::tie(y, x, ho, wo, hi, wi, k, c, n) = fetchDimensions(op);
+  // Fetch convolution dimensions.
+  llvm::StringMap<int64_t> filterDim, inputDim, outputDim;
+  std::tie(filterDim, inputDim, outputDim) = fetchDimensions(op);
 
   int64_t gemmMSize, gemmNSize, gemmKSize;
   // FIXME : support forward convolution only right now.
   // compute we should use extra padding kernel or not
   // c,k already / g ,so we can skip / g here
-  gemmMSize = k;
-  gemmKSize = c * y * x;
-  gemmNSize = n * ho * wo;
+  gemmMSize = filterDim["k"];
+  gemmKSize = filterDim["c"] * filterDim["y"] * filterDim["x"];
+  gemmNSize = outputDim["n"] * outputDim["ho"] * outputDim["wo"];
 
   int64_t gemmMExtra, gemmNExtra, gemmKExtra;
   gemmMExtra = gemmNExtra = gemmKExtra = 0;

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -268,12 +268,6 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto archAttr = op->template getAttrOfType<StringAttr>("arch");
   auto numCuAttr = op->template getAttrOfType<IntegerAttr>("num_cu");
 
-  auto filterLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("filter_layout");
-  auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
-  auto outputLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("output_layout");
-
   auto dilationsAttr = op->template getAttrOfType<ArrayAttr>("dilations");
   auto stridesAttr = op->template getAttrOfType<ArrayAttr>("strides");
   auto paddingAttr = op->template getAttrOfType<ArrayAttr>("padding");
@@ -343,17 +337,7 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   std::tie(y, x, ho, wo, hi, wi, k, c, n) = fetchDimensions(op);
 
   llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
-  for (size_t i = 0; i < filterLayoutAttr.size(); ++i) {
-    auto filterAttr =
-        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto outputAttr =
-        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
-
-    filterNames.push_back(filterAttr.getValue());
-    inputNames.push_back(inputAttr.getValue());
-    outputNames.push_back(outputAttr.getValue());
-  }
+  std::tie(filterNames, inputNames, outputNames) = fetchDimensionNames(op);
 
   // calculate gemmKBlocks
   // static const int64_t MaxSubBlockNum = 2048 / standardBockNum;
@@ -547,12 +531,6 @@ LogicalResult backwardData(Conv2DBwdDataOp op, PatternRewriter &b) {
   auto archAttr = op->template getAttrOfType<StringAttr>("arch");
   auto numCuAttr = op->template getAttrOfType<IntegerAttr>("num_cu");
 
-  auto filterLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("filter_layout");
-  auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
-  auto outputLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("output_layout");
-
   auto dilationsAttr = op->template getAttrOfType<ArrayAttr>("dilations");
   auto stridesAttr = op->template getAttrOfType<ArrayAttr>("strides");
   auto paddingAttr = op->template getAttrOfType<ArrayAttr>("padding");
@@ -593,17 +571,7 @@ LogicalResult backwardData(Conv2DBwdDataOp op, PatternRewriter &b) {
   std::tie(y, x, ho, wo, hi, wi, k, c, n) = fetchDimensions(op);
 
   llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
-  for (size_t i = 0; i < filterLayoutAttr.size(); ++i) {
-    auto filterAttr =
-        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
-    auto outputAttr =
-        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
-
-    filterNames.push_back(filterAttr.getValue());
-    inputNames.push_back(inputAttr.getValue());
-    outputNames.push_back(outputAttr.getValue());
-  }
+  std::tie(filterNames, inputNames, outputNames) = fetchDimensionNames(op);
 
   if (failed(
           checkNames(filterNames, {"k", "g", "c", "y", "x"}, "filter", op)) ||
@@ -1089,13 +1057,6 @@ template <typename T> struct Conv2DRewritePattern : public OpRewritePattern<T> {
     auto KPackAttr = op->template getAttrOfType<IntegerAttr>("kpack");
     int64_t KPack = KPackAttr.getInt();
 
-    auto filterLayoutAttr =
-        op->template getAttrOfType<ArrayAttr>("filter_layout");
-    auto inputLayoutAttr =
-        op->template getAttrOfType<ArrayAttr>("input_layout");
-    auto outputLayoutAttr =
-        op->template getAttrOfType<ArrayAttr>("output_layout");
-
     auto dilationsAttr = op->template getAttrOfType<ArrayAttr>("dilations");
     auto stridesAttr = op->template getAttrOfType<ArrayAttr>("strides");
     auto paddingAttr = op->template getAttrOfType<ArrayAttr>("padding");
@@ -1136,17 +1097,7 @@ template <typename T> struct Conv2DRewritePattern : public OpRewritePattern<T> {
     std::tie(y, x, ho, wo, hi, wi, k, c, n) = fetchDimensions(op);
 
     llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
-    for (size_t i = 0; i < filterLayoutAttr.size(); ++i) {
-      auto filterAttr =
-          filterLayoutAttr.getValue()[i].template cast<StringAttr>();
-      auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
-      auto outputAttr =
-          outputLayoutAttr.getValue()[i].template cast<StringAttr>();
-
-      filterNames.push_back(filterAttr.getValue());
-      inputNames.push_back(inputAttr.getValue());
-      outputNames.push_back(outputAttr.getValue());
-    }
+    std::tie(filterNames, inputNames, outputNames) = fetchDimensionNames(op);
 
     if (failed(
             checkNames(filterNames, {"k", "g", "c", "y", "x"}, "filter", op)) ||

--- a/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
@@ -7,6 +7,7 @@
 //===-----------------------------------------------------===//
 
 #include "mlir/Dialect/MIOpen/utility/loweringUtils.h"
+#include "mlir/Dialect/MIOpen/MIOpenOpTraits.h"
 
 namespace mlir {
 namespace miopen {
@@ -26,6 +27,8 @@ std::tuple<Value, ArrayAttr> untransform(OpBuilder &b, Value transformed,
 std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
            int64_t, int64_t>
 fetchDimensions(Operation *op) {
+  assert(op->hasTrait<OpTrait::miopen::ConvolutionOp>());
+
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");
   auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");

--- a/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
@@ -22,5 +22,65 @@ std::tuple<Value, ArrayAttr> untransform(OpBuilder &b, Value transformed,
   }
   return {ret, b.getArrayAttr(transformList)};
 }
+
+std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+           int64_t, int64_t>
+fetchDimensions(Operation *op) {
+  auto filterLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("filter_layout");
+  auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
+  auto outputLayoutAttr =
+      op->template getAttrOfType<ArrayAttr>("output_layout");
+
+  // Get shape of filter tensor.
+  auto filterType = op->getOperand(0).getType().template cast<MemRefType>();
+  auto filterShape = filterType.getShape();
+
+  // Get shape of input tensor.
+  auto inputType = op->getOperand(1).getType().template cast<MemRefType>();
+  auto inputShape = inputType.getShape();
+
+  // Get shape of output tensor.
+  auto outputType = op->getOperand(2).getType().template cast<MemRefType>();
+  auto outputShape = outputType.getShape();
+
+  // get y, x, ho, wo, hi, wi, k, c, n
+  int64_t y, x, ho, wo, hi, wi, k, c, n;
+  y = x = ho = wo = hi = wi = k = c = n = 0;
+
+  for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
+    auto filterAttr =
+        filterLayoutAttr.getValue()[i].template cast<StringAttr>();
+    auto inputAttr = inputLayoutAttr.getValue()[i].template cast<StringAttr>();
+    auto outputAttr =
+        outputLayoutAttr.getValue()[i].template cast<StringAttr>();
+
+    if (filterAttr.getValue() == "y") {
+      y = filterShape[i];
+    } else if (filterAttr.getValue() == "x") {
+      x = filterShape[i];
+    } else if (filterAttr.getValue() == "k") {
+      k = filterShape[i];
+    } else if (filterAttr.getValue() == "c") {
+      c = filterShape[i];
+    }
+
+    if (inputAttr.getValue() == "hi") {
+      hi = inputShape[i];
+    } else if (inputAttr.getValue() == "wi") {
+      wi = inputShape[i];
+    } else if (inputAttr.getValue() == "ni") {
+      n = inputShape[i];
+    }
+
+    if (outputAttr.getValue() == "ho") {
+      ho = outputShape[i];
+    } else if (outputAttr.getValue() == "wo") {
+      wo = outputShape[i];
+    }
+  }
+
+  return std::make_tuple(y, x, ho, wo, hi, wi, k, c, n);
+}
 } // namespace miopen
 } // namespace mlir

--- a/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
@@ -37,7 +37,8 @@ static llvm::StringMap<int64_t> canonicalizeDims(ArrayRef<int64_t> dims,
 std::tuple<llvm::StringMap<int64_t>, llvm::StringMap<int64_t>,
            llvm::StringMap<int64_t>>
 fetchDimensions(Operation *op) {
-  assert(op->hasTrait<OpTrait::miopen::ConvolutionOp>());
+  assert(op->hasTrait<OpTrait::miopen::ConvolutionOp>() &&
+         "Op is not a convolution.");
 
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");


### PR DESCRIPTION
Refactor how dimension names / sizes are fetched in tuning and lowering pipeline.

Introduce a `ConvolutionOp` trait.
Steal the idea of `canonicalizeDims` currently in use in the generator, and teach `fetchDimensions` to return 3 maps instead of a list of scalar values. Use the maps in the tuning and lowering pipeline.

No attempt is made to consolidate data structures between tuning and generator logic yet. It would be addressed in separate PRs.