### PR TITLE
Fold duplicated dims before miopen fusion

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -505,7 +505,7 @@ LogicalResult LGDropDimsPattern::matchAndRewrite(linalg::GenericOp laGeneric,
         regType = user->getResult(0).getType().template cast<MemRefType>();
         if (isa<memref::CopyOp>(copyOp)) {
           // getTarget
-          laOut = copyOp->getOperand(1));
+          laOut = copyOp->getOperand(1);
         }
       }
       eliminateAll(user);

--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -501,10 +501,11 @@ LogicalResult LGDropDimsPattern::matchAndRewrite(linalg::GenericOp laGeneric,
   // Check memref alloc as output and eliminate it with all users
   for (Operation *user : out.getUsers()) {
     if (isa<memref::CollapseShapeOp>(user)) {
-      for (Operation *copyOp : user.getUsers()) {
+      for (Operation *copyOp : user->getUsers()) {
         regType = user->getResult(0).getType().template cast<MemRefType>();
         if (isa<memref::CopyOp>(copyOp)) {
-          laOut = copyOp->getTarget();
+          // getTarget
+          laOut = copyOp->getOperand(1));
         }
       }
       eliminateAll(user);

--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -532,10 +532,8 @@ LogicalResult LGDropDimsPattern::matchAndRewrite(linalg::GenericOp laGeneric,
   Value laOut;
   bool bFirst = true;
   // Reconfigure the linalg.generic, this tries to restore the original rank
-  // which was already compatible
-  elementwise fusion duplicated some dims.for (auto pair :
-                                               llvm::zip(idxMaps,
-                                                         laGeneric.inputs())) {
+  // which was already compatible elementwise fusion duplicated some dims.
+  for (auto pair : llvm::zip(idxMaps, laGeneric.inputs())) {
     AffineMap inpIdxMap = std::get<0>(pair);
     Value inp = std::get<1>(pair);
     if (auto expanded = inp.getDefiningOp<memref::ExpandShapeOp>()) {

--- a/mlir/test/fusion/e2e/tosa-to-miopen-bias.e2e.mlir
+++ b/mlir/test/fusion/e2e/tosa-to-miopen-bias.e2e.mlir
@@ -1,7 +1,4 @@
-// FIXME: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
-
-// RUN: mlir-miopen-driver -h
-
+// RUN: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
 // CHECK: Unranked Memref base
 func.func @test_fusion(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x3x3x8xf32>, %arg2: tensor<16xf32>) -> tensor<1x30x30x16xf32> attributes {kernel} {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x32x32x8xf32>, tensor<16x3x3x8xf32>, tensor<16xf32>) -> tensor<1x30x30x16xf32>


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/594
by eliminating shape change to the fusing in/out.