### PR TITLE
conv2d_regression e2e tests failure with float random inputs

### DIFF
--- a/mlir/test/e2e/conv2d_regression_bwd.toml
+++ b/mlir/test/e2e/conv2d_regression_bwd.toml
@@ -1,6 +1,6 @@
 directory = "conv2d_regression_bwd"
 prefix = "rocmlir-gen"
-suffix = "--arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--arch %arch %pv %random_data %rocmlir_gen_flags -rand_min=1 -rand_max=3  -relDiff_threshold=0.000035 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"
@@ -13,7 +13,7 @@ values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc
 
 [[axis]]
 name = "data type"
-values = ["f32", "f16"]
+values = ["f32", "f16 -RMS_threshold=0.0007"]
 prefix = "-t "
 
 [[axis]]

--- a/mlir/test/e2e/conv2d_regression_bwd.toml
+++ b/mlir/test/e2e/conv2d_regression_bwd.toml
@@ -16,6 +16,10 @@ name = "data type"
 values = ["f32", "f16"]
 prefix = "-t "
 
+[[axis]]
+name = "rand type"
+values = ["float"]
+prefix = "-rand_type "
 
 [[suite]]
 name = "config"

--- a/mlir/test/e2e/conv2d_regression_bwd.toml
+++ b/mlir/test/e2e/conv2d_regression_bwd.toml
@@ -1,6 +1,6 @@
 directory = "conv2d_regression_bwd"
 prefix = "rocmlir-gen"
-suffix = "--arch %arch %pv %random_data %rocmlir_gen_flags -rand_min=1 -rand_max=3  -relDiff_threshold=0.000035 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "-rand_type float -rand_min 1 -rand_max 3 -relDiff_threshold 0.000035 -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"
@@ -15,11 +15,6 @@ values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc
 name = "data type"
 values = ["f32", "f16 -RMS_threshold=0.0007"]
 prefix = "-t "
-
-[[axis]]
-name = "rand type"
-values = ["float"]
-prefix = "-rand_type "
 
 [[suite]]
 name = "config"

--- a/mlir/test/e2e/conv2d_regression_fwd.toml
+++ b/mlir/test/e2e/conv2d_regression_fwd.toml
@@ -1,6 +1,6 @@
 directory = "conv2d_regression_fwd"
 prefix = "rocmlir-gen"
-suffix = "--arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--arch %arch %pv %random_data %rocmlir_gen_flags -rand_min=1 -rand_max=3 -relDiff_threshold=0.00001 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"

--- a/mlir/test/e2e/conv2d_regression_fwd.toml
+++ b/mlir/test/e2e/conv2d_regression_fwd.toml
@@ -16,6 +16,10 @@ name = "data type"
 values = ["f32", "f16"]
 prefix = "-t "
 
+[[axis]]
+name = "rand type"
+values = ["float"]
+prefix = "-rand_type "
 
 [[suite]]
 name = "config"

--- a/mlir/test/e2e/conv2d_regression_fwd.toml
+++ b/mlir/test/e2e/conv2d_regression_fwd.toml
@@ -1,6 +1,6 @@
 directory = "conv2d_regression_fwd"
 prefix = "rocmlir-gen"
-suffix = "--arch %arch %pv %random_data %rocmlir_gen_flags -rand_min=1 -rand_max=3 -relDiff_threshold=0.00001 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "-rand_type float -rand_min 1 -rand_max 3 -relDiff_threshold 0.00001 -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"
@@ -16,14 +16,8 @@ name = "data type"
 values = ["f32", "f16"]
 prefix = "-t "
 
-[[axis]]
-name = "rand type"
-values = ["float"]
-prefix = "-rand_type "
-
 [[suite]]
 name = "config"
-
 
 [[suite.test]]
 config = "-p"

--- a/mlir/test/rocmlir-driver/populate_random_data.mlir
+++ b/mlir/test/rocmlir-driver/populate_random_data.mlir
@@ -36,10 +36,10 @@
 // SEED2: %[[two:.*]] = arith.constant 2 : i32
 // SEED2: call @seedRandomValues(%[[two]])
 
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_type float | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_FLOAT
+// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_type float -rand_min 1 -rand_max 3 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_FLOAT
 
