### PR TITLE
Make load/store positioning consistent in gridwise gemm

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1170,20 +1170,6 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     TransformingForOp blockwiseLoadA = createGlobalLoadLoop(
         b, loc, op.a(), blockwiseLoadACoords, aLoadIntermediate, aLoadType,
         blockwiseCopyABounds, blockwiseVectorDimA, useIndexDiffs);
-    SmallVector<Value, 4> blockwiseStoreACoords;
-    if (KPack > 1) {
-      blockwiseStoreACoords = {zeroConstantOp, GemmABlockCopyDestCoord_Z,
-                               GemmABlockCopyDestCoord_Y,
-                               GemmABlockCopyDestCoord_X};
-    } else {
-      blockwiseStoreACoords = {zeroConstantOp, GemmABlockCopyDestCoord_Y,
-                               GemmABlockCopyDestCoord_X};
-    }
-    // Emit blockwise store for matrix A.
-    TransformingForOp blockwiseStoreA = createLdsStoreLoop(
-        b, loc, blockwiseLoadA.getResult(0), ldsMatrixASubviewOp,
-        blockwiseStoreACoords, aStoreType, blockwiseCopyABounds,
-        blockwiseVectorDimA);
 
     SmallVector<Value, 4> blockwiseLoadBCoords;
     if (KPack > 1) {
@@ -1198,6 +1184,21 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     TransformingForOp blockwiseLoadB = createGlobalLoadLoop(
         b, loc, op.b(), blockwiseLoadBCoords, bLoadIntermediate, bLoadType,
         blockwiseCopyBBounds, blockwiseVectorDimB, useIndexDiffs);
+
+    SmallVector<Value, 4> blockwiseStoreACoords;
+    if (KPack > 1) {
+      blockwiseStoreACoords = {zeroConstantOp, GemmABlockCopyDestCoord_Z,
+                               GemmABlockCopyDestCoord_Y,
+                               GemmABlockCopyDestCoord_X};
+    } else {
+      blockwiseStoreACoords = {zeroConstantOp, GemmABlockCopyDestCoord_Y,
+                               GemmABlockCopyDestCoord_X};
+    }
+    // Emit blockwise store for matrix A.
+    TransformingForOp blockwiseStoreA = createLdsStoreLoop(
+        b, loc, blockwiseLoadA.getResult(0), ldsMatrixASubviewOp,
+        blockwiseStoreACoords, aStoreType, blockwiseCopyABounds,
+        blockwiseVectorDimA);
 
     SmallVector<Value, 4> blockwiseStoreBCoords;
     if (KPack > 1) {
@@ -2102,6 +2103,20 @@ struct GridwiseGemmV2RewritePattern
         b, loc, op.a(), blockwiseLoadACoords, aLoadIntermediate, aLoadType,
         blockwiseCopyABounds, blockwiseVectorDimA, useIndexDiffs);
 
+    SmallVector<Value, 4> blockwiseLoadBCoords;
+    if (KPack > 1) {
+      blockwiseLoadBCoords = {GemmBlockCoord_G, GemmBBlockCopySourceCoord_Z,
+                              GemmBBlockCopySourceCoord_Y,
+                              GemmBBlockCopySourceCoord_X};
+    } else {
+      blockwiseLoadBCoords = {GemmBlockCoord_G, GemmBBlockCopySourceCoord_Y,
+                              GemmBBlockCopySourceCoord_X};
+    }
+    // Emit blockwise load for matrix B.
+    TransformingForOp blockwiseLoadB = createGlobalLoadLoop(
+        b, loc, op.b(), blockwiseLoadBCoords, bLoadIntermediate, bLoadType,
+        blockwiseCopyBBounds, blockwiseVectorDimB, useIndexDiffs);
+
     SmallVector<Value, 4> blockwiseStoreACoords;
     if (KPack > 1) {
       blockwiseStoreACoords = {zeroConstantOp, GemmABlockCopyDestCoord_Z,
@@ -2116,20 +2131,6 @@ struct GridwiseGemmV2RewritePattern
         b, loc, blockwiseLoadA.getResult(0), ldsMatrixASubviewOp,
         blockwiseStoreACoords, aStoreType, blockwiseCopyABounds,
         blockwiseVectorDimA);
-
-    SmallVector<Value, 4> blockwiseLoadBCoords;
-    if (KPack > 1) {
-      blockwiseLoadBCoords = {GemmBlockCoord_G, GemmBBlockCopySourceCoord_Z,
-                              GemmBBlockCopySourceCoord_Y,
-                              GemmBBlockCopySourceCoord_X};
-    } else {
-      blockwiseLoadBCoords = {GemmBlockCoord_G, GemmBBlockCopySourceCoord_Y,
-                              GemmBBlockCopySourceCoord_X};
-    }
-    // Emit blockwise load for matrix B.
-    TransformingForOp blockwiseLoadB = createGlobalLoadLoop(
-        b, loc, op.b(), blockwiseLoadBCoords, bLoadIntermediate, bLoadType,
-        blockwiseCopyBBounds, blockwiseVectorDimB, useIndexDiffs);
 
     SmallVector<Value, 4> blockwiseStoreBCoords;
     if (KPack > 1) {


### PR DESCRIPTION
Now, both in the body of the loops and in the loop header, the ops go
load A ; load B ; store A ; store B

Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/457