### PR TITLE
Run clang-format on the whole mlir/ directory

### DIFF
--- a/mlir/include/mlir/Conversion/TosaToRock/TosaToRock.h
+++ b/mlir/include/mlir/Conversion/TosaToRock/TosaToRock.h
@@ -32,7 +32,7 @@ void populateTosaToRockConversionPatterns(MLIRContext *context,
                                           RewritePatternSet &patterns);
 
 void populateTosaToRockTensorConversionPatterns(MLIRContext *context,
-                                                  RewritePatternSet &patterns);
+                                                RewritePatternSet &patterns);
 
 } // namespace tosa
 

--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.h
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.h
@@ -1,4 +1,4 @@
-//===- MIGraphXOps.h - MIGraphX MLIR Operations ---------------------*- C++ -*-===//
+//===- MIGraphXOps.h - MIGraphX MLIR Operations --------------*- C++-* -===//
 //
 // Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,23 +15,22 @@
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Types.h"
-#include "mlir/IR/BuiltinTypes.h"
 
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace mlir {
-namespace migraphx {
-
-} // end namespace migraphx
+namespace migraphx {} // end namespace migraphx
 } // end namespace mlir
 
 #include "mlir/Dialect/MIGraphX/MIGraphXOpsDialect.h.inc"
 
-#define GET_OP_CLASSES
 #include "mlir/Dialect/MIGraphX/MIGraphXTypes.h.inc"
+
+#define GET_OP_CLASSES
 #include "mlir/Dialect/MIGraphX/MIGraphXOps.h.inc"
 
 #endif // MLIR_MIGRAPHXOPS_OPS_H_

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -19,7 +19,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "mlir/Conversion/RockToGPU/RockToGPU.h"
 
 #include "mlir/Dialect/AMDGPU/AMDGPUDialect.h"
