### PR TITLE
Generalise --tosa-partition to allow other specified ops as primary op [DO NOT SQUASH]

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
@@ -31,9 +31,11 @@ std::unique_ptr<Pass> createTosaInferShapesPass();
 std::unique_ptr<Pass> createTosaMakeBroadcastablePass();
 std::unique_ptr<Pass> createTosaTestQuantUtilAPIPass();
 std::unique_ptr<Pass> createTosaPartitionPass();
-std::unique_ptr<Pass> createPostPartitionCollapsePass();
+std::unique_ptr<Pass>
+createTosaPartitionPass(llvm::function_ref<bool(Operation *)> &pred,
+                        std::string attributeName = "kernel",
+                        bool nofront = false);
 std::unique_ptr<Pass> createTosaOptionalDecompositions();
-void registerTosaPartitionPipelinePass();
 
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/Tosa/Transforms/Passes.h.inc"

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
@@ -31,10 +31,8 @@ std::unique_ptr<Pass> createTosaInferShapesPass();
 std::unique_ptr<Pass> createTosaMakeBroadcastablePass();
 std::unique_ptr<Pass> createTosaTestQuantUtilAPIPass();
 std::unique_ptr<Pass> createTosaPartitionPass();
-std::unique_ptr<Pass>
-createTosaPartitionPass(llvm::function_ref<bool(Operation *)> &pred,
-                        std::string attributeName = "kernel",
-                        bool nofront = false);
+class PartitionConfig;
+std::unique_ptr<Pass> createTosaPartitionPass(PartitionConfig *config);
 std::unique_ptr<Pass> createTosaOptionalDecompositions();
 
 #define GEN_PASS_REGISTRATION

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -52,7 +52,13 @@ def TosaPartition : Pass<"tosa-partition", "ModuleOp"> {
   let constructor = "createTosaPartitionPass()";
 
   let options = [
-    Option<"nofront", "nofront", "bool", /*default=*/"false",
+    ListOption<"primaryOps", "primary-ops", "std::string",
+               "One or more operations to be used as focus of partitioned "
+               "kernels",
+               "llvm::cl::ZeroOrMore">,
+    Option<"attributeName", "attribute-name", "std::string",
+           /*default=*/"\"kernel\"", "Attribute for outlined functions">,
+    Option<"noFront", "trailing-only", "bool", /*default=*/"false",
            "Don't gather ops ahead of Conv2D">
   ];
   let dependentDialects = ["tosa::TosaDialect"];

--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -50,17 +50,6 @@ def TosaPartition : Pass<"tosa-partition", "ModuleOp"> {
   }];
 
   let constructor = "createTosaPartitionPass()";
