### PR TITLE
Fix up shared library arguments in performance tests and parameter sw…

### DIFF
--- a/mlir/utils/jenkins/MIOpenDriver.py
+++ b/mlir/utils/jenkins/MIOpenDriver.py
@@ -21,7 +21,7 @@ LLVM_BIN_DIR = './external/llvm-project/llvm/bin'
 MIOPEN_GEN = 'miopen-gen'
 MLIR_MIOPEN_DRIVER = 'mlir-miopen-driver'
 MLIR_ROCM_RUNNER = 'mlir-rocm-runner'
-MLIR_ROCM_RUNNER_ARGS = ['--shared-libs=./lib/librocm-runtime-wrappers.so,./external/llvm-project/llvm/lib/libmlir_runner_utils.so', '--entry-point-result=void']
+MLIR_ROCM_RUNNER_ARGS = ['--shared-libs=./external/llvm-project/llvm/lib/libmlir_rocm_runtime.so,./lib/librocm-runtime-wrappers.so,./external/llvm-project/llvm/lib/libmlir_runner_utils.so', '--entry-point-result=void']
 ROCPROF = '/opt/rocm/bin/rocprof'
 MIOPEN_DRIVER = '../MIOpen/build/bin/MIOpenDriver'
 BENCHMARKING_RESULT_FILE_NAME = 'results.stats.csv'

--- a/mlir/utils/jenkins/parameterSweeps.py
+++ b/mlir/utils/jenkins/parameterSweeps.py
@@ -193,7 +193,7 @@ Return code = {lowering.returncode}""")
 Output = {runnerOut}
 Errors = {runnerErrs.decode('utf-8')}
 Return code = {runner.returncode}""", file=sys.stderr)
-        return False
+        return TestResult.FAIL
 
     if not CORRECT_RESULT_RE.search(runnerOut):
         print(f"""Convolution returned intorrect result


### PR DESCRIPTION
…eeps

The recent change to use more of upstream's copy of the runtime failed to update the performance test script.