### PR TITLE
[NFC] Rename threadwise_copy_v2 to global_store

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -758,9 +758,9 @@ def Rock_GlobalLoadOp :
   }];
 }
 
-// threadwise_copy_v2
-def Rock_ThreadwiseCopyV2Op :
-    Rock_Op<"threadwise_copy_v2", [AllElementTypesMatch<["source", "dest"]>]>,
+// global_store
+def Rock_GlobalStoreOp :
+    Rock_Op<"global_store", [AllElementTypesMatch<["source", "dest"]>]>,
     Arguments<(ins MemRefRankOf<[F32, F16, BF16, I32], [1]>:$source,
                    AnyMemRef:$dest,
                    IndexAttr:$length,
@@ -771,7 +771,7 @@ def Rock_ThreadwiseCopyV2Op :
                    Variadic<Index>:$destCoord)> {
   let summary = "Marker for stores to global memory";
   let description = [{
-    The `threadwise_copy_v2` op is a wrapper around storing to a global buffer.
+    The `global_store` op is a wrapper around storing to a global buffer.
     This is used in order to make it easier for operator
     fusion to identify the write out to global memory produced within a gridwise
     gemm.

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -170,20 +170,20 @@ static Value makeBroadcast(PatternRewriter &b, MemRefType outType, Value inp,
   return inp;
 }
 
-static void insertCopyFromOtherArg(PatternRewriter &b, Location loc,
-                                   ThreadwiseCopyV2Op op, Value srcOp,
-                                   Value dest) {
+static void insertLoadFromOtherSource(PatternRewriter &b, Location loc,
+                                      GlobalStoreOp gemmStoreOp, Value srcOp,
+                                      Value dest) {
   while (auto expOp = srcOp.getDefiningOp<memref::ExpandShapeOp>()) {
     srcOp = expOp.getOperand();
   }
-  LLVM_DEBUG(llvm::dbgs() << "Src type: " << srcOp.getType()
-                          << " dest type: " << op.getDest().getType() << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "Src type: " << srcOp.getType() << " dest type: "
+                          << gemmStoreOp.getDest().getType() << "\n");
   ArrayRef<int64_t> sType, dType;
   sType = srcOp.getType().cast<ShapedType>().getShape();
-  dType = op.getDest().getType().getShape();
+  dType = gemmStoreOp.getDest().getType().getShape();
   assert(sType.size() == dType.size() &&
          "Rank of extra fusion arguments matches shape of C tensor");
-  SmallVector<Value, 6> loadCoord = op.getDestCoord();
+  SmallVector<Value, 6> loadCoord = gemmStoreOp.getDestCoord();
   Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
   for (unsigned i = 0; i < sType.size(); i++) {
     assert((sType[i] == dType[i] || sType[i] == 1) &&
@@ -194,21 +194,21 @@ static void insertCopyFromOtherArg(PatternRewriter &b, Location loc,
       loadCoord[i] = zero;
   }
 
-  auto writeCLoop = op->getParentOfType<TransformingForOp>();
-  assert(writeCLoop && "threadwise_copy_v2 must be in a transforming_for");
+  auto writeCLoop = gemmStoreOp->getParentOfType<TransformingForOp>();
+  assert(writeCLoop && "global_store must be in a transforming_for");
 
   // Handle broadcasts introduced during fusion.
   ArrayAttr sourceTransformsFromOp;
   Value source;
   std::tie(source, sourceTransformsFromOp) = untransform(b, srcOp);
 
-  int64_t copyLength = op.getLength().getSExtValue();
+  int64_t copyLength = gemmStoreOp.getLength().getSExtValue();
   Type typeToLoad = dest.getType().cast<MemRefType>().getElementType();
   if (copyLength > 1)
     typeToLoad = VectorType::get({copyLength}, typeToLoad);
 
-  ArrayAttr sourceLeftOob = op.getLeftOobDims();
-  ArrayAttr sourceRightOob = op.getRightOobDims();
+  ArrayAttr sourceLeftOob = gemmStoreOp.getLeftOobDims();
+  ArrayAttr sourceRightOob = gemmStoreOp.getRightOobDims();
 
   // In general, note that keeping the vectorization of the writeback is safe
   // on account of the fact that vectorization means that the maps for the
@@ -217,9 +217,8 @@ static void insertCopyFromOtherArg(PatternRewriter &b, Location loc,
 
   // If there are no broadcasts, re-use the coordianes for the writeback
   if (sourceTransformsFromOp.empty()) {
-    Value loaded = b.create<BufferLoadOp>(
-        loc, typeToLoad, source, sourceLeftOob, sourceRightOob, loadCoord,
-        /*offset=*/IntegerAttr());
+    Value loaded = b.create<GlobalLoadOp>(
+        loc, typeToLoad, source, sourceLeftOob, sourceRightOob, loadCoord);
     b.create<InBoundsStoreOp>(loc, loaded, dest, zero);
   } else {
     // Note: this is a hack around the fact that we don't have a good way
@@ -237,36 +236,36 @@ static void insertCopyFromOtherArg(PatternRewriter &b, Location loc,
     {
       OpBuilder::InsertionGuard guard(b);
       b.setInsertionPointToStart(copyLoop.getBody());
-      Value loaded = b.create<BufferLoadOp>(
+      Value loaded = b.create<GlobalLoadOp>(
           loc, typeToLoad, source, sourceLeftOob, sourceRightOob,
-          copyLoop.getLowerCoords(/*domain=*/0), /*offset=*/IntegerAttr());
+          copyLoop.getLowerCoords(/*domain=*/0));
       b.create<InBoundsStoreOp>(loc, loaded, dest, zero);
     }
   }
 }
 
-static Value makeTransformingCopyLoop(PatternRewriter &b,
-                                      ThreadwiseCopyV2Op miTwCopy, Value inp) {
+static Value makeTransformingCopyLoop(PatternRewriter &b, GlobalStoreOp storeOp,
+                                      Value inp) {
   // 0. capture the memref containing the outputs being written
-  Location loc = miTwCopy.getLoc();
-  Value gemmOuts = miTwCopy.getSource();
+  Location loc = storeOp.getLoc();
+  Value gemmOuts = storeOp.getSource();
   auto gemmOutsType = gemmOuts.getType().cast<MemRefType>();
-  int64_t sliceLength = miTwCopy.getLength().getSExtValue();
+  int64_t sliceLength = storeOp.getLength().getSExtValue();
   auto sliceLengthType = gemmOutsType.clone(sliceLength).cast<MemRefType>();
 
   // 1. create a second allocation of the same type to hold loaded elements
   Value alloc = b.create<GpuAllocOp>(loc, sliceLengthType);
 
   // 2. clone twcopy for <addend> -> regs as transforming_for
-  insertCopyFromOtherArg(b, loc, miTwCopy, inp, alloc);
+  insertLoadFromOtherSource(b, loc, storeOp, inp, alloc);
   return alloc;
 }
 
-Value applyTransforms(PatternRewriter &b, ThreadwiseCopyV2Op miTWCopy,
-                      Value inp, AffineMap inpMap) {
+Value applyTransforms(PatternRewriter &b, GlobalStoreOp gemmStoreOp, Value inp,
+                      AffineMap inpMap) {
   Value ret = inp;
   // 0. move all input preceding ops before
-  Operation *pred = miTWCopy;
+  Operation *pred = gemmStoreOp;
   while (Operation *op = inp.getDefiningOp()) {
     assert(isa<memref::ExpandShapeOp>(op) || isa<memref::CollapseShapeOp>(op));
     op->moveBefore(pred);
@@ -275,21 +274,21 @@ Value applyTransforms(PatternRewriter &b, ThreadwiseCopyV2Op miTWCopy,
   }
 
   // 1. insert broadcast op if necessary
-  MemRefType outType = miTWCopy.getDest().getType();
+  MemRefType outType = gemmStoreOp.getDest().getType();
   std::tie(ret, inpMap) = makeTransposeTransform(b, ret, inpMap);
   ret = makeBroadcast(b, outType, ret, inpMap);
 
-  // 2. also create threadwise_copy_v2 from global to regs
+  // 2. also create global_store from global to regs
   //    TODO(sjw): make sure output buffer writes (means these inputs will be
   //    buffer reads)
-  return makeTransformingCopyLoop(b, miTWCopy, ret);
+  return makeTransformingCopyLoop(b, gemmStoreOp, ret);
 }
 
-static ThreadwiseCopyV2Op traceToThreadwiseCopy(Value inp) {
+static GlobalStoreOp traceToGlobalStore(Value inp) {
   // 1. Validate that the only uses of the linalg.generic input are the one
   // generic and a copy operation or transform.
   bool allValidUses = true;
-  ThreadwiseCopyV2Op result;
+  GlobalStoreOp result;
   for (Operation *use : inp.getUsers()) {
     if (isa<memref::DeallocOp>(use)) {
       // ignore
@@ -297,13 +296,14 @@ static ThreadwiseCopyV2Op traceToThreadwiseCopy(Value inp) {
     }
     if (isa<linalg::GenericOp>(use)) {
       // reader
-    } else if (auto copy = dyn_cast<ThreadwiseCopyV2Op>(use)) {
+    } else if (auto store = dyn_cast<GlobalStoreOp>(use)) {
       // Threadwise copy that is already unttransformed (new style)
       if (result) {
-        LLVM_DEBUG(llvm::dbgs() << "Multiple copies somehow, no fusion\n");
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Multiple global stores somehow, no fusion\n");
         allValidUses = false;
       }
-      result = copy;
+      result = store;
     } else {
       allValidUses = false;
     }
@@ -314,12 +314,13 @@ static ThreadwiseCopyV2Op traceToThreadwiseCopy(Value inp) {
   if (auto expanded = inp.getDefiningOp<memref::ExpandShapeOp>()) {
     auto src = expanded.getSrc();
     for (Operation *use : src.getUsers()) {
-      if (auto copy = dyn_cast<ThreadwiseCopyV2Op>(use)) {
+      if (auto store = dyn_cast<GlobalStoreOp>(use)) {
         if (result) {
-          LLVM_DEBUG(llvm::dbgs() << "Multiple copies somehow, no fusion\n");
+          LLVM_DEBUG(llvm::dbgs()
+                     << "Multiple global stores somehow, no fusion\n");
           allValidUses = false;
         }
-        result = copy;
+        result = store;
       }
     }
   }
@@ -328,17 +329,17 @@ static ThreadwiseCopyV2Op traceToThreadwiseCopy(Value inp) {
     LLVM_DEBUG(llvm::dbgs() << "Align tiling: generic not tracing to copy");
   if (!allValidUses)
     LLVM_DEBUG(llvm::dbgs() << "Align tiling: found invalid use\n");
-  return allValidUses ? result : ThreadwiseCopyV2Op();
+  return allValidUses ? result : GlobalStoreOp();
 }
 
 // Returns the value of the buffer that's meant to be the new writeback.
 static Value reconfigureLAGeneric(PatternRewriter &b,
                                   linalg::GenericOp laGeneric, Value laIn,
                                   ArrayRef<AffineMap> idxMaps,
-                                  ThreadwiseCopyV2Op twcopy) {
+                                  GlobalStoreOp gemmGlobalStore) {
   MLIRContext *ctx = laGeneric.getContext();
   Location loc = laGeneric.getLoc();
-  Value twout = twcopy.getDest();
+  Value twout = gemmGlobalStore.getDest();
   auto regType = laIn.getType().template cast<MemRefType>();
   auto laOut = b.create<GpuAllocOp>(loc, regType);
 
@@ -353,7 +354,7 @@ static Value reconfigureLAGeneric(PatternRewriter &b,
         newInput = laIn;
       } else {
         // 2.1.1. Align tiling of other inputs
-        newInput = applyTransforms(b, twcopy, inp, inpIdxMap);
+        newInput = applyTransforms(b, gemmGlobalStore, inp, inpIdxMap);
       }
       newInputs.push_back(newInput);
       laGenericAMaps.push_back(AffineMap::getMultiDimIdentityMap(
@@ -423,13 +424,13 @@ LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
   // 1. Trace input to threadwise_copy. Collect transforms (to be applied to
   // other inputs).
   // 1.1. Find the conv2d output
-  ThreadwiseCopyV2Op copyOp;
+  GlobalStoreOp gemmStoreOp;
   for (auto pair : llvm::zip(idxMaps, laGeneric.inputs())) {
     AffineMap inpIdxMap = std::get<0>(pair);
     Value inp = std::get<1>(pair);
-    ThreadwiseCopyV2Op maybeCopy = traceToThreadwiseCopy(inp);
-    if (maybeCopy) {
-      if (copyOp) {
+    GlobalStoreOp maybeStore = traceToGlobalStore(inp);
+    if (maybeStore) {
+      if (gemmStoreOp) {
         LLVM_DEBUG(llvm::dbgs()
                    << "Multiple generic inputs come from writeback\n");
         return failure();
@@ -439,7 +440,7 @@ LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
                                    "- earlier lowering should've fixed\n");
         return failure();
       }
-      copyOp = maybeCopy;
+      gemmStoreOp = maybeStore;
     } else {
       // Other inputs must have access maps compatible with current fusion
       // rewrites
@@ -451,7 +452,7 @@ LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
       }
     }
   }
-  if (!copyOp) {
+  if (!gemmStoreOp) {
     LLVM_DEBUG(llvm::dbgs() << "Align tiling: couldn't find writeback\n");
     return failure();
   }
@@ -463,45 +464,45 @@ LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
     out = expanded.getSrc();
   }
 
-  Value gemmV2Outs = copyOp.getSource();
-  auto gemmV2OutsType = gemmV2Outs.getType().cast<MemRefType>();
+  Value gemmOuts = gemmStoreOp.getSource();
+  auto gemmOutsType = gemmOuts.getType().cast<MemRefType>();
   {
     PatternRewriter::InsertionGuard guard(b);
     // 2.0. Reset insertion point to before the copy.
-    b.setInsertionPoint(copyOp);
+    b.setInsertionPoint(gemmStoreOp);
     Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
 
     // 2.1. Take out a slice of the result vector to create a vector-sized
     // slice to enable creating the fusion section.
-    int64_t sliceLength = copyOp.getLength().getSExtValue();
-    MemRefType sliceType = gemmV2OutsType.clone(sliceLength).cast<MemRefType>();
+    int64_t sliceLength = gemmStoreOp.getLength().getSExtValue();
+    MemRefType sliceType = gemmOutsType.clone(sliceLength).cast<MemRefType>();
     Value fusionSlice = b.create<GpuAllocOp>(loc, sliceType);
     Type typeToCopy = sliceType.getElementType();
     if (sliceType.getNumElements() > 1)
       typeToCopy =
           VectorType::get(sliceType.getShape(), sliceType.getElementType());
-    Value sliceVals = b.create<InBoundsLoadOp>(loc, typeToCopy, gemmV2Outs,
-                                               copyOp.getSourceCoord());
+    Value sliceVals = b.create<InBoundsLoadOp>(loc, typeToCopy, gemmOuts,
+                                               gemmStoreOp.getSourceCoord());
     b.create<InBoundsStoreOp>(loc, sliceVals, fusionSlice, zero);
 
     // 2.2. Tile linalg.generic with vgpr as input, return output vgprs
     Value laOutRegs =
-        reconfigureLAGeneric(b, laGeneric, fusionSlice, idxMaps, copyOp);
+        reconfigureLAGeneric(b, laGeneric, fusionSlice, idxMaps, gemmStoreOp);
     // 2.2.0. Move the generic before the write-back. This'll put all
     // the copy loops for other inputs before the generic due to insertion
     // order.
-    laGeneric->moveBefore(copyOp);
+    laGeneric->moveBefore(gemmStoreOp);
 
     // 2.3. Replace twcopy inputs with la.generic result vgprs
 
     // Since the threadwise copy arg has gone through untransform()
     // its expected output type is the same as the output type of the
     // linalg.generic.
-    copyOp.getSourceMutable().assign(laOutRegs);
+    gemmStoreOp.getSourceMutable().assign(laOutRegs);
     // The indexing has been moved into slice creation, reset source
     // coord.
-    copyOp.getSourceCoordMutable().assign(zero);
-    copyOp.getDestMutable().assign(out);
+    gemmStoreOp.getSourceCoordMutable().assign(zero);
+    gemmStoreOp.getDestMutable().assign(out);
 
     return success();
   }

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -421,9 +421,8 @@ LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
   if (!outIdxMap.isIdentity())
     return failure();
 
-  // 1. Trace input to threadwise_copy. Collect transforms (to be applied to
-  // other inputs).
-  // 1.1. Find the conv2d output
+  // 1. Trace input to global_store.
+  // 1.1. Find the (implicit) gemm output
   GlobalStoreOp gemmStoreOp;
   for (auto pair : llvm::zip(idxMaps, laGeneric.inputs())) {
     AffineMap inpIdxMap = std::get<0>(pair);

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -636,12 +636,11 @@ struct GlobalLoadRewritePattern : public OpRewritePattern<GlobalLoadOp> {
 };
 
 //===----------------------------------------------------------------------===//
-// ThreadwiseCopyV2 lowering.
+// GlobalStore lowering.
 //===----------------------------------------------------------------------===//
-struct ThreadwiseCopyV2RewritePattern
-    : public OpRewritePattern<ThreadwiseCopyV2Op> {
-  using OpRewritePattern<ThreadwiseCopyV2Op>::OpRewritePattern;
-  LogicalResult matchAndRewrite(ThreadwiseCopyV2Op op,
+struct GlobalStoreRewritePattern : public OpRewritePattern<GlobalStoreOp> {
+  using OpRewritePattern<GlobalStoreOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(GlobalStoreOp op,
                                 PatternRewriter &b) const override {
     Location loc = op.getLoc();
 
@@ -696,14 +695,14 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   ConversionTarget target(*ctx);
   target.addIllegalOp<FillOp, BlockwiseGemmOp, BlockwiseGemmV2Op, GlobalLoadOp,
-                      ThreadwiseCopyV2Op>();
+                      GlobalStoreOp>();
   target.addLegalDialect<arith::ArithmeticDialect, rock::RockDialect,
                          AffineDialect, memref::MemRefDialect>();
 
   RewritePatternSet patterns(ctx);
   patterns.add<FillRewritePattern, BlockwiseGemmRewritePattern,
                BlockwiseGemmV2RewritePattern, GlobalLoadRewritePattern,
-               ThreadwiseCopyV2RewritePattern>(ctx);
+               GlobalStoreRewritePattern>(ctx);
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))
     signalPassFailure();

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1046,7 +1046,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     {
       OpBuilder::InsertionGuard guard(b);
       b.setInsertionPointToStart(outLoop.getBody());
-      b.create<ThreadwiseCopyV2Op>(
+      b.create<GlobalStoreOp>(
           loc, registerC, tensorC,
           /*length=*/b.getIndexAttr(tensorCDataPerCopy),
           StoreMethodAttr::get(op.getContext(), StoreMethod::Set),
@@ -2206,7 +2206,7 @@ struct GridwiseGemmV2RewritePattern
     {
       OpBuilder::InsertionGuard guard(b);
       b.setInsertionPointToStart(outLoop.getBody());
-      b.create<ThreadwiseCopyV2Op>(
+      b.create<GlobalStoreOp>(
           loc, registerC, tensorC, b.getIndexAttr(tensorCDataPerCopy),
           op.getStoreMethodAttr(), std::get<0>(writeOobDims),
           std::get<1>(writeOobDims), outLoop.getLowerCoords(/*domain=*/0)[0],

--- a/mlir/test/Dialect/Rock/lowering_global_moves.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_moves.mlir
@@ -1,53 +1,53 @@
 // RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise %s | FileCheck %s
 
-// CHECK-LABEL: func.func @rock_threadwise_copy_v2
-func.func @rock_threadwise_copy_v2(%source : memref<32xf32, 5>,
+// CHECK-LABEL: func.func @rock_global_store
+func.func @rock_global_store(%source : memref<32xf32, 5>,
                                 %dest2D : memref<32x32xf32>) {
   %c0 = arith.constant 0 : index
   // CHECK: %[[slice:.*]] = rock.in_bounds_load{{.*}}: memref<32xf32, 5>, index -> vector<4xf32>
   // CHECK: rock.buffer_store set %[[slice]]{{.*}}: vector<4xf32> -> memref<32x32xf32>
-  rock.threadwise_copy_v2 %source[%c0] -> %dest2D[%c0, %c0]
+  rock.global_store %source[%c0] -> %dest2D[%c0, %c0]
       storeMethod(set) {
       length = 4 : index, leftOobDims = [], rightOobDims = [] }
     : memref<32xf32, 5> -> memref<32x32xf32>, index, index
   func.return
 }
 
-// CHECK-LABEL: func @rock_threadwise_copy_v2_long
-func.func @rock_threadwise_copy_v2_long(%source : memref<32xf32, 5>,
+// CHECK-LABEL: func @rock_global_store_long
+func.func @rock_global_store_long(%source : memref<32xf32, 5>,
                                 %dest2D : memref<32x32xf32>) {
   %c0 = arith.constant 0 : index
   // CHECK: rock.buffer_store set %{{.*}} -> %{{.*}}[%[[coords:[^{]*]]{{.*}}: vector<4xf32> -> memref<32x32xf32>
   // CHECK: rock.buffer_store set {{.*}}%[[coords]]{{.*}} offset = 4 : index{{.*}}: vector<4xf32> -> memref<32x32xf32>
-  rock.threadwise_copy_v2 %source[%c0] -> %dest2D[%c0, %c0]
+  rock.global_store %source[%c0] -> %dest2D[%c0, %c0]
       storeMethod(set) {
       length = 8 : index, leftOobDims = [], rightOobDims = [] }
     : memref<32xf32, 5> -> memref<32x32xf32>, index, index
   func.return
 }
 
-// CHECK-LABEL: func @rock_threadwise_copy_v2_8xf16
-func.func @rock_threadwise_copy_v2_8xf16(%source : memref<32xf16, 5>,
+// CHECK-LABEL: func @rock_global_store_8xf16
+func.func @rock_global_store_8xf16(%source : memref<32xf16, 5>,
                                            %dest : memref<64xf16>) {
   %c0 = arith.constant 0 : index
   // CHECK: rock.buffer_store
   // CHECK-NOT: rock.buffer_store
-  rock.threadwise_copy_v2 %source[%c0] -> %dest[%c0]
+  rock.global_store %source[%c0] -> %dest[%c0]
       storeMethod(set) {
       length = 8 : index, leftOobDims = [], rightOobDims = [] }
     : memref<32xf16, 5> -> memref<64xf16>, index
   func.return
 }
 
-// CHECK-LABEL: func @rock_threadwise_copy_v2_7xf16
-func.func @rock_threadwise_copy_v2_7xf16(%source : memref<32xf16, 5>,
+// CHECK-LABEL: func @rock_global_store_7xf16
+func.func @rock_global_store_7xf16(%source : memref<32xf16, 5>,
                                            %dest : memref<64xf16>) {
   %c0 = arith.constant 0 : index
   // CHECK: rock.buffer_store {{.*}} : vector<4xf16>
   // CHECK: rock.buffer_store {{.*}} : vector<2xf16>
   // CHECK: rock.buffer_store {{.*}} : f16
   // CHECK-NOT: rock.buffer_store
-  rock.threadwise_copy_v2 %source[%c0] -> %dest[%c0]
+  rock.global_store %source[%c0] -> %dest[%c0]
       storeMethod(set) {
       length = 7 : index, leftOobDims = [], rightOobDims = [] }
     : memref<32xf16, 5> -> memref<64xf16>, index

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -458,14 +458,14 @@ func.func @rock_global_load(%source : memref<?x?x?x?x?xf32>) -> vector<8xf32> {
 // CHECK: rock.global_load
 
 // --------------------------
-// threadwise_copy_v2 tests.
+// global_store tests.
 
-func.func @rock_threadwise_copy_v2(%source : memref<32xf32, 5>,
+func.func @rock_global_store(%source : memref<32xf32, 5>,
                                 %dest : memref<?x?x?x?x?xf32>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   // check source and destination with coordinate transforms.
-  rock.threadwise_copy_v2
+  rock.global_store
     %source[%c0] ->
     %dest[%c1, %c1, %c1, %c1, %c1]
     storeMethod(set)
@@ -476,8 +476,8 @@ func.func @rock_threadwise_copy_v2(%source : memref<32xf32, 5>,
   return
 }
 
-// CHECK-LABEL: func.func @rock_threadwise_copy_v2
-// CHECK: rock.threadwise_copy_v2
+// CHECK-LABEL: func.func @rock_global_store
+// CHECK: rock.global_store
 
 func.func @rock_threadwise_gemm(%lhs : memref<4x8x1xf32, 5>, %rhs : memref<4x8x1xf32, 5>, %output : memref<8x8xf32, 5>) {
   rock.threadwise_gemm %output += %lhs * %rhs

--- a/mlir/test/fusion/tosa-to-rock-tp-add-tp.mlir
+++ b/mlir/test/fusion/tosa-to-rock-tp-add-tp.mlir
@@ -3,7 +3,7 @@
 // CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<{{.*}} by [<PassThrough ["dim0", "dim2", "dim3", "dim1"] at [0, 1, 2, 3] -> ["dim0", "dim2", "dim3", "dim1"] at [0, 2, 3, 1]>] bounds = [256, 28, 28, 64] -> [256, 64, 28, 28]>
 // CHECK: rock.transforming_for{{.*}} #[[MAP1]], #[[MAP2]]
 // CHECK: linalg.generic{{.*}} outs(%[[outBuf:.*]] : memref<4xf32, 5>)
-// CHECK: threadwise_copy_v2 %[[outBuf]]{{.*}} -> %arg3
+// CHECK: global_store %[[outBuf]]{{.*}} -> %arg3
 // to test transpose is converted as transform and fused.
 
 func.func @test_fusion(%arg0: tensor<256x28x28x128xf32>, %arg1: tensor<64x3x3x128xf32>, %arg2: tensor<256x64x28x28xf32>) -> tensor<256x64x28x28xf32> attributes {kernel, arch = ""} {

--- a/mlir/test/fusion/tosa-to-rock-tp-add.mlir
+++ b/mlir/test/fusion/tosa-to-rock-tp-add.mlir
@@ -5,9 +5,9 @@
 // CHECK: rock.transforming_for
 // CHECK-SAME: [#[[MAP2]]]
 // CHECK-SAME: bounds [1, 1, 1, 1]
-// CHECK-NEXT: rock.buffer_load %arg2
+// CHECK-NEXT: rock.global_load %arg2
 // CHECK: linalg.generic{{.*}} outs(%[[outBuf:.*]] : memref<1xf32, 5>)
-// CHECK: threadwise_copy_v2 %[[outBuf]]{{.*}} -> %arg3
+// CHECK: global_store %[[outBuf]]{{.*}} -> %arg3
 // to test transpose is converted as transform and fused.
 
 func.func @test_fusion(%arg0: tensor<256x28x28x128xf32>, %arg1: tensor<64x3x3x128xf32>, %arg2: tensor<256x64x28x28xf32>) -> tensor<256x28x28x64xf32> attributes {kernel, arch = ""} {

--- a/mlir/test/fusion/xdlops/fused_ir_tosa_conv1x1.mlir
+++ b/mlir/test/fusion/xdlops/fused_ir_tosa_conv1x1.mlir
@@ -18,13 +18,13 @@ module {
 //CHECK: rock.transforming_for
 
 // 2. Check if ops are fused and copy_v2 is not present here
-//CHECK-NOT: rock.threadwise_copy_v2
+//CHECK-NOT: rock.global_store
 
 // 3. Check correct sequence of load-linalg-store
 //CHECK: rock.transforming_for
 //CHECK: rock.yield
 //CHECK: linalg.generic
-//CHECK: rock.threadwise_copy_v2
+//CHECK: rock.global_store
 
 // 4. Check if there is leftover ops.
 //CHECK: rock.yield

--- a/mlir/test/fusion/xdlops/fused_ir_tosa_conv7x7.mlir
+++ b/mlir/test/fusion/xdlops/fused_ir_tosa_conv7x7.mlir
@@ -18,13 +18,13 @@ module {
 //CHECK: rock.transforming_for
 
 // 2. Check if ops are fused and copy_v2 is not present here
-//CHECK-NOT: rock.threadwise_copy_v2
+//CHECK-NOT: rock.global_store
 
 // 3. Check correct sequence of load-linalg-store
 //CHECK: rock.transforming_for
 //CHECK: rock.yield
 //CHECK: linalg.generic
-//CHECK: rock.threadwise_copy_v2
+//CHECK: rock.global_store
 
 // 4. Check if there is leftover ops.
 //CHECK: rock.yield

--- a/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
+++ b/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
@@ -92,11 +92,14 @@ static llvm::cl::opt<DataType>
                               clEnumValN(DataType::I8, "i8", "8-bit integer")),
              llvm::cl::Required);
 
-static llvm::cl::opt<std::string> operation("operation", llvm::cl::desc("Operation (ignored, for MLIR compat)"),
-  llvm::cl::init("gemm"));
+static llvm::cl::opt<std::string>
+    operation("operation",
+              llvm::cl::desc("Operation (ignored, for MLIR compat)"),
+              llvm::cl::init("gemm"));
 
-static llvm::cl::opt<std::string> arch("arch", llvm::cl::desc("Arch (ignored, MLIR compat)"),
-  llvm::cl::init("gemm"));
+static llvm::cl::opt<std::string>
+    arch("arch", llvm::cl::desc("Arch (ignored, MLIR compat)"),
+         llvm::cl::init("gemm"));
 
 static size_t getByteSize(size_t elems, bool isOut) {
   switch (dataType) {


### PR DESCRIPTION
Change some names in AlignTiling.cpp to make it slightly clearer what's going on.

Also, amend the fusion flow from BufferLoad to GlobalLoad, which is one level higher up the stack (it can be one or more BufferLoad ops) so as to prevent any potential issues when the output loop vectorizes to a global_store that involves multiple buffer_store operations.