### PR TITLE
Make buffer load read potential garbage and then replace it with 0

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -523,7 +523,9 @@ def MIOpen_BufferLoadOp :
     bounds checked on the left or right, respectively.
     If a load is determined to be out of bounds, its value is 0.
 
-    This op can perform vector reads.
+    This op can perform vector reads. Bounds checks on vector loads are all or nothing:
+    if the index at which the vector begins is in bounds, the whole read occurs,
+    and vice-versa.
 
     The memref must be in global memory (memory space 0).
   }];


### PR DESCRIPTION
In order to reduce the number of instructions used in address
computation and to give the processor something to do while it waits
for values to come back, have buffer_load perform its loads even if
they're going to a bad address (since actual out of bounds access will
be rejected in hardware) and then replace oob values with zero.

This is inspired by @whchung's note about trying not to schedule consecutive buffer loads and a conversation I had with @jerryyin. Inspection of ISA shows that the kernel has definitely gotten shorter, but benchmark runs done on 112 are being rather unclear about whether it's any *faster* (some configs seem to be faster, some slower, maybe it's all a matter of tuning).

I'll try and get some results from MI-200 tomorrow (someone went and upgraded the ROCm version on lockhart5 in a way that apparently made /dev/dri go away)