### PR TITLE
Match i8 sanity tests with other data types

### DIFF
--- a/mlir/test/mlir-miopen-driver/populate_host_convert.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host_convert.mlir
@@ -1,6 +1,7 @@
 // RUN: miopen-gen -p -ph -pr | FileCheck %s --check-prefix=F32
 // RUN: miopen-gen -p -ph -pr -t f16 | FileCheck %s --check-prefix=F16
 // RUN: miopen-gen -p -ph -pr -t bf16 | FileCheck %s --check-prefix=BF16
+// RUN: miopen-gen -p -ph -pr -t i8 | FileCheck %s --check-prefix=I8
 
 // F32-NOT: func @_memcpy_
 
@@ -29,4 +30,15 @@
 // BF16-NEXT:   }
 // BF16-NEXT:   return
 // BF16-NEXT: }
+
+// I8:  func @_memcpy_i32_f32(%arg0: memref<?xi32>, %arg1: memref<?xf32>, %arg2: index) {
+// I8-NEXT:   %c0 = arith.constant 0 : index
+// I8-NEXT:   %c1 = arith.constant 1 : index
+// I8-NEXT:   scf.for %arg3 = %c0 to %arg2 step %c1 {
+// I8-NEXT:     %0 = memref.load %arg0[%arg3] : memref<?xi32>
+// I8-NEXT:     %1 = arith.sitofp %0 : i32 to f32
+// I8-NEXT:     memref.store %1, %arg1[%arg3] : memref<?xf32>
+// I8-NEXT:   }
+// I8-NEXT:   return
+// I8-NEXT: }
 

--- a/mlir/test/mlir-miopen-driver/populate_host_print.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host_print.mlir
@@ -1,250 +1,83 @@
-// RUN: miopen-gen -p -ph -pr | FileCheck %s --check-prefix=F32
+// RUN: miopen-gen -p -ph -pr | FileCheck %s
 // RUN: miopen-gen -p -ph -pr -t f16 | FileCheck %s --check-prefix=F16
 // RUN: miopen-gen -p -ph -pr -t bf16 | FileCheck %s --check-prefix=BF16
+// RUN: miopen-gen -p -ph -pr -t i8 | FileCheck %s --check-prefix=I8
 
-// F32: func @main()
-// F32-NEXT: memref.alloc() : memref<[[G:[0-9]+]]x[[K:[0-9]+]]x[[C:[0-9]+]]x[[Y:[0-9]+]]x[[X:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>
-// F32-NEXT: arith.constant dense{{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// F32-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
-// F32-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
-// F32-NEXT: affine.for %[[y:.*]] = 0 to [[Y]]
-// F32-NEXT: affine.for %[[x:.*]] = 0 to [[X]]
-// F32-NEXT: affine.apply {{.*}}(%[[g]], %[[k]], %[[c]], %[[y]], %[[x]])
-// F32-NEXT: vector.extractelement
-// F32-NEXT: memref.store {{.*}}[%[[g]], %[[k]], %[[c]], %[[y]], %[[x]]] : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: memref.alloc() : memref<[[N:[0-9]+]]x[[G:[0-9]+]]x[[C]]x[[HI:[0-9]+]]x[[WI:[0-9]+]]x[[TYPE]]>
-// F32-NEXT: arith.constant dense{{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
-// F32-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// F32-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
-// F32-NEXT: affine.for %[[hi:.*]] = 0 to [[HI]]
-// F32-NEXT: affine.for %[[wi:.*]] = 0 to [[WI]]
-// F32-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]])
-// F32-NEXT: vector.extractelement
-// F32-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]]] : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: memref.alloc() : memref<[[N]]x[[G:[0-9]+]]x[[K]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]x[[TYPE]]>
-// F32-NEXT: arith.constant dense{{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: arith.constant {{.*}} : f32
-// F32-NEXT: arith.constant {{.*}} : index
-// F32-NEXT: vector.insertelement {{.*}} : vector<3xf32>
-// F32-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
-// F32-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// F32-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
-// F32-NEXT: affine.for %[[ho:.*]] = 0 to [[HO]]
-// F32-NEXT: affine.for %[[wo:.*]] = 0 to [[WO]]
-// F32-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]])
-// F32-NEXT: vector.extractelement
-// F32-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]]] : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: }
-// F32-NEXT: call @{{.*}}({{.*}}, {{.*}}, {{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
-// F32-NEXT: memref.dealloc {{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
-// F32-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
-// F32-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<*x[[TYPE]]>
-// F32-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*x[[TYPE]]>) -> ()
-// F32-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
-// F32-NEXT: return
+// CHECK-LABEL: func @main()
+// CHECK-NEXT: memref.alloc() : memref<[[G:[0-9]+]]x[[K:[0-9]+]]x[[C:[0-9]+]]x[[Y:[0-9]+]]x[[X:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
+// CHECK-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
+// CHECK-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
+// CHECK-NEXT: affine.for %[[y:.*]] = 0 to [[Y]]
+// CHECK-NEXT: affine.for %[[x:.*]] = 0 to [[X]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[g]], %[[k]], %[[c]], %[[y]], %[[x]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store {{.*}}[%[[g]], %[[k]], %[[c]], %[[y]], %[[x]]] : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
 
