### PR TITLE
[CI][Navi21] Enable Navi21 codepath for nightly CI

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -148,9 +148,10 @@ String getLabelFromCodepath(String codepath) {
     if (codepath == "mfma") {
         label = 'mlir && (gfx908 || gfx90a)'
     } else if (codepath == "navi21") {
-        // For now, both navi21 workstations (gfx1030w) and CI nodes (gfx1030) works
+        // For now, both navi21 workstations (gfx1030w) and CI nodes (gfx1030) work
         // for PR CI tests
-        label = 'mlir && (gfx1030w || gfx1030)'
+        // But only navi workstations (gfx1030w) work for nightly CI tests
+        label = 'mlir && gfx1030w'
     } else if (codepath == "vanilla"){
         label = 'mlir && gfx906'
     } else {
@@ -177,19 +178,25 @@ void tuneMLIRKernels() {
     }
 }
 
-void build_fixedE2ETests() {
+void build_fixedE2ETests(String codepath) {
+    // Limit the number of lit workers to 8 for navi21 codepath on nightly CI as a workaround for issue#702
+    limit_lit_workers = false
+    if ( (codepath == 'navi21') && (params.nightly == true) ) {
+        limit_lit_workers = true
+    }
     buildProject('check-mlir-build-only check-rocmlir-build-only', """
               -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=${params.nightly ? '0' : '1'}
               -DROCMLIR_DRIVER_E2E_TEST_ENABLED=${params.nightly ? '1' : '0'}
               -DROCK_E2E_TEST_ENABLED=${params.nightly ? '1' : '0'}
               -DROCMLIR_DRIVER_MISC_E2E_TEST_ENABLED=${params.nightly ? '1' : '0'}
               -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=1
-              -DLLVM_LIT_ARGS='-v --time-tests'
+              -DLLVM_LIT_ARGS='-v --time-tests ${ limit_lit_workers ? '-j 8' : ' ' }'
               -DCMAKE_EXPORT_COMPILE_COMMANDS=1
              """)
 }
 
-void check_randomE2ETests() {
+void check_randomE2ETests(String codepath) {
+    // Limit the number of lit workers to 8 for navi21 codepath on nightly CI as a workaround for issue#702
     buildProject('check-rocmlir', """
               -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=0
               -DROCMLIR_DRIVER_E2E_TEST_ENABLED=1
@@ -197,7 +204,7 @@ void check_randomE2ETests() {
               -DROCMLIR_DRIVER_RANDOM_DATA_SEED=1
               -DROCMLIR_DRIVER_MISC_E2E_TEST_ENABLED=0
               -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=0
-              -DLLVM_LIT_ARGS='-v --time-tests'
+              -DLLVM_LIT_ARGS='-v --time-tests ${ codepath == 'navi21' ? '-j 8' : ' ' }'
               -DCMAKE_EXPORT_COMPILE_COMMANDS=1
              """)
 }
@@ -221,8 +228,8 @@ boolean shouldRunFromCodepath(String codepath) {
     }
     // Run navi21 on private CI only if it is not disabled
     if (params.canXdlops && (params.disableNavi21 == false) && (codepath == "navi21")) {
-        // Temporarily disable navi21 codepath for nightly and weekly
-        if ((params.weekly == false) && (params.nightly == false))
+        // Temporarily disable navi21 codepath for weekly
+        if (params.weekly == false)
             return true
     }
     return false
@@ -362,7 +369,7 @@ pipeline {
                             equals expected: true, actual: params.sharedLib;
                         }
                         steps {
-                            build_fixedE2ETests()
+                            build_fixedE2ETests("${CODEPATH}")
                             preMergeCheck("${CODEPATH}")
                             sh 'cd build; ninja check-mlir check-rocmlir'
                         }
@@ -376,7 +383,7 @@ pipeline {
                             }
                         }
                         steps {
-                            check_randomE2ETests()
+                            check_randomE2ETests("${CODEPATH}")
                         }
                     }
                     stage("Static Library: test librockCompiler with MIOpen") {


### PR DESCRIPTION
This PR limits the number of lit workers to 8 at the [build and test] stage for both navi21 workstations and server nodes.