### PR TITLE
Backport #772 to release/rocm-5.4

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/ConvToGemm.cpp
@@ -889,17 +889,6 @@ template <typename T> struct Conv2DRewritePattern : public OpRewritePattern<T> {
       break;
     }
 
-    // Hotfix: handle problems with the gemm logic not interecting well with
-    // even padding Note: xdlops doesn't use any of the suspect logic yet, and
-    // so we can put this fix after we move to atomic add.
-    int64_t x = filterTransform.startSize("x");
-    if ((x > 1) && ((leftPadW > 0 && leftPadW % x == 0) ||
-                    (rightPadW > 0 && rightPadW % x == 0))) {
-      return op.emitOpError(
-          "padding of input tensor in w dimension that's an exact multiple of "
-          "the filter width is temporarily disabled");
-    }
-
     TransformMapAttr filterTransformAttr = filterTransform.get();
     Value gemmFilter =
         b.create<TransformOp>(loc, op.filter(), filterTransformAttr);


### PR DESCRIPTION
Revert "[hotfix] Disable conv when padding is an exact multiple of filter width (#770)"

This reverts commit 63d561b75386d528acb78e87a6188474c6e4cd12.

Resolve incorrect results by handling alignment in the autovectorizer

Previously, if we had, for example, an image with width 4 padded to width 6 (on the right) with a filter of 2, the vectorizer would infer a vectorization length of 2 in the M dimension because, all else being held constant, you could fetch the vectors (I[0], I[1]) (I[2], I[3]), [faild bounds check -> (0, 0)] without partial oob.

However, suppose we had added 1 to the input coordinate to handle the case where x = 1. Then we'd fetch the vectors (I[1], I[2]), (I[3], I[4]), (0, 0). Note that I[4], which is reading into the next row and should've been (I[3], 0) instead.

This commit resolves the issue by tracking alignment in the vectorizer, and using that information to resolve the vectorization of padding.

Add a test, loosen up alignment logic a bit to make it pass in a reasonable way

Fix up logic for merge, unmerge, embed