### PR TITLE
Replace mgpu with gpu ops

### DIFF
--- a/mlir/test/mlir-miopen-driver/populate_host.mlir
+++ b/mlir/test/mlir-miopen-driver/populate_host.mlir
@@ -81,27 +81,19 @@
 // CHECK-NEXT: return
 
 // CHECK: func @miopen_conv2d_gkcyx_ngchw_ngkhw_0_gpu(%{{.*}}: memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, %{{.*}}: memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, %{{.*}}: memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>)
-// CHECK-NEXT: constant 1 : i32
-// CHECK-NEXT: constant 2 : i32
-// CHECK-NEXT: memref.cast %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]> to memref<?x?x?x?x?x[[TYPE]]>
-// CHECK-NEXT: call @mgpuMemAlloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> memref<?x?x?x?x?x[[TYPE]]>
-// CHECK-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// CHECK-NEXT: memref.cast %{{.*}} : memref<?x?x?x?x?x[[TYPE]]> to memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
-// CHECK-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]> to memref<?x?x?x?x?x[[TYPE]]>
-// CHECK-NEXT: call @mgpuMemAlloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> memref<?x?x?x?x?x[[TYPE]]>
-// CHECK-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// CHECK-NEXT: memref.cast %{{.*}} : memref<?x?x?x?x?x[[TYPE]]> to memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
-// CHECK-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<?x?x?x?x?x[[TYPE]]>
-// CHECK-NEXT: call @mgpuMemAlloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> memref<?x?x?x?x?x[[TYPE]]>
-// CHECK-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// CHECK-NEXT: memref.cast %{{.*}} : memref<?x?x?x?x?x[[TYPE]]> to memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
+// CHECK-NEXT: gpu.alloc  () : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>,  memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// CHECK-NEXT: gpu.alloc  () : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>,  memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.alloc  () : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>,  memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
 // CHECK-NEXT: call @miopen_conv2d_gkcyx_ngchw_ngkhw_0(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
-// CHECK-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// CHECK-NEXT: call @mgpuMemDealloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> ()
-// CHECK-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// CHECK-NEXT: call @mgpuMemDealloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> ()
-// CHECK-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// CHECK-NEXT: call @mgpuMemDealloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> ()
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>,  memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// CHECK-NEXT: gpu.dealloc  %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>,  memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.dealloc  %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>,  memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
+// CHECK-NEXT: gpu.dealloc  %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
 // CHECK-NEXT: return
 
 // RUN: miopen-gen -p -ph -t i8 | FileCheck %s --check-prefix=INT8
@@ -186,25 +178,17 @@
 // INT8-NEXT: return
 
 // INT8: func @miopen_conv2d_gkcyx_ngchw_ngkhw_0_gpu(%{{.*}}: memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, %{{.*}}: memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, %{{.*}}: memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>)
-// INT8-NEXT: constant 1 : i32
-// INT8-NEXT: constant 2 : i32
-// INT8-NEXT: memref.cast %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]> to memref<?x?x?x?x?x[[TYPE]]>
-// INT8-NEXT: call @mgpuMemAlloc5DInt8(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> memref<?x?x?x?x?x[[TYPE]]>
-// INT8-NEXT: call @mgpuMemCopy5DInt8(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// INT8-NEXT: memref.cast %{{.*}} : memref<?x?x?x?x?x[[TYPE]]> to memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
-// INT8-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]> to memref<?x?x?x?x?x[[TYPE]]>
-// INT8-NEXT: call @mgpuMemAlloc5DInt8(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> memref<?x?x?x?x?x[[TYPE]]>
-// INT8-NEXT: call @mgpuMemCopy5DInt8(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// INT8-NEXT: memref.cast %{{.*}} : memref<?x?x?x?x?x[[TYPE]]> to memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
-// INT8-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]> to memref<?x?x?x?x?x[[TYPEI32]]>
-// INT8-NEXT: call @mgpuMemAlloc5DInt32(%{{.*}}) : (memref<?x?x?x?x?x[[TYPEI32]]>) -> memref<?x?x?x?x?x[[TYPEI32]]>
-// INT8-NEXT: call @mgpuMemCopy5DInt32(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPEI32]]>, memref<?x?x?x?x?x[[TYPEI32]]>, i32) -> ()
-// INT8-NEXT: memref.cast %{{.*}} : memref<?x?x?x?x?x[[TYPEI32]]> to memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>
+// INT8-NEXT: gpu.alloc  () : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// INT8-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>,  memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// INT8-NEXT: gpu.alloc  () : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// INT8-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>,  memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// INT8-NEXT: gpu.alloc  () : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>
+// INT8-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>,  memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>
 // INT8-NEXT: call @miopen_conv2d_gkcyx_ngchw_ngkhw_0(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>) -> ()
