### PR TITLE
[release branch] Code object abi released

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -282,6 +282,10 @@ SerializeToHsacoPass::translateToLLVMIR(llvm::LLVMContext &llvmContext) {
                          .getZExtValue();
     uint32_t isaNumber = minor + 1000 * major;
     addControlConstant("__oclc_ISA_version", isaNumber, 32);
+
+    // This constant must always match the default code object ABI version
+    // of the AMDGPU backend.
+    addControlConstant("__oclc_ABI_version", 400, 32);
   }
 
   // Determine libraries we need to link - order matters due to dependencies


### PR DESCRIPTION
As of ROCm 5.2, device library users must set the code object ABI
version, either by defining the __oclc_ABI_version variable or linking
in a device library that does so.

MLIR did not do this, this commit fixes the issue by backporting the
upstream fix.

Corresponding upstream fix https://reviews.llvm.org/D126913