### PR TITLE
Make miopen.transform into a more typical view op, fix memory space

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -114,17 +114,15 @@ def MIOpen_TransformOp :
   }];
   let builders = [
    // Custom builder to populate bounds of input and output memrefs as attributes.
-   OpBuilder<(ins "Value":$input, "TransformMapAttr":$transforms,
-    CArg<"unsigned", "0">:$memorySpace),
+   OpBuilder<(ins "Value":$input, "TransformMapAttr":$transform),
    [{
      $_state.addOperands({input});
      MemRefType lowerType = input.getType().template cast<MemRefType>();
      Type elemType = lowerType.getElementType();
-     AffineMap lowerMap = lowerType.getLayout().getAffineMap();
-     AffineMap composed = lowerMap.compose(transforms.getMap().getAffineMap());
-     MemRefType upperType = MemRefType::get(transforms.getUpperBounds(), elemType,
-      composed, memorySpace);
-     $_state.addAttribute("transforms", $_builder.getArrayAttr({transforms}));
+     int memorySpace = lowerType.getMemorySpaceAsInt();
+     MemRefType upperType = MemRefType::get(transform.getUpperBounds(), elemType,
+      /*layout=*/{}, memorySpace);
+     $_state.addAttribute("transforms", $_builder.getArrayAttr({transform}));
      $_state.addTypes(upperType);
    }]>,
   ];

--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -87,8 +87,7 @@ makeTransposeTransform(PatternRewriter &b, Value inp, AffineMap inpMap) {
 
       permuteBuilder.passThrough(permutation, identityIdxs);
       TransformMapAttr permuteAttr = permuteBuilder.get();
-      Value ret = b.create<TransformOp>(loc, inp, permuteAttr,
-                                        inputType.getMemorySpaceAsInt());
+      Value ret = b.create<TransformOp>(loc, inp, permuteAttr);
       AffineMap composed = permuteAttr.getMap().getAffineMap().compose(inpMap);
       LLVM_DEBUG(llvm::dbgs() << "indexing = " << inpMap << " then transform "
                               << permuteAttr.getMap().getAffineMap() << " is "
@@ -131,8 +130,7 @@ static Value makeBroadcast(PatternRewriter &b, MemRefType outType, Value inp,
         bcastDims.push_back(i);
       }
 
-      inp = b.create<TransformOp>(loc, inp, transform.get(),
-                                  inpType.getMemorySpaceAsInt());
+      inp = b.create<TransformOp>(loc, inp, transform.get());
 
       inpType = inp.getType().template cast<MemRefType>();
       inpShape = inpType.getShape();
@@ -161,8 +159,7 @@ static Value makeBroadcast(PatternRewriter &b, MemRefType outType, Value inp,
     transform.passThrough(ptDims, ptDims);
     transform.broadcast(bcastDims, bcastSizes);
 
-    inp = b.create<TransformOp>(loc, inp, transform.get(),
-                                inpType.getMemorySpaceAsInt());
+    inp = b.create<TransformOp>(loc, inp, transform.get());
   }
   return inp;
 }

--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
@@ -1497,8 +1497,7 @@ struct RemoveTrivialTransposePattern
     }
     miopen::BottomUpTMBuilder transform(b, inpShape, loc);
     transform.passThrough(endDims, startDims);
-    auto tfOp = b.create<miopen::TransformOp>(loc, inp, transform.get(),
-                                              inpType.getMemorySpaceAsInt());
+    auto tfOp = b.create<miopen::TransformOp>(loc, inp, transform.get());
     return tfOp;
   }
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/GridwiseGemmToBlockwise.cpp
@@ -278,8 +278,7 @@ static Value sliceBufferSubview(OpBuilder &b, Location loc, Value buffer,
   transform.slice({"slice"}, {"buffer"}, {start}, {end});
 
   TransformMapAttr transformAttr = transform.get();
-  Value subview = b.create<TransformOp>(loc, buffer, transformAttr,
-                                        bufferType.getMemorySpaceAsInt());
+  Value subview = b.create<TransformOp>(loc, buffer, transformAttr);
   return subview;
 }
 