-// F16: func @main()
-// F16-NEXT: memref.alloc() : memref<[[G:[0-9]+]]x[[K:[0-9]+]]x[[C:[0-9]+]]x[[Y:[0-9]+]]x[[X:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>
-// F16-NEXT: arith.constant dense{{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// F16-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
-// F16-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
-// F16-NEXT: affine.for %[[y:.*]] = 0 to [[Y]]
-// F16-NEXT: affine.for %[[x:.*]] = 0 to [[X]]
-// F16-NEXT: affine.apply {{.*}}(%[[g]], %[[k]], %[[c]], %[[y]], %[[x]])
-// F16-NEXT: vector.extractelement
-// F16-NEXT: memref.store {{.*}}[%[[g]], %[[k]], %[[c]], %[[y]], %[[x]]] : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: memref.alloc() : memref<[[N:[0-9]+]]x[[G:[0-9]+]]x[[C]]x[[HI:[0-9]+]]x[[WI:[0-9]+]]x[[TYPE]]>
-// F16-NEXT: arith.constant dense{{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
-// F16-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// F16-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
-// F16-NEXT: affine.for %[[hi:.*]] = 0 to [[HI]]
-// F16-NEXT: affine.for %[[wi:.*]] = 0 to [[WI]]
-// F16-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]])
-// F16-NEXT: vector.extractelement
-// F16-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]]] : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: memref.alloc() : memref<[[N]]x[[G:[0-9]+]]x[[K]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]x[[TYPE]]>
-// F16-NEXT: arith.constant dense{{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: arith.constant {{.*}} : f16
-// F16-NEXT: arith.constant {{.*}} : index
-// F16-NEXT: vector.insertelement {{.*}} : vector<3xf16>
-// F16-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
-// F16-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// F16-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
-// F16-NEXT: affine.for %[[ho:.*]] = 0 to [[HO]]
-// F16-NEXT: affine.for %[[wo:.*]] = 0 to [[WO]]
-// F16-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]])
-// F16-NEXT: vector.extractelement
-// F16-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]]] : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: }
-// F16-NEXT: call @{{.*}}({{.*}}, {{.*}}, {{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
-// F16-NEXT: memref.dealloc {{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
-// F16-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
-// F16-NEXT: memref.alloc() : memref<[[N]]x[[G:[0-9]+]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>
-// F16: call @_memcpy_f16_f32(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<{{.*}}x[[TYPE]]>, memref<{{.*}}x[[PRINT_TYPE]]>, index) -> ()
-// F16-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]> to memref<*x[[PRINT_TYPE]]>
-// F16-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*x[[PRINT_TYPE]]>) -> ()
-// F16-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]>
-// F16-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
-// F16-NEXT: return
+// CHECK: memref.alloc() : memref<[[N:[0-9]+]]x[[G:[0-9]+]]x[[C]]x[[HI:[0-9]+]]x[[WI:[0-9]+]]x[[TYPE]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
+// CHECK-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
+// CHECK-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
+// CHECK-NEXT: affine.for %[[hi:.*]] = 0 to [[HI]]
+// CHECK-NEXT: affine.for %[[wi:.*]] = 0 to [[WI]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]]] : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
 
