### PR TITLE
[DO NOT SQUASH] Move to using HIP config instead of HIP module in CMake

### DIFF
--- a/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -197,23 +197,8 @@ if(MLIR_ENABLE_ROCM_RUNNER)
       set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which ROCm has been installed")
     endif()
   endif()
-  set(HIP_PATH "${ROCM_PATH}/hip" CACHE PATH "Path to which HIP has been installed")
-  set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
-  find_package(HIP)
-  if (NOT HIP_FOUND)
-    message(SEND_ERROR "Building mlir with ROCm support requires a working ROCm and HIP install")
-  else()
-    message(STATUS "ROCm HIP version: ${HIP_VERSION}")
-  endif()
-
-  # Locate HIP runtime library.
-  find_library(ROCM_RUNTIME_LIBRARY amdhip64
-               PATHS "${HIP_PATH}/lib")
-  if (NOT ROCM_RUNTIME_LIBRARY)
-    message(SEND_ERROR "Could not locate ROCm HIP runtime library")
-  else()
-    message(STATUS "ROCm HIP runtime lib: ${ROCM_RUNTIME_LIBRARY}")
-  endif()
+  list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
+  find_package(hip REQUIRED)
 
   if (NOT DEFINED ROCM_TEST_CHIPSET)
     execute_process(COMMAND "${ROCM_PATH}/bin/rocm_agent_enumerator"
@@ -270,28 +255,13 @@ if(MLIR_ENABLE_ROCM_RUNNER)
      "-Wno-gnu-anonymous-struct")
   endif()
 
-  target_compile_definitions(mlir_rocm_runtime
-    PRIVATE
-    __HIP_PLATFORM_HCC__
-  )
-  target_include_directories(mlir_rocm_runtime
-    PRIVATE
-    ${HIP_PATH}/include
-    ${ROCM_PATH}/include
-  )
   set_property(TARGET mlir_rocm_runtime
     PROPERTY INSTALL_RPATH_USE_LINK_PATH ON)
 
   target_link_libraries(mlir_rocm_runtime
     PUBLIC
-    ${ROCM_RUNTIME_LIBRARY}
+    hip::host hip::amdhip64
   )
-
-  # Set HIP compile-time flags.
-  add_definitions(-D__HIP_PLATFORM_AMD__)
-
-  set_source_files_properties(RocmSystemDetect.cpp PROPERTIES
-    COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types;-Wno-c++98-compat-extra-semi")
 
   add_mlir_library(MLIRRocmExecutionEngineUtils
     RocmSystemDetect.cpp
@@ -303,16 +273,26 @@ if(MLIR_ENABLE_ROCM_RUNNER)
     intrinsics_gen
   )
 
-  llvm_update_compile_flags(MLIRRocmExecutionEngineUtils)
-  target_include_directories(MLIRRocmExecutionEngineUtils
-    PRIVATE
-    ${HIP_PATH}/include
-    ${ROCM_PATH}/include
-  )
+  if (CXX_SUPPORTS_CXX98_COMPAT_EXTRA_SEMI_FLAG)
+    target_compile_options(MLIRRocmExecutionEngineUtils PRIVATE
+    "-Wno-c++98-compat-extra-semi")
+  endif()
+  if (CXX_SUPPORTS_WNO_RETURN_TYPE_C_LINKAGE_FLAG)
+    target_compile_options(MLIRRocmExecutionEngineUtils PRIVATE
+      "-Wno-return-type-c-linkage")
+  endif()
+  if (CXX_SUPPORTS_WNO_NESTED_ANON_TYPES_FLAG)
+    target_compile_options(MLIRRocmExecutionEngineUtils PRIVATE
+      "-Wno-nested-anon-types")
+  endif()
+  if (CXX_SUPPORTS_WNO_GNU_ANONYMOUS_STRUCT_FLAG)
+    target_compile_options(MLIRRocmExecutionEngineUtils PRIVATE
+     "-Wno-gnu-anonymous-struct")
+  endif()
 
   target_link_libraries(MLIRRocmExecutionEngineUtils PRIVATE
-    MLIRExecutionEngineUtils
-    ${ROCM_RUNTIME_LIBRARY}
+    MLIRExecutionEngineUtils)
+  target_link_libraries(MLIRRocmExecutionEngineUtils PUBLIC
+    hip::host hip::amdhip64
   )
-
 endif()

--- a/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -264,6 +264,7 @@ if(MLIR_ENABLE_ROCM_RUNNER)
   )
 
   add_mlir_library(MLIRRocmExecutionEngineUtils
+    SHARED
     RocmSystemDetect.cpp
 
     ADDITIONAL_HEADER_DIRS
@@ -291,7 +292,8 @@ if(MLIR_ENABLE_ROCM_RUNNER)
   endif()
 
   target_link_libraries(MLIRRocmExecutionEngineUtils PRIVATE
-    MLIRExecutionEngineUtils)
+    MLIRExecutionEngineUtils
+  )
   target_link_libraries(MLIRRocmExecutionEngineUtils PUBLIC
     hip::host hip::amdhip64
   )

