### PR TITLE
Clean up option handling of perf script

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -653,9 +653,9 @@ pipeline {
                     steps {
                         buildProject('ci-performance-scripts', '')
                         dir('build') {
-                           sh 'python3 ./bin/MIOpenDriver.py -bmiopen_use_tuned_mlir'
+                           sh 'python3 ./bin/MIOpenDriver.py --miopen_use_tuned_mlir'
                            sh 'rm -rf ${WORKSPACE}/MIOpen/build/MIOpenUserDB'
-                           sh 'python3 ./bin/MIOpenDriver.py -bmiopen_use_untuned_mlir'
+                           sh 'python3 ./bin/MIOpenDriver.py --miopen_use_untuned_mlir'
                         }
                     }
                 }

--- a/mlir/utils/jenkins/MIOpenDriver.py
+++ b/mlir/utils/jenkins/MIOpenDriver.py
@@ -535,7 +535,7 @@ def main(args=None):
         help="Only tune the MLIR kernels"
     )
     mutex_arg_group.add_argument(
-        "-b", "--batch",
+        "-b", "--batch_mlir",
         action="store_true",
         help="CSV batch benchmarking mode with MLIR"
     )
@@ -591,7 +591,7 @@ def main(args=None):
         if not parsed_args.miopen_build_dir:
             raise RuntimeError("MIOpen build dir was not provided/found where the test requires it")
 
-    if parsed_args.batch or parsed_args.batch_both:
+    if parsed_args.batch_mlir or parsed_args.batch_both:
         if not parsed_args.mlir_build_dir:
             raise RuntimeError("MLIR build dir was not provided/found")
 
@@ -610,7 +610,7 @@ def main(args=None):
     elif parsed_args.tuning:
         tuneMLIRKernels(configs, xdlops, paths)
     else:
-        if parsed_args.batch:
+        if parsed_args.batch_mlir:
             df = pd.DataFrame(benchmarkMLIR(testVector.split(sep=' '), xdlops, paths) for testVector in configs)
         elif parsed_args.batch_miopen:
             df = pd.DataFrame(benchmarkMIOpen(testVector.split(sep=' '), xdlops, paths) for testVector in configs)


### PR DESCRIPTION
1. Remove the single-dash -> double-dash hack
2. Explicitly use a positional argument to capture the case where you want to benchmark a specific config. This has the consequence that you will need to use -- to separate the config from other options
3. Make -o work again
4. Add --batch_bath in order to allow explicitly selecting the default behavior instead of relying on a lack of args (which would break with -o)
5. Update the Jenkinsfile to the new arguments