### PR TITLE
Restore tosa partition tests

### DIFF
--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
@@ -1,0 +1,52 @@
+// RUN: mlir-opt %s -pass-pipeline="func.func(tosa-to-linalg-named)" \
+// RUN: -pass-pipeline="func.func(tosa-to-linalg)" --tosa-to-tensor \
+// RUN: -tosa-to-arith -arith-bufferize \
+// RUN: -linalg-comprehensive-module-bufferize="allow-return-allocs" \
+// RUN: -linalg-bufferize -vector-bufferize -tensor-bufferize \
+// RUN: -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
+// RUN: -lower-affine -convert-linalg-to-llvm --convert-scf-to-cf \
+// RUN: -convert-math-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: > %t1
+//
+// RUN  cat %t1 | FileCheck %s
+// CHECK:  Unranked Memref
+// CHECK-SAME:  sizes = [1, 10, 10, 2] strides = [200, 20, 2, 1]
+// CHECK-NEXT:  [[[[0.458882,     0.344086],
+// CHECK-NEXT:     [0.336863,     0.469958],
+// CHECK-NEXT:     [0.214844,     0.595831],
+// CHECK-NEXT:     [0.0928252,     0.721703],
+//
+// RUN: mlir-opt %s --tosa-partition --pass-pipeline="func.func(tosa-to-linalg-named)" \
+// RUN: -pass-pipeline="func.func(tosa-to-linalg)" --tosa-to-tensor \
+// RUN: -tosa-to-arith -arith-bufferize \
+// RUN: -linalg-comprehensive-module-bufferize="allow-return-allocs" \
+// RUN: -linalg-bufferize -vector-bufferize -tensor-bufferize \
+// RUN: -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
+// RUN: -lower-affine -convert-linalg-to-llvm --convert-scf-to-cf \
+// RUN: --convert-math-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:   -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: > %t2
+//
+// RUN: diff --ignore-matching-lines='Unranked Memref' %t1 %t2
+
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 808 : i32}}  {
+  func private @print_memref_f32(memref<*xf32>)
+  func private @printNewline()
+  func @main() {
+    %0 = "tosa.const"() {value = dense<[[[[-1.747810e-01], [0.356973231], [-0.166753888]], [[-0.298198819], [0.110798746], [-0.314905882]], [[-0.267817706], [0.318314373], [0.329790294]]], [[[-0.236702681], [-0.0709462166], [-0.192342982]], [[0.138438225], [-0.217499733], [0.0627906919]], [[0.0631466805], [-2.780110e-01], [0.357007563]]]]> : tensor<2x3x3x1xf32>} : () -> tensor<2x3x3x1xf32>
+    %1 = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
+    %2 = "tosa.const"() {value = dense<[[[[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]]]]> : tensor<1x10x10x1xf32>} : () -> tensor<1x10x10x1xf32>
+    %4 = "tosa.conv2d"(%2, %0, %1) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<1x10x10x1xf32>, tensor<2x3x3x1xf32>, tensor<2xf32>) -> tensor<1x10x10x2xf32>
+    %5 = "tosa.clamp"(%4) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<1x10x10x2xf32>) -> tensor<1x10x10x2xf32>
+    %8 = bufferization.to_memref %5 : memref<1x10x10x2xf32>
+    %9 = memref.cast %8 : memref<1x10x10x2xf32> to memref<*xf32>
+    call @print_memref_f32(%9) : (memref<*xf32>) -> ()
+    call @printNewline() : () -> ()
+    return
+  }
+}

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s -pass-pipeline="func.func(tosa-to-linalg-named)" \
 // RUN: -pass-pipeline="func.func(tosa-to-linalg)" --tosa-to-tensor \
 // RUN: -tosa-to-arith -arith-bufferize \
-// RUN: -linalg-comprehensive-module-bufferize="allow-return-allocs" \
+// RUN: -one-shot-bufferize="allow-return-allocs bufferize-function-boundaries" \
 // RUN: -linalg-bufferize -vector-bufferize -tensor-bufferize \
 // RUN: -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
 // RUN: -lower-affine -convert-linalg-to-llvm --convert-scf-to-cf \
@@ -22,7 +22,7 @@
 // RUN: mlir-opt %s --tosa-partition --pass-pipeline="func.func(tosa-to-linalg-named)" \
 // RUN: -pass-pipeline="func.func(tosa-to-linalg)" --tosa-to-tensor \
 // RUN: -tosa-to-arith -arith-bufferize \