--- a/mlir/tools/mlir-rocm-runner/CMakeLists.txt
+++ b/mlir/tools/mlir-rocm-runner/CMakeLists.txt
@@ -10,29 +10,8 @@ if(MLIR_ENABLE_ROCM_RUNNER)
       "Building the mlir rocm runner requires the AMDGPU backend")
   endif()
 
-  # Set compile-time flags for ROCm path.
-  add_definitions(-D__ROCM_PATH__="${ROCM_PATH}")
-
-  set(HIP_PATH "${ROCM_PATH}/hip" CACHE PATH " Path to which HIP has been installed")
-  set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
-  find_package(HIP)
-  if (NOT HIP_FOUND)
-    message(SEND_ERROR "Build the mlir rocm runner requires a working ROCm and HIP install")
-  else()
-    message(STATUS "ROCm HIP version: ${HIP_VERSION}")
-  endif()
-
-  # Locate HIP runtime library.
-  find_library(ROCM_RUNTIME_LIBRARY amdhip64
-    PATHS "${HIP_ROOT_DIR}/lib")
-  if (NOT ROCM_RUNTIME_LIBRARY)
-    message(SEND_ERROR "Could not locate ROCm HIP runtime library")
-  else()
-    message(STATUS "ROCm HIP runtime lib: ${ROCM_RUNTIME_LIBRARY}")
-  endif()
-
-  # Set HIP compile-time flags.
-  add_definitions(-D__HIP_PLATFORM_AMD__)
+  list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
+  find_package(hip REQUIRED)
 
   set_source_files_properties(mlir-rocm-runner.cpp PROPERTIES
     COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types;-Wno-c++98-compat-extra-semi")
@@ -59,7 +38,6 @@ if(MLIR_ENABLE_ROCM_RUNNER)
     MLIRTestDialect
     MLIRTransforms
     MLIRTranslateLib
-    ${ROCM_RUNTIME_LIBRARY}
   )
 
   add_llvm_tool(mlir-rocm-runner
@@ -69,12 +47,7 @@ if(MLIR_ENABLE_ROCM_RUNNER)
     mlir_rocm_runtime
     conv-validation-wrappers
     )
-  llvm_update_compile_flags(mlir-rocm-runner)
-  target_include_directories(mlir-rocm-runner
-    PRIVATE
-    "${HIP_PATH}/../include"
-    "${HIP_PATH}/include"
-  )
   target_link_libraries(mlir-rocm-runner PRIVATE ${LIBS})
+  target_link_libraries(mlir-rocm-runner PUBLIC hip::host hip::amdhip64)
 
 endif()

--- a/mlir/tools/mlir-rocm-runner/CMakeLists.txt
+++ b/mlir/tools/mlir-rocm-runner/CMakeLists.txt
@@ -12,6 +12,7 @@ if(MLIR_ENABLE_ROCM_RUNNER)
 
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
   find_package(hip REQUIRED)
+  message("Found HIP version: ${hip_VERSION}")
 
   set_source_files_properties(mlir-rocm-runner.cpp PROPERTIES
     COMPILE_OPTIONS "-Wno-gnu-anonymous-struct;-Wno-nested-anon-types;-Wno-c++98-compat-extra-semi")


### PR DESCRIPTION
To quote the external commit

[[mlir] Use hip's config mode to find libraries](https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/780/commits/953bf47f35f037ea0d050c07b1d11367e0e69067)
[953bf47](https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/780/commits/953bf47f35f037ea0d050c07b1d11367e0e69067)

Instead of using find_package(HIP) to find FindHIP.cmake, which
doesn't seem to be the preferred way to find HIP anymore, use
find_package(hip CONFIG) to find the HIP configuration. Give
preference to ${ROCM_PATH} over ${ROCM_PATH}/hip in order to handle
the fact that newer ROCm versions prefer the include path to use
${ROCM_PATH}/include/hip over ${ROCM_PATH}/hip/innclude/hip (the
latter throws up a bunch of deprecation warnings)

Then, instead of trying to manually find the host-side headers and
runtime library by hand, use the hip::host and hip::amdhip64 libraries
that the config module defines.

This makes the CMake config much less error-prone and brings it in
line with the recommended approach to finding HIP.

Fixes
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/658