### PR TITLE
Fix bounds check rules for unfold

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenAttrDefs.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenAttrDefs.td
@@ -131,7 +131,7 @@ def MIOpen_TransformAttr : MIOpen_Attr<"Transform"> {
           This has the effect of concatentating the dimensions if they are consecutive
         - Unfold{c1, ..., cN} - Has the semantics of merge, but asserts that the lower
           dimensions are consecutive so that the derivative operation does not need
-          to explicitly handle overflow
+          to perform carry checks on indices.
         - AddDim{size} - Adds one upper dimension of the given size that does not
           correspond to any lower dimension.
     }];


### PR DESCRIPTION
The bounds checks rules for unfold were causing valid writes to be
dropped in some backwards weight kernels. Having considered the
semantics of unfold, I've determined that, just like with merge,
checking the leftmost coordinate is correct, since an out of bounds
input to the unfold() will cause the leftmost coordinate of the unfold
to overflow.