### PR TITLE
[DO NOT SQUASH] MLIR#633: Support multiple or independent transposes on miopen.conv2d params

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -114,9 +114,11 @@ bool isZeroAttribute(Attribute value) {
 
 bool isConstantZero(Operation *op) {
   // test for zero
-  if (auto cst = dyn_cast<arith::ConstantOp>(op)) {
+  // test for zero
+  if (auto cst = dyn_cast<arith::ConstantOp>(op))
     return isZeroAttribute(cst.getValue());
-  }
+  else if (auto cst = dyn_cast<tosa::ConstOp>(op))
+    return isZeroAttribute(cst->getAttr("value"));
   return false;
 }
 

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
@@ -1,6 +1,7 @@
 // RUN: mlir-opt --tosa-partition %s | FileCheck %s
 // CHECK-LABEL: func private @forward_outlined_part_0
 // CHECK-NEXT: tosa.const
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.conv2d
@@ -8,6 +9,7 @@
 // CHECK-NEXT: tosa.transpose
 // CHECK: return
 // CHECK-LABEL: func private @forward_outlined_part_1
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.transpose

--- a/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
+++ b/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
@@ -356,6 +356,7 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
         convOp->setAttr("expected_filter_layout", b.getStringAttr(layout));
         top.replaceAllUsesWith({tInput});
       }
+      top.erase();
     }
 
     return success();

