### PR TITLE
Fix `calculateKBlockNum` for group convolution.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -859,7 +859,8 @@ private:
            (params.gemmMPerWave * params.gemmNPerWave);
   }
 
-  int64_t getKBlocks(ConvolutionContext &ctx, InitParamsXDL &params) {
+  LogicalResult getKBlocks(ConvolutionContext &ctx, InitParamsXDL &params,
+                           int64_t *nKBlocks) {
     int64_t n = ctx.dimIndexAndSize["no"].size;
     int64_t ho = ctx.dimIndexAndSize["ho"].size;
     int64_t wo = ctx.dimIndexAndSize["wo"].size;
@@ -871,7 +872,7 @@ private:
 
     return mlir::miopen::calculateKBlockNum(
         n, ho, wo, g, k, c, y, x, params.gemmMPerBlock, params.gemmNPerBlock,
-        params.gemmKPerBlock, params.gemmKPack, ctx.num_cu);
+        params.gemmKPerBlock, params.gemmKPack, ctx.num_cu, nKBlocks);
   }
 
   LogicalResult calculateGemmABlockCopyPerformanceParameters(

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -847,22 +847,6 @@ private:
   };
   // clang-format on
 
-  // XXX FIXME: Initial tuning parameters for fp32 backward weight convolution.
-  // Deliberately avoid KPACK=4 for fp32 backward weight convolution. It has
-  // been verified some configs would cause intermittent failures.
-  // TODO(whchung): Get to the bottom of this.
-  // clang-format off
-  llvm::SmallVector<InitParamsXDL, 4> initParametersBwdWeightF32 = {
-      // M/block N/block K/block M/wave N/wave kPack aCopyMore bCopyMore
-      {128, 128, 8, 64, 64, 1, false, false},
-      {128, 128, 16, 64, 64, 1, false, false},
-      {8, 64, 8, 8, 64, 1, false, false},
-      {4, 64, 16, 4, 64, 1, false, false},
-      {32, 64, 4, 32, 64, 1, false, false},
-      {16, 16, 16, 16, 16, 1, false, false},
-      {16, 16, 4, 16, 16, 1, false, false} ,
-  };
-  // clang-format on
   const int64_t waveSize = 64;
 
   // if can't select config from above , use this config to do
@@ -875,11 +859,19 @@ private:
            (params.gemmMPerWave * params.gemmNPerWave);
   }
 
