### PR TITLE
[ROCm 5.2] Get rid of unnecessary warning messages from tuning

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -989,14 +989,10 @@ private:
     // For fp32: reject anything wider than 4.
     // For fp16/bf16: reject anything narrower than 4, or greater than 8.
     if (dataType.isF32() && param.gemmKPack > 4) {
-      llvm::errs() << "Invalid KPACK tuning parameter: " << param.gemmKPack
-                   << "\n";
       return failure();
     } else if ((dataType.isF16() || dataType.isBF16()) &&
                (param.gemmKPack != 1) &&
                ((param.gemmKPack < 4) || (param.gemmKPack > 8))) {
-      llvm::errs() << "Invalid KPACK tuning parameter: " << param.gemmKPack
-                   << "\n";
       return failure();
     }
 


### PR DESCRIPTION
MIOpen caught those messages in tuning. Requirement: those error messages should not be visible in tuning process or at least suppressible. The messages violate this requirement.

I'm doing this change directly upon release branch because there's little risk on this PR.

Please review/approve.