### PR TITLE
Enabling lld as a library invokation

### DIFF
--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -9,7 +9,7 @@ set(MLIR_CMAKE_CONFIG_DIR
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
 # LLVM settings
-set(LLVM_ENABLE_PROJECTS "mlir" CACHE STRING "List of default llvm targets")
+set(LLVM_ENABLE_PROJECTS "mlir;lld" CACHE STRING "List of default llvm targets")
 set(LLVM_BUILD_EXAMPLES ON CACHE BOOL "")
 set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")

--- a/external/llvm-project/lld/ELF/Driver.cpp
+++ b/external/llvm-project/lld/ELF/Driver.cpp
@@ -1326,7 +1326,13 @@ static void readConfigs(opt::InputArgList &args) {
       error(errPrefix + toString(pat.takeError()));
   }
 
-  cl::ResetAllOptionOccurrences();
+  // This was added by https://reviews.llvm.org/D88461 to address a problem
+  // we rocMlir do not care about in cmd options. However, the side effect
+  // of this is it will reset and corrupt global static cl::cmd options,
+  // causing issues in rocm and xmir runner. Since there is no easy way to
+  // back up the cl::cmd hidden state in JitRunner, the most straightforward
+  // fix is to undo this global reset in lld invokation.
+  // cl::ResetAllOptionOccurrences();
 
   // Parse LTO options.
   if (auto *arg = args.getLastArg(OPT_plugin_opt_mcpu_eq))

--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -127,6 +127,11 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
       "Building mlir with ROCm support requires the AMDGPU backend")
   endif()
 
+  if (NOT ("lld" IN_LIST LLVM_ENABLE_PROJECTS))
+    message(SEND_ERROR
+      "LLD is not enabled, please reconfigure llvm build")
+  endif()
+
   set(DEFAULT_ROCM_PATH "/opt/rocm" CACHE PATH "Fallback path to search for ROCm installs")
   target_compile_definitions(obj.MLIRGPUTransforms
     PRIVATE
@@ -134,9 +139,21 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
     MLIR_GPU_TO_HSACO_PASS_ENABLE=1
   )
 
+  target_include_directories(obj.MLIRGPUTransforms
+    PRIVATE
+    ${MLIR_SOURCE_DIR}/../lld/include
+  )
+
   target_link_libraries(MLIRGPUTransforms
     PRIVATE
+    lldELF
+    lldCommon
     MLIRExecutionEngine
     MLIRROCDLToLLVMIRTranslation
   )
+
+  # Link lldELF also to libmlir.so. Create an alias that starts with LLVM
+  # because LINK_COMPONENTS elements are implicitly prefixed with LLVM.
+  add_library(LLVMAliasTolldELF ALIAS lldELF)
+  set_property(GLOBAL APPEND PROPERTY MLIR_LLVM_LINK_COMPONENTS AliasTolldELF)
 endif()

--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -28,6 +28,8 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Linker/Linker.h"
 
+#include "lld/Common/Driver.h"
+
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCCodeEmitter.h"
@@ -447,15 +449,17 @@ SerializeToHsacoPass::createHsaco(const SmallVectorImpl<char> &isaBinary) {
   }
   llvm::FileRemover cleanupHsaco(tempHsacoFilename);
 
-  std::string theRocmPath = getRocmPath();
-  llvm::SmallString<32> lldPath(theRocmPath);
-  llvm::sys::path::append(lldPath, "llvm", "bin", "ld.lld");
-  int lldResult = llvm::sys::ExecuteAndWait(
-      lldPath,
-      {"ld.lld", "-shared", tempIsaBinaryFilename, "-o", tempHsacoFilename});
-  if (lldResult != 0) {
-    emitError(loc, "lld invocation error");
-    return {};
+  {
+    static std::mutex mutex;
+    const std::lock_guard<std::mutex> lock(mutex);
+    // Invoke lld. Expect a true return value from lld.
+    if (!lld::elf::link({"ld.lld", "-shared", tempIsaBinaryFilename.c_str(),
+                         "-o", tempHsacoFilename.c_str()},
+                        llvm::outs(), llvm::errs(), false, false)) {
+      emitError(loc, "lld invocation error");
+      return {};
+    }
+    lld::CommonLinkerContext::destroy();
   }
 
   // Load the HSA code object.


### PR DESCRIPTION
For the most part, this PR reverts #504. After this PR, MLIR won't be dependent on a LLD binary on a particular place of the OS. Key changes:
 - lld::CommonLinkerContext::destroy();
   - This is brough from COMGR and will destroy the linker state after linking
 - // cl::ResetAllOptionOccurrences();
   - This reverted the change from LLD to erase all cl::cmd options, causing `JitRunner` to malfunction
   - However, this is likely make the change un-upstreamable.