### PR TITLE
Add non-unit strides to transforming_for

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -325,6 +325,7 @@ def MIOpen_TransformingForOp :
       ArgTransformsAttr:$transforms,
       Variadic<AnyType>:$iterInits,
       IndexArrayAttr:$bounds,
+      IndexArrayAttr:$strides,
       // This is a derived attribute that holds where in the block arguments
       // the coordinates for each lower domain are stored. It contains
       // one value for each iteration domain, and a final value for
@@ -344,7 +345,7 @@ def MIOpen_TransformingForOp :
 
     For each domain, when we have
     `(%l0, %l1, ... %lL) = [#transform_map1](%u0, %u1, ... %uU)`
-    with bounds `[b0, b1, ... bU]`
+    with bounds `[b0, b1, ... bU]` and strides `[1, 1, ..., 1]`
     the loop arguments %l0, ... %lL will take on the values
     - (%l0, ... %lL) = #transform_map1(%u0, %u1, ... %uU)
     - (%l0, ... %lL) = #transform_map1(%u0, %u1, ... %uU + 1)
@@ -366,8 +367,8 @@ def MIOpen_TransformingForOp :
     ```
     will lower to
     ```mlir
-    %res = affine.for %d0 = 0 to 4 (%arg0 = %cst0 : index) {
-      %res1 = affine.for %d1 = 0 to 8 (%arg1 = %arg0 : index) {
+    %res = affine.for %d0 = 0 to 4 step 1 (%arg0 = %cst0 : index) {
+      %res1 = affine.for %d1 = 0 to 8 step 1 (%arg1 = %arg0 : index) {
         %i0_shifted = arith.addi %i0, %d0
         %j0_shifted = arith.addi %j0, %d1
         %a1, %a2, %a3 = [expand affine map in #transform_map1 at %i0_shifted, %j0_shifted]
@@ -383,6 +384,8 @@ def MIOpen_TransformingForOp :
     When multiple transform_maps are specified for an interatino domain,
     they are composed, with the left one applying first (to the upper coordinates),
     and a lack of transform_maps simply passes the upper cooridate values through.
+
+    If `strides` is not specified during building, it will default to all 1s.
 
     If the `forceUnroll` attribute is specified, the loops above are unrolled
     after being generated.
@@ -406,22 +409,26 @@ def MIOpen_TransformingForOp :
   let builders = [
     OpBuilder<(ins "ArrayRef<ValueRange>":$inits,
     "ArrayRef<Attribute>":$transforms,
-    "ArrayRef<int64_t>":$bounds, "bool":$forceUnroll, "bool":$useIndexDiffs,
+    "ArrayRef<int64_t>":$bounds, "Optional<ArrayRef<int64_t>>":$strides,
+    "bool":$forceUnroll, "bool":$useIndexDiffs,
     CArg<"ValueRange", "llvm::None">:$iterArgs)>,
 
     OpBuilder<(ins "ArrayRef<ValueRange>":$inits,
     "ArrayRef<Attribute>":$transforms,
-    "ArrayAttr":$bounds, "bool":$forceUnroll, "bool":$useIndexDiffs,
+    "ArrayAttr":$bounds, "ArrayAttr":$strides,
+    "bool":$forceUnroll, "bool":$useIndexDiffs,
     CArg<"ValueRange", "llvm::None">:$iterArgs)>,
 
     OpBuilder<(ins "ArrayRef<ValueRange>":$inits,
     "ArrayAttr":$transforms,
-    "ArrayRef<int64_t>":$bounds, "bool":$forceUnroll, "bool":$useIndexDiffs,
+    "ArrayRef<int64_t>":$bounds, "Optional<ArrayRef<int64_t>>":$strides,
+    "bool":$forceUnroll, "bool":$useIndexDiffs,
     CArg<"ValueRange", "llvm::None">:$iterArgs)>,
 
     OpBuilder<(ins "ArrayRef<ValueRange>":$inits,
     "ArrayAttr":$transforms,
-    "ArrayAttr":$bounds, "bool":$forceUnroll, "bool":$useIndexDiffs,
+    "ArrayAttr":$bounds, "ArrayAttr":$strides,
+    "bool":$forceUnroll, "bool":$useIndexDiffs,
     CArg<"ValueRange", "llvm::None">:$iterArgs)>];
 
   let extraClassDeclaration = [{

--- a/mlir/lib/Dialect/MIOpen/MIOpenDialect.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenDialect.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Support/MathExtras.h"
 
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -441,38 +442,55 @@ LogicalResult InsertSliceOp::verify() {
 //===-----------------------------------------------------===//
 // TransformingForOp
 //===-----------------------------------------------------===//
+static ArrayAttr maybeIndexArray(OpBuilder &b,
+                                 Optional<ArrayRef<int64_t>> vals) {
+  return vals.map([&b](ArrayRef<int64_t> v) { return b.getIndexArrayAttr(v); })
+      .getValueOr(ArrayAttr{});
+}
+
 void TransformingForOp::build(OpBuilder &b, OperationState &state,
                               ArrayRef<ValueRange> inits,
                               ArrayRef<Attribute> transforms,
-                              ArrayRef<int64_t> bounds, bool forceUnroll,
-                              bool useIndexDiffs, ValueRange iterArgs) {
+                              ArrayRef<int64_t> bounds,
+                              Optional<ArrayRef<int64_t>> strides,
+                              bool forceUnroll, bool useIndexDiffs,
+                              ValueRange iterArgs) {
   build(b, state, inits, b.getArrayAttr(transforms),
-        b.getIndexArrayAttr(bounds), forceUnroll, useIndexDiffs, iterArgs);
+        b.getIndexArrayAttr(bounds), maybeIndexArray(b, strides), forceUnroll,
+        useIndexDiffs, iterArgs);
 }
 
 void TransformingForOp::build(OpBuilder &b, OperationState &state,
                               ArrayRef<ValueRange> inits,
                               ArrayRef<Attribute> transforms, ArrayAttr bounds,
+                              ArrayAttr strides, bool forceUnroll,
+                              bool useIndexDiffs, ValueRange iterArgs) {
+  build(b, state, inits, b.getArrayAttr(transforms), bounds, strides,
+        forceUnroll, useIndexDiffs, iterArgs);
+}
+
+void TransformingForOp::build(OpBuilder &b, OperationState &state,
+                              ArrayRef<ValueRange> inits, ArrayAttr transforms,
+                              ArrayRef<int64_t> bounds,
+                              Optional<ArrayRef<int64_t>> strides,
                               bool forceUnroll, bool useIndexDiffs,
                               ValueRange iterArgs) {
-  build(b, state, inits, b.getArrayAttr(transforms), bounds, forceUnroll,
-        useIndexDiffs, iterArgs);
+  build(b, state, inits, transforms, b.getIndexArrayAttr(bounds),
+        maybeIndexArray(b, strides), forceUnroll, useIndexDiffs, iterArgs);
 }
 
 void TransformingForOp::build(OpBuilder &b, OperationState &state,
                               ArrayRef<ValueRange> inits, ArrayAttr transforms,
-                              ArrayRef<int64_t> bounds, bool forceUnroll,
-                              bool useIndexDiffs, ValueRange iterArgs) {
-  build(b, state, inits, transforms, b.getIndexArrayAttr(bounds), forceUnroll,
-        useIndexDiffs, iterArgs);
-}
-
-void TransformingForOp::build(OpBuilder &b, OperationState &state,
-                              ArrayRef<ValueRange> inits, ArrayAttr transforms,
-                              ArrayAttr bounds, bool forceUnroll,
-                              bool useIndexDiffs, ValueRange iterArgs) {
+                              ArrayAttr bounds, ArrayAttr strides,
+                              bool forceUnroll, bool useIndexDiffs,
+                              ValueRange iterArgs) {
   // Set up user-provided attributes
   state.addAttribute(boundsAttrName(state.name), bounds);
+  if (!strides) {
+    SmallVector<int64_t> strideVec(bounds.size(), 1LL);
+    strides = b.getIndexArrayAttr(strideVec);
+  }
+  state.addAttribute(stridesAttrName(state.name), strides);
   state.addAttribute(transformsAttrName(state.name), transforms);
   if (forceUnroll)
     state.addAttribute(forceUnrollAttrName(state.name), b.getUnitAttr());
@@ -625,23 +643,38 @@ ParseResult TransformingForOp::parse(OpAsmParser &parser,
     return failure();
   }
 
+  auto intListParser = [&](SmallVectorImpl<int64_t> &dest) -> ParseResult {
+    int64_t res;
+    if (parser.parseInteger(res)) {
+      return failure();
+    }
+    dest.push_back(res);
+    return success();
+  };
   llvm::SmallVector<int64_t> bounds;
   ParseResult boundsRes = parser.parseCommaSeparatedList(
-      Delimiter::Square,
-      [&]() -> ParseResult {
-        int64_t res;
-        if (parser.parseInteger(res)) {
-          return failure();
-        }
-        bounds.push_back(res);
-        return success();
-      },
+      Delimiter::Square, [&]() -> ParseResult { return intListParser(bounds); },
       "list of bounds");
   if (boundsRes) {
     return failure();
   }
   result.addAttribute(TransformingForOp::boundsAttrName(result.name),
                       b.getIndexArrayAttr(bounds));
+
+  if (parser.parseKeyword("strides")) {
+    return failure();
+  }
+
+  llvm::SmallVector<int64_t> strides;
+  ParseResult stridesRes = parser.parseCommaSeparatedList(
+      Delimiter::Square,
+      [&]() -> ParseResult { return intListParser(strides); },
+      "list of strides");
+  if (stridesRes) {
+    return failure();
+  }
+  result.addAttribute(TransformingForOp::stridesAttrName(result.name),
+                      b.getIndexArrayAttr(strides));
 
   SmallVector<Type> regionArgTypes(lowerArgs.size(), indexTy);
   regionArgTypes.append(iterTypes);
@@ -674,7 +707,7 @@ void TransformingForOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict(getOperation()->getAttrs(), /*elidedAttrs=*/{
                               TransformingForOp::getOperandSegmentSizeAttr(),
                               transformsAttrName(), lowerStartsAttrName(),
-                              boundsAttrName()});
+                              boundsAttrName(), stridesAttrName()});
   p << " ";
   for (uint32_t i = 0, e = domains(); i < e; ++i) {
     p << "(";
@@ -702,12 +735,31 @@ void TransformingForOp::print(OpAsmPrinter &p) {
   llvm::interleaveComma(bounds().getAsValueRange<IntegerAttr>(), p,
                         [&](llvm::APInt bound) { p << bound; });
   p << "] ";
+  p << "strides [";
+  llvm::interleaveComma(strides().getAsValueRange<IntegerAttr>(), p,
+                        [&](llvm::APInt stride) { p << stride; });
+  p << "] ";
   p.printRegion(region(), /*printEntryBlockArgs=*/false);
 }
 
 LogicalResult TransformingForOp::verify() {
   if (bounds().empty())
     return emitOpError("Must have at least one iteration dimension");
+  if (bounds().size() != strides().size())
+    return emitOpError("Bounds list and strides list must have same length");
+
+  for (size_t i = 0, e = bounds().size(); i < e; ++i) {
+    int64_t bound = bounds()[i].cast<IntegerAttr>().getInt();
+    int64_t stride = strides()[i].cast<IntegerAttr>().getInt();
+    if (stride <= 0)
+      return emitOpError("Negative and zero strides are not permitted");
+    if (bound % stride != 0)
+      return emitOpError(
+          "Bound for dimension " + Twine(i) + " (" + Twine(bound) +
+          ") does not evenly divide the stride in that dimension (" +
+          Twine(stride));
+  }
+
   if (getNumResults() != getIterArgs().size()) {
     return emitOpError(
         "Mismatch between number of yielded values and number of op results");
@@ -729,7 +781,8 @@ LogicalResult TransformingForOp::verify() {
     if (transforms.size() == 0) {
       if (upperInits.size() != lowerArgs.size()) {
         return emitOpError("Mismatch between number of lower and upper "
-                           "coordinates without a transform");
+                           "coordinates without a transform in domain #" +
+                           Twine(i));
       }
     } else {
       size_t nUpper = transforms[0]
@@ -743,17 +796,22 @@ LogicalResult TransformingForOp::verify() {
                           .getValue()
                           .getNumResults();
       if (upperInits.size() != nUpper) {
-        return emitOpError("Mismatch between number of upper initial values "
-                           "and number of inputs to transform sequence");
+        return emitOpError(
+            "Mismatch between number of upper initial values "
+            "and number of inputs to transform sequence in domain #" +
+            Twine(i));
       }
       if (lowerArgs.size() != nLower) {
-        return emitOpError("Mismatch between number of lower arguments and "
-                           "number of outputs of transform sequence");
+        return emitOpError(
+            "Mismatch between number of lower arguments and "
+            "number of outputs of transform sequence in domain #" +
+            Twine(i));
       }
     }
     lowerArgsCount += lowerArgs.size();
     if (lowerStart(i + 1) != lowerArgsCount) {
-      return emitOpError("Lower starts attribute not accurate");
+      return emitOpError("Lower starts attribute not accurate after domain #" +
+                         Twine(i));
     }
   }
   return success();

--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -278,9 +278,12 @@ template <typename T> struct MILARewritePattern : public OpRewritePattern<T> {
     std::tie(srcLeftOob, srcRightOob) =
         miopen::computeOobFromTransforms(b, sourceTransforms);
 
+    SmallVector<int64_t> strides(bounds.size(), 1LL);
+
     miopen::TransformingForOp copyLoop = b.create<miopen::TransformingForOp>(
         loc, ArrayRef<ValueRange>{inCoords, outCoords},
         ArrayRef<Attribute>{sourceTransforms, destTransforms}, bounds,
+        ArrayRef<int64_t>(strides),
         /*forceUnroll=*/true, /*useIndexDiffs=*/true);
     OpBuilder::InsertionGuard guard(b);
     b.setInsertionPointToStart(copyLoop.getBody());

--- a/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -231,7 +231,7 @@ struct BlockwiseGemmRewritePattern : public OpRewritePattern<BlockwiseGemmOp> {
                              matrixAThreadwiseCopyDestCoords},
         ArrayRef<Attribute>{transformsA, emptyArr},
         ArrayRef<int64_t>{1, KPerThread, MPerThreadSubC},
-        /*forceUnroll=*/true, /*indexDiffs=*/false);
+        /*strides=*/llvm::None, /*forceUnroll=*/true, /*indexDiffs=*/false);
     OpBuilder copyABuilder =
         OpBuilder::atBlockTerminator(copyALoop.getBody(), lab.getListener());
     Value aCopy = copyABuilder.create<memref::LoadOp>(
@@ -286,7 +286,7 @@ struct BlockwiseGemmRewritePattern : public OpRewritePattern<BlockwiseGemmOp> {
                              matrixBThreadwiseCopyDestCoords},
         ArrayRef<Attribute>{transformsB, emptyArr},
         ArrayRef<int64_t>{1, KPerThread, NPerThreadSubC},
-        /*forceUnroll=*/true, /*indexDiffs=*/false);
+        /*strides=*/llvm::None, /*forceUnroll=*/true, /*indexDiffs=*/false);
     OpBuilder copyBBuilder =
         OpBuilder::atBlockTerminator(copyBLoop.getBody(), lbb.getListener());
     Value bCopy = copyBBuilder.create<memref::LoadOp>(
@@ -499,7 +499,7 @@ struct ThreadwiseCopyRewritePattern
     TransformingForOp loop = b.create<TransformingForOp>(
         loc, ArrayRef<ValueRange>{op.sourceCoord(), op.destCoord()},
         ArrayRef<Attribute>{srcTransforms, destTransforms}, op.bounds(),
-        /*forceUnroll=*/true, useIndexDiffs);
+        /*strides=*/ArrayAttr{}, /*forceUnroll=*/true, useIndexDiffs);
     PatternRewriter::InsertionGuard loopGuard(b);
     b.setInsertionPointToStart(loop.getBody());
 
@@ -583,7 +583,7 @@ struct ThreadwiseCopyV2RewritePattern
     auto loop = b.create<TransformingForOp>(
         loc, ArrayRef<ValueRange>{op.sourceCoord(), op.destCoord()},
         ArrayRef<Attribute>{srcTransforms, destTransforms}, bounds,
-        /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+        /*strides=*/llvm::None, /*forceUnroll=*/true, /*useIndexDiffs=*/true);
     PatternRewriter::InsertionGuard guard(b);
     b.setInsertionPointToStart(loop.getBody());
     Value loaded = b.create<ExtractSliceOp>(

--- a/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
@@ -196,7 +196,7 @@ TransformingForOp createGlobalLoadLoop(OpBuilder &b, Location loc, Value global,
   Value dest = createZeroConstantOp(b, loc, resultType);
   auto loop = b.create<TransformingForOp>(
       loc, ArrayRef<ValueRange>{globalStart, linearInit}, loopTransforms,
-      loopBounds,
+      loopBounds, /*strides=*/llvm::None,
       /*forceUnroll=*/true, useIndexDiffs, dest);
   OpBuilder::InsertionGuard guard(b);
   b.setInsertionPointToStart(loop.getBody());
@@ -220,7 +220,8 @@ TransformingForOp createGlobalLoadLoop(OpBuilder &b, Location loc, Value global,
           loc,
           ArrayRef<ValueRange>{linearInit, loop.getLowerCoords(/*domain=*/1)},
           ArrayRef<Attribute>{loadedValIdxMap, resultIdxMap}, vectorIdxBounds,
-          /*forceUnroll=*/true, /*useIndexDiffs=*/true, loopArg);
+          /*strides=*/llvm::None, /*forceUnroll=*/true, /*useIndexDiffs=*/true,
+          loopArg);
 
       {
         OpBuilder::InsertionGuard innerGuard(b);
@@ -277,7 +278,7 @@ TransformingForOp createLdsStoreLoop(OpBuilder &b, Location loc, Value loaded,
   auto loop = b.create<TransformingForOp>(
       loc, ArrayRef<ValueRange>{linearInit, bufferStart}, loopTransforms,
       loopBounds,
-      /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+      /*strides=*/llvm::None, /*forceUnroll=*/true, /*useIndexDiffs=*/true);
   OpBuilder::InsertionGuard guard(b);
   b.setInsertionPointToStart(loop.getBody());
 
@@ -301,7 +302,8 @@ TransformingForOp createLdsStoreLoop(OpBuilder &b, Location loc, Value loaded,
         loc,
         ArrayRef<ValueRange>{loop.getLowerCoords(/*domain=*/0), linearInit},
         ArrayRef<Attribute>{resultIdxMap, loadedValIdxMap}, vectorIdxBounds,
-        /*forceUnroll=*/true, /*useIndexDiffs=*/true, gatherInit);
+        /*strides=*/llvm::None, /*forceUnroll=*/true, /*useIndexDiffs=*/true,
+        gatherInit);
     {
       OpBuilder::InsertionGuard innerGuard(b);
       b.setInsertionPointToStart(gatherLoop.getBody());
@@ -2541,7 +2543,7 @@ struct GridwiseGemmV2RewritePattern
     TransformingForOp outLoop = b.create<TransformingForOp>(
         loc, ArrayRef<ValueRange>{c0}, ArrayRef<Attribute>{b.getArrayAttr({})},
         bounds,
-        /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+        /*strides=*/llvm::None, /*forceUnroll=*/true, /*useIndexDiffs=*/true);
     OpBuilder::InsertionGuard guard(b);
     b.setInsertionPointToStart(outLoop.getBody());
     {


### PR DESCRIPTION
Fixes
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/469

Makes my life easier when writing
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/543

These aren't yet integrated into any other code, but it'll be good
that they're there.