### PR TITLE
Making memref to capture vectorC/D in gemm from xdlops lowering

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -793,7 +793,7 @@ def MIOpen_XdlopsGemmV2Op:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type(operands) `->` type(results)
+    `(` operands `)` attr-dict `:` type(operands)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -199,9 +199,10 @@ def MIOpen_GpuAllocOp:
 
 // TBD: eventually replace this with linalg.fill?
 def MIOpen_FillOp:
-    MIOpen_Op<"fill", [AllElementTypesMatch<["input", "value"]>]>,
+    MIOpen_Op<"fill">,
     Arguments<(ins AnyMemRef:$input,
-                   AnyTypeOf<[AnyInteger, AnyFloat]>:$value)> {
+                   //AnyTypeOf<[AnyInteger, AnyFloat]>:$value)> {
+                   AnyTypeOf<[AnyInteger, AnyFloat, AnyVector]>:$value)> {
   let summary = "Fill memory with constant value on GPU";
   let description = [{
     The `miopen.fill` op fills a memref on GPU with a constant value.
@@ -730,7 +731,8 @@ def MIOpen_BlockwiseGemmV2Op:
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
                              VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
-                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes)>{
+                   MemRefOf<[F32, F16, BF16, I32,
+                             VectorOf<[F32, F16, BF16, I32]>]>:$matrixC)>{
   let summary = "Blockwise GEMM XDLOPS version";
   let description = [{
     The `miopen.block_gemm` op does GEMM at workgroup (block) level.
@@ -784,7 +786,8 @@ def MIOpen_XdlopsGemmV2Op:
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
                              VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
-                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes)>{
+                   MemRefOf<[F32, F16, BF16, I32,
+                             VectorOf<[F32, F16, BF16, I32]>]>:$matrixC)>{
   let summary = "XDLOPS GEMM V2";
   let description = [{
     The `miopen.xdlops_gemm_v2` op is an abstraction of doing GEMM based on XDLOPS.

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -730,9 +730,7 @@ def MIOpen_BlockwiseGemmV2Op:
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
                              VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
-                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes,
-                   Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
-    Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>: $vectorDs)> {
+                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes)>{
   let summary = "Blockwise GEMM XDLOPS version";
   let description = [{
     The `miopen.block_gemm` op does GEMM at workgroup (block) level.
@@ -743,7 +741,7 @@ def MIOpen_BlockwiseGemmV2Op:
     not slices of a larger object.
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type(operands) `->` type($vectorDs)
+    `(` operands `)` attr-dict `:` type(operands)
   }];
 }
 
@@ -786,9 +784,7 @@ def MIOpen_XdlopsGemmV2Op:
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
                              VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
-                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes,
-                   Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
-    Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorDs)> {
+                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes)>{
   let summary = "XDLOPS GEMM V2";
   let description = [{
     The `miopen.xdlops_gemm_v2` op is an abstraction of doing GEMM based on XDLOPS.

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -743,10 +743,10 @@ def MIOpen_BlockwiseGemmV2Op:
     not slices of a larger object.
   }];
   let assemblyFormat = [{
-    $matrixC `+` `` `=` $bufferA `by` $matrixA `[` $waveOffsetA `]` `*`
-                        $bufferB `by` $matrixB `[` $waveOffsetB `]` attr-dict
-    `:` type($matrixC) `+` `` `=` type($bufferA) `by` type($matrixA) `*` 
-                                  type($bufferB) `by` type($matrixB)
+    $matrixC `+` `` `=` $bufferA `from` $matrixA `[` $waveOffsetA `]` `*`
+                        $bufferB `from` $matrixB `[` $waveOffsetB `]` attr-dict
+    `:` type($matrixC) `+` `` `=` type($bufferA) `from` type($matrixA) `*` 
+                                  type($bufferB) `from` type($matrixB)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -743,7 +743,10 @@ def MIOpen_BlockwiseGemmV2Op:
     not slices of a larger object.
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type(operands)
+    $matrixC `+` `` `=` $bufferA `by` $matrixA `[` $waveOffsetA `]` `*`
+                        $bufferB `by` $matrixB `[` $waveOffsetB `]` attr-dict
+    `:` type($matrixC) `+` `` `=` type($bufferA) `by` type($matrixA) `*` 
+                                  type($bufferB) `by` type($matrixB)
   }];
 }
 
@@ -772,20 +775,16 @@ def MIOpen_ThreadwiseGemmOp:
 // xdlops_gemm_V2
 def MIOpen_XdlopsGemmV2Op:
     MIOpen_Op<"xdlops_gemm_v2">,
-    Arguments<(ins MemRefOf<[F32, F16, BF16, I8]>:$matrixA,
-                   MemRefOf<[F32, F16, BF16, I8]>:$matrixB,
-                   IndexAttr:$ldsBufferOffsetA,
-                   IndexAttr:$ldsBufferOffsetB,
-                   IndexAttr:$regOffsetA,
+    Arguments<(ins IndexAttr:$regOffsetA,
                    IndexAttr:$regOffsetB,
                    MemRefOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferA,
+                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$matrixA,
                    MemRefOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
+                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$matrixB,
                    MemRefOf<[F32, F16, BF16, I32,
                              VectorOf<[F32, F16, BF16, I32]>]>:$matrixC)>{
   let summary = "XDLOPS GEMM V2";
@@ -796,7 +795,9 @@ def MIOpen_XdlopsGemmV2Op:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type(operands)
+    $matrixC `+` `` `=` $matrixA `[` $regOffsetA `]` `*` 
+                        $matrixB  `[` $regOffsetB `]` attr-dict
+    `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -730,6 +730,7 @@ def MIOpen_BlockwiseGemmV2Op:
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
                              VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
+                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes,
                    Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
     Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>: $vectorDs)> {
   let summary = "Blockwise GEMM XDLOPS version";
@@ -775,8 +776,8 @@ def MIOpen_XdlopsGemmV2Op:
                    MemRefOf<[F32, F16, BF16, I8]>:$matrixB,
                    IndexAttr:$ldsBufferOffsetA,
                    IndexAttr:$ldsBufferOffsetB,
-                   Index:$regOffsetA,
-                   Index:$regOffsetB,
+                   IndexAttr:$regOffsetA,
+                   IndexAttr:$regOffsetB,
                    MemRefOf<[F32, F16, BF16, I8,
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
@@ -785,6 +786,7 @@ def MIOpen_XdlopsGemmV2Op:
                              VectorOfLengthAndType<[2, 4], [F32]>,
                              VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
                              VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$bufferB,
+                   MemRefOf<[F32, F16, BF16, I32]>:$matrixRes,
                    Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorCs)>,
     Results<(outs Variadic<VectorOfRankAndType<[1], [F32, F16, I32]>>:$vectorDs)> {
   let summary = "XDLOPS GEMM V2";

--- a/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -546,9 +546,9 @@ struct BlockwiseGemmV2RewritePattern
 
       auto xdlopsGemmV2Op = b.replaceOpWithNewOp<XdlopsGemmV2Op>(
           op, resultTypes, adaptor.matrixA(), adaptor.matrixB(),
-          op.ldsBufferOffsetA(), op.ldsBufferOffsetB(), zeroConstantOp,
-          zeroConstantOp, adaptor.bufferA(), adaptor.bufferB(),
-          adaptor.vectorCs());
+          op.ldsBufferOffsetAAttr(), op.ldsBufferOffsetBAttr(),
+          b.getIndexAttr(0), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixRes(), adaptor.vectorCs());
 
       xdlopsGemmV2Op->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op->setAttr("n", op->getAttr("n"));
@@ -570,8 +570,9 @@ struct BlockwiseGemmV2RewritePattern
 
       auto xdlopsGemmV2Op0 = b.create<XdlopsGemmV2Op>(
           loc, resultTypes0, adaptor.matrixA(), adaptor.matrixB(),
-          op.ldsBufferOffsetA(), op.ldsBufferOffsetB(), zeroConstantOp,
-          zeroConstantOp, adaptor.bufferA(), adaptor.bufferB(),
+          op.ldsBufferOffsetAAttr(), op.ldsBufferOffsetBAttr(),
+          b.getIndexAttr(0), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixRes(),
           adaptor.vectorCs().take_front(2));
 
       xdlopsGemmV2Op0->setAttr("m", op->getAttr("m"));
@@ -590,8 +591,9 @@ struct BlockwiseGemmV2RewritePattern
 
       auto xdlopsGemmV2Op1 = b.create<XdlopsGemmV2Op>(
           loc, resultTypes1, adaptor.matrixA(), adaptor.matrixB(),
-          op.ldsBufferOffsetA(), op.ldsBufferOffsetB(), KPerBlockConstantOp,
-          zeroConstantOp, adaptor.bufferA(), adaptor.bufferB(),
+          op.ldsBufferOffsetAAttr(), op.ldsBufferOffsetBAttr(),
+          b.getIndexAttr(KPerThread), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixRes(),
           adaptor.vectorCs().drop_front(2));
 
       xdlopsGemmV2Op1->setAttr("m", op->getAttr("m"));
@@ -621,8 +623,9 @@ struct BlockwiseGemmV2RewritePattern
 
       auto xdlopsGemmV2Op0 = b.create<XdlopsGemmV2Op>(
           loc, resultTypes0, adaptor.matrixA(), adaptor.matrixB(),
-          op.ldsBufferOffsetA(), op.ldsBufferOffsetB(), zeroConstantOp,
-          zeroConstantOp, adaptor.bufferA(), adaptor.bufferB(),
+          op.ldsBufferOffsetAAttr(), op.ldsBufferOffsetBAttr(),
+          b.getIndexAttr(0), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixRes(),
           adaptor.vectorCs().take_front(2));
 
       xdlopsGemmV2Op0->setAttr("m", op->getAttr("m"));
@@ -641,8 +644,9 @@ struct BlockwiseGemmV2RewritePattern
 
       auto xdlopsGemmV2Op1 = b.create<XdlopsGemmV2Op>(
           loc, resultTypes1, adaptor.matrixA(), adaptor.matrixB(),
-          op.ldsBufferOffsetA(), op.ldsBufferOffsetB(), zeroConstantOp,
-          KPerBlockConstantOp, adaptor.bufferA(), adaptor.bufferB(),
+          op.ldsBufferOffsetAAttr(), op.ldsBufferOffsetBAttr(),
+          b.getIndexAttr(0), b.getIndexAttr(KPerThread), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixRes(),
           adaptor.vectorCs().drop_front(2));
 
       xdlopsGemmV2Op1->setAttr("m", op->getAttr("m"));

--- a/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -538,9 +538,8 @@ struct BlockwiseGemmV2RewritePattern
 
     if (MRepeats == 1 && NRepeats == 1) {
       auto xdlopsGemmV2Op = b.create<XdlopsGemmV2Op>(
-          loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
-          op.ldsBufferOffsetBAttr(), b.getIndexAttr(0), b.getIndexAttr(0),
-          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixC());
+          loc, b.getIndexAttr(0), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op->setAttr("n", op->getAttr("n"));
@@ -559,9 +558,8 @@ struct BlockwiseGemmV2RewritePattern
       // p_a_block + MPerXdlops, p_b_block, p_c_thread.s.y.l);
 
       auto xdlopsGemmV2Op0 = b.create<XdlopsGemmV2Op>(
-          loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
-          op.ldsBufferOffsetBAttr(), b.getIndexAttr(0), b.getIndexAttr(0),
-          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixC());
+          loc, b.getIndexAttr(0), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op0->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op0->setAttr("n", op->getAttr("n"));
@@ -574,10 +572,8 @@ struct BlockwiseGemmV2RewritePattern
         xdlopsGemmV2Op0->setAttr("kpack", op->getAttr("kpack"));
 
       auto xdlopsGemmV2Op1 = b.create<XdlopsGemmV2Op>(
-          loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
-          op.ldsBufferOffsetBAttr(), b.getIndexAttr(KPerThread),
-          b.getIndexAttr(0), adaptor.bufferA(), adaptor.bufferB(),
-          adaptor.matrixC());
+          loc, b.getIndexAttr(KPerThread), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op1->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op1->setAttr("n", op->getAttr("n"));
@@ -598,9 +594,8 @@ struct BlockwiseGemmV2RewritePattern
       // p_a_block, p_b_block + NPerXdlops, p_c_thread.s.y.l);
 
       auto xdlopsGemmV2Op0 = b.create<XdlopsGemmV2Op>(
-          loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
-          op.ldsBufferOffsetBAttr(), b.getIndexAttr(0), b.getIndexAttr(0),
-          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixC());
+          loc, b.getIndexAttr(0), b.getIndexAttr(0), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op0->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op0->setAttr("n", op->getAttr("n"));
@@ -613,10 +608,8 @@ struct BlockwiseGemmV2RewritePattern
         xdlopsGemmV2Op0->setAttr("kpack", op->getAttr("kpack"));
 
       auto xdlopsGemmV2Op1 = b.create<XdlopsGemmV2Op>(
-          loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
-          op.ldsBufferOffsetBAttr(), b.getIndexAttr(0),
-          b.getIndexAttr(KPerThread), adaptor.bufferA(), adaptor.bufferB(),
-          adaptor.matrixC());
+          loc, b.getIndexAttr(0), b.getIndexAttr(KPerThread), adaptor.bufferA(),
+          adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op1->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op1->setAttr("n", op->getAttr("n"));

--- a/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -540,7 +540,7 @@ struct BlockwiseGemmV2RewritePattern
       auto xdlopsGemmV2Op = b.create<XdlopsGemmV2Op>(
           loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
           op.ldsBufferOffsetBAttr(), b.getIndexAttr(0), b.getIndexAttr(0),
-          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixRes());
+          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op->setAttr("n", op->getAttr("n"));
@@ -561,7 +561,7 @@ struct BlockwiseGemmV2RewritePattern
       auto xdlopsGemmV2Op0 = b.create<XdlopsGemmV2Op>(
           loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
           op.ldsBufferOffsetBAttr(), b.getIndexAttr(0), b.getIndexAttr(0),
-          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixRes());
+          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op0->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op0->setAttr("n", op->getAttr("n"));
@@ -577,7 +577,7 @@ struct BlockwiseGemmV2RewritePattern
           loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
           op.ldsBufferOffsetBAttr(), b.getIndexAttr(KPerThread),
           b.getIndexAttr(0), adaptor.bufferA(), adaptor.bufferB(),
-          adaptor.matrixRes());
+          adaptor.matrixC());
 
       xdlopsGemmV2Op1->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op1->setAttr("n", op->getAttr("n"));
@@ -600,7 +600,7 @@ struct BlockwiseGemmV2RewritePattern
       auto xdlopsGemmV2Op0 = b.create<XdlopsGemmV2Op>(
           loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
           op.ldsBufferOffsetBAttr(), b.getIndexAttr(0), b.getIndexAttr(0),
-          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixRes());
+          adaptor.bufferA(), adaptor.bufferB(), adaptor.matrixC());
 
       xdlopsGemmV2Op0->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op0->setAttr("n", op->getAttr("n"));
@@ -616,7 +616,7 @@ struct BlockwiseGemmV2RewritePattern
           loc, adaptor.matrixA(), adaptor.matrixB(), op.ldsBufferOffsetAAttr(),
           op.ldsBufferOffsetBAttr(), b.getIndexAttr(0),
           b.getIndexAttr(KPerThread), adaptor.bufferA(), adaptor.bufferB(),
-          adaptor.matrixRes());
+          adaptor.matrixC());
 
       xdlopsGemmV2Op1->setAttr("m", op->getAttr("m"));
       xdlopsGemmV2Op1->setAttr("n", op->getAttr("n"));

--- a/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
@@ -5,7 +5,7 @@ func.func @miopen_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
                                                 %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK:  miopen.xdlops_gemm_v2
-  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
+  miopen.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
     block_size = 256 : i32,
     k = 2 : i32,
     kpack = 2 : i32,
@@ -17,7 +17,7 @@ func.func @miopen_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
     n_waves = 2 : i32,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 512 : index
-  } : memref<1024xf32, 3>, memref<1024xf32, 3>, index, index, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, memref<2xvector<32xf32>, 5>
+  } : memref<2xvector<32xf32>, 5> += memref<2xvector<2xf32>, 5> from memref<1024xf32, 3> * memref<2xvector<2xf32>, 5> from memref<1024xf32, 3>
   return
 }
 
@@ -26,7 +26,7 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>,
                                                %matrixC : memref<1xvector<16xi32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK:  miopen.xdlops_gemm_v2
-  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
+  miopen.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
     block_size = 256 : i32,
     k = 2 : i32,
     kpack = 8 : i32,
@@ -38,6 +38,6 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>,
     n_waves = 2 : i32,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 1024 : index
-  } : memref<2048xi8, 3>, memref<2048xi8, 3>, index, index, memref<2xvector<4xi8>, 5>, memref<2xvector<4xi8>, 5>, memref<1xvector<16xi32>, 5>
+  } : memref<1xvector<16xi32>, 5> += memref<2xvector<4xi8>, 5> from memref<2048xi8, 3> * memref<2xvector<4xi8>, 5> from memref<2048xi8, 3>
   return
 }

--- a/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
@@ -1,12 +1,11 @@
 // RUN: miopen-opt -miopen-blockwise-gemm-to-threadwise %s | FileCheck %s
 
-func.func @miopen_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>, %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>) -> (vector<32xf32>, vector<32xf32>) {
+func.func @miopen_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>, 
+                                                %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>, 
+                                                %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f32
-  %vectorC0 = vector.splat %c0f : vector<32xf32>
-  %vectorC1 = vector.splat %c0f : vector<32xf32>
   // CHECK:  miopen.xdlops_gemm_v2
-  %vectorD0, %vectorD1 = miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0, %vectorC1) {
+  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
     block_size = 256 : i32,
     k = 2 : i32,
     kpack = 2 : i32,
@@ -18,16 +17,16 @@ func.func @miopen_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>, %
     n_waves = 2 : i32,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 512 : index
-  } : memref<1024xf32, 3>, memref<1024xf32, 3>, index, index, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, vector<32xf32>, vector<32xf32> -> vector<32xf32>, vector<32xf32>
-  return %vectorD0, %vectorD1 : vector<32xf32>, vector<32xf32>
+  } : memref<1024xf32, 3>, memref<1024xf32, 3>, index, index, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, memref<2xvector<32xf32>, 5>
+  return
 }
 
-func.func @miopen_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>, %bufferA : memref<2xvector<4xi8>, 5>, %bufferB : memref<2xvector<4xi8>, 5>) -> (vector<16xi32>) {
+func.func @miopen_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>, 
+                                               %bufferA : memref<2xvector<4xi8>, 5>, %bufferB : memref<2xvector<4xi8>, 5>, 
+                                               %matrixC : memref<1xvector<16xi32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0i = arith.constant 0 : i32
-  %vectorC0 = vector.splat %c0i : vector<16xi32>
   // CHECK:  miopen.xdlops_gemm_v2
-  %vectorD0 = miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
     block_size = 256 : i32,
     k = 2 : i32,
     kpack = 8 : i32,
@@ -39,6 +38,6 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>, %bu
     n_waves = 2 : i32,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 1024 : index
-  } : memref<2048xi8, 3>, memref<2048xi8, 3>, index, index, memref<2xvector<4xi8>, 5>, memref<2xvector<4xi8>, 5>, vector<16xi32> -> vector<16xi32>
-  return %vectorD0 : vector<16xi32>
+  } : memref<2048xi8, 3>, memref<2048xi8, 3>, index, index, memref<2xvector<4xi8>, 5>, memref<2xvector<4xi8>, 5>, memref<1xvector<16xi32>, 5>
+  return
 }

--- a/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
@@ -1,35 +1,31 @@
 // RUN: miopen-opt -miopen-threadwise-gemm-lowering %s | FileCheck %s
 
-func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32, 3>, 
-                                                      %bufferA : memref<8xf32, 5>, %bufferB : memref<8xf32, 5>, 
+func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrixA : memref<8xf32, 5>, 
+                                                      %matrixB : memref<8xf32, 5>, 
                                                       %matrixC : memref<1xvector<32xf32>, 5>) {
   // CHECK: memref.load 
   // CHECK: memref.load 
   // CHECK: amdgpu.mfma
-  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
      k = 8 : i32, 
      kpack = 1 : i32, 
-     ldsBufferOffsetA = 0 : index, 
-     ldsBufferOffsetB = 1024 : index, 
      m = 128 : i32, 
      m_per_wave = 64 : i32, 
      n = 64 : i32, 
-     n_per_wave = 32 : i32,
-     regOffsetA = 0 : index,
-     regOffsetB = 0 : index
-     } : memref<1536xf32, 3>, memref<1536xf32, 3>, memref<8xf32, 5>, memref<8xf32, 5>, memref<1xvector<32xf32>, 5>
+     n_per_wave = 32 : i32
+     } : memref<1xvector<32xf32>, 5> += memref<8xf32, 5> * memref<8xf32, 5>
   return
 }
 
-func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrix : memref<1024xf32, 3>, 
-                                                    %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>,
+func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrixA : memref<2xvector<2xf32>, 5>, 
+                                                    %matrixB : memref<2xvector<2xf32>, 5>,
                                                     %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK: miopen.extract_slice
   // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK: amdgpu.mfma
-  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
     block_size = 256 : i32,
     k = 2 : i32,
     kpack = 2 : i32,
@@ -38,24 +34,20 @@ func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrix : memref<1024xf32, 3
     m_waves = 2 : i32,
     n = 128 : i32,
     n_per_wave = 64 : i32,
-    n_waves = 2 : i32,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 512 : index,
-    regOffsetA = 0 : index,
-    regOffsetB = 0 : index
-  } : memref<1024xf32, 3>, memref<1024xf32, 3>, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, memref<2xvector<32xf32>, 5>
+    n_waves = 2 : i32
+  } : memref<2xvector<32xf32>, 5> += memref<2xvector<2xf32>, 5> * memref<2xvector<2xf32>, 5>
   return
 }
 
-func.func @miopen_xdlops_gemm_v2_reduction_kpack(%matrix : memref<2048xi8, 3>, 
-                                                 %bufferA : memref<2xvector<8xi8>, 5>, %bufferB : memref<2xvector<8xi8>, 5>, 
+func.func @miopen_xdlops_gemm_v2_reduction_kpack(%matrixA : memref<2xvector<8xi8>, 5>, 
+                                                 %matrixB : memref<2xvector<8xi8>, 5>, 
                                                  %matrixC : memref<1xvector<16xi32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK: miopen.extract_slice
   // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK-NOT: amdgpu.mfma
-  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
     block_size = 256 : i32, // m_waves * n_waves * 64
     k = 4 : i32,
     kpack = 8 : i32,
@@ -64,11 +56,7 @@ func.func @miopen_xdlops_gemm_v2_reduction_kpack(%matrix : memref<2048xi8, 3>,
     m = 64 : i32, // m_waves * m/wave
     n = 64 : i32, // n_waves * n/wave
     m_waves = 2 : i32,
-    n_waves = 2 : i32,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 1024 : index,
-    regOffsetA = 0 : index,
-    regOffsetB = 0 : index
-  } : memref<2048xi8, 3>, memref<2048xi8, 3>, memref<2xvector<8xi8>, 5>, memref<2xvector<8xi8>, 5>, memref<1xvector<16xi32>, 5> 
+    n_waves = 2 : i32
+  } : memref<1xvector<16xi32>, 5> += memref<2xvector<8xi8>, 5> * memref<2xvector<8xi8>, 5>
   return
 }

--- a/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
@@ -1,10 +1,12 @@
 // RUN: miopen-opt -miopen-threadwise-gemm-lowering %s | FileCheck %s
 
-func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32, 3>, %bufferA : memref<8xf32, 5>, %bufferB : memref<8xf32, 5>, %bufferC : memref<32xf32, 5>) {
+func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32, 3>, 
+                                                      %bufferA : memref<8xf32, 5>, %bufferB : memref<8xf32, 5>, 
+                                                      %matrixC : memref<1xvector<32xf32>, 5>) {
   // CHECK: memref.load 
   // CHECK: memref.load 
   // CHECK: amdgpu.mfma
-  miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %bufferC) {
+  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
      k = 8 : i32, 
      kpack = 1 : i32, 
      ldsBufferOffsetA = 0 : index, 
@@ -12,20 +14,22 @@ func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32,
      m = 128 : i32, 
      m_per_wave = 64 : i32, 
      n = 64 : i32, 
-     n_per_wave = 32 : i32
-     } : memref<1536xf32, 3>, memref<1536xf32, 3>, index, index, memref<8xf32, 5>, memref<8xf32, 5>, memref<32xf32, 5>
+     n_per_wave = 32 : i32,
+     regOffsetA = 0 : index,
+     regOffsetB = 0 : index
+     } : memref<1536xf32, 3>, memref<1536xf32, 3>, memref<8xf32, 5>, memref<8xf32, 5>, memref<1xvector<32xf32>, 5>
+  return
 }
 
-func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrix : memref<1024xf32, 3>, %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>) -> (vector<32xf32>, vector<32xf32>) {
+func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrix : memref<1024xf32, 3>, 
+                                                    %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>,
+                                                    %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f32
-  %vectorC0 = vector.splat %c0f : vector<32xf32>
-  %vectorC1 = vector.splat %c0f : vector<32xf32>
   // CHECK: miopen.extract_slice
   // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma
-  // CHECK-NEXT: amdgpu.mfma
-  %vectorD0, %vectorD1 = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0, %vectorC1) {
+  // CHECK: amdgpu.mfma
+  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
     block_size = 256 : i32,
     k = 2 : i32,
     kpack = 2 : i32,
@@ -36,20 +40,22 @@ func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrix : memref<1024xf32, 3
     n_per_wave = 64 : i32,
     n_waves = 2 : i32,
     ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 512 : index
-  } : memref<1024xf32, 3>, memref<1024xf32, 3>, index, index, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, vector<32xf32>, vector<32xf32> -> vector<32xf32>, vector<32xf32>
-  return %vectorD0, %vectorD1 : vector<32xf32>, vector<32xf32>
+    ldsBufferOffsetB = 512 : index,
+    regOffsetA = 0 : index,
+    regOffsetB = 0 : index
+  } : memref<1024xf32, 3>, memref<1024xf32, 3>, memref<2xvector<2xf32>, 5>, memref<2xvector<2xf32>, 5>, memref<2xvector<32xf32>, 5>
+  return
 }
 
-func.func @miopen_xdlops_gemm_v2_reduction_kpack(%matrix : memref<2048xi8, 3>, %bufferA : memref<2xvector<8xi8>, 5>, %bufferB : memref<2xvector<8xi8>, 5>) -> vector<16xi32> {
+func.func @miopen_xdlops_gemm_v2_reduction_kpack(%matrix : memref<2048xi8, 3>, 
+                                                 %bufferA : memref<2xvector<8xi8>, 5>, %bufferB : memref<2xvector<8xi8>, 5>, 
+                                                 %matrixC : memref<1xvector<16xi32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0i = arith.constant 0 : i32
-  %vectorC0 = vector.splat %c0i : vector<16xi32>
   // CHECK: miopen.extract_slice
   // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK-NOT: amdgpu.mfma
-  %vectorD0 = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
     block_size = 256 : i32, // m_waves * n_waves * 64
     k = 4 : i32,
     kpack = 8 : i32,
@@ -60,7 +66,9 @@ func.func @miopen_xdlops_gemm_v2_reduction_kpack(%matrix : memref<2048xi8, 3>, %
     m_waves = 2 : i32,
     n_waves = 2 : i32,
     ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 1024 : index
-  } : memref<2048xi8, 3>, memref<2048xi8, 3>, index, index, memref<2xvector<8xi8>, 5>, memref<2xvector<8xi8>, 5>, vector<16xi32> -> vector<16xi32>
-  return %vectorD0 : vector<16xi32>
+    ldsBufferOffsetB = 1024 : index,
+    regOffsetA = 0 : index,
+    regOffsetB = 0 : index
+  } : memref<2048xi8, 3>, memref<2048xi8, 3>, memref<2xvector<8xi8>, 5>, memref<2xvector<8xi8>, 5>, memref<1xvector<16xi32>, 5> 
+  return
 }

--- a/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
@@ -1,13 +1,10 @@
 // RUN: miopen-opt -miopen-threadwise-gemm-lowering %s | FileCheck %s
 
-func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32, 3>, %bufferA : memref<8xf32, 5>, %bufferB : memref<8xf32, 5>) -> (vector<32xf32>) {
-  %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f32
-  %vectorC = vector.splat %c0f : vector<32xf32>
+func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32, 3>, %bufferA : memref<8xf32, 5>, %bufferB : memref<8xf32, 5>, %bufferC : memref<32xf32, 5>) {
   // CHECK: memref.load 
   // CHECK: memref.load 
   // CHECK: amdgpu.mfma
-   %vectorD = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC) {
+  miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %bufferC) {
      k = 8 : i32, 
      kpack = 1 : i32, 
      ldsBufferOffsetA = 0 : index, 
@@ -16,8 +13,7 @@ func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrix : memref<1536xf32,
      m_per_wave = 64 : i32, 
      n = 64 : i32, 
      n_per_wave = 32 : i32
-     } : memref<1536xf32, 3>, memref<1536xf32, 3>, index, index, memref<8xf32, 5>, memref<8xf32, 5>, vector<32xf32> -> vector<32xf32>
-  return %vectorD : vector<32xf32>
+     } : memref<1536xf32, 3>, memref<1536xf32, 3>, index, index, memref<8xf32, 5>, memref<8xf32, 5>, memref<32xf32, 5>
 }
 
 func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrix : memref<1024xf32, 3>, %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>) -> (vector<32xf32>, vector<32xf32>) {

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -473,21 +473,17 @@ func.func @miopen_threadwise_gemm(%lhs : memref<4x8x1xf32, 5>, %rhs : memref<4x8
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
-                                            %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
+func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<32xf32, 5>, 
+                                            %matrixB : memref<16xf32, 5>,
                                             %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2(%matrixA, %matrixB, %bufferA, %bufferB, %matrixC) {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
-    n_per_wave = 64,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index,
-    regOffsetA = 0 : index,
-    regOffsetB = 0 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, memref<32xf32, 5>, memref<16xf32, 5>, memref<1xvector<32xf32>, 5>
+    n_per_wave = 64
+  } : memref<1xvector<32xf32>, 5> += memref<32xf32, 5> * memref<16xf32, 5>
   return
 }
 
@@ -496,21 +492,17 @@ func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, %ma
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
-                                            %bufferA : memref<32xf32, 5>, %bufferB: memref<16xf32, 5>,
-                                            %matrixC : memref<2xvector<32xf32>, 5>) {
+func.func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<32xf32, 5>, 
+                                             %matrixB : memref<16xf32, 5>,
+                                             %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2(%matrixA, %matrixB, %bufferA, %bufferB, %matrixC) {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
-    n_per_wave = 64,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index,
-    regOffsetA = 0 : index,
-    regOffsetB = 0 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, memref<32xf32, 5>, memref<16xf32, 5>, memref<2xvector<32xf32>, 5>
+    n_per_wave = 64
+  } : memref<2xvector<32xf32>, 5> += memref<32xf32, 5> * memref<16xf32, 5>
   return
 }
 
@@ -523,7 +515,7 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, 
                                               %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
                                               %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.blockwise_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %matrixC) {
+  miopen.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
     m = 256,
     n = 256,
     k = 16,
@@ -531,7 +523,7 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, 
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 0 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, memref<1xvector<32xf32>, 5>
+  } : memref<1xvector<32xf32>, 5> += memref<32xf32, 5> from memref<12288xf32, 3> * memref<16xf32, 5> from memref<12288xf32, 3>
   return
 }
 
@@ -544,7 +536,7 @@ func.func @miopen_blockwise_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>,
                                                 %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
                                                 %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.blockwise_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %matrixC) {
+  miopen.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
     m = 256,
     n = 256,
     k = 16,
@@ -552,7 +544,7 @@ func.func @miopen_blockwise_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>,
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, memref<2xvector<32xf32>, 5>
+  } : memref<2xvector<32xf32>, 5> += memref<32xf32, 5> from memref<12288xf32, 3> * memref<16xf32, 5> from memref<12288xf32, 3>
   return
 }
 

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -474,20 +474,21 @@ func.func @miopen_threadwise_gemm(%lhs : memref<4x8x1xf32, 5>, %rhs : memref<4x8
 // ----
 
 func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
-                                       %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>) -> vector<32xf32> {
+                                            %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
+                                            %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f32
-  %vectorC0 = vector.splat %c0f : vector<32xf32>
-  %vectorD0 = miopen.xdlops_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+  miopen.xdlops_gemm_v2(%matrixA, %matrixB, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, vector<32xf32> -> vector<32xf32>
-  return %vectorD0 : vector<32xf32>
+    ldsBufferOffsetB = 8192 : index,
+    regOffsetA = 0 : index,
+    regOffsetB = 0 : index
+  } : memref<12288xf32, 3>, memref<12288xf32, 3>, memref<32xf32, 5>, memref<16xf32, 5>, memref<1xvector<32xf32>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_xdlops_gemm_v2_one_result
@@ -496,21 +497,21 @@ func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, %ma
 // ----
 
 func.func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
-                                        %bufferA : memref<32xf32, 5>, %bufferB: memref<16xf32, 5>) -> (vector<32xf32>, vector<32xf32>) {
+                                            %bufferA : memref<32xf32, 5>, %bufferB: memref<16xf32, 5>,
+                                            %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f32
-  %vectorC0 = vector.splat %c0f : vector<32xf32>
-  %vectorC1 = vector.splat %c0f : vector<32xf32>
-  %vectorD0, %vectorD1 = miopen.xdlops_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %vectorC0, %vectorC1) {
+  miopen.xdlops_gemm_v2(%matrixA, %matrixB, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, vector<32xf32>, vector<32xf32> -> vector<32xf32>, vector<32xf32>
-  return %vectorD0, %vectorD1 : vector<32xf32>, vector<32xf32>
+    ldsBufferOffsetB = 8192 : index,
+    regOffsetA = 0 : index,
+    regOffsetB = 0 : index
+  } : memref<12288xf32, 3>, memref<12288xf32, 3>, memref<32xf32, 5>, memref<16xf32, 5>, memref<2xvector<32xf32>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_xdlops_gemm_v2_two_results
@@ -519,11 +520,10 @@ func.func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>, %m
 // ----
 
 func.func @miopen_blockwise_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
-                                          %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>) -> vector<32xf32> {
+                                              %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
+                                              %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f32
-  %vectorC0 = vector.splat %c0f : vector<32xf32>
-  %vectorD0 = miopen.blockwise_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+  miopen.blockwise_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
@@ -531,8 +531,8 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, 
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 0 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, vector<32xf32> -> vector<32xf32>
-  return %vectorD0 : vector<32xf32>
+  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, memref<1xvector<32xf32>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_blockwise_gemm_v2_one_result
@@ -541,12 +541,10 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, 
 // ----
 
 func.func @miopen_blockwise_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
-                                           %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>) -> (vector<32xf32>, vector<32xf32>) {
+                                                %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
+                                                %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f32
-  %vectorC0 = vector.splat %c0f : vector<32xf32>
-  %vectorC1 = vector.splat %c0f : vector<32xf32>
-  %vectorD0, %vectorD1 = miopen.blockwise_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %vectorC0, %vectorC1) {
+  miopen.blockwise_gemm_v2(%matrixA, %matrixB, %c0, %c0, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
@@ -554,8 +552,8 @@ func.func @miopen_blockwise_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>,
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, vector<32xf32>, vector<32xf32> -> vector<32xf32>, vector<32xf32>
-  return %vectorD0, %vectorD1 : vector<32xf32>, vector<32xf32>
+  } : memref<12288xf32, 3>, memref<12288xf32, 3>, index, index, memref<32xf32, 5>, memref<16xf32, 5>, memref<2xvector<32xf32>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_blockwise_gemm_v2_two_results

--- a/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
@@ -20,21 +20,17 @@ func.func @miopen_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
-                                           %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>, 
-                                           %matrixC : memref<1xvector<32xf16>, 5>) {
+func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrixA : memref<32xf16, 5>, 
+                                                %matrixB : memref<16xf16, 5>, 
+                                                %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
-    n_per_wave = 64,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index,
-    regOffsetA = 0 : index,
-    regOffsetB = 0 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, memref<32xf16, 5>, memref<16xf16, 5>, memref<1xvector<32xf16>, 5>
+    n_per_wave = 64
+  } : memref<1xvector<32xf16>, 5> += memref<32xf16, 5> * memref<16xf16, 5>
   return
 }
 
@@ -43,21 +39,17 @@ func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 3>,
-                                            %bufferA : memref<32xf16, 5>, %bufferB: memref<16xf16, 5>,
-                                            %matrixC : memref<1xvector<32xf16>, 5>) {
+func.func @miopen_xdlops_gemm_v2_two_results_f16(%matrixA : memref<32xf16, 5>, 
+                                                 %matrixB: memref<16xf16, 5>,
+                                                 %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
-    n_per_wave = 64,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index,
-    regOffsetA = 0 : index,
-    regOffsetB = 0 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, memref<32xf16, 5>, memref<16xf16, 5>, memref<1xvector<32xf16>, 5>
+    n_per_wave = 64
+  } : memref<1xvector<32xf16>, 5> += memref<32xf16, 5> * memref<16xf16, 5>
   return
 }
 
@@ -71,7 +63,7 @@ func.func @miopen_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3
                                           %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
   %c0f = arith.constant 0.0 : f16
-  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
+  miopen.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
     m = 256,
     n = 256,
     k = 16,
@@ -79,7 +71,7 @@ func.func @miopen_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, memref<1xvector<32xf16>, 5>
+  } : memref<1xvector<32xf16>, 5> +=  memref<32xf16, 5> from memref<12288xf16, 3> * memref<16xf16, 5> from memref<12288xf16, 3>
   return
 }
 
@@ -92,7 +84,7 @@ func.func @miopen_blockwise_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 
                                                %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>,
                                                %matrixC : memref<2xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
+  miopen.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
     m = 256,
     n = 256,
     k = 16,
@@ -100,7 +92,7 @@ func.func @miopen_blockwise_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, memref<2xvector<32xf16>, 5>
+  } : memref<2xvector<32xf16>, 5> += memref<32xf16, 5> from memref<12288xf16, 3> * memref<16xf16, 5> from memref<12288xf16, 3>
   return
 }
 

--- a/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
@@ -21,20 +21,21 @@ func.func @miopen_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x
 // ----
 
 func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
-                                       %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>) -> vector<32xf16> {
+                                           %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>, 
+                                           %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f16
-  %vectorC0 = vector.splat %c0f : vector<32xf16>
-  %vectorD0 = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, vector<32xf16> -> vector<32xf16>
-  return %vectorD0 : vector<32xf16>
+    ldsBufferOffsetB = 8192 : index,
+    regOffsetA = 0 : index,
+    regOffsetB = 0 : index
+  } : memref<12288xf16, 3>, memref<12288xf16, 3>, memref<32xf16, 5>, memref<16xf16, 5>, memref<1xvector<32xf16>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_xdlops_gemm_v2_one_result_f16
@@ -43,21 +44,21 @@ func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
 // ----
 
 func.func @miopen_xdlops_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 3>,
-                                        %bufferA : memref<32xf16, 5>, %bufferB: memref<16xf16, 5>) -> (vector<32xf16>, vector<32xf16>) {
+                                            %bufferA : memref<32xf16, 5>, %bufferB: memref<16xf16, 5>,
+                                            %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f16
-  %vectorC0 = vector.splat %c0f : vector<32xf16>
-  %vectorC1 = vector.splat %c0f : vector<32xf16>
-  %vectorD0, %vectorD1 = miopen.xdlops_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0, %vectorC1) {
+  miopen.xdlops_gemm_v2(%matrix, %matrix, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
     m_per_wave = 128,
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, vector<32xf16>, vector<32xf16> -> vector<32xf16>, vector<32xf16>
-  return %vectorD0, %vectorD1 : vector<32xf16>, vector<32xf16>
+    ldsBufferOffsetB = 8192 : index,
+    regOffsetA = 0 : index,
+    regOffsetB = 0 : index
+  } : memref<12288xf16, 3>, memref<12288xf16, 3>, memref<32xf16, 5>, memref<16xf16, 5>, memref<1xvector<32xf16>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_xdlops_gemm_v2_two_results_f16
@@ -66,11 +67,11 @@ func.func @miopen_xdlops_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 3>,
 // ----
 
 func.func @miopen_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
-                                          %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>) -> vector<32xf16> {
+                                          %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>, 
+                                          %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
   %c0f = arith.constant 0.0 : f16
-  %vectorC0 = vector.splat %c0f : vector<32xf16>
-  %vectorD0 = miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0) {
+  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
@@ -78,8 +79,8 @@ func.func @miopen_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, vector<32xf16> -> vector<32xf16>
-  return %vectorD0 : vector<32xf16>
+  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, memref<1xvector<32xf16>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_blockwise_gemm_v2_one_result_f16
@@ -88,12 +89,10 @@ func.func @miopen_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3
 // ----
 
 func.func @miopen_blockwise_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 3>,
-                                           %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>) -> (vector<32xf16>, vector<32xf16>) {
+                                               %bufferA : memref<32xf16, 5>, %bufferB : memref<16xf16, 5>,
+                                               %matrixC : memref<2xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  %c0f = arith.constant 0.0 : f16
-  %vectorC0 = vector.splat %c0f : vector<32xf16>
-  %vectorC1 = vector.splat %c0f : vector<32xf16>
-  %vectorD0, %vectorD1 = miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %vectorC0, %vectorC1) {
+  miopen.blockwise_gemm_v2(%matrix, %matrix, %c0, %c0, %bufferA, %bufferB, %matrixC) {
     m = 256,
     n = 256,
     k = 16,
@@ -101,8 +100,8 @@ func.func @miopen_blockwise_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 
     n_per_wave = 64,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 8192 : index
-  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, vector<32xf16>, vector<32xf16> -> vector<32xf16>, vector<32xf16>
-  return %vectorD0, %vectorD1 : vector<32xf16>, vector<32xf16>
+  } : memref<12288xf16, 3>, memref<12288xf16, 3>, index, index, memref<32xf16, 5>, memref<16xf16, 5>, memref<2xvector<32xf16>, 5>
+  return
 }
 
 // CHECK-LABEL: func.func @miopen_blockwise_gemm_v2_two_results_f16


### PR DESCRIPTION
First commit:
 - Amended blockwisegemm and xdlopsgemm op signature to include return
 - Fixed xdlopsgemm out of bound access when kPack = 1 and k_base > 1
 - Moved xdlops register offset to attributes
 - Moved gridwisegemm allocation before blockwisegemm compuation

Second commit:
 - Replaced vectorC/D as memref in blockwise/xdlops gemm

Third commit: 
 - Added vectorC/D type conversion before write back

Forth commit
 - Amended memref of scalars to memref of vectors
 - Fixed the redundantly allocated vgpr in populated ISA

Fifth commit
 - Fixed all unit tests failures