### PR TITLE
[HOTFIX] Relax the matrix size check on rock.gemm

### DIFF
--- a/mlir/test/Dialect/Rock/invalid.mlir
+++ b/mlir/test/Dialect/Rock/invalid.mlir
@@ -5,7 +5,7 @@
 func.func @gemm_too_big(%a: memref<2048x2048x2048xf32>,
                         %b: memref<2048x2048x2048xf32>,
                         %c: memref<2048x2048x2048xf32>) {
-  // expected-error@+1 {{'rock.gemm' op matrix A cannot potentially be 4 GB or more}}
+  // expected-error@+1 {{'rock.gemm' op underlying storage for matrix A cannot potentially be 4 GB or more}}
   rock.gemm %c = %a * %b features = dot storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx1030",
     numCu = 64 : i32}
@@ -18,7 +18,7 @@ func.func @gemm_too_big(%a: memref<2048x2048x2048xf32>,
 func.func @gemm_c_big(%a: memref<2048x2048x1xf32>,
                       %b: memref<2048x1x2048xf32>,
                       %c: memref<2048x2048x2048xf32>) {
-  // expected-error@+1 {{'rock.gemm' op matrix C cannot potentially be 4 GB or more}}
+  // expected-error@+1 {{'rock.gemm' op underlying storage for matrix C cannot potentially be 4 GB or more}}
   rock.gemm %c = %a * %b features = dot storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx1030",
     numCu = 64 : i32}
@@ -31,7 +31,7 @@ func.func @gemm_c_big(%a: memref<2048x2048x1xf32>,
 func.func @gemm_c_too_big(%a: memref<2048x2048x2048xf32>,
                         %b: memref<2048x2048x2048xf32>,
                         %c: memref<2048x2048x2048xf32>) {
-  // expected-error@+1 {{'rock.gemm' op matrix A cannot potentially be 4 GB or more}}
+  // expected-error@+1 {{'rock.gemm' op underlying storage for matrix A cannot potentially be 4 GB or more}}
   rock.gemm %c = %a * %b features = dot storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx1030",
     numCu = 64 : i32}

--- a/mlir/test/Dialect/Rock/invalid.mlir
+++ b/mlir/test/Dialect/Rock/invalid.mlir
@@ -5,7 +5,7 @@
 func.func @gemm_too_big(%a: memref<2048x2048x2048xf32>,
                         %b: memref<2048x2048x2048xf32>,
                         %c: memref<2048x2048x2048xf32>) {
-  // expected-error@+1 {{'rock.gemm' op matrix A cannot potentially be over 2 GB}}
+  // expected-error@+1 {{'rock.gemm' op matrix A cannot potentially be 4 GB or more}}
   rock.gemm %c = %a * %b features = dot storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx1030",
     numCu = 64 : i32}
@@ -18,7 +18,7 @@ func.func @gemm_too_big(%a: memref<2048x2048x2048xf32>,
 func.func @gemm_c_big(%a: memref<2048x2048x1xf32>,
                       %b: memref<2048x1x2048xf32>,
                       %c: memref<2048x2048x2048xf32>) {
-  // expected-error@+1 {{'rock.gemm' op matrix C cannot potentially be over 2 GB}}
+  // expected-error@+1 {{'rock.gemm' op matrix C cannot potentially be 4 GB or more}}
   rock.gemm %c = %a * %b features = dot storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx1030",
     numCu = 64 : i32}
@@ -31,7 +31,7 @@ func.func @gemm_c_big(%a: memref<2048x2048x1xf32>,
 func.func @gemm_c_too_big(%a: memref<2048x2048x2048xf32>,
                         %b: memref<2048x2048x2048xf32>,
                         %c: memref<2048x2048x2048xf32>) {
-  // expected-error@+1 {{'rock.gemm' op matrix A cannot potentially be over 2 GB}}
+  // expected-error@+1 {{'rock.gemm' op matrix A cannot potentially be 4 GB or more}}
   rock.gemm %c = %a * %b features = dot storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx1030",
     numCu = 64 : i32}


### PR DESCRIPTION
In some convolution configs, a tensor of size < 2 GB could be viewed as a matrix of size >= 2 GB because of padding, strides, or other convolution parameters. The previous applicability logic did not account for this possibility, but the configs worked anyway, and so the check may have been too strict.

Since we are currently much less likely to use signed math for large indices due to the integer range inference pass, and since our main uses of signed numbers are in mod() (which will have arguments generally smaller than the tensor size), it is, in practice, safe to proceed with matrix sizes below 4 GB.