### PR TITLE
[DO NOT SQUASH] Separate call-graph roots from kernels;  main() calls roots, kernels …

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -419,6 +419,10 @@ public:
     ModuleOp module = getOperation();
     auto funcOps = module.getOps<FuncOp>();
     for (auto func : llvm::make_early_inc_range(funcOps)) {
+      // Don't partition a kernel;  it may be already partitioned.
+      if (func->hasAttr("kernel"))
+        continue;
+
       int count = 0;
       // (Problems with node mismatches and unexpected uses if we have the
       // candidates list at module level.)

--- a/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpenPass.cpp
+++ b/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpenPass.cpp
@@ -49,7 +49,8 @@ public:
 
     tensor_target.addLegalDialect<miopen::MIOpenDialect, tosa::TosaDialect,
                                   memref::MemRefDialect, StandardOpsDialect,
-                                  BuiltinDialect, arith::ArithmeticDialect>();
+                                  BuiltinDialect, arith::ArithmeticDialect,
+                                  bufferization::BufferizationDialect>();
     tensor_target.addDynamicallyLegalOp<tosa::TransposeOp>(
         [&](tosa::TransposeOp op) {
           auto attrDeletable = op->getAttr("changing_layout_root");

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -12,6 +12,7 @@
 
 #include "mlir/Conversion/MIOpenPasses.h"
 #include "mlir/Conversion/MIOpenToGPU/MIOpenToGPU.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/MIOpen/Generator/Conv2dGenerator.h"
 #include "mlir/Dialect/MIOpen/MIOpen.h"
@@ -259,10 +260,10 @@ int main(int argc, char **argv) {
   test::registerTestDialect(registry);
 #endif
   MLIRContext context(registry);
-  context
-      .loadDialect<miopen::MIOpenDialect, StandardOpsDialect, scf::SCFDialect,
-                   AffineDialect, memref::MemRefDialect, math::MathDialect,
-                   arith::ArithmeticDialect, gpu::GPUDialect>();
+  context.loadDialect<miopen::MIOpenDialect, StandardOpsDialect,
+                      scf::SCFDialect, AffineDialect, memref::MemRefDialect,
+                      math::MathDialect, arith::ArithmeticDialect,
+                      gpu::GPUDialect, bufferization::BufferizationDialect>();
   mlir::registerAllPasses();
   mlir::registerMIOpenConversionPasses();
   miopen::registerPasses();


### PR DESCRIPTION
…get wrapped

* Add bufferization dialect to loaded dialects.
* Use a special 'wrapped_call' attribute to avoid replacing calls that are already wrapped.
* Control the print options for roots after making the CallOp.  Remove wrapped_call attribute.
* Don't count a created CPUConvFunc as a kernel, because those get GPU-wrapped.  It'll be a root.
* Recognise when a root is a kernel, and call with localVars instead of validation's valVars.
* Refactoring the emitPrintTensor flag flag.
* Let's not count -fut as a kernel.
* Sort the roots by name, because sometimes order matters and DenseSet isn't deterministic.
* Clean up root/kernel and printp predicates.