### PR TITLE
Fixed reshape to collapse-expand fusion

### DIFF
--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case2.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case2.e2e.mlir
@@ -1,5 +1,4 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -c  | mlir-rocm-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
-// XFAIL: *
 module {
   // CHECK:  [4, 4, 4, 4, 4],
   // CHECK-NEXT: [4, 4, 4, 4, 4],


### PR DESCRIPTION
This commit fixes the fusion of reshape
that gets lowered to collapse and expand memref ops.