-// INT8-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// INT8-NEXT: call @mgpuMemDealloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> ()
-// INT8-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>, memref<?x?x?x?x?x[[TYPE]]>, i32) -> ()
-// INT8-NEXT: call @mgpuMemDealloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPE]]>) -> ()
-// INT8-NEXT: call @mgpuMemCopy5D{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<?x?x?x?x?x[[TYPEI32]]>, memref<?x?x?x?x?x[[TYPEI32]]>, i32) -> ()
-// INT8-NEXT: call @mgpuMemDealloc5D{{.*}}(%{{.*}}) : (memref<?x?x?x?x?x[[TYPEI32]]>) -> ()
+// INT8-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>,  memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// INT8-NEXT: gpu.dealloc  %{{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
+// INT8-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>,  memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// INT8-NEXT: gpu.dealloc  %{{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
+// INT8-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>,  memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>
+// INT8-NEXT: gpu.dealloc  %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPEI32]]>
 // INT8-NEXT: return

--- a/mlir/tools/miopen-gen/miopen-gen.cpp
+++ b/mlir/tools/miopen-gen/miopen-gen.cpp
@@ -690,141 +690,31 @@ static FuncOp createGPUWrapper(ModuleOp &module, const KernelIF &kernel) {
         loc, b.create<arith::ConstantIntOp>(loc, deviceNum.getValue(),
                                             b.getIntegerType(32)));
 
-  // Emit some constant values for HIP runtime API calls.
-  auto oneConstantI32Op =
-      b.create<arith::ConstantIntOp>(loc, 1, b.getIntegerType(32));
-  auto twoConstantI32Op =
-      b.create<arith::ConstantIntOp>(loc, 2, b.getIntegerType(32));
-
-  auto getGpuAllocFunc = [&](mlir::Type elemType) -> FuncOp {
-    StringRef allocFuncName = "mgpuMemAlloc5DFloat";
-    if (elemType.isF32()) {
-    } else if (elemType.isF16()) {
-      allocFuncName = "mgpuMemAlloc5DHalf";
-    } else if (elemType.isBF16()) {
-      allocFuncName = "mgpuMemAlloc5DBF16";
-    } else if (elemType.isInteger(8)) {
-      allocFuncName = "mgpuMemAlloc5DInt8";
-    } else if (elemType.isInteger(32)) {
-      allocFuncName = "mgpuMemAlloc5DInt32";
-    }
-    auto unk5DType = MemRefType::get({-1, -1, -1, -1, -1}, elemType);
-    return makeFuncDecl(module, allocFuncName, {unk5DType}, {unk5DType});
-  };
-
-  auto getGpuDeallocFunc = [&](mlir::Type elemType) -> FuncOp {
-    StringRef deallocFuncName = "mgpuMemDealloc5DFloat";
-    if (elemType.isF32()) {
-    } else if (elemType.isF16()) {
-      deallocFuncName = "mgpuMemDealloc5DHalf";
-    } else if (elemType.isBF16()) {
-      deallocFuncName = "mgpuMemDealloc5DBF16";
-    } else if (elemType.isInteger(8)) {
-      deallocFuncName = "mgpuMemDealloc5DInt8";
-    } else if (elemType.isInteger(32)) {
-      deallocFuncName = "mgpuMemDealloc5DInt32";
-    }
-    auto unk5DType = MemRefType::get({-1, -1, -1, -1, -1}, elemType);
-    return makeFuncDecl(module, deallocFuncName, {unk5DType});
-  };
-
-  auto getGpuCopyFunc = [&](mlir::Type elemType) -> FuncOp {
-    StringRef allocFuncName = "mgpuMemCopy5DFloat";
-    if (elemType.isF32()) {
-    } else if (elemType.isF16()) {
-      allocFuncName = "mgpuMemCopy5DHalf";
-    } else if (elemType.isBF16()) {
-      allocFuncName = "mgpuMemCopy5DBF16";
-    } else if (elemType.isInteger(8)) {
-      allocFuncName = "mgpuMemCopy5DInt8";
-    } else if (elemType.isInteger(32)) {
-      allocFuncName = "mgpuMemCopy5DInt32";
-    }
-    auto unk5DType = MemRefType::get({-1, -1, -1, -1, -1}, elemType);
-    return makeFuncDecl(module, allocFuncName,
-                        {unk5DType, unk5DType, b.getIntegerType(32)});
-  };
-
   SmallVector<mlir::Value, 4> cpuMem;
   SmallVector<mlir::Value, 4> gpuMem;
