### PR TITLE
[DO NOT SQUASH] MLIR#217: Add broadcast support to miopen.transform

### DIFF
--- a/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -670,7 +670,7 @@ elementwiseMatchAndRewriteHelper(Operation *operation,
     SmallVector<AffineExpr, 4> affineExprs;
     newShape.reserve(type.getRank());
     for (const auto &it : llvm::enumerate(type.getShape())) {
-      if (it.value() == resultTy.getDimSize(it.index())) {
+      if (it.value() == resultTy.getDimSize(it.index()) && it.value() != 1) {
         newShape.push_back(it.value());
         affineExprs.push_back(
             mlir::getAffineDimExpr(it.index(), rewriter.getContext()));

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
@@ -126,6 +126,8 @@ public:
   void passThrough(ArrayRef<StringRef> names);
   void passThrough(ArrayRef<StringRef> outNames, ArrayRef<uint32_t> outDims,
                    ArrayRef<StringRef> inNames);
+  void passThrough(ArrayRef<uint32_t> endIndices,
+                   ArrayRef<uint32_t> startIndices);
 
   // Parameters is the pre and post padding for each dimension in the order they
   // appear as arguments. For example, padding x with 2 on the left and 1 on the
@@ -266,8 +268,6 @@ public:
 
   // Defines a dimension that is not mapped to any coordinates in the output
   void addDim(StringRef name, uint32_t dim, int64_t size);
-
-  void expand(ArrayRef<uint32_t> dims, ArrayRef<int64_t> sizes);
 
   void broadcast(ArrayRef<uint32_t> bcastDims, ArrayRef<int64_t> endDims);
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
@@ -142,6 +142,8 @@ public:
 protected:
   CoordTransformsBuilder(mlir::Builder &builder, ArrayRef<StringRef> startNames,
                          ArrayRef<int64_t> startShape, mlir::Location loc);
+  CoordTransformsBuilder(mlir::Builder &builder, ArrayRef<int64_t> startShape,
+                         mlir::Location loc);
 
   template <class T, typename = typename std::enable_if<std::is_base_of<
                          CoordTransformsBuilder, T>::value>::type>
@@ -160,6 +162,8 @@ protected:
                              SmallVectorImpl<int64_t> &lowerBounds) = 0;
 
   virtual int64_t paddingSign() const = 0;
+
+  llvm::SmallVector<SmallString<8>, 8> &nStartNames() { return startNames; }
 
   uint32_t nStartDims();
   uint32_t nEndDims();
@@ -250,6 +254,10 @@ public:
                     ArrayRef<int64_t> startShape, mlir::Location loc)
       : CoordTransformsBuilder(builder, startNames, startShape, loc) {}
 
+  BottomUpCTBuilder(mlir::Builder &builder, ArrayRef<int64_t> startShape,
+                    mlir::Location loc)
+      : CoordTransformsBuilder(builder, startShape, loc) {}
+
   static BottomUpCTBuilder above(BottomUpCTBuilder &previous,
                                  TransformMapAttr &result) {
     return CoordTransformsBuilder::nextTransforms(previous,
@@ -258,6 +266,10 @@ public:
 
   // Defines a dimension that is not mapped to any coordinates in the output
   void addDim(StringRef name, uint32_t dim, int64_t size);
+
+  void expand(ArrayRef<uint32_t> dims, ArrayRef<int64_t> sizes);
+
+  void broadcast(ArrayRef<uint32_t> bcastDims, ArrayRef<int64_t> endDims);
 
   void slice(ArrayRef<StringRef> upperNames, ArrayRef<StringRef> lowerNames,
              ArrayRef<int64_t> begins, ArrayRef<int64_t> ends);

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpen.h
@@ -165,7 +165,7 @@ protected:
 
   virtual int64_t paddingSign() const = 0;
 
-  llvm::SmallVector<SmallString<8>, 8> &nStartNames() { return startNames; }
+  llvm::SmallVector<SmallString<8>, 8> &getStartNames() { return startNames; }
 
   uint32_t nStartDims();
   uint32_t nEndDims();
@@ -269,7 +269,7 @@ public:
   // Defines a dimension that is not mapped to any coordinates in the output
   void addDim(StringRef name, uint32_t dim, int64_t size);
 
-  void broadcast(ArrayRef<uint32_t> bcastDims, ArrayRef<int64_t> endDims);
+  void broadcast(ArrayRef<uint32_t> endDims, ArrayRef<int64_t> endSizes);
 
   void slice(ArrayRef<StringRef> upperNames, ArrayRef<StringRef> lowerNames,
              ArrayRef<int64_t> begins, ArrayRef<int64_t> ends);

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenAttrDefs.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenAttrDefs.td
@@ -59,10 +59,11 @@ def Unmerge : I32EnumAttrCase<"Unmerge", 4>;
 def Merge : I32EnumAttrCase<"Merge", 5>;
 def Unfold : I32EnumAttrCase<"Unfold", 6>;
 def AddDim : I32EnumAttrCase<"AddDim", 7>;
+def Broadcast : I32EnumAttrCase<"Broadcast", 8>;
 
 def TransformType : MIOpen_I32Enum<"TransformType",
     "The operation type for a coordinate transformation",
-    [PassThrough, Pad, Slice, Embed, Unmerge, Merge, Unfold, AddDim]>;
+    [PassThrough, Pad, Slice, Embed, Unmerge, Merge, Unfold, AddDim, Broadcast]>;
 
 /// StoreMethod
 
@@ -134,6 +135,8 @@ def MIOpen_TransformAttr : MIOpen_Attr<"Transform"> {
           to perform carry checks on indices.
         - AddDim{size} - Adds one upper dimension of the given size that does not
           correspond to any lower dimension.
+        - Broadcast{c1, c2, ..., cN} - Broadcast lower dimensions of size 1 to
+          upper dimensions.
     }];
 
     let parameters = (ins

--- a/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
+++ b/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
@@ -78,8 +78,15 @@ static Value expandMemRef(ConversionPatternRewriter &rw, Operation *op,
   }
   ArrayRef<int64_t> shape = oprType.getShape();
 
+  SmallVector<uint32_t, 8> endDims;
+  SmallVector<uint32_t, 8> startDims;
+  for (uint32_t i = 0, e = shape.size(); i < e; ++i) {
+    startDims.push_back(i);
+    endDims.push_back(i < idx ? i : i + 1);
+  }
   miopen::BottomUpCTBuilder transform(rw, shape, loc);
-  transform.expand({idx}, {1});
+  transform.passThrough(endDims, startDims);
+  transform.addDim("g", idx, 1);
 
   return rw.create<miopen::TransformOp>(loc, operand, transform.get());
 }

--- a/mlir/lib/Dialect/MIOpen/CoordTransformBuilder.cpp
+++ b/mlir/lib/Dialect/MIOpen/CoordTransformBuilder.cpp
@@ -568,22 +568,22 @@ void BottomUpCTBuilder::addDim(StringRef name, uint32_t dim, int64_t size) {
   addTransform(TransformType::AddDim, {size}, {}, {}, {name}, {dim});
 }
 
-void BottomUpCTBuilder::broadcast(ArrayRef<uint32_t> bcastDims,
+void BottomUpCTBuilder::broadcast(ArrayRef<uint32_t> endDims,
                                   ArrayRef<int64_t> endSizes) {
   SmallVector<int64_t, 8> params;
   SmallVector<StringRef, 8> lowerNames;
   SmallVector<StringRef, 8> upperNames;
-  for (auto tuple : llvm::zip(bcastDims, endSizes)) {
+  for (auto tuple : llvm::zip(endDims, endSizes)) {
     uint32_t dim = std::get<0>(tuple);
     int64_t size = std::get<1>(tuple);
-    auto &name = nStartNames()[dim];
+    auto &name = getStartNames()[dim];
     params.push_back(startSize(dim));
     lowerNames.push_back(name);
     upperNames.push_back(name);
     defineDim(upperNames[dim], dim, size);
   }
-  addTransform(TransformType::Broadcast, params, upperNames, bcastDims,
-               lowerNames, bcastDims);
+  addTransform(TransformType::Broadcast, params, upperNames, endDims,
+               lowerNames, endDims);
 }
 
 void BottomUpCTBuilder::slice(ArrayRef<StringRef> upperNames,

--- a/mlir/lib/Dialect/MIOpen/MIOpenDialect.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenDialect.cpp
@@ -284,6 +284,11 @@ TransformAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
       return emitError() << "The added dimension cannot be mapped anywhere";
     }
     break;
+  case TransformType::Broadcast:
+    if (upperDims.size() != lowerDims.size()) {
+      return emitError() << "Broadcast must have same rank";
+    }
+    break;
   }
   return success();
 }

--- a/mlir/lib/Dialect/MIOpen/Pipeline/Pipeline.cpp
+++ b/mlir/lib/Dialect/MIOpen/Pipeline/Pipeline.cpp
@@ -47,12 +47,12 @@ void miopen::addHighLevelPipeline(PassManager &pm, bool toMIOpen) {
   }
   pm.addPass(tosa::createTosaToLinalgNamed());
   pm.addPass(tosa::createTosaToLinalg());
-  pm.addPass(createLinalgElementwiseOpFusionPass());
   pm.addPass(createLinalgBufferizePass());
   pm.addPass(arith::createArithmeticBufferizePass());
   pm.addPass(createFuncBufferizePass());
   pm.addPass(bufferization::createBufferResultsToOutParamsPass());
   pm.addPass(bufferization::createFinalizingBufferizePass());
+  pm.addPass(createLinalgElementwiseOpFusionPass());
   pm.addPass(miopen::createMIOpenCopyOptPass());
 }
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -371,8 +371,9 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
         return fail;
     }
 
-    auto idxMaps = laGeneric->template getAttrOfType<ArrayAttr>("indexing_maps");
-    auto outIdxMap = idxMaps[idxMaps.size()-1].template cast<AffineMapAttr>();
+    auto idxMaps =
+        laGeneric->template getAttrOfType<ArrayAttr>("indexing_maps");
+    auto outIdxMap = idxMaps[idxMaps.size() - 1].template cast<AffineMapAttr>();
 
     if (!outIdxMap.isIdentity()) {
       return fail;

--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
@@ -1020,6 +1020,9 @@ struct IndexDiffUpdateRewritePattern
         }
       } else if (transformation == TransformType::AddDim) {
         // Do nothing - the dimension will be dropped by the code below
+      } else if (transformation == TransformType::Broadcast) {
+        // lower broadcast dims, uses map
+        assert(0);
       }
     } // for (auto mapping : transforms.getOps())
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseToStdlib.cpp
@@ -1023,21 +1023,25 @@ struct IndexDiffUpdateRewritePattern
       } else if (transformation == TransformType::Broadcast) {
         // lower broadcast dims, uses map
         for (uint32_t i = 0; i < e.size(); ++i) {
-            int64_t lowerLen = e[i];
-            Value lowerLenOp = b.create<ConstantIndexOp>(loc, lowerLen);
-            auto mbUpperDiff = isConstantValue(upperIndicesDiff[p[i]]);
-            Value wrappedDiff;
-            if (mbUpperDiff.hasValue()) {
-              wrappedDiff = b.create<ConstantIndexOp>(loc, *mbUpperDiff % lowerLen);
-            } else {
-              wrappedDiff = b.create<RemUIOp>(loc, upperIndicesDiff[p[i]], lowerLenOp);
-            }
-            Value newLower = addToOriginal(lowerIndicesOriginal[q[i]], wrappedDiff);
-            newLower = b.create<RemUIOp>(loc, newLower, lowerLenOp);
-            Value lowerDiff = b.create<SubIOp>(loc, newLower, lowerIndicesOriginal[q[i]]);
-            lowerIndicesDiffMap[q[i]] = lowerDiff;
-            lowerIndicesUpdatedMap[q[i]] = newLower;
+          int64_t lowerLen = e[i];
+          Value lowerLenOp = b.create<ConstantIndexOp>(loc, lowerLen);
+          auto mbUpperDiff = isConstantValue(upperIndicesDiff[p[i]]);
+          Value wrappedDiff;
+          if (mbUpperDiff.hasValue()) {
+            wrappedDiff =
+                b.create<ConstantIndexOp>(loc, *mbUpperDiff % lowerLen);
+          } else {
+            wrappedDiff =
+                b.create<RemUIOp>(loc, upperIndicesDiff[p[i]], lowerLenOp);
           }
+          Value newLower =
+              addToOriginal(lowerIndicesOriginal[q[i]], wrappedDiff);
+          newLower = b.create<RemUIOp>(loc, newLower, lowerLenOp);
+          Value lowerDiff =
+              b.create<SubIOp>(loc, newLower, lowerIndicesOriginal[q[i]]);
+          lowerIndicesDiffMap[q[i]] = lowerDiff;
+          lowerIndicesUpdatedMap[q[i]] = newLower;
+        }
       }
     } // for (auto mapping : transforms.getOps())
 

