### PR TITLE
Fb option

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -62,7 +62,7 @@ std::unique_ptr<Pass> createMIOpenLoopsToCfPass();
 std::unique_ptr<Pass>
 createAffixTuningParametersPass(int64_t blockSizeOverride = 0,
                                 int64_t gridSizeOverride = 0,
-                                bool fallBackNoConfig);
+                                bool fallBackNoConfig = false);
 
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/MIOpen/Passes.h.inc"

--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -61,7 +61,8 @@ std::unique_ptr<Pass> createMIOpenLoopsToCfPass();
 /// Create a pass to affix tuning parameters to gridwise gemm ops.
 std::unique_ptr<Pass>
 createAffixTuningParametersPass(int64_t blockSizeOverride = 0,
-                                int64_t gridSizeOverride = 0);
+                                int64_t gridSizeOverride = 0,
+                                bool fallBackNoConfig);
 
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/MIOpen/Passes.h.inc"

--- a/mlir/include/mlir/Dialect/MIOpen/Pipelines.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Pipelines.h
@@ -79,6 +79,9 @@ struct BackendOptions : public PassPipelineOptions<BackendOptions> {
       *this, "opt-level", desc("GPU compiler optimization level"), init(3)};
   PassOptions::Option<int32_t> indexBitwidth{*this, "index-bitwidth",
                                              desc("Index bit-width"), init(32)};
+  PassOptions::Option<bool> tuningFallback{
+      *this, "tuningFallback",
+      desc("Falls back default if invalid config is given"), init(false)};
 };
 
 /// Adds the `kernel` pipeline to the `OpPassManager`.

--- a/mlir/include/mlir/Dialect/MIOpen/Pipelines.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Pipelines.h
@@ -60,6 +60,9 @@ struct KernelOptions : public PassPipelineOptions<KernelOptions> {
       *this, "enable-fusion",
       desc("Enable fusion alignment between anchor op and peripheral ops"),
       init(true)};
+  PassOptions::Option<bool> tuningFallback{
+      *this, "tuningFallback",
+      desc("Falls back default if invalid config is given"), init(false)};
 };
 
 /// Adds the `kernel` pipeline to the `OpPassManager`.
@@ -79,9 +82,6 @@ struct BackendOptions : public PassPipelineOptions<BackendOptions> {
       *this, "opt-level", desc("GPU compiler optimization level"), init(3)};
   PassOptions::Option<int32_t> indexBitwidth{*this, "index-bitwidth",
                                              desc("Index bit-width"), init(32)};
-  PassOptions::Option<bool> tuningFallback{
-      *this, "tuningFallback",
-      desc("Falls back default if invalid config is given"), init(false)};
 };
 
 /// Adds the `kernel` pipeline to the `OpPassManager`.

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -117,13 +117,14 @@ MLIR_CAPI_EXPORTED void mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
   mlir::registerGpuSerializeToHsacoPass();
   auto passMan = unwrap(pm);
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
-  mlir::miopen::buildKernelPipeline(*passMan);
+  miopen::KernelOptions kOpts;
+  kOpts.tuningFallback = true;
+  mlir::miopen::buildKernelPipeline(*passMan, kOpts);
   mlir::miopen::BackendOptions opts;
   opts.triple = triple;
   opts.chip = chip;
   opts.features = features;
   opts.optLevel = 3;
   opts.indexBitwidth = 64;
-  opts.tuningFallback = true;
   mlir::miopen::buildBackendPipeline(*passMan, opts);
 }

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -19,8 +19,8 @@
 #include "mlir/Dialect/MIOpen/Pipelines.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "llvm/Support/TargetSelect.h"
-#include <vector>
 #include <mutex>
+#include <vector>
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(MIGraphX, migraphx,
                                       mlir::migraphx::MIGraphXDialect)
@@ -117,6 +117,8 @@ MLIR_CAPI_EXPORTED void mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
                                                        const char *features) {
   static std::mutex target_mutex;
   target_mutex.lock();
+  // Some calls included in regiserGpuSerializeToHsacoPass() are not thread safe
+  // and user may call this pipeline from different threads.
   mlir::registerGpuSerializeToHsacoPass();
   target_mutex.unlock();
   auto passMan = unwrap(pm);

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -117,7 +117,7 @@ MLIR_CAPI_EXPORTED void mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
   mlir::registerGpuSerializeToHsacoPass();
   auto passMan = unwrap(pm);
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
-  miopen::KernelOptions kOpts;
+  mlir::miopen::KernelOptions kOpts;
   kOpts.tuningFallback = true;
   mlir::miopen::buildKernelPipeline(*passMan, kOpts);
   mlir::miopen::BackendOptions opts;

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -20,6 +20,7 @@
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "llvm/Support/TargetSelect.h"
 #include <vector>
+#include <mutex>
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(MIGraphX, migraphx,
                                       mlir::migraphx::MIGraphXDialect)
@@ -114,7 +115,10 @@ MLIR_CAPI_EXPORTED void mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
                                                        const char *chip,
                                                        const char *triple,
                                                        const char *features) {
+  static std::mutex target_mutex;
+  target_mutex.lock();
   mlir::registerGpuSerializeToHsacoPass();
+  target_mutex.unlock();
   auto passMan = unwrap(pm);
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::miopen::KernelOptions kOpts;

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -124,5 +124,6 @@ MLIR_CAPI_EXPORTED void mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
   opts.features = features;
   opts.optLevel = 3;
   opts.indexBitwidth = 64;
+  opts.tuningFallback = true;
   mlir::miopen::buildBackendPipeline(*passMan, opts);
 }

