### PR TITLE
Fix calculateKBlockNum for group convolution.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -42,10 +42,8 @@ inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo, int64_t g,
                                   int64_t MPerBlock, int64_t NPerBlock,
                                   int64_t KPerBlock, int64_t KPack,
                                   int64_t num_cu) {
-  const int64_t KPerGroup = k / g;
-  const int64_t CPerGroup = c / g;
-  const int64_t gemmM = KPerGroup;
-  const int64_t gemmN = CPerGroup * y * x;
+  const int64_t gemmM = k;
+  const int64_t gemmN = c * y * x;
 
   const int64_t gemmK = n * ho * wo;
   int64_t gemmKBlock = 1;


### PR DESCRIPTION
In MLIR MIOpen dialect implementation, k (output channel) and c (input channel)
are independent of g (group count).

In MIOpen implementation, k and c are implicitly timed by g, so they have to be
divided with g. This computation is not necessary inside MLIR MIOpen dialect
implementation.

Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/531

Relevant MIOpen logic:
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/src/include/miopen/conv/problem_description.hpp#L167
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/src/include/miopen/conv/problem_description.hpp#L201

It can be observed g is not a standalone dimension in MIOpen problem description.