### PR TITLE
Backport to 5.3: use set() instead of list() to append rpath flags (#688)

### DIFF
--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -48,8 +48,6 @@ list(APPEND LLVM_INCLUDE_DIRS
 )
 
 # Linker flags
-list(APPEND CMAKE_EXE_LINKER_FLAGS
-  " -Wl,-rpath -Wl,${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/lib"
-)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/lib")
 
 add_subdirectory("${LLVM_PROJ_SRC}/llvm" "external/llvm-project/llvm" EXCLUDE_FROM_ALL)


### PR DESCRIPTION
In cmake/llvm-project.cmake rpath flags are appended to CMAKE_EXE_LINKER_FLAGS with list(APPEND .... This inserts a ";" between the previous flags (if present) and the newly appended flags, breaking compilation. This can be avoided by using set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ..." to append the flags instead.

This breaks people externally and needs to be in 5.3. It's already in master as #688