### PR TITLE
Eliminate temporary tuning parameters for fp32 wrw.

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -202,8 +202,6 @@ private:
   // Tuning parameters for i8 convolutions.
   static const InitParamsXDL initParametersForwardI8[nInitParametersForwardI8];
 
-  static constexpr size_t nInitParametersBwdWeightF32 = 7;
-
   static constexpr int64_t waveSize = 64;
 
   // if can't select config from above , use this config to do

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -203,12 +203,6 @@ private:
   static const InitParamsXDL initParametersForwardI8[nInitParametersForwardI8];
 
   static constexpr size_t nInitParametersBwdWeightF32 = 7;
-  // XXX FIXME: Initial tuning parameters for fp32 backward weight convolution.
-  // Deliberately avoid KPACK=4 for fp32 backward weight convolution. It has
-  // been verified some configs would cause intermittent failures.
-  // TODO(whchung): Get to the bottom of this.
-  static const InitParamsXDL
-      initParametersBwdWeightF32[nInitParametersBwdWeightF32];
 
   static constexpr int64_t waveSize = 64;
 

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -856,19 +856,6 @@ PopulateParamsXDL::initParametersForwardI8[
   {16, 16, 32, 16, 16, 1, false, false},
   {16, 16, 16, 16, 16, 1, false, false},
 };
-
-const InitParamsXDL
-PopulateParamsXDL::initParametersBwdWeightF32[
-    PopulateParamsXDL::nInitParametersBwdWeightF32] = {
-  // M/block N/block K/block M/wave N/wave kPack aCopyMore bCopyMore
-  {128, 128, 8, 64, 64, 1, false, false},
-  {128, 128, 16, 64, 64, 1, false, false},
-  {8, 64, 8, 8, 64, 1, false, false},
-  {4, 64, 16, 4, 64, 1, false, false},
-  {32, 64, 4, 32, 64, 1, false, false},
-  {16, 16, 16, 16, 16, 1, false, false},
-  {16, 16, 4, 16, 16, 1, false, false} ,
-};
 // clang-format on
 
 const InitParams PopulateParamsXDL::universalParameters = {32, 64, 4};
@@ -1309,14 +1296,6 @@ ArrayRef<InitParamsXDL>
 PopulateParamsXDL::getTuningParameters(ConvOpType dir, Type dataType) const {
   if (dataType.isInteger(8)) {
     return {initParametersForwardI8, nInitParametersForwardI8};
-  }
-
-  // XXX FIXME: Temporarily use another vector of heuristic tuning
-  // parameters to get around the issue that when KPACK=4, fp32 backward
-  // weight kernels would fail intermittently.
-  // TODO(whchung): Get to the bottom of this.
-  if ((dir == miopen::ConvOpType::BwdWeight) && dataType.isF32()) {
-    return {initParametersBwdWeightF32, nInitParametersBwdWeightF32};
   }
 
   return {initParameters, nInitParameters};


### PR DESCRIPTION
This should not be getting into our way now.