### PR TITLE
[NFC] Make rock.transform only take one map

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -173,7 +173,7 @@ def Rock_GemmOp :
 
 def Rock_TransformOp :
     Rock_Op<"transform", [NoSideEffect, ViewLikeOpInterface]>,
-    Arguments<(ins AnyShaped:$input, TransformMapArrayAttr:$transforms)>,
+    Arguments<(ins AnyShaped:$input, Rock_TransformMapAttr:$transform)>,
     Results<(outs AnyShaped:$output)> {
   let summary = "Tensor transformation";
   let description = [{
@@ -197,12 +197,12 @@ def Rock_TransformOp :
      } else {
        upperType = lowerType.cloneWith(transform.getUpperBounds(), elemType);
      }
-     $_state.addAttribute("transforms", $_builder.getArrayAttr({transform}));
+     $_state.addAttribute("transform", transform);
      $_state.addTypes(upperType);
    }]>,
   ];
   let assemblyFormat = [{
-    $input `by` $transforms attr-dict `:` type($input) `to` type($output)
+    $input `by` $transform attr-dict `:` type($input) `to` type($output)
   }];
 
   let extraClassDeclaration = [{

--- a/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -123,16 +123,8 @@ struct TransformOpInterface
     if (failed(input))
       return failure();
 
-    ArrayAttr transforms = transformOp.getTransforms();
-    // We really need to replace the multi-transform form of transform(), it
-    // just adds pointless complexiyty and no on uses it. For now, just fail
-    // that case.
-    if (transforms.size() != 1)
-      return op->emitOpError(
-          "cannot bufferize with multiple transforms on one op");
-    auto transform = transforms[0].cast<TransformMapAttr>();
     replaceOpWithNewBufferizedOp<rock::TransformOp>(rewriter, op, *input,
-                                                    transform);
+                                                    transformOp.getTransform());
     return success();
   }
 };

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -194,7 +194,7 @@ mlir::rock::untransform(OpBuilder &b, Value transformed, ArrayAttr existing) {
     transformList.append(existing.begin(), existing.end());
   Value ret = transformed;
   while (auto transform = dyn_cast_or_null<TransformOp>(ret.getDefiningOp())) {
-    llvm::copy(transform.transforms(), std::back_inserter(transformList));
+    transformList.push_back(transform.getTransform());
     ret = transform.input();
   }
   return {ret, b.getArrayAttr(transformList)};

--- a/mlir/test/Dialect/Rock/lowering_input_tensor_non_zero_padding.mlir
+++ b/mlir/test/Dialect/Rock/lowering_input_tensor_non_zero_padding.mlir
@@ -6,7 +6,7 @@
 
 // CHECK-DAG: #[[$MAP:transform_map[0-9]+]] = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 - 1, d4 - 1)> by [<PassThrough ["ni"] at [2] -> ["ni"] at [2]>, <PassThrough ["gi"] at [0] -> ["gi"] at [0]>, <PassThrough ["ci"] at [1] -> ["ci"] at [1]>, <Pad{1, 1, 1, 1} ["hipad", "wipad"] at [3, 4] -> ["hi", "wi"] at [3, 4]>] bounds = [1, 8, 128, 34, 34] -> [1, 8, 128, 32, 32]>
 // CHECK-LABEL: func.func @rock_conv2d_gcyxk_gcnhw_gknhw
-// CHECK: rock.transform %arg1 by [#[[$MAP]]] : memref<1x8x128x32x32xf32> to memref<1x8x128x34x34xf32>
+// CHECK: rock.transform %arg1 by #[[$MAP]] : memref<1x8x128x32x32xf32> to memref<1x8x128x34x34xf32>
 func.func @rock_conv2d_gcyxk_gcnhw_gknhw(%filter : memref<1x8x3x3x128xf32>, %input : memref<1x8x128x32x32xf32>, %output : memref<1x128x128x32x32xf32>) {
   rock.conv2d(%filter, %input, %output) features = none {
     arch = "gfx906",

--- a/mlir/test/Dialect/Rock/lowering_padding_kernel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_padding_kernel.mlir
@@ -7,7 +7,7 @@
 // CHECK-LABEL: func.func @rock_conv2d_kcyx_nchw_nkhw_padding_kernel
 // CHECK-SAME: %[[filter:.*]]: memref<32x128x2x3x3xf32>
 // CHECK: %[[gemmFilter:.*]] = rock.transform %[[filter]]
-// CHECK: %[[padK:.*]] = rock.transform %[[gemmFilter]] by [#[[$PAD_GEMMK]]]
+// CHECK: %[[padK:.*]] = rock.transform %[[gemmFilter]] by #[[$PAD_GEMMK]]
 // CHECK: rock.gridwise_gemm %{{.*}} = %[[padK]] * %{{.*}}
 func.func @rock_conv2d_kcyx_nchw_nkhw_padding_kernel(%filter : memref<32x128x2x3x3xf32>, %input : memref<64x32x2x11x11xf32>, %output : memref<64x32x128x9x9xf32>) {
   rock.conv2d(%filter, %input, %output) features = none {
@@ -44,7 +44,7 @@ func.func @rock_conv2d_kcyx_nchw_nkhw_no_extra_padding(%filter : memref<1x128x64
 // CHECK-LABEL: func.func @rock_conv2d_kcyx_nchw_nkhw_partial_padding_kernel
 // CHECK-SAME: %[[filter:.*]]: memref<32x128x2x3x3xf32>
 // CHECK: %[[gemmFilter:.*]] = rock.transform %[[filter]]
-// CHECK: %[[padK:.*]] = rock.transform %[[gemmFilter]] by [#[[$PAD_GEMMK]]]
+// CHECK: %[[padK:.*]] = rock.transform %[[gemmFilter]] by #[[$PAD_GEMMK]]
 // CHECK: rock.gridwise_gemm %{{.*}} = %[[padK]] * %{{.*}}
 
 func.func @rock_conv2d_kcyx_nchw_nkhw_partial_padding_kernel(%filter : memref<32x128x2x3x3xf32>, %input : memref<128x32x2x11x11xf32>, %output : memref<128x32x128x9x9xf32>) {

--- a/mlir/test/Dialect/Rock/lowering_top_level.mlir
+++ b/mlir/test/Dialect/Rock/lowering_top_level.mlir
@@ -52,11 +52,11 @@ func.func @rock_conv2d(%filter : memref<1x128x8x3x3xf32>, %input : memref<128x1x
 }
 // CHECK-LABEL: func.func {{@rock_conv2d.*%arg0.*%arg1.*%arg2}}
 // CHECK-NOT:   rock.conv2d
-// CHECK-NEXT:  %[[FILTER:.*]] = rock.transform %arg0 by [#[[$MAP_FILTER_FWD]]]
-// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by [#[[$MAP_INPUT1_FWD]]]
-// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by [#[[$MAP_INPUT2_FWD]]]
-// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by [#[[$MAP_INPUT3_FWD]]]
-// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by [#[[$MAP_OUTPUT_FWD]]]
+// CHECK-NEXT:  %[[FILTER:.*]] = rock.transform %arg0 by #[[$MAP_FILTER_FWD]]
+// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by #[[$MAP_INPUT1_FWD]]
+// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by #[[$MAP_INPUT2_FWD]]
+// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by #[[$MAP_INPUT3_FWD]]
+// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by #[[$MAP_OUTPUT_FWD]]
 // CHECK-NEXT:  rock.gemm %[[OUT]] = tr %[[FILTER]] * %[[IN3]]
 
 func.func @rock_conv2d_f16(%filter : memref<1x128x8x3x3xf16>, %input : memref<128x1x8x32x32xf16>, %output : memref<128x1x128x30x30xf16>) {
@@ -77,11 +77,11 @@ func.func @rock_conv2d_f16(%filter : memref<1x128x8x3x3xf16>, %input : memref<12
 }
 // CHECK-LABEL: func.func {{@rock_conv2d_f16.*%arg0.*%arg1.*%arg2}}
 // CHECK-NOT:   rock.conv2d
-// CHECK-NEXT:  %[[FILTER:.*]] = rock.transform %arg0 by [#[[$MAP_FILTER_FWD]]]
-// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by [#[[$MAP_INPUT1_FWD]]]
-// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by [#[[$MAP_INPUT2_FWD]]]
-// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by [#[[$MAP_INPUT3_FWD]]]
-// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by [#[[$MAP_OUTPUT_FWD]]]
+// CHECK-NEXT:  %[[FILTER:.*]] = rock.transform %arg0 by #[[$MAP_FILTER_FWD]]
+// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by #[[$MAP_INPUT1_FWD]]
+// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by #[[$MAP_INPUT2_FWD]]
+// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by #[[$MAP_INPUT3_FWD]]
+// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by #[[$MAP_OUTPUT_FWD]]
 // CHECK-NEXT:  rock.gemm %[[OUT]] = tr %[[FILTER]] * %[[IN3]]
 
 func.func @rock_conv2d_i8(%filter : memref<1x128x8x3x3xi8>, %input : memref<128x1x8x32x32xi8>, %output : memref<128x1x128x30x30xi32>) {
@@ -102,11 +102,11 @@ func.func @rock_conv2d_i8(%filter : memref<1x128x8x3x3xi8>, %input : memref<128x
 }
 // CHECK-LABEL: func.func {{@rock_conv2d_i8.*%arg0.*%arg1.*%arg2}}
 // CHECK-NOT:   rock.conv2d
-// CHECK-NEXT:  %[[FILTER:.*]] = rock.transform %arg0 by [#[[$MAP_FILTER_FWD]]]
-// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by [#[[$MAP_INPUT1_FWD]]]
-// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by [#[[$MAP_INPUT2_FWD]]]
-// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by [#[[$MAP_INPUT3_FWD]]]
-// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by [#[[$MAP_OUTPUT_FWD]]]
+// CHECK-NEXT:  %[[FILTER:.*]] = rock.transform %arg0 by #[[$MAP_FILTER_FWD]]
+// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by #[[$MAP_INPUT1_FWD]]
+// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by #[[$MAP_INPUT2_FWD]]
+// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by #[[$MAP_INPUT3_FWD]]
+// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by #[[$MAP_OUTPUT_FWD]]
 // CHECK-NEXT:  rock.gemm %[[OUT]] = tr %[[FILTER]] * %[[IN3]]
 
 
@@ -130,16 +130,16 @@ func.func @rock_conv2d_bwd_data(%filter: memref<1x1024x1024x1x1xf32>, %input: me
 
 // CHECK-LABEL: func.func {{@rock_conv2d_bwd_data.*%arg0.*%arg1.*%arg2}}
 // CHECK-NOT:   rock.conv2d_bwd_data
-// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by [#[[$MAP_BWD_DATA_FIL1_NO_PAD]]]
-// CHECK-NEXT:  %[[FIL2:.*]] = rock.transform %[[FIL1]] by [#[[$MAP_BWD_DATA_FIL2_NO_PAD]]]
-// CHECK-NEXT:  %[[FIL3:.*]] = rock.transform %[[FIL2]] by [#[[$MAP_BWD_DATA_FIL3_NO_PAD]]]
-// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by [#[[$MAP_BWD_DATA_IN1_NO_PAD]]]
-// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by [#[[$MAP_BWD_DATA_IN2_NO_PAD]]]
-// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by [#[[$MAP_BWD_DATA_IN3_NO_PAD]]]
-// CHECK-NEXT:  %[[IN4:.*]] = rock.transform %[[IN3]] by [#[[$MAP_BWD_DATA_IN4_NO_PAD]]]
-// CHECK-NEXT:  %[[OUT1:.*]] = rock.transform %arg2 by [#[[$MAP_BWD_DATA_OUT1_NO_PAD]]]
-// CHECK-NEXT:  %[[OUT2:.*]] = rock.transform %[[OUT1]] by [#[[$MAP_BWD_DATA_OUT2_NO_PAD]]]
-// CHECK-NEXT:  %[[OUT3:.*]] = rock.transform %[[OUT2]] by [#[[$MAP_BWD_DATA_OUT3_NO_PAD]]]
+// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by #[[$MAP_BWD_DATA_FIL1_NO_PAD]]
+// CHECK-NEXT:  %[[FIL2:.*]] = rock.transform %[[FIL1]] by #[[$MAP_BWD_DATA_FIL2_NO_PAD]]
+// CHECK-NEXT:  %[[FIL3:.*]] = rock.transform %[[FIL2]] by #[[$MAP_BWD_DATA_FIL3_NO_PAD]]
+// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by #[[$MAP_BWD_DATA_IN1_NO_PAD]]
+// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by #[[$MAP_BWD_DATA_IN2_NO_PAD]]
+// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by #[[$MAP_BWD_DATA_IN3_NO_PAD]]
+// CHECK-NEXT:  %[[IN4:.*]] = rock.transform %[[IN3]] by #[[$MAP_BWD_DATA_IN4_NO_PAD]]
+// CHECK-NEXT:  %[[OUT1:.*]] = rock.transform %arg2 by #[[$MAP_BWD_DATA_OUT1_NO_PAD]]
+// CHECK-NEXT:  %[[OUT2:.*]] = rock.transform %[[OUT1]] by #[[$MAP_BWD_DATA_OUT2_NO_PAD]]
+// CHECK-NEXT:  %[[OUT3:.*]] = rock.transform %[[OUT2]] by #[[$MAP_BWD_DATA_OUT3_NO_PAD]]
 // CHECK-NEXT:  rock.gemm %[[IN4]] = tr %[[FIL3]] * %[[OUT3]]{{.*}}
 
 func.func @rock_conv2d_bwd_data_f16(%filter: memref<1x1024x1024x1x1xf16>, %input: memref<128x1x1024x14x14xf16>, %output: memref<128x1x1024x14x14xf16>) attributes {kernel = 0 : i32} {
@@ -162,16 +162,16 @@ rock.conv2d_bwd_data(%filter, %input, %output) features = mfma|dot|atomic_add {
 
 // CHECK-LABEL: func.func {{@rock_conv2d_bwd_data_f16.*%arg0.*%arg1.*%arg2}}
 // CHECK-NOT:   rock.conv2d_bwd_data
-// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by [#[[$MAP_BWD_DATA_FIL1_NO_PAD]]]
-// CHECK-NEXT:  %[[FIL2:.*]] = rock.transform %[[FIL1]] by [#[[$MAP_BWD_DATA_FIL2_NO_PAD]]]
-// CHECK-NEXT:  %[[FIL3:.*]] = rock.transform %[[FIL2]] by [#[[$MAP_BWD_DATA_FIL3_NO_PAD]]]
-// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by [#[[$MAP_BWD_DATA_IN1_NO_PAD]]]
-// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by [#[[$MAP_BWD_DATA_IN2_NO_PAD]]]
-// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by [#[[$MAP_BWD_DATA_IN3_NO_PAD]]]
-// CHECK-NEXT:  %[[IN4:.*]] = rock.transform %[[IN3]] by [#[[$MAP_BWD_DATA_IN4_NO_PAD]]]
-// CHECK-NEXT:  %[[OUT1:.*]] = rock.transform %arg2 by [#[[$MAP_BWD_DATA_OUT1_NO_PAD]]]
-// CHECK-NEXT:  %[[OUT2:.*]] = rock.transform %[[OUT1]] by [#[[$MAP_BWD_DATA_OUT2_NO_PAD]]]
-// CHECK-NEXT:  %[[OUT3:.*]] = rock.transform %[[OUT2]] by [#[[$MAP_BWD_DATA_OUT3_NO_PAD]]]
+// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by #[[$MAP_BWD_DATA_FIL1_NO_PAD]]
+// CHECK-NEXT:  %[[FIL2:.*]] = rock.transform %[[FIL1]] by #[[$MAP_BWD_DATA_FIL2_NO_PAD]]
+// CHECK-NEXT:  %[[FIL3:.*]] = rock.transform %[[FIL2]] by #[[$MAP_BWD_DATA_FIL3_NO_PAD]]
+// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by #[[$MAP_BWD_DATA_IN1_NO_PAD]]
+// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by #[[$MAP_BWD_DATA_IN2_NO_PAD]]
+// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by #[[$MAP_BWD_DATA_IN3_NO_PAD]]
+// CHECK-NEXT:  %[[IN4:.*]] = rock.transform %[[IN3]] by #[[$MAP_BWD_DATA_IN4_NO_PAD]]
+// CHECK-NEXT:  %[[OUT1:.*]] = rock.transform %arg2 by #[[$MAP_BWD_DATA_OUT1_NO_PAD]]
+// CHECK-NEXT:  %[[OUT2:.*]] = rock.transform %[[OUT1]] by #[[$MAP_BWD_DATA_OUT2_NO_PAD]]
+// CHECK-NEXT:  %[[OUT3:.*]] = rock.transform %[[OUT2]] by #[[$MAP_BWD_DATA_OUT3_NO_PAD]]
 // CHECK-NEXT:  rock.gemm %[[IN4]] = tr %[[FIL3]] * %[[OUT3]]{{.*}}
 
 func.func @rock_conv2d_bwd_weight(%filter : memref<1x128x8x3x3xf32>, %input : memref<128x1x8x32x32xf32>, %output : memref<128x1x128x30x30xf32>) {
@@ -193,11 +193,11 @@ func.func @rock_conv2d_bwd_weight(%filter : memref<1x128x8x3x3xf32>, %input : me
 }
 // CHECK-LABEL: func.func {{@rock_conv2d_bwd_weight.*%arg0.*%arg1.*%arg2}}
 // CHECK-NOT:   rock.conv2d_bwd_weight
-// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by [#[[$MAP_BWD_WEIGHT_FIL1]]]
-// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by [#[[$MAP_INPUT1_FWD]]]
-// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by [#[[$MAP_INPUT2_FWD]]]
-// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by [#[[$MAP_BWD_WEIGHT_IN3]]]
-// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by [#[[$MAP_BWD_WEIGHT_OUT]]]
+// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by #[[$MAP_BWD_WEIGHT_FIL1]]
+// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by #[[$MAP_INPUT1_FWD]]
+// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by #[[$MAP_INPUT2_FWD]]
+// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by #[[$MAP_BWD_WEIGHT_IN3]]
+// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by #[[$MAP_BWD_WEIGHT_OUT]]
 // CHECK-NEXT:  rock.gemm %[[FIL1]] = tr %[[OUT]] * %[[IN3]]{{.*}}
 
 func.func @rock_conv2d_bwd_weight_f16(%filter : memref<1x128x8x3x3xf16>, %input : memref<128x1x8x32x32xf16>, %output : memref<128x1x128x30x30xf16>) {
@@ -219,9 +219,9 @@ func.func @rock_conv2d_bwd_weight_f16(%filter : memref<1x128x8x3x3xf16>, %input 
 }
 // CHECK-LABEL: func.func {{@rock_conv2d_bwd_weight_f16.*%arg0.*%arg1.*%arg2}}
 // CHECK-NOT:   rock.conv2d_bwd_weight
-// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by [#[[$MAP_BWD_WEIGHT_FIL1]]]
-// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by [#[[$MAP_INPUT1_FWD]]]
-// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by [#[[$MAP_INPUT2_FWD]]]
-// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by [#[[$MAP_BWD_WEIGHT_IN3]]]
-// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by [#[[$MAP_BWD_WEIGHT_OUT]]]
+// CHECK-NEXT:  %[[FIL1:.*]] = rock.transform %arg0 by #[[$MAP_BWD_WEIGHT_FIL1]]
+// CHECK-NEXT:  %[[IN1:.*]] = rock.transform %arg1 by #[[$MAP_INPUT1_FWD]]
+// CHECK-NEXT:  %[[IN2:.*]] = rock.transform %[[IN1]] by #[[$MAP_INPUT2_FWD]]
+// CHECK-NEXT:  %[[IN3:.*]] = rock.transform %[[IN2]] by #[[$MAP_BWD_WEIGHT_IN3]]
+// CHECK-NEXT:  %[[OUT:.*]] = rock.transform %arg2 by #[[$MAP_BWD_WEIGHT_OUT]]
 // CHECK-NEXT:  rock.gemm %[[FIL1]] = tr %[[OUT]] * %[[IN3]]{{.*}}

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
@@ -13,9 +13,9 @@ func.func @rock_xdlops_gemm_v2_nonreduction_nokpack(%matrixA : memref<8xf32, 5>,
   // CHECK: rock.in_bounds_load
   // CHECK: rock.in_bounds_load
   // CHECK: amdgpu.mfma
-  %A = rock.transform %matrixA by [#transform_map0] : memref<8xf32, 5> to memref<1x8xf32, #map0, 5>
-  %B = rock.transform %matrixB by [#transform_map1] : memref<8xf32, 5> to memref<1x8xf32, #map0, 5>
-  %C = rock.transform %matrixC by [#transform_map2] : memref<2xvector<32xf32>, 5> to memref<1x1x2xvector<32xf32>, #map1, 5>
+  %A = rock.transform %matrixA by #transform_map0 : memref<8xf32, 5> to memref<1x8xf32, #map0, 5>
+  %B = rock.transform %matrixB by #transform_map1 : memref<8xf32, 5> to memref<1x8xf32, #map0, 5>
+  %C = rock.transform %matrixC by #transform_map2 : memref<2xvector<32xf32>, 5> to memref<1x1x2xvector<32xf32>, #map1, 5>
   rock.xdlops_gemm_v2 %C += %A * %B {
     params = #rock.xdlops_gemm_params<
        kPerBlock = 8,
@@ -44,9 +44,9 @@ func.func @rock_xdlops_gemm_v2_nonreduction_kpack(%matrixA : memref<2xvector<2xf
   // CHECK: rock.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK: amdgpu.mfma
-  %A = rock.transform %matrixA by [#transform_map3] : memref<2xvector<2xf32>, 5> to memref<1x2xvector<2xf32>, #map2, 5>
-  %B = rock.transform %matrixB by [#transform_map4] : memref<2xvector<2xf32>, 5> to memref<1x2xvector<2xf32>, #map2, 5>
-  %C = rock.transform %matrixC by [#transform_map5] : memref<2xvector<32xf32>, 5> to memref<1x1x2xvector<32xf32>, #map3, 5>
+  %A = rock.transform %matrixA by #transform_map3 : memref<2xvector<2xf32>, 5> to memref<1x2xvector<2xf32>, #map2, 5>
+  %B = rock.transform %matrixB by #transform_map4 : memref<2xvector<2xf32>, 5> to memref<1x2xvector<2xf32>, #map2, 5>
+  %C = rock.transform %matrixC by #transform_map5 : memref<2xvector<32xf32>, 5> to memref<1x1x2xvector<32xf32>, #map3, 5>
   rock.xdlops_gemm_v2 %C += %A * %B {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 2,
@@ -68,9 +68,9 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack(%matrixA : memref<2xvector<8xi8>,
   // CHECK: rock.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK-NOT: amdgpu.mfma
-  %A = rock.transform %matrixA by [#transform_map3] : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
-  %B = rock.transform %matrixB by [#transform_map4] : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
-  %C = rock.transform %matrixC by [#transform_map5] : memref<1xvector<16xi32>, 5> to memref<1x1x1xvector<16xi32>, #map3, 5>
+  %A = rock.transform %matrixA by #transform_map3 : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
+  %B = rock.transform %matrixB by #transform_map4 : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
+  %C = rock.transform %matrixC by #transform_map5 : memref<1xvector<16xi32>, 5> to memref<1x1x1xvector<16xi32>, #map3, 5>
   rock.xdlops_gemm_v2 %C += %A * %B {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 4,

--- a/mlir/test/Dialect/Rock/ops.mlir
+++ b/mlir/test/Dialect/Rock/ops.mlir
@@ -119,15 +119,15 @@ func.func @rock_gemm(%a : memref<32x64xf16>, %b : memref<1x32x128xf16>, %c : mem
 
 // test 1-1 dimension mappings.
 func.func @rock_transform_1_to_1(%memref: memref<1x2x3x4x5xf32, 3>) {
-  %transformed_memref = rock.transform %memref by [
-    #rock.transform_map<#map0 by [
-      #rock.transform<PassThrough ["g"] at [0] -> ["g"] at [1]>,
-      #rock.transform<PassThrough ["n"] at [1] -> ["n"] at [0]>,
-      #rock.transform<PassThrough ["c"] at [2] -> ["c"] at [2]>,
-      #rock.transform<Pad{1, 1} ["hipad"] at [3] -> ["hi"] at [3]>,
-      #rock.transform<Pad{2, 2} ["wipad"] at [4] -> ["wi"] at [4]>
+  %transformed_memref = rock.transform %memref by
+    <#map0 by [
+      <PassThrough ["g"] at [0] -> ["g"] at [1]>,
+      <PassThrough ["n"] at [1] -> ["n"] at [0]>,
+      <PassThrough ["c"] at [2] -> ["c"] at [2]>,
+      <Pad{1, 1} ["hipad"] at [3] -> ["hi"] at [3]>,
+      <Pad{2, 2} ["wipad"] at [4] -> ["wi"] at [4]>
     ] bounds = [2, 1, 3, 6, 9] -> [1, 2, 3, 4, 5]>
-  ] : memref<1x2x3x4x5xf32, 3> to memref<2x1x3x6x9xf32, #map0, 3>
+  : memref<1x2x3x4x5xf32, 3> to memref<2x1x3x6x9xf32, #map0, 3>
   return
 }
 // CHECK-LABEL: func.func @rock_transform_1_to_1
@@ -135,13 +135,13 @@ func.func @rock_transform_1_to_1(%memref: memref<1x2x3x4x5xf32, 3>) {
 
 // test multiple source dimensions map to 1 target dimension.
 func.func @rock_transform_n_to_1(%memref : memref<1x128x64x32x16xf32>) {
-  %transformed_memref = rock.transform %memref by [
-    #rock.transform_map<#map1 by [
+  %transformed_memref = rock.transform %memref by
+    <#map1 by [
       #rock.transform<PassThrough ["gemmG"] at [0] -> ["g"] at [0]>,
       #rock.transform<Merge{64, 32, 16} ["gemmK"] at [1] -> ["c", "y", "x"] at [2, 3, 4]>,
       #rock.transform<PassThrough ["gemmM"] at [2] -> ["k"] at [1]>
     ] bounds = [1, 32768, 128] -> [1, 128, 64, 32, 16]>
-  ] : memref<1x128x64x32x16xf32> to memref<1x32768x128xf32, #map1>
+  : memref<1x128x64x32x16xf32> to memref<1x32768x128xf32, #map1>
   return
 }
 // CHECK-LABEL: func.func @rock_transform_n_to_1
@@ -149,15 +149,15 @@ func.func @rock_transform_n_to_1(%memref : memref<1x128x64x32x16xf32>) {
 
 // test 1 source dimension map to multiple target dimensions.
 func.func @rock_transform_1_to_n(%memref : memref<?x?x?x?x?xf32>) {
-  %transformed_memref = rock.transform %memref by [
-    #rock.transform_map<#map2 by [
+  %transformed_memref = rock.transform %memref by
+    <#map2 by [
       #rock.transform<PassThrough ["n", "g", "c"] at [0, 1, 2] ->
         ["n", "g", "c"] at [1, 0, 2]>,
       #rock.transform<Embed{1, 1} ["y", "ho"] at [3, 4] -> ["hipad"] at [3]>,
       #rock.transform<Embed{1, 1} ["x", "wo"] at [5, 6] -> ["wipad"] at [4]>
       // Note: fake data should work fine for now
      ] bounds = [0, 0, 0, 0, 0, 0, 0] -> [0, 0, 0, 0, 0]>
-  ] : memref<?x?x?x?x?xf32> to memref<?x?x?x?x?x?x?xf32, #map2>
+  : memref<?x?x?x?x?xf32> to memref<?x?x?x?x?x?x?xf32, #map2>
   return
 }
 


### PR DESCRIPTION
Having rock.transform take an array of maps was an archaic thing we don't use anymore that just causes complications and unforseen edge cases. That support was there from back when we didn't use untransform() or transforming_for but instead had the transformations as attributes on things like threadwise_copy_v2. This caused a lot of headache and was removed quite a while back.

Fixes
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/676