--- a/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
@@ -26,8 +26,17 @@ void propagateTransformOob(TransformMapAttr transformMap,
     ArrayRef<int64_t> params = transform.getParams();
 
     switch (transform.getType()) {
+    case TransformType::Broadcast: {
+      // Broadcast makes non-negative indices in-bounds, only check left bounds
+      for (auto pair : llvm::zip(upperDims, lowerDims)) {
+        uint32_t upper = std::get<0>(pair);
+        uint32_t lower = std::get<1>(pair);
+        if (upperLeft.contains(upper))
+          lowerLeft.insert(lower);
+      }
+      break;
+    }
     case TransformType::PassThrough:
-    case TransformType::Broadcast: // is this right??
     case TransformType::Slice:
     case TransformType::AddDim: {
       // Zip ends at end of shortes array, allowing addDim here

--- a/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/MIOpen/utility/loweringUtils.cpp
@@ -27,6 +27,7 @@ void propagateTransformOob(TransformMapAttr transformMap,
 
     switch (transform.getType()) {
     case TransformType::PassThrough:
+    case TransformType::Broadcast: // is this right??
     case TransformType::Slice:
     case TransformType::AddDim: {
       // Zip ends at end of shortes array, allowing addDim here

--- a/mlir/test/fusion/miopen-bcast-exp.e2e.mlir
+++ b/mlir/test/fusion/miopen-bcast-exp.e2e.mlir
@@ -1,0 +1,18 @@
+// RUN: miopen-gen -ph -print-results -rand none %s | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+
+
+// CHECK:  73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
+module {
+  func @test_fusion(%arg0: memref<1x1x32x32x8xf32>, %arg1: memref<1x16x3x3x8xf32>, %arg2: memref<16xf32>, %arg3: memref<1x1x30x30x16xf32>) attributes {kernel} {
+    %0 = memref.alloc() : memref<1x1x30x30x16xf32>
+    miopen.conv2d(%arg1, %arg0, %0) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], num_cu = 64 : i32, output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = false} : memref<1x16x3x3x8xf32>, memref<1x1x32x32x8xf32>, memref<1x1x30x30x16xf32>
+    linalg.generic {indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%0, %arg2 : memref<1x1x30x30x16xf32>, memref<16xf32>) outs(%arg3 : memref<1x1x30x30x16xf32>) {
+    ^bb0(%arg4: f32, %arg5: f32, %arg6: f32):
+      %8 = arith.addf %arg4, %arg5 : f32
+      linalg.yield %8 : f32
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/miopen-bcast-exp.mlir
+++ b/mlir/test/fusion/miopen-bcast-exp.mlir
@@ -1,0 +1,19 @@
+// RUN: miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-linalg-align %s | FileCheck %s
+
+// CHECK: #miopen.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d4)> by[#miopen.transform<PassThrough ["dim0"] at [4] -> ["dim0"] at [0]>, #miopen.transform<AddDim{1} ["exp0"] at [0] -> [] at []>, #miopen.transform<AddDim{1} ["exp1"] at [1] -> [] at []>, #miopen.transform<AddDim{1} ["exp2"] at [2] -> [] at []>, #miopen.transform<AddDim{1} ["exp3"] at [3] -> [] at []>] bounds = [1, 1, 1, 1, 16] -> [16]>
+// CHECK-NEXT: #miopen.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)> by[#miopen.transform<PassThrough ["dim4"] at [4] -> ["dim4"] at [4]>, #miopen.transform<Broadcast{1, 1, 1, 1} ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>] bounds = [1, 1, 30, 30, 16] -> [1, 1, 1, 1, 16]>
+
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
+module {
+  func @test_fusion(%arg0: memref<1x1x32x32x8xf32>, %arg1: memref<1x16x3x3x8xf32>, %arg2: memref<16xf32>, %arg3: memref<1x1x30x30x16xf32>) attributes {kernel} {
+    %0 = memref.alloc() : memref<1x1x30x30x16xf32>
+    miopen.conv2d(%arg1, %arg0, %0) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], num_cu = 64 : i32, output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = false} : memref<1x16x3x3x8xf32>, memref<1x1x32x32x8xf32>, memref<1x1x30x30x16xf32>
+    linalg.generic {indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%0, %arg2 : memref<1x1x30x30x16xf32>, memref<16xf32>) outs(%arg3 : memref<1x1x30x30x16xf32>) {
+    ^bb0(%arg4: f32, %arg5: f32, %arg6: f32):
+      %8 = arith.addf %arg4, %arg5 : f32
+      linalg.yield %8 : f32
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/miopen-bcast-idxmap.e2e.mlir
+++ b/mlir/test/fusion/miopen-bcast-idxmap.e2e.mlir
@@ -1,0 +1,19 @@
+// RUN: miopen-gen -ph -print-results -rand none %s | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+
+// CHECK: 65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65
+
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)>
+module {
+  func @test_fusion(%arg0: memref<1x64x64x64x64xf32>, %arg1: memref<1x64x1x1x64xf32>, %arg2: memref<64xf32>, %arg3: memref<1x64x64x64x64xf32>) attributes {kernel} {
+    %0 = memref.alloc() : memref<1x64x64x64x64xf32>
+    miopen.conv2d(%arg1, %arg0, %0) {arch = "gfx908", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], num_cu = 64 : i32, output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = false} : memref<1x64x1x1x64xf32>, memref<1x64x64x64x64xf32>, memref<1x64x64x64x64xf32>
+    %4 = memref.expand_shape %arg2 [[0, 1, 2, 3, 4]] : memref<64xf32> into memref<1x1x1x1x64xf32>
+    linalg.generic {indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%0, %4 : memref<1x64x64x64x64xf32>, memref<1x1x1x1x64xf32>) outs(%arg3 : memref<1x64x64x64x64xf32>) {
+    ^bb0(%arg4: f32, %arg5: f32, %arg6: f32):
+      %8 = arith.addf %arg4, %arg5 : f32
+      linalg.yield %8 : f32
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/miopen-bcast.e2e.mlir
+++ b/mlir/test/fusion/miopen-bcast.e2e.mlir
@@ -1,0 +1,19 @@
+// RUN: miopen-gen -ph -print-results -rand none %s | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+
+
+// CHECK:  73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)>
+module {
+  func @test_fusion(%arg0: memref<1x1x32x32x8xf32>, %arg1: memref<1x16x3x3x8xf32>, %arg2: memref<16xf32>, %arg3: memref<1x1x30x30x16xf32>) attributes {kernel} {
+    %0 = memref.alloc() : memref<1x1x30x30x16xf32>
+    miopen.conv2d(%arg1, %arg0, %0) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], num_cu = 64 : i32, output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = false} : memref<1x16x3x3x8xf32>, memref<1x1x32x32x8xf32>, memref<1x1x30x30x16xf32>
+    %4 = memref.expand_shape %arg2 [[0, 1, 2, 3, 4]] : memref<16xf32> into memref<1x1x1x1x16xf32>
+    linalg.generic {indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%0, %4 : memref<1x1x30x30x16xf32>, memref<1x1x1x1x16xf32>) outs(%arg3 : memref<1x1x30x30x16xf32>) {
+    ^bb0(%arg4: f32, %arg5: f32, %arg6: f32):
+      %8 = arith.addf %arg4, %arg5 : f32
+      linalg.yield %8 : f32
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/miopen-bcast.mlir
+++ b/mlir/test/fusion/miopen-bcast.mlir
@@ -1,0 +1,19 @@
+// RUN: miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-linalg-align %s | FileCheck %s
+
+// CHECK:  #miopen.transform<Broadcast{1, 1, 1, 1} ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>] bounds = [1, 1, 30, 30, 16] -> [1, 1, 1, 1, 16]>
+    
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)>
+module {
+  func @test_fusion(%arg0: memref<1x1x32x32x8xf32>, %arg1: memref<1x16x3x3x8xf32>, %arg2: memref<16xf32>, %arg3: memref<1x1x30x30x16xf32>) attributes {kernel} {
+    %0 = memref.alloc() : memref<1x1x30x30x16xf32>
+    miopen.conv2d(%arg1, %arg0, %0) {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], num_cu = 64 : i32, output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32], xdlopsV2 = false} : memref<1x16x3x3x8xf32>, memref<1x1x32x32x8xf32>, memref<1x1x30x30x16xf32>
+    %4 = memref.expand_shape %arg2 [[0, 1, 2, 3, 4]] : memref<16xf32> into memref<1x1x1x1x16xf32>
+    linalg.generic {indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%0, %4 : memref<1x1x30x30x16xf32>, memref<1x1x1x1x16xf32>) outs(%arg3 : memref<1x1x30x30x16xf32>) {
+    ^bb0(%arg4: f32, %arg5: f32, %arg6: f32):
+      %8 = arith.addf %arg4, %arg5 : f32
+      linalg.yield %8 : f32
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/tosa-to-miopen-bcast-add.e2e.mlir
+++ b/mlir/test/fusion/tosa-to-miopen-bcast-add.e2e.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-inputs -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
+
+// CHECK: Unranked Memref base
+//func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg3: tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
+func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
+  %zero = arith.constant dense<0.0> : tensor<8xf32>
+  %0 = "tosa.conv2d"(%arg0, %arg1, %zero) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x8x8x4xf32>, tensor<8x1x1x4xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
+//  %2 = "tosa.add"(%0, %arg3) {} : (tensor<1x8x8x8xf32>, tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32>
+
+  //return %2 : tensor<1x8x8x8xf32>
+  return %0 : tensor<1x8x8x8xf32>
+}
+
+// -----
+

--- a/mlir/test/fusion/tosa-to-miopen-bias.e2e.mlir
+++ b/mlir/test/fusion/tosa-to-miopen-bias.e2e.mlir
@@ -1,0 +1,11 @@
+// RUN: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
+
+// CHECK: Unranked Memref base
+func @test_fusion(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x3x3x8xf32>, %arg2: tensor<16xf32>) -> tensor<1x30x30x16xf32> attributes {kernel} {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x32x32x8xf32>, tensor<16x3x3x8xf32>, tensor<16xf32>) -> tensor<1x30x30x16xf32>
+
+  return %0 : tensor<1x30x30x16xf32>
+}
+
+// -----
+

--- a/mlir/test/fusion/tosa-to-miopen-clamp.e2e.mlir
+++ b/mlir/test/fusion/tosa-to-miopen-clamp.e2e.mlir
@@ -12,8 +12,10 @@ module {
     }
      : (tensor<128x32x32x8xf32>, tensor<128x3x3x8xf32>, tensor<128xf32>) -> tensor<128x30x30x128xf32>
 
-    %1 = "tosa.reluN"(%0) {
+    %1 = "tosa.clamp"(%0) {
+      min_fp = 0.0 : f32,
       max_fp = 6.0 : f32,
+      min_int = 0 : i64,
       max_int = 6 : i64
     }
      : (tensor<128x30x30x128xf32>) -> tensor<128x30x30x128xf32>

--- a/mlir/test/fusion/tosa-to-miopen-exp.e2e.mlir
+++ b/mlir/test/fusion/tosa-to-miopen-exp.e2e.mlir
@@ -12,10 +12,7 @@ module {
     }
      : (tensor<128x32x32x8xf32>, tensor<128x3x3x8xf32>, tensor<128xf32>) -> tensor<128x30x30x128xf32>
 
-    %1 = "tosa.reluN"(%0) {
-      max_fp = 6.0 : f32,
-      max_int = 6 : i64
-    }
+    %1 = "tosa.exp"(%0)
      : (tensor<128x30x30x128xf32>) -> tensor<128x30x30x128xf32>
  
     return %1 : tensor<128x30x30x128xf32>

--- a/mlir/test/fusion/tosa-to-miopen-rsqrt.e2e.mlir
+++ b/mlir/test/fusion/tosa-to-miopen-rsqrt.e2e.mlir
@@ -12,10 +12,7 @@ module {
     }
      : (tensor<128x32x32x8xf32>, tensor<128x3x3x8xf32>, tensor<128xf32>) -> tensor<128x30x30x128xf32>
 
-    %1 = "tosa.reluN"(%0) {
-      max_fp = 6.0 : f32,
-      max_int = 6 : i64
-    }
+    %1 = "tosa.rsqrt"(%0)
      : (tensor<128x30x30x128xf32>) -> tensor<128x30x30x128xf32>
  
     return %1 : tensor<128x30x30x128xf32>

--- a/mlir/test/fusion/tosa-to-miopen-sigmoid.e2e.mlir
+++ b/mlir/test/fusion/tosa-to-miopen-sigmoid.e2e.mlir
@@ -12,10 +12,7 @@ module {
     }
      : (tensor<128x32x32x8xf32>, tensor<128x3x3x8xf32>, tensor<128xf32>) -> tensor<128x30x30x128xf32>
 
-    %1 = "tosa.reluN"(%0) {
-      max_fp = 6.0 : f32,
-      max_int = 6 : i64
-    }
+    %1 = "tosa.sigmoid"(%0)
      : (tensor<128x30x30x128xf32>) -> tensor<128x30x30x128xf32>
  
     return %1 : tensor<128x30x30x128xf32>

--- a/mlir/test/fusion/tosa-to-miopen-tanh.e2e.mlir
+++ b/mlir/test/fusion/tosa-to-miopen-tanh.e2e.mlir
@@ -12,10 +12,7 @@ module {
     }
      : (tensor<128x32x32x8xf32>, tensor<128x3x3x8xf32>, tensor<128xf32>) -> tensor<128x30x30x128xf32>
 
-    %1 = "tosa.reluN"(%0) {
-      max_fp = 6.0 : f32,
-      max_int = 6 : i64
-    }
+    %1 = "tosa.tanh"(%0)
      : (tensor<128x30x30x128xf32>) -> tensor<128x30x30x128xf32>
  
     return %1 : tensor<128x30x30x128xf32>

--- a/mlir/unittests/Dialect/MIOpen/CoordTransformBuilderTests.cpp
+++ b/mlir/unittests/Dialect/MIOpen/CoordTransformBuilderTests.cpp
@@ -194,6 +194,18 @@ TEST_F(CTBuilderTest, AddDim) {
   EXPECT_EQ(resUp, resDown);
 }
 
+TEST_F(CTBuilderTest, Broadcast) {
+  auto buildUp = makeBottomUp({"a", "b"}, {1, 3});
+
+  buildUp.passThrough({1}, {1});
+  buildUp.broadcast({0}, {1});
+
+  TransformMapAttr resUp = buildUp.get();
+
+  EXPECT_EQ(resUp.getMap().getAffineMap(),
+            AffineMap::get(2, 0, {affC(0), affD(1)}, &context));
+}
+
 TEST_F(CTBuilderTest, GemmOut) {
   auto buildDown =
       makeTopDown({"gemmG", "gemmM", "gemmN"}, {1, 64, 32 * 14 * 14});


### PR DESCRIPTION
* use index maps to ensure minority identity maps for linalg.generic
* insert miopen.transform<Broadcast> before applying output transforms
* * generate affine map to access broadcast dimensions
* moved linalg-elementwise-fusion pass to after bufferization

* fixed tosa-to-linalg to prefer minor-identity matrix maps

Changes to CoordTransformBuilder:
* added constructor to assign names generically
* added broadcast method
* added expand macro (passThrough + addDim)

https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/217
