### PR TITLE
Use a smaller rebuild in CMake, saving CI time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,30 +52,45 @@ message(STATUS "ROCMLIR_BIN_DIR: ${ROCMLIR_BIN_DIR}")
 set(CMAKE_BUILD_RPATH "${ROCMLIR_LIB_DIR};${LLVM_EXTERNAL_LIB_DIR}")
 message(STATUS "CMAKE_BUILD_RPATH: ${CMAKE_BUILD_RPATH}")
 
+set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "")
+
+function(_maybe_force_set var val type docs force)
+  if (${force})
+    set(${var} ${val} CACHE ${type} "${docs}" FORCE)
+  else()
+    set(${var} ${val} CACHE ${type} "${docs}")
+  endif()
+endfunction()
+
+function(_set_librockcompiler_varying_bools value force)
+  _maybe_force_set(BUILD_SHARED_LIBS ${value} BOOL "" ${force})
+  _maybe_force_set(LLVM_BUILD_LLVM_DYLIB ${value} BOOL "" ${force})
+  _maybe_force_set(LLVM_BUILD_EXAMPLES ${value} BOOL "" ${force})
+  _maybe_force_set(MLIR_ENABLE_ROCM_RUNNER ${value} BOOL "" ${force})
+  _maybe_force_set(MLIR_INCLUDE_INTEGRATION_TESTS ${value} BOOL "" ${force})
+  _maybe_force_set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED ${value}
+    BOOL "Enable build PR-triggered E2E tests for Rock driver" ${force})
+endfunction()
+
+# Set up defaults for not using librockcompiler either way
+_set_librockcompiler_varying_bools(ON OFF)
+
 if(BUILD_MIXR_TARGET)
   set(BUILD_FAT_LIBROCKCOMPILER ON CACHE BOOL "Build static librockCompiler")
   set(EXPORT_ALL_HEADERS ON CACHE BOOL "Export internal headers")
 endif()
 
 # Library type and linkage settings
-if( NOT DEFINED BUILD_FAT_LIBROCKCOMPILER )
+if(NOT DEFINED BUILD_FAT_LIBROCKCOMPILER)
   set(BUILD_FAT_LIBROCKCOMPILER OFF CACHE BOOL "Build fat librockCompiler to link into Rock driver")
 endif()
-if( BUILD_FAT_LIBROCKCOMPILER )
-  set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
-  set(LLVM_BUILD_LLVM_DYLIB OFF CACHE BOOL "")
-  # rocm-runner is not supported with static libraries
-  set(MLIR_ENABLE_ROCM_RUNNER 0 CACHE BOOL "")
-  set(MLIR_INCLUDE_INTEGRATION_TESTS OFF CACHE BOOL "")
-  set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "")
-  set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
-else()
-  set(BUILD_SHARED_LIBS ON CACHE BOOL "")
-  set(LLVM_BUILD_LLVM_DYLIB ON CACHE BOOL "")
-  set(LLVM_BUILD_EXAMPLES ON CACHE BOOL "")
-  set(MLIR_ENABLE_ROCM_RUNNER 1 CACHE BOOL "")
-  set(MLIR_INCLUDE_INTEGRATION_TESTS ON CACHE BOOL "")
-  set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 1 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
+
+if(BUILD_FAT_LIBROCKCOMPILER)
+  _set_librockcompiler_varying_bools(OFF ON)
+  set(FAT_LIBROCKCOMPILER_OPTS_APPLIED ON CACHE INTERNAL "was fat librockcompiler used before?" FORCE)
+elseif(FAT_LIBROCKCOMPILER_OPTS_APPLIED)
+  _set_librockcompiler_varying_bools(ON ON)
+  set(FAT_LIBROCKCOMPILER_OPTS_APPLIED OFF CACHE INTERNAL "was fat librockcompiler used before?" FORCE)
 endif()
 
 # Set up the build for the LLVM/MLIR git-submodule

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,15 +65,13 @@ endfunction()
 function(_set_librockcompiler_varying_bools value force)
   _maybe_force_set(BUILD_SHARED_LIBS ${value} BOOL "" ${force})
   _maybe_force_set(LLVM_BUILD_LLVM_DYLIB ${value} BOOL "" ${force})
-  _maybe_force_set(LLVM_BUILD_EXAMPLES ${value} BOOL "" ${force})
+  # Don't force LLVM_BUILD_EXAMPLES, swaping it changes CFLAGS
+  set(LLVM_BUILD_EXAMPLES ${value} CACHE BOOL "")
   _maybe_force_set(MLIR_ENABLE_ROCM_RUNNER ${value} BOOL "" ${force})
   _maybe_force_set(MLIR_INCLUDE_INTEGRATION_TESTS ${value} BOOL "" ${force})
   _maybe_force_set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED ${value}
     BOOL "Enable build PR-triggered E2E tests for Rock driver" ${force})
 endfunction()
-
-# Set up defaults for not using librockcompiler either way
-_set_librockcompiler_varying_bools(ON OFF)
 
 if(BUILD_MIXR_TARGET)
   set(BUILD_FAT_LIBROCKCOMPILER ON CACHE BOOL "Build static librockCompiler")
@@ -91,6 +89,9 @@ if(BUILD_FAT_LIBROCKCOMPILER)
 elseif(FAT_LIBROCKCOMPILER_OPTS_APPLIED)
   _set_librockcompiler_varying_bools(ON ON)
   set(FAT_LIBROCKCOMPILER_OPTS_APPLIED OFF CACHE INTERNAL "was fat librockcompiler used before?" FORCE)
+else()
+  # Set up defaults for not using librockcompiler either way
+  _set_librockcompiler_varying_bools(ON OFF)
 endif()
 
 # Set up the build for the LLVM/MLIR git-submodule

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -386,7 +386,6 @@ pipeline {
                             LD_LIBRARY_PATH="${WORKSPACE}/MIOpen/build/lib:$LD_LIBRARY_PATH:"
                         }
                         steps {
-                            sh 'rm build/CMakeCache.txt'
                             buildMIOpenWithMLIR()
                             testMIOpenDriver(/*testInt8=*/true, /*tuning=*/false, "selected-resnet50-miopen-configs")
                             testMIOpenDriver(/*testInt8=*/true, /*tuning=*/true, "selected-resnet50-miopen-configs")
@@ -709,10 +708,10 @@ pipeline {
                     }
                     stage("Build MLIR") {
                         steps {
-                            // Clean up build settings to disable static library and allow
-                            // ROCm testing
-                            sh 'rm build/CMakeCache.txt'
-                            buildProject('check-rocmlir-build-only ci-performance-scripts', '')
+                            // We must explicitly turn libRockCompiler off here to ensure
+                            // we get the executables needed for ROCm testing
+                            buildProject('check-rocmlir-build-only ci-performance-scripts',
+                                '-DBUILD_FAT_LIBROCKCOMPILER=OFF')
                         }
                     }
                     stage("Test MLIR vs MIOpen") {


### PR DESCRIPTION
Instead of clearing the build cache to switch shared/static lib, set the CMake file up to FORCE the relevant settings (shared libraries, PR tests, and so on) ON or OFF when someone explicitly passes in -DBUILD_FAT_LIBROCKCOMPILER . Note that we introduce a variable that tracks when the forcing has taken place to ensure that we don't FORCE over options when we don't need to - that is, if we build static library and then build the normal build, we need to force the options back, but not in any other case, where we might've wanted to set those options manually.

I expect this will save on CI time.

Fixes
https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/689