### PR TITLE
Fix gemm size calculation, probably fixing some bwd data bugs

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -417,7 +417,7 @@ static void obtainGemmSize(ConvolutionContext &ctx, GemmSize &gemmSize) {
     auto dilationH = ctx.dilationVal[0];
     auto dilationW = ctx.dilationVal[1];
     auto leftPadH = ctx.paddingVal[0];
-    auto leftPadW = ctx.paddingVal[1];
+    auto leftPadW = ctx.paddingVal[2];
 
     auto gcdStrideDilationH = math_util::gcd(strideH, dilationH);
     auto gcdStrideDilationW = math_util::gcd(strideW, dilationW);


### PR DESCRIPTION
The value for leftPadW was actually the value for rightPadH

This fixes the two configs specifically called out in
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/534
but I'll need to re-test to confirm if that is the entire issue.

For the second suspicious config (with strides=2 in both h and w)
we get a change in grid_size from 72 to 96 on the kernels, which
matches the failure state (which was that no one was writing to
input[48:64]).

(I am going to duly suspect that this might be the reason we've got some of those bwd data padding kernel configs excluded as well, but that's something for future me to check)