### PR TITLE
Fusion fix for broadcast

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AlignTiling.cpp
@@ -438,6 +438,12 @@ LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
   }
   // 2. Apply if input found
 
+  // move reshape before la access it.
+  if (out.getDefiningOp<memref::ExpandShapeOp>()) {
+    auto parentTransff = copyOp->getParentOp();
+    out.getDefiningOp()->moveBefore(parentTransff);
+  }
+
   Value gemmV2Outs = copyOp.source();
   auto gemmV2OutsType = gemmV2Outs.getType().cast<MemRefType>();
   {

--- a/mlir/test/fusion/e2e/tosa-to-miopen-bcast-add.e2e.mlir
+++ b/mlir/test/fusion/e2e/tosa-to-miopen-bcast-add.e2e.mlir
@@ -1,14 +1,12 @@
 // RUN: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-inputs -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
 
 // CHECK: Unranked Memref base
-//func.func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg3: tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
-func.func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
+func.func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg3: tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32> attributes {kernel} {
   %zero = arith.constant dense<0.0> : tensor<8xf32>
   %0 = "tosa.conv2d"(%arg0, %arg1, %zero) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x8x8x4xf32>, tensor<8x1x1x4xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
-//  %2 = "tosa.add"(%0, %arg3) {} : (tensor<1x8x8x8xf32>, tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32>
+  %2 = "tosa.add"(%0, %arg3) {} : (tensor<1x8x8x8xf32>, tensor<1x1x1x8xf32>) -> tensor<1x8x8x8xf32>
 
-  //return %2 : tensor<1x8x8x8xf32>
-  return %0 : tensor<1x8x8x8xf32>
+  return %2 : tensor<1x8x8x8xf32>
 }
 
 // -----

--- a/mlir/test/fusion/e2e/tosa-to-miopen-bias.e2e.mlir
+++ b/mlir/test/fusion/e2e/tosa-to-miopen-bias.e2e.mlir
@@ -1,7 +1,4 @@
-// FIXME: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
-
-// RUN: mlir-miopen-driver -h
-
+// RUN: mlir-miopen-driver -host-pipeline highlevel %s | miopen-gen -ph -print-results -rand none - | mlir-miopen-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
 // CHECK: Unranked Memref base
 func.func @test_fusion(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x3x3x8xf32>, %arg2: tensor<16xf32>) -> tensor<1x30x30x16xf32> attributes {kernel} {
   %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x32x32x8xf32>, tensor<16x3x3x8xf32>, tensor<16xf32>) -> tensor<1x30x30x16xf32>


### PR DESCRIPTION
- Optimize the copy with collapseShape, replace with expandShape to the original memory
- handle broadcast input and reshape in the align pattern
- type checking assertion needs to be changed since this case covers elementwise input has different shape as the C-tensor (but it's broadcast and checking if it's broadcastable)