### PR TITLE
Introduce `kblocks` attribute.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -586,11 +586,10 @@ struct InitParamsNonXDL : InitParams, Serializable<InitParamsNonXDL> {
   InitParamsNonXDL(int64_t bSize, int64_t mPerBlock, int64_t nPerBlock,
                    int64_t kPerBlock, int64_t mPerThread, int64_t nPerThread)
       : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerThread(mPerThread),
-        gemmNPerThread(nPerThread), blockSize(bSize), gemmKBlocks(1LL) {}
+        gemmNPerThread(nPerThread), blockSize(bSize) {}
   int64_t gemmMPerThread;
   int64_t gemmNPerThread;
   int64_t blockSize;
-  int64_t gemmKBlocks;
 
   InitParamsNonXDL() : InitParamsNonXDL(0LL, 0LL, 0LL, 0LL, 0LL, 0LL) {}
 

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -595,7 +595,6 @@ struct InitParamsNonXDL : InitParams, Serializable<InitParamsNonXDL> {
   InitParamsNonXDL() : InitParamsNonXDL(0LL, 0LL, 0LL, 0LL, 0LL, 0LL) {}
 
   template <class Self, class F> static void visit(Self &&self, F f) {
-    f(self.gemmKBlocks);
     f(self.blockSize);
     f(self.gemmMPerBlock);
     f(self.gemmNPerBlock);
@@ -632,7 +631,6 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
     f(self.gemmKPack);
     f(self.gemmAThreadCopyMoreGemmK);
     f(self.gemmBThreadCopyMoreGemmKPack);
-    f(self.gemmKBlocks);
   }
 };
 

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -610,7 +610,7 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
       : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerWave(mPerWave),
         gemmNPerWave(nPerWave), gemmKPack(kPack),
         gemmAThreadCopyMoreGemmK(aThreadCopyMoreGemmK),
-        gemmBThreadCopyMoreGemmKPack(bThreadCopyMoreGemmKPack), gemmKBlocks(1LL) {}
+        gemmBThreadCopyMoreGemmKPack(bThreadCopyMoreGemmKPack) {}
 
   InitParamsXDL() : InitParamsXDL(0LL, 0LL, 0LL, 0LL, 0LL, 0LL, false, false) {}
 
@@ -619,7 +619,6 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
   int64_t gemmKPack;
   bool gemmAThreadCopyMoreGemmK;
   bool gemmBThreadCopyMoreGemmKPack;
-  int64_t gemmKBlocks;
 
   template <class Self, class F> static void visit(Self &&self, F f) {
     f(self.gemmMPerBlock);
@@ -876,7 +875,8 @@ private:
            (params.gemmMPerWave * params.gemmNPerWave);
   }
 
-  LogicalResult getKBlocks(ConvolutionContext &ctx, InitParamsXDL &params) {
+  LogicalResult getKBlocks(ConvolutionContext &ctx, InitParamsXDL &params,
+                           int64_t &gemmKBlocks) {
     int64_t n = ctx.dimIndexAndSize["no"].size;
     int64_t ho = ctx.dimIndexAndSize["ho"].size;
     int64_t wo = ctx.dimIndexAndSize["wo"].size;
@@ -888,7 +888,7 @@ private:
 
     return mlir::miopen::calculateKBlockNum(
         n, ho, wo, g, k, c, y, x, params.gemmMPerBlock, params.gemmNPerBlock,
-        params.gemmKPerBlock, params.gemmKPack, ctx.num_cu, &params.gemmKBlocks);
+        params.gemmKPerBlock, params.gemmKPack, ctx.num_cu, gemmKBlocks);
   }
 
   LogicalResult calculateGemmABlockCopyPerformanceParameters(
@@ -1056,7 +1056,8 @@ private:
                                 DerivedParams &gemmADerivedParam,
                                 DerivedParams &gemmBDerivedParam,
                                 DerivedOutParams &gemmCDerivedParam,
-                                int64_t &blockSize, int64_t &gridSize);
+                                int64_t &blockSize, int64_t &gridSize,
+                                int64_t &gemmKBlocks);
 
   LogicalResult populatePaddingKernelDerived(
       ConvolutionContext &ctx, InitParamsXDL &validParams, GemmSize &gemmSize,
@@ -1081,13 +1082,11 @@ private:
   }
 
 public:
