### PR TITLE
Consolidate mfma loop in reduction/non-reduction

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
@@ -283,14 +283,16 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
       // Note: p_a_wave need to be offseted by waveOffsetA.
 
       auto outerLoopM = b.create<AffineForOp>(loc, 0, MRepeats);
-      auto olmb = OpBuilder::atBlockBegin(outerLoopM.getBody());
+      auto olmb = ConversionPatternRewriter::atBlockBegin(outerLoopM.getBody(),
+                                                          b.getListener());
       auto olmiv = outerLoopM.getInductionVar();
       auto mOffset = olmb.create<AddIOp>(
           loc, aBase, olmb.create<MulIOp>(loc, MPerXdlopsConstantOp, olmiv));
       auto kOffsetA = olmb.create<MulIOp>(loc, olmiv, KConstantOp);
 
       auto innerLoopMK = olmb.create<AffineForOp>(loc, 0, KPerThread);
-      auto ilmkb = OpBuilder::atBlockBegin(innerLoopMK.getBody());
+      auto ilmkb = ConversionPatternRewriter::atBlockBegin(
+          innerLoopMK.getBody(), olmb.getListener());
       auto ilmkiv = innerLoopMK.getInductionVar();
 
       Value sourceOffsetA = ilmkb.create<AddIOp>(
@@ -318,14 +320,16 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
       // Note: p_b_wave need to be offseted by waveOffsetB.
 
       auto outerLoopN = b.create<AffineForOp>(loc, 0, NRepeats);
-      auto olnb = OpBuilder::atBlockBegin(outerLoopN.getBody());
+      auto olnb = ConversionPatternRewriter::atBlockBegin(outerLoopN.getBody(),
+                                                          b.getListener());
       auto olniv = outerLoopN.getInductionVar();
       auto nOffset = olnb.create<AddIOp>(
           loc, bBase, olnb.create<MulIOp>(loc, NPerXdlopsConstantOp, olniv));
       auto kOffsetB = olnb.create<MulIOp>(loc, olniv, KConstantOp);
 
       auto innerLoopNK = olnb.create<AffineForOp>(loc, 0, KPerThread);
-      auto ilnkb = OpBuilder::atBlockBegin(innerLoopNK.getBody());
+      auto ilnkb = ConversionPatternRewriter::atBlockBegin(
+          innerLoopNK.getBody(), olnb.getListener());
       auto ilnkiv = innerLoopNK.getInductionVar();
 
       Value sourceOffsetB = ilnkb.create<AddIOp>(
@@ -367,7 +371,8 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
           b.create<ConstantIndexOp>(loc, num_input_blks);
 
       auto loopKLoad = b.create<AffineForOp>(loc, 0, KPerThread);
-      auto lklb = OpBuilder::atBlockBegin(loopKLoad.getBody());
+      auto lklb = ConversionPatternRewriter::atBlockBegin(loopKLoad.getBody(),
+                                                          b.getListener());
       auto lkliv = loopKLoad.getInductionVar();
 
       Value sourceOffsetA = lklb.create<AddIOp>(
@@ -424,7 +429,8 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
 
     auto outerLoop =
         b.create<AffineForOp>(loc, 0, KPerThread, 1, op.vectorCs());
-    auto outerLoopb = OpBuilder::atBlockBegin(outerLoop.getBody());
+    auto outerLoopb = ConversionPatternRewriter::atBlockBegin(
+        outerLoop.getBody(), b.getListener());
     auto outerLoopiv = outerLoop.getInductionVar();
 
     Value bufferAElement = outerLoopb.create<memref::LoadOp>(
@@ -434,7 +440,8 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
 
     auto innerLoop = outerLoopb.create<AffineForOp>(
         loc, 0, KRepeats * k_base, k_base, outerLoop.getRegionIterArgs());
-    auto innerLoopb = OpBuilder::atBlockBegin(innerLoop.getBody());
+    auto innerLoopb = ConversionPatternRewriter::atBlockBegin(
+        innerLoop.getBody(), outerLoopb.getListener());
     auto innerLoopiv = innerLoop.getInductionVar();
 
     Value argA;

--- a/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
@@ -1,10 +1,32 @@
 // RUN: miopen-opt -miopen-threadwise-gemm-lowering %s | FileCheck %s
 
-func @miopen_xdlops_gemm_v2_two_results(%matrix : memref<1024xf32, 3>, %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>) -> (vector<32xf32>, vector<32xf32>) {
+func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32, 3>, %bufferA : memref<8xf32, 5>, %bufferB : memref<8xf32, 5>) -> (vector<32xf32>) {
+  %c0 = arith.constant 0 : index
+  %c0f = arith.constant 0.0 : f32
+  %vectorC = vector.splat %c0f : vector<32xf32>
+  // CHECK: memref.load 
+  // CHECK: memref.load 
+  // CHECK: amdgpu.mfma
+   %vectorD = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC) {
+     k = 8 : i32, 
+     kpack = 1 : i32, 
+     ldsBufferOffsetA = 0 : index, 
+     ldsBufferOffsetB = 1024 : index, 
+     m = 128 : i32, 
+     m_per_wave = 64 : i32, 
+     n = 64 : i32, 
+     n_per_wave = 32 : i32
+     } : memref<1536xf32, 3>, memref<1536xf32, 3>, index, index, memref<8xf32, 5>, memref<8xf32, 5>, vector<32xf32> -> vector<32xf32>
+  return %vectorD : vector<32xf32>
+}
+
+func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrix : memref<1024xf32, 3>, %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>) -> (vector<32xf32>, vector<32xf32>) {
   %c0 = arith.constant 0 : index
   %c0f = arith.constant 0.0 : f32
   %vectorC0 = vector.splat %c0f : vector<32xf32>
   %vectorC1 = vector.splat %c0f : vector<32xf32>
+  // CHECK: miopen.extract_slice
+  // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK-NEXT: amdgpu.mfma
   %vectorD0, %vectorD1 = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0, %vectorC1) {
@@ -23,15 +45,17 @@ func @miopen_xdlops_gemm_v2_two_results(%matrix : memref<1024xf32, 3>, %bufferA 
   return %vectorD0, %vectorD1 : vector<32xf32>, vector<32xf32>
 }
 
-func @miopen_xdlops_gemm_v2_one_result(%matrix : memref<2048xi8, 3>, %bufferA : memref<2xvector<4xi8>, 5>, %bufferB : memref<2xvector<4xi8>, 5>) -> vector<16xi32> {
+func @miopen_xdlops_gemm_v2_reduction_kpack(%matrix : memref<2048xi8, 3>, %bufferA : memref<2xvector<8xi8>, 5>, %bufferB : memref<2xvector<8xi8>, 5>) -> vector<16xi32> {
   %c0 = arith.constant 0 : index
   %c0i = arith.constant 0 : i32
   %vectorC0 = vector.splat %c0i : vector<16xi32>
+  // CHECK: miopen.extract_slice
+  // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK-NOT: amdgpu.mfma
   %vectorD0 = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
     block_size = 256 : i32, // m_waves * n_waves * 64
-    k = 2 : i32,
+    k = 4 : i32,
     kpack = 8 : i32,
     m_per_wave = 32 : i32, // xdlops requires 32x32
     n_per_wave = 32 : i32, // xdlops requires 32x32
@@ -41,6 +65,6 @@ func @miopen_xdlops_gemm_v2_one_result(%matrix : memref<2048xi8, 3>, %bufferA : 
     n_waves = 2 : i32,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 1024 : index
-  } : memref<2048xi8, 3>, memref<2048xi8, 3>, index, index, memref<2xvector<4xi8>, 5>, memref<2xvector<4xi8>, 5>, vector<16xi32> -> vector<16xi32>
+  } : memref<2048xi8, 3>, memref<2048xi8, 3>, index, index, memref<2xvector<8xi8>, 5>, memref<2xvector<8xi8>, 5>, vector<16xi32> -> vector<16xi32>
   return %vectorD0 : vector<16xi32>
 }


### PR DESCRIPTION
I made the following changes in this PR:
 - Consolidated the gemm calculation between reduction and non-reduction cases
   - Both share the same implementation as the register structure from lds -> register are the same
   - Added `KPerThread` definition to share K dimension calculation between the two
 - Added test coverage in `lowering_xdlops_gemm_v2.mlir`
 - Misc cleanups:
   - Removed redundant `emitLoadLogic`, and use `InBoundsLoadOp` instead
