### PR TITLE
Reduce number of parameter sweep workers to [# CPUs] / 2

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -127,6 +127,12 @@ def resetBuild() {
     }
 }
 
+void setHeartbeat() {
+    script {
+        System.setProperty("org.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL", "86400");
+    }
+}
+
 def rebootNode() {
     build job: 'reboot-slaves', propagate: false , parameters: [string(name: 'server', value: "${env.NODE_NAME}"),]
 }
@@ -154,9 +160,7 @@ pipeline {
     stages {
         stage("Set System Property") {
             steps {
-                script {
-                     System.setProperty("org.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL", "86400");
-                }
+                setHeartbeat()
             }
         }
         stage("Kill old PR builds") {
@@ -377,6 +381,7 @@ pipeline {
                     }
                     stage("Sweep parameters") {
                         steps {
+                            setHeartbeat()
                             buildProject(
                                 'check-mlir-miopen-build-only ci-performance-scripts',
                                 '')
@@ -447,9 +452,7 @@ pipeline {
                             equals expected: "gfx90a", actual: "${ARCH}"
                         }
                         steps {
-                            script {
-                               System.setProperty("org.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL", "86400");
-                            }
+                            setHeartbeat()
                         }
                     }
                     stage("Environment") {

--- a/mlir/utils/jenkins/parameterSweeps.py
+++ b/mlir/utils/jenkins/parameterSweeps.py
@@ -375,7 +375,7 @@ def main() -> bool:
     parser.add_argument('--no-xdlops', '-X', dest='xdlops', action='store_false',
         help='Explicitly disable xdlops usage')
     parser.add_argument('--jobs', '-j', type=int,
-        default=(2 * len(os.sched_getaffinity(0))),
+        default=(len(os.sched_getaffinity(0)) // 2),
         help="Number of jobs to run in parallel (default %(default)s)")
     args = parser.parse_args()
     options = Options(debug=args.debug, quiet=args.quiet, xdlops=args.xdlops,


### PR DESCRIPTION
Also, in case it helps fix the non-xdlops failures, set the heartbeat
property within the parameter sweep job.