-// RUN: -linalg-comprehensive-module-bufferize="allow-return-allocs" \
+// RUN: -one-shot-bufferize="allow-return-allocs bufferize-function-boundaries allow-unknown-ops" \
 // RUN: -linalg-bufferize -vector-bufferize -tensor-bufferize \
 // RUN: -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
 // RUN: -lower-affine -convert-linalg-to-llvm --convert-scf-to-cf \
@@ -35,9 +35,9 @@
 // RUN: diff --ignore-matching-lines='Unranked Memref' %t1 %t2
 
 module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 808 : i32}}  {
-  func private @print_memref_f32(memref<*xf32>)
-  func private @printNewline()
-  func @main() {
+  func.func private @print_memref_f32(memref<*xf32>)
+  func.func private @printNewline()
+  func.func @main() {
     %0 = "tosa.const"() {value = dense<[[[[-1.747810e-01], [0.356973231], [-0.166753888]], [[-0.298198819], [0.110798746], [-0.314905882]], [[-0.267817706], [0.318314373], [0.329790294]]], [[[-0.236702681], [-0.0709462166], [-0.192342982]], [[0.138438225], [-0.217499733], [0.0627906919]], [[0.0631466805], [-2.780110e-01], [0.357007563]]]]> : tensor<2x3x3x1xf32>} : () -> tensor<2x3x3x1xf32>
     %1 = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
     %2 = "tosa.const"() {value = dense<[[[[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]]]]> : tensor<1x10x10x1xf32>} : () -> tensor<1x10x10x1xf32>

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-run.mlir
@@ -1,9 +1,8 @@
 // RUN: mlir-opt %s -pass-pipeline="func.func(tosa-to-linalg-named)" \
 // RUN: -pass-pipeline="func.func(tosa-to-linalg)" --tosa-to-tensor \
-// RUN: -tosa-to-arith -arith-bufferize \
+// RUN: -tosa-to-arith \
 // RUN: -one-shot-bufferize="allow-return-allocs bufferize-function-boundaries" \
-// RUN: -linalg-bufferize -vector-bufferize -tensor-bufferize \
-// RUN: -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
+// RUN: --convert-linalg-to-loops \
 // RUN: -lower-affine -convert-linalg-to-llvm --convert-scf-to-cf \
 // RUN: -convert-math-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \
@@ -13,18 +12,16 @@
 //
 // RUN  cat %t1 | FileCheck %s
 // CHECK:  Unranked Memref
-// CHECK-SAME:  sizes = [1, 10, 10, 2] strides = [200, 20, 2, 1]
-// CHECK-NEXT:  [[[[0.458882,     0.344086],
-// CHECK-NEXT:     [0.336863,     0.469958],
-// CHECK-NEXT:     [0.214844,     0.595831],
-// CHECK-NEXT:     [0.0928252,     0.721703],
+// CHECK-SAME:  sizes = [5, 10, 8, 18] strides = [1440, 144, 18, 1]
+// CHECK-NEXT:  [-0.399353
+// CHECK-NEXT:  [-0.399353
+// CHECK-NEXT:  [-0.399353
 //
 // RUN: mlir-opt %s --tosa-partition --pass-pipeline="func.func(tosa-to-linalg-named)" \
 // RUN: -pass-pipeline="func.func(tosa-to-linalg)" --tosa-to-tensor \
-// RUN: -tosa-to-arith -arith-bufferize \
-// RUN: -one-shot-bufferize="allow-return-allocs bufferize-function-boundaries allow-unknown-ops" \
-// RUN: -linalg-bufferize -vector-bufferize -tensor-bufferize \
-// RUN: -func-bufferize -finalizing-bufferize --convert-linalg-to-loops \
+// RUN: -tosa-to-arith \
+// RUN: -one-shot-bufferize="allow-return-allocs bufferize-function-boundaries" \
+// RUN: --convert-linalg-to-loops \
 // RUN: -lower-affine -convert-linalg-to-llvm --convert-scf-to-cf \
 // RUN: --convert-math-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \
@@ -34,18 +31,23 @@
 //
 // RUN: diff --ignore-matching-lines='Unranked Memref' %t1 %t2
 
-module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 808 : i32}}  {
-  func.func private @print_memref_f32(memref<*xf32>)
+module attributes {torch.debug_module_name = "Conv2dNoPaddingModule"} {
+  func.func private @printMemrefF32(memref<*xf32>)
   func.func private @printNewline()
   func.func @main() {
-    %0 = "tosa.const"() {value = dense<[[[[-1.747810e-01], [0.356973231], [-0.166753888]], [[-0.298198819], [0.110798746], [-0.314905882]], [[-0.267817706], [0.318314373], [0.329790294]]], [[[-0.236702681], [-0.0709462166], [-0.192342982]], [[0.138438225], [-0.217499733], [0.0627906919]], [[0.0631466805], [-2.780110e-01], [0.357007563]]]]> : tensor<2x3x3x1xf32>} : () -> tensor<2x3x3x1xf32>
-    %1 = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
-    %2 = "tosa.const"() {value = dense<[[[[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]], [[1.000000e+00], [2.000000e+00], [3.000000e+00], [4.000000e+00], [5.000000e+00], [-1.000000e+00], [-2.000000e+00], [-3.000000e+00], [-4.000000e+00], [-5.000000e+00]]]]> : tensor<1x10x10x1xf32>} : () -> tensor<1x10x10x1xf32>
-    %4 = "tosa.conv2d"(%2, %0, %1) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<1x10x10x1xf32>, tensor<2x3x3x1xf32>, tensor<2xf32>) -> tensor<1x10x10x2xf32>
-    %5 = "tosa.clamp"(%4) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<1x10x10x2xf32>) -> tensor<1x10x10x2xf32>
-    %8 = bufferization.to_memref %5 : memref<1x10x10x2xf32>
-    %9 = memref.cast %8 : memref<1x10x10x2xf32> to memref<*xf32>
-    call @print_memref_f32(%9) : (memref<*xf32>) -> ()
+    %0 = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi32>} : () -> tensor<4xi32>
+    %1 = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi32>} : () -> tensor<4xi32>
+    %2 = "tosa.const"() {value = dense<0.000000e+00> : tensor<10xf32>} : () -> tensor<10xf32>
+    %3 = "tosa.const"() {value = dense<1> : tensor<5x2x10x20xi32>} : () -> tensor<5x2x10x20xi32>
+    %4 = "tosa.const"() {value = dense<"0x2E4CE7BABE79013E42A646BE27A031BEC9EBB9BDC771813DE50699BB015F3F3E7D5AABBC74777F3D3EE291BD7AC53DBD029566BE0BD91FBED4FCC6BD880D0F3CE4D5BE3D2BD2103E94A023BEB234D2BDDF54AF3DF56B483EDFAF46BDA39C343EBF9C1BBD4750CC3C818B5A3ED6E65FBED9F117BE3B6A74BDDE29BCBDD388503EAE711CBE0936DEBD8D9F28BE2B0C62BE1EE40CBEC9784F3ED265D73DD5F5E93D62184B3C4F7BF7BD4A56233D115B61BEE0652EBE11DBF8BD5A48183E94830D3E4915D6BD4C570BBC225D1A3E6EF16F3E0F95BF3D6F6C023DF7D3213EE11C0EBE40E7333D86203BBE5C4827BE435DF9BDC06ADA3D5221C23D3DF80EBE25D5913DD97F043EAEB5F3BC8A72133C39B25F3DCABB153E69C0673E3DFF39BED1E6B0BD8AB6BD3D5BFA473E5008523E00F7543ECA22403DB7E151BE36A0B13CDDFE16BE85EF60BE1D72563E0F85373E31C370BEE6B3343D2FA322BD93DF1EBDB4F7DCBDDDA1B93D36F50EBED8F5B03D511DF43D3AC82C3E657EB43DB2E16EBEA4911CBE4907F13D31114A3DC7473CBEB2FA0ABEF40E633ED0A1223E2F7AD2BD55FC72BD11EB65BEB7D28ABBF4C135BE892C3ABEDAC754BC9CF4103D0FB0C5BD93370F3E60E012BE86005B3E4367253EB6884BBE314870BD8A402E3CB5DB0C3D08FA643DAA6EBD3DB851673C3888EBBDBE6AE43D028667BE1F0E0FBE75AD71BD7523EBBDF6DEA8BDBBD245BEEB5C4DBD475E4E3DB93C1DBEAD2E46BCF2C62C3E857EC6BC27A7D63B0493A6BCE862433D3577193E63A0643ECB46193E4D26653ED8A48BBC6ED158BE81D8E4BDBA57243E0345C8BAEFEEEFBDD2F438BE5DE061BE86B54BBE74D343BDE05C043E187D023E41C668BE348E163EA4DD3CBE6B1A4CBDA2BAC3BD33F539BD718E3DBD669558BE0B6650BE2D1217BD60C3473B6A49DBBDEED6B53DBF3C59BE2D4F82BC8341543E9BE5C4BDB2F2593E77D1AE3D32D159BE10B5183EE3CFDEBC1D7DD7BDED00413E890A43BE"> : tensor<10x2x3x3xf32>} : () -> tensor<10x2x3x3xf32>
+    %5 = "tosa.cast"(%3) : (tensor<5x2x10x20xi32>) -> tensor<5x2x10x20xf32>
+    %6 = "tosa.transpose"(%5, %1) : (tensor<5x2x10x20xf32>, tensor<4xi32>) -> tensor<5x10x20x2xf32>
+    %7 = "tosa.transpose"(%4, %1) : (tensor<10x2x3x3xf32>, tensor<4xi32>) -> tensor<10x3x3x2xf32>
+    %8 = "tosa.conv2d"(%6, %7, %2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<5x10x20x2xf32>, tensor<10x3x3x2xf32>, tensor<10xf32>) -> tensor<5x8x18x10xf32>
+    %9 = "tosa.transpose"(%8, %0) : (tensor<5x8x18x10xf32>, tensor<4xi32>) -> tensor<5x10x8x18xf32>
+    %10 = bufferization.to_memref %9 : memref<5x10x8x18xf32>
+    %11 = memref.cast %10 : memref<5x10x8x18xf32> to memref<*xf32>
+    call @printMemrefF32(%11) : (memref<*xf32>) -> ()
     call @printNewline() : () -> ()
     return
   }

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
@@ -6,7 +6,7 @@
 // CHECK: return
 // CHECK: func @test_fusion
 // CHECK: call @test_fusion_outlined_part_0
