### PR TITLE
Fix buildbot problems with an upstream CMakeLists.txt patch and our own miopen-deps patch [DO NOT SQUASH]

### DIFF
--- a/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
@@ -15,25 +15,18 @@
 FROM rocm/mlir:rocm5.1-latest
 
 RUN apt-get update; \
-    apt-get install -y dumb-init; \
+    apt-get install -y dumb-init cmake; \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 ;\
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 ;\
     update-alternatives --install /usr/bin/lld lld /usr/bin/lld-10 100
 
 # LTS releases often bundle obsolete pip versions that cannot access newest
 # Linux binary wheels.
-RUN python3 -m pip install --upgrade pip
-
-RUN apt-add-repository ppa:deadsnakes/ppa && apt-get update \
-     && apt-get install -y --no-install-recommends \
-            python3.8 python3.8-dev python3.8-venv \
-     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10 \
-     && python3 -m pip install --upgrade pip \
-     && python3 -m pip install --ignore-installed PyYAML
+RUN rm /usr/local/bin/python3 && python3 -m pip install --upgrade pip && python3 -m pip install --ignore-installed PyYAML
 
 # Refer to mlir/lib/Bindings/Python/requirements.txt. Listed explicitly here
 # and version pinned for consistency as this is a bot.
-RUN python3 -m pip install numpy pybind11>=2.8.0 PyYAML>5 dataclasses
+RUN python3 -m pip install numpy 'pybind11>=2.8.0' dataclasses
 
 # Install build bot (server was at 2.8.5-dev at time of writing).
 RUN pip3 install buildbot-worker


### PR DESCRIPTION
One simple change is to install cmake without limiting it to 3.15.  This is a workaround for a problem introduced upstream when a commit used features that first appear in 3.18 or later.  They're working on retrofitting it, but for now let's cope by using a newer cmake.

The rest of the changes in Dockerfile remove a redundant installation of python3.8 and fix some library issues by removing /usr/local/bin/python3.  The rocm/mlir Dockerfile installs python3.8 in /usr/bin, but then the section that installs MIOpen dependences installs it again, in /usr/local because of --prefix.  When building MLIR, cmake's find_package finds python3 in /usr/bin even though it's not the first one in $PATH, and thus we have a python3 that doesn't have the libraries that were installed earlier.  Let's flush /usr/local/bin/python3 because we already have the same thing in /usr/bin.  Yeah, it's ugly, but the alternative is "--prefix /usr" and I like that less.

Finally, add --time-tests to the MLIR regression tests so we might spot outliers in CI.  Optional.