### PR TITLE
Remove bwd data restriction, take 2

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -276,16 +276,14 @@ public:
 // we set gemmMExtra be 64 so (gemmM+gemmMExtra)%gemmMPerBlock=0.
 //
 // Returns:
-// - isOriginalKernelSupport : a bool only used in backward data convolution.
 // - needExtraPad : a bool to indicate whether padding kernel is needed.
 // - gemmM/N/KExtra : additional padding required along Gemm M/N/K dimension.
 //                    They would be all be 0 in case needExtraPad is false.
 template <typename T>
-std::tuple<bool, bool, int64_t, int64_t, int64_t>
+std::tuple<bool, int64_t, int64_t, int64_t>
 calculatePaddingKernelSize(int64_t gemmMSize, int64_t gemmNSize,
                            int64_t gemmKSize, ConvOpType dir, Type dataType,
                            T populateParams) {
-  bool isOriginalKernelSupport = true;
   bool needExtraPad = false;
   int64_t gemmMExtra, gemmNExtra, gemmKExtra;
   gemmMExtra = gemmNExtra = gemmKExtra = 0;
@@ -296,10 +294,8 @@ calculatePaddingKernelSize(int64_t gemmMSize, int64_t gemmNSize,
     if (gemmMSize % params.gemmMPerBlock == 0 &&
         gemmKSize % params.gemmKPerBlock == 0 &&
         gemmNSize % params.gemmNPerBlock == 0) {
-      isOriginalKernelSupport = true;
       break;
     }
-    isOriginalKernelSupport = false;
     numOfFailedConfigs++;
   }
 
@@ -324,8 +320,7 @@ calculatePaddingKernelSize(int64_t gemmMSize, int64_t gemmNSize,
     // gemmNExtra << "gemmKExtra: " << gemmKExtra << "\n";
   }
 
-  return std::make_tuple(isOriginalKernelSupport, needExtraPad, gemmMExtra,
-                         gemmNExtra, gemmKExtra);
+  return std::make_tuple(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra);
 }
 
 } // namespace miopen

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -353,10 +353,8 @@ bool Conv2dGenerator::needExtraPad(OpBuilder &builder) const {
   // gemmM/N/KExtra is not used.
   // populateParamsXDL is not used either.
   // Only needExtraPad is used.
-  bool isOriginalKernelSupport = true;
   bool needExtraPad = false;
   int64_t gemmMExtra, gemmNExtra, gemmKExtra;
-
   if (!config.xdlops) {
     PopulateParams populateParams;
     std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =

--- a/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/MIOpen/Generator/Conv2dGenerator.cpp
@@ -350,7 +350,6 @@ bool Conv2dGenerator::needExtraPad(OpBuilder &builder) const {
   gemmKSize = outDim["n"] * outDim["h"] * outDim["w"];
   gemmNSize = filDim["c"] * filDim["y"] * filDim["x"];
 
-  // isOriginalKernelSupport is not used.
   // gemmM/N/KExtra is not used.
   // populateParamsXDL is not used either.
   // Only needExtraPad is used.
@@ -360,14 +359,12 @@ bool Conv2dGenerator::needExtraPad(OpBuilder &builder) const {
 
   if (!config.xdlops) {
     PopulateParams populateParams;
-    std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-             gemmKExtra) =
+    std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
         calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize, dir,
                                    dataType, populateParams);
   } else {
     PopulateParamsXDL populateParamsXDL;
-    std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-             gemmKExtra) =
+    std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
         calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize, dir,
                                    dataType, populateParamsXDL);
   }

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -168,13 +168,9 @@ void AffixTuningParameters::affixBackwardWeightUtilityKernels(
     int64_t gemmMExtra, gemmNExtra, gemmKExtra;
     gemmMExtra = gemmNExtra = gemmKExtra = 0;
 
-    // isOriginalKernelSupport is not used.
-    // Only needExtraPad is used.
-    bool isOriginalKernelSupport = true;
     bool needExtraPad = false;
     PopulateParamsXDL populateParamsXDL;
-    std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-             gemmKExtra) =
+    std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
         calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
                                    obtainConvDirection(op),
                                    obtainConvDataType(op), populateParamsXDL);
@@ -222,9 +218,7 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
   int64_t gemmMExtra, gemmNExtra, gemmKExtra;
   gemmMExtra = gemmNExtra = gemmKExtra = 0;
 
