### PR TITLE
Revert "* encourage minor identity mappings in elementwise conversion"

### DIFF
--- a/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -631,7 +631,7 @@ elementwiseMatchAndRewriteHelper(Operation *operation,
     SmallVector<AffineExpr, 4> affineExprs;
     newShape.reserve(type.getRank());
     for (const auto &it : llvm::enumerate(type.getShape())) {
-      if (it.value() == resultTy.getDimSize(it.index()) && it.value() != 1) {
+      if (it.value() == resultTy.getDimSize(it.index())) {
         newShape.push_back(it.value());
         affineExprs.push_back(
             mlir::getAffineDimExpr(it.index(), rewriter.getContext()));


### PR DESCRIPTION
This reverts commit 45ecde6aedeb2085abee1785abbd4189be7c7a71.

Fixes a failure in MIGraphX integration test. Caused by folding 1x1x1x1xF32 -> F32 scalar type and further coordinate manipulation doesn't work (especially in fusion) as it doesn't have any coordinate.