### PR TITLE
Fix clang-tidy error by including cstdint.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/UtilityParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/UtilityParams.h
@@ -13,6 +13,8 @@
 #ifndef MLIR_DIALECT_MIOPEN_UTILITY_PARAMS_H
 #define MLIR_DIALECT_MIOPEN_UTILITY_PARAMS_H
 
+#include <cstdint>
+
 namespace mlir {
 namespace miopen {
 


### PR DESCRIPTION
Fix clang-tidy error after #548 was merged.