### PR TITLE
Remove reduction xdlops limitations

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/MIOpen/Tuning/GridwiseGemmParams.cpp
@@ -1003,26 +1003,6 @@ LogicalResult PopulateParamsXDL::isValidBlockwiseGemmXDLOPS(
     return failure();
   }
 
-  // TODO remove : Ignore KReduction XDLOPS path for forward and backward
-  // weight convolution now (unless int8). These M/NPerBlock combinations used
-  // to result in lowering errors at tuning. Once non-int8 types are tested,
-  // we should get rid of this limitation.
-  if (param.gemmKPack > 1 && !dataType.isInteger(8)) {
-    if ((param.gemmMPerBlock == 16 || param.gemmMPerBlock == 32 ||
-         param.gemmMPerBlock == 64) &&
-        (param.gemmNPerBlock == 16 || param.gemmNPerBlock == 32 ||
-         param.gemmNPerBlock == 64)) {
-      return failure();
-    }
-
-    if (param.gemmMPerBlock == 32 && param.gemmNPerBlock == 128) {
-      return failure();
-    }
-    if (param.gemmMPerBlock == 128 && param.gemmNPerBlock == 32) {
-      return failure();
-    }
-  }
-
   return success();
 }
 


### PR DESCRIPTION
This pull request is a small yet impactful change. Look at the nightly performance measurement from this PR, [here](http://rocmhead.amd.com:8080/job/MLIR/job/test-weeklyCI/24/Performance_20report/). All previous reduction xdlops enablement/refactoring has lead to this step to remove the tuning limitation.

### Observations

- Baseline: int8 performance stay the same because it has only reduction xdlops enabled. It also give us a baseline that between the two gfx90a machines that executes this, they are on the same performance scale.
- For selected configs I tested, this doubled the amount of tuning parameters and expand the tuning space over existing span.
- Across all configs, this brings an overall 11% improvement in geo mean and 26% improvement on arith mean
  - Improved average arith mean of resnet50 by ~20% to ~60%
  - Improved average geo mean of resnet50 by ~5% to ~30%
- Doubled/tripled the performance of smaller configs accross different data types, due to more conservative m/n repeats from the reduction routine. This drastic improvement likely due to the entire problem is able to fit into the L2 cache for each iteration.
  - K:Y:X = 64x1x1, 64x3x3 configs mostly benefit from it because they are fewer elements to fetch per iteration.