### PR TITLE
Change ABI version to 400 to match the currently included LLVM

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -288,7 +288,7 @@ SerializeToHsacoPass::translateToLLVMIR(llvm::LLVMContext &llvmContext) {
 
     // This constant must always match the default code object ABI version
     // of the AMDGPU backend.
-    addControlConstant("__oclc_ABI_version", 500, 32);
+    addControlConstant("__oclc_ABI_version", 400, 32);
   }
 
   // Determine libraries we need to link - order matters due to dependencies


### PR DESCRIPTION
This constant needs to match the default value for
-mcode-object-version in whichever copy of upstream we're bundling,
since we use that upstream to generate the code objects. Otherwise,
the device libraries in ROCm will not match the code the backend is
generating for things like printf().

This change fixes the printf() tests on ROCm 5.2, which is the first
ROCm to pay attention to the device library version field.

We'll need to bump the constant when upstream bumps the constant,
which they'll do when they change the default.

Since nothing in the release branch can call `gpu.printf`, this does
not need to be backported.