### PR TITLE
[mlir][SerializeToHsaco] Minimize dependencies of AMDGPU compilation

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 if (MLIR_ENABLE_ROCM_CONVERSIONS)
   set(AMDGPU_LIBS
     IRReader
+    IPO
     linker
     MCParser
     AMDGPUAsmParser
@@ -148,7 +149,6 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
     PRIVATE
     lldELF
     lldCommon
-    MLIRExecutionEngine
     MLIRROCDLToLLVMIRTranslation
   )
 


### PR DESCRIPTION
The SerializeToHsaco uses functions from ExecutionEngineUtils to set up LLVM pass pipelines, but does not otherwise depend on the execution engine (except indirectly via a dependency on IPO). This commit removes the dependency on the execution engine to prevent unnecessarily compilations.