### PR TITLE
Adjustments to buildbot support after some experience

### DIFF
--- a/mlir/utils/buildbot/README
+++ b/mlir/utils/buildbot/README
@@ -1,0 +1,7 @@
+To start up the buildbot:
+
+  git clone https://github.com/ROCmSoftwarePlatform/llvm-project-mlir.git
+  cd ./llvm-project-mlir/mlir/utils/buildbot
+  export BUILDBOT_PORT=9994
+  export BUILDBOT_MASTER=lab.llvm.org
+  ./build-run.sh mlir-rocm-mi200 `pwd`/mlir-rocm-mi200

--- a/mlir/utils/buildbot/build-run.sh
+++ b/mlir/utils/buildbot/build-run.sh
@@ -69,4 +69,6 @@ else
 fi
 
 docker build ${BUILDPROXY} -t "${IMAGE_NAME}:latest" .
-docker run -it --net=host --device=/dev/kfd --device=/dev/dri --group-add video --name buildbot --restart always ${RUNPROXY} ${VOLUMES} ${ARGS} "${IMAGE_NAME}:latest" ${CMD}
+# Use "--group-add root" to work around container putting /dev/kfd and /dev/dri
+# in root instead of the proper video or render.
+docker run -d --net=host --device=/dev/kfd --device=/dev/dri --group-add video --group-add root --name buildbot --restart always ${RUNPROXY} ${VOLUMES} ${ARGS} "${IMAGE_NAME}:latest" ${CMD}

--- a/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
@@ -21,14 +21,19 @@ RUN apt-get update; \
     update-alternatives --install /usr/bin/lld lld /usr/bin/lld-10 100
 
 # LTS releases often bundle obsolete pip versions that cannot access newest
-# Linux binary wheels. This pinned version is not special: it was just current
-# at the time this was added. Refer to compatibility table:
-# https://github.com/pypa/manylinux
+# Linux binary wheels.
 RUN python3 -m pip install --upgrade pip
+
+RUN apt-add-repository ppa:deadsnakes/ppa && apt-get update \
+     && apt-get install -y --no-install-recommends \
+            python3.8 python3.8-dev python3.8-venv \
+     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10 \
+     && python3 -m pip install --upgrade pip \
+     && python3 -m pip install --ignore-installed PyYAML
 
 # Refer to mlir/lib/Bindings/Python/requirements.txt. Listed explicitly here
 # and version pinned for consistency as this is a bot.
-RUN python3 -m pip install numpy pybind11 PyYAML
+RUN python3 -m pip install numpy pybind11>=2.8.0 PyYAML>5 dataclasses
 
 # Install build bot (server was at 2.8.5-dev at time of writing).
 RUN pip3 install buildbot-worker
@@ -49,7 +54,7 @@ ENV CCACHE_DIR=/vol/ccache
 VOLUME /vol/worker
 
 # Create user account, some tests fail if run as root.
-RUN useradd buildbot --create-home
+RUN useradd buildbot --create-home -u 2000
 WORKDIR /vol/worker
 
 # copy startup script
@@ -57,7 +62,7 @@ COPY run.sh /home/buildbot/
 RUN chmod a+rx /home/buildbot/run.sh
 
 USER buildbot
-ENV WORKER_NAME="mlir-rocm-mi200"
+ENV WORKER_NAME="mi200-buildbot"
 
 # Allow the server port of this agent to be configurable during deployment.
 # This way we can connect the same image to production and integration.


### PR DESCRIPTION
* Change buildbot login name, run docker as daemon.
  The login name used at the master isn't the original one I'd submitted, so change here to match it.
* Use python 3.8 to include some newer libraries.
* Use '--group-add root' to work around /dev/kfd group glitch, update PyYAML, add python3.8-dev.
  /dev/kfd and /dev/dri are coming into the docker with group root instead of video or render, and I don't know why, but I can compensate.
* Add README with buildbot startup instructions.