-  SmallVector<mlir::Value, 4> paramCasts;
-  uint32_t i = 0;
-  for (auto &paramType : kernel.params) {
-    auto shapedType = paramType.dyn_cast<ShapedType>();
-    assert(shapedType);
-
-    auto elemType = shapedType.getElementType();
-
-    // Emit memref.expand_shape (if needed)
-    auto fiveDimUnknownSizeMemRefType =
-        MemRefType::get({-1, -1, -1, -1, -1}, elemType);
-
-    // Emit memref.cast.
-    mlir::Value arg = block->getArgument(i++);
-    mlir::Value castOp = b.create<memref::CastOp>(
-        loc, fiveDimUnknownSizeMemRefType, makeNDMemRef(b, arg, 5));
-    cpuMem.push_back(castOp);
+  for (auto pair : llvm::enumerate(kernel.params)) {
+    mlir::Value arg = block->getArgument(pair.index());
+    cpuMem.push_back(arg);
 
     // Emit GPU memory allocation function calls.
-    auto gpuAllocOp = b.create<func::CallOp>(loc, getGpuAllocFunc(elemType),
-                                             ValueRange{castOp});
+    auto gpuAllocOp =
+        b.create<gpu::AllocOp>(loc, arg.getType(), mlir::Type(), ValueRange{},
+                               ValueRange{}, ValueRange{});
     mlir::Value gpuAlloc = gpuAllocOp.getResult(0);
     gpuMem.push_back(gpuAlloc);
 
     // Emit CPU->GPU memcpy function calls.
-    b.create<func::CallOp>(loc, getGpuCopyFunc(elemType),
-                           ValueRange{castOp, gpuAlloc, oneConstantI32Op});
-
-    auto shape = shapedType.getShape();
-    if (shape.size() < 5) {
-      SmallVector<int64_t, 5> expShape(shape.begin(), shape.end());
-      for (int i = shape.size(); i < 5; ++i)
-        expShape.push_back(1);
-      auto param5DType = MemRefType::get(expShape, elemType);
-      // Emit memref.cast.
-      castOp = b.create<memref::CastOp>(loc, param5DType, gpuAlloc);
-
-      // Emit memref.collapse_shape
-      SmallVector<ReassociationExprs, 5> reassociations;
-      uint32_t dim = 0;
-      for (; dim < shape.size() - 1; ++dim) {
-        reassociations.push_back({getAffineDimExpr(dim, context)});
-      }
-
-      // last dimensions
-      SmallVector<AffineExpr, 2> exprs;
-      for (; dim < 5; ++dim)
-        exprs.push_back(getAffineDimExpr(dim, context));
-      reassociations.push_back(exprs);
-
-      castOp = b.create<memref::CollapseShapeOp>(loc, paramType, castOp,
-                                                 reassociations);
-    } else {
-      // Emit memref.cast.
-      castOp = b.create<memref::CastOp>(loc, paramType, gpuAlloc);
-    }
-
-    paramCasts.push_back(castOp);
+    b.create<gpu::MemcpyOp>(loc, TypeRange{}, ValueRange{arg, gpuAlloc});
   }
 
   // Emit kernel function call.
-  auto wrappedCall = b.create<func::CallOp>(loc, kernel.func, paramCasts);
+  auto wrappedCall = b.create<func::CallOp>(loc, kernel.func, gpuMem);
   wrappedCall->setAttr("wrapped_call", b.getUnitAttr());
 
-  i = 0;
-  for (auto &param : paramCasts) {
-    auto elemType = param.getType();
-    if (auto shapedType = param.getType().dyn_cast<ShapedType>())
-      elemType = shapedType.getElementType();
-
-    // Emit memref.expand_shape (if needed)
-    b.create<func::CallOp>(loc, getGpuCopyFunc(elemType),
-                           ValueRange{gpuMem[i], cpuMem[i], twoConstantI32Op});
-
-    // Emit GPU dealloc
-    b.create<func::CallOp>(loc, getGpuDeallocFunc(elemType),
-                           ValueRange{gpuMem[i]});
-    i++;
+  for (auto &pair : llvm::enumerate(kernel.params)) {
+    uint32_t i = pair.index();
+    b.create<gpu::MemcpyOp>(loc, TypeRange{}, ValueRange{gpuMem[i], cpuMem[i]});
+    b.create<gpu::DeallocOp>(loc, TypeRange{}, ValueRange{gpuMem[i]});
   }
 
   b.create<func::ReturnOp>(loc, ValueRange{});
@@ -1893,7 +1783,8 @@ int main(int argc, char **argv) {
   MLIRContext context(registry);
   context.loadDialect<miopen::MIOpenDialect, func::FuncDialect, scf::SCFDialect,
                       AffineDialect, memref::MemRefDialect, math::MathDialect,
-                      arith::ArithmeticDialect, vector::VectorDialect>();
+                      arith::ArithmeticDialect, vector::VectorDialect,
+                      gpu::GPUDialect>();
 
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv,

--- a/mlir/tools/miopen-gen/miopen-gen.cpp
+++ b/mlir/tools/miopen-gen/miopen-gen.cpp
@@ -697,9 +697,9 @@ static FuncOp createGPUWrapper(ModuleOp &module, const KernelIF &kernel) {
     cpuMem.push_back(arg);
 
     // Emit GPU memory allocation function calls.
-    auto gpuAllocOp =
-        b.create<gpu::AllocOp>(loc, arg.getType(), mlir::Type(), ValueRange{},
-                               ValueRange{}, ValueRange{});
+    auto gpuAllocOp = b.create<gpu::AllocOp>(
+        loc, arg.getType(), mlir::Type(), /*asyncDependencies=*/ValueRange{},
+        /*dynamicSizes=*/ValueRange{}, /*symbolOperands*/ ValueRange{});
     mlir::Value gpuAlloc = gpuAllocOp.getResult(0);
     gpuMem.push_back(gpuAlloc);
 

--- a/mlir/tools/miopen-gen/miopen-gen.cpp
+++ b/mlir/tools/miopen-gen/miopen-gen.cpp
@@ -704,7 +704,7 @@ static FuncOp createGPUWrapper(ModuleOp &module, const KernelIF &kernel) {
     gpuMem.push_back(gpuAlloc);
 
     // Emit CPU->GPU memcpy function calls.
-    b.create<gpu::MemcpyOp>(loc, TypeRange{}, ValueRange{arg, gpuAlloc});
+    b.create<gpu::MemcpyOp>(loc, TypeRange{}, ValueRange{gpuAlloc, arg});
   }
 
   // Emit kernel function call.
@@ -713,7 +713,7 @@ static FuncOp createGPUWrapper(ModuleOp &module, const KernelIF &kernel) {
 
   for (auto &pair : llvm::enumerate(kernel.params)) {
     uint32_t i = pair.index();
-    b.create<gpu::MemcpyOp>(loc, TypeRange{}, ValueRange{gpuMem[i], cpuMem[i]});
+    b.create<gpu::MemcpyOp>(loc, TypeRange{}, ValueRange{cpuMem[i], gpuMem[i]});
     b.create<gpu::DeallocOp>(loc, TypeRange{}, ValueRange{gpuMem[i]});
   }
 

--- a/mlir/tools/miopen-gen/miopen-gen.cpp
+++ b/mlir/tools/miopen-gen/miopen-gen.cpp
@@ -699,7 +699,7 @@ static FuncOp createGPUWrapper(ModuleOp &module, const KernelIF &kernel) {
     // Emit GPU memory allocation function calls.
     auto gpuAllocOp = b.create<gpu::AllocOp>(
         loc, arg.getType(), mlir::Type(), /*asyncDependencies=*/ValueRange{},
-        /*dynamicSizes=*/ValueRange{}, /*symbolOperands*/ ValueRange{});
+        /*dynamicSizes=*/ValueRange{}, /*symbolOperands=*/ValueRange{});
     mlir::Value gpuAlloc = gpuAllocOp.getResult(0);
     gpuMem.push_back(gpuAlloc);
 


### PR DESCRIPTION
In the gpu wrapper function, use gpu.alloc, gpu.memcpy, and gpu.dealloc instead of `mgpuMemAlloc5D*`, `mgpuMemCopy5D*`, and `mgpuDealloc5D*`.

Now we should be safely delete these `mgpu*5D*` functions restored in the following PR:
https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/pull/658