-// BF16: func @main()
-// BF16-NEXT: memref.alloc() : memref<[[G:[0-9]+]]x[[K:[0-9]+]]x[[C:[0-9]+]]x[[Y:[0-9]+]]x[[X:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>
-// BF16-NEXT: arith.constant dense{{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// BF16-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
-// BF16-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
-// BF16-NEXT: affine.for %[[y:.*]] = 0 to [[Y]]
-// BF16-NEXT: affine.for %[[x:.*]] = 0 to [[X]]
-// BF16-NEXT: affine.apply {{.*}}(%[[g]], %[[k]], %[[c]], %[[y]], %[[x]])
-// BF16-NEXT: vector.extractelement
-// BF16-NEXT: arith.bitcast
-// BF16-NEXT: memref.store {{.*}}[%[[g]], %[[k]], %[[c]], %[[y]], %[[x]]] : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: memref.alloc() : memref<[[N:[0-9]+]]x[[G:[0-9]+]]x[[C]]x[[HI:[0-9]+]]x[[WI:[0-9]+]]x[[TYPE]]>
-// BF16-NEXT: arith.constant dense{{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
-// BF16-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// BF16-NEXT: affine.for %[[c:.*]] = 0 to [[C]]
-// BF16-NEXT: affine.for %[[hi:.*]] = 0 to [[HI]]
-// BF16-NEXT: affine.for %[[wi:.*]] = 0 to [[WI]]
-// BF16-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]])
-// BF16-NEXT: vector.extractelement
-// BF16-NEXT: arith.bitcast
-// BF16-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[c]], %[[hi]], %[[wi]]] : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: memref.alloc() : memref<[[N]]x[[G:[0-9]+]]x[[K]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]x[[TYPE]]>
-// BF16-NEXT: arith.constant dense{{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: arith.constant {{.*}} : i16
-// BF16-NEXT: arith.constant {{.*}} : index
-// BF16-NEXT: vector.insertelement {{.*}} : vector<3xi16>
-// BF16-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
-// BF16-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
-// BF16-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
-// BF16-NEXT: affine.for %[[ho:.*]] = 0 to [[HO]]
-// BF16-NEXT: affine.for %[[wo:.*]] = 0 to [[WO]]
-// BF16-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]])
-// BF16-NEXT: vector.extractelement
-// BF16-NEXT: arith.bitcast
-// BF16-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]]] : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: }
-// BF16-NEXT: call @miopen_conv2d_gkcyx_ngchw_ngkhw_0_gpu({{.*}}, {{.*}}, {{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
-// BF16: memref.alloc() : memref<[[N]]x[[G:[0-9]+]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE:[a-zA-Z0-9]+]]>
-// BF16: call @_memcpy_bf16_f32({{.*}}, {{.*}}, {{.*}}) : (memref<?xbf16>, memref<?xf32>, index) -> ()
-// BF16-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[PRINT_TYPE]]> to memref<*x[[PRINT_TYPE]]>
-// BF16-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*x[[PRINT_TYPE]]>) -> ()
+// CHECK: memref.alloc() : memref<[[N]]x[[G:[0-9]+]]x[[K]]x[[HO:[0-9]+]]x[[WO:[0-9]+]]x[[TYPE]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: affine.for %[[n:.*]] = 0 to [[N]]
+// CHECK-NEXT: affine.for %[[g:.*]] = 0 to [[G]]
+// CHECK-NEXT: affine.for %[[k:.*]] = 0 to [[K]]
+// CHECK-NEXT: affine.for %[[ho:.*]] = 0 to [[HO]]
+// CHECK-NEXT: affine.for %[[wo:.*]] = 0 to [[WO]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]]] : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
+
+// CHECK: call @{{.*}}({{.*}}, {{.*}}, {{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
+// CHECK-NEXT: memref.dealloc {{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// CHECK-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+
+// F16: memref.alloc() : memref<{{.*}}>
+// F16: call @_memcpy_f16_f32(%{{.*}}, %{{.*}}, %{{.*}}) : ({{.*}} -> ()
+// BF16: memref.alloc() : memref<{{.*}}>
+// BF16: call @_memcpy_bf16_f32(%{{.*}}, %{{.*}}, %{{.*}}) : ({{.*}} -> ()
+// I8: memref.alloc() : memref<{{.*}}>
+// I8: call @_memcpy_i32_f32(%{{.*}}, %{{.*}}, %{{.*}}) : ({{.*}} -> ()
+// CHECK-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<*x[[TYPE]]>
+// CHECK-NEXT: call @print_memref_f32(%{{.*}}) : (memref<*x[[TYPE]]>) -> ()
+// F16: memref.dealloc {{.*}} : memref<{{.*}}>
+// BF16: memref.dealloc {{.*}} : memref<{{.*}}>
+// I8: memref.dealloc {{.*}} : memref<{{.*}}>
+// CHECK-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
+// CHECK-NEXT: return

