### PR TITLE
Verify GPU kernel by cloning a copy for CPU and comparing results

### DIFF
--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -376,13 +376,13 @@ bool Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder) const {
       needExtraPad =
           calculatePadding(validParams.gemmKPerBlock, validParams.gemmMPerBlock,
                            validParams.gemmNPerBlock, gemmSize)
-              .hasValue();
+              .has_value();
     } else {
       // This function will go through the list and pick a valid configuration
       // the following code will return if the resulting config needs padding
       needExtraPad =
           calculatePaddingKernelSize(gemmSize, dir, dataType, populateParams)
-              .hasValue();
+              .has_value();
     }
   } else {
     PopulateParamsXDL populateParamsXDL;
@@ -394,13 +394,13 @@ bool Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder) const {
           calculatePadding(validParams.gemmKPerBlock, validParams.gemmMPerBlock,
                            validParams.gemmNPerBlock, gemmSize,
                            validParams.gemmKPack)
-              .hasValue();
+              .has_value();
     } else {
       // This function will go through the list and pick a valid configuration
       // the following code will return if the resulting config needs padding
       needExtraPad =
           calculatePaddingKernelSize(gemmSize, dir, dataType, populateParamsXDL)
-              .hasValue();
+              .has_value();
     }
   }
   return needExtraPad;

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -173,7 +173,7 @@ void AffixTuningParameters::affixBackwardWeightUtilityKernels(
     Optional<GemmContext> extraPadSizes = calculatePadding(
         gemmParams.getKPerBlock(), gemmParams.getMPerBlock(),
         gemmParams.getNPerBlock(), gemmSize, gemmParams.getKpack());
-    if (extraPadSizes.hasValue()) {
+    if (extraPadSizes.has_value()) {
       assert(gemmId == 0 &&
              "if there is padding, only a single kernel should be generated");
     } else {
@@ -231,14 +231,13 @@ void AffixTuningParameters::affixTuningParametersImpl(T &op) {
         signalPassFailure();
     }
 
-    ConvOpType dir = obtainConvDirection(op);
     Type dataType = obtainConvDataType(op);
 
     // Disable kpack in case we need padding kernel.
     Optional<GemmContext> gemmExtraPad = calculatePadding(
         validParams.gemmKPerBlock, validParams.gemmMPerBlock,
         validParams.gemmNPerBlock, gemmSize, validParams.gemmKPack);
-    if (gemmExtraPad.hasValue()) {
+    if (gemmExtraPad.has_value()) {
       validParams.gemmKPack = 1;
     }
 

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -577,7 +577,7 @@ LogicalResult PopulateParams::populateDerived(
   auto gemmExtraPad =
       calculatePadding(params.gemmKPerBlock, params.gemmMPerBlock,
                        params.gemmNPerBlock, gemmSize);
-  if (gemmExtraPad.hasValue()) {
+  if (gemmExtraPad.has_value()) {
     gemmSize.gemmM += gemmExtraPad->m;
     gemmSize.gemmK += gemmExtraPad->k;
     gemmSize.gemmN += gemmExtraPad->n;
@@ -918,7 +918,7 @@ LogicalResult PopulateParamsXDL::populateDerived(
   auto gemmExtraPad =
       calculatePadding(params.gemmKPerBlock, params.gemmMPerBlock,
                        params.gemmNPerBlock, gemmSize, params.gemmKPack);
-  if (gemmExtraPad.hasValue()) {
+  if (gemmExtraPad.has_value()) {
     gemmSize.gemmM += gemmExtraPad->m;
     gemmSize.gemmK += gemmExtraPad->k;
     gemmSize.gemmN += gemmExtraPad->n;

--- a/mlir/test/rocmlir-driver/populate_host_print.mlir
+++ b/mlir/test/rocmlir-driver/populate_host_print.mlir
@@ -65,6 +65,8 @@
 // CHECK-NEXT: memref.store {{.*}}[%[[n]], %[[g]], %[[k]], %[[ho]], %[[wo]]] : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>
 
 // CHECK: call @{{.*}}({{.*}}, {{.*}}, {{.*}}) : (memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>, memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]>) -> ()
+// CHECK-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<*x[[TYPE]]>
+// CHECK-NEXT: call @printMemrefF32(%{{.*}}) : (memref<*x[[TYPE]]>) -> ()
 // CHECK-NEXT: memref.dealloc {{.*}} : memref<[[G]]x[[K]]x[[C]]x[[Y]]x[[X]]x[[TYPE]]>
 // CHECK-NEXT: memref.dealloc {{.*}} : memref<[[N]]x[[G]]x[[C]]x[[HI]]x[[WI]]x[[TYPE]]>
 
@@ -74,8 +76,6 @@
 // BF16: call @_memcpy_bf16_f32(%{{.*}}, %{{.*}}, %{{.*}}) : ({{.*}} -> ()
 // I8: memref.alloc() : memref<{{.*}}>
 // I8: call @_memcpy_i32_f32(%{{.*}}, %{{.*}}, %{{.*}}) : ({{.*}} -> ()
-// CHECK-NEXT: memref.cast %{{.*}} : memref<[[N]]x[[G]]x[[K]]x[[HO]]x[[WO]]x[[TYPE]]> to memref<*x[[TYPE]]>
-// CHECK-NEXT: call @printMemrefF32(%{{.*}}) : (memref<*x[[TYPE]]>) -> ()
 // F16: memref.dealloc {{.*}} : memref<{{.*}}>
 // BF16: memref.dealloc {{.*}} : memref<{{.*}}>
 // I8: memref.dealloc {{.*}} : memref<{{.*}}>

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -35,6 +35,7 @@
 #include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Types.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
@@ -45,6 +46,7 @@
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/Support/CommandLine.h"
@@ -293,10 +295,10 @@ static cl::alias
 
 // populate host validation logic.
 static cl::opt<std::string> genValidation(
-    "verifier", cl::desc("Select verification from: none(default), cpu, gpu"),
+    "verifier", cl::desc("Select verification from: none(default), cpu, gpu, cpp, mlir"),
     cl::cb<void, std::string>([](const std::string &v) {
       if (!v.empty())
-        genHostHarness.setValue(true);
+        genHostHarness = true;
     }),
     cl::value_desc("Specify host validation logic"), cl::init(""));
 
@@ -304,8 +306,8 @@ static cl::opt<bool> genCPUValidation("pv", cl::Hidden, cl::init(false),
                                       cl::Optional,
                                       cl::cb<void, bool>([](bool v) {
                                         if (v) {
-                                          genValidation.setValue("mlir");
-                                          genHostHarness.setValue(true);
+                                          genValidation = "mlir";
+                                          genHostHarness = true;
                                         }
                                       }));
 
@@ -313,8 +315,8 @@ static cl::opt<bool> genCPPValidation("pv_with_cpp", cl::Hidden,
                                       cl::init(false), cl::Optional,
                                       cl::cb<void, bool>([](bool v) {
                                         if (v) {
-                                          genValidation.setValue("cpp");
-                                          genHostHarness.setValue(true);
+                                          genValidation = "cpp";
+                                          genHostHarness = true;
                                         }
                                       }));
 
@@ -322,8 +324,8 @@ static cl::opt<bool> genMLIRValidation("pv_with_mlir", cl::Hidden,
                                        cl::init(false), cl::Optional,
                                        cl::cb<void, bool>([](bool v) {
                                          if (v) {
-                                           genValidation.setValue("mlir");
-                                           genHostHarness.setValue(true);
+                                           genValidation = "mlir";
+                                           genHostHarness = true;
                                          }
                                        }));
 
@@ -331,8 +333,8 @@ static cl::opt<bool> genGPUValidation("pv_with_gpu", cl::Hidden,
                                       cl::init(false), cl::Optional,
                                       cl::cb<void, bool>([](bool v) {
                                         if (v) {
-                                          genValidation.setValue("gpu");
-                                          genHostHarness.setValue(true);
+                                          genValidation = "gpu";
+                                          genHostHarness = true;
                                         }
                                       }));
 
@@ -341,9 +343,8 @@ static cl::opt<bool> genCPUKernel("cpu-kernels",
                                   cl::init(false), cl::Optional,
                                   cl::cb<void, bool>([](bool v) {
                                     if (v) {
-                                      genValidation.setValue("mlir");
-                                      genHostHarness.setValue(true);
-                                      printResults.setValue(true);
+                                      genHostHarness = true;
+                                      printResults = true;
                                     }
                                   }));
 static cl::alias aliasGenCPUKernel("prc", cl::aliasopt(genCPUKernel));
@@ -429,65 +430,50 @@ static void correctParameters() {
   std::string filterLayoutValue = filterLayout.getValue();
   std::string inputLayoutValue = inputLayout.getValue();
   std::string outputLayoutValue = outputLayout.getValue();
-  if (filterLayoutValue.size() == 4) { // yxcgk not implement yet
-    if (filterLayoutValue == "kcyx")
-      filterLayout.setValue("gkcyx");
-    else if (filterLayoutValue == "kyxc")
-      filterLayout.setValue("gkyxc");
-    else
-      filterLayout.setValue("g" + filterLayoutValue);
-  }
-  if (outputLayoutValue.size() == 4) {
-    if (outputLayoutValue == "nkhw")
-      outputLayout.setValue("ngkhw");
-    else if (outputLayoutValue == "nhwk")
-      outputLayout.setValue("nhwgk");
-    else
-      outputLayout.setValue("g" + outputLayoutValue);
-  }
+  // yxcgk not implement yet
+  if (filterLayoutValue == "kcyx")
+    filterLayout = "gkcyx";
+  else if (filterLayoutValue == "kyxc")
+    filterLayout = "gkyxc";
+  else if (filterLayoutValue.size() == 4)
+    filterLayout = "g" + filterLayoutValue;
 
-  if (inputLayoutValue.size() == 4) {
-    if (inputLayoutValue == "nchw")
-      inputLayout.setValue("ngchw");
-    else if (inputLayoutValue == "nhwc")
-      inputLayout.setValue("nhwgc");
-    else
-      inputLayout.setValue("g" + inputLayoutValue);
-  }
+  if (outputLayoutValue == "nkhw")
+    outputLayout = "ngkhw";
+  else if (outputLayoutValue == "nhwk")
+    outputLayout = "nhwgk";
+  else if (outputLayoutValue.size() == 4)
+    outputLayout = "g" + outputLayoutValue;
 
-  // we can use paddingHeight or paddingHeightLeft + paddingHeightRight
-  // if use paddingHeight , paddingHeightLeft and paddingHeightRight =
-  // paddingHeight if use paddingHeightLeft + paddingHeightRight , please
-  // assigne value
-  if (paddingHeight.getValue() > 0) {
-    if (paddingHeightLeft.getValue() == 0 &&
-        paddingHeightRight.getValue() == 0) {
-      paddingHeightLeft.setValue(paddingHeight.getValue());
-      paddingHeightRight.setValue(paddingHeight.getValue());
-    } else {
-      if (paddingHeightLeft.getValue() != paddingHeight.getValue() ||
-          paddingHeightRight.getValue() != paddingHeight.getValue()) {
-        llvm::errs()
-            << "you can't use both padding_h and (padding_h_l,padding_h_r).\n";
+  if (inputLayoutValue == "nchw")
+    inputLayout = "ngchw";
+  else if (inputLayoutValue == "nhwc")
+    inputLayout = "nhwgc";
+  else if (inputLayoutValue.size() == 4)
+    inputLayout = "g" + inputLayoutValue;
+
+  auto validatePadding = [](cl::opt<int> &combined, cl::opt<int> &left,
+                            cl::opt<int> &right, StringRef name) {
+    if (combined.getValue() > 0) {
+      int combinedVal = combined.getValue();
+      int leftVal = left.getValue();
+      int rightVal = right.getValue();
+      if (leftVal == 0 && rightVal == 0) {
+        left = combinedVal;
+        right = combinedVal;
+      } else {
+        if (leftVal != combinedVal || rightVal != combinedVal) {
+          llvm::errs() << "you can't use both " << name << " and (" << name
+                       << "_l," << name << "_r).\n";
+        }
       }
     }
-  }
+  };
 
-  // we can use paddingWidth or paddingWidthLeft + paddingWidthRight
-  // if use paddingWidth , paddingWidthLeft and paddingWidthRight = paddingWidth
-  // if use paddingWidthLeft + paddingWidthRight , please assigne value
-  if (paddingWidth.getValue() > 0) {
-    if (paddingWidthLeft.getValue() == 0 && paddingWidthRight.getValue() == 0) {
-      paddingWidthLeft.setValue(paddingWidth.getValue());
-      paddingWidthRight.setValue(paddingWidth.getValue());
-    } else {
-      if (paddingWidthLeft.getValue() != paddingWidth.getValue() ||
-          paddingWidthRight.getValue() != paddingWidth.getValue()) {
-        llvm::errs()
-            << "you can't use both padding_w and (padding_w_l,padding_w_r).\n";
-      }
-    }
-  }
+  validatePadding(paddingHeight, paddingHeightLeft, paddingHeightRight,
+                  "padding_h");
+  validatePadding(paddingWidth, paddingWidthLeft, paddingWidthRight,
+                  "padding_w");
 
   // adjust the padding size
   // getOutputDim can give us correct output size
@@ -517,7 +503,7 @@ static void correctParameters() {
   // add extra padding on the right to allow the convolution to execute
   // successfully.
   if (hi_minimum > hi_specified)
-    paddingHeightRight.setValue(in_right_pad_h + (hi_minimum - hi_specified));
+    paddingHeightRight = in_right_pad_h + (hi_minimum - hi_specified);
 
   int wi = inputWidth.getValue();
   int x = filterWidth.getValue();
@@ -536,7 +522,7 @@ static void correctParameters() {
   // add extra padding on the right to allow the convolution to execute
   // successfully.
   if (wi_minimum > wi_specified)
-    paddingWidthRight.setValue(in_right_pad_w + (wi_minimum - wi_specified));
+    paddingWidthRight = in_right_pad_w + (wi_minimum - wi_specified);
 }
 
 static void verifyLayout() {
@@ -564,64 +550,64 @@ static void populateDefaults() {
   // We don't particularly care about this field in the lowering
   // process unless it is tuning related. Therefore, setting this
   // field to a default value regardless.
-  arch.setValue("amdgcn-amd-amdhsa:gfx900");
+  arch = "amdgcn-amd-amdhsa:gfx900";
 
-  if (populateDefaultValues == true) {
-    if (xdlopsV2.getValue() == false) {
-      groupSize.setValue(1);
-      batchSize.setValue(128);
-      inputChannel.setValue(8);
-      outputChannel.setValue(128);
-      inputHeight.setValue(32);
-      inputWidth.setValue(32);
-      filterHeight.setValue(3);
-      filterWidth.setValue(3);
-      dilationHeight.setValue(1);
-      dilationWidth.setValue(1);
-      strideHeight.setValue(1);
-      strideWidth.setValue(1);
-      paddingHeightLeft.setValue(0);
-      paddingHeightRight.setValue(0);
-      paddingWidthLeft.setValue(0);
-      paddingWidthRight.setValue(0);
+  if (populateDefaultValues) {
+    if (!xdlopsV2.getValue()) {
+      groupSize = 1;
+      batchSize = 128;
+      inputChannel = 8;
+      outputChannel = 128;
+      inputHeight = 32;
+      inputWidth = 32;
+      filterHeight = 3;
+      filterWidth = 3;
+      dilationHeight = 1;
+      dilationWidth = 1;
+      strideHeight = 1;
+      strideWidth = 1;
+      paddingHeightLeft = 0;
+      paddingHeightRight = 0;
+      paddingWidthLeft = 0;
+      paddingWidthRight = 0;
     } else {
-      groupSize.setValue(1);
-      batchSize.setValue(128);
-      inputChannel.setValue(1024);
-      outputChannel.setValue(1024);
-      inputHeight.setValue(14);
-      inputWidth.setValue(14);
-      filterHeight.setValue(1);
-      filterWidth.setValue(1);
-      dilationHeight.setValue(1);
-      dilationWidth.setValue(1);
-      strideHeight.setValue(1);
-      strideWidth.setValue(1);
-      paddingHeightLeft.setValue(0);
-      paddingHeightRight.setValue(0);
-      paddingWidthLeft.setValue(0);
-      paddingWidthRight.setValue(0);
-      num_cu.setValue(120);
-      arch.setValue("amdgcn-amd-amdhsa:gfx908");
+      groupSize = 1;
+      batchSize = 128;
+      inputChannel = 1024;
+      outputChannel = 1024;
+      inputHeight = 14;
+      inputWidth = 14;
+      filterHeight = 1;
+      filterWidth = 1;
+      dilationHeight = 1;
+      dilationWidth = 1;
+      strideHeight = 1;
+      strideWidth = 1;
+      paddingHeightLeft = 0;
+      paddingHeightRight = 0;
+      paddingWidthLeft = 0;
+      paddingWidthRight = 0;
+      num_cu = 120;
+      arch = "amdgcn-amd-amdhsa:gfx908";
     }
   }
 
-  if (xdlopsV2.getValue() == true) {
-    num_cu.setValue(120);
-    arch.setValue("amdgcn-amd-amdhsa:gfx908");
+  if (xdlopsV2.getValue()) {
+    num_cu = 120;
+    arch = "amdgcn-amd-amdhsa:gfx908";
   }
 
   if (outputHeight.getNumOccurrences() == 0) {
-    outputHeight.setValue(rock::Conv2dGenerator::outputDim(
+    outputHeight = rock::Conv2dGenerator::outputDim(
         inputHeight.getValue(), filterHeight.getValue(),
         paddingHeightLeft.getValue(), paddingHeightRight.getValue(),
-        strideHeight.getValue(), dilationHeight.getValue()));
+        strideHeight.getValue(), dilationHeight.getValue());
   }
   if (outputWidth.getNumOccurrences() == 0) {
-    outputWidth.setValue(rock::Conv2dGenerator::outputDim(
+    outputWidth = rock::Conv2dGenerator::outputDim(
         inputWidth.getValue(), filterWidth.getValue(),
         paddingWidthLeft.getValue(), paddingWidthRight.getValue(),
-        strideWidth.getValue(), dilationWidth.getValue()));
+        strideWidth.getValue(), dilationWidth.getValue());
   }
 }
 
@@ -791,7 +777,7 @@ static std::tuple<short, short, int> getRandomTestData(int idx) {
     break;
   }
 
-  if (randomSeed.getValue() != "none" && randomSeed.getValue() != "fixed") {
+  if (randomSeed != "none" && randomSeed != "fixed") {
     if ((idx_spec >= 0) && (idx_spec != idx)) {
     } else if (randomDataType.getValue() == "int") {
       // generate random integer in [-5, 5)
@@ -802,7 +788,7 @@ static std::tuple<short, short, int> getRandomTestData(int idx) {
       min = -1;
       max = 1;
     }
-    std::string rseed = randomSeed.getValue();
+    std::string rseed = randomSeed;
     if (rseed[0] >= '0' and rseed[0] <= '9')
       seed = std::stoi(rseed);
     else
@@ -1432,20 +1418,11 @@ createCPUConvFunc(ModuleOp module,
   return func;
 }
 
-const char *getTypeStr(const mlir::Type &type) {
-  if (type.isF32())
-    return "f32";
-  else if (type.isF16())
-    return "f16";
-  else if (type.isBF16())
-    return "bf16";
-  else if (type.isInteger(32))
-    return "i32";
-  else if (type.isInteger(16))
-    return "i16";
-  else if (type.isInteger(8))
-    return "i8";
-  return "na";
+std::string getTypeStr(const mlir::Type &type) {
+  std::string typeName;
+  llvm::raw_string_ostream nameStream(typeName);
+  nameStream << type;
+  return nameStream.str();
 }
 
 static func::FuncOp getMemcpyFuncDecl(ModuleOp &module,
@@ -1736,11 +1713,13 @@ static func::FuncOp createVerifierFunc(ModuleOp &module, const KernelIF &kernel,
           b.create<memref::StoreOp>(loc, valExt, arg1, ivs);
         });
   } else {
-    testResult = b.create<memref::CastOp>(loc, mr5DUnkType, arg0);
+    testResult = makeNDMemRef(b, arg0, 5);
+    testResult = b.create<memref::CastOp>(loc, mr5DUnkType, testResult);
   }
 
   // Prepare the validation result for the verify function
-  valResult = b.create<memref::CastOp>(loc, mr5DUnkType, arg1);
+  valResult = makeNDMemRef(b, arg1, 5);
+  valResult = b.create<memref::CastOp>(loc, mr5DUnkType, valResult);
   // Declare and call the wrapper verify function
   auto verifyFuncDecl = makeFuncDecl(
       module, verifyFuncName,
@@ -1831,12 +1810,87 @@ static LogicalResult populateTensorFillLogic(mlir::OpBuilder &b,
   return success();
 }
 
+static void
+insertValidationCalls(const miopen::Conv2dGenerator::Config &genConfig,
+                      OpBuilder &b, ModuleOp &module,
+                      SmallVectorImpl<mlir::Value> &valVars,
+                      SmallVectorImpl<mlir::Value> &localVars,
+                      int32_t outIdx, Operation *func, KernelIF &root0) {
+  auto validationType = genValidation.getValue();
+  auto loc = b.getUnknownLoc();
+  bool hasXdlops =
+      miopen::bitEnumContains(genConfig.features, miopen::GemmFeatures::xdlops);
+  if (validationType == "gpu" &&
+      (hasXdlops || genConfig.dataTypeStr == "f16" ||
+       genConfig.dataTypeStr == "bf16")) {
+    // generate generic kernels
+    miopen::Conv2dGenerator conv2dGenerator(genConfig);
+    // use non-xdlops kernels to verify xdlops kernels
+    if (hasXdlops)
+      conv2dGenerator.flipXdlops();
+    if (!hasXdlops || genConfig.dataTypeStr != "i8")
+      // use f32 data type to verify non-f32 or xdlops f32 kernels
+      // except that i8 xdlops is verified with i8 non-xdlops
+      conv2dGenerator.setDataType("f32");
+
+    int kernelStart = genConfig.kernelId;
+    int kernelCount = conv2dGenerator.getKernelCount(b);
+    if (kernelStart < 0) {
+      kernelStart = 0;
+    } else {
+      kernelCount = kernelStart + 1;
+    }
+    // generate all sub-kernels, and get corresponding gemmId
+    std::string kernelBaseName = genConfig.kernelBaseName;
+    for (int i = kernelStart; i < kernelCount; ++i) {
+      conv2dGenerator.setKernelName(kernelBaseName + "_" + std::to_string(i));
+      if (failed(conv2dGenerator.genConvModule(module, i, true,
+                                               /*ignoreTuning=*/true))) {
+        llvm::errs() << "Module population failed.\n";
+        exit(1);
+      }
+      KernelIF kernel(conv2dGenerator.getKernelFunc());
+      miopen::Conv2dGenerator::Config newConfig = conv2dGenerator.getConfig();
+      auto kernelWrapperFunc = createGPUWrapper(module, kernel);
+
+      // Decide whether to trim the last workspace argument to the verifier
+      // GPU kernel.
+      miopen::Conv2dGenerator originalConv2dGenerator(genConfig);
+      bool originalHasWorkspace = originalConv2dGenerator.hasWorkspace(b);
+      bool verifierHasWorkspace = conv2dGenerator.hasWorkspace(b);
+      if (originalHasWorkspace && !verifierHasWorkspace) {
+        valVars.resize(valVars.size() - 1);
+      }
+
+      b.create<func::CallOp>(loc, kernelWrapperFunc, valVars);
+    }
+    conv2dGenerator.setKernelName(kernelBaseName);
+  } else if (validationType != "clone") { // -pv_with_cpp or -pv_with_mlir (-pv)
+    // Emit call to host_<conv>
+    auto cpuConvFunc = createCPUConvFunc(module, genConfig);
+    b.create<func::CallOp>(loc, cpuConvFunc, valVars);
+  } else {                            // clone
+    auto cloneAttr = func->getAttrOfType<SymbolRefAttr>("clone_func");
+    assert(cloneAttr);
+    b.create<func::CallOp>(loc, cloneAttr, TypeRange{}, valVars);
+  }
+
+  // Emit call to verifier
+  mlir::Value testResult = localVars[outIdx];
+  mlir::Value valResult = valVars[outIdx];
+
+  auto testType = testResult.getType().dyn_cast<MemRefType>();
+  auto valType = valResult.getType().dyn_cast<MemRefType>();
+  auto verifierFunc = createVerifierFunc(module, root0, testType, valType);
+  b.create<func::CallOp>(loc, verifierFunc,
+                         ValueRange{testResult, valResult});
+}
+
 static LogicalResult
 populateHostHarnessLogic(ModuleOp &module,
                          const SmallVector<KernelIF, 8> &kernels,
                          const SmallVector<KernelIF, 8> &roots,
                          const rock::Conv2dGenerator::Config &genConfig) {
-
   auto context = module.getContext();
   OpBuilder b(context);
   auto loc = b.getUnknownLoc();
@@ -1893,6 +1947,7 @@ populateHostHarnessLogic(ModuleOp &module,
   auto root0 = *roots.begin();
   bool isCPUKernel = !root0.func->hasAttr("kernel");
   bool hasValidation = !validationType.empty() && !genCPUKernel.getValue();
+  bool hasCloneValidation = hasValidation && (validationType == "clone");
   SmallVector<mlir::Value, 5> localVars;
   SmallVector<mlir::Value, 5> valVars;
   int32_t idx = 0;
@@ -1971,17 +2026,53 @@ populateHostHarnessLogic(ModuleOp &module,
     } else if (!valVars.empty()) {
       b.create<func::CallOp>(loc, root.func, valVars);
       if (!root.func->hasAttr("kernel")) {
-        printValidationResults.setValue(true);
-        printResults.setValue(false);
+        printValidationResults = true;
+        printResults = false;
       }
     } else {
       b.create<func::CallOp>(loc, root.func, localVars);
       if (!root.func->hasAttr("kernel")) {
-        printValidationResults.setValue(false);
-        printResults.setValue(true);
+        printValidationResults = false;
+        printResults = true;
       }
     }
+    // Clone-style validation wants to validate each root function.
+    // Non-clone validation validates at end;  the roots are related kernels.
+    if (hasCloneValidation)
+      insertValidationCalls(genConfig, b, module, valVars, localVars, outIdx,
+                            root.func, root0);
   }
+
+  // Run validation
+  if (hasValidation && !hasCloneValidation )
+    insertValidationCalls(genConfig, b, module, valVars, localVars, outIdx,
+                          func, root0);
+
+  // Print and cleanup validation vars
+  for (auto &vvar : valVars) {
+    // print vvar
+    if ((vvar == valVars[outIdx]) && printValidationResults.getValue())
+      emitPrintTensor(b, vvar);
+  }
+
+  // Print and cleanup
+  for (auto &lvar : localVars) {
+    // print lvar
+    bool printp = printInputs.getValue();
+    if (lvar == localVars[outIdx])
+      printp = printResults.getValue();
+    if (printp)
+      emitPrintTensor(b, lvar);
+  }
+
+  for (auto &vvar : valVars) {
+    b.create<memref::DeallocOp>(loc, vvar);
+  }
+  for (auto &lvar : localVars) {
+    b.create<memref::DeallocOp>(loc, lvar);
+  }
+
+  b.create<func::ReturnOp>(loc, ValueRange{});
 
   // Wrap the kernels and gather them to substitute in calls.
   llvm::SmallDenseMap<func::FuncOp, func::FuncOp> wrappedFuncs;
@@ -1994,115 +2085,86 @@ populateHostHarnessLogic(ModuleOp &module,
   }
 
   // Redirect calls to kernel functions to point at wrapped functions.
-  module.walk([&](func::CallOp call) -> WalkResult {
+  module.walk([&](Operation *op) -> WalkResult {
     // Don't substitute the call inside the wrapper.
-    if (call->hasAttr("wrapped_call")) {
-      call->removeAttr("wrapped_call");
+    if (op->hasAttr("wrapped_call")) {
+      op->removeAttr("wrapped_call");
       return WalkResult::advance();
     }
 
     // If the callee matches a wrapped function, update the call.
-    Operation *op = call;
     CallOpInterface callInt = dyn_cast<CallOpInterface>(op);
-    Operation *callableFromInt = callInt.resolveCallable();
-    func::FuncOp fop = dyn_cast<func::FuncOp>(*callableFromInt);
-    if (wrappedFuncs.find(fop) != wrappedFuncs.end()) {
-      call->setAttr("callee", FlatSymbolRefAttr::get(
-                                  context, wrappedFuncs[fop].getSymName()));
+    if (callInt) {
+      Operation *callableFromInt = callInt.resolveCallable();
+      if (callableFromInt) {
+        func::FuncOp fop = dyn_cast<func::FuncOp>(*callableFromInt);
+        if (wrappedFuncs.find(fop) != wrappedFuncs.end()) {
+          op->setAttr("callee", FlatSymbolRefAttr::get(
+                                    context, wrappedFuncs[fop].getSymName()));
+        }
+      }
     }
     return WalkResult::advance();
   });
 
-  // Run validation
-  bool hasXdlops =
-      rock::bitEnumContainsAll(genConfig.features, rock::GemmFeatures::mfma);
-  if (hasValidation) {
-    if (validationType == "gpu" &&
-        (hasXdlops || genConfig.dataTypeStr == "f16" ||
-         genConfig.dataTypeStr == "bf16")) {
-      // generate generic kernels
-      rock::Conv2dGenerator conv2dGenerator(genConfig);
-      // use non-xdlops kernels to verify xdlops kernels
-      if (hasXdlops)
-        conv2dGenerator.flipXdlops();
-      if (!hasXdlops || genConfig.dataTypeStr != "i8")
-        // use f32 data type to verify non-f32 or xdlops f32 kernels
-        // except that i8 xdlops is verified with i8 non-xdlops
-        conv2dGenerator.setDataType("f32");
-
-      int kernelStart = genConfig.kernelId;
-      int kernelCount = conv2dGenerator.getKernelCount(b);
-      if (kernelStart < 0) {
-        kernelStart = 0;
-      } else {
-        kernelCount = kernelStart + 1;
-      }
-      // generate all sub-kernels, and get corresponding gemmId
-      std::string kernelBaseName = genConfig.kernelBaseName;
-      for (int i = kernelStart; i < kernelCount; ++i) {
-        conv2dGenerator.setKernelName(kernelBaseName + "_" + std::to_string(i));
-        if (failed(conv2dGenerator.genConvModule(module, i, true,
-                                                 /*ignoreTuning=*/true))) {
-          llvm::errs() << "Module population failed.\n";
-          exit(1);
-        }
-        KernelIF kernel(conv2dGenerator.getKernelFunc());
-        rock::Conv2dGenerator::Config newConfig = conv2dGenerator.getConfig();
-        auto kernelWrapperFunc = createGPUWrapper(module, kernel);
-
-        // Decide whether to trim the last workspace argument to the verifier
-        // GPU kernel.
-        rock::Conv2dGenerator originalConv2dGenerator(genConfig);
-        bool originalHasWorkspace = originalConv2dGenerator.hasWorkspace(b);
-        bool verifierHasWorkspace = conv2dGenerator.hasWorkspace(b);
-        if (originalHasWorkspace && !verifierHasWorkspace) {
-          valVars.resize(valVars.size() - 1);
-        }
-
-        b.create<func::CallOp>(loc, kernelWrapperFunc, valVars);
-      }
-      conv2dGenerator.setKernelName(kernelBaseName);
-    } else { // -pv_with_cpp or -pv_with_mlir (-pv)
-      // Emit call to host_<conv>
-      auto cpuConvFunc = createCPUConvFunc(module, genConfig);
-      b.create<func::CallOp>(loc, cpuConvFunc, valVars);
-    }
-
-    // Emit call to verifier
-    mlir::Value testResult = localVars[outIdx];
-    mlir::Value valResult = valVars[outIdx];
-
-    auto testType = testResult.getType().dyn_cast<MemRefType>();
-    auto valType = valResult.getType().dyn_cast<MemRefType>();
-    auto verifierFunc = createVerifierFunc(module, root0, testType, valType);
-    b.create<func::CallOp>(loc, verifierFunc,
-                           ValueRange{testResult, valResult});
-  }
-
-  // Print and cleanup validation vars
-  for (auto &vvar : valVars) {
-    // print vvar
-    if ((vvar == valVars[outIdx]) && printValidationResults.getValue())
-      emitPrintTensor(b, vvar);
-    // dealloc vvar
-    b.create<memref::DeallocOp>(loc, vvar);
-  }
-
-  // Print and cleanup
-  for (auto &lvar : localVars) {
-    // print lvar
-    bool printp = printInputs.getValue();
-    if (lvar == localVars[outIdx])
-      printp = printResults.getValue();
-    if (printp)
-      emitPrintTensor(b, lvar);
-    // dealloc lvar
-    b.create<memref::DeallocOp>(loc, lvar);
-  }
-
-  b.create<func::ReturnOp>(loc, ValueRange{});
-
   return success();
+}
+
+void postOrderTraverseInternal(
+    CallGraphNode *node, SymbolTable &symbolTable,
+    llvm::SmallDenseSet<CallGraphNode *> &calleesSeen,
+    llvm::SmallDenseMap<Operation *, Operation *> &calleesRemapped) {
+  for (auto &edge : *node) {
+    if (!calleesSeen.count(edge.getTarget()))
+      postOrderTraverseInternal(edge.getTarget(), symbolTable, calleesSeen,
+                                calleesRemapped);
+    else
+      ; // Replace callee with new callee.
+  }
+
+  auto *callableRegion = node->getCallableRegion();
+  auto *parentOp = callableRegion->getParentOp();
+
+  // clone the func
+  auto *cloneFunc = parentOp->clone();
+  SymbolOpInterface cloneFuncOp = dyn_cast<SymbolOpInterface>(cloneFunc);
+  SmallString<128> nameBuffer(cloneFuncOp.getName());
+  nameBuffer += "_cloned";
+  cloneFuncOp.setName(nameBuffer);
+  cloneFunc->removeAttr("kernel");
+  cloneFunc->setAttr("original_func", SymbolRefAttr::get(parentOp));
+  parentOp->setAttr("clone_func", SymbolRefAttr::get(cloneFunc));
+
+  // add the clone into the symbol table.
+  symbolTable.insert(cloneFunc);
+
+  // update callees
+  auto *context = cloneFunc->getContext();
+  cloneFunc->walk([&](Operation *op) -> WalkResult {
+    CallOpInterface callInt = dyn_cast<CallOpInterface>(op);
+    if (callInt) {
+      Operation *callableFromInt = callInt.resolveCallable();
+      if (callableFromInt) {
+        if (calleesRemapped.find(callableFromInt) != calleesRemapped.end()) {
+          func::FuncOp fop =
+              dyn_cast<func::FuncOp>(*calleesRemapped[callableFromInt]);
+          op->setAttr("callee",
+                      FlatSymbolRefAttr::get(context, fop.getSymName()));
+        } else {
+          // must be an external function, or a bug;  how to check?
+        }
+      }
+    }
+    return WalkResult::advance();
+  });
+  calleesRemapped[parentOp] = cloneFunc;
+  calleesSeen.insert(node);
+}
+
+void postOrderTraverse(CallGraphNode *node, SymbolTable &symbolTable) {
+  llvm::SmallDenseSet<CallGraphNode *> calleesSeen;
+  llvm::SmallDenseMap<Operation *, Operation *> calleesRemapped;
+  postOrderTraverseInternal(node, symbolTable, calleesSeen, calleesRemapped);
 }
 
 int main(int argc, char **argv) {
@@ -2130,8 +2192,6 @@ int main(int argc, char **argv) {
   populateDefaults();
 
   rock::Conv2dGenerator conv2dGenerator;
-
-  SmallVector<KernelIF, 8> kernels;
 
   auto testFuncNameVal = testFuncName.getValue();
   bool hasUserKernel = !testFuncNameVal.empty();
@@ -2164,6 +2224,11 @@ int main(int argc, char **argv) {
       return WalkResult::advance();
     });
   } else {
+    if (genValidation == "clone") {
+      llvm::errs() << "Clone validation is not compatible with kernel generation.\n";
+      exit(1);
+    }
+
     // Construct a new ModuleOp.
     module = ModuleOp::create(builder.getUnknownLoc());
   }
@@ -2256,19 +2321,33 @@ int main(int argc, char **argv) {
   // order to match an older implementation.
   CallGraph cg(module);
   mlir::SetVector<CallGraphNode *> roots(cg.begin(), cg.end());
-  for (auto &node : roots)
+  for (auto &node : roots) {
     for (auto &edge : *node)
       roots.remove(edge.getTarget());
+    func::FuncOp func =
+      dyn_cast<func::FuncOp>(node->getCallableRegion()->getParentOp());
+    if (func->hasAttr("orig_func"))
+      roots.remove(node);
+  }
+
+  if (0&& genValidation == "clone") {
+    SymbolTable symbolTable(module);
+    for (auto &root : roots) {
+      postOrderTraverse(root, symbolTable);
+    }
+  }
+
+  SmallVector<KernelIF, 8> kernels;
 
   // Make KernelIFs for the roots, to pass to populateHostHarnessLogic().
   SmallVector<KernelIF, 8> rootIFs;
-  for (auto *node : roots) {
-    func::FuncOp func =
-        dyn_cast<func::FuncOp>(node->getCallableRegion()->getParentOp());
-    rootIFs.emplace_back(func);
-  }
 
   if (testFuncNameVal.empty()) {
+    for (auto *node : roots) {
+      func::FuncOp func =
+          dyn_cast<func::FuncOp>(node->getCallableRegion()->getParentOp());
+      rootIFs.emplace_back(func);
+    }
     module.walk([&](func::FuncOp func) -> WalkResult {
       if (func->hasAttr("kernel")) {
         kernels.emplace_back(func);
@@ -2278,8 +2357,7 @@ int main(int argc, char **argv) {
   } else {
     auto func = module.lookupSymbol<func::FuncOp>(testFuncName);
     assert(func);
-    rootIFs.clear();
-    kernels.emplace_back(func);
+    kernels.emplace_back(func); // +++pf: should it be a kernel?
     rootIFs.emplace_back(func);
   }
 

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2136,7 +2136,8 @@ populateHostHarnessLogic(ModuleOp &module,
     if (callable) {
       func::FuncOp fop = dyn_cast<func::FuncOp>(*callable);
       if (wrappedFuncs.find(fop) != wrappedFuncs.end()) {
-        callOp->setAttr("callee", FlatSymbolRefAttr::get(context, wrappedFuncs[fop].getSymName()));
+        callOp->setAttr("callee", FlatSymbolRefAttr::get(
+                                      context, wrappedFuncs[fop].getSymName()));
       }
     }
     return WalkResult::advance();

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1810,6 +1810,44 @@ static LogicalResult populateTensorFillLogic(mlir::OpBuilder &b,
   return success();
 }
 
+
+void undoAsyncLaunchPass(Operation *cloneFunc) {
+  SymbolTableCollection symbolTable;
+  auto walker = [&](Operation *op) {
+                  OpBuilder builder(op);
+                  if (auto launch = dyn_cast<async::LaunchOp>(op)) {
+                    SymbolRefAttr calleeAttr = launch->getAttrOfType<SymbolRefAttr>("callee");
+
+                    assert(launch->getNumResults() == 1);
+                    auto aresults = launch->getResults();
+                    mlir::Type tokenType = aresults.front().getType();
+
+                    auto operands = launch->getOperands();
+                    BitVector indicesToErase(launch.getNumOperands());
+                    for (auto idx : llvm::seq<int>(0, launch.getNumOperands()))
+                      if (!launch->getOperand(idx) || launch->getOperand(idx).getType() == tokenType)
+                        indicesToErase.set(idx);
+                    launch->eraseOperands(indicesToErase);
+                    operands = launch->getOperands();
+
+                    auto call = builder.create<func::CallOp>(op->getLoc(), calleeAttr,
+                                                             TypeRange{}, operands);
+
+                    call->moveBefore(op);
+                    op->dropAllUses();
+                    op->erase();
+                    return WalkResult::interrupt();
+                  } else if (auto launch = dyn_cast<async::AwaitOp>(op)) {
+                    op->erase();
+                    return WalkResult::interrupt();
+                  }
+                  return WalkResult::advance();
+                };
+  while (cloneFunc->walk(walker).wasInterrupted()) {
+  }
+}
+
+
 static void
 insertValidationCalls(const miopen::Conv2dGenerator::Config &genConfig,
                       OpBuilder &b, ModuleOp &module,
@@ -1870,9 +1908,20 @@ insertValidationCalls(const miopen::Conv2dGenerator::Config &genConfig,
     auto cpuConvFunc = createCPUConvFunc(module, genConfig);
     b.create<func::CallOp>(loc, cpuConvFunc, valVars);
   } else {                            // clone
-    auto cloneAttr = func->getAttrOfType<SymbolRefAttr>("clone_func");
-    assert(cloneAttr);
-    b.create<func::CallOp>(loc, cloneAttr, TypeRange{}, valVars);
+    auto *cloneFunc = func->clone();
+
+    undoAsyncLaunchPass(cloneFunc);
+
+    SymbolOpInterface cloneFuncOp = dyn_cast<SymbolOpInterface>(cloneFunc);
+    SmallString<128> nameBuffer(cloneFuncOp.getName());
+    nameBuffer += "_cloned";
+    cloneFuncOp.setName(nameBuffer);
+    cloneFunc->removeAttr("kernel");
+//     cloneFunc->setAttr("original_func", SymbolRefAttr::get(func));
+//     func->setAttr("clone_func", SymbolRefAttr::get(cloneFunc));
+    SymbolTable symbolTable(module);
+    symbolTable.insert(cloneFunc);
+    b.create<func::CallOp>(loc, SymbolRefAttr::get(cloneFunc), TypeRange{}, valVars);
   }
 
   // Emit call to verifier
@@ -2326,7 +2375,9 @@ int main(int argc, char **argv) {
       roots.remove(edge.getTarget());
     func::FuncOp func =
       dyn_cast<func::FuncOp>(node->getCallableRegion()->getParentOp());
-    if (func->hasAttr("orig_func"))
+    if (func->hasAttr("original_func"))
+      roots.remove(node);
+    if (func->getParentOp() && func->getParentOp()->getParentOp())
       roots.remove(node);
   }
 


### PR DESCRIPTION
Cleanups and clone-validation-related refactoring.
Working version of '--verifier clone', using the kernel clones from '-host-pipeline partition'.  Clones the root function and reverts async.launch to func.call.
Add a '--verifier clone' run to the resnet50_blk.e2e.mlir test.
Clean up some warnings.

There are a lot of cleanup/refactoring changes.  In particular, since for Option, operator=() calls setValue(), I changed setValue() to "=" for aesthetics.  I also abstracted some repeated sections into functions.

For the actual clone-verification, I take advantage of the pattern of a function calling kernels, where the kernels have arch-specific alternatives in sub-modules.  The caller has async.launch to call the kernels, and a later pass will do the magic to choose the right GPU implementation.  Here, I clone the caller and make it just call the original MLIR, which naturally goes to the CPU.

While I'll try to generalise it to create the caller when given just a kernel, the whole idea does depend on the cloned kernels in sub-modules;  nothing here can cause some code to be compiled for GPU and some for CPU.