### PR TITLE
Decouple between kPack/non-kPack in xdlopsgemm

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
@@ -212,119 +212,123 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
     if (KRepeats == 0)
       KRepeats = 1;
 
-    auto KBaseConstantOp = b.create<ConstantIndexOp>(loc, k_base);
-
-    // XdlopsGemm Logic, similar between reduction/non-reduction path
-    // for(index_t k_i = 0; k_i < KPerThread; ++k_i) {
-    //   matrixAElement = a[k_i];
-    //   matrixBElement = b[k_i];
-    //   // Loop within a kpack
-    //   for(index_t ki_i = 0; ki_i < k_base * KRepeats; ki_i += k_base)
-    //     argA = &matrixAElement[ki_i];
-    //     argB = &matrixAElement[ki_i];
-    //     p_c_thread = mfma_type.template run<MPerXlops * MRepeats,
-    //                                         NPerXdlops * NRepeats,
-    //                                         AStride,
-    //                                         BStride>(argA, argB,
-    //       p_c_thread);
-    // }
-    int64_t outerLoopUpperBound = KPerThread;
-    // In case xdlops consume multiple elements from memref<T>, divide by k_base
-    // such that the generated loop is not out of bounds.
-    if (KPack == 1) {
-      outerLoopUpperBound /= k_base;
-    }
     auto regAConstantOp =
         b.create<ConstantIndexOp>(loc, op.regOffsetAAttr().getInt());
     auto regBConstantOp =
         b.create<ConstantIndexOp>(loc, op.regOffsetBAttr().getInt());
 
