### PR TITLE
Removing CK and its dependency

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -125,6 +125,7 @@ WORKDIR /MIOpenDepsWork
 RUN wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/MIOpen/develop/requirements.txt \
     && wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/MIOpen/develop/install_deps.cmake \
     && sed -i -e '/rocMLIR/d' requirements.txt \
+    && sed -i -e '/composable_kernel/d' requirements.txt \
     && cmake -P install_deps.cmake --prefix /usr/local
 RUN echo $(git ls-remote https://github.com/ROCmSoftwarePlatform/MIOpen HEAD) > miopen-deps-commit-hash
 WORKDIR /

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -24,7 +24,7 @@ void buildMIOpen(String cmakeOpts) {
 }
 
 void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
-    git branch: 'develop', poll: false,\
+    git branch: 'fix-kernel-count-MLIR', poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
     buildMIOpen(cmakeOpts)
 }
@@ -36,7 +36,7 @@ void buildMIOpenWithMLIR() {
         installation: 'InSearchPath', workingDir: 'build'
 
     dir('MIOpen') {
-        git branch: 'develop', poll: false,\
+        git branch: 'fix-kernel-count-MLIR', poll: false,\
             url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
         // Note: setting cxxflags here works around https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1604
         buildMIOpen("""-DMIOPEN_USE_MLIR=On

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -24,7 +24,7 @@ void buildMIOpen(String cmakeOpts) {
 }
 
 void getAndBuildMIOpen(String prefixOpt, String cmakeOpts) {
-    git branch: 'fix-kernel-count-MLIR', poll: false,\
+    git branch: 'develop', poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
     buildMIOpen(cmakeOpts)
 }
@@ -36,16 +36,17 @@ void buildMIOpenWithMLIR() {
         installation: 'InSearchPath', workingDir: 'build'
 
     dir('MIOpen') {
-        git branch: 'fix-kernel-count-MLIR', poll: false,\
+        git branch: 'develop', poll: false,\
             url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
         // Note: setting cxxflags here works around https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1604
         buildMIOpen("""-DMIOPEN_USE_MLIR=On
-                        -DMIOPEN_BACKEND=HIP
-                        -DCMAKE_PREFIX_PATH=${WORKSPACE}/MIOpenDeps
-                        -DCMAKE_CXX_FLAGS="-isystem ${WORKSPACE}/MIOpenDeps/include"
-                        -DMIOPEN_USER_DB_PATH=${WORKSPACE}/MIOpen/build/MIOpenUserDB
-                        -DMIOPEN_TEST_FLAGS="--verbose --disable-verification-cache"
-                        """)
+                       -DMIOPEN_USE_COMPOSABLEKERNEL=Off
+                       -DMIOPEN_BACKEND=HIP
+                       -DCMAKE_PREFIX_PATH=${WORKSPACE}/MIOpenDeps
+                       -DCMAKE_CXX_FLAGS="-isystem ${WORKSPACE}/MIOpenDeps/include"
+                       -DMIOPEN_USER_DB_PATH=${WORKSPACE}/MIOpen/build/MIOpenUserDB
+                       -DMIOPEN_TEST_FLAGS="--verbose --disable-verification-cache"
+                       """)
     }
 }
 
@@ -665,7 +666,9 @@ pipeline {
                         sh 'rm -rf MIOpen'
                         dir('MIOpen') {
                             getAndBuildMIOpen("--prefix ${WORKSPACE}/MIOpen/MIOpenDeps",
-                                '''-DMIOPEN_BACKEND=HIP -DMIOPEN_USE_MLIR=OFF
+                                '''-DMIOPEN_USE_MLIR=OFF
+                                   -DMIOPEN_USE_COMPOSABLEKERNEL=Off
+                                   -DMIOPEN_BACKEND=HIP
                                    -DCMAKE_PREFIX_PATH="${WORKSPACE}/MIOpen/MIOpenDeps"
                                    -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/MIOpen/build/MIOpenInstallDir
                                    ''')

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -148,9 +148,10 @@ pipeline {
                         stage("Build MIOpen with librockCompiler") {
                             steps {
                                 dir('MIOpen') {
-                                git branch: 'fix-kernel-count-MLIR', poll: false,\
+                                git branch: 'develop', poll: false,\
                                     url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
                                 buildMIOpen("""-DMIOPEN_USE_MLIR=On
+                                        -DMIOPEN_USE_COMPOSABLEKERNEL=Off
                                         -DMIOPEN_BACKEND=HIP
                                         -DCMAKE_PREFIX_PATH=${WORKSPACE}/MIOpenDeps
                                         -DCMAKE_CXX_FLAGS="-isystem ${WORKSPACE}/MIOpenDeps/include"

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -148,7 +148,7 @@ pipeline {
                         stage("Build MIOpen with librockCompiler") {
                             steps {
                                 dir('MIOpen') {
-                                git branch: 'develop', poll: false,\
+                                git branch: 'fix-kernel-count-MLIR', poll: false,\
                                     url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
                                 buildMIOpen("""-DMIOPEN_USE_MLIR=On
                                         -DMIOPEN_USE_COMPOSABLEKERNEL=Off

--- a/mlir/utils/widgets/tune_MLIR_kernels.sh
+++ b/mlir/utils/widgets/tune_MLIR_kernels.sh
@@ -72,6 +72,7 @@ buildMIOpenWithlibrockCompiler() {
           -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
           -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
           -DMIOPEN_USE_MLIR=On \
+          -DMIOPEN_USE_COMPOSABLEKERNEL=Off \
           -DMIOPEN_BACKEND=HIP \
           -DCMAKE_PREFIX_PATH=${WORKSPACE}/MIOpenDeps \
           "-DCMAKE_CXX_FLAGS=-isystem ${WORKSPACE}/MIOpenDeps/include" \


### PR DESCRIPTION
Context: auto builds dockers continue to fail at CK building step:
 - Bumping the MIOpen branch back to develop as all pending PRs are merged
 - Explicitly removing miopen-CK backend as it depends on customized compiler versions