### PR TITLE
[DO NOT SQUASH] Use LLVM dialect inline_asm op for LDS barrier.

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -116,17 +116,6 @@ def ROCDL_BarrierOp : ROCDL_Op<"barrier"> {
   let assemblyFormat = "attr-dict";
 }
 
-def ROCDL_LDSBarrierOp : ROCDL_Op<"lds_barrier"> {
-  // Guarantees LDS update until this point are all completed.
-  string llvmBuilder = [{
-    llvm::LLVMContext &llvmContext = builder.getContext();
-    builder.CreateFence(llvm::AtomicOrdering::Release,
-                       llvmContext.getOrInsertSyncScopeID("workgroup"));
-    createIntrinsicCall(builder, llvm::Intrinsic::amdgcn_s_barrier);
-  }];
-  let assemblyFormat = "attr-dict";
-}
-
 //===---------------------------------------------------------------------===//
 // Xdlops intrinsics
 

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/GPUToROCDL.td
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/GPUToROCDL.td
@@ -18,6 +18,5 @@ include "mlir/Dialect/GPU/GPUOps.td"
 include "mlir/Dialect/LLVMIR/ROCDLOps.td"
 
 def : Pat<(GPU_BarrierOp), (ROCDL_BarrierOp)>;
-def : Pat<(GPU_LDSBarrierOp), (ROCDL_LDSBarrierOp)>;
 
 #endif // MLIR_CONVERSION_GPUTOROCDL_TD

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -722,14 +722,11 @@ struct SoftwareBF16Trunc : OpRewritePattern<LLVM::FPTruncOp> {
   }
 };
 
