### PR TITLE
[WA] disable multithreading in migraphx pipeline

### DIFF
--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -103,6 +103,8 @@ MLIR_CAPI_EXPORTED bool mlirGetBinary(MlirModule module, int *size, char *bin) {
 MLIR_CAPI_EXPORTED
 void mlirMIGraphXAddHighLevelPipeline(MlirPassManager pm) {
   auto passMan = unwrap(pm);
+  // FIXME : WA for the multithreading issue, potentially fixed in upstream.
+  passMan->getContext()->disableMultithreading();
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::migraphx::addHighLevelPipeline(*passMan);
   mlir::miopen::buildBufferizePipeline(*passMan);


### PR DESCRIPTION
Temporary WA to avoid potential multithreading issue reported by UBsan.
Possibly fixed in upstream https://github.com/llvm/llvm-project/commit/072e0aabbc457b8802dcf7b483e3acebfbde1c33