-  // isOriginalKernelSupport is not used.
   // Only needExtraPad is used.
-  bool isOriginalKernelSupport = true;
   bool needExtraPad = false;
 
   std::string perfConfig;
@@ -259,8 +253,7 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     Type dataType = obtainConvDataType(op);
 
     // Disable kpack in case we need padding kernel.
-    std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-             gemmKExtra) =
+    std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
         calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize, dir,
                                    dataType, populateParamsXDL);
     if (needExtraPad) {

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -932,6 +932,7 @@ LogicalResult backwardData(Conv2DBwdDataOp op, PatternRewriter &b) {
 
       TransformMapAttr padTransformAttr = padTransform.get();
       // Replace output gemm with padded version
+      gemmOutputTransformAttr = padTransformAttr;
       gemmOutput = b.create<TransformOp>(loc, gemmOutput, padTransformAttr);
     }
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemmLowering.cpp
@@ -61,20 +61,6 @@ struct LowerMIOpenOpsStep1Pass
   void runOnOperation() override;
 };
 
-LogicalResult
-isSupportedBackwardDataPaddingKernel(bool isXdlops, bool isStride2Pad1,
-                                     int64_t gemmMExtra, int64_t gemmKExtra,
-                                     int64_t gemmNExtra, Conv2DBwdDataOp &op) {
-  if (isXdlops && (gemmMExtra || gemmNExtra)) {
-    if (isStride2Pad1) {
-      return op->emitOpError(
-          "can't support backward data padding kernel when xdlops stride 2 "
-          "pad_h,pad_w>0 and pad gemmM or gemmN due to store issue\n");
-    }
-  }
-  return success();
-}
-
 template <typename T>
 LogicalResult checkNames(ArrayRef<StringRef> actual,
                          ArrayRef<StringRef> expected, StringRef argName,
@@ -708,36 +694,21 @@ LogicalResult backwardData(Conv2DBwdDataOp op, PatternRewriter &b) {
   if (xdlopsV2Attr && xdlopsV2Attr.getValue() == true)
     isXdlops = true;
 
-  bool hasHPadding = (leftPadH != 0 || rightPadH != 0);
-  bool hasWPadding = (leftPadW != 0 || rightPadW != 0);
-  bool hasPadding = hasHPadding || hasWPadding;
-  bool isStride2Pad1 = ((strideH > 1 || strideW > 1) && hasPadding);
 
-  // Both isOriginalKernelSupport and needExtraPad are used.
   bool needExtraPad = false;
-  bool isOriginalKernelSupport = true;
-
   if (!isXdlops) {
     PopulateParams populateParams;
-    std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-             gemmKExtra) =
+    std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
         calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
                                    obtainConvDirection(op),
                                    obtainConvDataType(op), populateParams);
   } else { // xdlops
     PopulateParamsXDL populateParamsXDL;
-    std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-             gemmKExtra) =
+    std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
         calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
                                    obtainConvDirection(op),
                                    obtainConvDataType(op), populateParamsXDL);
   }
-
-  LogicalResult supportedPaddingKernel = isSupportedBackwardDataPaddingKernel(
-      isXdlops, isStride2Pad1, gemmMExtra, gemmKExtra, gemmNExtra, op);
-  // don't do backward data padding kernel if isSupportPaddingKernel=false
-  if (failed(supportedPaddingKernel) && !isOriginalKernelSupport)
-    return failure();
 
   Value gemmFilter, gemmInput, gemmOutput;
   Value gemmFilterKPack, gemmOutputKPack;
@@ -1146,21 +1117,15 @@ template <typename T> struct Conv2DRewritePattern : public OpRewritePattern<T> {
       break;
     }
 
-    // isOriginalKernelSupport is not used.
-    // Only needExtraPad is used.
-    bool isOriginalKernelSupport = true;
     bool needExtraPad = false;