-struct LDSBarrierOpLowering : ConvertToLLVMPattern {
-  explicit LDSBarrierOpLowering(MLIRContext *context,
-                                LLVMTypeConverter &typeConverter)
-      : ConvertToLLVMPattern(gpu::LDSBarrierOp::getOperationName(), context,
-                             typeConverter) {}
+struct LDSBarrierOpLowering : public ConvertOpToLLVMPattern<gpu::LDSBarrierOp> {
+  using ConvertOpToLLVMPattern<gpu::LDSBarrierOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  matchAndRewrite(gpu::LDSBarrierOp op, gpu::LDSBarrierOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
                                                     LLVM::AsmDialect::AD_ATT);
@@ -822,8 +819,8 @@ void mlir::populateGpuToROCDLConversionPatterns(
       GCNRawBufferOpLowering<gpu::GCNRawBufferLoadOp, ROCDL::RawBufferLoadOp>,
       GCNRawBufferOpLowering<gpu::GCNRawBufferStoreOp, ROCDL::RawBufferStoreOp>,
       GCNRawBufferOpLowering<gpu::GCNRawBufferAtomicFaddOp,
-                             ROCDL::RawBufferAtomicFAddOp>>(converter);
-  patterns.insert<LDSBarrierOpLowering>(ctx, converter);
+                             ROCDL::RawBufferAtomicFAddOp>,
+      LDSBarrierOpLowering>(converter);
 }
 
 void mlir::populateBF16ToROCDLConversionPatterns(LLVMTypeConverter &converter,

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -721,6 +721,31 @@ struct SoftwareBF16Trunc : OpRewritePattern<LLVM::FPTruncOp> {
     return success();
   }
 };
+
+struct LDSBarrierOpLowering : ConvertToLLVMPattern {
+  explicit LDSBarrierOpLowering(MLIRContext *context,
+                                LLVMTypeConverter &typeConverter)
+      : ConvertToLLVMPattern(gpu::LDSBarrierOp::getOperationName(), context,
+                             typeConverter) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                                    LLVM::AsmDialect::AD_ATT);
+    const auto *asmStr = "s_waitcnt lgkmcnt(0) \n s_barrier";
+    const auto *asmCstr = "";
+    SmallVector<Value> asmVals{};
+    SmallVector<Type> types{};
+    rewriter.replaceOpWithNewOp<LLVM::InlineAsmOp>(
+        op,
+        /*resultTypes=*/types, /*operands=*/asmVals, /*asm_string=*/asmStr,
+        /*constraints=*/asmCstr, /*has_side_effects=*/true,
+        /*is_align_stack=*/false, /*asm_dialect=*/asmDialectAttr,
+        /*operand_attrs=*/ArrayAttr());
+    return success();
+  }
+};
 } // namespace mlir
 
 void mlir::populateGpuToROCDLConversionPatterns(
@@ -798,6 +823,7 @@ void mlir::populateGpuToROCDLConversionPatterns(
       GCNRawBufferOpLowering<gpu::GCNRawBufferStoreOp, ROCDL::RawBufferStoreOp>,
       GCNRawBufferOpLowering<gpu::GCNRawBufferAtomicFaddOp,
                              ROCDL::RawBufferAtomicFAddOp>>(converter);
+  patterns.insert<LDSBarrierOpLowering>(ctx, converter);
 }
 
 void mlir::populateBF16ToROCDLConversionPatterns(LLVMTypeConverter &converter,

--- a/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
@@ -84,6 +84,17 @@ gpu.module @test_module_gpu_sync {
 
 // -----
 
+gpu.module @test_module_gpu_sync_lds {
+  // CHECK-LABEL: func @gpu_sync_lds()
+  func.func @gpu_sync_lds() {
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att "s_waitcnt lgkmcnt(0) \0A s_barrier"
+    gpu.lds_barrier
+    func.return
+  }
+}
+
+// -----
+
 gpu.module @test_module_gpu_fabs {
   // CHECK: llvm.func @__ocml_fabs_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_fabs_f64(f64) -> f64

--- a/external/llvm-project/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -35,12 +35,6 @@ func @rocdl.barrier() {
   llvm.return
 }
 
-func @rocdl.lds_barrier() {
-  // CHECK: rocdl.lds_barrier
-  rocdl.lds_barrier
-  llvm.return
-}
-
 func @rocdl.xdlops(%arg0 : f32, %arg1 : f32,
                    %arg2 : vector<32xf32>, %arg3 : i32,
                    %arg4 : vector<16xf32>, %arg5 : vector<4xf32>,

--- a/mlir/test/Target/rocdl.mlir
+++ b/mlir/test/Target/rocdl.mlir
@@ -45,13 +45,6 @@ llvm.func @rocdl.barrier() {
   llvm.return
 }
 
-llvm.func @rocdl.lds_barrier() {
-  // CHECK:      fence syncscope("workgroup") release
-  // CHECK-NEXT: call void @llvm.amdgcn.s.barrier()
-  rocdl.lds_barrier
-  llvm.return
-}
-
 llvm.func @rocdl.xdlops(%arg0 : f32, %arg1 : f32,
                    %arg2 : vector<32 x f32>, %arg30 : i32,
                    %arg4 : vector<16 x f32>, %arg5 : vector<4xf32>,


### PR DESCRIPTION
Currently `rocdl.lds_barrier` creates an LLVM fence with release ordering and workgroup syncscope. It would still introduce a `s_waitcnt vmcnt(0)` within the hot loop of a convolution kernel. From thread trace it can be seen we have stalled holes due to `s_waitcnt vmcnt(0)`.

In this PR, we reinstate using inline assembly for LDS barrier.

- Remove `rocdl.lds_barrier` and its lowering logic.
- Modify `gpu.lds_barrier` and use LLVM dialect `inline_asm` op to convey the
  instruction sequence we want in the hot loop:

```
  s_waitcnt lgkmcnt(0)
  s_barrier
```

Empirical testing shows 8~10% performance improvement in resnet50 configs.

As denoted at https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/503, a follow up ticket could be created to modify the behavior of the backend so we fallback to using intrinsics but still retain the same assembly output where no `s_waitcnt vmcnt(0)` is emitted. This requires more thorough understanding about the behavior in the backend.