-  int64_t getKBlocks(ConvolutionContext &ctx) {
+  int64_t getKBlocks(ConvolutionContext &ctx, InitParamsXDL &params) {
     int64_t n = ctx.dimIndexAndSize["no"].size;
     int64_t ho = ctx.dimIndexAndSize["ho"].size;
     int64_t wo = ctx.dimIndexAndSize["wo"].size;
-    return mlir::miopen::calculateKBlockNum(n, ho, wo);
+    int64_t g = ctx.dimIndexAndSize["g"].size;
+    int64_t k = ctx.dimIndexAndSize["k"].size;
+    int64_t c = ctx.dimIndexAndSize["c"].size;
+    int64_t y = ctx.dimIndexAndSize["y"].size;
+    int64_t x = ctx.dimIndexAndSize["x"].size;
+
+    return mlir::miopen::calculateKBlockNum(
+        n, ho, wo, g, k, c, y, x, params.gemmMPerBlock, params.gemmNPerBlock,
+        params.gemmKPerBlock, params.gemmKPack, ctx.num_cu);
   }
 
   LogicalResult calculateGemmABlockCopyPerformanceParameters(
@@ -1007,18 +999,6 @@ private:
       return failure();
     }
 
-    // XXX FIXME: Temporarily reject KPACK=4 for fp32 backward weight
-    // convolution. It has been verified some configs would cause intermittent
-    // failures.
-    // TODO(whchung): Get to the bottom of this.
-    if ((param.gemmKPack == 4) &&
-        (ctx.getOpType() == miopen::ConvOpType::BwdWeight) &&
-        dataType.isF32()) {
-      llvm::errs() << "Invalid config: fp32 XDLOPS backward weight convolution "
-                      "with KPACK=4\n";
-      return failure();
-    }
-
     // TODO remove : Ignore KReduction XDLOPS path for forward and backward
     // weight convolution now (unless int8). These M/NPerBlock combinations used
     // to result in lowering errors at tuning. Once non-int8 types are tested,
@@ -1084,14 +1064,6 @@ public:
   getTuningParameters(miopen::ConvOpType dir, mlir::Type dataType) {
     if (dataType.isInteger(8)) {
       return initParametersForwardI8;
-    }
-
-    // XXX FIXME: Temporarily use another vector of heuristic tuning
-    // parameters to get around the issue that when KPACK=4, fp32 backward
-    // weight kernels would fail intermittently.
-    // TODO(whchung): Get to the bottom of this.
-    if ((dir == miopen::ConvOpType::BwdWeight) && dataType.isF32()) {
-      return initParametersBwdWeightF32;
     }
 
     return initParameters;

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -42,10 +42,8 @@ inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo, int64_t g,
                                   int64_t MPerBlock, int64_t NPerBlock,
                                   int64_t KPerBlock, int64_t KPack,
                                   int64_t num_cu) {
-  const int64_t KPerGroup = k / g;
-  const int64_t CPerGroup = c / g;
-  const int64_t gemmM = KPerGroup;
-  const int64_t gemmN = CPerGroup * y * x;
+  const int64_t gemmM = k;
+  const int64_t gemmN = c * y * x;
 
   const int64_t gemmK = n * ho * wo;
   int64_t gemmKBlock = 1;

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -69,9 +69,9 @@ inline LogicalResult calculateKBlockNum(int64_t n, int64_t ho, int64_t wo,
     break;
   }
   // not more than n
-  gemmKBlocks = std::min(n, gemmKBlocks);
+  gemmKBlock = std::min(n, gemmKBlock);
   // not less than 1
-  gemmKBlocks = std::max((__int64_t)1, gemmKBlocks);
+  gemmKBlock = std::max((__int64_t)1, gemmKBlock);
 
   *nKBlock = gemmKBlock;
   return success();

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -22,27 +22,62 @@
 namespace mlir {
 namespace miopen {
 
-inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo) {
-  int64_t gemmK = n * ho * wo;
-  int64_t gemmKBlocks = 1;
-  if (gemmK % 16 == 0) {
-    auto lcm = math_util::lcm(ho * wo, (int64_t)16);
-    gemmKBlocks = std::min(gemmK / lcm, n);
-  } else if (gemmK % 8 == 0) {
-    auto comm = math_util::lcm(ho * wo, (int64_t)8);
-    gemmKBlocks = std::min(gemmK / comm, n);
-  } else if (gemmK % 4 == 0) {
-    auto comm = math_util::lcm(ho * wo, (int64_t)4);
-    gemmKBlocks = std::min(gemmK / comm, n);
-  }
-  // not more than n
-  gemmKBlocks = std::min(n, gemmKBlocks);
-  // not less than 1
-  gemmKBlocks = std::max((__int64_t)1, gemmKBlocks);
+// Heuristic logic to compute KBlock for backward weight atomic add kernel.
+// The logic is adopted from MIOpen.
+//
+// The logic searches within the range of [1, 20 * number of CUs / gridSize],
+// where gridSize is the original number of workgroups required for the
+// convolution, and find the largest KBlock number which preserves the 2
+// contraints:
+// - GemmK (before splitting) = KBlock * KPerBlock * KPack * GemmK (after
+// splitting).
+// - n (batch size) is divisible by KBlock.
+//
+// 20 is a magic number obtained in MIOpen after empirical testing. It offers a
+// reasonable reduction of GemmK after splitting, without incurring too much
+// overheads on atomic adds. One potential future work is to make this value be
+// tunable.
+inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo, int64_t g,
+                                  int64_t k, int64_t c, int64_t y, int64_t x,
+                                  int64_t MPerBlock, int64_t NPerBlock,
+                                  int64_t KPerBlock, int64_t KPack,
+                                  int64_t num_cu) {
+  const int64_t KPerGroup = k / g;
+  const int64_t CPerGroup = c / g;
+  const int64_t gemmM = KPerGroup;
+  const int64_t gemmN = CPerGroup * y * x;
 
-  // llvm::errs() << "\n gemmKBlocks: " << gemmKBlocks << " gemmK: " << gemmK
+  const int64_t gemmK = n * ho * wo;
+  int64_t gemmKBlock = 1;
+
+  assert(gemmM % MPerBlock == 0);
+  assert(gemmN % NPerBlock == 0);
+  assert(gemmK % (KPerBlock * KPack) == 0);
+
+  const int64_t gridSize = g * (gemmM / MPerBlock) * (gemmN / NPerBlock);
+  const int64_t maxGridSize = 20 * num_cu;
+
+  gemmKBlock = std::max(maxGridSize / gridSize, static_cast<int64_t>(1));
+  gemmKBlock = std::min(gemmKBlock, n);
+
+  for (; gemmKBlock > 1; --gemmKBlock) {
+    if (n % gemmKBlock != 0)
+      continue;
+
+    if (gemmK % (gemmKBlock * KPerBlock * KPack) != 0)
+      continue;
+
+    break;
+  }
+
+  // not more than n
+  gemmKBlock = std::min(n, gemmKBlock);
+  // not less than 1
+  gemmKBlock = std::max(static_cast<int64_t>(1), gemmKBlock);
+
+  // llvm::errs() << "\n gemmKBlock: " << gemmKBlock << " gemmK: " << gemmK
   //               << " ho: " << ho << " wo: " << wo << "\n";
-  return gemmKBlocks;
+  return gemmKBlock;
 }
 
 /// Unwrap a value from the transforms surrounding it, gathering up the

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -22,62 +22,27 @@
 namespace mlir {
 namespace miopen {
 
-// Heuristic logic to compute KBlock for backward weight atomic add kernel.
-// The logic is adopted from MIOpen.
-//
-// The logic searches within the range of [1, 20 * number of CUs / gridSize],
-// where gridSize is the original number of workgroups required for the
-// convolution, and find the largest KBlock number which preserves the 2
-// contraints:
-// - GemmK (before splitting) = KBlock * KPerBlock * KPack * GemmK (after
-// splitting).
-// - n (batch size) is divisible by KBlock.
-//
-// 20 is a magic number obtained in MIOpen after empirical testing. It offers a
-// reasonable reduction of GemmK after splitting, without incurring too much
-// overheads on atomic adds. One potential future work is to make this value be
-// tunable.
-inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo, int64_t g,
-                                  int64_t k, int64_t c, int64_t y, int64_t x,
-                                  int64_t MPerBlock, int64_t NPerBlock,
-                                  int64_t KPerBlock, int64_t KPack,
-                                  int64_t num_cu) {
-  const int64_t KPerGroup = k / g;
-  const int64_t CPerGroup = c / g;
-  const int64_t gemmM = KPerGroup;
-  const int64_t gemmN = CPerGroup * y * x;
-
-  const int64_t gemmK = n * ho * wo;
-  int64_t gemmKBlock = 1;
-
-  assert(gemmM % MPerBlock == 0);
-  assert(gemmN % NPerBlock == 0);
-  assert(gemmK % (KPerBlock * KPack) == 0);
-
-  const int64_t gridSize = g * (gemmM / MPerBlock) * (gemmN / NPerBlock);
-  const int64_t maxGridSize = 20 * num_cu;
-
-  gemmKBlock = std::max(maxGridSize / gridSize, static_cast<int64_t>(1));
-  gemmKBlock = std::min(gemmKBlock, n);
-
-  for (; gemmKBlock > 1; --gemmKBlock) {
-    if (n % gemmKBlock != 0)
-      continue;
-
-    if (gemmK % (gemmKBlock * KPerBlock * KPack) != 0)
-      continue;
-
-    break;
+inline int64_t calculateKBlockNum(int64_t n, int64_t ho, int64_t wo) {
+  int64_t gemmK = n * ho * wo;
+  int64_t gemmKBlocks = 1;
+  if (gemmK % 16 == 0) {
+    auto lcm = math_util::lcm(ho * wo, (int64_t)16);
+    gemmKBlocks = std::min(gemmK / lcm, n);
+  } else if (gemmK % 8 == 0) {
+    auto comm = math_util::lcm(ho * wo, (int64_t)8);
+    gemmKBlocks = std::min(gemmK / comm, n);
+  } else if (gemmK % 4 == 0) {
+    auto comm = math_util::lcm(ho * wo, (int64_t)4);
+    gemmKBlocks = std::min(gemmK / comm, n);
   }
-
   // not more than n
-  gemmKBlock = std::min(n, gemmKBlock);
+  gemmKBlocks = std::min(n, gemmKBlocks);
   // not less than 1
-  gemmKBlock = std::max(static_cast<int64_t>(1), gemmKBlock);
+  gemmKBlocks = std::max((__int64_t)1, gemmKBlocks);
 
-  // llvm::errs() << "\n gemmKBlock: " << gemmKBlock << " gemmK: " << gemmK
+  // llvm::errs() << "\n gemmKBlocks: " << gemmKBlocks << " gemmK: " << gemmK
   //               << " ho: " << ho << " wo: " << wo << "\n";
-  return gemmKBlock;
+  return gemmKBlocks;
 }
 
 /// Unwrap a value from the transforms surrounding it, gathering up the

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -270,17 +270,9 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto gemmIdAttr = op->template getAttrOfType<IntegerAttr>("gemm_id");
   auto archAttr = op->template getAttrOfType<StringAttr>("arch");
   auto numCuAttr = op->template getAttrOfType<IntegerAttr>("num_cu");
-  int64_t numCu = numCuAttr.getInt();
 
   auto KPackAttr = op->template getAttrOfType<IntegerAttr>("kpack");
   int64_t KPack = KPackAttr.getInt();
-
-  auto MPerBlockAttr = op->template getAttrOfType<IntegerAttr>("m_per_block");
-  auto NPerBlockAttr = op->template getAttrOfType<IntegerAttr>("n_per_block");
-  auto KPerBlockAttr = op->template getAttrOfType<IntegerAttr>("k_per_block");
-  int64_t MPerBlock = MPerBlockAttr.getInt();
-  int64_t NPerBlock = NPerBlockAttr.getInt();
-  int64_t KPerBlock = KPerBlockAttr.getInt();
 
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");
@@ -352,8 +344,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto strideW =
       stridesAttr.getValue()[1].template cast<IntegerAttr>().getInt();
   // get y, x, ho, wo, hi, wi
-  int64_t g, n, k, c, y, x, ho, wo, hi, wi;
-  g = n = k = c = y = x = ho = wo = hi = wi = 0;
+  int64_t n, k, c, y, x, ho, wo, hi, wi;
+  n = k = c = y = x = ho = wo = hi = wi = 0;
   llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
   for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
     auto filterAttr =
@@ -374,8 +366,6 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
       y = filterShape[i];
     } else if (filterAttr.getValue() == "x") {
       x = filterShape[i];
-    } else if (filterAttr.getValue() == "g") {
-      g = filterShape[i];
     }
 
     if (inputAttr.getValue() == "ni") {
@@ -394,8 +384,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   }
   // calculate gemmKBlocks
 
-  int64_t gemmKBlocks = calculateKBlockNum(n, ho, wo, g, k, c, y, x, MPerBlock,
-                                           NPerBlock, KPerBlock, KPack, numCu);
+  // static const int64_t MaxSubBlockNum = 2048 / standardBockNum;
+  int64_t gemmKBlocks = calculateKBlockNum(n, ho, wo);
 
   Value gemmFilter, gemmInput, gemmOutput;
   Value gemmInputKPack, gemmOutputKPack;

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -270,9 +270,17 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto gemmIdAttr = op->template getAttrOfType<IntegerAttr>("gemm_id");
   auto archAttr = op->template getAttrOfType<StringAttr>("arch");
   auto numCuAttr = op->template getAttrOfType<IntegerAttr>("num_cu");
+  int64_t numCu = numCuAttr.getInt();
 
   auto KPackAttr = op->template getAttrOfType<IntegerAttr>("kpack");
   int64_t KPack = KPackAttr.getInt();
+
+  auto MPerBlockAttr = op->template getAttrOfType<IntegerAttr>("m_per_block");
+  auto NPerBlockAttr = op->template getAttrOfType<IntegerAttr>("n_per_block");
+  auto KPerBlockAttr = op->template getAttrOfType<IntegerAttr>("k_per_block");
+  int64_t MPerBlock = MPerBlockAttr.getInt();
+  int64_t NPerBlock = NPerBlockAttr.getInt();
+  int64_t KPerBlock = KPerBlockAttr.getInt();
 
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");
@@ -344,8 +352,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto strideW =
       stridesAttr.getValue()[1].template cast<IntegerAttr>().getInt();
   // get y, x, ho, wo, hi, wi
-  int64_t n, k, c, y, x, ho, wo, hi, wi;
-  n = k = c = y = x = ho = wo = hi = wi = 0;
+  int64_t g, n, k, c, y, x, ho, wo, hi, wi;
+  g = n = k = c = y = x = ho = wo = hi = wi = 0;
   llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
   for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
     auto filterAttr =
@@ -366,6 +374,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
       y = filterShape[i];
     } else if (filterAttr.getValue() == "x") {
       x = filterShape[i];
+    } else if (filterAttr.getValue() == "g") {
+      g = filterShape[i];
     }
 
     if (inputAttr.getValue() == "ni") {
@@ -384,8 +394,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   }
   // calculate gemmKBlocks
 
-  // static const int64_t MaxSubBlockNum = 2048 / standardBockNum;
-  int64_t gemmKBlocks = calculateKBlockNum(n, ho, wo);
+  int64_t gemmKBlocks = calculateKBlockNum(n, ho, wo, g, k, c, y, x, MPerBlock,
+                                           NPerBlock, KPerBlock, KPack, numCu);
 
   Value gemmFilter, gemmInput, gemmOutput;
   Value gemmInputKPack, gemmOutputKPack;

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -394,8 +394,12 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   }
   // calculate gemmKBlocks
 
-  int64_t gemmKBlocks = calculateKBlockNum(n, ho, wo, g, k, c, y, x, MPerBlock,
-                                           NPerBlock, KPerBlock, KPack, numCu);
+  int64_t gemmKBlocks = 1;
+  if (failed(calculateKBlockNum(n, ho, wo, g, k, c, y, x, MPerBlock, NPerBlock,
+                                KPerBlock, KPack, numCu, &gemmKBlocks))) {
+    op->emitOpError("Invalid tuning parameters to compute KBlock.");
+    return failure();
+  }
 
   Value gemmFilter, gemmInput, gemmOutput;
   Value gemmInputKPack, gemmOutputKPack;

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -284,7 +284,7 @@ LogicalResult PopulateParamsXDL::populateDerived(
   int64_t nKBlocks = 1;
   if (ctx.opType == miopen::ConvOpType::BwdWeight &&
       (ctx.getDataType().isF32() || ctx.getDataType().isF16())) {
-    nKBlocks = getKBlocks(ctx, params);
+    nKBlocks = getKBlocks(ctx);
   }
   gridSize = obtainGridSize(gemmSize, &params) * nKBlocks;
 

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -284,7 +284,7 @@ LogicalResult PopulateParamsXDL::populateDerived(
   int64_t nKBlocks = 1;
   if (ctx.opType == miopen::ConvOpType::BwdWeight &&
       (ctx.getDataType().isF32() || ctx.getDataType().isF16())) {
-    nKBlocks = getKBlocks(ctx);
+    nKBlocks = getKBlocks(ctx, params);
   }
   gridSize = obtainGridSize(gemmSize, &params) * nKBlocks;
 

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -284,7 +284,12 @@ LogicalResult PopulateParamsXDL::populateDerived(
   int64_t nKBlocks = 1;
   if (ctx.opType == miopen::ConvOpType::BwdWeight &&
       (ctx.getDataType().isF32() || ctx.getDataType().isF16())) {
-    nKBlocks = getKBlocks(ctx, params);
+    res = getKBlocks(ctx, params, &nKBlocks);
+    if (failed(res)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Invalid tuning parameters for computing KBlocks.\n");
+      return failure();
+    }
   }
   gridSize = obtainGridSize(gemmSize, &params) * nKBlocks;
 


### PR DESCRIPTION
In MLIR MIOpen dialect implementation, k (output channel) and c (input channel)
are independent of g (group count).

In MIOpen implementation, k and c are implicitly timed by g, so they have to be
divided with g. This computation is not necessary inside MLIR MIOpen dialect
implementation.

Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/531

Relevant MIOpen logic:
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/src/include/miopen/conv/problem_description.hpp#L167
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/src/include/miopen/conv/problem_description.hpp#L201

It can be observed g is not a standalone dimension in MIOpen problem description.

Per @jerryyin 's comment I've also made the function returning `LogicalResult` so it could also be used to reject invalid tuning parameters, instead of simply crashing due to assert.