### PR TITLE
Fix expand shape support in AlignTiling

### DIFF
--- a/mlir/test/fusion/e2e/mixr-mbcast-add-relu-align-tiling-collapse-expand-chains.mlir
+++ b/mlir/test/fusion/e2e/mixr-mbcast-add-relu-align-tiling-collapse-expand-chains.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-opt --rock-fold-transpose -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise -rock-linalg-align | FileCheck %s
+
+module {
+    // CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)> by [<PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1, 1, 1} ["dim0", "dim2", "dim3"] at [0, 2, 3] -> ["dim0", "dim2", "dim3"] at [0, 2, 3]>] bounds = [4, 4, 1, 1] -> [1, 4, 1, 1]>
+    // CHECK: rock.transforming_for{{.*}}#[[MAP]]
+    // CHECK-NEXT: %[[ldVal:.*]] = rock.global_load{{.*}}: memref<1x4x1x1xf32> -> f32
+    // CHECK-NEXT: rock.in_bounds_store %[[ldVal]]{{.*}}: f32 -> memref<1xf32, 5>, index
+    func.func @test(%arg0: tensor<1x4x1x1xf32>, %arg1: tensor<4x3x3x3xf32>, %arg2: tensor<4x3x3x3xf32>) -> tensor<4x4x1x1xf32> attributes {arch = "gfx908:sramecc+:xnack-", kernel = "mixr"} {
+        %0 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [4, 4, 1, 1]} : (tensor<1x4x1x1xf32>) -> tensor<4x4x1x1xf32>
+        %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1], xdlopsV2 = true} : (tensor<4x3x3x3xf32>, tensor<4x3x3x3xf32>) -> tensor<4x4x1x1xf32>
+        %2 = migraphx.add(%1, %0) : (tensor<4x4x1x1xf32>, tensor<4x4x1x1xf32>) -> tensor<4x4x1x1xf32>
+        %3 = migraphx.relu(%2) : (tensor<4x4x1x1xf32>) -> tensor<4x4x1x1xf32>
+        return %3 : tensor<4x4x1x1xf32>
+    }
+}

--- a/mlir/test/fusion/multi-collapse-expand-chains.mlir
+++ b/mlir/test/fusion/multi-collapse-expand-chains.mlir
@@ -1,0 +1,33 @@
+// RUN: rocmlir-opt --rock-fold-transpose -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise -rock-linalg-align %s | FileCheck %s
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+#transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)> by [<PassThrough ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>, <AddDim{1} ["g"] at [4] -> [] at []>] bounds = [4, 3, 3, 3, 1] -> [4, 3, 3, 3]>
+#transform_map1 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)> by [<PassThrough ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>, <AddDim{1} ["g"] at [4] -> [] at []>] bounds = [4, 4, 1, 1, 1] -> [4, 4, 1, 1]>
+module {
+    // CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)> by [<PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1, 1, 1} ["dim0", "dim2", "dim3"] at [0, 2, 3] -> ["dim0", "dim2", "dim3"] at [0, 2, 3]>] bounds = [4, 4, 1, 1] -> [1, 4, 1, 1]>
+    // CHECK: rock.transforming_for{{.*}}#[[MAP]]
+    // CHECK-NEXT: %[[ldVal:.*]] = rock.global_load{{.*}}: memref<1x4x1x1xf32> -> f32
+    // CHECK-NEXT: rock.in_bounds_store %[[ldVal]]{{.*}}: f32 -> memref<1xf32, 5>, index
+  func.func @test(%arg0: memref<1x4x1x1xf32>, %arg1: memref<4x3x3x3xf32>, %arg2: memref<4x3x3x3xf32>, %arg3: memref<4x4x1x1xf32>) attributes {arch = "gfx908:sramecc+:xnack-", kernel = "mixr"} {
+    %cst = arith.constant 0.000000e+00 : f32
+    %cst_0 = arith.constant 3.40282347E+38 : f32
+    %0 = memref.alloc() {alignment = 128 : i64} : memref<4x4x1x1xf32>
+    %1 = rock.transform %arg1 by #transform_map0 : memref<4x3x3x3xf32> to memref<4x3x3x3x1xf32>
+    %2 = rock.transform %arg2 by #transform_map0 : memref<4x3x3x3xf32> to memref<4x3x3x3x1xf32>
+    %3 = rock.transform %0 by #transform_map1 : memref<4x4x1x1xf32> to memref<4x4x1x1x1xf32>
+    rock.conv2d(%2, %1, %3) features =  mfma|dot|atomic_add {arch = "gfx908:sramecc+:xnack-", dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x", "g"], input_layout = ["ni", "ci", "hi", "wi", "gi"], output_layout = ["no", "ko", "ho", "wo", "go"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<4x3x3x3x1xf32>, memref<4x3x3x3x1xf32>, memref<4x4x1x1x1xf32>
+    %4 = memref.expand_shape %0 [[0], [1, 2], [3], [4]] : memref<4x4x1x1xf32> into memref<4x1x4x1x1xf32>
+    %5 = memref.collapse_shape %4 [[0, 1], [2, 3, 4]] : memref<4x1x4x1x1xf32> into memref<4x4xf32>
+    %6 = memref.collapse_shape %arg0 [[0, 1, 2, 3]] : memref<1x4x1x1xf32> into memref<4xf32>
+    %7 = memref.expand_shape %arg3 [[0], [1, 2], [3], [4]] : memref<4x4x1x1xf32> into memref<4x1x4x1x1xf32>
+    %8 = memref.collapse_shape %7 [[0, 1], [2, 3, 4]] : memref<4x1x4x1x1xf32> into memref<4x4xf32>
+    linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel"]} ins(%5, %6 : memref<4x4xf32>, memref<4xf32>) outs(%8 : memref<4x4xf32>) {
+    ^bb0(%arg4: f32, %arg5: f32, %arg6: f32):
+      %9 = arith.addf %arg4, %arg5 : f32
+      %10 = arith.minf %9, %cst_0 : f32
+      %11 = arith.maxf %10, %cst : f32
+      linalg.yield %11 : f32
+    }
+    return
+  }
+}


### PR DESCRIPTION
This commit fixes a bug in passing the subset
of the shape to create affine maps to be folded.