-
     if (!isXdlops) {
       PopulateParams populateParams;
-      std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-               gemmKExtra) =
+      std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
           calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
                                      convOpType, dataType, populateParams);
     } else { // xdlops
       PopulateParamsXDL populateParamsXDL;
-      std::tie(isOriginalKernelSupport, needExtraPad, gemmMExtra, gemmNExtra,
-               gemmKExtra) =
+      std::tie(needExtraPad, gemmMExtra, gemmNExtra, gemmKExtra) =
           calculatePaddingKernelSize(gemmMSize, gemmNSize, gemmKSize,
                                      convOpType, dataType, populateParamsXDL);
     }

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -417,7 +417,7 @@ static void obtainGemmSize(ConvolutionContext &ctx, GemmSize &gemmSize) {
     auto dilationH = ctx.dilationVal[0];
     auto dilationW = ctx.dilationVal[1];
     auto leftPadH = ctx.paddingVal[0];
-    auto leftPadW = ctx.paddingVal[1];
+    auto leftPadW = ctx.paddingVal[2];
 
     auto gcdStrideDilationH = math_util::gcd(strideH, dilationH);
     auto gcdStrideDilationW = math_util::gcd(strideW, dilationW);

--- a/mlir/test/mlir-miopen-driver/auto_e2e/Resnext101/F32_tests/Resnext101_f32_16.mlir
+++ b/mlir/test/mlir-miopen-driver/auto_e2e/Resnext101/F32_tests/Resnext101_f32_16.mlir
@@ -8,11 +8,11 @@
 // CHECK_Resnext101_f32_16_2: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_Resnext101_f32_16_2: [1]
 
-// FIXME: miopen-gen -batchsize=256 -groupsize=1 -in_channels=3 -in_h=224 -in_w=224 -out_channels=64 -fil_h=7 -fil_w=7 --dilation_h=1 --dilation_w=1 --conv_stride_h=2 --conv_stride_w=2 --padding_h=3 --padding_w=3 --operation conv2d_bwd_data -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -t f32  %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_Resnext101_f32_16_3
+// RUN: miopen-gen -batchsize=256 -groupsize=1 -in_channels=3 -in_h=224 -in_w=224 -out_channels=64 -fil_h=7 -fil_w=7 --dilation_h=1 --dilation_w=1 --conv_stride_h=2 --conv_stride_w=2 --padding_h=3 --padding_w=3 --operation conv2d_bwd_data -fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw -t f32  %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_Resnext101_f32_16_3
 // CHECK_Resnext101_f32_16_3: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_Resnext101_f32_16_3: [1]
 
-// FIXME: miopen-gen -batchsize=256 -groupsize=1 -in_channels=3 -in_h=224 -in_w=224 -out_channels=64 -fil_h=7 -fil_w=7 --dilation_h=1 --dilation_w=1 --conv_stride_h=2 --conv_stride_w=2 --padding_h=3 --padding_w=3 --operation conv2d_bwd_data -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk -t f32  %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_Resnext101_f32_16_4
+// RUN: miopen-gen -batchsize=256 -groupsize=1 -in_channels=3 -in_h=224 -in_w=224 -out_channels=64 -fil_h=7 -fil_w=7 --dilation_h=1 --dilation_w=1 --conv_stride_h=2 --conv_stride_w=2 --padding_h=3 --padding_w=3 --operation conv2d_bwd_data -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk -t f32  %pv %random_data %xdlops | mlir-miopen-driver -c | mlir-rocm-runner --shared-libs=%rocm_wrapper_library_dir/librocm-runtime-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_Resnext101_f32_16_4
 // CHECK_Resnext101_f32_16_4: Unranked Memref base@ = 0x{{.*}} rank = 1 offset = 0 sizes = [1] strides = [1] data =
 // CHECK_Resnext101_f32_16_4: [1]
 

--- a/mlir/utils/Resnext101Config.toml
+++ b/mlir/utils/Resnext101Config.toml
@@ -95,7 +95,3 @@ config = "-batchsize=64 -groupsize=1 -in_channels=64 -in_h=56 -in_w=56 -out_chan
 
 [[suite.test]]
 config = "-batchsize=256 -groupsize=1 -in_channels=3 -in_h=224 -in_w=224 -out_channels=64 -fil_h=7 -fil_w=7 --dilation_h=1 --dilation_w=1 --conv_stride_h=2 --conv_stride_w=2 --padding_h=3 --padding_w=3"
-[[suite.test.exclude]]
-name = "operation"
-values = ["conv2d_bwd_data"]
-


### PR DESCRIPTION
Depends on #619 

Testing with #619 applied revealed that that bug was also a cause of the store issue - which explains why in my previous attempts to debug the "store issue" showed that entire rows of batches (particular `n` coordinates) were missing.

In addition, the kPackLogic for backward data wasn't being given the correct transformation when the output tensor was padded, so I fixed that up too.

I can report a successful parameter sweep of backward data kernels and a successful nightly run on MI-200 .

Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/259 , https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/529 , and https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/297 