### PR TITLE
Moving M/NRepeats to xdlops gemm as looping constructs

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpen/MIOpenOps.td
@@ -769,18 +769,16 @@ def MIOpen_ThreadwiseGemmOp:
 // xdlops_gemm_V2
 def MIOpen_XdlopsGemmV2Op:
     MIOpen_Op<"xdlops_gemm_v2">,
-    Arguments<(ins IndexAttr:$regOffsetA,
-                   IndexAttr:$regOffsetB,
-                   MemRefOf<[F32, F16, BF16, I8,
-                             VectorOfLengthAndType<[2, 4], [F32]>,
-                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$matrixA,
-                   MemRefOf<[F32, F16, BF16, I8,
-                             VectorOfLengthAndType<[2, 4], [F32]>,
-                             VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                             VectorOfLengthAndType<[4, 8, 16], [I8]>]>:$matrixB,
-                   MemRefOf<[F32, F16, BF16, I32,
-                             VectorOf<[F32, F16, BF16, I32]>]>:$matrixC,
+    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8,
+                      VectorOfLengthAndType<[2, 4], [F32]>,
+                      VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [2]>:$matrixA,
+                   MemRefRankOf<[F32, F16, BF16, I8,
+                      VectorOfLengthAndType<[2, 4], [F32]>,
+                      VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [2]>:$matrixB,
+                   MemRefRankOf<[F32, F16, BF16, I32,
+                      VectorOf<[F32, F16, BF16, I32]>], [3]>:$matrixC,
                    MIOpen_XdlopsGemmParamsAttr:$params)> {
   let summary = "XDLOPS GEMM V2";
   let description = [{
@@ -790,10 +788,10 @@ def MIOpen_XdlopsGemmV2Op:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    $matrixC `+` `` `=` $matrixA `[` $regOffsetA `]` `*`
-                        $matrixB  `[` $regOffsetB `]` attr-dict
+    $matrixC `+` `` `=` $matrixA `*` $matrixB attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
+  let hasVerifier = 1;
 }
 
 // TODO(kdrewnia): upstream these

--- a/mlir/lib/Dialect/MIOpen/MIOpenDialect.cpp
+++ b/mlir/lib/Dialect/MIOpen/MIOpenDialect.cpp
@@ -1045,6 +1045,22 @@ LogicalResult ThreadwiseGemmOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// XdlopsGemmV2Op
+//===----------------------------------------------------------------------===//
+LogicalResult XdlopsGemmV2Op::verify() {
+  ArrayRef<int64_t> aShape = matrixA().getType().cast<MemRefType>().getShape(),
+                    bShape = matrixB().getType().cast<MemRefType>().getShape(),
+                    cShape = matrixC().getType().cast<MemRefType>().getShape();
+
+  if (aShape[1] != bShape[1])
+    return emitOpError("K dimensions don't match");
+  if (aShape[0] != cShape[0])
+    return emitOpError("M dimensions don't match");
+  if (bShape[0] != cShape[1])
+    return emitOpError("N dimensions don't match");
+  return success();
+}
+//===----------------------------------------------------------------------===//
 // InWarpTransposeOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ThreadwiseGemmLowering.cpp
@@ -163,6 +163,14 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
     int64_t MPerWave = tuningParams.getMPerWave();
     int64_t NPerWave = tuningParams.getNPerWave();
 
+    // Workload of either MPerWave and NPerWave that are larger
+    // than wave size of 64 will be executed by repeats
+    // TODO: amend this for tuning parameter selection as well
+    int64_t MRepeats = (MPerWave > 64) ? (MPerWave / 64) : 1;
+    int64_t NRepeats = (NPerWave > 64) ? (NPerWave / 64) : 1;
+    MPerWave = (MPerWave > 64) ? 64 : MPerWave;
+    NPerWave = (NPerWave > 64) ? 64 : NPerWave;
+
     auto dataType = adaptor.matrixA()
                         .getType()
                         .template cast<MemRefType>()
@@ -194,40 +202,65 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
 
     Value matrixA = adaptor.matrixA();
     Value matrixB = adaptor.matrixB();
+    Value matrixC = adaptor.matrixC();
     auto matrixAType = adaptor.matrixA().getType().cast<MemRefType>();
     auto matrixBType = adaptor.matrixB().getType().cast<MemRefType>();
     Type matrixAElementType = matrixAType.getElementType();
     Type matrixBElementType = matrixBType.getElementType();
 
     int64_t KPerThread = IsKReduction ? K / inputSpansPerMfmaIn : K;
-    int64_t KRepeats = KPack / k_base;
-    if (KRepeats == 0)
-      KRepeats = 1;
 
-    auto regAConstantOp =
-        b.create<ConstantIndexOp>(loc, op.regOffsetAAttr().getInt());
-    auto regBConstantOp =
-        b.create<ConstantIndexOp>(loc, op.regOffsetBAttr().getInt());
+    Value reshapedARegisters =
+        reshapeBuffer(b, loc, matrixA, {"m", "k"}, {MRepeats, KPerThread});
+    matrixA = reshapedARegisters;
+    Value reshapedBRegisters =
+        reshapeBuffer(b, loc, matrixB, {"n", "k"}, {NRepeats, KPerThread});
+    matrixB = reshapedBRegisters;
+    Value reshapedCRegisters = reshapeBuffer(
+        b, loc, matrixC, {"m", "n", "v"}, {MRepeats, NRepeats, nResultVectors});
+    matrixC = reshapedCRegisters;
 
-    auto populateMfma = [&](OpBuilder &b, Value &argA, Value &argB) {
+    SmallVector<int64_t> dimensions = {MRepeats, NRepeats, KPerThread,
+                                       nResultVectors};
+    TopDownTMBuilder aView(b, {"m", "n", "k", "v"}, dimensions, loc);
+    aView.ignore("n");
+    aView.ignore("v");
+    aView.passThrough({"m", "k"}, {0, 1}, {"m", "k"});
+    TransformMapAttr aViewAttr = aView.get();
+
+    TopDownTMBuilder bView(b, {"m", "n", "k", "v"}, dimensions, loc);
+    bView.ignore("m");
+    bView.ignore("v");
+    bView.passThrough({"n", "k"}, {0, 1}, {"n", "k"});
+    TransformMapAttr bViewAttr = bView.get();
+
+    TopDownTMBuilder cView(b, {"m", "n", "k", "v"}, dimensions, loc);
+    cView.ignore("k");
+    cView.passThrough({"m", "n", "v"}, {0, 1, 2}, {"m", "n", "v"});
+    TransformMapAttr cViewAttr = cView.get();
+
+    Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
+    SmallVector<Value, 4> startCoords(4, zeroConstantOp);
+
+    ArrayAttr aTransforms, bTransforms, cTransforms;
+    Value bufferA, bufferB, bufferC;
+    // Use linear coordinate on original 1d buffer
+    std::tie(bufferA, aTransforms) = untransform(b, matrixA, {aViewAttr});
+    std::tie(bufferB, bTransforms) = untransform(b, matrixB, {bViewAttr});
+    std::tie(bufferC, cTransforms) = untransform(b, matrixC, {cViewAttr});
+
+    auto populateMfma = [&](OpBuilder &b, Value &argA, Value &argB,
+                            Value &regCOffset) {
       for (int64_t i = 0; i < nResultVectors; ++i) {
-        // Note below is assuming only one of MRepeats or NRepeats is larger
-        // than 1, which fits the existing blockwisegemmv2op implementation.
-        // TODO: Move MRepeats and NRepeats into xdlopsgemmv2op
-        int64_t regDOffset = 0;
-        if (op.regOffsetAAttr().getInt() > 0 ||
-            op.regOffsetBAttr().getInt() > 0) {
-          regDOffset += nResultVectors;
-        }
-        Value offset =
-            b.createOrFold<arith::ConstantIndexOp>(loc, regDOffset + i);
+        Value offset = b.createOrFold<arith::ConstantIndexOp>(loc, i);
+        offset = b.create<AddIOp>(loc, offset, regCOffset);
 
         auto vectorC = b.create<memref::LoadOp>(loc, vectorType,
                                                 adaptor.matrixC(), offset);
         auto mfma = b.create<amdgpu::MFMAOp>(
-            loc, vectorType, /*m=*/mfmaNonKDim, /*n=*/mfmaNonKDim, xcs.k,
-            xcs.blocksMfma, argA, argB, vectorC, imms[i].cbsz, imms[i].abid,
-            imms[i].blgp, /*reducePrecision=*/false, /*negateA=*/false,
+            loc, vectorType, mfmaNonKDim, mfmaNonKDim, xcs.k, xcs.blocksMfma,
+            argA, argB, vectorC, /*cbsz=*/imms[i].cbsz, /*abid=*/imms[i].abid,
+            /*blgp=*/imms[i].blgp, /*reducePrecision=*/false, /*negateA=*/false,
             /*negateB=*/false, /*negateC=*/false);
         auto vectorD = mfma.destD();
 
@@ -235,95 +268,107 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
       }
     };
 
-    // TODO: zyin adopt generic layout: K, KRepeats, k_base
-    // After that, we'd be able to uniform between kPack/nonKPack
-    if (KPack == 1) {
-      // for(index_t k_i = 0; k_i < KPerThread; k_i += k_base) {
-      //   argA = a[k_i];
-      //   argB = a[k_i];
-      //   p_c_thread = mfma(argA, argB, p_c_thread);
-      // }
-      Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
-      auto mfmaLoop = b.create<TransformingForOp>(
-          loc, ArrayRef<ValueRange>{{zeroConstantOp}},
-          ArrayRef<Attribute>{b.getArrayAttr({})},
-          /*bounds=*/ArrayRef<int64_t>{KPerThread},
-          /*strides=*/ArrayRef<int64_t>{k_base},
-          /*useIndexDiffs=*/true, /*forceUnroll=*/true);
-      {
-        OpBuilder::InsertionGuard guard(b);
-        b.setInsertionPointToStart(mfmaLoop.getBody());
-        Value coord = mfmaLoop.getLowerCoords(/*domain=*/0)[0];
+    auto generateMfmaOnKDim = [&](Value &regAOffset, Value &regBOffset,
+                                  Value &regCOffset) {
+      if (KPack == 1) {
+        auto mfmaLoop = b.create<TransformingForOp>(
+            loc, ArrayRef<ValueRange>{{zeroConstantOp}},
+            ArrayRef<Attribute>{b.getArrayAttr({})},
+            /*bounds=*/ArrayRef<int64_t>{KPerThread},
+            /*strides=*/ArrayRef<int64_t>{k_base},
+            /*useIndexDiffs=*/true, /*forceUnroll=*/true);
+        {
+          OpBuilder::InsertionGuard guard(b);
+          b.setInsertionPointToStart(mfmaLoop.getBody());
+          Value coord = mfmaLoop.getLowerCoords(/*domain=*/0)[0];
 
-        auto loadArg = [&](Value regOffset, Value matrix) {
-          Value regIdx = b.create<AddIOp>(loc, regOffset, coord);
-          Value arg;
-          if (k_base == 1) {
-            // xdlops needs only 1 element, load directly from buffer.
-            arg = b.create<InBoundsLoadOp>(loc, argType, matrix,
-                                           ValueRange{regIdx});
-          } else {
-            // k_base > 1, use transferRead to load a vector length equivalent
-            // with a xdlops argument.
-            arg = b.create<vector::TransferReadOp>(
-                loc, argType.cast<VectorType>(), matrix, ValueRange{regIdx},
-                /*InBounds*/ ArrayRef<bool>(true));
-          }
-          return arg;
+          auto loadArg = [&](Value regOffset, Value matrix) {
+            Value regIdx = b.create<AddIOp>(loc, regOffset, coord);
+            Value arg;
+            if (k_base == 1) {
+              // xdlops needs only 1 element, load directly from buffer.
+              arg = b.create<InBoundsLoadOp>(loc, argType, matrix,
+                                             ValueRange{regIdx});
+            } else {
+              // k_base > 1, use transferRead to load a vector length equivalent
+              // with a xdlops argument.
+              arg = b.create<vector::TransferReadOp>(
+                  loc, argType.cast<VectorType>(), matrix, ValueRange{regIdx},
+                  /*InBounds*/ ArrayRef<bool>(true));
+            }
+            return arg;
+          };
+
+          Value argA = loadArg(regAOffset, bufferA);
+          Value argB = loadArg(regBOffset, bufferB);
+          populateMfma(b, argA, argB, regCOffset);
+        };
+      } else {
+        // for(index_t k_i = 0; k_i < KPerThread; ++k_i) {
+        //   matrixAElement = a[k_i];
+        //   matrixBElement = b[k_i];
+        //   // Loop within a kpack
+        //   for(index_t ki_i = 0; ki_i < k_base * KRepeats; ki_i += k_base)
+        //     argA = &matrixAElement[ki_i];
+        //     argB = &matrixAElement[ki_i];
+        //     p_c_thread = mfma_type.template run<MPerXlops * MRepeats,
+        //                                         NPerXdlops * NRepeats,
+        //                                         AStride,
+        //                                         BStride>(argA, argB,
+        //       p_c_thread);
+        // }
+        int64_t outerLoopUpperBound = KPerThread;
+        int64_t KRepeats = KPack / k_base;
+
+        auto outerLoop = b.create<AffineForOp>(loc, 0, outerLoopUpperBound);
+        auto outerLoopb = ConversionPatternRewriter::atBlockBegin(
+            outerLoop.getBody(), b.getListener());
+        auto outerLoopiv = outerLoop.getInductionVar();
+
+        auto loadSingleKPack = [&](Value regOffset, Type elementType,
+                                   Value matrix) {
+          Value regIdx = outerLoopb.create<AddIOp>(loc, regOffset, outerLoopiv);
+          Value element = outerLoopb.create<memref::LoadOp>(
+              loc, elementType, matrix, ValueRange{regIdx});
+          return element;
         };
 
-        Value argA = loadArg(regAConstantOp, matrixA);
-        Value argB = loadArg(regBConstantOp, matrixB);
-        populateMfma(b, argA, argB);
+        Value matrixAElement =
+            loadSingleKPack(regAOffset, matrixAElementType, bufferA);
+        Value matrixBElement =
+            loadSingleKPack(regBOffset, matrixBElementType, bufferB);
+
+        auto innerLoop =
+            outerLoopb.create<AffineForOp>(loc, 0, KRepeats * k_base, k_base);
+        auto innerLoopb = ConversionPatternRewriter::atBlockBegin(
+            innerLoop.getBody(), outerLoopb.getListener());
+        auto innerLoopiv = innerLoop.getInductionVar();
+
+        // At this point, we are guaranteed that buffer element vectorization
+        // length (kPack) must be a multiple of k_base. Use extractsliceop
+        // to handle a independent data slice at a time.
+        Value argA = innerLoopb.create<ExtractSliceOp>(
+            loc, argType, matrixAElement, innerLoopiv);
+        Value argB = innerLoopb.create<ExtractSliceOp>(
+            loc, argType, matrixBElement, innerLoopiv);
+        populateMfma(innerLoopb, argA, argB, regCOffset);
       }
-    } else {
-      // for(index_t k_i = 0; k_i < KPerThread; ++k_i) {
-      //   matrixAElement = a[k_i];
-      //   matrixBElement = b[k_i];
-      //   // Loop within a kpack
-      //   for(index_t ki_i = 0; ki_i < k_base * KRepeats; ki_i += k_base)
-      //     argA = &matrixAElement[ki_i];
-      //     argB = &matrixAElement[ki_i];
-      //     p_c_thread = mfma_type.template run<MPerXlops * MRepeats,
-      //                                         NPerXdlops * NRepeats,
-      //                                         AStride,
-      //                                         BStride>(argA, argB,
-      //       p_c_thread);
-      // }
-      int64_t outerLoopUpperBound = KPerThread;
+    };
 
-      auto outerLoop = b.create<AffineForOp>(loc, 0, outerLoopUpperBound);
-      auto outerLoopb = ConversionPatternRewriter::atBlockBegin(
-          outerLoop.getBody(), b.getListener());
-      auto outerLoopiv = outerLoop.getInductionVar();
+    auto gemmLoop = b.create<TransformingForOp>(
+        loc, ArrayRef<ValueRange>{startCoords, startCoords, startCoords},
+        ArrayRef<Attribute>{aTransforms, bTransforms, cTransforms}, dimensions,
+        /*strides=*/ArrayRef<int64_t>{1, 1, KPerThread, nResultVectors},
+        /*forceUnroll=*/true, /*useIndexDiffs=*/false);
+    {
+      Value regAOffset = gemmLoop.getLowerCoords(/*domain=*/0)[0];
+      Value regBOffset = gemmLoop.getLowerCoords(/*domain=*/1)[0];
+      Value regCOffset = gemmLoop.getLowerCoords(/*domain=*/2)[0];
 
-      auto loadSingleKPack = [&](Value regOffset, Type elementType,
-                                 Value matrix) {
-        Value regIdx = outerLoopb.create<AddIOp>(loc, regOffset, outerLoopiv);
-        Value element = outerLoopb.create<memref::LoadOp>(
-            loc, elementType, matrix, ValueRange{regIdx});
-        return element;
-      };
-      Value matrixAElement =
-          loadSingleKPack(regAConstantOp, matrixAElementType, matrixA);
-      Value matrixBElement =
-          loadSingleKPack(regBConstantOp, matrixBElementType, matrixB);
-
-      auto innerLoop =
-          outerLoopb.create<AffineForOp>(loc, 0, KRepeats * k_base, k_base);
-      auto innerLoopb = ConversionPatternRewriter::atBlockBegin(
-          innerLoop.getBody(), outerLoopb.getListener());
-      auto innerLoopiv = innerLoop.getInductionVar();
-
-      // At this point, we are guaranteed that buffer element vectorization
-      // length (kPack) must be a multiple of k_base. Use extractsliceop
-      // to handle a independent data slice at a time.
-      Value argA = innerLoopb.create<ExtractSliceOp>(
-          loc, argType, matrixAElement, innerLoopiv);
-      Value argB = innerLoopb.create<ExtractSliceOp>(
-          loc, argType, matrixBElement, innerLoopiv);
-      populateMfma(innerLoopb, argA, argB);
-    }
+      OpBuilder::InsertionGuard guard(b);
+      b.setInsertionPointToStart(gemmLoop.getBody());
+      generateMfmaOnKDim(regAOffset, regBOffset, regCOffset);
+    };
 
     b.eraseOp(op);
     return success();

--- a/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
+++ b/mlir/test/Dialect/MIOpen/lowering_blockwise_gemm_v2.mlir
@@ -21,7 +21,7 @@ func.func @miopen_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
 }
 
 func.func @miopen_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>,
-                                               %bufferA : memref<2xvector<4xi8>, 5>, %bufferB : memref<2xvector<4xi8>, 5>,
+                                               %bufferA : memref<1xvector<4xi8>, 5>, %bufferB : memref<1xvector<4xi8>, 5>,
                                                %matrixC : memref<1xvector<16xi32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK:  miopen.xdlops_gemm_v2
@@ -36,6 +36,6 @@ func.func @miopen_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>,
       nPerWave = 32>,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 1024 : index
-  } : memref<1xvector<16xi32>, 5> += memref<2xvector<4xi8>, 5> from memref<2048xi8, 3> * memref<2xvector<4xi8>, 5> from memref<2048xi8, 3>
+  } : memref<1xvector<16xi32>, 5> += memref<1xvector<4xi8>, 5> from memref<2048xi8, 3> * memref<1xvector<4xi8>, 5> from memref<2048xi8, 3>
   return
 }

--- a/mlir/test/Dialect/MIOpen/ops_2.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_2.mlir
@@ -477,11 +477,11 @@ func.func @miopen_threadwise_gemm(%lhs : memref<4x8x1xf32, 5>, %rhs : memref<4x8
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<32xf32, 5>,
-                                            %matrixB : memref<16xf32, 5>,
-                                            %matrixC : memref<1xvector<32xf32>, 5>) {
+func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<2x16xf32, 5>,
+                                            %matrixB : memref<1x16xf32, 5>,
+                                            %matrixC : memref<2x1x1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
     params = #miopen.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -489,7 +489,7 @@ func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<32xf32, 5>,
       mPerWave = 128,
       nPerWave = 64,
       kpack = 1>
-  } : memref<1xvector<32xf32>, 5> += memref<32xf32, 5> * memref<16xf32, 5>
+  } : memref<2x1x1xvector<32xf32>, 5> += memref<2x16xf32, 5> * memref<1x16xf32, 5>
   return
 }
 
@@ -498,11 +498,11 @@ func.func @miopen_xdlops_gemm_v2_one_result(%matrixA : memref<32xf32, 5>,
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<32xf32, 5>,
-                                             %matrixB : memref<16xf32, 5>,
-                                             %matrixC : memref<2xvector<32xf32>, 5>) {
+func.func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<2x16xf32, 5>,
+                                             %matrixB : memref<1x16xf32, 5>,
+                                             %matrixC : memref<2x1x1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
     params = #miopen.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -510,7 +510,7 @@ func.func @miopen_xdlops_gemm_v2_two_results(%matrixA : memref<32xf32, 5>,
       mPerWave = 128,
       nPerWave = 64,
       kpack = 1>
-  } : memref<2xvector<32xf32>, 5> += memref<32xf32, 5> * memref<16xf32, 5>
+  } : memref<2x1x1xvector<32xf32>, 5> += memref<2x16xf32, 5> * memref<1x16xf32, 5>
   return
 }
 

