### PR TITLE
[NFC] Remove raw accessors to head off issues at next LLVM update

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -22,9 +22,6 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 def MIGraphX_Dialect : Dialect {
   let name = "migraphx";
   let cppNamespace = "mlir::migraphx";
-
-    // TODO: move this to Prefixed by removing it
-  let emitAccessorPrefix = kEmitAccessorPrefix_Both;
 }
 
 // Base class for MIGraphX dialect ops.

--- a/mlir/include/mlir/Dialect/Rock/IR/RockBase.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockBase.td
@@ -16,9 +16,6 @@ def Rock_Dialect : Dialect {
   let name = "rock";
   let cppNamespace = "::mlir::rock";
 
-  // TODO: move this to Prefixed by removing it
-  let emitAccessorPrefix = kEmitAccessorPrefix_Both;
-
   let useDefaultAttributePrinterParser = 1;
 
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -206,7 +206,7 @@ def Rock_TransformOp :
   }];
 
   let extraClassDeclaration = [{
-    Value getViewSource() { return input(); }
+    Value getViewSource() { return getInput(); }
   }];
 }
 
@@ -514,7 +514,7 @@ def Rock_TransformingForOp :
   let regions = (region SizedRegion<1>:$region);
 
   DerivedAttr upperLen = DerivedAttr<"uint32_t", [{
-    return upperInits().size() / transforms().size();
+    return getUpperInits().size() / getTransforms().size();
   }], [{ $_builder.getI32IntegerAttr($_self) }]>;
 
   let skipDefaultBuilders = 1;
