### PR TITLE
Adding support of int8 inference in miopen_validate.sh

### DIFF
--- a/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
+++ b/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
@@ -5,7 +5,7 @@ declare -g TMPFILE
 declare -ig XDLOPS=-1
 declare -ig TUNING=0
 declare -ig TESTALL=0
-declare -ig TESTINF=0
+declare -ig TESTFWD=0
 declare -g DTYPE=""
 declare -g DIRECTION=""
 declare -g LAYOUT=""
@@ -42,7 +42,7 @@ function parse_options() {
 
     local parsed_args
     parsed_args=$(getopt -n "$0" -o d:t:l:xXh \
-                         --long direction:,dtype:,layout:,xdlops,no-xdlops,driver:,driver:,tuning,no-tuning,test-all,test-inf,help -- "$@")
+                         --long direction:,dtype:,layout:,xdlops,no-xdlops,driver:,driver:,tuning,no-tuning,test-all,test-fwd,help -- "$@")
     local -i valid_args=$?
     if [[ $valid_args -ne 0 ]]; then
         usage
@@ -57,7 +57,7 @@ function parse_options() {
             --tuning ) TUNING=1; shift; ;;
             --no-tuning ) TUNING=0; shift; ;;
             --test-all ) TESTALL=1; shift; ;;
-            --test-inf ) TESTINF=1; shift; ;;
+            --test-fwd) TESTFWD=1; shift; ;;
             -d | --direction ) got_direction=1; DIRECTION="$2"; shift 2 ;;
             -l | --layout ) got_layout=1; LAYOUT="$2"; shift 2 ;;
             -t | --dtype ) got_dtype=1; DTYPE="$2"; shift 2 ;;
@@ -69,7 +69,7 @@ function parse_options() {
 
     # Check required args
     [[ $got_layout == 1 && $got_direction == 1 && $got_dtype == 1 ]] || [[ $TESTALL == 1 ]] || \
-        [[ $got_dtype == 1 && $TESTINF == 1 ]] || usage
+        [[ $got_dtype == 1 && $TESTFWD == 1 ]] || usage
 
     # Validate options
     if [[ $got_dtype == 1 ]]; then
@@ -220,7 +220,7 @@ function main() {
     get_configs
     if [[ $TESTALL == 1 ]]; then
         run_tests_for_all_configs
-    elif [[ $TESTINF == 1 ]]; then
+    elif [[ $TESTFWD == 1 ]]; then
         run_tests_for_inference
     else
         run_tests_for_a_config

--- a/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
+++ b/mlir/utils/jenkins/miopen-tests/miopen_validate.sh
@@ -5,6 +5,7 @@ declare -g TMPFILE
 declare -ig XDLOPS=-1
 declare -ig TUNING=0
 declare -ig TESTALL=0
+declare -ig TESTINF=0
 declare -g DTYPE=""
 declare -g DIRECTION=""
 declare -g LAYOUT=""
@@ -17,7 +18,7 @@ declare -a ALL_CONFIGS=()
 
 function usage() {
     cat <<END
-$0: [-d | --direction] DIR [-t | --dtype] [fp16 | fp32] [-l | --layout] LAYOUT
+$0: [-d | --direction] DIR [-t | --dtype] [int8 | fp16 | fp32] [-l | --layout] LAYOUT
 [-x | --xdlops] [-X | --no-xdlops (default)] [--tuning | --no-tuning (default)]
 [--driver DRIVER (default bin/MIOpenDriver)] [--test-all]
 
@@ -41,7 +42,7 @@ function parse_options() {
 
     local parsed_args
     parsed_args=$(getopt -n "$0" -o d:t:l:xXh \
-                         --long direction:,dtype:,layout:,xdlops,no-xdlops,driver:,driver:,tuning,no-tuning,test-all,help -- "$@")
+                         --long direction:,dtype:,layout:,xdlops,no-xdlops,driver:,driver:,tuning,no-tuning,test-all,test-inf,help -- "$@")
     local -i valid_args=$?
     if [[ $valid_args -ne 0 ]]; then
         usage
@@ -56,6 +57,7 @@ function parse_options() {
             --tuning ) TUNING=1; shift; ;;
             --no-tuning ) TUNING=0; shift; ;;
             --test-all ) TESTALL=1; shift; ;;
+            --test-inf ) TESTINF=1; shift; ;;
             -d | --direction ) got_direction=1; DIRECTION="$2"; shift 2 ;;
             -l | --layout ) got_layout=1; LAYOUT="$2"; shift 2 ;;
             -t | --dtype ) got_dtype=1; DTYPE="$2"; shift 2 ;;
@@ -66,12 +68,13 @@ function parse_options() {
     done
 
     # Check required args
-    [[ $got_layout == 1 && $got_direction == 1 && $got_dtype == 1 ]] || [[ $TESTALL == 1 ]] || usage
+    [[ $got_layout == 1 && $got_direction == 1 && $got_dtype == 1 ]] || [[ $TESTALL == 1 ]] || \
+        [[ $got_dtype == 1 && $TESTINF == 1 ]] || usage
 
     # Validate options
     if [[ $got_dtype == 1 ]]; then
         case "$DTYPE" in
-            fp16 | fp32 ) ;;
+            int8 | fp16 | fp32 ) ;;
             * ) echo "$0: Invalid dtype $DTYPE"; usage ;;
         esac
     fi
@@ -108,6 +111,7 @@ function construct_fixed_args() {
     case "$DTYPE" in
         fp16 ) FIXED_CONFIG_ARGS=("convfp16") ;;
         fp32 ) FIXED_CONFIG_ARGS=("conv") ;;
+        int8 ) FIXED_CONFIG_ARGS=("convint8") ;;
         * ) echo "Can't happen"; exit 3 ;;
     esac
 
@@ -202,12 +206,22 @@ function run_tests_for_all_configs() {
     done
 }
 
+function run_tests_for_inference() {
+   for l in ${ALL_LAYOUTS[@]}; do
+       DIRECTION=1
+       LAYOUT=$l
+       run_tests_for_a_config
+   done
+}
+
 function main() {
     clean_miopen_caches
     parse_options "$@"
     get_configs
     if [[ $TESTALL == 1 ]]; then
         run_tests_for_all_configs
+    elif [[ $TESTINF == 1 ]]; then
+        run_tests_for_inference
     else
         run_tests_for_a_config
     fi


### PR DESCRIPTION
This PR adds the following capability:
 - inference run for convolution configs
 - int8 data type

To run the script in int8 inference:
```bash
 bash ~/llvm-project-mlir/mlir/utils/jenkins/miopen-tests/miopen_validate.sh --test-inf --dtype int8 --tuning  < ~/llvm-project-mlir/mlir/utils/jenkins/miopen-tests/resnet50-miopen-configs
```

TODO:
 - Adding int8 MIOpen (MLIR solver) support to its branch
 - Add int8 inference tuning to weekly test/ selected configs test