-// RAND_FLOAT-DAG: %[[min:.*]] = arith.constant -1 : i16
-// RAND_FLOAT-DAG: %[[max:.*]] = arith.constant 1 : i16
+// RAND_FLOAT-DAG: %[[min:.*]] = arith.constant 1 : i16
+// RAND_FLOAT-DAG: %[[max:.*]] = arith.constant 3 : i16
 // RAND_FLOAT-DAG: %[[one:.*]] = arith.constant 1 : i32
 // RAND_FLOAT: call @seedRandomValues(%[[one]])
 

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -488,12 +488,14 @@ static llvm::cl::opt<float>
                      llvm::cl::value_desc("error"), llvm::cl::init(100.0f));
 static llvm::cl::opt<std::string> printVerifyResults(
     "print-verify-results",
-    llvm::cl::desc("Choose when to print verbose debug information in the "
-                   "verification function:"
-                   "always: print debug info"
-                   "failure: print debug info if the test fails (default)"
-                   "off: do not print debug info"),
-    llvm::cl::value_desc("info"), llvm::cl::init("failure"));
+    llvm::cl::desc(
+        "Choose when to print verbose debug information in the "
+        "verification function:"
+        "always: print debug info"
+        "failure: print debug info (elem-wise diff + summary) if the test fails"
+        "summary: print summary info if the test fails (default)"
+        "off: do not print debug info"),
+    llvm::cl::value_desc("info"), llvm::cl::init("summary"));
 static llvm::cl::alias
     aliasPrintVerifyResults("p_verify", llvm::cl::aliasopt(printVerifyResults));
 
@@ -1986,15 +1988,17 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
   char printDebug = 1;
   std::string printVerifyOption = printVerifyResults.getValue();
   if (printVerifyOption == "always") {
-    printDebug = 2;
+    printDebug = 3;
   } else if (printVerifyOption == "failure") {
+    printDebug = 2;
+  } else if (printVerifyOption == "summary") {
     printDebug = 1;
   } else if (printVerifyOption == "off") {
     printDebug = 0;
   } else {
     llvm::errs() << "Unsupported print-verify-results option: "
                  << printVerifyOption;
-    llvm::errs() << " (supported options: always, failure, off)\n";
+    llvm::errs() << " (supported options: always, failure, summary, off)\n";
     exit(1);
   }
   auto printDebugVal =

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -178,8 +178,8 @@ String getLabelFromChip(String chip) {
             return "mlir && gfx90a"
         case "gfx1030":
             // For [Tune MLIR Kernels] and [Performance report] stages,
-            // fix the vm-1 workstation for testing
-            return "mlir && vm-1"
+            // fix the vm-5 workstation for testing
+            return "mlir && vm-5"
     }
 }
 


### PR DESCRIPTION
When using `-rand_type float` for conv2d regression tests, a lot of tests failed.
This PR resolves the issue by adjusting random range and thresholds.
- random range for float inputs are parameterized in `rocmlir-gen` as `-rand_min` and `-rand_max`.
   - The default float random range is kept as [-1,1]. 
   - For conv2d regression tests, the float random range is set to [1,3].
- `relDiff_threshold` is now used to set relative diff threshold for all data types except for f16, 
   whose relDiff threshold stays as 100.0f.
   - The default value of `relDiff_threshold` is 1e-6.
   - For fwd regression tests, `relDiff_threshold` is set to 1e-5.
   - For bwd regression tests, `relDiff_threshold` is set to 3.5e-5.
- `RMS_threshold` is set to 7e-4 for f16 bwd regression tests. 

This PR also adds a `-p_verify=summary` mode as a verification print option. This mode is similar to `-p_verify=failure` in that it prints debug info only when the test fails. The difference is that `-p_verify=summary` only prints the max values of each metric and the histogram of relDiff. It does not print the element wise information as `-p_verify=faliure` does.
The `summary` mode is set to be the default. We can have a better view of `check-rocmlir` when some tests fail, especially on jenkins.

This PR closes the following two tickets:
- https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/621
- https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/646