### PR TITLE
Add cmake dependences needed for single-threaded Unix-Makefile builds.

### DIFF
--- a/mlir/lib/Conversion/GPUToMIGraphX/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToMIGraphX/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_conversion_library(MLIRGPUToMIGraphX
 
   DEPENDS
   MLIRMIOpenConversionPassIncGen
+  MLIRMIGraphXTypeIncGen
 )
 
 target_link_libraries(MLIRGPUToMIGraphX

--- a/mlir/lib/Conversion/MIOpenToGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/MIOpenToGPU/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_conversion_library(MLIRMIOpenToGPU
   DEPENDS
   MLIRConversionPassIncGen
   MLIRMIOpenConversionPassIncGen
+  MLIRMIOpenPassIncGen
 )
 target_link_libraries(MLIRMIOpenToGPU
   PUBLIC

--- a/mlir/lib/Dialect/MIGraphX/CMakeLists.txt
+++ b/mlir/lib/Dialect/MIGraphX/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRMIGraphX
   MLIRMIGraphXTypeIncGen
   MLIRMIGraphXOpsIncGen
   MLIRMIGraphXPassIncGen
+  MLIRFuncOpsIncGen
 
   )
 target_link_libraries(MLIRMIGraphX

--- a/mlir/lib/Dialect/MIOpen/Tuning/CMakeLists.txt
+++ b/mlir/lib/Dialect/MIOpen/Tuning/CMakeLists.txt
@@ -9,6 +9,8 @@ add_mlir_dialect_library(MLIRMIOpenTuning
 
   DEPENDS
   MLIRSupport
+  MLIRGPUOpInterfacesIncGen
+  MLIRMIOpenPassIncGen
 )
 
 if (MLIR_MIOPEN_SQLITE_ENABLED)

--- a/mlir/lib/Dialect/MIOpen/Tuning/CMakeLists.txt
+++ b/mlir/lib/Dialect/MIOpen/Tuning/CMakeLists.txt
@@ -9,7 +9,6 @@ add_mlir_dialect_library(MLIRMIOpenTuning
 
   DEPENDS
   MLIRSupport
-  MLIRGPUOpInterfacesIncGen
   MLIRMIOpenPassIncGen
 )
 


### PR DESCRIPTION
rocm-arch #785 and #787 report build failures when using -DBUILD_FAT_LIBMLIRMIOPEN=1, Unix Makefiles, and single-threaded compilation.  This patch adds some dependences to CMakeLists.txt to make sure those included files are built before their includers.  Tested with the 5.1.0 and 5.2.0 release source and the latest main line, patched on the main line.