### PR TITLE
Generalize bufferization, getting rid of rock.tensor_conv2d

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td
@@ -33,7 +33,7 @@ def RockGemmWrapperInterface : OpInterface<"RockGemmWrapperInterface"> {
           Return the OpOperand that corresponds to the operand argument
           that corresponds to the output result of the operation.
         }],
-        /*retType=*/"OpOperand &",
+        /*retType=*/"OpOperand *",
         /*methodName=*/"getOutArgument",
         /*args=*/(ins),
         /*methodBody=*/"",
@@ -52,6 +52,17 @@ def RockGemmWrapperInterface : OpInterface<"RockGemmWrapperInterface"> {
       >
     // TODO: more methods here as needed
   ];
+
+  let verify = [{
+    auto concreteOp = ::mlir::cast<ConcreteOp>($_op);
+    if ($_op->getNumResults() == 1) {
+      if ($_op->getResult(0).getType() !=
+          concreteOp.getOutArgument()->get().getType()) {
+        return $_op->emitOpError("result type must match output argument type");
+      }
+    }
+    return ::mlir::success();
+  }];
 }
 
 #endif // ROCK_GEM_WRAPPER_INTERFACE

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -38,103 +38,92 @@ def ArgTransformsAttr : TypedArrayAttrBase<TransformMapArrayAttr,
 
 class ArgTransforms<int n> : ConfinedAttr<ArgTransformsAttr, [ArrayCount<n>]>;
 