--- a/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
+++ b/mlir/lib/Conversion/TosaToMIOpen/TosaToMIOpen.cpp
@@ -30,24 +30,6 @@ using namespace mlir;
 
 namespace {
 
-// Tell if the given tosa conv2d is supposed to have NCHW layout
-static bool checkNCHW(tosa::Conv2DOp &convOp) {
-  // Check if the convolution has expected layout
-  auto fLayout = convOp->getAttr("expected_filter_layout");
-  auto iLayout = convOp->getAttr("expected_input_layout");
-  auto oLayout = convOp->getAttr("expected_output_layout");
-  if (!fLayout || !iLayout || !oLayout) {
-    return false;
-  }
-  // Test if all match
-  if (!(fLayout.dyn_cast<StringAttr>().getValue().equals("kcyx") &&
-        iLayout.dyn_cast<StringAttr>().getValue().equals("nchw") &&
-        oLayout.dyn_cast<StringAttr>().getValue().equals("nkhw"))) {
-    return false;
-  }
-  return true;
-}
-
 static bool isZeroAttribute(Attribute value) {
   if (auto intValue = value.dyn_cast<IntegerAttr>())
     return intValue.getValue().isNullValue();
@@ -63,9 +45,10 @@ static bool isZeroAttribute(Attribute value) {
 }
 
 static bool isConstantZero(Value v) {
-  if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
+  if (auto cst = v.getDefiningOp<arith::ConstantOp>())
     return isZeroAttribute(cst.getValue());
-  }
+  if (auto cst = v.getDefiningOp<tosa::ConstOp>())
+    return isZeroAttribute(cst->getAttr("value"));
   return false;
 }
 
@@ -95,9 +78,8 @@ static Value expandMemRef(ConversionPatternRewriter &rw, Operation *op,
 
 static LogicalResult
 makeMIOpenConv2D(ConversionPatternRewriter &rw, Operation *op, Value input,
-                 const char *inputLayout, Value filter,
-                 const char *filterLayout, Value output,
-                 const char *outputLayout, const ArrayAttr &pad,
+                 StringRef inputLayout, Value filter, StringRef filterLayout,
+                 Value output, StringRef outputLayout, const ArrayAttr &pad,
                  const ArrayAttr &stride, const ArrayAttr &dilation) {
   auto loc = op->getLoc();
   auto func = op->getParentOfType<func::FuncOp>();
@@ -150,12 +132,10 @@ makeMIOpenConv2D(ConversionPatternRewriter &rw, Operation *op, Value input,
   SmallVector<StringAttr, 5> inputLayoutSpec;
   SmallVector<StringAttr, 5> outputLayoutSpec;
   for (size_t i = 0; i < 5; ++i) {
-    filterLayoutSpec.push_back(
-        rw.getStringAttr(StringRef(&filterLayout[i], 1).str()));
-    inputLayoutSpec.push_back(
-        rw.getStringAttr((StringRef(&inputLayout[i], 1) + "i").str()));
+    filterLayoutSpec.push_back(rw.getStringAttr(filterLayout.substr(i, 1)));
+    inputLayoutSpec.push_back(rw.getStringAttr(inputLayout.substr(i, 1) + "i"));
     outputLayoutSpec.push_back(
-        rw.getStringAttr((StringRef(&outputLayout[i], 1) + "o").str()));
+        rw.getStringAttr(outputLayout.substr(i, 1) + "o"));
   }
 
   // arch-specific attributes
@@ -211,11 +191,15 @@ public:
         getTypeConverter()->convertType(resultType).cast<MemRefType>();
     Value output = rw.create<memref::AllocOp>(loc, outputType);
 
-    bool isNCHW = checkNCHW(op);
-
-    const char *filterLayout = isNCHW ? "kcyxg" : "kyxcg";
-    const char *inputLayout = isNCHW ? "nchwg" : "nhwcg";
-    const char *outputLayout = isNCHW ? "nkhwg" : "nhwkg";
+    SmallString<5> filterLayout("kyxcg");
+    if (auto attr = op->getAttrOfType<StringAttr>("expected_filter_layout"))
+      filterLayout = Twine(attr.getValue() + "g").str();
+    SmallString<5> inputLayout("nhwcg");
+    if (auto attr = op->getAttrOfType<StringAttr>("expected_input_layout"))
+      inputLayout = Twine(attr.getValue() + "g").str();
+    SmallString<5> outputLayout("nhwkg");
+    if (auto attr = op->getAttrOfType<StringAttr>("expected_output_layout"))
+      outputLayout = Twine(attr.getValue() + "g").str();
 
     if (failed(makeMIOpenConv2D(rw, op, input, inputLayout, filter,
                                 filterLayout, output, outputLayout, op.pad(),
@@ -297,147 +281,82 @@ public:
   }
 };
 
-class TransposeConverter final : public OpConversionPattern<tosa::TransposeOp> {
-public:
-  using OpConversionPattern<tosa::TransposeOp>::OpConversionPattern;
-
-  bool transposeEqualTo(SmallVector<int64_t> &given,
-                        SmallVector<int64_t> &perm) const {
-    for (uint32_t i = 0; i < 4; i++) {
-      if (perm[i] != given[i])
-        return false;
-    }
-    // all matches.
-    return true;
+static SmallVector<int32_t> getTransposeDims(Value v) {
+  if (Operation *cval = v.getDefiningOp<arith::ConstantOp>()) {
+    auto cattr = cval->getAttr("value").cast<DenseElementsAttr>();
+    return SmallVector<int32_t>(cattr.getValues<int64_t>());
   }
+  if (Operation *cval = v.getDefiningOp<tosa::ConstOp>()) {
+    auto cattr = cval->getAttr("value").cast<DenseElementsAttr>();
+    return SmallVector<int32_t>(cattr.getValues<int32_t>());
+  }
+  // assert!! must be bufferization.cast
+  return getTransposeDims(v.getDefiningOp()->getOperand(0));
+}
+
+struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
+  using OpRewritePattern<tosa::TransposeOp>::OpRewritePattern;
 
   // Fold transpose ops and convert convolution into changed layout.
   // case #0 : fold TP(NCHW2NHWC)+tosa.conv.NHWC+TP(NHWC2NCHW) back to
   //           miopen.conv.NCHW
   // Pattern match start from the output transpose
-  LogicalResult
-  matchAndRewrite(tosa::TransposeOp top, tosa::TransposeOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const final {
-    auto operands = adaptor.getOperands();
-    auto loc = top->getLoc();
+  LogicalResult matchAndRewrite(tosa::TransposeOp top,
+                                PatternRewriter &b) const final {
+    auto dims = getTransposeDims(top.getOperand(1));
 
-    SmallVector<int64_t> NCHW2NHWC{0, 2, 3, 1};
-    SmallVector<int64_t> NHWC2NCHW{0, 3, 1, 2};
-
-    // Check if output has been transposed NHWC2NCHW
-    auto bottomOp = dyn_cast<arith::ConstantOp>(operands[1].getDefiningOp());
-    if (!bottomOp) {
-      bottomOp = dyn_cast<arith::ConstantOp>(
-          operands[1].getDefiningOp()->getOperand(0).getDefiningOp());
-    }
-    auto bottomAttr = bottomOp->getAttr("value").cast<DenseElementsAttr>();
-    SmallVector<int64_t> bottomPerm;
-    for (auto i : bottomAttr.getValues<int64_t>()) {
-      bottomPerm.push_back(i);
-    }
-    if (!transposeEqualTo(bottomPerm, NHWC2NCHW)) {
-      return rewriter.notifyMatchFailure(
-          bottomOp, [&](::mlir::Diagnostic &diag) {
-            diag << "Bottom transpose not matching";
-          });
-    }
-    auto convOp = dyn_cast<tosa::Conv2DOp>(operands[0].getDefiningOp());
-    if (!(convOp)) {
-      return rewriter.notifyMatchFailure(convOp, [&](::mlir::Diagnostic &diag) {
-        diag << "Second is not tosa::conv2d";
+    if (dims.size() != 4) {
+      return b.notifyMatchFailure(top, [&](::mlir::Diagnostic &diag) {
+        diag << "Bad constant transpose dims";
       });
     }
 
-    if (!checkNCHW(convOp)) {
-      return rewriter.notifyMatchFailure(convOp, [&](::mlir::Diagnostic &diag) {
-        diag << "Convolution doesn't expect NHWC->NCHW conversion";
-      });
+    Value tInput = top.getOperand(0);
+    Value tOutput = top.getResult();
+
+    if (tosa::Conv2DOp convOp = tInput.getDefiningOp<tosa::Conv2DOp>()) {
+      // tosa.conv2d output is transpose
+      assert(dims[0] == 0 && dims[1] == 3 && dims[2] == 1 && dims[3] == 2);
+      convOp->setAttr("expected_output_layout", b.getStringAttr("nkhw"));
+      convOp->getResult(0).setType(tOutput.getType());
+      top->replaceAllUsesWith(convOp);
+    } else {
+      // trace output to tosa.conv2d
+      for (auto &use : tOutput.getUses()) {
+        if (auto op = dyn_cast<tosa::Conv2DOp>(use.getOwner())) {
+          if (convOp)
+            return failure();
+          convOp = op;
+        } else {
+          return failure();
+        }
+      }
+
+      // conv Input Modifier
+      // replace conv input
+      if (convOp.getOperand(0) == tOutput) {
+        // input feature map
+        const char *layout = "nhwc";
+        if (dims[0] == 0 && dims[1] == 2 && dims[2] == 3 && dims[3] == 1) {
+          layout = "nchw";
+        } else {
+          assert(dims[0] == 0 && dims[1] == 3 && dims[2] == 1 && dims[3] == 2);
+        }
+        convOp->setAttr("expected_input_layout", b.getStringAttr(layout));
+        top.replaceAllUsesWith({tInput});
+      } else {
+        // filter
+        assert(convOp.getOperand(1) == tOutput);
+        const char *layout = "kyxc";
+        if (dims[0] == 0 && dims[1] == 2 && dims[2] == 3 && dims[3] == 1) {
+          layout = "kcyx";
+        } else {
+          assert(dims[0] == 0 && dims[1] == 3 && dims[2] == 1 && dims[3] == 2);
+        }
+        convOp->setAttr("expected_filter_layout", b.getStringAttr(layout));
+        top.replaceAllUsesWith({tInput});
+      }
     }
-
-    auto opr0 = *convOp.getODSOperands(0).begin();
-    auto opr1 = *convOp.getODSOperands(1).begin();
-    auto inputTpOp = dyn_cast<tosa::TransposeOp>(opr0.getDefiningOp());
-    auto filterTpOp = dyn_cast<tosa::TransposeOp>(opr1.getDefiningOp());
-    if (!(inputTpOp) || !(filterTpOp)) {
-      return rewriter.notifyMatchFailure(convOp, [&](::mlir::Diagnostic &diag) {
-        diag << "No transpose found for input/filter";
-      });
-    }
-    auto inputTpOpr1 = *inputTpOp.getODSOperands(1).begin();
-    auto filterTpOpr1 = *filterTpOp.getODSOperands(1).begin();
-
-    // Try to get transpose to input
-    auto inTpConstOp = dyn_cast<arith::ConstantOp>(inputTpOpr1.getDefiningOp());
-    if (!inTpConstOp) {
-      inTpConstOp = dyn_cast<arith::ConstantOp>(
-          inputTpOpr1.getDefiningOp()->getOperand(0).getDefiningOp());
-    }
-    SmallVector<int64_t> inTpPerm;
-    auto inTpConstAttr =
-        inTpConstOp->getAttr("value").cast<DenseElementsAttr>();
-    for (auto i : inTpConstAttr.getValues<int64_t>()) {
-      inTpPerm.push_back(i);
-    }
-
-    // Try to get transpose to filter
-    auto filTpConstOp =
-        dyn_cast<arith::ConstantOp>(filterTpOpr1.getDefiningOp());
-    if (!filTpConstOp) {
-      filTpConstOp = dyn_cast<arith::ConstantOp>(
-          filterTpOpr1.getDefiningOp()->getOperand(0).getDefiningOp());
-    }
-    SmallVector<int64_t> filTpPerm;
-    auto filTpConstAttr =
-        filTpConstOp->getAttr("value").cast<DenseElementsAttr>();
-    for (auto i : filTpConstAttr.getValues<int64_t>()) {
-      filTpPerm.push_back(i);
-    }
-
-    // Reject if pattern doesn't match
-    if (!transposeEqualTo(inTpPerm, NCHW2NHWC) ||
-        !transposeEqualTo(filTpPerm, NCHW2NHWC)) {
-      return rewriter.notifyMatchFailure(convOp, [&](::mlir::Diagnostic &diag) {
-        diag << "No expected input/filter transpose shapes";
-      });
-    }
-
-    auto input_t = inputTpOp->getOperand(0);
-    auto filter_t = filterTpOp->getOperand(0);
-
-    // fold input transpose
-    inputTpOp->replaceAllUsesWith(ValueRange(input_t));
-    rewriter.replaceOp(inputTpOp, {input_t});
-
-    // fold filter transpose
-    filterTpOp->replaceAllUsesWith(ValueRange(filter_t));
-    rewriter.replaceOp(filterTpOp, {filter_t});
-
-    // fold result transpose
-    auto op = dyn_cast<tosa::Conv2DOp>(operands[0].getDefiningOp());
-
-    // Reshape output dimensions
-    // Note - new conv op has NCHW layout so that input/output shapes
-    // in the operators chain remains valid during this conversion.
-    auto results = op->getResults();
-    auto convTy = results[0].getType().cast<ShapedType>();
-    auto convElemTy = convTy.getElementType();
-    auto convShape = convTy.getShape();
-    // NHWC into NCHW
-    SmallVector<int64_t> newShape{convShape[0], convShape[3], convShape[1],
-                                  convShape[2]};
-    Type newOutTy = RankedTensorType::get(newShape, convElemTy);
-
-    // Construct a new Conv2DOp with a new layout
-    auto cop = rewriter.create<tosa::Conv2DOp>(
-        loc, newOutTy,
-        ValueRange{op->getOperand(0), op->getOperand(1), op->getOperand(2)});
-    cop->setAttrs(op->getAttrs());
-
-    // Replace ((op)->(top)) with (cop)
-    op->replaceAllUsesWith(cop);
-    top->replaceAllUsesWith(cop);
-    rewriter.replaceOp(top, {cop});
-    op->erase();
 
     return success();
   }
@@ -453,5 +372,5 @@ void tosa::populateTosaToMIOpenConversionPatterns(
 }
 void tosa::populateTosaToMIOpenTensorConversionPatterns(
     MLIRContext *context, RewritePatternSet &patterns) {
-  patterns.insert<TransposeConverter>(context);
+  patterns.insert<TransposeRewritePattern>(context);
 }

--- a/mlir/test/fusion/tosa-tp2-highlevel-fused.mlir
+++ b/mlir/test/fusion/tosa-tp2-highlevel-fused.mlir
@@ -1,0 +1,23 @@
+// RUN: mlir-miopen-driver --host-pipeline highlevel %s | FileCheck %s
+
+// CHECK: miopen.conv2d(%{{.*}}, %{{.*}}, %{{.*}}) features =  none {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x", "g"], input_layout = ["ni", "hi", "wi", "ci", "gi"], numCu = 64 : i32, output_layout = ["no", "ho", "wo", "ko", "go"], padding = [1 : i32, 1 : i32, 1 : i32, 1 : i32], strides = [1 : i32, 1 : i32]} : memref<64x128x3x3x1xf32>, memref<256x28x28x128x1xf32>, memref<256x28x28x64x1xf32>
+    
+// CHECK-COUNT-1: linalg.generic
+// CHECK-NOT: linalg.generic
+
+module {
+  func.func @test_fusion(%arg0: tensor<256x28x28x128xf32>, %arg1: tensor<64x128x3x3xf32>, %arg2: tensor<256x64x28x28xf32>) -> tensor<256x28x28x64xf32> attributes {kernel} {
+    %cst_t = arith.constant dense<[0, 3, 1, 2]> : tensor<4xi64>
+    %cst = arith.constant dense<[0, 2, 3, 1]> : tensor<4xi64>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<1xf32>
+    %a = "tosa.transpose"(%arg0, %cst_t) : (tensor<256x28x28x128xf32>, tensor<4xi64>) -> tensor<256x128x28x28xf32>
+    %a2 = "tosa.transpose"(%a, %cst) : (tensor<256x128x28x28xf32>, tensor<4xi64>) -> tensor<256x28x28x128xf32>
+    %b = "tosa.transpose"(%arg1, %cst) : (tensor<64x128x3x3xf32>, tensor<4xi64>) -> tensor<64x3x3x128xf32>
+    %0 = "tosa.conv2d"(%a2, %b, %cst_0) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<256x28x28x128xf32>, tensor<64x3x3x128xf32>, tensor<1xf32>) -> tensor<256x28x28x64xf32>
+
+    %1 = "tosa.transpose"(%arg2, %cst) : (tensor<256x64x28x28xf32>, tensor<4xi64>) -> tensor<256x28x28x64xf32>
+    %2 = "tosa.add"(%0, %1) : (tensor<256x28x28x64xf32>, tensor<256x28x28x64xf32>) -> tensor<256x28x28x64xf32>
+    
+    return %2 : tensor<256x28x28x64xf32>
+  }
+}

--- a/mlir/test/fusion/tosa-tp3-highlevel-fused.mlir
+++ b/mlir/test/fusion/tosa-tp3-highlevel-fused.mlir
@@ -1,0 +1,23 @@
+// RUN: mlir-miopen-driver --host-pipeline highlevel %s | FileCheck %s
+
+// CHECK: miopen.conv2d(%{{.*}}, %{{.*}}, %{{.*}}) features =  none {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x", "g"], input_layout = ["ni", "hi", "wi", "ci", "gi"], numCu = 64 : i32, output_layout = ["no", "ko", "ho", "wo", "go"], padding = [1 : i32, 1 : i32, 1 : i32, 1 : i32], strides = [1 : i32, 1 : i32]} : memref<64x128x3x3x1xf32>, memref<256x28x28x128x1xf32>, memref<256x64x28x28x1xf32>
+    
+// CHECK-COUNT-1: linalg.generic
+// CHECK-NOT: linalg.generic
+
+module {
+  func.func @test_fusion(%arg0: tensor<256x28x28x128xf32>, %arg1: tensor<64x128x3x3xf32>, %arg2: tensor<256x64x28x28xf32>) -> tensor<256x64x28x28xf32> attributes {kernel} {
+    %cst_t = arith.constant dense<[0, 3, 1, 2]> : tensor<4xi64>
+    %cst = arith.constant dense<[0, 2, 3, 1]> : tensor<4xi64>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<1xf32>
+    %a = "tosa.transpose"(%arg0, %cst_t) : (tensor<256x28x28x128xf32>, tensor<4xi64>) -> tensor<256x128x28x28xf32>
+    %a2 = "tosa.transpose"(%a, %cst) : (tensor<256x128x28x28xf32>, tensor<4xi64>) -> tensor<256x28x28x128xf32>
+    %b = "tosa.transpose"(%arg1, %cst) : (tensor<64x128x3x3xf32>, tensor<4xi64>) -> tensor<64x3x3x128xf32>
+    %0 = "tosa.conv2d"(%a2, %b, %cst_0) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<256x28x28x128xf32>, tensor<64x3x3x128xf32>, tensor<1xf32>) -> tensor<256x28x28x64xf32>
+
+    %c1 = "tosa.transpose"(%0, %cst_t) : (tensor<256x28x28x64xf32>, tensor<4xi64>) -> tensor<256x64x28x28xf32>
+    %2 = "tosa.add"(%c1, %arg2) : (tensor<256x64x28x28xf32>, tensor<256x64x28x28xf32>) -> tensor<256x64x28x28xf32>
+    
+    return %2 : tensor<256x64x28x28xf32>
+  }
+}

--- a/mlir/test/fusion/tosa-tp4-highlevel-fused.mlir
+++ b/mlir/test/fusion/tosa-tp4-highlevel-fused.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-miopen-driver --host-pipeline highlevel %s | FileCheck %s
+
+// CHECK: miopen.conv2d(%{{.*}}, %{{.*}}, %{{.*}}) features =  none {arch = "gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x", "g"], input_layout = ["ni", "hi", "wi", "ci", "gi"], numCu = 64 : i32, output_layout = ["no", "ho", "wo", "ko", "go"], padding = [1 : i32, 1 : i32, 1 : i32, 1 : i32], strides = [1 : i32, 1 : i32]} : memref<64x128x3x3x1xf32>, memref<256x28x28x128x1xf32>, memref<256x28x28x64x1xf32>
+    
+// CHECK-COUNT-1: linalg.generic
+// CHECK-NOT: linalg.generic
+
+module {
+  func.func @test_fusion(%arg0: tensor<256x28x28x128xf32>, %arg1: tensor<64x128x3x3xf32>, %arg2: tensor<256x64x28x28xf32>) -> tensor<256x28x28x64xf32> attributes {kernel} {
+    %cst_t = arith.constant dense<[0, 3, 1, 2]> : tensor<4xi64>
+    %cst = arith.constant dense<[0, 2, 3, 1]> : tensor<4xi64>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<1xf32>
+    %a = "tosa.transpose"(%arg0, %cst_t) : (tensor<256x28x28x128xf32>, tensor<4xi64>) -> tensor<256x128x28x28xf32>
+    %a2 = "tosa.transpose"(%a, %cst) : (tensor<256x128x28x28xf32>, tensor<4xi64>) -> tensor<256x28x28x128xf32>
+    %b = "tosa.transpose"(%arg1, %cst) : (tensor<64x128x3x3xf32>, tensor<4xi64>) -> tensor<64x3x3x128xf32>
+    %c0 = "tosa.conv2d"(%a2, %b, %cst_0) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<256x28x28x128xf32>, tensor<64x3x3x128xf32>, tensor<1xf32>) -> tensor<256x28x28x64xf32>
+
+    %c1 = "tosa.transpose"(%c0, %cst_t) : (tensor<256x28x28x64xf32>, tensor<4xi64>) -> tensor<256x64x28x28xf32>
+    %c2 = "tosa.transpose"(%c1, %cst) : (tensor<256x64x28x28xf32>, tensor<4xi64>) -> tensor<256x28x28x64xf32>
+    %1 = "tosa.transpose"(%arg2, %cst) : (tensor<256x64x28x28xf32>, tensor<4xi64>) -> tensor<256x28x28x64xf32>
+    %2 = "tosa.add"(%c2, %1) : (tensor<256x28x28x64xf32>, tensor<256x28x28x64xf32>) -> tensor<256x28x28x64xf32>
+    
+    return %2 : tensor<256x28x28x64xf32>
+  }
+}


### PR DESCRIPTION

        * removed memory space param on miopen.transform, gets from input
        * removed affine_map on output of miopen.transpose, encoded in op
    
        https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/633
