### PR TITLE
Generalise --tosa-partition to allow other specified ops as primary op.

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -52,8 +52,14 @@ def TosaPartition : Pass<"tosa-partition", "ModuleOp"> {
   let constructor = "createTosaPartitionPass()";
 
   let options = [
-    Option<"nofront", "nofront", "bool", /*default=*/"false",
-           "Don't gather ops ahead of Conv2D">
+    ListOption<"anchorOps", "anchor-ops", "std::string",
+               "One or more operations to be used as focus of partitioned "
+               "kernels",
+               "llvm::cl::ZeroOrMore">,
+    Option<"partitionTagOpt", "partition-tag", "std::string",
+           /*default=*/"\"kernel\"", "Attribute for outlined functions">,
+    Option<"trailingOnly", "trailing-only", "bool", /*default=*/"false",
+           "Don't gather ops ahead of anchor op">
   ];
   let dependentDialects = ["tosa::TosaDialect"];
 }

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -6,11 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Replace conv2d followed by elementwise with call to function containing them.
+// Replace conv2d followed by elementwise op with call to function containing
+// them.  Generalised, outline any anchor op, all its trailing elementwise ops,
+// and all its leading elementwise ops.  (Where "elementwise" itself is
+// generalised to include transpose and reshape ops.)
 //
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/Dialect/Tosa/Transforms/PassDetail.h"
@@ -36,6 +40,7 @@
 using llvm::SmallVector;
 
 using namespace mlir;
