### PR TITLE
Remove a bunch of old applicability/tuning restrictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ pythonenv*
 .dir-locals.el
 /.ccls-cache
 .ipynb_checkpoints
+/MIOpenDeps

--- a/mlir/include/mlir/Dialect/Rock/IR/XdlopsCodeSelection.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/XdlopsCodeSelection.h
@@ -566,16 +566,16 @@ struct XdlopsCodeSelection {
 
   // Checks whether given XDLOp config is valid for a given
   // KPack and KPerBlock values.
-  bool isValid(int64_t KPack, int64_t KPerBlock) {
-    bool IsKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
-    if (KPack > 1) {
-      if (KPack < k_base) {
+  bool isValid(int64_t kpack, int64_t kPerBlock) {
+    bool isKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
+    if (kpack > 1) {
+      if (kpack < k_base) {
         // llvm::dbgs()
         //     << "Should pack at least k_base elements and avoid waste
         //     xdlopsgemm cycles\n";
         return false;
       }
-      if (IsKReduction && KPerBlock < inputSpansPerMfmaIn) {
+      if (isKReduction && kPerBlock < inputSpansPerMfmaIn) {
         // llvm::dbgs()
         //     << " When reduction, KPerBlock must be at least
         //     num_input_blks\n";
@@ -583,12 +583,12 @@ struct XdlopsCodeSelection {
       }
       return true;
     } else {
-      if (!IsKReduction && KPerBlock < k_base) {
+      if (!isKReduction && kPerBlock < k_base) {
         // llvm::dbgs()
         //     << "When non-reduction, KPerBlock must be at least k_base\n";
         return false;
       }
-      if (IsKReduction && KPerBlock < k_base * inputSpansPerMfmaIn) {
+      if (isKReduction && kPerBlock < k_base * inputSpansPerMfmaIn) {
         // llvm::dbgs()
         //     << "When reduction, KPerBlock must be at least k_base *
         //     num_input_blks\n";

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -248,8 +248,6 @@ private:
                                              uint32_t &blockSize,
                                              uint32_t &gridSize);
 
-  LogicalResult isValidGridGemmXdlops(GemmSize &gemmSize);
-
 public:
   LogicalResult obtainTuningParameters(RockGemmWrapperInterface op,
                                        uint32_t blockSizeOverride,

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -28,6 +28,7 @@ llvm::raw_ostream &mlir::rock::operator<<(llvm::raw_ostream &os,
   case GemmDimension::MorN:
     return os << "GemmDimension::MorN";
   }
+  return os;
 }
 
 static int64_t obtainGridSize(const GemmSize &gemmSize,

--- a/mlir/utils/widgets/tune_MLIR_kernels.sh
+++ b/mlir/utils/widgets/tune_MLIR_kernels.sh
@@ -58,11 +58,13 @@ gitCheckoutMIOpen() {
 buildlibrockCompiler() {
     echo ">>> build librockCompiler"
     cd ${WORKSPACE}
-    cmake . -G Ninja -B build-static -DBUILD_FAT_LIBROCKCOMPILER=ON
+    cmake . -G Ninja -B build-static \
+          -DBUILD_FAT_LIBROCKCOMPILER=ON \
+          -DCMAKE_BUILD_TYPE=Release # or RelWithDebInfo
     cd build-static
-    ninja
+    ninja librockCompiler
     rm -rf ${WORKSPACE}/MIOpenDeps
-    cmake --install . --prefix ${WORKSPACE}/MIOpenDeps
+    cmake --install . --component librockCompiler --prefix ${WORKSPACE}/MIOpenDeps
 }
 
 buildMIOpenWithlibrockCompiler() {

--- a/mlir/utils/widgets/tune_MLIR_kernels.sh
+++ b/mlir/utils/widgets/tune_MLIR_kernels.sh
@@ -9,6 +9,7 @@ printUsage() {
     echo "  -c <\"config\">: Run MIOpenDriver on a single config"
     echo "                 Otherwise, on all configs in resnet50-miopen-configs"
     echo "  -u: turn off tuning (tuning is on be default)"
+    echo "  -b: don't run any tuning, just the compilation actions"
     echo "  -d <direction>: choose one direction"
     echo "                  Otherwise, run config(s) with all directions (1,2,4)"
     echo "  -l <layout>: choose one layout"
@@ -57,17 +58,16 @@ gitCheckoutMIOpen() {
 buildlibrockCompiler() {
     echo ">>> build librockCompiler"
     cd ${WORKSPACE}
-    rm -f build-static/CMakeCache.txt
     cmake . -G Ninja -B build-static -DBUILD_FAT_LIBROCKCOMPILER=ON
     cd build-static
     ninja
+    rm -rf ${WORKSPACE}/MIOpenDeps
     cmake --install . --prefix ${WORKSPACE}/MIOpenDeps
 }
 
 buildMIOpenWithlibrockCompiler() {
     echo ">>> build MIOpenDriver with librockCompiler"
     cd ${MIOPEN_DIR}
-    rm -f build/CMakeCache.txt
     cmake . -G "Unix Makefiles" -B build -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
           -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
@@ -156,6 +156,7 @@ run_a_single_test() {
     ${DRIVER} ${FIXED_CONFIG_ARGS[@]} $4
 }
 
+# b (build only)
 # d <direction>
 # l <layout>
 # t <datatype>
@@ -164,6 +165,7 @@ run_a_single_test() {
 # s: build librockCompiler
 # c <"config">
 # v: verbose
+build_only=0
 got_direction=0
 got_layout=0
 got_dtype=0
@@ -172,11 +174,14 @@ checkoutMIOpen=0
 buildStaticLib=0
 SINGLE_CONFIG=""
 VERBOSE=0
-while getopts "hd:l:t:umsc:v" opt; do
+while getopts "hd:l:t:umsbc:v" opt; do
     case "$opt" in
         h)
             printUsage
             exit 0
+            ;;
+        b)
+            build_only=1
             ;;
         d)
             got_direction=1
@@ -227,20 +232,28 @@ if [[ $checkoutMIOpen -eq 1 ]]; then
     buildMIOpenWithlibrockCompiler
 fi
 
-# Step 3: Run MIOpenDriver with MLIR solver
 declare -a ALL_DTYPES=(fp16 fp32 int8)
 declare -a ALL_DIRECTIONS=(1 2 4)
 declare -a ALL_LAYOUTS=(NCHW NHWC)
 
-if [[ "${SINGLE_CONFIG}" == "" ]]; then
-    while read -r config
-    do
-        run_tests_for_a_config "${config}"
-    done < ${CONFIG_POOL}
-else
-    run_tests_for_a_config "${SINGLE_CONFIG}"
+# Step 3: Run MIOpenDriver with MLIR solver
+if [[ $build_only -eq 0 ]]; then
+# Step 3.1: Clean out stale tuning databases
+    if [[ -d ${MIOPEN_DIR}/build/MIOpenUserDB ]]; then
+        rm -rf ${MIOPEN_DIR}/build/MIOpenUserDB
+    fi
+    if [[ -d ${HOME}/.cache/miopen ]]; then
+        rm -rf ${HOME}/.cache/miopen
+    fi
+
+
+    if [[ "${SINGLE_CONFIG}" == "" ]]; then
+        while read -r config
+        do
+            run_tests_for_a_config "${config}"
+        done < ${CONFIG_POOL}
+    else
+        run_tests_for_a_config "${SINGLE_CONFIG}"
+    fi
 fi
-
-
-
 


### PR DESCRIPTION
Going off of the comments and/or what they do, I can find no fundamental reason that the restrictions removed (or, in the case of kPack for various datatypes, loosened) needed to exist now that Jerry's refactoring of gridwise_gemm_v2 (and other previous coordinate transforms refactorings) need to exist.

This commit message will be updated with explanations for fixes for any bugs that this removal uncovers.