### PR TITLE
Move the computation of the thread offset in LDS to blockwise_gemm

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -684,13 +684,13 @@ def MIOpen_BlockwiseGemmOp:
     Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [3]>:$matrixA,
                    MemRefRankOf<[F32, F16, BF16, I8], [3]>:$matrixB,
                    MemRefRankOf<[F32, F16, BF16, I32], [2]>:$matrixC,
-                   Index:$threadOffsetA,
-                   Index:$threadOffsetB,
                    IndexAttr:$kPerThread,
                    IndexAttr:$mPerThread,
                    IndexAttr:$nPerThread,
-                   IndexAttr:$mRepeatStride,
-                   IndexAttr:$nRepeatStride
+                   IndexAttr:$mThreadsPerCuwave,
+                   IndexAttr:$nThreadsPerCuwave,
+                   IndexAttr:$mCuwavesPerBlock,
+                   IndexAttr:$nCuwavesPerBlock
                    )> {
   let summary = "Blockwise GEMM non-XDLOPS version";
   let description = [{
@@ -706,8 +706,11 @@ def MIOpen_BlockwiseGemmOp:
     mRepeatStride elements later in the buffer.
   }];
   let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` type(operands)
+    $matrixC `+` `=` $matrixA `*` $matrixB attr-dict
+    `:` type($matrixC) `+` `=` type($matrixA) `*` type($matrixB)
   }];
+
+  let hasVerifier = 1;
 }
 
 // blockwise_gemm_v2

--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -706,8 +706,8 @@ def MIOpen_BlockwiseGemmOp:
     mRepeatStride elements later in the buffer.
   }];
   let assemblyFormat = [{
-    $matrixC `+` `=` $matrixA `*` $matrixB attr-dict
-    `:` type($matrixC) `+` `=` type($matrixA) `*` type($matrixB)
+    $matrixC `+` `` `=` $matrixA `*` $matrixB attr-dict
+    `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
 
   let hasVerifier = 1;

--- a/mlir/include/mlir/Dialect/MIOpen/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/MIOpen/TransformMapBuilder.h
@@ -33,6 +33,10 @@ class TransformMapBuilder {
 public:
   virtual ~TransformMapBuilder() = default;
 
+  TransformMapBuilder(const TransformMapBuilder &other);
+  TransformMapBuilder &operator=(const TransformMapBuilder &other);
+  TransformMapBuilder(TransformMapBuilder &&other);
+
   // Get the TransformsAttr that's being built up by the builder
   TransformMapAttr get();
   // Only valid after the transformation has been built.
@@ -65,9 +69,6 @@ public:
   void pad(StringRef outName, StringRef inName, int64_t left, int64_t right);
   void pad(ArrayRef<StringRef> outNames, ArrayRef<uint32_t> outDims,
            ArrayRef<StringRef> inNames, ArrayRef<int64_t> params);
-
-  TransformMapBuilder(const TransformMapBuilder &other) = default;
-  TransformMapBuilder &operator=(const TransformMapBuilder &other);
 
 protected:
   TransformMapBuilder(mlir::Builder &builder, ArrayRef<StringRef> startNames,

--- a/mlir/include/mlir/Dialect/MIOpen/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/MIOpen/TransformMapBuilder.h
@@ -34,8 +34,8 @@ public:
   virtual ~TransformMapBuilder() = default;
 
   TransformMapBuilder(const TransformMapBuilder &other);
+  TransformMapBuilder(TransformMapBuilder &&other) = delete;
   TransformMapBuilder &operator=(const TransformMapBuilder &other);
-  TransformMapBuilder(TransformMapBuilder &&other);
 
   // Get the TransformsAttr that's being built up by the builder
   TransformMapAttr get();

--- a/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Tuning/GridwiseGemmParams.h
@@ -128,10 +128,10 @@ template <typename T> std::string genDebugForParams(T params) {
 // block gemm tuning params that sepcific the layout of thread-wise gemm in a
 // workgroup
 struct DerivedBlockGemmParams {
-  int64_t gemmMLevel0Cluster;
-  int64_t gemmNLevel0Cluster;
-  int64_t gemmMLevel1Cluster;
-  int64_t gemmNLevel1Cluster;
+  int64_t gemmMThreadsPerCuwave;
+  int64_t gemmNThreadsPerCuwave;
+  int64_t gemmMCuwavesPerBlock;
+  int64_t gemmNCuwavesPerBlock;
 };
 
 class PopulateParams {

--- a/mlir/lib/Dialect/MIOpen/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/MIOpen/TransformMapBuilder.cpp
@@ -376,15 +376,41 @@ TransformMapBuilder::operator=(const TransformMapBuilder &other) {
     result = other.result;
     loc = other.loc;
 
-    startIndices = other.startIndices;
     startNames = other.startNames;
     startShape = other.startShape;
-    endIndices = other.endIndices;
     endNames = other.endNames;
     endShape = other.endShape;
     frozen = other.frozen;
+
+    startIndices.clear();
+    for (uint32_t i = 0, e = startNames.size(); i < e; ++i)
+      startIndices.insert({StringRef(startNames[i]), i});
+
+    endIndices.clear();
+    for (const auto &pair : endNames)
+      endIndices.insert({StringRef(pair.second), pair.first});
   }
   return *this;
+}
+
+TransformMapBuilder::TransformMapBuilder(const TransformMapBuilder &other)
+    : b(other.b), result(other.result), loc(other.loc), startIndices(),
+      startNames(other.startNames), startShape(other.startShape), endIndices(),
+      endNames(other.endNames), endShape(other.endShape), frozen(other.frozen) {
+  for (uint32_t i = 0, e = startNames.size(); i < e; ++i)
+    startIndices.insert({StringRef(startNames[i]), i});
+  for (const auto &pair : endNames)
+    endIndices.insert({StringRef(pair.second), pair.first});
+}
+
+TransformMapBuilder::TransformMapBuilder(TransformMapBuilder &&other)
+    : b(other.b), result(other.result), loc(other.loc), startIndices(),
+      startNames(other.startNames), startShape(other.startShape), endIndices(),
+      endNames(other.endNames), endShape(other.endShape), frozen(other.frozen) {
+  for (uint32_t i = 0, e = startNames.size(); i < e; ++i)
+    startIndices.insert({StringRef(startNames[i]), i});
+  for (const auto &pair : endNames)
+    endIndices.insert({StringRef(pair.second), pair.first});
 }
 
 /// Building from a defined set of upper dimensions

--- a/mlir/lib/Dialect/MIOpen/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/MIOpen/TransformMapBuilder.cpp
@@ -403,16 +403,6 @@ TransformMapBuilder::TransformMapBuilder(const TransformMapBuilder &other)
     endIndices.insert({StringRef(pair.second), pair.first});
 }
 
-TransformMapBuilder::TransformMapBuilder(TransformMapBuilder &&other)
-    : b(other.b), result(other.result), loc(other.loc), startIndices(),
-      startNames(other.startNames), startShape(other.startShape), endIndices(),
-      endNames(other.endNames), endShape(other.endShape), frozen(other.frozen) {
-  for (uint32_t i = 0, e = startNames.size(); i < e; ++i)
-    startIndices.insert({StringRef(startNames[i]), i});
-  for (const auto &pair : endNames)
-    endIndices.insert({StringRef(pair.second), pair.first});
-}
-
 /// Building from a defined set of upper dimensions
 void TopDownTMBuilder::addTransform(TransformType type,
                                     ArrayRef<int64_t> params,

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -326,14 +326,14 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
     // Hard coded parameters, will change in a different pass. Please visit
     // gridwise_convolution_implicit_gemm_v4r4_nchw_kcyx_nkhw for details
     op->setAttr("k_per_thread", b.getI32IntegerAttr(1));
-    op->setAttr("m_level0_cluster",
-                b.getI32IntegerAttr(blockGemmDerivedParam.gemmMLevel0Cluster));
-    op->setAttr("n_level0_cluster",
-                b.getI32IntegerAttr(blockGemmDerivedParam.gemmNLevel0Cluster));
-    op->setAttr("m_level1_cluster",
-                b.getI32IntegerAttr(blockGemmDerivedParam.gemmMLevel1Cluster));
-    op->setAttr("n_level1_cluster",
-                b.getI32IntegerAttr(blockGemmDerivedParam.gemmNLevel1Cluster));
+    op->setAttr("m_threads_per_cuwave",
+                b.getIndexAttr(blockGemmDerivedParam.gemmMThreadsPerCuwave));
+    op->setAttr("n_threads_per_cuwave",
+                b.getIndexAttr(blockGemmDerivedParam.gemmNThreadsPerCuwave));
+    op->setAttr("m_cuwaves_per_block",
+                b.getIndexAttr(blockGemmDerivedParam.gemmMCuwavesPerBlock));
+    op->setAttr("n_cuwaves_per_block",
+                b.getIndexAttr(blockGemmDerivedParam.gemmNCuwavesPerBlock));
 
     op->setAttr("matrix_c_data_per_copy",
                 b.getI32IntegerAttr(gemmCDerivedParam.dataPerCopy));

--- a/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -81,6 +81,8 @@ struct FillRewritePattern : public OpConversionPattern<FillOp> {
 // BlockwiseGemm lowering.
 //===----------------------------------------------------------------------===//
 
+// The structure of this lowing is documented at
+// https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/issues/719
 struct BlockwiseGemmRewritePattern
     : public OpConversionPattern<BlockwiseGemmOp> {
   using OpConversionPattern<BlockwiseGemmOp>::OpConversionPattern;

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
@@ -160,10 +160,12 @@ void affixGridwiseGemmAttributes(Operation *convOp, Operation *gop,
     gop->setAttr("m_per_thread", convOp->getAttr("m_per_thread"));
     gop->setAttr("n_per_thread", convOp->getAttr("n_per_thread"));
     gop->setAttr("k_per_thread", convOp->getAttr("k_per_thread"));
-    gop->setAttr("m_level0_cluster", convOp->getAttr("m_level0_cluster"));
-    gop->setAttr("m_level1_cluster", convOp->getAttr("m_level1_cluster"));
-    gop->setAttr("n_level0_cluster", convOp->getAttr("n_level0_cluster"));
-    gop->setAttr("n_level1_cluster", convOp->getAttr("n_level1_cluster"));
+    gop->setAttr("m_threads_per_cuwave",
+                 convOp->getAttr("m_threads_per_cuwave"));
+    gop->setAttr("m_cuwaves_per_block", convOp->getAttr("m_cuwaves_per_block"));
+    gop->setAttr("n_threads_per_cuwave",
+                 convOp->getAttr("n_threads_per_cuwave"));
+    gop->setAttr("n_cuwaves_per_block", convOp->getAttr("n_cuwaves_per_block"));
   }
 }
 

--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -516,26 +516,26 @@ LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
     const InitParamsNonXDL &param, const ConvolutionContext &ctx,
     DerivedBlockGemmParams &derived) {
 
-  derived.gemmMLevel0Cluster = 0;
-  derived.gemmNLevel0Cluster = 0;
-  derived.gemmMLevel1Cluster = 0;
-  derived.gemmNLevel1Cluster = 0;
+  derived.gemmMThreadsPerCuwave = 0;
+  derived.gemmNThreadsPerCuwave = 0;
+  derived.gemmMCuwavesPerBlock = 0;
+  derived.gemmNCuwavesPerBlock = 0;
 
   if (param.blockSize == 64) {
-    derived.gemmMLevel0Cluster = 4;
-    derived.gemmNLevel0Cluster = 4;
-    derived.gemmMLevel1Cluster = 2;
-    derived.gemmNLevel1Cluster = 2;
+    derived.gemmMThreadsPerCuwave = 4;
+    derived.gemmNThreadsPerCuwave = 4;
+    derived.gemmMCuwavesPerBlock = 2;
+    derived.gemmNCuwavesPerBlock = 2;
   } else if (param.blockSize == 128) {
-    derived.gemmMLevel0Cluster = 4;
-    derived.gemmNLevel0Cluster = 4;
-    derived.gemmMLevel1Cluster = 4;
-    derived.gemmNLevel1Cluster = 2;
+    derived.gemmMThreadsPerCuwave = 4;
+    derived.gemmNThreadsPerCuwave = 4;
+    derived.gemmMCuwavesPerBlock = 4;
+    derived.gemmNCuwavesPerBlock = 2;
   } else if (param.blockSize == 256) {
-    derived.gemmMLevel0Cluster = 4;
-    derived.gemmNLevel0Cluster = 4;
-    derived.gemmMLevel1Cluster = 4;
-    derived.gemmNLevel1Cluster = 4;
+    derived.gemmMThreadsPerCuwave = 4;
+    derived.gemmNThreadsPerCuwave = 4;
+    derived.gemmMCuwavesPerBlock = 4;
+    derived.gemmNCuwavesPerBlock = 4;
   } else {
     return failure();
   }
@@ -554,9 +554,9 @@ LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
   const auto threadGemmNPerBlock = param.gemmNPerBlock / param.gemmNPerThread;
 
   const auto threadGemmMPerCluster =
-      derived.gemmMLevel0Cluster * derived.gemmMLevel1Cluster;
+      derived.gemmMThreadsPerCuwave * derived.gemmMCuwavesPerBlock;
   const auto threadGemmNPerCluster =
-      derived.gemmNLevel0Cluster * derived.gemmNLevel1Cluster;
+      derived.gemmNThreadsPerCuwave * derived.gemmNCuwavesPerBlock;
 
   if (!(threadGemmMPerBlock % threadGemmMPerCluster == 0) &&
       (threadGemmNPerBlock % threadGemmNPerCluster == 0))

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -67,14 +67,15 @@ func.func @miopen_indexing() {
 //   CHECK-NEXT: miopen.workitem_id
 
 func.func @miopen_blockwise_gemm(%A : memref<8x128x1xf32, 3>, %B : memref<8x128x1xf32, 3>, %C : memref<8x8xf32, 5>) {
-  %c0 = arith.constant 0 : index
-  miopen.blockwise_gemm(%A, %B, %C, %c0, %c0) {
+  miopen.blockwise_gemm %C += %A * %B {
     kPerThread = 1 : index,
     mPerThread = 4 : index,
-    mRepeatStride = 64 : index,
+    mThreadsPerCuwave = 4 : index,
+    mCuwavesPerBlock = 4 : index,
     nPerThread = 4 : index,
-    nRepeatStride = 64 : index
-  } : memref<8x128x1xf32, 3>, memref<8x128x1xf32, 3>, memref<8x8xf32, 5>, index, index
+    nThreadsPerCuwave = 4 : index,
+    nCuwavesPerBlock = 4 : index
+  } :  memref<8x8xf32, 5> += memref<8x128x1xf32, 3> * memref<8x128x1xf32, 3>
   return
 }
 

--- a/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
@@ -3,14 +3,15 @@
 // Run: miopen-opt -mlir-print-op-generic %s | miopen-opt | FileCheck %s
 
 func.func @miopen_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x128x1xf16, 3>, %C : memref<8x8xf16, 5>) {
-  %c0 = arith.constant 0 : index
-  miopen.blockwise_gemm(%A, %B, %C, %c0, %c0) {
+  miopen.blockwise_gemm %C += %A * %B {
     kPerThread = 1 : index,
     mPerThread = 4 : index,
-    mRepeatStride = 64 : index,
+    mThreadsPerCuwave = 4 : index,
+    mCuwavesPerBlock = 4 : index,
     nPerThread = 4 : index,
-    nRepeatStride = 64 : index
-  } : memref<8x128x1xf16, 3>, memref<8x128x1xf16, 3>, memref<8x8xf16, 5>, index, index
+    nThreadsPerCuwave = 4 : index,
+    nCuwavesPerBlock = 4 : index
+  } : memref<8x8xf16, 5> += memref<8x128x1xf16, 3> * memref<8x128x1xf16, 3>
   return
 }
 


### PR DESCRIPTION
In order to make progress on removing hardcoded math in gridwise_gemm,
moves the computation of thread offsets into a map that lives in
blockwise_gemm. This means that gridwise_gemm no longer needs to
compute the offset in the m and n dimensions that each particular
thread should use.

In addition
- Rename the level0 and level1 clusters to be more descriptive. The
level 0 cluster represented the 16 threads of a CU wave being arranged
into a mPerCuwave x nPerCuwave grid, and the level 1 cluster was a 2D
grid made of the cuwaves in a block. More descriptive names will
hopefully save future refactorers the headache of understanding what
all this cluster stuff is about
- Change the IR format of blockwise_gemm in pursuit of the general
aesthetics project