### PR TITLE
[DO NOT SQUASH] Allow padding kernels when both GemmN and GemmK dimensions are padded.

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
@@ -112,7 +112,8 @@ static LogicalResult updateCalls(ModuleOp module) {
     newOperands.append(outParams.begin(), outParams.end());
     auto newResultTypes = llvm::to_vector<6>(llvm::map_range(
         replaceWithNewCallResults, [](Value v) { return v.getType(); }));
-    auto *newCallOp = op.clone(builder, op.getLoc(), newResultTypes, newOperands);
+    auto *newCallOp =
+        op.clone(builder, op.getLoc(), newResultTypes, newOperands);
 
     for (auto t : llvm::zip(replaceWithNewCallResults, newCallOp->getResults()))
       std::get<0>(t).replaceAllUsesWith(std::get<1>(t));

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -65,12 +65,6 @@ LogicalResult
 isSupportedBackwardDataPaddingKernel(bool isXdlops, bool isStride2Pad1,
                                      int64_t gemmMExtra, int64_t gemmKExtra,
                                      int64_t gemmNExtra, Conv2DBwdDataOp &op) {
-  if (gemmNExtra && gemmKExtra) {
-    return op.emitOpError(
-        "can't support backward data padding kernel when both pad "
-        "gemmN and gemmK due to load issue\n");
-  }
-
   if (isXdlops && (gemmMExtra || gemmNExtra)) {
     if (isStride2Pad1) {
       return op->emitOpError(

--- a/mlir/test/mlir-miopen-driver/auto_e2e/padding_kernel_gemmN_gemmK.mlir
+++ b/mlir/test/mlir-miopen-driver/auto_e2e/padding_kernel_gemmN_gemmK.mlir
@@ -1,0 +1,14 @@
+// RUN: miopen-gen -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=5 --padding_h=0 --padding_w=0 -in_channels=13 -out_channels=11 -in_h=7 -in_w=7 -fil_h=3 -fil_w=3 -p=false --conv_stride_h=1 --conv_stride_w=1 --operation=conv2d_bwd_data %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_PADDING_GEMMN_GEMMK_CONFIG1
+
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG1: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG1: [1]
+
+// RUN: miopen-gen -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=15 --padding_h=1 --padding_w=1 -in_channels=13 -out_channels=11 -in_h=7 -in_w=7 -fil_h=3 -fil_w=3 -p=false --conv_stride_h=1 --conv_stride_w=1 --operation=conv2d_bwd_data %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_PADDING_GEMMN_GEMMK_CONFIG2
+
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG2: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG2: [1]
+
+// RUN:miopen-gen -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=15 --padding_h=1 --padding_w=1 -in_channels=11 -out_channels=7 -in_h=5 -in_w=5 -fil_h=3 -fil_w=3 -p=false --conv_stride_h=2 --conv_stride_w=2 --operation=conv2d_bwd_data %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_PADDING_GEMMN_GEMMK_CONFIG3
+
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG3: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG3: [1]


### PR DESCRIPTION
Empirical testing show these previously failing configs are now passing. Remove those restrictions and add them into the test suite.

Realizes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/528