--- a/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/MIOpen/ops_blockwise_f16.mlir
@@ -26,11 +26,11 @@ func.func @miopen_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrixA : memref<32xf16, 5>,
-                                                %matrixB : memref<16xf16, 5>,
-                                                %matrixC : memref<1xvector<32xf16>, 5>) {
+func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrixA : memref<2x16xf16, 5>,
+                                                %matrixB : memref<1x16xf16, 5>,
+                                                %matrixC : memref<2x1x1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
     params = #miopen.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -38,7 +38,7 @@ func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrixA : memref<32xf16, 5>,
       mPerWave = 128,
       nPerWave = 64,
       kpack = 1>
-  } : memref<1xvector<32xf16>, 5> += memref<32xf16, 5> * memref<16xf16, 5>
+  } : memref<2x1x1xvector<32xf16>, 5> += memref<2x16xf16, 5> * memref<1x16xf16, 5>
   return
 }
 
@@ -47,11 +47,11 @@ func.func @miopen_xdlops_gemm_v2_one_result_f16(%matrixA : memref<32xf16, 5>,
 
 // ----
 
-func.func @miopen_xdlops_gemm_v2_two_results_f16(%matrixA : memref<32xf16, 5>,
-                                                 %matrixB: memref<16xf16, 5>,
-                                                 %matrixC : memref<1xvector<32xf16>, 5>) {
+func.func @miopen_xdlops_gemm_v2_two_results_f16(%matrixA : memref<2x16xf16, 5>,
+                                                 %matrixB: memref<1x16xf16, 5>,
+                                                 %matrixC : memref<2x1x1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  miopen.xdlops_gemm_v2 %matrixC += %matrixA[0] * %matrixB[0] {
+  miopen.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
     params = #miopen.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -59,7 +59,7 @@ func.func @miopen_xdlops_gemm_v2_two_results_f16(%matrixA : memref<32xf16, 5>,
       mPerWave = 128,
       nPerWave = 64,
       kpack = 1>
-  } : memref<1xvector<32xf16>, 5> += memref<32xf16, 5> * memref<16xf16, 5>
+  } : memref<2x1x1xvector<32xf16>, 5> += memref<2x16xf16, 5> * memref<1x16xf16, 5>
   return
 }
 


### PR DESCRIPTION
This PR did the following:
 - Get rid of the hard-coded repeats definition in blockwisegemmV2
   - It is xdlops gemm's responsibility to perform the execution in register level
 - M/N Repeats become a loop so we can potentially go with arbitrary repeats numbers (with larger tile size)
 - Abstracted the Repeats in coordinate transform infrastructure
   - The common coordinate space is [m, n, k, v] with:
     - m: MRepeats
     - n: NRepeats
     - k: KPerThread
     - v: Vector length along the result dimension, such that if the group of xdlops generate 2 result vectors, the number is 2
   - Inconsistencies between K dimension caused by divergence between reduction/non-reduction will be address later
   - Note: I struggled with how to use the proper coordinate space on especially v dimension and ended up deciding it is key to describe a xdlops gemm.
 - Fix and amend unit tests 