@@ -69,7 +68,8 @@ struct MIGPUAllocRewritePattern : public OpRewritePattern<rock::GpuAllocOp> {
     auto func = op->getParentOfType<gpu::GPUFuncOp>();
     Location loc = op->getLoc();
 
-    if (type.getMemorySpaceAsInt() == gpu::GPUDialect::getWorkgroupAddressSpace()) {
+    if (type.getMemorySpaceAsInt() ==
+        gpu::GPUDialect::getWorkgroupAddressSpace()) {
       Value attribution = func.addWorkgroupAttribution(type, loc);
       op.replaceAllUsesWith(attribution);
     } else if (type.getMemorySpaceAsInt() ==

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -39,7 +39,7 @@ using namespace mlir;
 //===- Consolidate the Rock Pipelines here ---------------------===//
 
 void rock::buildBufferizePipeline(OpPassManager &pm,
-                                    const rock::BufferizeOptions &options) {
+                                  const rock::BufferizeOptions &options) {
   bool noRock = options.disableRock;
 
   // TOSA conversion to rock and/or linalg with async.launch's
@@ -85,12 +85,12 @@ void rock::buildBufferizePipeline(OpPassManager &pm,
   bufOpts.functionBoundaryTypeConversion =
       bufferization::BufferizationOptions::LayoutMapOption::IdentityLayoutMap;
   bufOpts.unknownTypeConverterFn =
-    [](Value value, unsigned memorySpace,
-                                      const bufferization::BufferizationOptions &options) {
-    return bufferization::getMemRefTypeWithStaticIdentityLayout(
-        value.getType().cast<TensorType>(), memorySpace);
-  };
-      //bufferization::BufferizationOptions::LayoutMapOption::IdentityLayoutMap;
+      [](Value value, unsigned memorySpace,
+         const bufferization::BufferizationOptions &options) {
+        return bufferization::getMemRefTypeWithStaticIdentityLayout(
+            value.getType().cast<TensorType>(), memorySpace);
+      };
+  // bufferization::BufferizationOptions::LayoutMapOption::IdentityLayoutMap;
   pm.addPass(createOneShotBufferizePass(bufOpts));
 
   pm.addPass(bufferization::createBufferResultsToOutParamsPass());
@@ -102,7 +102,7 @@ void rock::buildBufferizePipeline(OpPassManager &pm,
 }
 
 void rock::buildKernelPipeline(OpPassManager &pm,
-                                 const rock::KernelOptions &options) {
+                               const rock::KernelOptions &options) {
   // Pre kernel lowering fixups for patterns that aren't amenable to lawer
   // fusion
   /* rocmlir-opt --rock-fold-transpose */
@@ -154,7 +154,7 @@ void rock::buildKernelPipeline(OpPassManager &pm,
 }
 
 void rock::buildBackendPipeline(OpPassManager &pm,
-                                  const rock::BackendOptions &options) {
+                                const rock::BackendOptions &options) {
   // lowering ROCDL (LLVM) to binary
   /* rocmlir-opt --strip-debuginfo
    *   "--convert-gpu-to-rocdl=chipset=$chip index-bitwidth=32"

--- a/mlir/lib/Dialect/Rock/Transforms/FoldTranspose.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/FoldTranspose.cpp
@@ -70,8 +70,8 @@ struct RemoveTrivialTransposePattern
       : OpRewritePattern<linalg::GenericOp>(ctx, /*benefit=*/2) {}
 
   rock::TransformOp makeTranspose(PatternRewriter &b, Value inp,
-                                    const AffineMapAttr &inMap,
-                                    const AffineMapAttr &outMap) const {
+                                  const AffineMapAttr &inMap,
+                                  const AffineMapAttr &outMap) const {
     AffineMap inpIdxMap = inMap.getAffineMap();
     AffineMap outpIdxMap = outMap.getAffineMap();
     Location loc = inp.getLoc();

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -164,8 +164,8 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
                                 params.cast<XdlopsGemmParamsAttr>());
     rw.eraseOp(op);
   } else {
-    rw.create<GridwiseGemmOp>(loc, a, b, c, op.getArchAttr(), 
-                              gridSize, params.cast<GeneralGemmParamsAttr>());
+    rw.create<GridwiseGemmOp>(loc, a, b, c, op.getArchAttr(), gridSize,
+                              params.cast<GeneralGemmParamsAttr>());
     rw.eraseOp(op);
   }
   return success();

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -398,8 +398,7 @@ struct IndexDiffUpdateRewritePattern
         }
         auto mbOriginalConst = isConstantValue(original);
         if (mbOriginalConst.has_value()) {
-          return b.create<ConstantIndexOp>(loc,
-                                           diff + mbOriginalConst.value());
+          return b.create<ConstantIndexOp>(loc, diff + mbOriginalConst.value());
         }
       }
       return b.create<AddIOp>(loc, original, diff);
@@ -428,8 +427,7 @@ struct IndexDiffUpdateRewritePattern
           auto mbLowerDiff = isConstantValue(lowerDiff);
           if (mbUpperDiff.has_value() && mbLowerDiff.has_value()) {
             lowerDiff = b.create<ConstantIndexOp>(
-                loc,
-                mbLowerDiff.value() + coefficient * mbUpperDiff.value());
+                loc, mbLowerDiff.value() + coefficient * mbUpperDiff.value());
           } else {
             lowerDiff = b.create<AddIOp>(
                 loc, lowerDiff,
@@ -455,8 +453,7 @@ struct IndexDiffUpdateRewritePattern
           auto mbLowerDiff = isConstantValue(lowerDiff);
           if (mbUpperDiff.has_value() && mbLowerDiff.has_value()) {
             lowerDiff = b.create<ConstantIndexOp>(
-                loc,
-                mbUpperDiff.value() + coefficient * mbLowerDiff.value());
+                loc, mbUpperDiff.value() + coefficient * mbLowerDiff.value());
           } else {
             lowerDiff = b.create<AddIOp>(
                 loc, upperIndicesDiff[upperDim],

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -19,7 +19,7 @@ using namespace mlir;
 using namespace mlir::rock;
 
 llvm::raw_ostream &mlir::rock::operator<<(llvm::raw_ostream &os,
-                                            GemmDimension dim) {
+                                          GemmDimension dim) {
   switch (dim) {
   case GemmDimension::G:
     return os << "GemmDimmension::G";

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -105,8 +105,7 @@ bool tuningSetParam(ModuleOp &mod, ParamEntry *paramEntry) {
         auto ctx = op.getContext();
         std::string perfConfig;
         paramEntry->param.getPerfConfigStr(perfConfig);
-        StringAttr attr =
-            StringAttr::get(ctx, perfConfig);
+        StringAttr attr = StringAttr::get(ctx, perfConfig);
         op->setAttr("perf_config", attr);
         return WalkResult::interrupt();
       });

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -202,13 +202,13 @@ mlir::rock::untransform(OpBuilder &b, Value transformed, ArrayAttr existing) {
 
 std::tuple<Value, ArrayAttr>
 mlir::rock::untransform(OpBuilder &b, Value transformed,
-                          ArrayRef<Attribute> existing) {
+                        ArrayRef<Attribute> existing) {
   return untransform(b, transformed, b.getArrayAttr(existing));
 }
 
-TransformOp mlir::rock::reshapeBuffer(OpBuilder &b, Location loc,
-                                        Value buffer, ArrayRef<StringRef> names,
-                                        ArrayRef<int64_t> shape) {
+TransformOp mlir::rock::reshapeBuffer(OpBuilder &b, Location loc, Value buffer,
+                                      ArrayRef<StringRef> names,
+                                      ArrayRef<int64_t> shape) {
   MemRefType bufferType = buffer.getType().cast<MemRefType>();
   ArrayRef<int64_t> outShape = bufferType.getShape();
   assert(outShape.size() == 1 && "Buffer being reshaped must start linear");
@@ -573,8 +573,8 @@ propagateVectorizationInfo(TransformMapAttr map,
 }
 
 int64_t mlir::rock::getMaxVectorization(ArrayAttr transforms, uint32_t dim,
-                                          int64_t len,
-                                          ArrayRef<int64_t> outputShape) {
+                                        int64_t len,
+                                        ArrayRef<int64_t> outputShape) {
   int64_t numInitialDims = transforms.empty() ? outputShape.size()
                                               : transforms[0]
                                                     .cast<TransformMapAttr>()

--- a/mlir/test/CAPI/mixrir.c
+++ b/mlir/test/CAPI/mixrir.c
@@ -1,4 +1,4 @@
-//===- mixrir.c - Simple test of C APIs ---------------------------------------===//
+//===- mixrir.c - Simple test of C APIs --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM
 // Exceptions.
@@ -31,7 +31,8 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
 
   // Set func arguments
   int64_t inDims[] = {1, 64, 56, 56};
-  MlirType inType = mlirRankedTensorTypeGet(4, inDims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
+  MlirType inType = mlirRankedTensorTypeGet(4, inDims, mlirF32TypeGet(ctx),
+                                            mlirAttributeGetNull());
   MlirType funcBodyArgTypes[] = {inType};
   MlirLocation funcBodyLocations[] = {location};
   MlirRegion funcBodyRegion = mlirRegionCreate();
@@ -46,9 +47,8 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
   MlirAttribute funcTypeAttr = mlirAttributeParseGet(
       ctx, mlirStringRefCreateFromCString(
                "(tensor<1x64x56x56xf32>) -> (tensor<1x64x56x56xf32>)"));
-  MlirAttribute funcNameAttr = mlirAttributeParseGet(
-      ctx,
-      mlirStringRefCreateFromCString("\"main\""));
+  MlirAttribute funcNameAttr =
+      mlirAttributeParseGet(ctx, mlirStringRefCreateFromCString("\"main\""));
   MlirNamedAttribute funcAttrs[] = {
       mlirNamedAttributeGet(
           mlirIdentifierGet(ctx,
@@ -76,15 +76,16 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
   }
 
   MlirAttribute filter0ValueAttr = mlirDenseElementsAttrFloatGet(
-      mlirRankedTensorTypeGet(4, filter0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull()), 4096,
-      f32Filter0);
+      mlirRankedTensorTypeGet(4, filter0Dims, mlirF32TypeGet(ctx),
+                              mlirAttributeGetNull()),
+      4096, f32Filter0);
   MlirNamedAttribute filter0Attrs[] = {mlirNamedAttributeGet(
       mlirIdentifierGet(ctx, mlirStringRefCreateFromCString("value")),
       filter0ValueAttr)};
 
   // Set constant op
-  MlirType filter0Type =
-      mlirRankedTensorTypeGet(4, filter0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
+  MlirType filter0Type = mlirRankedTensorTypeGet(
+      4, filter0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
   MlirOperationState filter0State = mlirOperationStateGet(
       mlirStringRefCreateFromCString("migraphx.constant"), location);
   mlirOperationStateAddResults(&filter0State, 1, &filter0Type);
@@ -108,10 +109,10 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
       ctx, mlirStringRefCreateFromCString("[1:i64, 1:i64]"));
   MlirAttribute conv0DilationAttr = mlirAttributeParseGet(
       ctx, mlirStringRefCreateFromCString("[1:i64, 1:i64]"));
-  MlirAttribute conv0GroupAttr = mlirAttributeParseGet(
-      ctx, mlirStringRefCreateFromCString("1:i64"));
-  MlirAttribute conv0PaddingModeAttr = mlirAttributeParseGet(
-      ctx, mlirStringRefCreateFromCString("0:i64"));
+  MlirAttribute conv0GroupAttr =
+      mlirAttributeParseGet(ctx, mlirStringRefCreateFromCString("1:i64"));
+  MlirAttribute conv0PaddingModeAttr =
+      mlirAttributeParseGet(ctx, mlirStringRefCreateFromCString("0:i64"));
   MlirNamedAttribute conv0Attrs[] = {
       mlirNamedAttributeGet(
           mlirIdentifierGet(ctx, mlirStringRefCreateFromCString("padding")),
@@ -126,12 +127,14 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
           mlirIdentifierGet(ctx, mlirStringRefCreateFromCString("group")),
           conv0GroupAttr),
       mlirNamedAttributeGet(
-          mlirIdentifierGet(ctx, mlirStringRefCreateFromCString("padding_mode")),
+          mlirIdentifierGet(ctx,
+                            mlirStringRefCreateFromCString("padding_mode")),
           conv0PaddingModeAttr)};
 
   // Set output shape
   int64_t conv0Dims[] = {1, 64, 56, 56};
-  MlirType conv0Type = mlirRankedTensorTypeGet(4, conv0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
+  MlirType conv0Type = mlirRankedTensorTypeGet(
+      4, conv0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
 
   // Set convolution op
   MlirOperationState conv0OpState = mlirOperationStateGet(
@@ -153,14 +156,16 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
                      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
   MlirAttribute bias0ValueAttr = mlirDenseElementsAttrFloatGet(
-      mlirRankedTensorTypeGet(4, bias0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull()), 64, f32Bias);
+      mlirRankedTensorTypeGet(4, bias0Dims, mlirF32TypeGet(ctx),
+                              mlirAttributeGetNull()),
+      64, f32Bias);
   MlirNamedAttribute bias0Attrs[] = {mlirNamedAttributeGet(
       mlirIdentifierGet(ctx, mlirStringRefCreateFromCString("value")),
       bias0ValueAttr)};
 
   // Set constant op
-  MlirType bias0Type =
-      mlirRankedTensorTypeGet(4, bias0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
+  MlirType bias0Type = mlirRankedTensorTypeGet(
+      4, bias0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
   MlirOperationState bias0State = mlirOperationStateGet(
       mlirStringRefCreateFromCString("migraphx.constant"), location);
   mlirOperationStateAddResults(&bias0State, 1, &bias0Type);
@@ -177,7 +182,8 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
 
   // Set add op
   int64_t add0Dims[] = {1, 64, 56, 56};
-  MlirType add0Type = mlirRankedTensorTypeGet(4, add0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
+  MlirType add0Type = mlirRankedTensorTypeGet(4, add0Dims, mlirF32TypeGet(ctx),
+                                              mlirAttributeGetNull());
   MlirOperationState add0State = mlirOperationStateGet(
       mlirStringRefCreateFromCString("migraphx.add"), location);
   mlirOperationStateAddResults(&add0State, 1, &add0Type);
@@ -194,7 +200,8 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
 
   // Set relu op
   int64_t relu0Dims[] = {1, 64, 56, 56};
-  MlirType relu0Type = mlirRankedTensorTypeGet(4, relu0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
+  MlirType relu0Type = mlirRankedTensorTypeGet(
+      4, relu0Dims, mlirF32TypeGet(ctx), mlirAttributeGetNull());
   MlirOperationState relu0State = mlirOperationStateGet(
       mlirStringRefCreateFromCString("migraphx.relu"), location);
   mlirOperationStateAddResults(&relu0State, 1, &relu0Type);
@@ -215,7 +222,7 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
 
   MlirOperation module = mlirModuleGetOperation(moduleOp);
   mlirOperationDump(module);
-// CHECK-LABEL: func @main
+  // CHECK-LABEL: func @main
 
   // module  {
   //  func @main(%arg0: tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32> {
@@ -254,7 +261,7 @@ int main() {
   mlirContextLoadAllAvailableDialects(ctx);
   mlirDialectRegistryDestroy(registry);
 
-  mlirContextSetAllowUnregisteredDialects(ctx, true/*allow*/);
+  mlirContextSetAllowUnregisteredDialects(ctx, true /*allow*/);
   if (constructAndTraverseIr(ctx))
     return 1;
 

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -54,20 +54,19 @@ static cl::opt<std::string>
                    cl::init(""));
 
 static cl::opt<std::string>
-    hostPipeline("host-pipeline",
-                 cl::desc("rocmlir-driver host pipeline list"),
+    hostPipeline("host-pipeline", cl::desc("rocmlir-driver host pipeline list"),
                  cl::value_desc("comma separated list of rock pipelines: "
                                 "partition,highlevel,execmodel or full"),
                  cl::init(""));
 
 static cl::opt<bool> legacyRockPipeline("c", cl::Hidden, cl::init(false),
-                                          cl::Optional,
-                                          cl::cb<void, bool>([](bool v) {
-                                            if (v) {
-                                              kernelPipeline.setValue("full");
-                                              hostPipeline.setValue("runner");
-                                            }
-                                          }));
+                                        cl::Optional,
+                                        cl::cb<void, bool>([](bool v) {
+                                          if (v) {
+                                            kernelPipeline.setValue("full");
+                                            hostPipeline.setValue("runner");
+                                          }
+                                        }));
 
 /////////////////////////////////////////////////////////////////////////////
 //// Backend target spec

--- a/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
+++ b/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
@@ -86,16 +86,17 @@ void miirLazyInit() {
 }
 
 LogicalResult RockEnabled(const mlir::rock::Conv2dGenerator::Config &conf) {
-  const std::string& inLayout = conf.inputLayout;
-  const std::string& filLayout = conf.filterLayout;
-  const std::string& outLayout = conf.outputLayout;
+  const std::string &inLayout = conf.inputLayout;
+  const std::string &filLayout = conf.filterLayout;
+  const std::string &outLayout = conf.outputLayout;
 
-  const static std::set<std::tuple<std::string, std::string, std::string>> supportedLayouts = {
-    {"ngchw", "gkcyx", "ngkhw"},
-    {"nhwgc", "gkyxc", "nhwgk"}
-  };
+  const static std::set<std::tuple<std::string, std::string, std::string>>
+      supportedLayouts = {{"ngchw", "gkcyx", "ngkhw"},
+                          {"nhwgc", "gkyxc", "nhwgk"}};
 
-  bool layoutSupported = supportedLayouts.count(std::make_tuple(inLayout, filLayout, outLayout)) > 0;
+  bool layoutSupported =
+      supportedLayouts.count(std::make_tuple(inLayout, filLayout, outLayout)) >
+      0;
   bool noBF16 = conf.dataTypeStr != "bf16";
   return LogicalResult::success(layoutSupported && noBF16);
 }
@@ -285,7 +286,8 @@ extern "C" MiirStatus miirBufferGet(MiirHandle mlirHandle, char *buffer,
   // 1st call: give client the size of buffer to allocate
   if ((buffer == nullptr) && (size != nullptr)) {
     module.walk([&](gpu::GPUModuleOp gpuModule) {
-      auto hsacoAttr = gpuModule->getAttrOfType<StringAttr>(gpu::getDefaultGpuBinaryAnnotation());
+      auto hsacoAttr = gpuModule->getAttrOfType<StringAttr>(
+          gpu::getDefaultGpuBinaryAnnotation());
       if (hsacoAttr) {
         *size = hsacoAttr.getValue().size();
       }
@@ -293,7 +295,8 @@ extern "C" MiirStatus miirBufferGet(MiirHandle mlirHandle, char *buffer,
     // 2nd call: copy the hsaco to the target buffer
   } else {
     module.walk([&](gpu::GPUModuleOp gpuModule) {
-      auto hsacoAttr = gpuModule->getAttrOfType<StringAttr>(gpu::getDefaultGpuBinaryAnnotation());
+      auto hsacoAttr = gpuModule->getAttrOfType<StringAttr>(
+          gpu::getDefaultGpuBinaryAnnotation());
       if (hsacoAttr) {
         std::string hsaco = hsacoAttr.getValue().str();
         std::copy(hsaco.begin(), hsaco.end(), buffer);


### PR DESCRIPTION
In case some of our clang-format issues are a result of code that already slipped in and then trips up the formatter, do a blanket reformat.