### PR TITLE
Adding kpack xdlops gemm implementation for i8

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -711,11 +711,11 @@ def MIOpen_BlockwiseGemmV2Op:
                    MemRefOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
+                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferA,
                    MemRefOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
+                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
                    Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
     Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>: $vectorDs)> {
   let summary = "Blockwise GEMM XDLOPS version";
@@ -784,11 +784,11 @@ def MIOpen_XdlopsGemmV2Op:
                    MemRefOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4], [I8]>]>:$bufferA,
+                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferA,
                    MemRefOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4], [I8]>]>:$bufferB,
+                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
                    Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
     Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorDs)> {
   let summary = "XDLOPS GEMM V2";

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -1033,9 +1033,10 @@ private:
       return failure();
     }
 
-    // XXX FIXME: Ignore KReduction XDLOPS path for forward and backward weight
-    // convolution now. These M/NPerBlock combinations will result in lowering
-    // errors at tuning.
+    // TODO remove : Ignore KReduction XDLOPS path for forward and backward
+    // weight convolution now (unless int8). These M/NPerBlock combinations used
+    // to result in lowering errors at tuning. Once non-int8 types are tested,
+    // we should get rid of this limitation.
     if (param.gemmKPack > 1 && !dataType.isInteger(8) &&
         ((ctx.getOpType() == miopen::ConvOpType::Fwd) ||
          (ctx.getOpType() == miopen::ConvOpType::BwdWeight))) {

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -1033,29 +1033,6 @@ private:
       return failure();
     }
 
-    if (dataType.isInteger(8)) {
-      // kpack for int8 must be larger than kbase of 4, which means
-      // kpack must be at least 4, once enabled.
-      if (param.gemmKPack == 2) {
-        return failure();
-      }
-
-      // When kpack is tunred off, K tile size must be larger than or
-      // equal to num_input_blks * k_base to qualify for a xdlops gemm
-      if (param.gemmKPack == 1) {
-        if ((param.gemmMPerBlock == 32) && (param.gemmNPerBlock == 32)) {
-          if (param.gemmKPerBlock < 8) {
-            return failure();
-          }
-        }
-        if ((param.gemmMPerBlock == 16) && (param.gemmNPerBlock == 16)) {
-          if (param.gemmKPerBlock < 16) {
-            return failure();
-          }
-        }
-      }
-    }
-
     // XXX FIXME: Ignore KReduction XDLOPS path for forward and backward weight
     // convolution now. These M/NPerBlock combinations will result in lowering
     // errors at tuning.

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -1033,7 +1033,7 @@ private:
     // XXX FIXME: Ignore KReduction XDLOPS path for forward and backward weight
     // convolution now. These M/NPerBlock combinations will result in lowering
     // errors at tuning.
-    if (param.gemmKPack > 1 &&
+    if (param.gemmKPack > 1 && !dataType.isInteger(8) &&
         ((ctx.getOpType() == miopen::ConvOpType::Fwd) ||
          (ctx.getOpType() == miopen::ConvOpType::BwdWeight))) {
       if ((param.gemmMPerBlock == 16 || param.gemmMPerBlock == 32 ||

--- a/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
@@ -670,6 +670,12 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     // llvm::errs() << GemmABlockCopyThreadSliceLengths_GemmM << " ";
     // llvm::errs() << GemmABlockCopyThreadSliceLengths_GemmKPack << "\n";
 
+    // Each thread should not read exceed the length of the corresponding tile
+    if (GemmABlockCopyThreadSliceLengths_GemmK > KPerBlock ||
+        GemmABlockCopyThreadSliceLengths_GemmM > MPerBlock) {
+      return failure();
+    }
+
     if (GemmABlockCopyThreadSliceLengths_GemmK == 0 ||
         GemmABlockCopyThreadSliceLengths_GemmM == 0 ||
         GemmABlockCopyThreadSliceLengths_GemmKPack == 0) {
@@ -740,6 +746,12 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     // llvm::errs() << GemmBBlockCopyThreadSliceLengths_GemmK << " ";
     // llvm::errs() << GemmBBlockCopyThreadSliceLengths_GemmN << " ";
     // llvm::errs() << GemmBBlockCopyThreadSliceLengths_GemmKPack << "\n";
+
+    // Each thread should not read exceed the length of the corresponding tile
+    if (GemmBBlockCopyThreadSliceLengths_GemmK > KPerBlock ||
+        GemmBBlockCopyThreadSliceLengths_GemmN > NPerBlock) {
+      return failure();
+    }
 
     if (GemmBBlockCopyThreadSliceLengths_GemmK == 0 ||
         GemmBBlockCopyThreadSliceLengths_GemmN == 0 ||

--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
@@ -1531,10 +1531,10 @@ struct XdlopsGemmV2RewritePattern : public OpRewritePattern<XdlopsGemmV2Op> {
         // kpack guarateed to be a multiple of the size of the xdlops
         // argument. Then it construct the xdlops argument by extracting
         // elements from the kpack vector.
-        auto constructXdlopsArg = [&outerLoopb, &innerLoopb, &loc,
-                                   &b](Value &buffer, Value &outerLoopiv,
-                                       Value &innerLoopiv, Type &argType,
-                                       int64_t k_base) {
+        auto constructXdlopsArg = [&outerLoopb, &innerLoopb,
+                                   &loc](Value &buffer, Value &outerLoopiv,
+                                         Value &innerLoopiv, Type &argType,
+                                         int64_t k_base) -> Value {
           Value arg = createZeroConstantOp(innerLoopb, loc, argType);
 
           Value argAWide = innerLoopb.create<memref::LoadOp>(

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -452,6 +452,7 @@ LogicalResult PopulateParamsXDL::obtainTuningParameters(
     LLVM_DEBUG(llvm::dbgs() << "Successfully picked tuning params from backup"
                             << " path.\n");
   }
+  LLVM_DEBUG(llvm::dbgs() << genDebugForParams(validParams) << "\n");
 
   return res;
 }


### PR DESCRIPTION
I have implemented and fixed majority of issues discovered from kpack + reduction combination. With this PR, all lowering compilation issues will be fixed. 

### Example: correct result with default kpack == 1 tuning parameters

```bash
./bin/miopen-gen -batchsize=64 -in_channels=128 -in_h=16 -in_w=16 -out_channels=128 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --conv_stride_h=1 --conv_stride_w=1 --padding_h=1 --padding_w=1 -t i8 -x2 --operation conv2d -pv | ./bin/mlir-miopen-driver -c | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./external/llvm-project/llvm/lib/libmlir_runner_utils.so --entry-point-result=void

Unranked Memref base@ = 0x559a10d423f0 rank = 1 offset = 0 sizes = [1] strides = [1] data =
[1]
```

### Example: correct result with kpack == 8 tuning parameters:

```bash
./bin/miopen-gen -batchsize=64 -in_channels=128 -in_h=16 -in_w=16 -out_channels=128 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --conv_stride_h=1 --conv_stride_w=1 --padding_h=1 --padding_w=1 -t i8 -x2 --operation conv2d --perf_config "64,64,8,32,32,8,0,0" -pv | ./bin/mlir-miopen-driver -c | ./bin/mlir-rocm-runner --shared-libs=./lib/librocm-runtime-wrappers.so,./external/llvm-project/llvm/lib/libmlir_runner_utils.so --entry-point-result=void

Unranked Memref base@ = 0x559a10d423f0 rank = 1 offset = 0 sizes = [1] strides = [1] data =
[1]
```

Done:
 - kicking off nightly on this PR to make sure this does not cause a regression on int8 resnet50 configs