### PR TITLE
Fix int8 verifier

### DIFF
--- a/mlir/tools/miopen-gen/miopen-gen.cpp
+++ b/mlir/tools/miopen-gen/miopen-gen.cpp
@@ -1291,7 +1291,6 @@ static void emitPrintTensor(OpBuilder &b, mlir::Value var, bool flag = true) {
 static FuncOp
 createVerifierFunc(ModuleOp &module, const KernelIF &kernel,
                    const mlir::Conv2dGenerator::Config &genConfig) {
-
   auto kfunc = kernel.func;
   std::string funcName = kfunc.getName().str() + "_verify";
   FuncOp func = module.lookupSymbol<FuncOp>(funcName);
@@ -1672,13 +1671,13 @@ populateHostHarnessLogic(ModuleOp &module,
     if (isCPUKernel) {
       assert(elemType.isF32() || elemType.isInteger(8) ||
              elemType.isInteger(32));
-      if (tensorDataType == "f32")
+      if (genConfig.dataTypeStr == "f32")
         elemType = b.getF32Type();
-      else if (tensorDataType == "f16")
+      else if (genConfig.dataTypeStr == "f16")
         elemType = b.getF16Type();
-      else if (tensorDataType == "bf16")
+      else if (genConfig.dataTypeStr == "bf16")
         elemType = b.getBF16Type();
-      else if (tensorDataType == "i8") {
+      else if (genConfig.dataTypeStr == "i8") {
         elemType = b.getI8Type();
         if (idx == 2) {
           elemType = b.getIntegerType(32);
@@ -1710,7 +1709,7 @@ populateHostHarnessLogic(ModuleOp &module,
         (isCPUKernel && (elemType.isF16() || elemType.isBF16()))) {
       // Emit validation var
       mlir::Type valElemType = floatType;
-      if (tensorDataType == "i8") {
+      if (genConfig.dataTypeStr == "i8") {
         valElemType = elemType;
       }
       auto valType = MemRefType::get(paramMRType.getShape(), valElemType);

--- a/mlir/utils/Resnext101Config.toml
+++ b/mlir/utils/Resnext101Config.toml
@@ -85,3 +85,10 @@ config = "-batchsize=64 -groupsize=1 -in_channels=64 -in_h=56 -in_w=56 -out_chan
 
 [[suite.test]]
 config = "-batchsize=64 -groupsize=1 -in_channels=64 -in_h=56 -in_w=56 -out_channels=256 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --conv_stride_h=1 --conv_stride_w=1 --padding_h=0 --padding_w=0"
+
+[[suite.test]]
+config = "-batchsize=256 -groupsize=1 -in_channels=3 -in_h=224 -in_w=224 -out_channels=64 -fil_h=7 -fil_w=7 --dilation_h=1 --dilation_w=1 --conv_stride_h=2 --conv_stride_w=2 --padding_h=3 --padding_w=3"
+[[suite.test.exclude]]
+name = "operation"
+values = ["conv2d_bwd_data"]
+


### PR DESCRIPTION
Fix a bug in cpu verifier that misused data type when --conv-config is used.

Also add a config in Resnext101Config.toml which was missing from my previous PR. E2E tests were generated correctly. Somehow I missed the config when I committed.