-    auto outerLoop = b.create<AffineForOp>(loc, 0, outerLoopUpperBound);
-    auto outerLoopb = ConversionPatternRewriter::atBlockBegin(
-        outerLoop.getBody(), b.getListener());
-    auto outerLoopiv = outerLoop.getInductionVar();
+    auto populateMfma = [&](OpBuilder &b, Value &argA, Value &argB) {
+      for (int64_t i = 0; i < vectorNumber; ++i) {
+        // Note below is assuming only one of MRepeats or NRepeats is larger
+        // than 1, which fits the existing blockwisegemmv2op implementation.
+        // TODO: Move MRepeats and NRepeats into xdlopsgemmv2op
+        int64_t regDOffset = 0;
+        if (op.regOffsetAAttr().getInt() > 0 ||
+            op.regOffsetBAttr().getInt() > 0) {
+          regDOffset += vectorNumber;
+        }
+        Value offset =
+            b.createOrFold<arith::ConstantIndexOp>(loc, regDOffset + i);
 
-    // matrixAElement and matrixBElement are only useful when KPack > 1
-    Value matrixAElement;
-    Value matrixBElement;
+        auto vectorC = b.create<memref::LoadOp>(loc, vectorType,
+                                                adaptor.matrixC(), offset);
+        auto mfma = b.create<amdgpu::MFMAOp>(
+            loc, vectorType, mfmaInstr, argA, argB, vectorC,
+            /*cbsz=*/imms[i][0], /*abid=*/imms[i][1], /*blgp=*/imms[i][2]);
+        auto vectorD = mfma.destD();
 
-    if (KPack > 1) {
+        b.create<memref::StoreOp>(loc, vectorD, adaptor.matrixC(), offset);
+      }
+    };
+
+    // TODO: zyin adopt generic layout: K, KRepeats, k_base
+    // After that, we'd be able to uniform between kPack/nonKPack
+    if (KPack == 1) {
+      // for(index_t k_i = 0; k_i < KPerThread; k_i += k_base) {
+      //   argA = a[k_i];
+      //   argB = a[k_i];
+      //   p_c_thread = mfma(argA, argB, p_c_thread);
+      // }
+      Value zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
+      auto mfmaLoop = b.create<TransformingForOp>(
+          loc, ArrayRef<ValueRange>{{zeroConstantOp}},
+          ArrayRef<Attribute>{b.getArrayAttr({})},
+          /*bounds=*/ArrayRef<int64_t>{KPerThread},
+          /*strides=*/ArrayRef<int64_t>{k_base},
+          /*useIndexDiffs=*/true, /*forceUnroll=*/true);
+      {
+        OpBuilder::InsertionGuard guard(b);
+        b.setInsertionPointToStart(mfmaLoop.getBody());
+        Value coord = mfmaLoop.getLowerCoords(/*domain=*/0)[0];
+
+        Value offset = coord;
+        Value regAIdx = b.create<AddIOp>(loc, regAConstantOp, offset);
+        Value regBIdx = b.create<AddIOp>(loc, regBConstantOp, offset);
+
+        Value argA;
+        Value argB;
+        if (k_base == 1) {
+          // xdlops needs only 1 element, load directly from buffer.
+          argA = b.create<memref::LoadOp>(loc, argType, matrixA,
+                                          ValueRange{regAIdx});
+          argB = b.create<memref::LoadOp>(loc, argType, matrixB,
+                                          ValueRange{regBIdx});
+        } else {
+          // k_base > 1, use transferRead to load a vector length equivalent
+          // with a xdlops argument.
+          argA = b.create<vector::TransferReadOp>(
+              loc, argType.cast<VectorType>(), matrixA, ValueRange{regAIdx});
+          argB = b.create<vector::TransferReadOp>(
+              loc, argType.cast<VectorType>(), matrixB, ValueRange{regBIdx});
+        }
+        populateMfma(b, argA, argB);
+      }
+    } else {
+      // for(index_t k_i = 0; k_i < KPerThread; ++k_i) {
+      //   matrixAElement = a[k_i];
+      //   matrixBElement = b[k_i];
+      //   // Loop within a kpack
+      //   for(index_t ki_i = 0; ki_i < k_base * KRepeats; ki_i += k_base)
+      //     argA = &matrixAElement[ki_i];
+      //     argB = &matrixAElement[ki_i];
+      //     p_c_thread = mfma_type.template run<MPerXlops * MRepeats,
+      //                                         NPerXdlops * NRepeats,
+      //                                         AStride,
+      //                                         BStride>(argA, argB,
+      //       p_c_thread);
+      // }
+      int64_t outerLoopUpperBound = KPerThread;
+
+      auto outerLoop = b.create<AffineForOp>(loc, 0, outerLoopUpperBound);
+      auto outerLoopb = ConversionPatternRewriter::atBlockBegin(
+          outerLoop.getBody(), b.getListener());
+      auto outerLoopiv = outerLoop.getInductionVar();
+
       Value regAIdx =
           outerLoopb.create<AddIOp>(loc, regAConstantOp, outerLoopiv);
-      matrixAElement = outerLoopb.create<memref::LoadOp>(
+      Value matrixAElement = outerLoopb.create<memref::LoadOp>(
           loc, matrixAElementType, matrixA, ValueRange{regAIdx});
 
       Value regBIdx =
           outerLoopb.create<AddIOp>(loc, regBConstantOp, outerLoopiv);
-      matrixBElement = outerLoopb.create<memref::LoadOp>(
+      Value matrixBElement = outerLoopb.create<memref::LoadOp>(
           loc, matrixBElementType, matrixB, ValueRange{regBIdx});
-    }
 
-    auto innerLoop =
-        outerLoopb.create<AffineForOp>(loc, 0, KRepeats * k_base, k_base);
-    auto innerLoopb = ConversionPatternRewriter::atBlockBegin(
-        innerLoop.getBody(), outerLoopb.getListener());
-    auto innerLoopiv = innerLoop.getInductionVar();
+      auto innerLoop =
+          outerLoopb.create<AffineForOp>(loc, 0, KRepeats * k_base, k_base);
+      auto innerLoopb = ConversionPatternRewriter::atBlockBegin(
+          innerLoop.getBody(), outerLoopb.getListener());
+      auto innerLoopiv = innerLoop.getInductionVar();
 
-    Value argA;
-    Value argB;
-
-    if (KPack == 1) {
-      // When KPack == 1, we are dealing with memref<T>.
-      // Use a combination of inner and outer offset to figure out the actual
-      // offset from vgpr
-      Value offset = innerLoopb.create<AddIOp>(
-          loc, innerLoopb.create<MulIOp>(loc, outerLoopiv, KBaseConstantOp),
-          innerLoopb.create<MulIOp>(loc, innerLoopiv, KBaseConstantOp));
-
-      Value regAIdx = innerLoopb.create<AddIOp>(loc, regAConstantOp, offset);
-      Value regBIdx = innerLoopb.create<AddIOp>(loc, regBConstantOp, offset);
-
-      if (k_base == 1) {
-        // xdlops needs only 1 element, load directly from buffer.
-        argA = innerLoopb.create<memref::LoadOp>(loc, argType, matrixA,
-                                                 ValueRange{regAIdx});
-        argB = innerLoopb.create<memref::LoadOp>(loc, argType, matrixB,
-                                                 ValueRange{regBIdx});
-      } else {
-        // k_base > 1, use transferRead to load a vector length equivalent
-        // with a xdlops argument.
-        argA = innerLoopb.create<vector::TransferReadOp>(
-            loc, argType.cast<VectorType>(), matrixA, ValueRange{regAIdx});
-        argB = innerLoopb.create<vector::TransferReadOp>(
-            loc, argType.cast<VectorType>(), matrixB, ValueRange{regBIdx});
-      }
-    } else {
       // At this point, we are guaranteed that buffer element vectorization
       // length (kPack) must be a multiple of k_base. Use extractsliceop
       // to handle a independent data slice at a time.
-      argA = innerLoopb.create<ExtractSliceOp>(loc, argType, matrixAElement,
-                                               innerLoopiv);
-      argB = innerLoopb.create<ExtractSliceOp>(loc, argType, matrixBElement,
-                                               innerLoopiv);
-    }
+      Value argA = innerLoopb.create<ExtractSliceOp>(
+          loc, argType, matrixAElement, innerLoopiv);
+      Value argB = innerLoopb.create<ExtractSliceOp>(
+          loc, argType, matrixBElement, innerLoopiv);
 
-    for (int64_t i = 0; i < vectorNumber; ++i) {
-      // Note below is assuming only one of MRepeats or NRepeats is larger
-      // than 1, which fits the existing blockwisegemmv2op implementation.
-      // TODO: Move MRepeats and NRepeats into xdlopsgemmv2op
-      int64_t regDOffset = 0;
-      if (op.regOffsetAAttr().getInt() > 0 ||
-          op.regOffsetBAttr().getInt() > 0) {
-        regDOffset += vectorNumber;
-      }
-      Value offset =
-          innerLoopb.createOrFold<arith::ConstantIndexOp>(loc, regDOffset + i);
-
-      auto vectorC = innerLoopb.create<memref::LoadOp>(
-          loc, vectorType, adaptor.matrixC(), offset);
-      auto mfma = innerLoopb.create<amdgpu::MFMAOp>(
-          loc, vectorType, mfmaInstr, argA, argB, vectorC,
-          /*cbsz=*/imms[i][0], /*abid=*/imms[i][1], /*blgp=*/imms[i][2]);
-      auto vectorD = mfma.destD();
-
-      innerLoopb.create<memref::StoreOp>(loc, vectorD, adaptor.matrixC(),
-                                         offset);
+      populateMfma(innerLoopb, argA, argB);
     }
 
     b.eraseOp(op);

--- a/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_xdlops_gemm_v2.mlir
@@ -3,8 +3,9 @@
 func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack(%matrixA : memref<8xf32, 5>, 
                                                       %matrixB : memref<8xf32, 5>, 
                                                       %matrixC : memref<1xvector<32xf32>, 5>) {
-  // CHECK: memref.load 
-  // CHECK: memref.load 
+  // CHECK-LABEL: func.func @miopen_xdlops_gemm_v2_nonreduction_nokpack
+  // CHECK: miopen.in_bounds_load 
+  // CHECK: miopen.in_bounds_load 
   // CHECK: amdgpu.mfma
   miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
      k = 8 : i32, 
@@ -21,6 +22,7 @@ func.func @miopen_xdlops_gemm_v2_nonreduction_kpack(%matrixA : memref<2xvector<2
                                                     %matrixB : memref<2xvector<2xf32>, 5>,
                                                     %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
+  // CHECK-LABEL: func.func @miopen_xdlops_gemm_v2_nonreduction_kpack
   // CHECK: miopen.extract_slice
   // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma
@@ -43,6 +45,7 @@ func.func @miopen_xdlops_gemm_v2_reduction_kpack(%matrixA : memref<2xvector<8xi8
                                                  %matrixB : memref<2xvector<8xi8>, 5>, 
                                                  %matrixC : memref<1xvector<16xi32>, 5>) {
   %c0 = arith.constant 0 : index
+  // CHECK-LABEL: func.func @miopen_xdlops_gemm_v2_reduction_kpack
   // CHECK: miopen.extract_slice
   // CHECK: miopen.extract_slice
   // CHECK: amdgpu.mfma


### PR DESCRIPTION
This is a partial work that makes xdlops and its IR cleaner. This is also as far as I can go for refactoring xdlops gemm for now. I will leave the next section of refactoring to when I will finish:
 - https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/623
 - https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/624
Then, existing xdlopsgemm will become a coordinate transfer on `[K, KRepeats, k_base]`

I will shift focus to adjusting the responsibility between blockwisegemmv2 and xdlopsgemm further in my next PR to unblock larger M/N repeats.