--- a/mlir/lib/Dialect/MIOpen/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/MIOpen/utility/transformMapUtils.cpp
@@ -228,8 +228,7 @@ TransformOp mlir::miopen::reshapeBuffer(OpBuilder &b, Location loc,
   transform.embed("raw", 0, outShape[0], names, strides);
 
   TransformMapAttr transformAttr = transform.get();
-  auto ret = b.create<TransformOp>(loc, buffer, transformAttr,
-                                   bufferType.getMemorySpaceAsInt());
+  auto ret = b.create<TransformOp>(loc, buffer, transformAttr);
   return ret;
 }
 

--- a/mlir/test/Conversion/TosaToMIOpen/tosa-to-miopen.mlir
+++ b/mlir/test/Conversion/TosaToMIOpen/tosa-to-miopen.mlir
@@ -1,7 +1,7 @@
 // RUN: miopen-opt --tosa-to-miopen %s -verify-diagnostics -o -| FileCheck %s
 
 // CHECK-LABEL: test_fusion
-// CHECK: miopen.conv2d(%{{.*}}, %{{.*}}, %{{.*}}) features = {{none|xdlops}} {arch = {{.*}}, dilations = [1 : i32, 1 : i32], filter_layout = ["k", "y", "x", "c", "g"], input_layout = ["ni", "hi", "wi", "ci", "gi"], numCu = {{.*}} : i32, output_layout = ["no", "ho", "wo", "ko", "go"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<128x8x3x3x1xf32, {{.*}}>, memref<128x8x32x32x1xf32, {{.*}}>, memref<128x128x30x30x1xf32, {{.*}}>
+// CHECK: miopen.conv2d(%{{.*}}, %{{.*}}, %{{.*}}) features = {{none|xdlops}} {arch = {{.*}}, dilations = [1 : i32, 1 : i32], filter_layout = ["k", "y", "x", "c", "g"], input_layout = ["ni", "hi", "wi", "ci", "gi"], numCu = {{.*}} : i32, output_layout = ["no", "ho", "wo", "ko", "go"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<128x8x3x3x1xf32>, memref<128x8x32x32x1xf32>, memref<128x128x30x30x1xf32>
 
 func.func @test_fusion(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>) -> tensor<128x128x30x30xf32> attributes {kernel} {
   %zero = arith.constant dense<0.0> : tensor<128xf32>

--- a/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_input_tensor_non_zero_padding.mlir
@@ -4,10 +4,9 @@
 
 // RUN: miopen-opt -miopen-affix-params -miopen-conv-to-gemm %s | FileCheck %s
 
-// CHECK-DAG: #[[$AFFINE:map[0-9]+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 - 1, d4 - 1)>
 // CHECK-DAG: #[[$MAP:transform_map[0-9]+]] = #miopen.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 - 1, d4 - 1)> by [<PassThrough ["ni"] at [2] -> ["ni"] at [2]>, <PassThrough ["gi"] at [0] -> ["gi"] at [0]>, <PassThrough ["ci"] at [1] -> ["ci"] at [1]>, <Pad{1, 1, 1, 1} ["hipad", "wipad"] at [3, 4] -> ["hi", "wi"] at [3, 4]>] bounds = [1, 8, 128, 34, 34] -> [1, 8, 128, 32, 32]>
 // CHECK-LABEL: func.func @miopen_conv2d_gcyxk_gcnhw_gknhw
-// CHECK: miopen.transform %arg1 by [#[[$MAP]]] : memref<1x8x128x32x32xf32> to memref<1x8x128x34x34xf32, #[[$AFFINE]]>
+// CHECK: miopen.transform %arg1 by [#[[$MAP]]] : memref<1x8x128x32x32xf32> to memref<1x8x128x34x34xf32>
 func.func @miopen_conv2d_gcyxk_gcnhw_gknhw(%filter : memref<1x8x3x3x128xf32>, %input : memref<1x8x128x32x32xf32>, %output : memref<1x128x128x32x32xf32>) {
   miopen.conv2d(%filter, %input, %output) features = none {
     arch = "gfx906",


### PR DESCRIPTION
Thanks to Simon for noticing these issues with how transform was
defined, which causes issues with bufferization.