### PR TITLE
[hotfix] Disable conv when padding is an exact multiple of filter width

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
@@ -889,6 +889,17 @@ template <typename T> struct Conv2DRewritePattern : public OpRewritePattern<T> {
       break;
     }
 
+    // Hotfix: handle problems with the gemm logic not interecting well with
+    // even padding Note: xdlops doesn't use any of the suspect logic yet, and
+    // so we can put this fix after we move to atomic add.
+    int64_t x = filterTransform.startSize("x");
+    if ((x > 1) && ((leftPadW > 0 && leftPadW % x == 0) ||
+                    (rightPadW > 0 && rightPadW % x == 0))) {
+      return op.emitOpError(
+          "padding of input tensor in w dimension that's an exact multiple of "
+          "the filter width is temporarily disabled");
+    }
+
     TransformMapAttr filterTransformAttr = filterTransform.get();
     Value gemmFilter =
         b.create<TransformOp>(loc, op.filter(), filterTransformAttr);


### PR DESCRIPTION
At some point, we introduced a bug that causes convolutions such as the following one to fail

./bin/miopen-gen --operation conv2d  -t f32 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 64 --in_h 64 --in_w 64 --out_channels 64 --fil_h 2 --fil_w 2 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h_l 0 --padding_h_r 0 --padding_w_l 0 --padding_w_r 2 -ph -pv | ./bin/mlir-miopen-driver -c | rocm-run 2>&1 | less

Since we're about to release, and since this isn't a particularly common usecase, disable convolutions that use such parameters so we can work out the bug later.