--- a/mlir/lib/Dialect/MIOpen/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/MIOpen/Pipelines/Pipelines.cpp
@@ -122,7 +122,8 @@ void miopen::buildKernelPipeline(OpPassManager &pm,
   /* miopen-opt --miopen-affix-params --miopen-conv-to-gemm
    * --miopen-gridwise-gemm-to-blockwise
    */
-  pm.addPass(miopen::createAffixTuningParametersPass(0, 0));
+  pm.addPass(
+      miopen::createAffixTuningParametersPass(0, 0, options.tuningFallback));
   pm.addNestedPass<FuncOp>(miopen::createMIOpenConvToGemmPass());
   pm.addNestedPass<FuncOp>(miopen::createMIOpenGridwiseGemmToBlockwisePass());
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -18,11 +18,13 @@ using namespace mlir;
 using namespace mlir::miopen;
 
 namespace {
-struct AffixTuningParameters : public MIOpenOpsAffixTuningParametersPassBase<AffixTuningParameters> {
+struct AffixTuningParameters
+    : public MIOpenOpsAffixTuningParametersPassBase<AffixTuningParameters> {
 public:
-  AffixTuningParameters(int64_t blockSizeOverride, int64_t gridSizeOverride)
+  AffixTuningParameters(int64_t blockSizeOverride, int64_t gridSizeOverride,
+                        bool fallBackNoConfig)
       : blockSizeOverride(blockSizeOverride),
-        gridSizeOverride(gridSizeOverride) {}
+        gridSizeOverride(gridSizeOverride), fallBackNoConfig(false) {}
   void runOnOperation() override;
 
 private:
@@ -39,9 +41,11 @@ private:
   //   coherent tuning parameters with the pre-set block size.
   int64_t blockSizeOverride;
   int64_t gridSizeOverride;
+  bool fallBackNoConfig;
 
-  // Actual implementation.
-  template <typename T> void affixTuningParametersImpl(T &op);
+      // Actual implementation.
+      template <typename T>
+      void affixTuningParametersImpl(T &op);
 
   void affixBackwardWeightUtilityKernels(Conv2DBwdWeightOp &op);
   void affixBackwardDataUtilityKernels(Conv2DBwdDataOp &op);
@@ -210,7 +214,16 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
         gemmBDerivedParam, gemmCDerivedParam, blockSize, gridSize, gemmKBlocks);
 
     if (failed(status)) {
-      signalPassFailure();
+      // Try again if allowed.
+      if (fallBackNoConfig) {
+        perfConfig.clear();
+        status = populateParamsXDL.obtainTuningParameters(
+            op, blockSizeOverride, perfConfig, validParams, gemmADerivedParam,
+            gemmBDerivedParam, gemmCDerivedParam, blockSize, gridSize,
+            gemmKBlocks);
+      }
+      if (failed(status))
+        signalPassFailure();
     }
 
     op->setAttr("m_per_wave", b.getI32IntegerAttr(validParams.gemmMPerWave));
@@ -340,7 +353,8 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
 
 std::unique_ptr<Pass>
 mlir::miopen::createAffixTuningParametersPass(int64_t blockSizeOverride,
-                                              int64_t gridSizeOverride) {
-  return std::make_unique<AffixTuningParameters>(blockSizeOverride,
-                                                 gridSizeOverride);
+                                              int64_t gridSizeOverride,
+                                              bool fallBackNoConfig) {
+  return std::make_unique<AffixTuningParameters>(
+      blockSizeOverride, gridSizeOverride, bool fallBackNoConfig);
 }

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -43,9 +43,8 @@ private:
   int64_t gridSizeOverride;
   bool fallBackNoConfig;
 
-      // Actual implementation.
-      template <typename T>
-      void affixTuningParametersImpl(T &op);
+  // Actual implementation.
+  template <typename T> void affixTuningParametersImpl(T &op);
 
   void affixBackwardWeightUtilityKernels(Conv2DBwdWeightOp &op);
   void affixBackwardDataUtilityKernels(Conv2DBwdDataOp &op);
@@ -356,5 +355,5 @@ mlir::miopen::createAffixTuningParametersPass(int64_t blockSizeOverride,
                                               int64_t gridSizeOverride,
                                               bool fallBackNoConfig) {
   return std::make_unique<AffixTuningParameters>(
-      blockSizeOverride, gridSizeOverride, bool fallBackNoConfig);
+      blockSizeOverride, gridSizeOverride, fallBackNoConfig);
 }

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -24,7 +24,7 @@ public:
   AffixTuningParameters(int64_t blockSizeOverride, int64_t gridSizeOverride,
                         bool fallBackNoConfig)
       : blockSizeOverride(blockSizeOverride),
-        gridSizeOverride(gridSizeOverride), fallBackNoConfig(false) {}
+        gridSizeOverride(gridSizeOverride), fallBackNoConfig(fallBackNoConfig) {}
   void runOnOperation() override;
 
 private:


### PR DESCRIPTION
Add Affix Tunig Param pass an option to recover from invalid perf_config.
This improves user experience when calling the pass as a part of the pipeline.

This also includes wrapping a call to registerGpuSerializeToHsaSoPass with mutex lock to avoid crash when called by multithreaded MIGraphX