@@ -546,24 +546,24 @@ def Rock_TransformingForOp :
   let extraClassDeclaration = [{
     void moveOutOfLoop(ArrayRef<Operation *> ops);
 
-    uint32_t lowerStart(uint32_t n) {
-      return *(lowerStarts().getValues<uint32_t>().begin() + n);
+    uint32_t getLowerStart(uint32_t n) {
+      return *(getLowerStarts().getValues<uint32_t>().begin() + n);
     }
 
     // Retreive the block arguments corresponding to the lower coordinates
     // for a given iteration domain.
     Block::BlockArgListType getLowerCoords(uint32_t domain) {
-      uint32_t start = lowerStart(domain);
-      uint32_t end = lowerStart(domain + 1);
+      uint32_t start = getLowerStart(domain);
+      uint32_t end = getLowerStart(domain + 1);
       return getBody()->getArguments().slice(start, end - start);
     }
     Block::BlockArgListType getLowerCoords() {
-      assert(lowerStarts().size() == 2 && "Ambiguous call to getLowerCoords() with multple iteration domains");
-      return getBody()->getArguments().take_front(lowerStart(1));
+      assert(getLowerStarts().size() == 2 && "Ambiguous call to getLowerCoords() with multple iteration domains");
+      return getBody()->getArguments().take_front(getLowerStart(1));
     }
 
     Block::BlockArgListType getIterArgs() {
-      return getBody()->getArguments().drop_front(lowerStart(lowerStarts().size() - 1));
+      return getBody()->getArguments().drop_front(getLowerStart(getLowerStarts().size() - 1));
     }
 
     ValueTypeRange<Block::BlockArgListType> getIterArgTypes() {
@@ -571,16 +571,16 @@ def Rock_TransformingForOp :
     }
 
     Operation::operand_range getUpperInits(uint32_t domain) {
-      uint32_t theUpperLen = upperLen();
-      return upperInits().slice(domain * theUpperLen, theUpperLen);
+      uint32_t theUpperLen = getUpperLen();
+      return getUpperInits().slice(domain * theUpperLen, theUpperLen);
     }
 
     ArrayAttr getTransforms(uint32_t domain) {
-      return transforms()[domain].cast<ArrayAttr>();
+      return getTransforms()[domain].cast<ArrayAttr>();
     }
 
     uint32_t domains() {
-      return transforms().size();
+      return getTransforms().size();
     }
   }];
 

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -65,7 +65,7 @@ struct MIGPUAllocRewritePattern : public OpRewritePattern<rock::GpuAllocOp> {
 
   LogicalResult matchAndRewrite(rock::GpuAllocOp op,
                                 PatternRewriter &b) const override {
-    auto type = op.output().getType().cast<MemRefType>();
+    auto type = op.getOutput().getType();
     auto func = op->getParentOfType<gpu::GPUFuncOp>();
     Location loc = op->getLoc();
 

--- a/mlir/lib/Dialect/MIGraphX/MIGraphXOps.cpp
+++ b/mlir/lib/Dialect/MIGraphX/MIGraphXOps.cpp
@@ -42,8 +42,8 @@ void MIGraphXDialect::initialize() {
 
 OpFoldResult RecipOp::fold(ArrayRef<Attribute> operands) {
   // 1/(1/x) = x
-  if (auto parentRecip = inA().getDefiningOp<RecipOp>()) {
-    return parentRecip.inA();
+  if (auto parentRecip = getInA().getDefiningOp<RecipOp>()) {
+    return parentRecip.getInA();
   }
   return {};
 }

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -31,6 +31,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/XdlopsCodeSelection.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/SmallVector.h"
@@ -66,14 +67,15 @@ struct FillRewritePattern : public OpConversionPattern<FillOp> {
   LogicalResult matchAndRewrite(FillOp op, FillOpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
-    auto inputType = op.input().getType().cast<MemRefType>();
+    MemRefType inputType = op.getInput().getType();
     ArrayRef<int64_t> inputShape = inputType.getShape();
     llvm::SmallVector<int64_t> lbs(inputShape.size(), 0);
     llvm::SmallVector<int64_t> strides(inputShape.size(), 1);
 
     buildAffineLoopNest(b, loc, lbs, inputShape, strides,
-                        [value = adaptor.value(), input = adaptor.input()](
-                            OpBuilder &b, Location loc, ValueRange ivs) {
+                        [value = adaptor.getValue(),
+                         input = adaptor.getInput()](OpBuilder &b, Location loc,
+                                                     ValueRange ivs) {
                           b.create<memref::StoreOp>(loc, value, input, ivs);
                         });
 
@@ -100,9 +102,9 @@ struct BlockwiseGemmRewritePattern
     // Prepare some useful constants.
     Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
 
-    auto blockAType = op.matrixA().getType().cast<MemRefType>();
-    auto blockBType = op.matrixB().getType().cast<MemRefType>();
-    auto bufferCType = op.matrixC().getType().cast<MemRefType>();
+    MemRefType blockAType = op.getMatrixA().getType(),
+               blockBType = op.getMatrixB().getType(),
+               bufferCType = op.getMatrixC().getType();
 
     auto elementType = bufferCType.getElementType();
 
@@ -116,7 +118,7 @@ struct BlockwiseGemmRewritePattern
     // Obtain critical attributes.
     int64_t mC = bufferCType.getShape()[0];
     int64_t nC = bufferCType.getShape()[1];
-    GeneralGemmParamsAttr params = op.params();
+    GeneralGemmParamsAttr params = op.getParams();
     int64_t kPerThread = params.getKPerThread();
     int64_t mPerThread = params.getMPerThread();
     int64_t nPerThread = params.getNPerThread();
@@ -190,10 +192,12 @@ struct BlockwiseGemmRewritePattern
 
     Value matrixA, matrixB;
     ArrayAttr transformsA, transformsB;
-    std::tie(matrixA, transformsA) = untransform(
-        b, adaptor.matrixA(), b.getArrayAttr({splitTidAAttr, toLdsIndexAAttr}));
-    std::tie(matrixB, transformsB) = untransform(
-        b, adaptor.matrixB(), b.getArrayAttr({splitTidBAttr, toLdsIndexBAttr}));
+    std::tie(matrixA, transformsA) =
+        untransform(b, adaptor.getMatrixA(),
+                    b.getArrayAttr({splitTidAAttr, toLdsIndexAAttr}));
+    std::tie(matrixB, transformsB) =
+        untransform(b, adaptor.getMatrixB(),
+                    b.getArrayAttr({splitTidBAttr, toLdsIndexBAttr}));
 
     int64_t threadANumRegisters = kPerThread * mC * kPack;
     int64_t threadBNumRegisters = kPerThread * nC * kPack;
@@ -274,7 +278,7 @@ struct BlockwiseGemmRewritePattern
         b, loc, threadBAllocOp, {"k", "n", "kpack"}, {kPerThread, nC, kPack});
     // Actually do the gemm - this goes inside the look over kOffset
     b.create<ThreadwiseGemmOp>(loc, reshapedARegisters, reshapedBRegisters,
-                               op.matrixC());
+                               op.getMatrixC());
 
     return success();
   }
@@ -293,7 +297,7 @@ struct BlockwiseGemmV2RewritePattern
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
 
-    XdlopsGemmParamsAttr tuningParams = op.params();
+    XdlopsGemmParamsAttr tuningParams = op.getParams();
     int64_t M = tuningParams.getMPerBlock();
     int64_t N = tuningParams.getNPerBlock();
     int64_t K = tuningParams.getKPerBlock();
@@ -313,14 +317,14 @@ struct BlockwiseGemmV2RewritePattern
     int64_t MPerXdlops = (MPerWave > 64) ? 64 : MPerWave;
     int64_t NPerXdlops = (NPerWave > 64) ? 64 : NPerWave;
 
-    int64_t ldsOffsetA = op.ldsBufferOffsetA().getSExtValue();
-    int64_t ldsOffsetB = op.ldsBufferOffsetB().getSExtValue();
+    int64_t ldsOffsetA = op.getLdsBufferOffsetA().getSExtValue();
+    int64_t ldsOffsetB = op.getLdsBufferOffsetB().getSExtValue();
 
     assert(ldsOffsetA % KPack == 0 &&
            "LDS buffer segment for A is kpack-aligned");
     assert(ldsOffsetB % KPack == 0 &&
            "LDS buffer segment for B is kpack-aligned");
-    auto dataType = adaptor.matrixA()
+    auto dataType = adaptor.getMatrixA()
                         .getType()
                         .template cast<MemRefType>()
                         .getElementType();
@@ -334,10 +338,10 @@ struct BlockwiseGemmV2RewritePattern
     // end) we must divide it by KPack here. Fortunately, this offset will be
     // KPack-alligned and so this is safe
     Value aBase =
-        b.create<AddIOp>(loc, adaptor.waveOffsetA(),
+        b.create<AddIOp>(loc, adaptor.getWaveOffsetA(),
                          b.create<ConstantIndexOp>(loc, ldsOffsetA / KPack));
     Value bBase =
-        b.create<AddIOp>(loc, adaptor.waveOffsetB(),
+        b.create<AddIOp>(loc, adaptor.getWaveOffsetB(),
                          b.create<ConstantIndexOp>(loc, ldsOffsetB / KPack));
 
     XdlopsCodeSelection xcs =
@@ -377,8 +381,8 @@ struct BlockwiseGemmV2RewritePattern
                << "argVectorType: " << argType << "\n"
                << "k_base: " << k_base << "\n"
                << "K: " << K << "\n"
-               << "bufferA type: " << adaptor.bufferA().getType() << "\n"
-               << "bufferB type: " << adaptor.bufferB().getType() << "\n");
+               << "bufferA type: " << adaptor.getBufferA().getType() << "\n"
+               << "bufferB type: " << adaptor.getBufferB().getType() << "\n");
 
     auto MConstantOp = b.create<ConstantIndexOp>(loc, M);
     auto NConstantOp = b.create<ConstantIndexOp>(loc, N);
@@ -387,10 +391,10 @@ struct BlockwiseGemmV2RewritePattern
     auto MPerXdlopsConstantOp = b.create<ConstantIndexOp>(loc, MPerXdlops);
     auto NPerXdlopsConstantOp = b.create<ConstantIndexOp>(loc, NPerXdlops);
 
-    Value bufferA = adaptor.bufferA();
-    Value bufferB = adaptor.bufferB();
-    auto bufferAType = adaptor.bufferA().getType().cast<MemRefType>();
-    auto bufferBType = adaptor.bufferB().getType().cast<MemRefType>();
+    Value bufferA = adaptor.getBufferA();
+    Value bufferB = adaptor.getBufferB();
+    auto bufferAType = adaptor.getBufferA().getType().cast<MemRefType>();
+    auto bufferBType = adaptor.getBufferB().getType().cast<MemRefType>();
     Type bufferAElementType = bufferAType.getElementType();
     Type bufferBElementType = bufferBType.getElementType();
 
@@ -429,8 +433,8 @@ struct BlockwiseGemmV2RewritePattern
 
       auto destOffsetA = ilmkb.create<AddIOp>(loc, ilmkiv, kOffsetA);
 
-      Value valueA = ilmkb.create<InBoundsLoadOp>(loc, bufferAElementType,
-                                                  op.matrixA(), sourceOffsetA);
+      Value valueA = ilmkb.create<InBoundsLoadOp>(
+          loc, bufferAElementType, op.getMatrixA(), sourceOffsetA);
       ilmkb.create<memref::StoreOp>(loc, valueA, bufferA,
                                     ValueRange{destOffsetA});
 
@@ -466,8 +470,8 @@ struct BlockwiseGemmV2RewritePattern
 
       auto destOffsetB = ilnkb.create<AddIOp>(loc, ilnkiv, kOffsetB);
 
-      Value valueB = ilnkb.create<InBoundsLoadOp>(loc, bufferBElementType,
-                                                  op.matrixB(), sourceOffsetB);
+      Value valueB = ilnkb.create<InBoundsLoadOp>(
+          loc, bufferBElementType, op.getMatrixB(), sourceOffsetB);
       ilnkb.create<memref::StoreOp>(loc, valueB, bufferB,
                                     ValueRange{destOffsetB});
     } else {
@@ -513,8 +517,8 @@ struct BlockwiseGemmV2RewritePattern
         sourceOffsetA = lklb.create<MulIOp>(
             loc, sourceOffsetA, lklb.create<ConstantIndexOp>(loc, KPack));
 
-      Value valueA = lklb.create<InBoundsLoadOp>(loc, bufferAElementType,
-                                                 op.matrixA(), sourceOffsetA);
+      Value valueA = lklb.create<InBoundsLoadOp>(
+          loc, bufferAElementType, op.getMatrixA(), sourceOffsetA);
       lklb.create<memref::StoreOp>(loc, valueA, bufferA, ValueRange{lkliv});
 
       Value sourceOffsetB = lklb.create<AddIOp>(
@@ -533,8 +537,8 @@ struct BlockwiseGemmV2RewritePattern
         sourceOffsetB = lklb.create<MulIOp>(
             loc, sourceOffsetB, lklb.create<ConstantIndexOp>(loc, KPack));
 
-      Value valueB = lklb.create<InBoundsLoadOp>(loc, bufferBElementType,
-                                                 op.matrixB(), sourceOffsetB);
+      Value valueB = lklb.create<InBoundsLoadOp>(
+          loc, bufferBElementType, op.getMatrixB(), sourceOffsetB);
       lklb.create<memref::StoreOp>(loc, valueB, bufferB, ValueRange{lkliv});
     }
 
@@ -543,11 +547,11 @@ struct BlockwiseGemmV2RewritePattern
     // TODO: amend this for tuning parameter selection as well
     xcs = XdlopsCodeSelection::get(dataType, MPerXdlops, NPerXdlops, b);
     Value reshapedARegisters = reshapeBuffer(
-        b, loc, adaptor.bufferA(), {"m", "k"}, {MRepeats, KPerThread});
+        b, loc, adaptor.getBufferA(), {"m", "k"}, {MRepeats, KPerThread});
     Value reshapedBRegisters = reshapeBuffer(
-        b, loc, adaptor.bufferB(), {"n", "k"}, {NRepeats, KPerThread});
+        b, loc, adaptor.getBufferB(), {"n", "k"}, {NRepeats, KPerThread});
     Value reshapedCRegisters =
-        reshapeBuffer(b, loc, adaptor.matrixC(), {"m", "n", "v"},
+        reshapeBuffer(b, loc, adaptor.getMatrixC(), {"m", "n", "v"},
                       {MRepeats, NRepeats, xcs.nResultVectors});
 
     b.replaceOpWithNewOp<XdlopsGemmV2Op>(op, reshapedARegisters,
@@ -566,13 +570,12 @@ struct GlobalLoadRewritePattern : public OpRewritePattern<GlobalLoadOp> {
                                 PatternRewriter &b) const override {
     Location loc = op.getLoc();
 
-    Value source = op.source();
-    auto sourceType = source.getType().cast<MemRefType>();
+    MemRefType sourceType = op.getSource().getType();
     Type sourceElemType = sourceType.getElementType();
     int64_t elemsPerWord = (32 / sourceElemType.getIntOrFloatBitWidth());
     int64_t maxLoadLen = 4 * elemsPerWord;
 
-    Type resType = op.result().getType();
+    Type resType = op.getResult().getType();
     int64_t totalLength = 1;
     if (auto vecType = resType.dyn_cast<VectorType>()) {
       totalLength = vecType.getNumElements();
@@ -601,9 +604,9 @@ struct GlobalLoadRewritePattern : public OpRewritePattern<GlobalLoadOp> {
       IntegerAttr offsetAttr =
           (offset > 0) ? b.getIndexAttr(offset) : IntegerAttr();
 
-      Value loaded = b.create<BufferLoadOp>(loc, typeToLoad, op.source(),
-                                            op.leftOobDims(), op.rightOobDims(),
-                                            op.sourceCoord(), offsetAttr);
+      Value loaded = b.create<BufferLoadOp>(
+          loc, typeToLoad, op.getSource(), op.getLeftOobDims(),
+          op.getRightOobDims(), op.getSourceCoord(), offsetAttr);
       if (totalLength == 1) {
         result = loaded;
       } else {
@@ -630,15 +633,15 @@ struct ThreadwiseCopyV2RewritePattern
                                 PatternRewriter &b) const override {
     Location loc = op.getLoc();
 
-    Value source = op.source();
-    auto sourceType = source.getType().cast<MemRefType>();
-    Value sourceCoord = op.sourceCoord();
+    Value source = op.getSource();
+    MemRefType sourceType = op.getSource().getType();
+    Value sourceCoord = op.getSourceCoord();
 
     Type sourceElemType = sourceType.getElementType();
-    Type destElemType = op.dest().getType().cast<MemRefType>().getElementType();
+    Type destElemType = op.getDest().getType().getElementType();
     int64_t elemsPerWord = (32 / destElemType.getIntOrFloatBitWidth());
     int64_t maxWriteLen = 4 * elemsPerWord;
-    int64_t remainingLength = op.length().getSExtValue();
+    int64_t remainingLength = op.getLength().getSExtValue();
     int64_t offset = 0;
     while (remainingLength > 0) {
       int64_t copyLength = std::min(remainingLength, maxWriteLen);
@@ -666,9 +669,9 @@ struct ThreadwiseCopyV2RewritePattern
           b.create<InBoundsLoadOp>(loc, typeToLoad, source, loadCoord);
       IntegerAttr offsetAttr =
           (offset > 0) ? b.getIndexAttr(offset) : IntegerAttr();
-      b.create<BufferStoreOp>(loc, loaded, op.dest(), op.leftOobDims(),
-                              op.rightOobDims(), op.destCoord(),
-                              op.storeMethodAttr(), offsetAttr);
+      b.create<BufferStoreOp>(loc, loaded, op.getDest(), op.getLeftOobDims(),
+                              op.getRightOobDims(), op.getDestCoord(),
+                              op.getStoreMethodAttr(), offsetAttr);
       remainingLength -= copyLength;
       offset += copyLength;
     }

--- a/mlir/lib/Dialect/Rock/Transforms/FoldTranspose.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/FoldTranspose.cpp
@@ -51,7 +51,7 @@ static Operation *getConvUser(Value v) {
     if (isa<Conv2DOp, Conv2DBwdDataOp, Conv2DBwdWeightOp>(user))
       return user;
     if (auto transform = dyn_cast<TransformOp>(user))
-      if (Operation *upstream = getConvUser(transform.output()))
+      if (Operation *upstream = getConvUser(transform.getOutput()))
         return upstream;
   }
   return nullptr;

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -574,7 +574,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
   void computeLDSBlockSizes(GridwiseGemmOp op, int64_t &a_block_space,
                             int64_t &b_block_space, int64_t &block_space,
                             int64_t KPack = 1) const {
-    GeneralGemmParamsAttr tuningParams = op.params();
+    GeneralGemmParamsAttr tuningParams = op.getParams();
     int64_t ThreadGemmAThreadCopySrcDataPerRead_M =
         tuningParams.getMPerThread();
     int64_t ThreadGemmBThreadCopySrcDataPerRead_N =
@@ -631,8 +631,8 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     Location loc = op.getLoc();
 
     // Obtain data type.
-    Type elementType = op.b().getType().cast<MemRefType>().getElementType();
-    Type destType = op.c().getType().cast<MemRefType>().getElementType();
+    Type elementType = op.getB().getType().getElementType();
+    Type destType = op.getC().getType().getElementType();
     Type accumulatorType = obtainAccumulatorType(b, elementType, destType);
 
     // Prepare some useful constants.
@@ -640,9 +640,9 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
 
     ArrayRef<int64_t> aShape, bShape, cShape;
-    aShape = op.a().getType().template cast<MemRefType>().getShape();
-    bShape = op.b().getType().template cast<MemRefType>().getShape();
-    cShape = op.c().getType().template cast<MemRefType>().getShape();
+    aShape = op.getA().getType().getShape();
+    bShape = op.getB().getType().getShape();
+    cShape = op.getC().getType().getShape();
     // Obtain critical matrix dimensions.
     int64_t G = aShape[0];
     int64_t K = aShape[1];
@@ -669,9 +669,9 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     }
 
     // Obtain critical tuning parameters.
-    uint32_t blockSize = op.blockSize();
-    uint32_t gridSize = op.gridSize();
-    GeneralGemmParamsAttr tuningParams = op.params();
+    uint32_t blockSize = op.getBlockSize();
+    uint32_t gridSize = op.getGridSize();
+    GeneralGemmParamsAttr tuningParams = op.getParams();
     int64_t kpack = tuningParams.getKpack();
     // TODO: kPerBlock, as defined in parameter selection etc,
     // is in units of kPack, not individual k. This should be changed
@@ -785,9 +785,9 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     int64_t aVectorLen, bVectorLen;
     GemmDimension aVectorDim, bVectorDim;
     std::tie(aVectorDim, aVectorLen) =
-        bestVectorization(b, op.a(), aCopyPerThread, vectorTiebreaker);
+        bestVectorization(b, op.getA(), aCopyPerThread, vectorTiebreaker);
     std::tie(bVectorDim, bVectorLen) =
-        bestVectorization(b, op.b(), bCopyPerThread, vectorTiebreaker);
+        bestVectorization(b, op.getB(), bCopyPerThread, vectorTiebreaker);
 
     LLVM_DEBUG(llvm::dbgs()
                << "aCopyPerThread: " << aCopyPerThread << "\n"
@@ -813,13 +813,15 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
                                  : bCopyPerThread / bVectorLen;
 
     FailureOr<Value> maybeWrappedA = wrapMatrixForGlobalLoad(
-        b, loc, op.a(), "m", bidGridOrder, bidGridLengths, gridSize, blockSize,
-        kPerBlock, mPerBlock, aCopyKPerThread, copyMPerThread, aVectorDim);
+        b, loc, op.getA(), "m", bidGridOrder, bidGridLengths, gridSize,
+        blockSize, kPerBlock, mPerBlock, aCopyKPerThread, copyMPerThread,
+        aVectorDim);
     if (failed(maybeWrappedA))
       return maybeWrappedA;
     FailureOr<Value> maybeWrappedB = wrapMatrixForGlobalLoad(
-        b, loc, op.b(), "n", bidGridOrder, bidGridLengths, gridSize, blockSize,
-        kPerBlock, nPerBlock, bCopyKPerThread, copyNPerThread, bVectorDim);
+        b, loc, op.getB(), "n", bidGridOrder, bidGridLengths, gridSize,
+        blockSize, kPerBlock, nPerBlock, bCopyKPerThread, copyNPerThread,
+        bVectorDim);
     if (failed(maybeWrappedB))
       return maybeWrappedB;
     Value wrappedA = std::move(*maybeWrappedA),
@@ -874,7 +876,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
       // Emit blockwise GEMM.
       blockwiseGemmOp = b.create<BlockwiseGemmOp>(
           loc, ldsMatrixASubviewOp, ldsMatrixBSubviewOp, registerMatrixCViewOp,
-          op.paramsAttr());
+          op.getParamsAttr());
 
       // LDS barrier.
       // This barrier prevents halo part of outputs having weird values.
@@ -991,7 +993,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     Value tensorC;
     ArrayAttr idToTensorCMaps;
     std::tie(tensorC, idToTensorCMaps) =
-        untransform(b, op.c(), idToMatrixCMaps);
+        untransform(b, op.getC(), idToMatrixCMaps);
     auto writeOobDims = computeOobFromTransforms(b, idToTensorCMaps);
 
     ArrayRef<int64_t> tensorCShape =
@@ -1038,7 +1040,7 @@ struct GridwiseGemmV2RewritePattern
                             int64_t KPack = 1) const {
     int64_t max_lds_align = 1;
 
-    XdlopsGemmParamsAttr tuningParams = op.params();
+    XdlopsGemmParamsAttr tuningParams = op.getParams();
     int64_t KPerBlock = tuningParams.getKPerBlock();
     int64_t MPerBlock = tuningParams.getMPerBlock();
     int64_t NPerBlock = tuningParams.getNPerBlock();
@@ -1082,16 +1084,16 @@ struct GridwiseGemmV2RewritePattern
     auto loc = op.getLoc();
 
     // Obtain data type.
-    auto elementType = op.b().getType().cast<MemRefType>().getElementType();
+    auto elementType = op.getB().getType().getElementType();
 
     // Prepare some useful constants.
     Value zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
 
     // Obtain critical matrix dimensions.
     ArrayRef<int64_t> aShape, bShape, cShape;
-    aShape = op.a().getType().template cast<MemRefType>().getShape();
-    bShape = op.b().getType().template cast<MemRefType>().getShape();
-    cShape = op.c().getType().template cast<MemRefType>().getShape();
+    aShape = op.getA().getType().getShape();
+    bShape = op.getB().getType().getShape();
+    cShape = op.getC().getType().getShape();
     // Obtain critical matrix dimensions.
     int64_t G = aShape[0];
     int64_t K = aShape[1];
@@ -1117,9 +1119,9 @@ struct GridwiseGemmV2RewritePattern
     }
 
     // Obtain critical tuning parameters.
-    uint32_t blockSize = op.blockSize();
-    uint32_t gridSize = op.gridSize();
-    XdlopsGemmParamsAttr tuningParams = op.params();
+    uint32_t blockSize = op.getBlockSize();
+    uint32_t gridSize = op.getGridSize();
+    XdlopsGemmParamsAttr tuningParams = op.getParams();
     int64_t KPack = tuningParams.getKpack();
     int64_t KPerBlock = tuningParams.getKPerBlock();
     int64_t MPerBlock = tuningParams.getMPerBlock();
@@ -1704,7 +1706,7 @@ struct GridwiseGemmV2RewritePattern
     }
     // Emit blockwise load for matrix A.
     TransformingForOp blockwiseLoadA = createGlobalLoadLoop(
-        b, loc, op.a(), blockwiseLoadACoords, aLoadIntermediate, aLoadType,
+        b, loc, op.getA(), blockwiseLoadACoords, aLoadIntermediate, aLoadType,
         blockwiseCopyABounds, blockwiseVectorDimA, useIndexDiffs);
 
     SmallVector<Value, 4> blockwiseLoadBCoords;
@@ -1718,7 +1720,7 @@ struct GridwiseGemmV2RewritePattern
     }
     // Emit blockwise load for matrix B.
     TransformingForOp blockwiseLoadB = createGlobalLoadLoop(
-        b, loc, op.b(), blockwiseLoadBCoords, bLoadIntermediate, bLoadType,
+        b, loc, op.getB(), blockwiseLoadBCoords, bLoadIntermediate, bLoadType,
         blockwiseCopyBBounds, blockwiseVectorDimB, useIndexDiffs);
 
     SmallVector<Value, 4> blockwiseStoreACoords;
@@ -1844,7 +1846,7 @@ struct GridwiseGemmV2RewritePattern
     // -----
     // Logic to allocate 0-initialized vectors for C.
     int64_t regCVectorLen = vectorType.getNumElements();
-    Type destType = op.c().getType().cast<MemRefType>().getElementType();
+    Type destType = op.getC().getType().getElementType();
     Type accumulatorType = obtainAccumulatorType(b, elementType, destType);
     VectorType accumulatorVectorType =
         vectorType.cloneWith({}, accumulatorType);
@@ -1898,7 +1900,7 @@ struct GridwiseGemmV2RewritePattern
     mfmalb.create<BlockwiseGemmV2Op>(
         loc, ldsGpuAllocOp, ldsGpuAllocOp, b.getIndexAttr(ldsBlockAOffset),
         b.getIndexAttr(ldsBlockBOffset), mMyWaveOffsetA, mMyWaveOffsetB, arrayA,
-        arrayB, regCAllocOp, op.blockSizeAttr(), op.paramsAttr());
+        arrayB, regCAllocOp, op.getBlockSizeAttr(), op.getParamsAttr());
 
     // LDS barrier : defer the next LDS update until this round's GEMM
     // calculation is done. requires barrier only.
@@ -1932,7 +1934,7 @@ struct GridwiseGemmV2RewritePattern
     auto blockwiseGemmV2TailOp = b.create<BlockwiseGemmV2Op>(
         loc, ldsGpuAllocOp, ldsGpuAllocOp, b.getIndexAttr(ldsBlockAOffset),
         b.getIndexAttr(ldsBlockBOffset), mMyWaveOffsetA, mMyWaveOffsetB, arrayA,
-        arrayB, regCAllocOp, op.blockSizeAttr(), op.paramsAttr());
+        arrayB, regCAllocOp, op.getBlockSizeAttr(), op.getParamsAttr());
 
     // -----
 
@@ -2004,7 +2006,7 @@ struct GridwiseGemmV2RewritePattern
     Value tensorC;
     ArrayAttr idToTensorCMaps;
     std::tie(tensorC, idToTensorCMaps) =
-        untransform(b, op.c(), idToMatrixCMaps);
+        untransform(b, op.getC(), idToMatrixCMaps);
 
     constexpr int64_t swizzleGroup = 4;
     ArrayRef<int64_t> tensorCShape =
@@ -2126,7 +2128,7 @@ struct GridwiseGemmV2RewritePattern
       b.setInsertionPointToStart(outLoop.getBody());
       b.create<ThreadwiseCopyV2Op>(
           loc, registerC, tensorC, b.getIndexAttr(tensorCDataPerCopy),
-          op.storeMethodAttr(), std::get<0>(writeOobDims),
+          op.getStoreMethodAttr(), std::get<0>(writeOobDims),
           std::get<1>(writeOobDims), outLoop.getLowerCoords(/*domain=*/0)[0],
           outLoop.getLowerCoords(/*domain=*/1));
     }

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -72,9 +72,9 @@ struct ThreadwiseGemmRewritePattern
                                 ThreadwiseGemmOpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
-    Value gemmA = adaptor.matrixA();
-    Value gemmB = adaptor.matrixB();
-    Value gemmC = adaptor.matrixC();
+    Value gemmA = adaptor.getMatrixA();
+    Value gemmB = adaptor.getMatrixB();
+    Value gemmC = adaptor.getMatrixC();
     auto gemmAType = gemmA.getType().cast<MemRefType>();
     Type dataType = gemmAType.getElementType();
 
@@ -179,7 +179,7 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
 
-    XdlopsGemmParamsAttr tuningParams = op.params();
+    XdlopsGemmParamsAttr tuningParams = op.getParams();
     // Obtain critical information.
     int64_t KPack = tuningParams.getKpack();
     int64_t K = tuningParams.getKPerBlock();
@@ -193,12 +193,10 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
     int64_t MPerXdlops = (MPerWave > waveSize) ? waveSize : MPerWave;
     int64_t NPerXdlops = (NPerWave > waveSize) ? waveSize : NPerWave;
 
-    auto dataType = adaptor.matrixA()
-                        .getType()
-                        .template cast<MemRefType>()
-                        .getElementType();
+    auto dataType =
+        adaptor.getMatrixA().getType().cast<MemRefType>().getElementType();
     if (dataType.isa<VectorType>()) {
-      dataType = dataType.template cast<VectorType>().getElementType();
+      dataType = dataType.cast<VectorType>().getElementType();
     }
 
     // Logic to do XDLOPS code selection.
@@ -222,11 +220,11 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
 
     bool IsKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
 
-    Value matrixA = adaptor.matrixA();
-    Value matrixB = adaptor.matrixB();
-    Value matrixC = adaptor.matrixC();
-    auto matrixAType = adaptor.matrixA().getType().cast<MemRefType>();
-    auto matrixBType = adaptor.matrixB().getType().cast<MemRefType>();
+    Value matrixA = adaptor.getMatrixA();
+    Value matrixB = adaptor.getMatrixB();
+    Value matrixC = adaptor.getMatrixC();
+    auto matrixAType = matrixA.getType().cast<MemRefType>();
+    auto matrixBType = matrixB.getType().cast<MemRefType>();
     Type matrixAElementType = matrixAType.getElementType();
     Type matrixBElementType = matrixBType.getElementType();
 

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -195,7 +195,7 @@ mlir::rock::untransform(OpBuilder &b, Value transformed, ArrayAttr existing) {
   Value ret = transformed;
   while (auto transform = dyn_cast_or_null<TransformOp>(ret.getDefiningOp())) {
     transformList.push_back(transform.getTransform());
-    ret = transform.input();
+    ret = transform.getInput();
   }
   return {ret, b.getArrayAttr(transformList)};
 }


### PR DESCRIPTION
Also, take advantage of TypedValue<> in a few places.