-func @test_fusion(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+func.func @test_fusion(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
   return %1 : tensor<128x128x30x30xf32>
@@ -19,7 +19,7 @@ func @test_fusion(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, 
 // CHECK: return
 // CHECK: func @test_fusion2
 // CHECK: call @test_fusion2_outlined_part_0
-func @test_fusion2(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+func.func @test_fusion2(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   %1 = "tosa.negate"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
   return %1 : tensor<128x128x30x30xf32>
@@ -33,7 +33,7 @@ func @test_fusion2(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>,
 // CHECK: return
 // CHECK: func @test_fusion3
 // CHECK: call @test_fusion3_outlined_part_0
-func @test_fusion3(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+func.func @test_fusion3(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
   %2 = "tosa.negate"(%1) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
@@ -48,7 +48,7 @@ func @test_fusion3(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>,
 // CHECK: return
 // CHECK: func @test_fusion4
 // CHECK: call @test_fusion4_outlined_part_0
-func @test_fusion4(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+func.func @test_fusion4(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
   %2 = "tosa.add"(%0, %1) {} : (tensor<128x128x30x30xf32>, tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
@@ -67,7 +67,7 @@ func @test_fusion4(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>,
 // CHECK: func @test_fusion5
 // CHECK-NEXT: call @test_fusion5_outlined_part_1
 // CHECK-NEXT: call @test_fusion5_outlined_part_0
-func @test_fusion5(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>, %arg3: tensor<128x8x32x32xf32>, %arg4: tensor<128x8x3x3xf32>, %arg5: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+func.func @test_fusion5(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>, %arg3: tensor<128x8x32x32xf32>, %arg4: tensor<128x8x3x3xf32>, %arg5: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   %1 = "tosa.conv2d"(%arg3, %arg4, %arg5) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   %2 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
@@ -82,7 +82,7 @@ func @test_fusion5(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>,
 // CHECK: func @test_fusion6
 // CHECK-NEXT: call @test_fusion6_outlined_part_0
 // CHECK-NEXT: return
-func @test_fusion6(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+func.func @test_fusion6(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   return %0 : tensor<128x128x30x30xf32>
 }
@@ -94,7 +94,7 @@ func @test_fusion6(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>,
 // CHECK: func @test_fusion7
 // CHECK-NEXT: call @test_fusion7_outlined_part_0
 // CHECK-NEXT: return
-func @test_fusion7(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+func.func @test_fusion7(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
   %0 = "tosa.abs"(%arg0) {} : (tensor<128x8x32x32xf32>) -> tensor<128x8x32x32xf32>
   %1 = "tosa.conv2d"(%0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
   return %1 : tensor<128x128x30x30xf32>

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
@@ -1,0 +1,101 @@
+// RUN: mlir-opt --split-input-file --tosa-partition %s -verify-each=0 -o - | FileCheck %s
+
+// CHECK-LABEL: func private @test_fusion_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.abs
+// CHECK: return
+// CHECK: func @test_fusion
+// CHECK: call @test_fusion_outlined_part_0
+func @test_fusion(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %1 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion2_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.negate
+// CHECK: return
+// CHECK: func @test_fusion2
+// CHECK: call @test_fusion2_outlined_part_0
+func @test_fusion2(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.negate"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %1 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion3_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.abs
+// CHECK: tosa.negate
+// CHECK: return
+// CHECK: func @test_fusion3
+// CHECK: call @test_fusion3_outlined_part_0
+func @test_fusion3(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.negate"(%1) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %2 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion4_outlined_part_0
+// CHECK: tosa.conv2d
+// CHECK: tosa.abs
+// +++pf:  This test used to absorb the tosa.add, too, but doesn't now.
+// CHECK: return
+// CHECK: func @test_fusion4
+// CHECK: call @test_fusion4_outlined_part_0
+func @test_fusion4(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.add"(%0, %1) {} : (tensor<128x128x30x30xf32>, tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %2 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion5_outlined_part_0
+// CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: tosa.abs
+// CHECK-NEXT: tosa.add
+// CHECK-NEXT: return
+// CHECK: func private @test_fusion5_outlined_part_1
+// CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: return
+// CHECK: func @test_fusion5
+// CHECK-NEXT: call @test_fusion5_outlined_part_1
+// CHECK-NEXT: call @test_fusion5_outlined_part_0
+func @test_fusion5(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>, %arg3: tensor<128x8x32x32xf32>, %arg4: tensor<128x8x3x3xf32>, %arg5: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %1 = "tosa.conv2d"(%arg3, %arg4, %arg5) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  %2 = "tosa.abs"(%0) {} : (tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  %3 = "tosa.add"(%2, %1) {} : (tensor<128x128x30x30xf32>, tensor<128x128x30x30xf32>) -> tensor<128x128x30x30xf32>
+  return %3 : tensor<128x128x30x30xf32>
+}
+
+
+// CHECK-LABEL: func private @test_fusion6_outlined_part_0
+// CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: return
+// CHECK: func @test_fusion6
+// CHECK-NEXT: call @test_fusion6_outlined_part_0
+// CHECK-NEXT: return
+func @test_fusion6(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  return %0 : tensor<128x128x30x30xf32>
+}
+
+// CHECK-LABEL: func private @test_fusion7_outlined_part_0
+// CHECK-NEXT: tosa.abs
+// CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: return
+// CHECK: func @test_fusion7
+// CHECK-NEXT: call @test_fusion7_outlined_part_0
+// CHECK-NEXT: return
+func @test_fusion7(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {
+  %0 = "tosa.abs"(%arg0) {} : (tensor<128x8x32x32xf32>) -> tensor<128x8x32x32xf32>
+  %1 = "tosa.conv2d"(%0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<128x8x32x32xf32>, tensor<128x8x3x3xf32>, tensor<8xf32>) -> tensor<128x128x30x30xf32>
+  return %1 : tensor<128x128x30x30xf32>
+}


### PR DESCRIPTION
I noticed the other day, while porting the tosa-partition code into torch-mlir, that the tosa-partition.mlir and tosa-partition-run.mlir tests had disappeared.  Turns out that they used --linalg-comprehensive-module-bufferize, which was recently removed.  There's a --one-shot-bufferize, but it isn't a direct replacement, and following the most obvious path foundered when a tosa.conv2d wouldn't bufferise.

This patch updates the tests to use the appropriate options, and I regenerated tosa-partition-run.mlir using torch and a simple torch.nn.Conv2d model to avoid the failure-to-bufferize error.