+using namespace mlir::tosa;
 
 namespace {
 
@@ -88,26 +93,53 @@ bool isElementwiseOp(Operation *op) {
   // clang-format on
 }
 
+bool isFuseableOp(Operation *op) {
+  return isElementwiseOp(op) || isa<tosa::TransposeOp, tosa::ReshapeOp>(op);
+}
+
+bool isZeroAttribute(Attribute value) {
+  if (auto intValue = value.dyn_cast<IntegerAttr>())
+    return intValue.getValue().isNullValue();
+  if (auto fpValue = value.dyn_cast<FloatAttr>())
+    return fpValue.getValue().isZero();
+  if (auto splatValue = value.dyn_cast<SplatElementsAttr>())
+    return isZeroAttribute(splatValue.getSplatValue<Attribute>());
+  if (auto elementsValue = value.dyn_cast<ElementsAttr>())
+    return llvm::all_of(elementsValue.getValues<Attribute>(), isZeroAttribute);
+  if (auto arrayValue = value.dyn_cast<ArrayAttr>())
+    return llvm::all_of(arrayValue.getValue(), isZeroAttribute);
+  return false;
+}
+
+bool isConstantZero(Operation *op) {
+  // test for zero
+  if (auto cst = dyn_cast<arith::ConstantOp>(op)) {
+    return isZeroAttribute(cst.getValue());
+  }
+  return false;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // Inspired by / adapted from outlineIfOp() in SCF/Transforms/Utils.cpp
 // and mergeIdenticalBlocks() in Utils/RegionUtils.cpp.
 
 struct OutliningCandidate {
-  OutliningCandidate(Operation *_convOp, ArrayRef<Operation *> &_secondOps,
-                     ArrayRef<Operation *> &_frontOps, ArrayRef<Value> &_params,
-                     ArrayRef<Value> &_returnVals, StringRef _partFnName);
+  OutliningCandidate(Operation *anchorOp_, ArrayRef<Operation *> &trailingOps_,
+                     ArrayRef<Operation *> &leadingOps_,
+                     ArrayRef<Value> &params_, ArrayRef<Value> &returnVals_,
+                     StringRef partFnName_);
 
   unsigned addOp(Operation *op, unsigned orderIt);
 
-  Operation *convOp;
-  SmallVector<Operation *> secondOps;
-  SmallVector<Operation *> frontOps;
+  Operation *anchorOp;
+  SmallVector<Operation *> trailingOps;
+  SmallVector<Operation *> leadingOps;
   SmallVector<Value> params;
   SmallVector<Value> returnVals;
   std::string partFnName;
   llvm::hash_code hash;
-  FuncOp function;
+  func::FuncOp function;
 
   /// Return the order index for the given value that is within the block of
   /// this data.
@@ -134,19 +166,19 @@ unsigned OutliningCandidate::addOp(Operation *op, unsigned orderIt) {
   return orderIt;
 }
 
-OutliningCandidate::OutliningCandidate(Operation *convOp_,
-                                       ArrayRef<Operation *> &secondOps_,
-                                       ArrayRef<Operation *> &frontOps_,
+OutliningCandidate::OutliningCandidate(Operation *anchorOp_,
+                                       ArrayRef<Operation *> &trailingOps_,
+                                       ArrayRef<Operation *> &leadingOps_,
                                        ArrayRef<Value> &params_,
                                        ArrayRef<Value> &returnVals_,
                                        StringRef partFnName_)
-    : convOp(convOp_), partFnName(partFnName_), hash(0), function(nullptr) {
+    : anchorOp(anchorOp_), partFnName(partFnName_), hash(0), function(nullptr) {
   // We'll need to grab the cloned ops to avoid use-after-free.
-  for (auto *op : secondOps_) {
-    secondOps.push_back(op);
+  for (auto *op : trailingOps_) {
+    trailingOps.push_back(op);
   }
-  for (auto *op : frontOps_) {
-    frontOps.push_back(op);
+  for (auto *op : leadingOps_) {
+    leadingOps.push_back(op);
   }
   for (auto val : params_) {
     params.push_back(val);
@@ -156,11 +188,11 @@ OutliningCandidate::OutliningCandidate(Operation *convOp_,
   }
 
   unsigned orderIt = params.size();
-  for (auto *op : frontOps) {
+  for (auto *op : leadingOps) {
     orderIt = addOp(op, orderIt);
   }
-  orderIt = addOp(convOp, orderIt);
-  for (auto *op : secondOps) {
+  orderIt = addOp(anchorOp, orderIt);
+  for (auto *op : trailingOps) {
     orderIt = addOp(op, orderIt);
   }
 }
@@ -235,15 +267,15 @@ bool outliningCandidatesEquivalent(OutliningCandidate &one,
     }
   }
 
-  for (auto ops : llvm::zip(one.frontOps, two.frontOps)) {
+  for (auto ops : llvm::zip(one.leadingOps, two.leadingOps)) {
     if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
       return false;
     }
   }
-  if (!opsMatch(one.convOp, two.convOp, one, two)) {
+  if (!opsMatch(one.anchorOp, two.anchorOp, one, two)) {
     return false;
   }
-  for (auto ops : llvm::zip(one.secondOps, two.secondOps)) {
+  for (auto ops : llvm::zip(one.trailingOps, two.trailingOps)) {
     if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
       return false;
     }
@@ -264,19 +296,20 @@ findOutliningCandidate(OutliningCandidate &newCandidate,
 
 // Given a convolution op and its fuse-able trailing (second) and leading
 // (front) ops, remove them into a separate function.
-void outlineConvPartOps(Operation *convOp, ArrayRef<Operation *> secondOps,
-                        ArrayRef<Operation *> frontOps, ArrayRef<Value> params,
-                        ArrayRef<Value> returnVals, StringRef partFnName,
-                        std::vector<OutliningCandidate> &candidates) {
+void outlinePartitionOps(Operation *anchorOp, ArrayRef<Operation *> trailingOps,
+                         ArrayRef<Operation *> leadingOps,
+                         ArrayRef<Value> params, ArrayRef<Value> returnVals,
+                         StringRef partFnName, StringRef attrName,
+                         std::vector<OutliningCandidate> &candidates) {
   ValueRange values(params);
-  OpBuilder b(convOp);
-  Location loc = convOp->getLoc();
-  FuncOp outlinedFunc;
+  OpBuilder b(anchorOp);
+  Location loc = anchorOp->getLoc();
+  func::FuncOp outlinedFunc;
 
   // ------------------------------------------------------------
   // Merging part.
 
-  OutliningCandidate newCandidate(convOp, secondOps, frontOps, params,
+  OutliningCandidate newCandidate(anchorOp, trailingOps, leadingOps, params,
                                   returnVals, partFnName);
 
   if (OutliningCandidate *found =
@@ -289,15 +322,15 @@ void outlineConvPartOps(Operation *convOp, ArrayRef<Operation *> secondOps,
 
     // Insert outlined function before current function.
     OpBuilder::InsertionGuard g(b);
-    b.setInsertionPoint(convOp->getParentOfType<FuncOp>());
+    b.setInsertionPoint(anchorOp->getParentOfType<func::FuncOp>());
 
-    // Make FuncOp from convOp's operand types and secondOp's result type.
-    MLIRContext *ctx = convOp->getContext();
+    // Make FuncOp from anchorOp's operand types and trailingOp's result type.
+    MLIRContext *ctx = anchorOp->getContext();
     ValueRange results(returnVals);
     FunctionType type =
         FunctionType::get(ctx, values.getTypes(), results.getTypes());
     SmallVector<NamedAttribute, 1> kernelAttrs{
-        b.getNamedAttr("kernel", b.getUnitAttr()),
+        b.getNamedAttr(attrName, b.getUnitAttr()),
     };
     outlinedFunc = b.create<func::FuncOp>(
         loc, partFnName, type, ArrayRef<NamedAttribute>(kernelAttrs));
@@ -329,36 +362,38 @@ void outlineConvPartOps(Operation *convOp, ArrayRef<Operation *> secondOps,
     }
     outlinedFunc->setAttr("access_map", ArrayAttr::get(ctx, accessVec));
 
-    // Clone frontOps, convOp, and secondOps into the body of the new function,
-    // while also updating the comparison details for future candidates.
+    // Clone leadingOps, anchorOp, and trailingOps into the body of the new
+    // function, while also updating the comparison details for future
+    // candidates.
     b.setInsertionPointToStart(outlinedFunc.addEntryBlock());
     BlockAndValueMapping bvm;
     for (auto it : llvm::zip(values, outlinedFunc.getArguments()))
       bvm.map(std::get<0>(it), std::get<1>(it));
 
-    newCandidate.frontOps.clear();
-    for (auto *op : llvm::reverse(frontOps)) {
-      newCandidate.frontOps.push_back(b.clone(*op, bvm));
-      newCandidate.opOrderIndex[newCandidate.frontOps.back()] =
+    newCandidate.leadingOps.clear();
+    for (auto *op : llvm::reverse(leadingOps)) {
+      newCandidate.leadingOps.push_back(b.clone(*op, bvm));
+      newCandidate.opOrderIndex[newCandidate.leadingOps.back()] =
           newCandidate.opOrderIndex[op];
     }
-    std::reverse(newCandidate.frontOps.begin(), newCandidate.frontOps.end());
+    std::reverse(newCandidate.leadingOps.begin(),
+                 newCandidate.leadingOps.end());
 
-    newCandidate.convOp = b.clone(*convOp, bvm);
-    newCandidate.opOrderIndex[newCandidate.convOp] =
-        newCandidate.opOrderIndex[convOp];
+    newCandidate.anchorOp = b.clone(*anchorOp, bvm);
+    newCandidate.opOrderIndex[newCandidate.anchorOp] =
+        newCandidate.opOrderIndex[anchorOp];
 
-    newCandidate.secondOps.clear();
-    for (auto *op : secondOps) {
+    newCandidate.trailingOps.clear();
+    for (auto *op : trailingOps) {
       // All operands should already be in bvm.
       assert(llvm::all_of(op->getOperands(),
                           [&](Value v) { return bvm.lookupOrNull(v); }));
-      newCandidate.secondOps.push_back(b.clone(*op, bvm));
-      newCandidate.opOrderIndex[newCandidate.secondOps.back()] =
+      newCandidate.trailingOps.push_back(b.clone(*op, bvm));
+      newCandidate.opOrderIndex[newCandidate.trailingOps.back()] =
           newCandidate.opOrderIndex[op];
     }
 
-    // Make ReturnOp from secondOps' results.
+    // Make ReturnOp from trailingOps' results.
     SmallVector<Value> returnOperands;
     for (auto op : returnVals) {
       returnOperands.push_back(bvm.lookup(op));
@@ -373,10 +408,10 @@ void outlineConvPartOps(Operation *convOp, ArrayRef<Operation *> secondOps,
   // ------------------------------------------------------------
   // Replacement part.
 
-  // Replace convOp, secondOps, and frontOps with CallOp to new function.
-  Operation *lastOp = convOp;
-  if (!secondOps.empty())
-    lastOp = secondOps[secondOps.size() - 1];
+  // Replace anchorOp, trailingOps, and leadingOps with CallOp to new function.
+  Operation *lastOp = anchorOp;
+  if (!trailingOps.empty())
+    lastOp = trailingOps[trailingOps.size() - 1];
   b.setInsertionPointAfter(lastOp);
   func::CallOp callOp = b.create<func::CallOp>(loc, outlinedFunc, values);
 
@@ -385,182 +420,203 @@ void outlineConvPartOps(Operation *convOp, ArrayRef<Operation *> secondOps,
   }
 
   // Erase the ops we outlined, which should be safe now.
-  for (auto &op : llvm::make_early_inc_range(llvm::reverse(secondOps))) {
+  for (auto &op : llvm::make_early_inc_range(llvm::reverse(trailingOps))) {
     if (op->use_empty()) {
       op->erase();
     }
   }
-  assert(convOp->use_empty() && "expected 'op' to have no uses");
-  convOp->erase();
-  for (auto &op : llvm::make_early_inc_range(frontOps)) {
+  assert(anchorOp->use_empty() && "expected 'op' to have no uses");
+  anchorOp->erase();
+  for (auto &op : llvm::make_early_inc_range(leadingOps)) {
     if (op->use_empty()) {
       op->erase();
     }
   }
 }
 
+} // namespace
+
+// Special case:  TransposeOp's second operand must be a
+// constant, which means we must include it too if we include
+// the TransposeOp.  "ops" here may be either leadingOps or trailingOps.
+void TosaPartitionPass::specialCaseForTranspose(Operation *op,
+                                                SetVector<Operation *> &ops) {
+  auto *operand = op->getOpOperand(1).get().getDefiningOp();
+  ops.insert(operand);
+}
+
+bool TosaPartitionPass::isAnchorOp(Operation *op) {
+  return isa<tosa::Conv2DOp, tosa::MatMulOp, tosa::DepthwiseConv2DOp>(op);
+}
+
+bool TosaPartitionPass::isLeadingOp(Operation *op) {
+  return isConstantZero(op) || isFuseableOp(op);
+}
+
+bool TosaPartitionPass::isTrailingOp(Operation *op) { return isFuseableOp(op); }
+
+StringRef TosaPartitionPass::partitionTag() { return "kernel"; }
+
+void TosaPartitionPass::traceInputs(Operation *op,
+                                    SetVector<Operation *> &predecessors,
+                                    SetVector<Value> &inputNodes) {
+  for (const auto &opnd : op->getOperands()) {
+    if (isa<tosa::TransposeOp>(op))
+      specialCaseForTranspose(op, predecessors);
+    Operation *usedOp = opnd.getDefiningOp();
+    if (usedOp && isLeadingOp(usedOp)) {
+      predecessors.insert(usedOp);
+      if (!mlir::detail::isConstantLike(usedOp)) {
+        // depth first
+        traceInputs(usedOp, predecessors, inputNodes);
+      }
+    } else {
+      inputNodes.insert(opnd);
+    }
+  }
+}
+
 // Inspired by / adapted from TestSCFIfUtilsPass in
 // test/lib/Transforms/TestSCFUtils.cpp.
-class TosaPartitionPass : public TosaPartitionBase<TosaPartitionPass> {
-public:
-  static bool isZeroAttribute(Attribute value) {
-    if (auto intValue = value.dyn_cast<IntegerAttr>())
-      return intValue.getValue().isNullValue();
-    if (auto fpValue = value.dyn_cast<FloatAttr>())
-      return fpValue.getValue().isZero();
-    if (auto splatValue = value.dyn_cast<SplatElementsAttr>())
-      return isZeroAttribute(splatValue.getSplatValue<Attribute>());
-    if (auto elementsValue = value.dyn_cast<ElementsAttr>())
-      return llvm::all_of(elementsValue.getValues<Attribute>(),
-                          isZeroAttribute);
-    if (auto arrayValue = value.dyn_cast<ArrayAttr>())
-      return llvm::all_of(arrayValue.getValue(), isZeroAttribute);
-    return false;
-  }
+void TosaPartitionPass::runOnOperation() {
+  ModuleOp module = getOperation();
+  auto funcOps = module.getOps<func::FuncOp>();
+  for (auto func : llvm::make_early_inc_range(funcOps)) {
+    // Don't partition a kernel;  it may be already partitioned.
+    if (func->hasAttr(partitionTag()))
+      continue;
 
-  static bool isConstantZero(Operation *op) {
-    // test for zero
-    if (auto cst = dyn_cast<arith::ConstantOp>(op)) {
-      return isZeroAttribute(cst.getValue());
-    }
-    return false;
-  }
+    int count = 0;
+    // (Problems with node mismatches and unexpected uses if we have the
+    // candidates list at module level.)
+    std::vector<OutliningCandidate> candidates;
+    auto callback = [&](Operation *op) {
+      if (!isAnchorOp(op))
+        return WalkResult::advance();
+      Operation *anchorOp = op;
+      auto strCount = std::string("_outlined_part_") + std::to_string(count++);
 
-  void traceInputs(Operation *op, SmallVector<Operation *> &predecessors,
-                   SetVector<Value> &inputNodes) {
-    for (const auto &opnd : op->getOperands()) {
-      Operation *usedOp = opnd.getDefiningOp();
-      if (usedOp && (isConstantZero(usedOp) || isElementwiseOp(usedOp))) {
-        predecessors.push_back(usedOp);
-        if (!detail::isConstantLike(usedOp)) {
-          // depth first
-          traceInputs(usedOp, predecessors, inputNodes);
-        }
-      } else {
-        inputNodes.insert(opnd);
-      }
-    }
-  }
+      // Given a Conv2DOp (or other anchor op), gather all the
+      // element-wise ops that are reachable from its results,
+      // contiguously.
+      //
+      // The ops after the anchor are "trailing" ops.
+      //
+      // inputNodes gathers what will become the parameters of the
+      // outlined function;  initially it's the anchor's arguments,
+      // and it accumulates arguments to other ops that don't come
+      // from inside the outlined function.
+      //
+      // resultNodes will become the results of the outlined function.
+      // It starts with the anchor's result(s) and gains the results
+      // of each new trailingOp.  When all a resultNode's users can be
+      // determined to lie within the outlined function, it's removed
+      // from the set.
+      //
+      // These are SetVectors because we test with contains() a lot,
+      // but still want to preserve order.
+      SetVector<Operation *> trailingOps;
+      SetVector<Value> inputNodes;
+      SetVector<Value> resultNodes(anchorOp->getResults().begin(),
+                                   anchorOp->getResults().end());
 
-  void runOnOperation() override {
-    ModuleOp module = getOperation();
-    auto funcOps = module.getOps<FuncOp>();
-    for (auto func : llvm::make_early_inc_range(funcOps)) {
-      // Don't partition a kernel;  it may be already partitioned.
-      if (func->hasAttr("kernel"))
-        continue;
+      // Grab a useful set of leading ops, like we do for trailing.
+      SetVector<Operation *> leadingOps;
+      traceInputs(anchorOp, leadingOps, inputNodes);
 
-      int count = 0;
-      // (Problems with node mismatches and unexpected uses if we have the
-      // candidates list at module level.)
-      std::vector<OutliningCandidate> candidates;
-      auto callback = [&](tosa::Conv2DOp convOp) {
-        auto strCount =
-            std::string("_outlined_part_") + std::to_string(count++);
+      DominanceInfo domInfo(func);
+      std::deque<Operation *> worklist; // cuz I want to pull from the front.
 
-        // Given a Conv2DOp, gather all the element-wise ops that are reachable
-        // from its results, contiguously.
-        //
-        // The ops after the Conv2D are "second" ops.
-        // inputNodes gathers what will become the parameters of the outlined
-        // function;  initially it's the Conv2D's arguments, and it accumulates
-        // arguments to other ops that don't come from inside the outlined
-        // function.
-        // resultNodes will become the results of the outlined function.  It
-        // starts with Conv2D's result(s) and gains the results of each new
-        // secondOp.  When all a resultNode's users can be determined to lie
-        // within the outlined function, it's removed from the set.
-        //
-        // These are SetVectors because we test with contains() a lot, but still
-        // want to preserve order.
-        SetVector<Operation *> secondOps;
-        SetVector<Value> inputNodes;
-        SetVector<Value> resultNodes(convOp->getResults().begin(),
-                                     convOp->getResults().end());
-
-        // Grab a useful set of leading ops, like we do for trailing.
-        // Let's limit it to only first arguments, with single uses.
-        SmallVector<Operation *> frontOps;
-        if (!nofront) {
-          traceInputs(convOp, frontOps, inputNodes);
-        } else {
-          inputNodes.insert(convOp->getOperands().begin(),
-                            convOp->getOperands().end());
-        }
-
-        DominanceInfo domInfo(func);
-        std::deque<Operation *> worklist; // cuz I want to pull from the front.
-
-        worklist.push_back(convOp);
-        while (!worklist.empty()) {
-          Operation *op = worklist.front();
-          worklist.pop_front();
-          for (auto *userOp : op->getUsers()) {
-            if (isElementwiseOp(userOp)) {
-              bool skip = false;
-              // First criterion is that the op is element-wise.  Second
-              // criterion is that the op dominates all the users of the
-              // accumulated results of the outlined function.  In other words,
-              // we can't take an op that comes "after" a user of the result
-              // from the eventual call, because the call needs to dominate all
-              // its users.
-              for (const Value &val : resultNodes) {
-                for (auto *user : val.getDefiningOp()->getUsers()) {
-                  if (user != userOp &&
-                      !domInfo.properlyDominates(userOp, user)) {
-                    skip = true;
-                  }
-                }
-              }
-
-              // userOp is acceptable.  Keep it as a secondOp, put it on the
-              // worklist.  Add its operands to inputNodes unless they come
-              // from other secondOps (indicated by being in resultNodes).
-              // If all the users of any resultNode are in secondOps, there's
-              // no need to return it so remove from resultNodes.  Finally,
-              // add all userOp's results to resultNodes.
-              if (!skip) {
-                secondOps.insert(userOp);
-                worklist.push_back(userOp);
-                for (Value opnd : userOp->getOperands()) {
-                  if (!resultNodes.contains(opnd)) {
-                    inputNodes.insert(opnd);
-                  }
-                }
-                for (const Value &val : resultNodes) {
-                  if (llvm::all_of(val.getUsers(), [&](Operation *u) {
-                        return secondOps.contains(u);
-                      })) {
-                    resultNodes.remove(val);
-                  }
-                }
-                for (auto res : userOp->getResults()) {
-                  resultNodes.insert(res);
+      worklist.push_back(anchorOp);
+      while (!worklist.empty()) {
+        Operation *op = worklist.front();
+        worklist.pop_front();
+        for (auto *userOp : op->getUsers()) {
+          if (isTrailingOp(userOp)) {
+            bool skip = false;
+            // First criterion is that the op is element-wise.  Second
+            // criterion is that the op dominates all the users of the
+            // accumulated results of the outlined function.  In other words,
+            // we can't take an op that comes "after" a user of the result
+            // from the eventual call, because the call needs to dominate all
+            // its users.
+            for (const Value &val : resultNodes) {
+              for (auto *user : val.getDefiningOp()->getUsers()) {
+                if (user != userOp &&
+                    !domInfo.properlyDominates(userOp, user)) {
+                  skip = true;
                 }
               }
             }
+
+            // userOp is acceptable.  Keep it as a trailingOp, put it on the
+            // worklist.  Add its operands to inputNodes unless they come
+            // from other trailingOps (indicated by being in resultNodes).
+            // If all the users of any resultNode are in trailingOps, there's
+            // no need to return it so remove from resultNodes.  Finally,
+            // add all userOp's results to resultNodes.
+            if (!skip) {
+              if (isa<tosa::TransposeOp>(userOp)) {
+                specialCaseForTranspose(userOp, trailingOps);
+              }
+              // General case.
+              trailingOps.insert(userOp);
+              worklist.push_back(userOp);
+              for (Value opnd : userOp->getOperands())
+                if (!resultNodes.contains(opnd))
+                  inputNodes.insert(opnd);
+              for (const Value &val : resultNodes)
+                if (llvm::all_of(val.getUsers(), [&](Operation *u) {
+                      return trailingOps.contains(u);
+                    }))
+                  resultNodes.remove(val);
+              for (auto res : userOp->getResults())
+                resultNodes.insert(res);
+            }
           }
         }
-
-        // Make the outlined function from the ops we've gathered.
-        outlineConvPartOps(convOp, secondOps.getArrayRef(), frontOps,
-                           inputNodes.getArrayRef(), resultNodes.getArrayRef(),
-                           std::string(func.getSymName()) + strCount,
-                           candidates);
-        // Outlining will erase nodes and thus perturb the walk, so
-        // signal interrupted to exit it and restart.
-        return WalkResult::interrupt();
-      };
-
-      // Walk until we've outlined all the Conv2D ops we can.
-      while (func.walk(callback).wasInterrupted()) {
       }
+
+      // Make the outlined function from the ops we've gathered.
+      outlinePartitionOps(anchorOp, trailingOps.getArrayRef(),
+                          leadingOps.getArrayRef(), inputNodes.getArrayRef(),
+                          resultNodes.getArrayRef(),
+                          std::string(func.getSymName()) + strCount,
+                          partitionTag(), candidates);
+      // Outlining will erase nodes and thus perturb the walk, so
+      // signal interrupted to exit it and restart.
+      return WalkResult::interrupt();
+    };
+
+    // Walk until we've outlined all the anchor ops we can.
+    while (func.walk(callback).wasInterrupted()) {
     }
   }
-};
+}
 
-} // namespace
+TosaPartitionPassWithOptions::TosaPartitionPassWithOptions(
+    ArrayRef<std::string> anchorOps_, const std::string &attrName,
+    bool trailingOnly_) {
+  anchorOps = anchorOps_;
+  partitionTagOpt = attrName;
+  trailingOnly = trailingOnly_;
+}
+
+bool TosaPartitionPassWithOptions::isAnchorOp(Operation *op) {
+  if (anchorOps.empty()) // ListOption doesn't have a default value.
+    anchorOps = {"tosa.conv2d", "tosa.matmul", "tosa.depthwise_conv2d"};
+
+  return llvm::is_contained(anchorOps, op->getName().getIdentifier().str());
+}
+
+bool TosaPartitionPassWithOptions::isLeadingOp(Operation *op) {
+  return !trailingOnly && (isConstantZero(op) || isFuseableOp(op));
+}
+
+StringRef TosaPartitionPassWithOptions::partitionTag() {
+  return partitionTagOpt;
+}
 
 std::unique_ptr<Pass> mlir::tosa::createTosaPartitionPass() {
-  return std::make_unique<TosaPartitionPass>();
+  return std::make_unique<TosaPartitionPassWithOptions>();
 }

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
@@ -1,0 +1,76 @@
+// RUN: mlir-opt --tosa-partition %s | FileCheck %s
+// RUN: mlir-opt --tosa-partition=partition-tag=one %s | FileCheck %s --check-prefix=ONE
+// RUN: mlir-opt --tosa-partition='anchor-ops=tosa.depthwise_conv2d partition-tag=two' %s | FileCheck %s --check-prefix=TWO
+// RUN: mlir-opt --tosa-partition='anchor-ops=tosa.depthwise_conv2d trailing-only partition-tag=three' %s | FileCheck %s --check-prefix=THREE
+// RUN: mlir-opt --tosa-partition='anchor-ops=tosa.conv2d partition-tag=four' %s | FileCheck %s --check-prefix=FOUR
+
+// RUN: mlir-opt --test-tosa-partition-options=default %s | FileCheck %s --check-prefix=CHECK
+// RUN: mlir-opt --test-tosa-partition-options=depthwise-only %s | FileCheck %s --check-prefix=TWO
+// RUN: mlir-opt --test-tosa-partition-options=conv-only %s | FileCheck %s --check-prefix=FOUR
+// RUN: mlir-opt --test-tosa-partition-options=attr-one %s | FileCheck %s --check-prefix=ONE
+// RUN: mlir-opt --test-tosa-partition-options=nofront-arg %s | FileCheck %s --check-prefix=THREE
+
+// CHECK-LABEL: func private @test_fusion8_outlined_part_0
+// CHECK-SAME: attributes {{{.*}}kernel}
+// CHECK-NEXT: arith.constant
+// CHECK-NEXT: tosa.transpose
+// CHECK-NEXT: tosa.depthwise_conv2d
+// CHECK-NEXT: tosa.abs
+// CHECK-NEXT: tosa.add
+// CHECK-NEXT: return
+// CHECK: func private @test_fusion8_outlined_part_1
+// CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: return
+// CHECK: func @test_fusion8
+// CHECK: call @test_fusion8_outlined_part_1
+// CHECK: call @test_fusion8_outlined_part_0
+
+// ONE-LABEL: func private @test_fusion8_outlined_part_0
+// ONE-SAME: attributes {{{.*}}one}
+// ONE-NEXT: arith.constant
+// ONE-NEXT: tosa.transpose
+// ONE-NEXT: tosa.depthwise_conv2d
+// ONE-NEXT: tosa.abs
+// ONE-NEXT: tosa.add
+// ONE-NEXT: return
+// ONE: func @test_fusion8
+// ONE: call @test_fusion8_outlined_part_0
+
+// TWO-LABEL: func private @test_fusion8_outlined_part_0
+// TWO-NEXT: arith.constant
+// TWO-NEXT: tosa.transpose
+// TWO-NEXT: tosa.depthwise_conv2d
+// TWO-NEXT: tosa.abs
+// TWO-NEXT: tosa.add
+// TWO-NEXT: return
+// TWO: func @test_fusion8
+// TWO: tosa.conv2d
+// TWO: call @test_fusion8_outlined_part_0
+
+// THREE-LABEL: func private @test_fusion8_outlined_part_0
+// THREE-NEXT: tosa.depthwise_conv2d
+// THREE-NEXT: tosa.abs
+// THREE-NEXT: tosa.add
+// THREE-NEXT: return
+// THREE: func @test_fusion8
+// THREE: tosa.transpose
+// THREE: tosa.conv2d
+// THREE: call @test_fusion8_outlined_part_0
+
+// FOUR-LABEL: func private @test_fusion8_outlined_part_0
+// FOUR-SAME: attributes {{{.*}}four}
+// FOUR-NEXT: tosa.conv2d
+// FOUR-NEXT: tosa.add
+// FOUR-NEXT: return
+// FOUR: func @test_fusion8
+// FOUR: call @test_fusion8_outlined_part_0
+
+func @test_fusion8(%arg0: tensor<128x32x32x8xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>, %arg3: tensor<128x8x32x32xf32>, %arg4: tensor<128x8x3x3xf32>, %arg5: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %cst = arith.constant dense<[0, 2, 3, 1]> : tensor<4xi64>
+  %0 = "tosa.transpose"(%arg0, %cst) {changing_layout_root = false} : (tensor<128x32x32x8xf32>, tensor<4xi64>) -> tensor<128x8x32x32xf32>
+  %1 = "tosa.depthwise_conv2d"(%0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.conv2d"(%arg3, %arg4, %arg5) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %3 = "tosa.abs"(%1) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %4 = "tosa.add"(%3, %2) {} : (tensor<128x128x30x30xf32>, tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %4 : tensor<128x128x30x30xf32>
+}

--- a/external/llvm-project/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
+++ b/external/llvm-project/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
@@ -14,4 +14,5 @@ add_mlir_dialect_library(MLIRTosaTestPasses
   MLIRPass
   MLIRTosa
   MLIRTransformUtils
+  MLIRTosaTransforms
   )

--- a/external/llvm-project/mlir/tools/mlir-opt/mlir-opt.cpp
+++ b/external/llvm-project/mlir/tools/mlir-opt/mlir-opt.cpp
@@ -107,6 +107,7 @@ void registerTestRecursiveTypesPass();
 void registerTestSCFUtilsPass();
 void registerTestSliceAnalysisPass();
 void registerTestTensorTransforms();
+void registerTestTosaPartitionOptionsPass();
 void registerTestVectorLowerings();
 } // namespace test
 } // namespace mlir
@@ -196,6 +197,7 @@ void registerTestPasses() {
   mlir::test::registerTestSCFUtilsPass();
   mlir::test::registerTestSliceAnalysisPass();
   mlir::test::registerTestTensorTransforms();
+  mlir::test::registerTestTosaPartitionOptionsPass();
   mlir::test::registerTestVectorLowerings();
 }
 #endif

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -173,7 +173,7 @@ public:
       SmallVector<Attribute, 5> newShapeAttr;
 
       // align the dimensions - by the given axis
-      for (int i = 0; i < outRank; i++) {
+      for (uint32_t i = 0; i < outRank; i++) {
         newShapeAttr.push_back(rewriter.getI64IntegerAttr(1));
         newShape.push_back(1);
       }
@@ -238,7 +238,7 @@ public:
           SmallVector<Attribute, 5> newShapeAttr;
 
           // align the dimensions - by the given in/out shape
-          int i = 0;
+          uint32_t i = 0;
           for (; i < outRank - inRank; i++) {
             newShapeAttr.push_back(rewriter.getI64IntegerAttr(inShape[i]));
             newShape.push_back(inShape[i]);

--- a/mlir/test/xmir/mobilenetv1.mid.mlir
+++ b/mlir/test/xmir/mobilenetv1.mid.mlir
@@ -6,20 +6,22 @@ module {
 
 // CHECK: func @mobilenetv1(%arg0: memref<1x224x224x3xf32>, %arg1: memref<32x3x3x3xf32>, %arg2: memref<3x3x32x1xf32>, %arg3: memref<64x1x1x32xf32>, %arg4: memref<3x3x64x1xf32>, %arg5: memref<128x1x1x64xf32>, %arg6: memref<1x56x56x128xf32>) {
 // CHECK:   %token = async.launch @mobilenetv1_outlined_part_0 (%arg0, %arg1, %{{.*}}) : (memref<1x224x224x3xf32>, memref<32x3x3x3xf32>, memref<1x112x112x32xf32>)
-// CHECK:   async.await %token : !async.token
 
-// CHECK:   %token_0 = async.launch @mobilenetv1_outlined_part_1 (%{{.*}}, %arg3, %{{.*}}) : (memref<1x112x112x32xf32>, memref<64x1x1x32xf32>, memref<1x112x112x64xf32>)
-// CHECK:   async.await %token_0 : !async.token
-        
-// CHECK:   %token_1 = async.launch @mobilenetv1_outlined_part_2 (%{{.*}}, %arg5, %arg6) : (memref<1x56x56x64xf32>, memref<128x1x1x64xf32>, memref<1x56x56x128xf32>)
-// CHECK:   async.await %token_1 : !async.token
-    
+// CHECK:   %token_0 = async.launch @mobilenetv1_outlined_part_1 [%token] (%{{.*}}, %arg2, %{{.*}}) : (memref<1x112x112x32xf32>, memref<3x3x32x1xf32>, memref<1x112x112x32xf32>)
+
+// CHECK:   %token_1 = async.launch @mobilenetv1_outlined_part_2 [%token_0] (%{{.*}}, %arg3, %{{.*}}) : (memref<1x112x112x32xf32>, memref<64x1x1x32xf32>, memref<1x112x112x64xf32>)
+
+// CHECK:   %token_2 = async.launch @mobilenetv1_outlined_part_3 [%token_1] (%{{.*}}, %arg4, %{{.*}}) : (memref<1x112x112x64xf32>, memref<3x3x64x1xf32>, memref<1x56x56x64xf32>)
+
+// CHECK:   %token_3 = async.launch @mobilenetv1_outlined_part_4 [%token_2] (%{{.*}}, %arg5, %arg6) : (memref<1x56x56x64xf32>, memref<128x1x1x64xf32>, memref<1x56x56x128xf32>)
+// CHECK:   async.await %token_3 : !async.token
+
   func @mobilenetv1(%input_image: tensor<1x224x224x3xf32>, %f0: tensor<32x3x3x3xf32>, %f1: tensor<3x3x32x1xf32>, %f2: tensor<64x1x1x32xf32>, %f3: tensor<3x3x64x1xf32>, %f4: tensor<128x1x1x64xf32>) -> tensor<1x56x56x128xf32> {
 
     %bias0 = arith.constant dense<0.0> : tensor<32xf32>
     %bias1 = arith.constant dense<0.0> : tensor<64xf32>
     %bias2 = arith.constant dense<0.0> : tensor<128xf32>
-    
+
     %conv0 = "tosa.conv2d"(%input_image, %f0, %bias0) {
       dilation = [1, 1],
       pad = [1, 1, 1, 1],
@@ -83,4 +85,3 @@ module {
     return %relu4 : tensor<1x56x56x128xf32>
   }
 }
-

--- a/mlir/test/xmir/mobilenetv1.small.mlir
+++ b/mlir/test/xmir/mobilenetv1.small.mlir
@@ -2,19 +2,20 @@
 
 
 module {
-// CHECK:  func private @mobilenetv1_outlined_part_0(%arg0: tensor<1x112x112x32xf32>, %arg1: tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32> attributes {{{.*}}kernel} {
+// CHECK:  func private @mobilenetv1_outlined_part_0(%arg0: tensor<1x112x112x32xf32>, %arg1: tensor<3x3x32x1xf32>) -> tensor<1x112x112x32xf32> attributes {{{.*}}kernel} {
+// CHECK:    %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %{{.*}}) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<1x112x112x32xf32>, tensor<3x3x32x1xf32>, tensor<32xf32>) -> tensor<1x112x112x32xf32>
 // CHECK:  func @mobilenetv1(%arg0: tensor<1x112x112x32xf32>, %arg1: tensor<32x3x3x3xf32>, %arg2: tensor<3x3x32x1xf32>, %arg3: tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32> {
-// CHECK:    %[[T0:.*]] = "tosa.depthwise_conv2d"(%arg0, %arg2, %{{.*}}) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<1x112x112x32xf32>, tensor<3x3x32x1xf32>, tensor<32xf32>) -> tensor<1x112x112x32xf32>
-// CHECK-NEXT:    %token, %[[RES0:.*]] = async.launch @mobilenetv1_outlined_part_0 (%[[T0]], %arg3) : (tensor<1x112x112x32xf32>, tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32>
-// CHECK-NEXT:    async.await %token : !async.token
-// CHECK:    return %[[RES0]] : tensor<1x112x112x64xf32>
+// CHECK-NEXT:    %[[T0:.*]], %[[RES0:.*]] = async.launch @mobilenetv1_outlined_part_0 (%arg0, %arg2) : (tensor<1x112x112x32xf32>, tensor<3x3x32x1xf32>) -> tensor<1x112x112x32xf32>
+// CHECK-NEXT:    %[[T1:.*]], %[[RES1:.*]] = async.launch @mobilenetv1_outlined_part_1 [%[[T0]]] (%[[RES0]], %arg3) : (tensor<1x112x112x32xf32>, tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32>
+// CHECK-NEXT:    async.await %[[T1]] : !async.token
+// CHECK:    return %[[RES1]] : tensor<1x112x112x64xf32>
 
   // TOSA Model Func
   func @mobilenetv1(%input_image: tensor<1x112x112x32xf32>, %f0: tensor<32x3x3x3xf32>, %f1: tensor<3x3x32x1xf32>, %f2: tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32> {
 
     %bias0 = arith.constant dense<0.0> : tensor<32xf32>
     %bias1 = arith.constant dense<0.0> : tensor<64xf32>
-    
+
     %dwconv0 = "tosa.depthwise_conv2d"(%input_image, %f1, %bias0) {
       dilation = [1, 1],
       pad = [1, 1, 1, 1],
@@ -41,4 +42,3 @@ module {
     return %relu1 : tensor<1x112x112x64xf32>
   }
 }
-

--- a/mlir/tools/miopen-gen/CMakeLists.txt
+++ b/mlir/tools/miopen-gen/CMakeLists.txt
@@ -5,9 +5,16 @@ set(LLVM_LINK_COMPONENTS
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
+if(MLIR_INCLUDE_TESTS)
+  set(test_libs
+    MLIRTestDialect
+    )
+endif()
+
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
+  ${test_libs}
   LLVMAMDGPUAsmParser
   LLVMX86AsmParser
   MLIRAnalysis
@@ -22,7 +29,6 @@ set(LIBS
   MLIRTransforms
   MLIRSupport
   MLIRIR
-  MLIRTestDialect
   MLIRMIOpenThin
   )
 
@@ -39,4 +45,3 @@ add_llvm_executable(miopen-gen
 llvm_update_compile_flags(miopen-gen)
 target_link_libraries(miopen-gen PRIVATE ${LIBS})
 mlir_check_link_libraries(miopen-gen)
-

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -5,9 +5,16 @@ set(LLVM_LINK_COMPONENTS
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
+if(MLIR_INCLUDE_TESTS)
+  set(test_libs
+    MLIRTestDialect
+    )
+endif()
+
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
+  ${test_libs}
   LLVMAMDGPUAsmParser
   LLVMX86AsmParser
   MLIRAnalysis
@@ -21,7 +28,6 @@ set(LIBS
   MLIRTransforms
   MLIRSupport
   MLIRIR
-  MLIRTestDialect
   MLIRMIOpenThin
   )
 


### PR DESCRIPTION
One more variation on the theme.  This one uses Krzysztof's idea of moving the partition-config interface into the Pass itself, and subclassing the Pass to change behavior.  I think I like this one.

There is no abstract class this time -- the base TosaPartitionPass implements the simple interface but allows it to be overridden.  I override for the with-options variant and in the test pass for its little variations.  I could see an argument that the base version should use the options;  what I have feels natural, but on the other hand the options are already defined in Passes.td.

I'm sorry I can't show a direct comparison with the last version, but I'll try to highlight differences.