### PR TITLE
Improve non-tuned param ordering

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -131,32 +131,68 @@ template <typename T> std::string genDebugForParams(T params) {
 }
 
 template <typename InitParamType> class BasePopulateParams {
+private:
+  struct InitParamData {
+    InitParamType paramSet;
+    size_t original_pos;
+    int64_t padding_amount;
+
+    bool operator<(const InitParamData &rhs) {
+      if (this->padding_amount < rhs.padding_amount) {
+        return true;
+      } else if (this->padding_amount == rhs.padding_amount) {
+        if (this->original_pos < rhs.original_pos) {
+          return true;
+        }
+        return false;
+      }
+      return false;
+    }
+  };
+
+  std::vector<InitParamData>
+  createParamData(const ArrayRef<InitParamType> &initParams,
+                  const GemmSize &gemmSize) {
+    std::vector<InitParamData> res;
+    for (size_t pos = 0; pos < initParams.size(); pos++) {
+      InitParamType paramSet = initParams[pos];
+      InitParamData paramData;
+      paramData.paramSet = paramSet;
+      paramData.original_pos = pos;
+      paramData.padding_amount = calculatePaddingAmount(paramSet, gemmSize);
+      assert(paramData.original_pos >= 0);
+      assert(paramData.padding_amount >= 0);
+      res.push_back(paramData);
+    }
+    return res;
+  }
+
 protected:
   // Interface function to check whether the given GEMM is valid
   virtual LogicalResult isValidGemm(const InitParamType &param,
                                     const GemmSize &gemmSize) const = 0;
 
+  // Interface function to calculate padding amount of a given param set
+  virtual int64_t calculatePaddingAmount(const InitParamType &params,
+                                         const GemmSize &gemmSize) const = 0;
+
   // This function will order the initParams used in a non-tuning flow to
   // prioritize params that does not require padding to come first while
   // otherwise maintaining the provided order.
-  // TODO(@manupak) : improve this to order based on amount of padding added.
   std::vector<InitParamType>
   orderInitParams(const ArrayRef<InitParamType> &initParams,
                   const GemmSize &gemmSize) {
-    std::vector<InitParamType> paddingRequiredParams;
-    std::vector<InitParamType> paddingNotRequiredParams;
-    for (const InitParamType &param : initParams) {
-      if (isValidGemm(param, gemmSize).succeeded()) {
-        paddingNotRequiredParams.emplace_back(param);
-      } else {
-        paddingRequiredParams.emplace_back(param);
-      }
-    }
+    std::vector<InitParamData> initParamData =
+        createParamData(initParams, gemmSize);
+    std::sort(initParamData.begin(), initParamData.end());
+
     std::vector<InitParamType> orderedParams;
-    std::move(paddingNotRequiredParams.begin(), paddingNotRequiredParams.end(),
-              std::back_inserter(orderedParams));
-    std::move(paddingRequiredParams.begin(), paddingRequiredParams.end(),
-              std::back_inserter(orderedParams));
+    orderedParams.resize(initParams.size());
+    std::transform(initParamData.begin(), initParamData.end(),
+                   orderedParams.begin(),
+                   [](InitParamData paramData) -> InitParamType {
+                     return paramData.paramSet;
+                   });
     return orderedParams;
   }
 
@@ -209,13 +245,16 @@ public:
       DerivedParams &gemmBDerivedParam,
       DerivedOutParams &gemmCDerivedParam, uint32_t &gridSize);
 
-  ArrayRef<InitParamsNonXDL> getTuningParameters(ConvOpType dir,
-                                                 Type dataType) const;
+  std::vector<InitParamsNonXDL> getTuningParameters(ConvOpType dir,
+                                                    Type dataType) const;
 
   const InitParams &getUniversalParameters() const;
 
   LogicalResult isValidGemm(const InitParamsNonXDL &param,
                             const GemmSize &gemmSize) const override;