-  LogicalResult obtainTuningParameters(Operation *op, int64_t blockSizeOverride,
-                                       const std::string &perfConfig,
-                                       InitParamsXDL &validParams,
-                                       DerivedParams &gemmADerivedParam,
-                                       DerivedParams &gemmBDerivedParam,
-                                       DerivedOutParams &gemmCDerivedParam,
-                                       int64_t &blockSize, int64_t &gridSize);
+  LogicalResult obtainTuningParameters(
+      Operation *op, int64_t blockSizeOverride, const std::string &perfConfig,
+      InitParamsXDL &validParams, DerivedParams &gemmADerivedParam,
+      DerivedParams &gemmBDerivedParam, DerivedOutParams &gemmCDerivedParam,
+      int64_t &blockSize, int64_t &gridSize, int64_t &gemmKBlocks);
 
   llvm::SmallVector<InitParamsXDL, 4>
   getTuningParameters(miopen::ConvOpType dir, mlir::Type dataType) {

--- a/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/MIOpen/utility/loweringUtils.h
@@ -42,7 +42,7 @@ inline LogicalResult calculateKBlockNum(int64_t n, int64_t ho, int64_t wo,
                                         int64_t y, int64_t x, int64_t MPerBlock,
                                         int64_t NPerBlock, int64_t KPerBlock,
                                         int64_t KPack, int64_t num_cu,
-                                        int64_t *nKBlock) {
+                                        int64_t &nKBlock) {
   const int64_t gemmM = k;
   const int64_t gemmN = c * y * x;
   const int64_t gemmK = n * ho * wo;
@@ -73,7 +73,7 @@ inline LogicalResult calculateKBlockNum(int64_t n, int64_t ho, int64_t wo,
   // not less than 1
   gemmKBlock = std::max((__int64_t)1, gemmKBlock);
 
-  *nKBlock = gemmKBlock;
+  nKBlock = gemmKBlock;
   return success();
 }
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -242,10 +242,11 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     DerivedOutParams gemmCDerivedParam;
     int64_t blockSize = 0;
     int64_t gridSize = 0;
+    int64_t gemmKBlocks = 1;
 
     LogicalResult status = populateParamsXDL.obtainTuningParameters(
         op, blockSizeOverride, perfConfig, validParams, gemmADerivedParam,
-        gemmBDerivedParam, gemmCDerivedParam, blockSize, gridSize);
+        gemmBDerivedParam, gemmCDerivedParam, blockSize, gridSize, gemmKBlocks);
 
     if (failed(status)) {
       signalPassFailure();
@@ -270,7 +271,7 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("kpack", b.getI32IntegerAttr(validParams.gemmKPack));
     // Set kblocks attribute only for backward weight convolutions.
     if (dir == miopen::ConvOpType::BwdWeight) {
-      op->setAttr("kblocks", b.getI32IntegerAttr(validParams.gemmKBlocks));
+      op->setAttr("kblocks", b.getI32IntegerAttr(gemmKBlocks));
     }
 
     // Set attributes on the function.

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -268,7 +268,10 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     }
 
     op->setAttr("kpack", b.getI32IntegerAttr(validParams.gemmKPack));
-    op->setAttr("kblocks", b.getI32IntegerAttr(validParams.gemmKBlocks));
+    // Set kblocks attribute only for backward weight convolutions.
+    if (dir == miopen::ConvOpType::BwdWeight) {
+      op->setAttr("kblocks", b.getI32IntegerAttr(validParams.gemmKBlocks));
+    }
 
     // Set attributes on the function.
     getOperation()->setAttr("block_size", b.getI32IntegerAttr(blockSize));
@@ -326,7 +329,6 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
     // For non-XDLOPS path, do not use KPack for now.
     op->setAttr("kpack", b.getI32IntegerAttr(1));
-    op->setAttr("kblocks", b.getI32IntegerAttr(validParams.gemmKBlocks));
 
     // Set attributes on the function.
     getOperation()->setAttr("block_size",

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -268,6 +268,7 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     }
 
     op->setAttr("kpack", b.getI32IntegerAttr(validParams.gemmKPack));
+    op->setAttr("kblocks", b.getI32IntegerAttr(validParams.gemmKBlocks));
 
     // Set attributes on the function.
     getOperation()->setAttr("block_size", b.getI32IntegerAttr(blockSize));
@@ -325,6 +326,7 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     op->setAttr("block_size", b.getI32IntegerAttr(validParams.blockSize));
     // For non-XDLOPS path, do not use KPack for now.
     op->setAttr("kpack", b.getI32IntegerAttr(1));
+    op->setAttr("kblocks", b.getI32IntegerAttr(validParams.gemmKBlocks));
 
     // Set attributes on the function.
     getOperation()->setAttr("block_size",

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -270,17 +270,12 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto gemmIdAttr = op->template getAttrOfType<IntegerAttr>("gemm_id");
   auto archAttr = op->template getAttrOfType<StringAttr>("arch");
   auto numCuAttr = op->template getAttrOfType<IntegerAttr>("num_cu");
-  int64_t numCu = numCuAttr.getInt();
 
   auto KPackAttr = op->template getAttrOfType<IntegerAttr>("kpack");
   int64_t KPack = KPackAttr.getInt();
 
-  auto MPerBlockAttr = op->template getAttrOfType<IntegerAttr>("m_per_block");
-  auto NPerBlockAttr = op->template getAttrOfType<IntegerAttr>("n_per_block");
-  auto KPerBlockAttr = op->template getAttrOfType<IntegerAttr>("k_per_block");
-  int64_t MPerBlock = MPerBlockAttr.getInt();
-  int64_t NPerBlock = NPerBlockAttr.getInt();
-  int64_t KPerBlock = KPerBlockAttr.getInt();
+  auto KBlocksAttr = op->template getAttrOfType<IntegerAttr>("kblocks");
+  int64_t gemmKBlocks = KBlocksAttr.getInt();
 
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");
@@ -352,8 +347,8 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
   auto strideW =
       stridesAttr.getValue()[1].template cast<IntegerAttr>().getInt();
   // get y, x, ho, wo, hi, wi
-  int64_t g, n, k, c, y, x, ho, wo, hi, wi;
-  g = n = k = c = y = x = ho = wo = hi = wi = 0;
+  int64_t n, k, c, y, x, ho, wo, hi, wi;
+  n = k = c = y = x = ho = wo = hi = wi = 0;
   llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
   for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
     auto filterAttr =
@@ -374,8 +369,6 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
       y = filterShape[i];
     } else if (filterAttr.getValue() == "x") {
       x = filterShape[i];
-    } else if (filterAttr.getValue() == "g") {
-      g = filterShape[i];
     }
 
     if (inputAttr.getValue() == "ni") {
@@ -391,14 +384,6 @@ LogicalResult backwardWeightAtomicAdd(Conv2DBwdWeightOp op,
     } else if (outputAttr.getValue() == "wo") {
       wo = outputShape[i];
     }
-  }
-  // calculate gemmKBlocks
-
-  int64_t gemmKBlocks = 1;
-  if (failed(calculateKBlockNum(n, ho, wo, g, k, c, y, x, MPerBlock, NPerBlock,
-                                KPerBlock, KPack, numCu, &gemmKBlocks))) {
-    op->emitOpError("Invalid tuning parameters to compute KBlock.");
-    return failure();
   }
 
   Value gemmFilter, gemmInput, gemmOutput;

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -281,17 +281,16 @@ LogicalResult PopulateParamsXDL::populateDerived(
   }
 
   // parameters derivable from tunable parameters.
-  int64_t nKBlocks = 1;
   if (ctx.opType == miopen::ConvOpType::BwdWeight &&
       (ctx.getDataType().isF32() || ctx.getDataType().isF16())) {
-    res = getKBlocks(ctx, params, &nKBlocks);
+    res = getKBlocks(ctx, params);
     if (failed(res)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Invalid tuning parameters for computing KBlocks.\n");
       return failure();
     }
   }
-  gridSize = obtainGridSize(gemmSize, &params) * nKBlocks;
+  gridSize = obtainGridSize(gemmSize, &params) * params.gemmKBlocks;
 
   res =
       calculateOutputDerivedParams(&params, blockSize, ctx, gemmCDerivedParam);


### PR DESCRIPTION
Address request made by @jerryyin in #608 . Avoid duplicated computation of `kblocks` by keeping it in an attribute.
