### PR TITLE
add resnet50 f32 fusion test cases

### DIFF
--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1.mlir
@@ -1,6 +1,15 @@
-// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-opt --rock-fold-transpose | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
+
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x128x1x1xf32>, %arg1: tensor<1x128x28x28xf32>, %arg2: tensor<128x128x3x3xf32>) -> tensor<1x128x28x28xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 128, 28, 28]} : (tensor<1x128x1x1xf32>) -> tensor<1x128x28x28xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x128x28x28xf32>, tensor<128x128x3x3xf32>) -> tensor<1x128x28x28xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x128x28x28xf32>, tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    return %3 : tensor<1x128x28x28xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-10.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-10.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-10.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-10.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x256x1x1xf32>, %arg1: tensor<1x256x56x56xf32>, %arg2: tensor<1x64x56x56xf32>, %arg3: tensor<256x64x1x1xf32>) -> tensor<1x256x56x56xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 256, 56, 56]} : (tensor<1x256x1x1xf32>) -> tensor<1x256x56x56xf32>
+    %1 = migraphx.convolution(%arg2, %arg3) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<256x64x1x1xf32>) -> tensor<1x256x56x56xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x256x56x56xf32>, tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    %3 = migraphx.add(%2, %arg1) : (tensor<1x256x56x56xf32>, tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    %4 = migraphx.relu(%3) : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    return %4 : tensor<1x256x56x56xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-11.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-11.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-11.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-11.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x128x1x1xf32>, %arg1: tensor<1x128x56x56xf32>, %arg2: tensor<128x128x3x3xf32>) -> tensor<1x128x28x28xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 128, 28, 28]} : (tensor<1x128x1x1xf32>) -> tensor<1x128x28x28xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x128x56x56xf32>, tensor<128x128x3x3xf32>) -> tensor<1x128x28x28xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x128x28x28xf32>, tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    return %3 : tensor<1x128x28x28xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-12.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-12.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-12.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-12.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x2048x1x1xf32>, %arg1: tensor<1x2048x7x7xf32>, %arg2: tensor<1x512x7x7xf32>, %arg3: tensor<2048x512x1x1xf32>) -> tensor<1x2048x7x7xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 2048, 7, 7]} : (tensor<1x2048x1x1xf32>) -> tensor<1x2048x7x7xf32>
+    %1 = migraphx.convolution(%arg2, %arg3) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x512x7x7xf32>, tensor<2048x512x1x1xf32>) -> tensor<1x2048x7x7xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %3 = migraphx.add(%2, %arg1) : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %4 = migraphx.relu(%3) : (tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    return %4 : tensor<1x2048x7x7xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-13.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-13.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-13.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-13.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x2048x7x7xf32>, %arg2: tensor<512x2048x1x1xf32>) -> tensor<1x512x7x7xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 512, 7, 7]} : (tensor<1x512x1x1xf32>) -> tensor<1x512x7x7xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x2048x7x7xf32>, tensor<512x2048x1x1xf32>) -> tensor<1x512x7x7xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x512x7x7xf32>, tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    return %3 : tensor<1x512x7x7xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-14.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-14.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-14.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-14.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x64x1x1xf32>, %arg1: tensor<1x64x56x56xf32>, %arg2: tensor<64x64x3x3xf32>) -> tensor<1x64x56x56xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 64, 56, 56]} : (tensor<1x64x1x1xf32>) -> tensor<1x64x56x56xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<64x64x3x3xf32>) -> tensor<1x64x56x56xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x64x56x56xf32>, tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    return %3 : tensor<1x64x56x56xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-15.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-15.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-15.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-15.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x384x28x28xf32>, %arg2: tensor<512x384x1x1xf32>) -> tensor<1x512x28x28xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 512, 28, 28]} : (tensor<1x512x1x1xf32>) -> tensor<1x512x28x28xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x384x28x28xf32>, tensor<512x384x1x1xf32>) -> tensor<1x512x28x28xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x512x28x28xf32>, tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    return %3 : tensor<1x512x28x28xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-16.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-16.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-16.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-16.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x2048x1x1xf32>, %arg1: tensor<1x1536x7x7xf32>, %arg2: tensor<2048x1536x1x1xf32>) -> tensor<1x2048x7x7xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 2048, 7, 7]} : (tensor<1x2048x1x1xf32>) -> tensor<1x2048x7x7xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x1536x7x7xf32>, tensor<2048x1536x1x1xf32>) -> tensor<1x2048x7x7xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    return %3 : tensor<1x2048x7x7xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-17.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-17.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-17.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-17.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x512x7x7xf32>, %arg2: tensor<512x512x3x3xf32>) -> tensor<1x512x7x7xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 512, 7, 7]} : (tensor<1x512x1x1xf32>) -> tensor<1x512x7x7xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x512x7x7xf32>, tensor<512x512x3x3xf32>) -> tensor<1x512x7x7xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x512x7x7xf32>, tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    return %3 : tensor<1x512x7x7xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-18.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-18.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-18.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-18.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x64x1x1xf32>, %arg1: tensor<1x3x224x224xf32>, %arg2: tensor<64x3x7x7xf32>) -> tensor<1x64x112x112xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 64, 112, 112]} : (tensor<1x64x1x1xf32>) -> tensor<1x64x112x112xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>) -> tensor<1x64x112x112xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x64x112x112xf32>, tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x64x112x112xf32>) -> tensor<1x64x112x112xf32>
+    return %3 : tensor<1x64x112x112xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-19.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-19.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-19.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-19.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x1024x1x1xf32>, %arg1: tensor<1x768x14x14xf32>, %arg2: tensor<1024x768x1x1xf32>) -> tensor<1x1024x14x14xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 1024, 14, 14]} : (tensor<1x1024x1x1xf32>) -> tensor<1x1024x14x14xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x768x14x14xf32>, tensor<1024x768x1x1xf32>) -> tensor<1x1024x14x14xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    return %3 : tensor<1x1024x14x14xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-2.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-2.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-2.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-2.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x256x1x1xf32>, %arg1: tensor<1x256x28x28xf32>, %arg2: tensor<256x256x3x3xf32>) -> tensor<1x256x14x14xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 256, 14, 14]} : (tensor<1x256x1x1xf32>) -> tensor<1x256x14x14xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x256x28x28xf32>, tensor<256x256x3x3xf32>) -> tensor<1x256x14x14xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x256x14x14xf32>, tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    return %3 : tensor<1x256x14x14xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-20.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-20.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-20.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-20.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x256x1x1xf32>, %arg1: tensor<1x128x56x56xf32>, %arg2: tensor<256x128x1x1xf32>) -> tensor<1x256x56x56xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 256, 56, 56]} : (tensor<1x256x1x1xf32>) -> tensor<1x256x56x56xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x128x56x56xf32>, tensor<256x128x1x1xf32>) -> tensor<1x256x56x56xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x256x56x56xf32>, tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32>
+    return %3 : tensor<1x256x56x56xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-21.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-21.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-21.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-21.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x512x14x14xf32>, %arg2: tensor<512x512x3x3xf32>) -> tensor<1x512x7x7xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 512, 7, 7]} : (tensor<1x512x1x1xf32>) -> tensor<1x512x7x7xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x512x14x14xf32>, tensor<512x512x3x3xf32>) -> tensor<1x512x7x7xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x512x7x7xf32>, tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x512x7x7xf32>) -> tensor<1x512x7x7xf32>
+    return %3 : tensor<1x512x7x7xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-22.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-22.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x64x1x1xf32>, %arg1: tensor<1x64x56x56xf32>, %arg2: tensor<64x64x1x1xf32>) -> tensor<1x64x56x56xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 64, 56, 56]} : (tensor<1x64x1x1xf32>) -> tensor<1x64x56x56xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x64x56x56xf32>, tensor<64x64x1x1xf32>) -> tensor<1x64x56x56xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x64x56x56xf32>, tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    return %3 : tensor<1x64x56x56xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-22.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-22.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-23.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-23.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-23.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-23.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x1024x14x14xf32>, %arg2: tensor<512x1024x1x1xf32>) -> tensor<1x512x14x14xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 512, 14, 14]} : (tensor<1x512x1x1xf32>) -> tensor<1x512x14x14xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x1024x14x14xf32>, tensor<512x1024x1x1xf32>) -> tensor<1x512x14x14xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x512x14x14xf32>, tensor<1x512x14x14xf32>) -> tensor<1x512x14x14xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x512x14x14xf32>) -> tensor<1x512x14x14xf32>
+    return %3 : tensor<1x512x14x14xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-24.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-24.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-24.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-24.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x128x1x1xf32>, %arg1: tensor<1x256x56x56xf32>, %arg2: tensor<128x256x1x1xf32>) -> tensor<1x128x56x56xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 128, 56, 56]} : (tensor<1x128x1x1xf32>) -> tensor<1x128x56x56xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x256x56x56xf32>, tensor<128x256x1x1xf32>) -> tensor<1x128x56x56xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x128x56x56xf32>, tensor<1x128x56x56xf32>) -> tensor<1x128x56x56xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x128x56x56xf32>) -> tensor<1x128x56x56xf32>
+    return %3 : tensor<1x128x56x56xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-3.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-3.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-3.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-3.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x128x1x1xf32>, %arg1: tensor<1x512x28x28xf32>, %arg2: tensor<128x512x1x1xf32>) -> tensor<1x128x28x28xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 128, 28, 28]} : (tensor<1x128x1x1xf32>) -> tensor<1x128x28x28xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x512x28x28xf32>, tensor<128x512x1x1xf32>) -> tensor<1x128x28x28xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x128x28x28xf32>, tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x128x28x28xf32>) -> tensor<1x128x28x28xf32>
+    return %3 : tensor<1x128x28x28xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-4.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-4.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.conv_2d
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-4.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-4.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.conv_2d
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x256x1x1xf32>, %arg1: tensor<1x256x14x14xf32>, %arg2: tensor<256x256x3x3xf32>) -> tensor<1x256x14x14xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 256, 14, 14]} : (tensor<1x256x1x1xf32>) -> tensor<1x256x14x14xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x256x14x14xf32>, tensor<256x256x3x3xf32>) -> tensor<1x256x14x14xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x256x14x14xf32>, tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    return %3 : tensor<1x256x14x14xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-5.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-5.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-5.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-5.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x64x1x1xf32>, %arg1: tensor<1x256x56x56xf32>, %arg2: tensor<64x256x1x1xf32>) -> tensor<1x64x56x56xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 64, 56, 56]} : (tensor<1x64x1x1xf32>) -> tensor<1x64x56x56xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x256x56x56xf32>, tensor<64x256x1x1xf32>) -> tensor<1x64x56x56xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x64x56x56xf32>, tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32>
+    return %3 : tensor<1x64x56x56xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-6.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-6.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-6.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-6.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x512x28x28xf32>, %arg2: tensor<1x128x28x28xf32>, %arg3: tensor<512x128x1x1xf32>) -> tensor<1x512x28x28xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 512, 28, 28]} : (tensor<1x512x1x1xf32>) -> tensor<1x512x28x28xf32>
+    %1 = migraphx.convolution(%arg2, %arg3) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x128x28x28xf32>, tensor<512x128x1x1xf32>) -> tensor<1x512x28x28xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x512x28x28xf32>, tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    %3 = migraphx.add(%2, %arg1) : (tensor<1x512x28x28xf32>, tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    %4 = migraphx.relu(%3) : (tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    return %4 : tensor<1x512x28x28xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-7.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-7.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-7.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-7.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x256x1x1xf32>, %arg1: tensor<1x512x28x28xf32>, %arg2: tensor<256x512x1x1xf32>) -> tensor<1x256x28x28xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 256, 28, 28]} : (tensor<1x256x1x1xf32>) -> tensor<1x256x28x28xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x512x28x28xf32>, tensor<256x512x1x1xf32>) -> tensor<1x256x28x28xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x256x28x28xf32>, tensor<1x256x28x28xf32>) -> tensor<1x256x28x28xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x256x28x28xf32>) -> tensor<1x256x28x28xf32>
+    return %3 : tensor<1x256x28x28xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-8.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-8.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-8.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-8.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x1024x1x1xf32>, %arg1: tensor<1x1024x14x14xf32>, %arg2: tensor<1x256x14x14xf32>, %arg3: tensor<1024x256x1x1xf32>) -> tensor<1x1024x14x14xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 1024, 14, 14]} : (tensor<1x1024x1x1xf32>) -> tensor<1x1024x14x14xf32>
+    %1 = migraphx.convolution(%arg2, %arg3) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x256x14x14xf32>, tensor<1024x256x1x1xf32>) -> tensor<1x1024x14x14xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    %3 = migraphx.add(%2, %arg1) : (tensor<1x1024x14x14xf32>, tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    %4 = migraphx.relu(%3) : (tensor<1x1024x14x14xf32>) -> tensor<1x1024x14x14xf32>
+    return %4 : tensor<1x1024x14x14xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-9.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-9.mlir
@@ -1,6 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
 // CHECK: linalg.matmul
-// CHECK: rock.conv2d
+// CHECK: %[[ALLOC:.*]] = memref.alloc() {{.*}}
+// CHECK-DAG: %[[ARG0_TR:.*]] = rock.transform %[[ARG0:.*]]
+// CHECK-DAG: %[[ARG1_TR:.*]] = rock.transform %[[ARG1:.*]]
+// CHECK-DAG: %[[ALLOC_TR:.*]] = rock.transform %[[ALLOC]]
+// CHECK-DAG: rock.conv2d(%[[ARG1_TR]], %[[ARG0_TR]], %[[ALLOC_TR]])
+// CHECK-DAG: %[[LAIN0:.*]] = memref.collapse_shape %[[ALLOC]]
+// CHECK-DAG: %[[LAIN1:.*]] = memref.collapse_shape %[[ARG2:.*]]
+// CHECK-DAG: %[[LAIN2:.*]] = memref.collapse_shape %[[ARG3:.*]]
+// CHECK-DAG: linalg.generic {{.*}} ins(%[[LAIN0]],
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // CLONE: [1 1 1]
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-9.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-9.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | FileCheck %s
+// CHECK: linalg.matmul
+// CHECK: rock.conv2d
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -verifier clone -fut test - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+
+module {
+  func.func @test(%arg0: tensor<1x256x1x1xf32>, %arg1: tensor<1x1024x14x14xf32>, %arg2: tensor<256x1024x1x1xf32>) -> tensor<1x256x14x14xf32> {
+    %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 256, 14, 14]} : (tensor<1x256x1x1xf32>) -> tensor<1x256x14x14xf32>
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x1024x14x14xf32>, tensor<256x1024x1x1xf32>) -> tensor<1x256x14x14xf32>
+    %2 = migraphx.add(%1, %0) : (tensor<1x256x14x14xf32>, tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    %3 = migraphx.relu(%2) : (tensor<1x256x14x14xf32>) -> tensor<1x256x14x14xf32>
+    return %3 : tensor<1x256x14x14xf32>
+  }
+}


### PR DESCRIPTION
This PR adds the resnet50 unique test cases.

Additionally, for this to work the GraphPipeline should
not call TosaOptionalDecompositions until we have 
support for tosa.fully_connected to rock.gemm.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/724