+
+  int64_t calculatePaddingAmount(const InitParamsNonXDL &params,
+                                 const GemmSize &gemmSize) const override;
 };
 
 class PopulateParamsXDL : public BasePopulateParams<InitParamsXDL> {
@@ -282,12 +321,15 @@ public:
       DerivedParams &gemmBDerivedParam, DerivedOutParams &gemmCDerivedParam,
       uint32_t &blockSize, uint32_t &gridSize, int64_t &gemmKBlocks);
 
-  ArrayRef<InitParamsXDL> getTuningParameters(ConvOpType dir,
-                                              Type dataType) const;
+  std::vector<InitParamsXDL> getTuningParameters(ConvOpType dir,
+                                                 Type dataType) const;
   const InitParams &getUniversalParameters() const;
 
   LogicalResult isValidGemm(const InitParamsXDL &param,
                             const GemmSize &gemmSize) const override;
+
+  int64_t calculatePaddingAmount(const InitParamsXDL &params,
+                                 const GemmSize &gemmSize) const override;
 };
 
 // This core function to calculate the required padding amount

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -358,7 +358,7 @@ struct BlockwiseGemmV2RewritePattern
                          b.create<ConstantIndexOp>(loc, ldsOffsetB / KPack));
 
     XdlopsCodeSelection xcs =
-        XdlopsCodeSelection::get(dataType, MPerWave, NPerWave, b);
+        XdlopsCodeSelection::get(dataType, MPerWave, NPerWave);
 
     // Extract values from XdlopsCodeSelection.
     Type argType = xcs.argType;
@@ -558,7 +558,7 @@ struct BlockwiseGemmV2RewritePattern
     // Workload of either MPerWave and NPerWave that are larger
     // than wave size of 64 will be executed by repeats
     // TODO: amend this for tuning parameter selection as well
-    xcs = XdlopsCodeSelection::get(dataType, MPerXdlops, NPerXdlops, b);
+    xcs = XdlopsCodeSelection::get(dataType, MPerXdlops, NPerXdlops);
     Value reshapedARegisters = reshapeBuffer(
         b, loc, adaptor.getBufferA(), {"m", "k"}, {MRepeats, KPerThread});
     Value reshapedBRegisters = reshapeBuffer(

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1759,7 +1759,11 @@ struct GridwiseGemmV2RewritePattern
 
     // Logic to do XDLOPS code selection.
     XdlopsCodeSelection xcs =
-        XdlopsCodeSelection::get(elementType, MPerWave, NPerWave, b);
+        XdlopsCodeSelection::get(elementType, MPerWave, NPerWave);
+    if (!xcs.isValid(KPack, KPerBlock)) {
+      LLVM_DEBUG(llvm::dbgs() << "XdlopsCodeSelection is not valid.\n");
+      return failure();
+    }
 
     // Extract values from XdlopsCodeSelection.
     int64_t MRepeats = xcs.MRepeats;
@@ -1777,7 +1781,6 @@ struct GridwiseGemmV2RewritePattern
     int64_t m = xcs.mfmaNonKDim;
     // Note n has the 4x4 => 4x64 behavior that necessitated inputSpansPerMfmaIn
     int64_t n = xcs.inputSpanLen;
-    int64_t k_base = xcs.k_base;
 
     int64_t blocksPerRepeat = (mPerRepeat * nPerRepeat) / (m * n);
     // -----
@@ -1811,17 +1814,6 @@ struct GridwiseGemmV2RewritePattern
                              : (KPerBlock / inputSpansPerMfmaIn * NRepeats);
     Type arrayAType, arrayBType;
     if (KPack > 1) {
-      // Should pack at least k_base elements and avoid waste xdlopsgemm
-      // cycles
-      if (KPack < k_base) {
-        return failure();
-      }
-
-      // When reduction, KPerBlock must be at least num_input_blks
-      if (IsKReduction && KPerBlock < inputSpansPerMfmaIn) {
-        return failure();
-      }
-
       arrayAType =
           MemRefType::get({arrayASize}, VectorType::get({KPack}, elementType),
                           {}, gpu::GPUDialect::getPrivateAddressSpace());
@@ -1829,16 +1821,6 @@ struct GridwiseGemmV2RewritePattern
           MemRefType::get({arrayBSize}, VectorType::get({KPack}, elementType),
                           {}, gpu::GPUDialect::getPrivateAddressSpace());
     } else {
-      // When non-reduction, KPerBlock must be at least k_base
-      if (!IsKReduction && KPerBlock < k_base) {
-        return failure();
-      }
-
-      // When reduction, KPerBlock must be at least k_base * num_input_blks
-      if (IsKReduction && KPerBlock < k_base * inputSpansPerMfmaIn) {
-        return failure();
-      }
-
       arrayAType = MemRefType::get({arrayASize}, elementType, {},
                                    gpu::GPUDialect::getPrivateAddressSpace());
       arrayBType = MemRefType::get({arrayBSize}, elementType, {},
@@ -2141,6 +2123,7 @@ struct GridwiseGemmV2RewritePattern
     return success();
   }
 };
+
 } // end anonymous namespace
 
 void RockGridwiseGemmToBlockwisePass::runOnOperation() {

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -206,7 +206,7 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
                             << "NPerXdlops: " << NPerXdlops << "\n");
 
     XdlopsCodeSelection xcs =
