### PR TITLE
[DO NOT SQUASH] Fix fusion test failure by modifying TosaToLinalg.

### DIFF
--- a/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -631,7 +631,7 @@ elementwiseMatchAndRewriteHelper(Operation *operation,
     SmallVector<AffineExpr, 4> affineExprs;
     newShape.reserve(type.getRank());
     for (const auto &it : llvm::enumerate(type.getShape())) {
-      if (it.value() == resultTy.getDimSize(it.index()) && it.value() != 1) {
+      if (it.value() == resultTy.getDimSize(it.index())) {
         newShape.push_back(it.value());
         affineExprs.push_back(
             mlir::getAffineDimExpr(it.index(), rewriter.getContext()));

--- a/mlir/test/fusion/e2e/tosa-to-miopen-bcast-add.e2e.mlir
+++ b/mlir/test/fusion/e2e/tosa-to-miopen-bcast-add.e2e.mlir
@@ -1,14 +1,12 @@
 // RUN: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-inputs -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
 
 // CHECK: Unranked Memref base
-//func.func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg3: tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
-func.func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
+func.func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg3: tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
   %zero = arith.constant dense<0.0> : tensor<8xf32>
   %0 = "tosa.conv2d"(%arg0, %arg1, %zero) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x8x8x4xf32>, tensor<8x1x1x4xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
-//  %2 = "tosa.add"(%0, %arg3) {} : (tensor<1x8x8x8xf32>, tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32>
+  %2 = "tosa.add"(%0, %arg3) {} : (tensor<1x8x8x8xf32>, tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32>
 
-  //return %2 : tensor<1x8x8x8xf32>
-  return %0 : tensor<1x8x8x8xf32>
+  return %2 : tensor<1x8x8x8xf32>
 }
 
 // -----

--- a/mlir/test/fusion/e2e/tosa-to-miopen-bias.e2e.mlir
+++ b/mlir/test/fusion/e2e/tosa-to-miopen-bias.e2e.mlir
@@ -1,7 +1,4 @@
-// FIXME: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
-
-// RUN: mlir-miopen-driver -h
-
+// RUN: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
 // CHECK: Unranked Memref base
 func.func @test_fusion(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x3x3x8xf32>, %arg2: tensor<16xf32>) -> tensor<1x30x30x16xf32> attributes {kernel} {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x32x32x8xf32>, tensor<16x3x3x8xf32>, tensor<16xf32>) -> tensor<1x30x30x16xf32>


### PR DESCRIPTION
TosaToLinalg folds its dim first when a dim size of the operands is 1 and add reshape ops later to match with the original shape.
This might complicate the later passes.

For example,
when tosa.add has two compatible tensor operands A[1,30,30,16] and B[1,1,1,16]
TosaToLinalg reshapes B to [16]
and LinalgElementwiseOpFusion pass reshapes A and B to A[1,30,30,1,1,1,16] and B[1,1,1,16] and result also needs to be reshaped from [1,30,30,1,1,1,16] to [1,30,30,16]

This PR prevents TosaToLinalg pass from dropping the dims with size=1 so that the operands of elementwise ops keep their shapes through the converting passes.
Not sure everyone upstream would be happy with this change but this looks more sensible to me (If something need this existing dimension folding, that should be optional)

This also fixes the failed fusion tests.