### PR TITLE
Use FMA in non-xdlops kernel

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/MIOpen/utility/transformMapUtils.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -77,12 +78,22 @@ struct ThreadwiseGemmRewritePattern
     int64_t m = aShape[1];
     int64_t kPack = aShape[2];
     int64_t n = gemmB.getType().cast<MemRefType>().getShape()[1];
+    // Note for future: when we use dot products, we should increase this to
+    // the number of elements supported by the relevant dot product.
+    int64_t loadKpackLen = 1;
     LLVM_DEBUG(llvm::dbgs() << "Threadwise gemm:\n"
                             << "k = " << k << "\n"
                             << "m = " << m << "\n"
                             << "n = " << n << "\n"
-                            << "kPack = " << kPack << "\n");
-    SmallVector<int64_t> dimensions = {k, m, n, kPack};
+                            << "kPack = " << kPack << "\n"
+                            << "loadKpackLen = " << loadKpackLen << "\n");
+    if (loadKpackLen > kPack || kPack % loadKpackLen != 0)
+      return op->emitOpError("load length " + Twine(loadKpackLen) +
+                             " not compatible with kpack of " + Twine(kPack));
+    SmallVector<int64_t, 4> dimensions = {k, m, n, kPack};
+    SmallVector<int64_t, 4> strides = {1, 1, 1, loadKpackLen};
+    auto abType = VectorType::get(loadKpackLen, dataType);
+    auto cType = VectorType::get(1, dataType);
 
     TopDownTMBuilder aView(b, {"k", "m", "n", "kpack"}, dimensions, loc);
     aView.ignore("n");
@@ -117,29 +128,30 @@ struct ThreadwiseGemmRewritePattern
     {
       OpBuilder::InsertionGuard guard(b);
       b.setInsertionPointToStart(gemmLoop.getBody());
-      Value aVal = b.create<InBoundsLoadOp>(
-          loc, dataType, bufferA, gemmLoop.getLowerCoords(/*domain=*/0));
-      Value bVal = b.create<InBoundsLoadOp>(
-          loc, dataType, bufferB, gemmLoop.getLowerCoords(/*domain=*/1));
-      Value mul;
-      if (dataType.isa<IntegerType>())
-        mul = b.create<MulIOp>(loc, aVal, bVal);
-      else if (dataType.isa<FloatType>())
-        mul = b.create<MulFOp>(loc, aVal, bVal);
-      else
-        llvm_unreachable("Validation should make this ints or floats only");
-
+      // These are vector::TransferRead ops so they always return a vector
+      // result so that FMA doesn't complain
+      Value aVal = b.create<vector::TransferReadOp>(
+          loc, abType, bufferA, gemmLoop.getLowerCoords(/*domain=*/0),
+          /*inBounds=*/ArrayRef<bool>(true));
+      Value bVal = b.create<vector::TransferReadOp>(
+          loc, abType, bufferB, gemmLoop.getLowerCoords(/*domain=*/1),
+          /*inBounds=*/ArrayRef<bool>(true));
       ValueRange cCoords = gemmLoop.getLowerCoords(/*domain=*/2);
-      Value cVal = b.create<InBoundsLoadOp>(loc, dataType, bufferC, cCoords);
-      Value add;
-      if (dataType.isa<IntegerType>())
-        add = b.create<AddIOp>(loc, mul, cVal);
-      else if (dataType.isa<FloatType>())
-        add = b.create<AddFOp>(loc, mul, cVal);
-      else
-        llvm_unreachable("Very serously can't happen");
+      Value cVal =
+          b.create<vector::TransferReadOp>(loc, cType, bufferC, cCoords,
+                                           /*inBounds=*/ArrayRef<bool>(true));
+      Value result;
+      if (dataType.isa<IntegerType>()) {
+        Value mul = b.create<MulIOp>(loc, aVal, bVal);
+        result = b.create<AddIOp>(loc, mul, cVal);
+      } else if (dataType.isa<FloatType>()) {
+        result = b.create<vector::FMAOp>(loc, aVal, bVal, cVal);
+      } else {
+        llvm_unreachable("Validation should make this ints or floats only");
+      }
 
-      b.create<InBoundsStoreOp>(loc, add, bufferC, cCoords);
+      b.create<vector::TransferWriteOp>(loc, result, bufferC, cCoords,
+                                        /*inBounds=*/ArrayRef<bool>(true));
     }
     return success();
   }


### PR DESCRIPTION
Since we have access to a FMA intrinsic that lowers to instructions avaialable
on all GCN+ (gfx900+) chips via LLVM's built-in FMA type, we might as well use
it.

This also changes the non-xdlops threadwise gemm to always use vector
transfer reads and writes so that we have vector-typed values, thus
making the FMA intrinsic work (though we could've used 0-D vectors instead)
*and* enabling future work on using dot product intrinsics (those intrinsics
will want to set loadKpackLen to some higher value that reflects the dot
product being carried out).

Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/634