### PR TITLE
Revert "Migrate `KBlock` heuristic logic from MIOpen to MLIR."

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -22,62 +22,27 @@
 namespace mlir {
 namespace miopen {
 
-// Heuristic logic to compute KBlock for backward weight atomic add kernel.
-// The logic is adopted from MIOpen.
-//
-// The logic searches within the range of [1, 20 * number of CUs / gridSize],
-// where gridSize is the original number of workgroups required for the
-// convolution, and find the largest KBlock number which preserves the 2
-// contraints:
-// - GemmK (before splitting) = KBlock * KPerBlock * KPack * GemmK (after
-// splitting).
-// - n (batch size) is divisible by KBlock.
-//
-// 20 is a magic number obtained in MIOpen after empirical testing. It offers a
-// reasonable reduction of GemmK after splitting, without incurring too much
-// overheads on atomic adds. One potential future work is to make this value be
-// tunable.
-inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo, int64_t g,
-                                  int64_t k, int64_t c, int64_t y, int64_t x,
-                                  int64_t MPerBlock, int64_t NPerBlock,
-                                  int64_t KPerBlock, int64_t KPack,
-                                  int64_t num_cu) {
-  const int64_t KPerGroup = k / g;
-  const int64_t CPerGroup = c / g;
-  const int64_t gemmM = KPerGroup;
-  const int64_t gemmN = CPerGroup * y * x;
-
-  const int64_t gemmK = n * ho * wo;
-  int64_t gemmKBlock = 1;
-
-  assert(gemmM % MPerBlock == 0);
-  assert(gemmN % NPerBlock == 0);
-  assert(gemmK % (KPerBlock * KPack) == 0);
-
-  const int64_t gridSize = g * (gemmM / MPerBlock) * (gemmN / NPerBlock);
-  const int64_t maxGridSize = 20 * num_cu;
-
-  gemmKBlock = std::max(maxGridSize / gridSize, static_cast<int64_t>(1));
-  gemmKBlock = std::min(gemmKBlock, n);
-
-  for (; gemmKBlock > 1; --gemmKBlock) {
-    if (n % gemmKBlock != 0)
-      continue;
-
-    if (gemmK % (gemmKBlock * KPerBlock * KPack) != 0)
-      continue;
-
-    break;
+inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo) {
+  int64_t gemmK = n * ho * wo;
+  int64_t gemmKBlocks = 1;
+  if (gemmK % 16 == 0) {
+    auto lcm = math_util::lcm(ho * wo, (int64_t)16);
+    gemmKBlocks = std::min(gemmK / lcm, n);
+  } else if (gemmK % 8 == 0) {
+    auto comm = math_util::lcm(ho * wo, (int64_t)8);
+    gemmKBlocks = std::min(gemmK / comm, n);
+  } else if (gemmK % 4 == 0) {
+    auto comm = math_util::lcm(ho * wo, (int64_t)4);
+    gemmKBlocks = std::min(gemmK / comm, n);
   }
-
   // not more than n
-  gemmKBlock = std::min(n, gemmKBlock);
+  gemmKBlocks = std::min(n, gemmKBlocks);
   // not less than 1
-  gemmKBlock = std::max(static_cast<int64_t>(1), gemmKBlock);
+  gemmKBlocks = std::max((__int64_t)1, gemmKBlocks);
 
-  // llvm::errs() << "\n gemmKBlock: " << gemmKBlock << " gemmK: " << gemmK
+  // llvm::errs() << "\n gemmKBlocks: " << gemmKBlocks << " gemmK: " << gemmK
   //               << " ho: " << ho << " wo: " << wo << "\n";
-  return gemmKBlock;
+  return gemmKBlocks;
 }
 
 /// Unwrap a value from the transforms surrounding it, gathering up the

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -270,17 +270,9 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto gemmIdAttr = op->template getAttrOfType<IntegerAttr>("gemm_id");
   auto archAttr = op->template getAttrOfType<StringAttr>("arch");
   auto numCuAttr = op->template getAttrOfType<IntegerAttr>("num_cu");
-  int64_t numCu = numCuAttr.getInt();
 
   auto KPackAttr = op->template getAttrOfType<IntegerAttr>("kpack");
   int64_t KPack = KPackAttr.getInt();
-
-  auto MPerBlockAttr = op->template getAttrOfType<IntegerAttr>("m_per_block");
-  auto NPerBlockAttr = op->template getAttrOfType<IntegerAttr>("n_per_block");
-  auto KPerBlockAttr = op->template getAttrOfType<IntegerAttr>("k_per_block");
-  int64_t MPerBlock = MPerBlockAttr.getInt();
-  int64_t NPerBlock = NPerBlockAttr.getInt();
-  int64_t KPerBlock = KPerBlockAttr.getInt();
 
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");
@@ -352,8 +344,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto strideW =
       stridesAttr.getValue()[1].template cast<IntegerAttr>().getInt();
   // get y, x, ho, wo, hi, wi
-  int64_t g, n, k, c, y, x, ho, wo, hi, wi;
-  g = n = k = c = y = x = ho = wo = hi = wi = 0;
+  int64_t n, k, c, y, x, ho, wo, hi, wi;
+  n = k = c = y = x = ho = wo = hi = wi = 0;
   llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
   for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
     auto filterAttr =
@@ -374,8 +366,6 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
       y = filterShape[i];
     } else if (filterAttr.getValue() == "x") {
       x = filterShape[i];
-    } else if (filterAttr.getValue() == "g") {
-      g = filterShape[i];
     }
 
     if (inputAttr.getValue() == "ni") {
@@ -394,8 +384,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   }
   // calculate gemmKBlocks
 
-  int64_t gemmKBlocks = calculateKBlockNum(n, ho, wo, g, k, c, y, x, MPerBlock,
-                                           NPerBlock, KPerBlock, KPack, numCu);
+  // static const int64_t MaxSubBlockNum = 2048 / standardBockNum;
+  int64_t gemmKBlocks = calculateKBlockNum(n, ho, wo);
 
   Value gemmFilter, gemmInput, gemmOutput;
   Value gemmInputKPack, gemmOutputKPack;

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -284,7 +284,7 @@ LogicalResult PopulateParamsXDL::populateDerived(
   int64_t nKBlocks = 1;
   if (ctx.opType == miopen::ConvOpType::BwdWeight &&
       (ctx.getDataType().isF32() || ctx.getDataType().isF16())) {
-    nKBlocks = getKBlocks(ctx, params);
+    nKBlocks = getKBlocks(ctx);
   }
   gridSize = obtainGridSize(gemmSize, &params) * nKBlocks;
 


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/llvm-project-mlir#586

Nightly CI fails:
http://[rocmhead.amd.com:8080/blue/rest/organizations/jenkins/pipelines/MLIR/pipelines/mlir-nightly-all/runs/359/nodes/20/steps/115/log/?start=0](http://rocmhead.amd.com:8080/blue/rest/organizations/jenkins/pipelines/MLIR/pipelines/mlir-nightly-all/runs/359/nodes/20/steps/115/log/?start=0)