### PR TITLE
Update cmake to 3.22.1.  Update buildbot to match, and for production.

### DIFF
--- a/mlir/utils/buildbot/README
+++ b/mlir/utils/buildbot/README
@@ -2,6 +2,8 @@ To start up the buildbot:
 
   git clone https://github.com/ROCmSoftwarePlatform/llvm-project-mlir.git
   cd ./llvm-project-mlir/mlir/utils/buildbot
-  export BUILDBOT_PORT=9994
+  export BUILDBOT_PORT=9990
   export BUILDBOT_MASTER=lab.llvm.org
   ./build-run.sh mlir-rocm-mi200 `pwd`/mlir-rocm-mi200
+
+See https://confluence.amd.com/display/MLSE/MLIR+Buildbot for more info.

--- a/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
@@ -15,7 +15,7 @@
 FROM rocm/mlir:rocm5.1-latest
 
 RUN apt-get update; \
-    apt-get install -y dumb-init cmake; \
+    apt-get install -y dumb-init; \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 ;\
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 ;\
     update-alternatives --install /usr/bin/lld lld /usr/bin/lld-10 100

--- a/mlir/utils/jenkins/Dockerfile.rocm
+++ b/mlir/utils/jenkins/Dockerfile.rocm
@@ -97,8 +97,11 @@ RUN echo "deb [arch=amd64] $ROCM_DEB_REPO $ROCM_BUILD_NAME $ROCM_BUILD_NUM" > /e
 RUN wget --no-check-certificate -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
 RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 
+
 # Note instead of installing the latest, we should always manually bump cmake version when necessary.
 # This make sure that we don't accidentally use newer cmake features incompatible with our client.
+# As of 2022-08-17, the rocm/miopen images has /opt/conda/bin/cmake at 3.22.1, so we'll match that.
+# Note that the mlir minimum is 3.18.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   rocm-dev \
   rocminfo \
@@ -111,8 +114,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   kmod \
   file \
   netcat-openbsd \
-  cmake-data=3.15.1-0kitware1 \
-  cmake=3.15.1-0kitware1 \
+  cmake-data=3.22.1-0kitware1ubuntu18.04.1 \
+  cmake=3.22.1-0kitware1ubuntu18.04.1 \
   libsqlite3-dev \
   parallel && \
   apt-get clean && \


### PR DESCRIPTION
Update cmake for general use, since the old 3.15 would break on the next update-llvm-from-main-line exercise.  Buildbot was already loading a newer one, but it's based on the rocm/mlir image so now it won't need to.  And update buildbot port to production and add a pointer to confluence documentation.