### PR TITLE
[HOTFIX] Fix incorrectly placed test configs.

### DIFF
--- a/mlir/test/mlir-miopen-driver/auto_e2e/padding_kernel_gemmN_gemmK.mlir
+++ b/mlir/test/mlir-miopen-driver/auto_e2e/padding_kernel_gemmN_gemmK.mlir
@@ -8,7 +8,12 @@
 // CHECK_PADDING_GEMMN_GEMMK_CONFIG2: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_PADDING_GEMMN_GEMMK_CONFIG2: [1]
 
-// RUN:miopen-gen -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=15 --padding_h=1 --padding_w=1 -in_channels=11 -out_channels=7 -in_h=5 -in_w=5 -fil_h=3 -fil_w=3 -p=false --conv_stride_h=2 --conv_stride_w=2 --operation=conv2d_bwd_data %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_PADDING_GEMMN_GEMMK_CONFIG3
+// RUN: miopen-gen -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=64 -in_channels=15 -out_channels=64 --padding_h=0 --padding_w=0 -in_h=5 -in_w=5 -fil_h=3 -fil_w=3 -p=false --conv_stride_h=2 --conv_stride_w=2 --operation=conv2d_bwd_data %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_PADDING_GEMMN_GEMMK_CONFIG3
 
 // CHECK_PADDING_GEMMN_GEMMK_CONFIG3: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_PADDING_GEMMN_GEMMK_CONFIG3: [1]
+
+// RUN: miopen-gen -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -groupsize=1 -batchsize=15 -in_channels=64 -out_channels=64 --padding_h=0 --padding_w=0 -in_h=5 -in_w=5 -fil_h=3 -fil_w=3 -p=false --conv_stride_h=2 --conv_stride_w=2 --operation=conv2d_bwd_data %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_PADDING_GEMMN_GEMMK_CONFIG4
+
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG4: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
+// CHECK_PADDING_GEMMN_GEMMK_CONFIG4: [1]


### PR DESCRIPTION
In https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/268 ,
2 configs were passing and 1 config was failing. In PR #610, the failing one was
incorrectly added instead of the passing 2. Fix in this commit.