### PR TITLE
Revert "Enable KPACK for backward weight convolution. (#551)"

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -267,8 +267,9 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
       validParams.gemmKPack = 1;
     }
 
-    // Disable kpack in case we do backward data convolution.
-    if (dir == mlir::miopen::ConvOpType::BwdData) {
+    // Disable kpack in case we do backward convolution.
+    if (dir == mlir::miopen::ConvOpType::BwdData ||
+        dir == mlir::miopen::ConvOpType::BwdWeight) {
       validParams.gemmKPack = 1;
     }
     op->setAttr("kpack", b.getI32IntegerAttr(validParams.gemmKPack));

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -22,7 +22,7 @@ void buildMIOpen(String cmakeOpts) {
 }
 
 void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
-    git branch: 'mlir-enlarge-tuning-search-space', poll: false,\
+    git branch: 'develop', poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
     cmake arguments: "-P install_deps.cmake --minimum ${prefixOpt}",\
         installation: "InSearchPath"
@@ -36,7 +36,7 @@ void buildMIOpenWithMLIR() {
         installation: 'InSearchPath', workingDir: 'build'
 
     dir('MIOpen') {
-        git branch: 'mlir-enlarge-tuning-search-space', poll: false,\
+        git branch: 'develop', poll: false,\
             url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
         sh 'sed -i "/ROCmSoftwarePlatform\\/llvm-project-mlir/d" ./requirements.txt'
         cmake arguments: "-P install_deps.cmake --minimum --prefix ${WORKSPACE}/MIOpenDeps",\

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -112,7 +112,7 @@ pipeline {
                         stage("Build MIOpen with libMLIRMIOpen") {
                             steps {
                                 dir('MIOpen') {
-                                git branch: 'mlir-enlarge-tuning-search-space', poll: false,\
+                                git branch: 'develop', poll: false,\
                                     url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
                                 sh 'sed -i "/ROCmSoftwarePlatform\\/llvm-project-mlir/d" ./requirements.txt'
                                 cmake arguments: "-P install_deps.cmake --minimum --prefix ${WORKSPACE}/MIOpenDeps",\


### PR DESCRIPTION
This reverts commit 395e80539e3128362b3a1ec6659aff81df597db2.

This commit causes the following kernel code to become incorrect:

```
./bin/miopen-gen "--conv-config=--x2 1 --operation conv2d_bwd_weight --num_cu 120 --arch amdgcn-amd-amdhsa:gfx908:sramecc+:xnack- --groupsize 1 --fil_layout GNCHW --fil_type fp32 --in_layout NGCHW --out_layout NGCHW --in_type fp32 --out_type fp32 --batchsize 256 --in_channels 1024 --out_channels 256 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name mlir_gen_igemm_conv2d_v4r4_wrw_xdlops1 --perf_config 128,128,8,64,64,4,1,1" -pv | ./bin/mlir-miopen-driver -c | rocm-run | tail
```

with outputs
```
Values: 618.312500, 30314.312500
Values: 29696.000000, 30314.312500
Values: -298.875000, -14634.875000
Values: -14336.000000, -14634.875000
Values: -298.000000, -14634.000000
Values: -14336.000000, -14634.000000
Values: 618.312500, 30314.312500
Values: 29696.000000, 30314.312500
Unranked Memref base@ = 0x13e43a0 rank = 1 offset = 0 sizes = [1] strides = [1] data =
[0]
```

As far as I'm concerned, we should merge this unless we find the bug or we can conclusively prove no one will ever try to run this config (the CI failures on #571 show that the PR in MIOpen isn't doing that)

Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/490