### PR TITLE
[DO NOT SQUASH] Supress hip semicolon warnings

### DIFF
--- a/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -204,6 +204,33 @@ if(MLIR_ENABLE_ROCM_RUNNER)
 
     EXCLUDE_FROM_LIBMLIR
   )
+
+  # Supress compiler warnings from HIP headers
+  check_cxx_compiler_flag(-Wno-c++98-compat-extra-semi
+    CXX_SUPPORTS_NO_CXX98_COMPAT_EXTRA_SEMI_FLAG)
+  if (CXX_SUPPORTS_CXX98_COMPAT_EXTRA_SEMI_FLAG)
+    target_compile_options(mlir_rocm_runtime PRIVATE
+      "-Wno-c++98-compat-extra-semi")
+  endif()
+  check_cxx_compiler_flag(-Wno-return-type-c-linkage
+      CXX_SUPPORTS_WNO_RETURN_TYPE_C_LINKAGE_FLAG)
+  if (CXX_SUPPORTS_WNO_RETURN_TYPE_C_LINKAGE_FLAG)
+    target_compile_options(mlir_rocm_runtime PRIVATE
+      "-Wno-return-type-c-linkage")
+  endif()
+  check_cxx_compiler_flag(-Wno-nested-anon-types
+    CXX_SUPPORTS_WNO_NESTED_ANON_TYPES_FLAG)
+  if (CXX_SUPPORTS_WNO_NESTED_ANON_TYPES_FLAG)
+    target_compile_options(mlir_rocm_runtime PRIVATE
+      "-Wno-nested-anon-types")
+  endif()
+  check_cxx_compiler_flag(-Wno-gnu-anonymous-struct
+    CXX_SUPPORTS_WNO_GNU_ANONYMOUS_STRUCT_FLAG)
+  if (CXX_SUPPORTS_WNO_GNU_ANONYMOUS_STRUCT_FLAG)
+    target_compile_options(mlir_rocm_runtime PRIVATE
+     "-Wno-gnu-anonymous-struct")
+  endif()
+
   target_compile_definitions(mlir_rocm_runtime
     PRIVATE
     __HIP_PLATFORM_HCC__

--- a/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/ROCm/CMakeLists.txt
@@ -52,9 +52,9 @@ target_link_libraries(rocm-runtime-wrappers
 # suppressions regard a GNU extension, the third an incomplete-type warning
 # that apparently works out okay.
 set_source_files_properties(rocm-runtime-wrappers.cpp PROPERTIES
-  COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types;-Wno-return-type-c-linkage")
+  COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types;-Wno-return-type-c-linkage;-Wno-c++98-compat-extra-semi")
 set_source_files_properties(BackendUtils.cpp PROPERTIES
-  COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types")
+  COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types;-Wno-c++98-compat-extra-semi")
 
 set(LIBS
   MLIRROCDLToLLVMIRTranslation


### PR DESCRIPTION
This removes tens of warnings from build logs that we can't do
anything about.

Differential Revision: https://reviews.llvm.org/D122927

(I suspect this is the sort of thing we can stick upstream on our own initiative without anyone complaining)