### PR TITLE
Set the ABI version constant to v5 for ROCm 5.3

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -285,6 +285,10 @@ SerializeToHsacoPass::translateToLLVMIR(llvm::LLVMContext &llvmContext) {
                          .getZExtValue();
     uint32_t isaNumber = minor + 1000 * major;
     addControlConstant("__oclc_ISA_version", isaNumber, 32);
+
+    // This constant must always match the default code object ABI version
+    // of the AMDGPU backend.
+    addControlConstant("__oclc_ABI_version", 500, 32);
   }
 
   // Determine libraries we need to link - order matters due to dependencies


### PR DESCRIPTION
In the ROCm 5.3 release, the default ABI version will be v5 instead of
v4. This means that the ABI version control constant must be set to
500 instead of 400.

The change of the default version has not yet landed upstream, but I
am assured it will land in time for the ROCm 5.3 release.

Note that, while setting this constant correctly will ensure that any
users linking against ROCm 5.3 will have their code function correctly
if they, for example, use exp(), it will also mean that usage of ROCm
5.2 device libraries in conjunction with code containing this
commit (as we might do in the interval between the 5.2 and 5.3
releases) will be incorrect.

This issue won't affect anyone external, but it does mean that the
process of bumping the ROCm version in the CI will need to skip 5.2.