### PR TITLE
Make Jenkinsfile play nicer with CI cluster

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1,11 +1,13 @@
 // ON CHANGING THESE, ALSO CHANGE Jenkinsfile.downstream
 void buildProject(String target, String cmakeOpts) {
-    cmakeBuild generator: 'Ninja',\
-        buildDir: 'build',\
-        buildType: 'RelWithDebInfo',\
-        installation: 'InSearchPath',\
-        steps: [[args: target]],\
-        cmakeArgs: "-DMLIR_MIOPEN_DRIVER_ENABLED=1 $cmakeOpts"
+    timeout(time: 30, activity: true, unit: 'MINUTES') {
+        cmakeBuild generator: 'Ninja',\
+            buildDir: 'build',\
+            buildType: 'RelWithDebInfo',\
+            installation: 'InSearchPath',\
+            steps: [[args: target]],\
+            cmakeArgs: "-DMLIR_MIOPEN_DRIVER_ENABLED=1 $cmakeOpts"
+    }
 }
 
 void buildMIOpen(String cmakeOpts) {
@@ -83,14 +85,16 @@ void preMergeCheck() {
 
 void testMIOpenDriver(String dtype, String layout, String direction, String tuning) {
     echo "Config is (${dtype}, ${layout}, dir=${direction}, tuning=${tuning})"
-    dir('MIOpen/build/') {
-        sh """
-        bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh \
-        --layout ${layout} \
-        --direction ${direction} \
-        --dtype ${dtype} \
-        ${tuning == '1' ? '--tuning' : '--no-tuning'} \
-        < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs"""
+    timeout(time: 30, activity: true, unit: 'MINUTES') {
+        dir('MIOpen/build/') {
+            sh """
+            bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh \
+            --layout ${layout} \
+            --direction ${direction} \
+            --dtype ${dtype} \
+            ${tuning == '1' ? '--tuning' : '--no-tuning'} \
+            < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs"""
+        }
     }
 }
 
@@ -113,6 +117,17 @@ void postProcessPerfRes() {
 
     // Save results for future comparison
     archiveArtifacts artifacts: 'build/mlir_*.csv,build/perf-run-date', onlyIfSuccessful: true
+}
+
+//makes sure multiple builds are not triggered for branch indexing
+def resetBuild() {
+    if (currentBuild.getPreviousBuild().getBuildCauses().toString().contains('BranchIndexingCause')) {
+        def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber)
+    }
+}
+
+def rebootNode() {
+    build job: 'reboot-slaves', propagate: false , parameters: [string(name: 'server', value: "${env.NODE_NAME}"),]
 }
 
 pipeline {
@@ -143,6 +158,15 @@ pipeline {
                 }
             }
         }
+        stage("Kill old PR builds") {
+            when {
+                equals expected: false, actual: params.weekly;
+                equals expected: false, actual: params.nightly;
+            }
+            steps {
+                resetBuild()
+            }
+        }
         stage("Build and Test") {
             parallel {
                 stage("Shared Library: fixed E2E tests") {
@@ -155,7 +179,7 @@ pipeline {
                         docker {
                             image dockerImage()
                             args dockerArgs()
-                            label "${params.canXdlops ? 'gfx908 || gfx90a' : 'rocm' }"
+                            label "mlir && ${params.canXdlops ? '(gfx908 || gfx90a)' : 'rocm' }"
                             alwaysPull true
                         }
                     }
@@ -193,6 +217,9 @@ pipeline {
                         }
                      }
                      post {
+                        unsuccessful {
+                            rebootNode()
+                        }
                         always {
                             cleanWs()
                         }
@@ -210,7 +237,7 @@ pipeline {
                         docker {
                             image dockerImage()
                             args dockerArgs()
-                            label "${params.canXdlops ? 'gfx908 || gfx90a' : 'rocm' }"
+                            label "mlir && ${params.canXdlops ? '(gfx908 || gfx90a)' : 'rocm' }"
                             alwaysPull true
                         }
                     }
@@ -239,6 +266,9 @@ pipeline {
                         }
                     }
                     post {
+                        unsuccessful {
+                            rebootNode()
+                        }
                         always {
                             cleanWs()
                         }
@@ -257,7 +287,7 @@ pipeline {
                         docker {
                             image dockerImage()
                             args dockerArgs()
-                            label "${params.canXdlops ? 'gfx908 || gfx90a' : 'gfx906' }"
+                            label "mlir && ${params.canXdlops ? '(gfx908 || gfx90a)' : 'gfx906' }"
                             alwaysPull true
                         }
                     }
@@ -282,18 +312,23 @@ pipeline {
                                 LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
                             }
                             steps {
-                                dir('MIOpen/build/') {
-                                    sh """
-                                    bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --test-all --no-tuning\
-                                       < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/selected-resnet50-miopen-configs"""
-                                    sh """
-                                    bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --test-all --tuning\
-                                       < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/selected-resnet50-miopen-configs"""
+                                timeout(time: 30, activity: true, unit: 'MINUTES') {
+                                    dir('MIOpen/build/') {
+                                        sh """
+                                        bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --test-all --no-tuning\
+                                           < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/selected-resnet50-miopen-configs"""
+                                        sh """
+                                        bash ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --test-all --tuning\
+                                           < ${WORKSPACE}/mlir/utils/jenkins/miopen-tests/selected-resnet50-miopen-configs"""
+                                    }
                                 }
                             }
                         }
                     }
                     post {
+                        unsuccessful {
+                            rebootNode()
+                        }
                         always {
                             cleanWs()
                         }
@@ -318,7 +353,7 @@ pipeline {
                     docker {
                         image dockerImage()
                         args dockerArgs()
-                        label "${ARCH}"
+                        label "mlir && ${ARCH}"
                         alwaysPull true
                     }
                 }
@@ -440,7 +475,7 @@ pipeline {
                             docker {
                                 image dockerImage()
                                 args dockerArgs()
-                                label "${params.canXdlops ? 'gfx908 || gfx90a' : 'gfx906'}"
+                                label "mlir && ${params.canXdlops ? '(gfx908 || gfx90a)' : 'gfx906'}"
                                 alwaysPull true
                             }
                         }
@@ -492,6 +527,9 @@ pipeline {
                             }
                         }
                         post {
+                            unsuccessful {
+                                rebootNode()
+                            }
                             always {
                                 cleanWs()
                             }
@@ -511,7 +549,7 @@ pipeline {
                 docker {
                     image dockerImage()
                     args dockerArgs()
-                    label "${params.canXdlops ? 'gfx90a' : 'gfx906' }"
+                    label "mlir && ${params.canXdlops ? 'gfx90a' : 'gfx906' }"
                     alwaysPull true
                 }
             }
@@ -607,6 +645,9 @@ pipeline {
                 }
             }
             post {
+                unsuccessful {
+                    rebootNode()
+                }
                 always {
                     cleanWs()
                 }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -121,7 +121,7 @@ void postProcessPerfRes() {
 
 //makes sure multiple builds are not triggered for branch indexing
 def resetBuild() {
-    if (currentBuild.getPreviousBuild().getBuildCauses().toString().contains('BranchIndexingCause')) {
+    if (currentBuild.getPreviousBuild() == null || currentBuild.getPreviousBuild().getBuildCauses().toString().contains('BranchIndexingCause')) {
         def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber)
     }
 }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -43,7 +43,7 @@ String dockerImage() {
 
 //makes sure multiple builds are not triggered for branch indexing
 def resetBuild() {
-    if (currentBuild.getPreviousBuild().getBuildCauses().toString().contains('BranchIndexingCause')) {
+    if (currentBuild.getPreviousBuild() == null || currentBuild.getPreviousBuild().getBuildCauses().toString().contains('BranchIndexingCause')) {
         def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber)
     }
 }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -1,26 +1,31 @@
 void buildProject(String target, String cmakeOpts) {
-    cmakeBuild generator: 'Ninja',\
-        buildDir: 'build',\
-        buildType: 'RelWithDebInfo',\
-        installation: 'InSearchPath',\
-        steps: [[args: target]],\
-        cmakeArgs: "-DMLIR_MIOPEN_DRIVER_ENABLED=1 $cmakeOpts"
+    timeout(time: 30, activity: true, unit: 'MINUTES') {
+        cmakeBuild generator: 'Ninja',\
+            buildDir: 'build',\
+            buildType: 'RelWithDebInfo',\
+            installation: 'InSearchPath',\
+            steps: [[args: target]],\
+            cmakeArgs: "-DMLIR_MIOPEN_DRIVER_ENABLED=1 $cmakeOpts"
+    }
 }
 
 void buildMIOpen(String cmakeOpts) {
     sh '[ ! -d build ] || rm -rf build'
-    cmakeBuild generator: 'Unix Makefiles',\
-        buildDir: 'build',\
-        buildType: 'Release',\
-        installation: 'InSearchPath',\
-        cmakeArgs: """-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
-                     -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
-                     ${cmakeOpts}
-                     """
-    sh 'cd build; make -j $(nproc) MIOpenDriver'
+    timeout(time: 30, activity: true, unit: 'MINUTES') {
+        cmakeBuild generator: 'Unix Makefiles',\
+            buildDir: 'build',\
+            buildType: 'Release',\
+            installation: 'InSearchPath',\
+            cmakeArgs: """-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+                         -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+                         ${cmakeOpts}
+                         """
+        sh 'cd build; make -j $(nproc) MIOpenDriver'
+    }
 }
 
 void showEnv() {
+    echo "$env.NODE_NAME"
     sh 'hostname'
     sh 'cat /etc/os-release'
     sh 'ulimit -a'
@@ -35,6 +40,18 @@ String dockerImage() {
     return 'rocm/mlir:rocm5.0-latest'
 }
 
+
+//makes sure multiple builds are not triggered for branch indexing
+def resetBuild() {
+    if (currentBuild.getPreviousBuild().getBuildCauses().toString().contains('BranchIndexingCause')) {
+        def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber)
+    }
+}
+
+def rebootNode() {
+    build job: 'reboot-slaves', propagate: false , parameters: [string(name: 'server', value: "${env.NODE_NAME}"),]
+}
+
 pipeline {
     agent none
     parameters {
@@ -44,6 +61,11 @@ pipeline {
             description: 'Run static library and MIOpen integration tests')
     }
     stages {
+        stage('Kill old PR builds') {
+            steps {
+                resetBuild()
+            }
+        }
         stage('Build and Test') {
             parallel {
                 stage("Shared Library: fixed E2E tests") {
@@ -63,6 +85,11 @@ pipeline {
                         PATH="$PATH:/opt/rocm/llvm/bin"
                     }
                     stages {
+                        stage("Environment") {
+                            steps {
+                                showEnv()
+                            }
+                        }
                         stage("Shared library build and fixed tests") {
                             steps {
                                 buildProject('check-mlir check-mlir-miopen', """
@@ -78,6 +105,9 @@ pipeline {
                         }
                     }
                     post {
+                        unsuccessful {
+                            rebootNode()
+                        }
                         always {
                             cleanWs()
                         }
@@ -100,6 +130,11 @@ pipeline {
                         PATH="$PATH:/opt/rocm/llvm/bin"
                     }
                     stages {
+                        stage("Environment") {
+                            steps {
+                                showEnv()
+                            }
+                        }
                         stage("Igemm build") {
                             steps {
                                 checkout scm
@@ -132,7 +167,6 @@ pipeline {
                                 LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
                             }
                             steps {
-                                showEnv()
                                 sh 'ldconfig'
                                 dir('MIOpen/build/') {
                                     sh """
@@ -146,6 +180,9 @@ pipeline {
                         }
                     }
                     post {
+                        unsuccessful {
+                            rebootNode()
+                        }
                         always {
                             cleanWs()
                         }


### PR DESCRIPTION
1. Limit execution to nodes with a `mlir` label

2. When a job fails, reboot the underlying node, since the failure is
_probably_ due to a GPU hang

3. Use timeouts to kill jobs that produce no output after 30 minutes,
indicating a hang