-def Rock_TensorConv2DOp :
-    Rock_Op<"tensor_conv2d", [AllTypesMatch<["output", "result"]>]>,
-    Arguments<(ins TensorRankOf<[F32, F16, BF16, I8], [5]>:$filter,
-                   TensorRankOf<[F32, F16, BF16, I8], [5]>:$input,
-                   TensorRankOf<[F32, F16, BF16, I32], [5]>:$output,
+class TensorOrMemRefRankOf<list<Type> allowedTypes, list<int> ranks> :
+  AnyTypeOf<[TensorRankOf<allowedTypes, ranks>,
+             MemRefRankOf<allowedTypes, ranks>],
+             /*summary=*/"",
+             "::mlir::ShapedType">;
+
+
+def Rock_Conv2DOp :
+    Rock_Op<"conv2d", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
+    Arguments<(ins TensorOrMemRefRankOf<[F32, F16, BF16, I8], [5]>:$filter,
+                   TensorOrMemRefRankOf<[F32, F16, BF16, I8], [5]>:$input,
+                   TensorOrMemRefRankOf<[F32, F16, BF16, I32], [5]>:$output,
                    StrAttr:$arch,
                    I32Attr:$numCu,
                    Rock_GemmFeaturesAttr:$features,
                    OptionalAttr<I32Attr>:$blockSize,
                    OptionalAttr<I32Attr>:$gridSize,
                    Rock_OptionalGemmParams:$params)>,
-    Results<(outs TensorRankOf<[F32, F16, BF16, I32], [5]>:$result)> {
-  let summary = "2D convolution forward, tensor version";
-  let description = [{
-    The `rock.tensor_conv2d` op computes 2D convolution forward.
-    TEMPORARY HACK: we'll make the conv operators all tensor ops later or something
-    No, seriously, TEMPORARY HACK!
-  }];
-  let assemblyFormat = [{
-    `(` operands `)` `features` `=` $features attr-dict `:` type($filter) `,` type($input) `,` type($output)
-  }];
-}
-
-
-def Rock_Conv2DOp :
-    Rock_Op<"conv2d", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
-    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [5]>:$filter,
-                   MemRefRankOf<[F32, F16, BF16, I8], [5]>:$input,
-                   MemRefRankOf<[F32, F16, BF16, I32], [5]>:$output,
-                   StrAttr:$arch,
-                   I32Attr:$numCu,
-                   Rock_GemmFeaturesAttr:$features,
-                   OptionalAttr<I32Attr>:$blockSize,
-                   OptionalAttr<I32Attr>:$gridSize,
-                   Rock_OptionalGemmParams:$params)> {
+    Results<(outs Optional<AnyRankedTensor>:$result)> {
   let summary = "2D convolution forward";
   let description = [{
     The `rock.conv2d` op computes 2D convolution forward.
   }];
   let hasVerifier = 1;
   let assemblyFormat = [{
-    `(` operands `)` `features` `=` $features attr-dict `:` type(operands)
+    `(` operands `)` `features` `=` $features attr-dict
+    `:` type(operands) (`->` type($result)^)?
   }];
 }
 
 def Rock_Conv2DBwdDataOp :
     Rock_Op<"conv2d_bwd_data", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
-    Arguments<(ins MemRefRankOf<[F32, F16, BF16], [5]>:$filter,
-                   MemRefRankOf<[F32, F16, BF16], [5]>:$input,
-                   MemRefRankOf<[F32, F16, BF16], [5]>:$output,
+    Arguments<(ins TensorOrMemRefRankOf<[F32, F16, BF16], [5]>:$filter,
+                   TensorOrMemRefRankOf<[F32, F16, BF16], [5]>:$input,
+                   TensorOrMemRefRankOf<[F32, F16, BF16], [5]>:$output,
                    StrAttr:$arch,
                    I32Attr:$numCu,
                    Rock_GemmFeaturesAttr:$features,
                    OptionalAttr<I32Attr>:$blockSize,
                    OptionalAttr<I32Attr>:$gridSize,
-                   Rock_OptionalGemmParams:$params)> {
+                   Rock_OptionalGemmParams:$params)>,
+    Results<(outs Optional<AnyRankedTensor>:$result)> {
   let summary = "2D convolution backward data";
   let description = [{
     The `rock.conv2d_bwd_data` op computes 2D convolution backward data.
   }];
   let hasVerifier = 1;
   let assemblyFormat = [{
-    `(` operands `)` `features` `=` $features attr-dict `:` type(operands)
+    `(` operands `)` `features` `=` $features attr-dict
+    `:` type(operands) (`->` type($result)^)?
   }];
 }
 
 def Rock_Conv2DBwdWeightOp :
     Rock_Op<"conv2d_bwd_weight", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
-    Arguments<(ins MemRefRankOf<[F32, F16, BF16], [5]>:$filter,
-                   MemRefRankOf<[F32, F16, BF16], [5]>:$input,
-                   MemRefRankOf<[F32, F16, BF16], [5]>:$output,
-                   Optional<MemRefRankOf<[F32], [5]>>:$workspace,
+    Arguments<(ins TensorOrMemRefRankOf<[F32, F16, BF16], [5]>:$filter,
+                   TensorOrMemRefRankOf<[F32, F16, BF16], [5]>:$input,
+                   TensorOrMemRefRankOf<[F32, F16, BF16], [5]>:$output,
+                   Optional<TensorOrMemRefRankOf<[F32], [5]>>:$workspace,
                    StrAttr:$arch,
                    I32Attr:$numCu,
                    Rock_GemmFeaturesAttr:$features,
                    OptionalAttr<I32Attr>:$blockSize,
                    OptionalAttr<I32Attr>:$gridSize,
                    Rock_OptionalGemmParams:$params,
-                   OptionalAttr<IndexAttr>:$kBlocks)> {
+                   OptionalAttr<IndexAttr>:$kBlocks)>,
+    Results<(outs Optional<AnyRankedTensor>:$result)> {
   let summary = "2D convolution backward weight";
   let description = [{
     The `rock.conv2d_bwd_weight` op computes 2D convolution backward weight.
   }];
   let hasVerifier = 1;
   let assemblyFormat = [{
-    `(` operands `)` `features` `=` $features attr-dict `:` type(operands)
+    `(` operands `)` `features` `=` $features attr-dict
+    `:` type(operands) (`->` type($result)^)?
   }];
 }
 
 def Rock_GemmOp :
     Rock_Op<"gemm", [AllElementTypesMatch<["a", "b"]>,
                      DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
-    Arguments<(ins Arg<MemRefRankOf<[F32, F16, BF16, I8], [2, 3]>,
+    Arguments<(ins Arg<TensorOrMemRefRankOf<[F32, F16, BF16, I8], [2, 3]>,
                        "matrix A", [MemRead]>:$a,
-                   Arg<MemRefRankOf<[F32, F16, BF16, I8], [2, 3]>,
+                   Arg<TensorOrMemRefRankOf<[F32, F16, BF16, I8], [2, 3]>,
                        "matrix B", [MemRead]>:$b,
-                   Arg<MemRefRankOf<[F32, F16, BF16, I32], [2, 3]>,
+                   Arg<TensorOrMemRefRankOf<[F32, F16, BF16, I32], [2, 3]>,
                        "matrix C", [MemRead, MemWrite]>:$c,
                    UnitAttr:$aTransposed,
                    UnitAttr:$bTransposed,
@@ -145,7 +134,8 @@ def Rock_GemmOp :
                    StoreMethodAttr:$storeMethod,
                    OptionalAttr<I32Attr>:$blockSize,
                    OptionalAttr<I32Attr>:$gridSize,
-                   Rock_OptionalGemmParams:$params)> {
+                   Rock_OptionalGemmParams:$params)>,
+    Results<(outs Optional<AnyRankedTensor>:$result)> {
   let summary = "General matrix multiplication (GEMM)";
   let description = [{
     Performs the operation C += A * B.
@@ -170,7 +160,7 @@ def Rock_GemmOp :
   let assemblyFormat = [{
     (`tr` $cTransposed^)? $c `=` (`tr` $aTransposed^)? $a `*` (`tr` $bTransposed^)? $b
     `features` `=` $features `storeMethod` `=` $storeMethod attr-dict
-    `:` type($c) `=` type($a) `*` type($b)
+    `:` type($c) `=` type($a) `*` type($b) (`->` type($result)^)?
   }];
 }
 

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -76,7 +76,7 @@ static Value expandTensor(ConversionPatternRewriter &rw, Operation *op,
   return rw.create<rock::TransformOp>(loc, operand, transform.get());
 }
 
-static FailureOr<rock::TensorConv2DOp>
+static FailureOr<rock::Conv2DOp>
 makeRockConv2D(ConversionPatternRewriter &rw, Operation *op, Value input,
                StringRef inputLayout, Value filter, StringRef filterLayout,
                Value output, StringRef outputLayout, const ArrayAttr &pad,
@@ -116,7 +116,7 @@ makeRockConv2D(ConversionPatternRewriter &rw, Operation *op, Value input,
   rock::GemmFeatures features = archInfo.defaultFeatures;
   if (xdlopsV2.has_value())
     features = rock::bitEnumSet(features, rock::GemmFeatures::mfma, *xdlopsV2);
-  auto cop = rw.create<rock::TensorConv2DOp>(
+  auto cop = rw.create<rock::Conv2DOp>(
       loc, outputExp.getType(), filterExp, inputExp, outputExp,
       rw.getStringAttr(chip), rw.getI32IntegerAttr(num_cu),
       rw.getAttr<rock::GemmFeaturesAttr>(features),
@@ -204,7 +204,7 @@ public:
     if (auto attr = op->getAttrOfType<StringAttr>("output_layout"))
       outputLayout = Twine(attr.getValue() + "g").str();
 
-    FailureOr<rock::TensorConv2DOp> rockConv = makeRockConv2D(
+    FailureOr<rock::Conv2DOp> rockConv = makeRockConv2D(
         rw, op, input, inputLayout, filter, filterLayout, output, outputLayout,
         op.getPad(), op.getStride(), op.getDilation());
     if (failed(rockConv))
@@ -273,7 +273,7 @@ public:
     auto one = rw.getIndexAttr(1);
     auto ones = rw.getArrayAttr({one, one});
 
-    FailureOr<rock::TensorConv2DOp> rockConv = makeRockConv2D(
+    FailureOr<rock::Conv2DOp> rockConv = makeRockConv2D(
         rw, op, A, ALayout, B, BLayout, C, CLayout, pad, ones, ones);
     if (failed(rockConv))
       return failure();

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -476,14 +476,14 @@ LogicalResult Conv2DBwdDataOp::verify() { return verifyConvOp(*this); }
 
 LogicalResult Conv2DBwdWeightOp::verify() { return verifyConvOp(*this); }
 
-OpOperand &Conv2DOp::getOutArgument() { return (*this)->getOpOperand(2); }
+OpOperand *Conv2DOp::getOutArgument() { return &(*this)->getOpOperand(2); }
 
-OpOperand &Conv2DBwdDataOp::getOutArgument() {
-  return (*this)->getOpOperand(1);
+OpOperand *Conv2DBwdDataOp::getOutArgument() {
+  return &(*this)->getOpOperand(1);
 }
 
-OpOperand &Conv2DBwdWeightOp::getOutArgument() {
-  return (*this)->getOpOperand(0);
+OpOperand *Conv2DBwdWeightOp::getOutArgument() {
+  return &(*this)->getOpOperand(0);
 }
 
 GemmContext Conv2DOp::getGemmSize() {
@@ -505,7 +505,7 @@ GemmContext Conv2DBwdWeightOp::getGemmSize() {
 // GemmOp
 //===-----------------------------------------------------===//
 LogicalResult GemmOp::verify() {
-  MemRefType typeA = getA().getType(), typeB = getB().getType(),
+  ShapedType typeA = getA().getType(), typeB = getB().getType(),
              typeC = getC().getType();
   Type inElems = typeA.getElementType(), outElems = typeC.getElementType();
   if (inElems.isa<IntegerType>() && !outElems.isInteger(32))
@@ -556,10 +556,10 @@ LogicalResult GemmOp::verify() {
   return success();
 }
 
-OpOperand &GemmOp::getOutArgument() { return (*this)->getOpOperand(2); }
+OpOperand *GemmOp::getOutArgument() { return &(*this)->getOpOperand(2); }
 
 GemmContext GemmOp::getGemmSize() {
-  MemRefType typeA = getA().getType(), typeB = getB().getType();
+  ShapedType typeA = getA().getType(), typeB = getB().getType();
   ArrayRef<int64_t> dimsA = typeA.getShape(), dimsB = typeB.getShape();
   int64_t offsetA = dimsA.size() == 2 ? 0 : 1,
           offsetB = dimsB.size() == 2 ? 0 : 1;

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -141,6 +141,9 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
                                     ConversionPatternRewriter &rw) const {
   Location loc = op->getLoc();
 
+  if (!adaptor.getA().getType().isa<MemRefType>())
+    return op.emitOpError("Cannot lower unbufferized gemm to gridwise");
+
   Attribute params = op.getParams().value_or(nullptr);
   if (!params) {
     return op.emitOpError("cannot lower gemm without tuning parameters");

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-opt --tosa-to-rock %s -verify-diagnostics -o -| FileCheck %s
 
 // CHECK-LABEL: test_fusion
-// CHECK: %[[convRes:.*]] = rock.tensor_conv2d(%{{.*}}, %{{.*}}, %{{.*}}) features = {{none|xdlops}} {arch = {{.*}}, dilations = [1 : i32, 1 : i32], filter_layout = ["k", "y", "x", "c", "g"], input_layout = ["ni", "hi", "wi", "ci", "gi"], numCu = {{.*}} : i32, output_layout = ["no", "ho", "wo", "ko", "go"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : tensor<128x8x3x3x1xf32>, tensor<128x8x32x32x1xf32>, tensor<128x128x30x30x1xf32>
+// CHECK: %[[convRes:.*]] = rock.conv2d(%{{.*}}, %{{.*}}, %{{.*}}) features = {{none|xdlops}} {arch = {{.*}}, dilations = [1 : i32, 1 : i32], filter_layout = ["k", "y", "x", "c", "g"], input_layout = ["ni", "hi", "wi", "ci", "gi"], numCu = {{.*}} : i32, output_layout = ["no", "ho", "wo", "ko", "go"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : tensor<128x8x3x3x1xf32>, tensor<128x8x32x32x1xf32>, tensor<128x128x30x30x1xf32>
 // CHECK-NEXT: %[[castRes:.*]] = rock.tensor_untransform_cast %[[convRes]] aka %{{.*}} : tensor<128x128x30x30x1xf32> to tensor<128x128x30x30xf32>
 // CHECK-NEXT: "tosa.abs"(%[[castRes]])
 


### PR DESCRIPTION
1. Change the RockGemmWrapperInterface to return a pointer, not a reference, to the out argument, allowing == to work and matching linalg's interfaces
2. Use the interface to implement bufferization for the ops that wrap around a rock.gemm (including rock.gemm itself).
3. Change conv2d* and gemm to take either tensors or memrefs as arguments, allowing for them to bufferize to themselves (note, this might get slightly funky with workspaces, but we won't be hitting that for quite a while, or ever)
4. Make the minor changes needed to make --conv-to-gemm and friends mostly work on tensors or memrefs as future-proofing - in any case, bufferization has to happen before --gemm-to-gridwise