--- a/mlir/test/mlir-miopen-driver/sanity.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity.mlir
@@ -58,3 +58,22 @@
 // RUN: miopen-gen -p -t bf16 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx900
 // RUN: miopen-gen -p -t bf16 | mlir-miopen-driver -kernel-pipeline=rocdl | miopen-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx900
 // RUN: miopen-gen -p -t bf16 --operation conv2d | mlir-miopen-driver -kernel-pipeline=rocdl | miopen-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx900
+
+// i8 tests
+
+// RUN: miopen-gen -p -t i8 | miopen-opt
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-translate -gpu-module-to-rocdlir
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S
+// RUN: miopen-gen -p -t i8 | miopen-opt -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx900
+// RUN: miopen-gen -p -t i8 | mlir-miopen-driver -kernel-pipeline=rocdl | miopen-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx900
+// RUN: miopen-gen -p -t i8 --operation conv2d | mlir-miopen-driver -kernel-pipeline=rocdl | miopen-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx900

--- a/mlir/test/mlir-miopen-driver/sanity_pv.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_pv.mlir
@@ -4,3 +4,4 @@
 // RUN: miopen-gen -p -pv | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -pv -t f16 | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -pv -t bf16 | mlir-miopen-driver -c | miopen-opt
+// RUN: miopen-gen -p -pv -t i8 | mlir-miopen-driver -c | miopen-opt

--- a/mlir/test/mlir-miopen-driver/sanity_pv_with_gpu.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_pv_with_gpu.mlir
@@ -4,3 +4,4 @@
 // RUN: miopen-gen -p -pv_with_gpu | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -pv_with_gpu -t f16 | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -pv_with_gpu -t bf16 | mlir-miopen-driver -c | miopen-opt
+// RUN: miopen-gen -p -pv_with_gpu -t i8 | mlir-miopen-driver -c | miopen-opt

--- a/mlir/test/mlir-miopen-driver/sanity_pv_with_gpu_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_pv_with_gpu_xdlops.mlir
@@ -4,3 +4,4 @@
 // RUN: miopen-gen -p -x2 -pv_with_gpu | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -x2 -pv_with_gpu -t f16 | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -x2 -pv_with_gpu -t bf16 | mlir-miopen-driver -c | miopen-opt
+// RUN: miopen-gen -p -x2 -pv_with_gpu -t i8 | mlir-miopen-driver -c | miopen-opt

--- a/mlir/test/mlir-miopen-driver/sanity_pv_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_pv_xdlops.mlir
@@ -4,3 +4,4 @@
 // RUN: miopen-gen -p -x2 -pv | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -x2 -pv -t f16 | mlir-miopen-driver -c | miopen-opt
 // RUN: miopen-gen -p -x2 -pv -t bf16 | mlir-miopen-driver -c | miopen-opt
+// RUN: miopen-gen -p -x2 -pv -t i8 | mlir-miopen-driver -c | miopen-opt

--- a/mlir/test/mlir-miopen-driver/sanity_xdlops.mlir
+++ b/mlir/test/mlir-miopen-driver/sanity_xdlops.mlir
@@ -48,3 +48,19 @@
 // RUN: miopen-gen -p -t bf16 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-opt
 // RUN: miopen-gen -p -t bf16 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-translate -gpu-module-to-rocdlir
 // RUN: miopen-gen -p -t bf16 -x2 | mlir-miopen-driver -kernel-pipeline=rocdl | miopen-translate -gpu-module-to-rocdlir
+
+// i8 tests.
+
+// RUN: miopen-gen -p -t i8 -x2 | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-opt
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -miopen-affix-params -miopen-lowering -miopen-lowering-step2 -miopen-lowering-step3 -miopen-lowering-step4 -miopen-expand-shorthand -miopen-loops-to-cf -convert-miopen-to-gpu -convert-gpu-to-rocdl | miopen-translate -gpu-module-to-rocdlir
+// RUN: miopen-gen -p -t i8 -x2 | mlir-miopen-driver -kernel-pipeline=rocdl | miopen-translate -gpu-module-to-rocdlir


### PR DESCRIPTION
I did the following in this PR: 
 - Matched i8 sanity tests with other data types
 - Amended applicability check to reject cases for i8 in corner cases