-
-  let options = [
-    ListOption<"primaryOps", "primary-ops", "std::string",
-               "One or more operations to be used as focus of partitioned "
-               "kernels",
-               "llvm::cl::ZeroOrMore">,
-    Option<"attributeName", "attribute-name", "std::string",
-           /*default=*/"\"kernel\"", "Attribute for outlined functions">,
-    Option<"noFront", "trailing-only", "bool", /*default=*/"false",
-           "Don't gather ops ahead of Conv2D">
-  ];
   let dependentDialects = ["tosa::TosaDialect"];
 }
 

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -90,7 +90,7 @@ bool isElementwiseOp(Operation *op) {
 }
 
 bool isFusibleOp(Operation *op) {
-  return isElementwiseOp(op) || isa<tosa::TransposeOp,tosa::ReshapeOp>(op);
+  return isElementwiseOp(op) || isa<tosa::TransposeOp, tosa::ReshapeOp>(op);
 }
 
 bool isZeroAttribute(Attribute value) {
@@ -101,8 +101,7 @@ bool isZeroAttribute(Attribute value) {
   if (auto splatValue = value.dyn_cast<SplatElementsAttr>())
     return isZeroAttribute(splatValue.getSplatValue<Attribute>());
   if (auto elementsValue = value.dyn_cast<ElementsAttr>())
-    return llvm::all_of(elementsValue.getValues<Attribute>(),
-                        isZeroAttribute);
+    return llvm::all_of(elementsValue.getValues<Attribute>(), isZeroAttribute);
   if (auto arrayValue = value.dyn_cast<ArrayAttr>())
     return llvm::all_of(arrayValue.getValue(), isZeroAttribute);
   return false;
@@ -418,7 +417,8 @@ namespace tosa {
 
 class PartitionConfig {
 public:
-  PartitionConfig() {     /*llvm::errs() << "new partition config\n";*/ }
+  PartitionConfig() { /*llvm::errs() << "new partition config\n";*/
+  }
   virtual bool isAnchorOp(Operation *) = 0;
   virtual bool isLeadingOp(Operation *) = 0;
   virtual bool isTrailingOp(Operation *) = 0;
@@ -428,9 +428,7 @@ public:
 
 class SimpleDefaultPartitionConfig : public PartitionConfig {
 public:
-  bool isAnchorOp(Operation *op) override {
-    return isa<tosa::Conv2DOp>(op);
-  }
+  bool isAnchorOp(Operation *op) override { return isa<tosa::Conv2DOp>(op); }
   bool isLeadingOp(Operation *op) override {
     return isConstantZero(op) || isFusibleOp(op);
   }
@@ -438,47 +436,53 @@ public:
   std::string attributeName() override { return "kernel"; }
 };
 
-
 class PartitionConfigWithOptions : public PartitionConfig {
   Pass::ListOption<std::string> anchorOps;
   Pass::Option<std::string> attributeNameOpt;
   Pass::Option<bool> nofront;
+
 public:
   PartitionConfigWithOptions(Pass *pass)
-    : anchorOps{*pass, "anchor-ops", llvm::cl::desc("One or more operations to be used as focus of partitioned kernels"), llvm::cl::ZeroOrMore},
-      attributeNameOpt{*pass, "attribute-name", ::llvm::cl::desc("Attribute for outlined functions"), ::llvm::cl::init("kernel")},
-      nofront{*pass, "trailing-only", ::llvm::cl::desc("Don't gather ops ahead of Conv2D"), ::llvm::cl::init(false)}
-  {
-//     if (!anchorOps.hasValue()) {
-//       llvm::errs() << "overriding empty anchor ops\n";
-//       anchorOps = {"tosa.conv2d"};
-//     } else {
-//       llvm::errs() << "anchor ops is '" << anchorOps.getArgStr() << "'\n";
-//     }
-//     for (auto *thing : llvm::cl::getRegisteredSubcommands())
-//       llvm::errs() << thing << "\n";
-//     llvm::errs() << "config with options:\n";
-//     llvm::errs() << "  anchorOps =\n    ";
-//     for (auto &anchor : anchorOps) llvm::errs() << anchor << " ";
-//     llvm::errs() << "\n";
-//     llvm::errs() << "  attrName = " << attributeNameOpt << "\n";
-//     llvm::errs() << "  nofront = " << nofront << "\n";
+      : anchorOps{*pass, "anchor-ops",
+                  llvm::cl::desc("One or more operations to be used as focus "
+                                 "of partitioned kernels"),
+                  llvm::cl::ZeroOrMore},
+        attributeNameOpt{*pass, "attribute-name",
+                         ::llvm::cl::desc("Attribute for outlined functions"),
+                         ::llvm::cl::init("kernel")},
+        nofront{*pass, "trailing-only",
+                ::llvm::cl::desc("Don't gather ops ahead of Conv2D"),
+                ::llvm::cl::init(false)} {
+    //     if (!anchorOps.hasValue()) {
+    //       llvm::errs() << "overriding empty anchor ops\n";
+    //       anchorOps = {"tosa.conv2d"};
+    //     } else {
+    //       llvm::errs() << "anchor ops is '" << anchorOps.getArgStr() <<
+    //       "'\n";
+    //     }
+    //     for (auto *thing : llvm::cl::getRegisteredSubcommands())
+    //       llvm::errs() << thing << "\n";
+    //     llvm::errs() << "config with options:\n";
+    //     llvm::errs() << "  anchorOps =\n    ";
+    //     for (auto &anchor : anchorOps) llvm::errs() << anchor << " ";
+    //     llvm::errs() << "\n";
+    //     llvm::errs() << "  attrName = " << attributeNameOpt << "\n";
+    //     llvm::errs() << "  nofront = " << nofront << "\n";
   }
   bool isAnchorOp(Operation *op) override {
-//     llvm::errs() << "given anchorOps =\n    ";
-//     for (auto &anchor : anchorOps) llvm::errs() << anchor << " ";
-//     llvm::errs() << "\n";
-//     llvm::errs() << "  is '" << op->getName().getIdentifier().str() << "' an anchor?  ";
-//     if (llvm::is_contained(anchorOps,
-//                            op->getName().getIdentifier().str()))
-//       llvm::errs() << "yes\n";
-//     else
-//       llvm::errs() << "no\n";
+    //     llvm::errs() << "given anchorOps =\n    ";
+    //     for (auto &anchor : anchorOps) llvm::errs() << anchor << " ";
+    //     llvm::errs() << "\n";
+    //     llvm::errs() << "  is '" << op->getName().getIdentifier().str() << "'
+    //     an anchor?  "; if (llvm::is_contained(anchorOps,
+    //                            op->getName().getIdentifier().str()))
+    //       llvm::errs() << "yes\n";
+    //     else
+    //       llvm::errs() << "no\n";
 
     if (anchorOps.empty())
       anchorOps = {"tosa.conv2d"};
-    return llvm::is_contained(anchorOps,
-                              op->getName().getIdentifier().str());
+    return llvm::is_contained(anchorOps, op->getName().getIdentifier().str());
   }
   bool isLeadingOp(Operation *op) override {
     return !nofront && (isConstantZero(op) || isFusibleOp(op));
@@ -499,19 +503,23 @@ class TosaPartitionPass : public TosaPartitionBase<TosaPartitionPass> {
 
 public:
   TosaPartitionPass() {
-//    llvm::errs() << "new pass 1\n";
+    //    llvm::errs() << "new pass 1\n";
     config = new mlir::tosa::PartitionConfigWithOptions(this);
   }
   TosaPartitionPass(mlir::tosa::PartitionConfig *config_)
-    : config(config_) {    /*llvm::errs() << "new pass 2\n";*/}
-  ~TosaPartitionPass() override {     /*llvm::errs() << "pass deleted\n"; delete config;*/ }
+      : config(config_) { /*llvm::errs() << "new pass 2\n";*/
+  }
+  ~TosaPartitionPass()
+      override { /*llvm::errs() << "pass deleted\n"; delete config;*/
+  }
 
   void traceInputs(Operation *op, SmallVector<Operation *> &predecessors,
                    SetVector<Value> &inputNodes) {
     for (const auto &opnd : op->getOperands()) {
       Operation *usedOp = opnd.getDefiningOp();
-      if (usedOp && (config->isLeadingOp(usedOp)
-                     || (isa<tosa::TransposeOp>(op) && isSmallishConstant(usedOp)))) {
+      if (usedOp &&
+          (config->isLeadingOp(usedOp) ||
+           (isa<tosa::TransposeOp>(op) && isSmallishConstant(usedOp)))) {
         predecessors.push_back(usedOp);
         if (!detail::isConstantLike(usedOp)) {
           // depth first
@@ -653,7 +661,8 @@ std::unique_ptr<Pass> mlir::tosa::createTosaPartitionPass() {
   return std::make_unique<TosaPartitionPass>();
 }
 
-std::unique_ptr<Pass> mlir::tosa::createTosaPartitionPass(mlir::tosa::PartitionConfig *config) {
+std::unique_ptr<Pass>
+mlir::tosa::createTosaPartitionPass(mlir::tosa::PartitionConfig *config) {
   return std::make_unique<TosaPartitionPass>(config);
 }
 
@@ -682,36 +691,41 @@ public:
     if (defaultCase) {
       pm.addPass(tosa::createTosaPartitionPass());
     } else if (depthwiseOnly) {
-      class DepthwiseOnlyPartitionConfig : public mlir::tosa::SimpleDefaultPartitionConfig {
+      class DepthwiseOnlyPartitionConfig
+          : public mlir::tosa::SimpleDefaultPartitionConfig {
       public:
         bool isAnchorOp(Operation *op) override {
           return isa<tosa::DepthwiseConv2DOp>(op);
         }
       };
-      pm.addPass(tosa::createTosaPartitionPass(new DepthwiseOnlyPartitionConfig()));
+      pm.addPass(
+          tosa::createTosaPartitionPass(new DepthwiseOnlyPartitionConfig()));
     } else if (both) {
-      class DepthwiseAlsoPartitionConfig : public mlir::tosa::SimpleDefaultPartitionConfig {
+      class DepthwiseAlsoPartitionConfig
+          : public mlir::tosa::SimpleDefaultPartitionConfig {
       public:
         bool isAnchorOp(Operation *op) override {
-          return isa<tosa::Conv2DOp,tosa::DepthwiseConv2DOp>(op);
+          return isa<tosa::Conv2DOp, tosa::DepthwiseConv2DOp>(op);
         }
       };
-      pm.addPass(tosa::createTosaPartitionPass(new DepthwiseAlsoPartitionConfig()));
+      pm.addPass(
+          tosa::createTosaPartitionPass(new DepthwiseAlsoPartitionConfig()));
     } else if (attrOne) {
-      class AttributeOnePartitionConfig : public mlir::tosa::SimpleDefaultPartitionConfig {
+      class AttributeOnePartitionConfig
+          : public mlir::tosa::SimpleDefaultPartitionConfig {
       public:
         std::string attributeName() override { return "one"; }
       };
-      pm.addPass(tosa::createTosaPartitionPass(new AttributeOnePartitionConfig()));
+      pm.addPass(
+          tosa::createTosaPartitionPass(new AttributeOnePartitionConfig()));
     } else if (nofrontArg) {
-      class NoFrontPartitionConfig : public mlir::tosa::SimpleDefaultPartitionConfig {
+      class NoFrontPartitionConfig
+          : public mlir::tosa::SimpleDefaultPartitionConfig {
       public:
         bool isAnchorOp(Operation *op) override {
           return isa<tosa::DepthwiseConv2DOp>(op);
         }
-        bool isLeadingOp(Operation *op) override {
-          return false;
-        }
+        bool isLeadingOp(Operation *op) override { return false; }
       };
       pm.addPass(tosa::createTosaPartitionPass(new NoFrontPartitionConfig()));
     }

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
@@ -1,0 +1,70 @@
+// RUN: mlir-opt --tosa-partition %s | FileCheck %s
+// RUN: mlir-opt --tosa-partition=attribute-name=one %s | FileCheck %s --check-prefix=ONE
+// RUN: mlir-opt --tosa-partition='primary-ops=tosa.depthwise_conv2d attribute-name=two' %s | FileCheck %s --check-prefix=TWO
+// RUN: mlir-opt --tosa-partition='primary-ops=tosa.depthwise_conv2d trailing-only attribute-name=three' %s | FileCheck %s --check-prefix=THREE
+// RUN: mlir-opt --tosa-partition='primary-ops=tosa.conv2d,tosa.depthwise_conv2d attribute-name=four' %s | FileCheck %s --check-prefix=FOUR
+
+// RUN: mlir-opt --test-tosa-partition-options=default %s | FileCheck %s --check-prefix=CHECK
+// RUN: mlir-opt --test-tosa-partition-options=depthwise-only %s | FileCheck %s --check-prefix=TWO
+// RUN: mlir-opt --test-tosa-partition-options=both-conv-ops %s | FileCheck %s --check-prefix=FOUR
+// RUN: mlir-opt --test-tosa-partition-options=attr-one %s | FileCheck %s --check-prefix=ONE
+// RUN: mlir-opt --test-tosa-partition-options=nofront-arg %s | FileCheck %s --check-prefix=THREE
+
+// CHECK-LABEL: func private @test_fusion8_outlined_part_0
+// CHECK-SAME: attributes {kernel}
+// CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: tosa.add
+// CHECK-NEXT: return
+// CHECK: func @test_fusion8
+// CHECK: call @test_fusion8_outlined_part_0
+
+// ONE-LABEL: func private @test_fusion8_outlined_part_0
+// ONE-SAME: attributes {one}
+// ONE-NEXT: tosa.conv2d
+// ONE-NEXT: tosa.add
+// ONE-NEXT: return
+// ONE: func @test_fusion8
+// ONE: call @test_fusion8_outlined_part_0
+
+// TWO-LABEL: func private @test_fusion8_outlined_part_0
+// TWO-NEXT: tosa.transpose
+// TWO-NEXT: tosa.depthwise_conv2d
+// TWO-NEXT: tosa.abs
+// TWO-NEXT: tosa.add
+// TWO-NEXT: return
+// TWO: func @test_fusion8
+// TWO: tosa.conv2d
+// TWO: call @test_fusion8_outlined_part_0
+
+// THREE-LABEL: func private @test_fusion8_outlined_part_0
+// THREE-NEXT: tosa.depthwise_conv2d
+// THREE-NEXT: tosa.abs
+// THREE-NEXT: tosa.add
+// THREE-NEXT: return
+// THREE: func @test_fusion8
+// THREE: tosa.transpose
+// THREE: tosa.conv2d
+// THREE: call @test_fusion8_outlined_part_0
+
+// FOUR-LABEL: func private @test_fusion8_outlined_part_0
+// FOUR-NEXT: tosa.transpose
+// FOUR-NEXT: tosa.depthwise_conv2d
+// FOUR-NEXT: tosa.abs
+// FOUR-NEXT: tosa.add
+// FOUR-NEXT: return
+// FOUR: func private @test_fusion8_outlined_part_1
+// FOUR-NEXT: tosa.conv2d
+// FOUR-NEXT: return
+// FOUR: func @test_fusion8
+// FOUR: call @test_fusion8_outlined_part_1
+// FOUR: call @test_fusion8_outlined_part_0
+
+func @test_fusion8(%arg0: tensor<128x32x32x8xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>, %arg3: tensor<128x8x32x32xf32>, %arg4: tensor<128x8x3x3xf32>, %arg5: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %cst = arith.constant dense<[0, 2, 3, 1]> : tensor<4xi64>
+  %0 = "tosa.transpose"(%arg0, %cst) {changing_layout_root = false} : (tensor<128x32x32x8xf32>, tensor<4xi64>) -> tensor<128x8x32x32xf32>
+  %1 = "tosa.depthwise_conv2d"(%0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.conv2d"(%arg3, %arg4, %arg5) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %3 = "tosa.abs"(%1) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %4 = "tosa.add"(%3, %2) {} : (tensor<128x128x30x30xf32>, tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %4 : tensor<128x128x30x30xf32>
+}

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
@@ -1,8 +1,8 @@
 // RUN: mlir-opt --tosa-partition %s | FileCheck %s
 // RUN: mlir-opt --tosa-partition=attribute-name=one %s | FileCheck %s --check-prefix=ONE
-// RUN: mlir-opt --tosa-partition='primary-ops=tosa.depthwise_conv2d attribute-name=two' %s | FileCheck %s --check-prefix=TWO
-// RUN: mlir-opt --tosa-partition='primary-ops=tosa.depthwise_conv2d trailing-only attribute-name=three' %s | FileCheck %s --check-prefix=THREE
-// RUN: mlir-opt --tosa-partition='primary-ops=tosa.conv2d,tosa.depthwise_conv2d attribute-name=four' %s | FileCheck %s --check-prefix=FOUR
+// RUN: mlir-opt --tosa-partition='anchor-ops=tosa.depthwise_conv2d attribute-name=two' %s | FileCheck %s --check-prefix=TWO
+// RUN: mlir-opt --tosa-partition='anchor-ops=tosa.depthwise_conv2d trailing-only attribute-name=three' %s | FileCheck %s --check-prefix=THREE
+// RUN: mlir-opt --tosa-partition='anchor-ops=tosa.conv2d,tosa.depthwise_conv2d attribute-name=four' %s | FileCheck %s --check-prefix=FOUR
 
 // RUN: mlir-opt --test-tosa-partition-options=default %s | FileCheck %s --check-prefix=CHECK
 // RUN: mlir-opt --test-tosa-partition-options=depthwise-only %s | FileCheck %s --check-prefix=TWO

--- a/external/llvm-project/mlir/tools/mlir-opt/mlir-opt.cpp
+++ b/external/llvm-project/mlir/tools/mlir-opt/mlir-opt.cpp
@@ -107,6 +107,7 @@ void registerTestRecursiveTypesPass();
 void registerTestSCFUtilsPass();
 void registerTestSliceAnalysisPass();
 void registerTestTensorTransforms();
+void registerTestTosaPartitionOptionsPass();
 void registerTestVectorLowerings();
 } // namespace test
 } // namespace mlir
@@ -196,6 +197,7 @@ void registerTestPasses() {
   mlir::test::registerTestSCFUtilsPass();
   mlir::test::registerTestSliceAnalysisPass();
   mlir::test::registerTestTensorTransforms();
+  mlir::test::registerTestTosaPartitionOptionsPass();
   mlir::test::registerTestVectorLowerings();
 }
 #endif

--- a/mlir/tools/miopen-gen/CMakeLists.txt
+++ b/mlir/tools/miopen-gen/CMakeLists.txt
@@ -5,9 +5,16 @@ set(LLVM_LINK_COMPONENTS
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
+if(MLIR_INCLUDE_TESTS)
+  set(test_libs
+    MLIRTestDialect
+    )
+endif()
+
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
+  ${test_libs}
   LLVMAMDGPUAsmParser
   LLVMX86AsmParser
   LLVMROCmBackendUtils
@@ -22,7 +29,6 @@ set(LIBS
   MLIRTransforms
   MLIRSupport
   MLIRIR
-  MLIRTestDialect
   MLIRMIOpenThin
   )
 
@@ -39,4 +45,3 @@ add_llvm_executable(miopen-gen
 llvm_update_compile_flags(miopen-gen)
 target_link_libraries(miopen-gen PRIVATE ${LIBS})
 mlir_check_link_libraries(miopen-gen)
-

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -5,9 +5,16 @@ set(LLVM_LINK_COMPONENTS
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
+if(MLIR_INCLUDE_TESTS)
+  set(test_libs
+    MLIRTestDialect
+    )
+endif()
+
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
+  ${test_libs}
   LLVMAMDGPUAsmParser
   LLVMX86AsmParser
   LLVMROCmBackendUtils
@@ -22,7 +29,6 @@ set(LIBS
   MLIRTransforms
   MLIRSupport
   MLIRIR
-  MLIRTestDialect
   MLIRMIOpenThin
   )
 
@@ -43,7 +49,7 @@ mlir_check_link_libraries(mlir-miopen-driver)
 # Performance test scripts
 # Defined here since mlir/utils/ isn't in Jenkins
 file(GLOB PERFORMANCE_SCRIPTS
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../utils/jenkins/*.py" 
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../utils/jenkins/*.py"
 )
 
 add_custom_target(ci-performance-scripts


### PR DESCRIPTION
Generalise --tosa-partition to allow other specified ops as primary op.
Allow tosa.transpose and tosa.reshape to be gathered along with the element-wise ops.
Allow specifying the name of the "kernel" attribute.
Test the sub-options primary-ops, trailing-only, and attribute-name.
Test both command-line and programmatic interfaces.