### PR TITLE
Force use of pull-request cget that works better on lockhart.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -10,6 +10,10 @@ void buildProject(String target, String cmakeOpts) {
     }
 }
 
+void MIOpen_cget_hack() {
+      sh 'sed -i "s|virtualenv_install(cget)|virtualenv_install(git+https://github.com/pcf000/cget.git@use-urlretrieve)|" install_deps.cmake'
+}
+
 void buildMIOpen(String cmakeOpts) {
     sh '[ ! -d build ] || rm -rf build'
     cmakeBuild generator: 'Unix Makefiles',\
@@ -27,6 +31,7 @@ void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
     git branch: 'int8-perf-config', poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
     sh 'sed -i "/ROCmSoftwarePlatform\\/llvm-project-mlir/d" ./requirements.txt'
+    MIOpen_cget_hack()
     cmake arguments: "-P install_deps.cmake --minimum ${prefixOpt}",\
         installation: "InSearchPath"
     buildMIOpen(cmakeOpts)
@@ -42,6 +47,7 @@ void buildMIOpenWithMLIR() {
         git branch: 'int8-perf-config', poll: false,\
             url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
         sh 'sed -i "/ROCmSoftwarePlatform\\/llvm-project-mlir/d" ./requirements.txt'
+        MIOpen_cget_hack()
         cmake arguments: "-P install_deps.cmake --minimum --prefix ${WORKSPACE}/MIOpenDeps",\
                 installation: "InSearchPath"
         buildMIOpen('''-DMIOPEN_USE_MLIR=On


### PR DESCRIPTION
What this commit does is have the Jenkinsfile MIOpen steps do

  pip install git+https://github.com/pcf000/cget.git@use-urlretrieve

instead of

  pip install cget

The funky syntax fetches the branch I made for a cget pull request, which updates cget to use requests.urlretrieve which works with the lockhart proxy better than the existing version which uses URLopener.retrieve.  (TIL that pip can install straight from github.)

I don't know how long it'll take for a pull request to make its way to pypi.org, but this is intended to be a short-term solution.  Preloading the MIOpen dependences in the docker image is impractical because we have two places in Jenkinsfile that need them and they need different versions (because one is MIOpen's main branch and one is the int8-perf-config branch).

I've tested by running the "cmake -P install_deps.cmake" command, but haven't done a full Jenkins run yet, because that would require reenabling the lockhart hosts.