### PR TITLE
Change MIOpen branch to develop

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -24,7 +24,7 @@ void buildMIOpen(String cmakeOpts) {
 }
 
 void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
-    git branch: 'fix-kernel-count-MLIR', poll: false,\
+    git branch: params.MIOpenBranch, poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
     buildMIOpen(cmakeOpts)
 }
@@ -36,7 +36,7 @@ void buildMIOpenWithMLIR() {
         installation: 'InSearchPath', workingDir: 'build'
 
     dir('MIOpen') {
-        git branch: 'fix-kernel-count-MLIR', poll: false,\
+        git branch: params.MIOpenBranch, poll: false,\
             url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
         // Note: setting cxxflags here works around https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1604
         buildMIOpen("""-DMIOPEN_USE_MLIR=On
@@ -144,6 +144,8 @@ pipeline {
                      description: 'Can this CI instance use xdlops (no for public server)')
         booleanParam(name: 'weekly', defaultValue: params.weekly ? true : false,
                      description: 'Run weekly-only jobs')
+        string(name: 'MIOpenBranch', defaultValue: 'develop',
+               description: 'The MIOpen branch to be used with the job')
 
         // Each below control whether to run a individual stage from parallel run
         // They default to true or empty but deverloper can toggle them for debugging purpose

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -59,6 +59,8 @@ pipeline {
             description: 'Run shared library tests')
         booleanParam(name: 'staticLib', defaultValue: true,
             description: 'Run static library and MIOpen integration tests')
+        string(name: 'MIOpenBranch', defaultValue: 'develop',
+            description: 'The MIOpen branch to be used with the job')
     }
     stages {
         stage('Kill old PR builds') {
@@ -148,7 +150,7 @@ pipeline {
                         stage("Build MIOpen with librockCompiler") {
                             steps {
                                 dir('MIOpen') {
-                                git branch: 'fix-kernel-count-MLIR', poll: false,\
+                                git branch: params.MIOpenBranch, poll: false,\
                                     url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
                                 buildMIOpen("""-DMIOPEN_USE_MLIR=On
                                         -DMIOPEN_USE_COMPOSABLEKERNEL=Off


### PR DESCRIPTION
This commit changes the MIOpen branch to be a
param to Jenkinsfile that will default to develop.