-        XdlopsCodeSelection::get(dataType, MPerXdlops, NPerXdlops, b);
+        XdlopsCodeSelection::get(dataType, MPerXdlops, NPerXdlops);
 
     VectorType vectorType = xcs.vectorType;
     int64_t nResultVectors = xcs.nResultVectors;

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -1,5 +1,6 @@
 #include "mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
+#include "mlir/Dialect/Rock/IR/XdlopsCodeSelection.h"
 #include "mlir/Dialect/Rock/Tuning/ConvContext.h"
 #include "mlir/Dialect/Rock/Tuning/GemmContext.h"
 #include "mlir/Dialect/Rock/Tuning/GeneralGemmBlockStructure.h"
@@ -569,6 +570,7 @@ LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
 
   return success();
 }
+
 LogicalResult PopulateParams::populateDerived(
     ConvolutionContext &ctx, const InitParamsNonXDL &params, GemmSize &gemmSize,
     DerivedParams &gemmADerivedParam, DerivedParams &gemmBDerivedParam,
@@ -673,7 +675,7 @@ LogicalResult PopulateParams::obtainTuningParameters(
 
   // Backup path: Use the set of default tuning parameters
   LogicalResult res = failure();
-  ArrayRef<InitParamsNonXDL> paramSets =
+  std::vector<InitParamsNonXDL> paramSets =
       getTuningParameters(ctx.getOpType(), ctx.getDataType());
   for (auto &params : orderInitParams(paramSets, gemmSize)) {
     // We have an override on the blockSize, only loop through the
@@ -694,9 +696,10 @@ LogicalResult PopulateParams::obtainTuningParameters(
   return res;
 }
 
-ArrayRef<InitParamsNonXDL>
+std::vector<InitParamsNonXDL>
 PopulateParams::getTuningParameters(ConvOpType dir, Type dataType) const {
-  return {initParameters, nInitParameters};
+  ArrayRef<InitParamsNonXDL> params = {initParameters, nInitParameters};
+  return std::vector<InitParamsNonXDL>(params);
 }
 
 const InitParams &PopulateParams::getUniversalParameters() const {
@@ -711,6 +714,39 @@ LogicalResult PopulateParams::isValidGemm(const InitParamsNonXDL &param,
     return failure();
   }
   return success();
+}
+
+static int64_t calculatePaddingComplexity(const GemmContext &paddingAmount,
+                                          const GemmSize &gemmSize) {
+  int64_t nonPaddedComplexity =
+      gemmSize.gemmM * gemmSize.gemmK * gemmSize.gemmN;
+  int64_t paddedComplexity = (gemmSize.gemmM + paddingAmount.m) *
+                             (gemmSize.gemmK + paddingAmount.k) *
+                             (gemmSize.gemmN + paddingAmount.n);
+  return paddedComplexity - nonPaddedComplexity;
+}
+
+int64_t PopulateParams::calculatePaddingAmount(const InitParamsNonXDL &params,
+                                               const GemmSize &gemmSize) const {
+  Optional<GemmContext> maybeGemmExtraPad =
+      calculatePadding(params.gemmKPerBlock, params.gemmMPerBlock,
+                       params.gemmNPerBlock, gemmSize);
+  if (maybeGemmExtraPad.has_value()) {
+    return calculatePaddingComplexity(maybeGemmExtraPad.value(), gemmSize);
+  }
+  return 0;
+}
+
+int64_t
+PopulateParamsXDL::calculatePaddingAmount(const InitParamsXDL &params,
+                                          const GemmSize &gemmSize) const {
+  Optional<GemmContext> maybeGemmExtraPad =
+      calculatePadding(params.gemmKPerBlock, params.gemmMPerBlock,
+                       params.gemmNPerBlock, gemmSize, params.gemmKPack);
+  if (maybeGemmExtraPad.has_value()) {
+    return calculatePaddingComplexity(maybeGemmExtraPad.value(), gemmSize);
+  }
+  return 0;
 }
 
 /// Xdlops
@@ -1050,7 +1086,7 @@ LogicalResult PopulateParamsXDL::obtainTuningParameters(
 #endif // MLIR_ENABLE_SQLITE
 
   LogicalResult res = failure();
-  ArrayRef<InitParamsXDL> paramSets =
+  std::vector<InitParamsXDL> paramSets =
       getTuningParameters(ctx.getOpType(), ctx.getDataType());
   for (const auto &params : orderInitParams(paramSets, gemmSize)) {
     blockSize = obtainBlockSize(params, waveSize);
@@ -1073,13 +1109,23 @@ LogicalResult PopulateParamsXDL::obtainTuningParameters(
   return res;
 }
 
-ArrayRef<InitParamsXDL>
+std::vector<InitParamsXDL>
 PopulateParamsXDL::getTuningParameters(ConvOpType dir, Type dataType) const {
+  ArrayRef<InitParamsXDL> params;
   if (dataType.isInteger(8)) {
-    return {initParametersForwardI8, nInitParametersForwardI8};
+    params = {initParametersForwardI8, nInitParametersForwardI8};
+  } else {
+    params = {initParameters, nInitParameters};
   }
-
-  return {initParameters, nInitParameters};
+  std::vector<InitParamsXDL> res;
+  // Only return valid XDLOp params
+  std::copy_if(params.begin(), params.end(), std::back_inserter(res),
+               [&](const InitParamsXDL &param) {
+                 return XdlopsCodeSelection::get(dataType, param.gemmMPerWave,
+                                                 param.gemmNPerWave)
+                     .isValid(param.gemmKPack, param.gemmKPerBlock);
+               });
+  return res;
 }
 
 const InitParams &PopulateParamsXDL::getUniversalParameters() const {

--- a/mlir/test/Dialect/Rock/lowering_padding_kernel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_padding_kernel.mlir
@@ -2,7 +2,7 @@
 // * The correct padding transformations are generated and added to the gemm
 
 // RUN: rocmlir-opt -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise %s | FileCheck %s
-// CHECK-DAG: #[[$PAD_GEMMK:.*]] = #rock.transform_map{{.*}}Pad{0, 14} ["gemmKPad"] at [1] -> ["gemmK"] at [1]
+// CHECK-DAG: #[[$PAD_GEMMK:.*]] = #rock.transform_map{{.*}}Pad{0, 2} ["gemmKPad"] at [1] -> ["gemmK"] at [1]
 
 // CHECK-LABEL: func.func @rock_conv2d_kcyx_nchw_nkhw_padding_kernel
 // CHECK-SAME: %[[filter:.*]]: memref<32x128x2x3x3xf32>


### PR DESCRIPTION
This commit improves the init param ordering
to be sorted based on padding amount.
i.e. lowest padding is preffered.

When in equal padding cases, the original
ordering will be respected.

Doing so, exposed some params should be
dynamically filtered out according to
XdlopsCodeSelection.