### PR TITLE
Cleanup AlignTiling for better creation of transforms.

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -36,6 +36,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -260,61 +261,48 @@ struct MILARewritePattern : public OpRewritePattern<linalg::GenericOp> {
 };
 } // end anonymous namespace
 
-/// If `inpMap` is a map of the form
-/// (d0, d1, ..., dk) -> (d(i0), d(i1), ..., d(ik))
-/// where thi i's don't make it the identity map, wrap `inp` in a
-/// rock.transform that corresponds to the map, and returns the indexing map
-/// that is the result of applying the permutation. If no permutation is needed,
-/// returns its inputs.
-static std::tuple<Value, AffineMap>
-makeTransposeTransform(PatternRewriter &b, Value inp, AffineMap inpMap) {
-  if (!inpMap.isMinorIdentityWithBroadcasting()) {
-    // permumation[i] says where the map output i should be sent.
-    SmallVector<uint32_t> permutation;
-    if (inpMap.isPermutationOfMinorIdentityWithBroadcasting(permutation)) {
-      Location loc = inp.getLoc();
-      MemRefType inputType = inp.getType().cast<MemRefType>();
-      ArrayRef<int64_t> inputShape = inputType.getShape();
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Transpose input type : " << inputType << "\n");
-      BottomUpTMBuilder permuteBuilder(b, inputShape, loc);
+// This function will create a permutation that will permute the originalMap to
+// be a MinorIdentityWithBroadcast. This is used to add a permutation later in
+// the chain.
+static void createPermutationForMinorIdentityWithBroadcast(
+    const AffineMap &originalMap, SmallVectorImpl<uint32_t> &perm) {
+  for (uint32_t i = 0; i < originalMap.getNumInputs(); ++i) {
+    perm.push_back(i);
+  }
 
-      SmallVector<uint32_t> identityIdxs;
-      identityIdxs.reserve(inputShape.size());
-      for (uint32_t idx = 0, e = inputShape.size(); idx < e; ++idx)
-        identityIdxs.push_back(idx);
-
-      permuteBuilder.passThrough(permutation, identityIdxs);
-      TransformMapAttr permuteAttr = permuteBuilder.get();
-      Value ret = b.create<TransformOp>(loc, inp, permuteAttr);
-      AffineMap composed = permuteAttr.getMap().getAffineMap().compose(inpMap);
-      LLVM_DEBUG(llvm::dbgs() << "indexing = " << inpMap << " then transform "
-                              << permuteAttr.getMap().getAffineMap() << " is "
-                              << composed << "\n");
-      return {ret, composed};
+  llvm::SmallSet<uint32_t, 4> foundInputDims;
+  for (const auto &idxAndValue : llvm::enumerate(originalMap.getResults())) {
+    auto idx = idxAndValue.index();
+    auto resultExpr = idxAndValue.value();
+    if (resultExpr.isa<AffineDimExpr>()) {
+      foundInputDims.insert(originalMap.getDimPosition(idx));
     }
   }
-  return {inp, inpMap};
-}
 
-static bool isMajorIdentityWithBroadcasting(AffineMap amap) {
-  if (amap.getNumDims() <= amap.getNumResults())
-    return false;
-  for (const auto &idxAndExpr : llvm::enumerate(amap.getResults())) {
-    unsigned resIdx = idxAndExpr.index();
-    AffineExpr expr = idxAndExpr.value();
-    if (auto dimExpr = expr.dyn_cast<AffineDimExpr>()) {
-      if (dimExpr.getPosition() != resIdx)
-        return false;
-    } else {
-      return false;
+  for (const auto &idxAndValue : llvm::enumerate(originalMap.getResults())) {
+    auto idx = idxAndValue.index();
+    auto resultExpr = idxAndValue.value();
+    if (resultExpr.isa<AffineDimExpr>()) {
+      auto swap1 = originalMap.getDimPosition(idx);
+      auto swap2 =
+          originalMap.getNumInputs() - originalMap.getNumResults() + idx;
+      perm[swap1] = swap2;
+      // Only do swap if the output expr does not define another place for the
+      // other input dim
+      if (!foundInputDims.contains(swap2)) {
+        perm[swap2] = swap1;
+      }
     }
   }
-  return true;
 }
 
-static Value makeBroadcast(PatternRewriter &b, MemRefType outType, Value inp,
-                           AffineMap inpIdxMap) {
+// This function will take a input Value and a index map that represents the
+// coordinate mapping that could be a combination of tranposes and broadcasts
+// and insert the necessary TransformOps
+static Value insertTransposeAndBroadcastTransforms(PatternRewriter &b,
+                                                   MemRefType outType,
+                                                   Value inp,
+                                                   AffineMap inpIdxMap) {
   if (!inpIdxMap.isIdentity()) {
     Location loc = inp.getLoc();
     auto inpType = inp.getType().template cast<MemRefType>();
@@ -322,64 +310,69 @@ static Value makeBroadcast(PatternRewriter &b, MemRefType outType, Value inp,
     ArrayRef<int64_t> outShape = outType.getShape();
 
     uint32_t diff = outShape.size() - inpShape.size();
-    SmallVector<uint32_t> bcastDims;
     LLVM_DEBUG(llvm::dbgs() << "Reached makeBroadcast with map " << inpIdxMap
                             << " and diff = " << diff << "\n");
-    if (diff) {
-      // 0.1 expand dims (size = 1) in front
-      SmallVector<uint32_t, 8> endDims;
-      SmallVector<uint32_t, 8> startDims;
-      for (uint32_t i = 0, e = inpShape.size(); i < e; ++i) {
-        startDims.push_back(i);
-        endDims.push_back(inpIdxMap.getDimPosition(i));
+
+    SmallVector<uint32_t> bcastDims;
+    SmallVector<uint32_t> bcastInDims;
+    SmallVector<uint32_t> passThroughInDims;
+    SmallVector<uint32_t> perm;
+    createPermutationForMinorIdentityWithBroadcast(inpIdxMap, perm);
+    auto permMap = AffineMap::getPermutationMap(perm, b.getContext());
+    inpIdxMap = inpIdxMap.compose(permMap);
+    assert(
+        (inpIdxMap.isMinorIdentityWithBroadcasting(&bcastDims)) &&
+        "this is guranteed by createPermutationForMinorIdentityWithBroadcast");
+
+    BottomUpTMBuilder bcastTransform(b, inpShape, loc);
+    bool isBcastDone = false;
+    for (uint32_t i = 0; i < inpShape.size(); ++i) {
+      if (!llvm::is_contained(bcastDims, i)) {
+        // Here the diff correspond to leading dropped dimensions when going
+        // from output co-ordinates to input co-ordinates.
+        assert(inpIdxMap.getDimPosition(i) == diff + i);
+        passThroughInDims.push_back(diff + i);
+        bcastTransform.passThrough({i}, {i});
+      } else {
+        isBcastDone = true;
+        bcastInDims.push_back(diff + i);
+        bcastTransform.broadcast({i}, {outShape[diff + i]});
       }
-      BottomUpTMBuilder transform(b, inpShape, loc);
-      transform.passThrough(endDims, startDims);
-      for (uint32_t i = 0; i < outShape.size(); ++i) {
-        uint32_t *it = llvm::find(endDims, i);
-        if (it != endDims.end())
-          continue;
+    }
+    if (isBcastDone) {
+      inp = b.create<TransformOp>(loc, inp, bcastTransform.get());
+    }
+
+    bool isDimAdded = false;
+    BottomUpTMBuilder addDimtransform(
+        b, inp.getType().cast<ShapedType>().getShape(), loc);
+    for (uint32_t i = 0; i < outShape.size(); ++i) {
+      if (llvm::is_contained(bcastInDims, i)) {
+        addDimtransform.passThrough({i}, {i - diff});
+      } else if (llvm::is_contained(passThroughInDims, i)) {
+        addDimtransform.passThrough({i}, {i - diff});
+      } else {
+        isDimAdded = true;
         SmallString<8> name;
         ("exp" + Twine(i)).toVector(name);
-        transform.addDim(name, i, 1);
-        bcastDims.push_back(i);
-      }
-
-      inp = b.create<TransformOp>(loc, inp, transform.get());
-
-      inpType = inp.getType().template cast<MemRefType>();
-      inpShape = inpType.getShape();
-    } else if (inpIdxMap.isMinorIdentityWithBroadcasting(&bcastDims)) {
-    } else if (isMajorIdentityWithBroadcasting(inpIdxMap)) {
-      for (uint32_t i = 0; i < inpShape.size(); ++i) {
-        if (inpShape[i] != outShape[i]) {
-          assert((outShape[i] % inpShape[i]) == 0);
-          bcastDims.push_back(i);
-        }
-      }
-    } else {
-      return inp;
-    }
-
-    LLVM_DEBUG(llvm::dbgs() << "Broadcast dims: ");
-    LLVM_DEBUG(llvm::interleaveComma(bcastDims, llvm::dbgs()));
-    LLVM_DEBUG(llvm::dbgs() << "\n");
-
-    // 1. insert a broadcast rock.transform
-    SmallVector<uint32_t, 8> ptDims;
-    SmallVector<int64_t, 8> bcastSizes;
-    for (uint32_t dim = 0; dim < inpShape.size(); ++dim) {
-      if (llvm::is_contained(bcastDims, dim)) {
-        bcastSizes.push_back(outShape[dim]);
-      } else {
-        ptDims.push_back(dim);
+        addDimtransform.addDim(name, i, outShape[i]);
       }
     }
-    BottomUpTMBuilder transform(b, inpShape, loc);
-    transform.passThrough(ptDims, ptDims);
-    transform.broadcast(bcastDims, bcastSizes);
+    if (isDimAdded) {
+      inp = b.create<TransformOp>(loc, inp, addDimtransform.get());
+    }
 
-    inp = b.create<TransformOp>(loc, inp, transform.get());
+    BottomUpTMBuilder permtransform(
+        b, inp.getType().cast<ShapedType>().getShape(), loc);
+    llvm::SmallVector<uint32_t, 4> identityVec;
+    for (uint32_t i = 0; i < outShape.size(); ++i) {
+      identityVec.push_back(i);
+    }
+    permtransform.passThrough(identityVec, perm);
+    if (!permMap.isIdentity()) {
+      inp = b.create<TransformOp>(loc, inp, permtransform.get());
+    }
+    return inp;
   }
   return inp;
 }
@@ -389,21 +382,8 @@ static void insertLoadFromOtherSource(PatternRewriter &b, Location loc,
                                       Value dest) {
   LLVM_DEBUG(llvm::dbgs() << "Src type: " << srcOp.getType() << " dest type: "
                           << gemmStoreOp.getDest().getType() << "\n");
-  ArrayRef<int64_t> sType, dType;
-  sType = srcOp.getType().cast<ShapedType>().getShape();
-  dType = gemmStoreOp.getDest().getType().getShape();
-  assert(sType.size() == dType.size() &&
-         "Rank of extra fusion arguments matches shape of C tensor");
   SmallVector<Value, 6> loadCoord = gemmStoreOp.getDestCoord();
   Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
-  for (unsigned i = 0; i < sType.size(); i++) {
-    assert((sType[i] == dType[i] || sType[i] == 1) &&
-           "shape of extra fusion arguments matches shape of C tensor or "
-           "broadcastable");
-    // broadcast source.
-    if (sType[i] != dType[i])
-      loadCoord[i] = zero;
-  }
 
   auto writeCLoop = gemmStoreOp->getParentOfType<TransformingForOp>();
   assert(writeCLoop && "global_store must be in a transforming_for");
@@ -497,8 +477,7 @@ Value applyTransforms(PatternRewriter &b, GlobalStoreOp gemmStoreOp, Value inp,
 
   // 1. insert broadcast op if necessary
   MemRefType outType = gemmStoreOp.getDest().getType();
-  std::tie(ret, outToInpMap) = makeTransposeTransform(b, ret, outToInpMap);
-  ret = makeBroadcast(b, outType, ret, outToInpMap);
+  ret = insertTransposeAndBroadcastTransforms(b, outType, ret, outToInpMap);
 
   // 2. also create global_store from global to regs
   //    TODO(sjw): make sure output buffer writes (means these inputs will be
@@ -538,6 +517,21 @@ static GlobalStoreOp traceToGlobalStore(Value inp) {
   return allValidUses ? result : GlobalStoreOp();
 }
 
+static AffineMap findAliasingOutputIdxMap(linalg::GenericOp laGeneric,
+                                          Value output) {
+  auto inpsAndIdxMaps =
+      llvm::zip(laGeneric.inputs(), laGeneric.getIndexingMapsArray());
+  auto aliasingOutput = std::find_if(
+      inpsAndIdxMaps.begin(), inpsAndIdxMaps.end(), [&](auto inpAndIndMap) {
+        Value inp = std::get<0>(inpAndIndMap);
+        if (inp == output) {
+          return true;
+        }
+        return false;
+      });
+  return std::get<1>(*aliasingOutput);
+}
+
 // Returns the value of the buffer that's meant to be the new writeback.
 static Value reconfigureLAGeneric(PatternRewriter &b,
                                   linalg::GenericOp laGeneric, Value laIn,
@@ -551,7 +545,6 @@ static Value reconfigureLAGeneric(PatternRewriter &b,
 
   AffineMap outIdxMap = idxMaps.back();
   auto invertOutIdxMap = inversePermutation(outIdxMap);
-
   SmallVector<AffineMap, 5> laGenericAMaps;
   SmallVector<Value, 5> newInputs;
   for (auto pair : llvm::zip(laGeneric.inputs(), idxMaps)) {
@@ -587,6 +580,61 @@ static Value reconfigureLAGeneric(PatternRewriter &b,
   return laOut;
 }
 
+static LogicalResult findGlobalStore(linalg::GenericOp laGeneric,
+                                     Value &inputLeadingToGlobalStore,
+                                     GlobalStoreOp &gemmStoreOp) {
+  for (auto pair :
+       llvm::zip(laGeneric.inputs(), laGeneric.getIndexingMapsArray())) {
+    AffineMap inpIdxMap = std::get<1>(pair);
+    Value input = std::get<0>(pair);
+    GlobalStoreOp maybeStore = traceToGlobalStore(input);
+    if (maybeStore) {
+      if (gemmStoreOp) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Multiple generic inputs come from writeback\n");
+        return failure();
+      }
+
+      auto aliasingOutputMap = findAliasingOutputIdxMap(laGeneric, input);
+      AffineMap invertOutIdxMap = inversePermutation(aliasingOutputMap);
+      auto outToInMap = inpIdxMap.compose(invertOutIdxMap);
+      SmallVector<unsigned> permutedDims;
+      // This is not to allow broadcasting but due to canonical linalg
+      // form if the unit dims can carry affine expr to be zero in the
+      // translation, hence there is a following check.
+      if (!outToInMap.isMinorIdentityWithBroadcasting(&permutedDims)) {
+        LLVM_DEBUG(llvm::dbgs() << outToInMap << "\n");
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "The store is not even a minor identity with broadcasting.\n");
+        return failure();
+      }
+      auto inpShape = input.getType().cast<ShapedType>().getShape();
+      LLVM_DEBUG(llvm::dbgs() << "outToInMap = " << outToInMap << "\n");
+      LLVM_DEBUG(llvm::dbgs() << "inp shape = "
+                              << input.getType().cast<ShapedType>() << "\n");
+      LLVM_DEBUG(llvm::dbgs() << "permutedDims = ");
+      LLVM_DEBUG(llvm::interleaveComma(permutedDims, llvm::dbgs()));
+      LLVM_DEBUG(llvm::dbgs() << "\n");
+
+      for (auto bDim : permutedDims) {
+        if (inpShape[bDim] != 1) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "The store input cannot be a real broacast.\n");
+          return failure();
+        };
+      }
+      gemmStoreOp = maybeStore;
+      inputLeadingToGlobalStore = input;
+    }
+  }
+  if (!gemmStoreOp) {
+    LLVM_DEBUG(llvm::dbgs() << "No input is leading to a global store.\n");
+    return failure();
+  }
+  return success();
+}
+
 LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
                                                   PatternRewriter &b) const {
   Location loc = laGeneric.getLoc();
@@ -611,44 +659,42 @@ LogicalResult MILARewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
     }
   }
 
-  SmallVector<AffineMap> idxMaps = laGeneric.getIndexingMapsArray();
-  AffineMap outIdxMap = idxMaps.back();
-  auto invertOutIdxMap = inversePermutation(outIdxMap);
+  if (laGeneric.getNumOutputs() != 1) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Currently, multi-output fusion is not supported.\n");
+    return failure();
+  }
 
   // 1. Trace input to global_store.
   // 1.1. Find the (implicit) gemm output
   GlobalStoreOp gemmStoreOp;
+  Value laGenericInputLeadingToGlobalStore;
+  if (findGlobalStore(laGeneric, laGenericInputLeadingToGlobalStore,
+                      gemmStoreOp)
+          .failed()) {
+    return failure();
+  }
+  auto actualLAGenericOut = laGeneric.getOutputOperand(0);
+  auto actualLAGenericOutIdxMap =
+      laGeneric.getTiedIndexingMap(actualLAGenericOut);
+  auto invertOutIdxMap = inversePermutation(actualLAGenericOutIdxMap);
+  if (laGenericInputLeadingToGlobalStore.getType() !=
+      actualLAGenericOut->get().getType()) {
+    LLVM_DEBUG(llvm::dbgs() << "Currently, we assume the shape of gemmStore op "
+                               "and linalg output is the same.\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "This instance it differs : "
+               << laGenericInputLeadingToGlobalStore.getType() << " vs "
+               << actualLAGenericOut->get().getType() << " .\n");
+    return failure();
+  }
+
+  SmallVector<AffineMap> idxMaps = laGeneric.getIndexingMapsArray();
   for (auto pair : llvm::zip(idxMaps, laGeneric.inputs())) {
     AffineMap inpIdxMap = std::get<0>(pair);
     auto outToInMap = inpIdxMap.compose(invertOutIdxMap);
     Value inp = std::get<1>(pair);
-    GlobalStoreOp maybeStore = traceToGlobalStore(inp);
-    if (maybeStore) {
-      if (gemmStoreOp) {
-        LLVM_DEBUG(llvm::dbgs()
-                   << "Multiple generic inputs come from writeback\n");
-        return failure();
-      }
-      SmallVector<unsigned> broadcastedDims;
-      // This is not to allow broadcasting but due to canonical linalg
-      // form if the unit dims can carry affine expr to be zero in the
-      // translation, hence there is a following check.
-      if (!outToInMap.isMinorIdentityWithBroadcasting(&broadcastedDims)) {
-        LLVM_DEBUG(
-            llvm::dbgs()
-            << "The store is not even a minor identity with broadcasting.\n");
-        return failure();
-      }
-      auto inpShape = inp.getType().cast<ShapedType>().getShape();
-      for (auto bDim : broadcastedDims) {
-        if (inpShape[bDim] != 1) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "The store input cannot be a real broacast.\n");
-          return failure();
-        };
-      }
-      gemmStoreOp = maybeStore;
-    } else {
+    if (inp != laGenericInputLeadingToGlobalStore) {
       SmallVector<unsigned> permutedDims;
       if (!outToInMap.isProjectedPermutation(/*allowZeroInResults=*/true)) {
         LLVM_DEBUG(llvm::dbgs() << outToInMap << "\n");

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -370,7 +370,7 @@ static Value insertTransposeAndBroadcastTransforms(PatternRewriter &b,
         isDimAdded = true;
         SmallString<8> name;
         ("exp" + Twine(i)).toVector(name);
-        addDimtransform.addDim(name, i, outShape[i]);
+        addDimtransform.addDim(name, i, outShape[perm[i]]);
       }
     }
     if (isDimAdded) {

--- a/mlir/test/fusion/e2e/mixr-bcast-add-align-tiling.mlir
+++ b/mlir/test/fusion/e2e/mixr-bcast-add-align-tiling.mlir
@@ -1,11 +1,14 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-opt --rock-fold-transpose -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise -rock-linalg-align | FileCheck %s
 
 module {
-    // CHECK-COUNT-2: %{{.*}} = rock.alloc() : memref<4xf32, 5>
-    // CHECK-NEXT: %[[vecBuf:.*]] = rock.alloc() : memref<4xf32, 5>
-    // CHECK-NEXT: rock.transforming_for {forceUnroll, useIndexDiffs}
-    // CHECK-NEXT: %[[ldVal:.*]] = rock.global_load
-    // CHECK-NEXT: rock.in_bounds_store %[[ldVal]] -> %[[vecBuf]]
+    // CHECK-DAG: #[[MAP1:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (d0, d3, d2, d1)> by [<PassThrough ["dim0", "dim3", "dim2", "dim1"] at [0, 1, 2, 3] -> ["dim0", "dim3", "dim2", "dim1"] at [0, 3, 2, 1]>] bounds = [1, 64, 112, 112] -> [1, 112, 112, 64]>
+    // CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (d3)> by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{112} ["exp1"] at [1] -> [] at []>, <AddDim{112} ["exp2"] at [2] -> [] at []>, <PassThrough ["dim0"] at [3] -> ["dim0"] at [0]>] bounds = [1, 112, 112, 64] -> [64]>
+    // CHECK: rock.transforming_for {{.*}} (%[[loadCoord:.*]]) = {{.*}}#[[MAP1]], #[[MAP2]]
+    // CHECK-SAME: bounds [1, 1, 1, 4]
+    // CHECK-SAME: strides [1, 1, 1, 1]
+    // CHECK-NEXT: rock.global_load %arg0[%[[loadCoord]]]
+    // CHECK: linalg.generic{{.*}} outs(%[[outBuf:.*]] : memref<4xf32, 5>)
+    // CHECK: global_store %[[outBuf]]{{.*}} -> %arg3
     func.func @test(%arg0: tensor<64xf32>, %arg1: tensor<1x3x224x224xf32>, %arg2: tensor<64x3x7x7xf32>) -> tensor<1x64x112x112xf32> attributes{kernel, arch = ""} {
         %0 = migraphx.broadcast(%arg0) {axis = 1:i64, out_lens= [1:i64, 64:i64, 112:i64, 112:i64] } : (tensor<64xf32>)-> tensor<1x64x112x112xf32>
         %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>) -> tensor<1x64x112x112xf32>

--- a/mlir/test/fusion/e2e/mixr-mbcast-add-align-tiling.mlir
+++ b/mlir/test/fusion/e2e/mixr-mbcast-add-align-tiling.mlir
@@ -1,11 +1,13 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-opt --rock-fold-transpose -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise -rock-linalg-align | FileCheck %s
 
 module {
-    // CHECK-COUNT-2: %{{.*}} = rock.alloc() : memref<4xf32, 5>
-    // CHECK-NEXT: %[[vecBuf:.*]] = rock.alloc() : memref<4xf32, 5>
-    // CHECK-NEXT: rock.transforming_for {forceUnroll, useIndexDiffs}
-    // CHECK-NEXT: %[[ldVal:.*]] = rock.global_load
-    // CHECK-NEXT: rock.in_bounds_store %[[ldVal]] -> %[[vecBuf]]
+    // CHECK-DAG: #[[MAP1:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)> by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>, <Broadcast{1} ["dim3"] at [3] -> ["dim3"] at [3]>] bounds = [1, 64, 112, 112] -> [1, 64, 1, 1]>
+    // CHECK: rock.transforming_for {{.*}} (%[[loadCoord:.*]]) = {{.*}}#[[MAP1]]
+    // CHECK-SAME: bounds [1, 1, 1, 4]
+    // CHECK-SAME: strides [1, 1, 1, 1]
+    // CHECK-NEXT: rock.global_load %arg0[%[[loadCoord]]]
+    // CHECK: linalg.generic{{.*}} outs(%[[outBuf:.*]] : memref<4xf32, 5>)
+    // CHECK: global_store %[[outBuf]]{{.*}} -> %arg3
     func.func @test(%arg0: tensor<1x64x1x1xf32>, %arg1: tensor<1x3x224x224xf32>, %arg2: tensor<64x3x7x7xf32>) -> tensor<1x64x112x112xf32> attributes{kernel, arch = ""} {
         %0 = migraphx.multibroadcast(%arg0) {out_lens = [1, 64, 112, 112]} : (tensor<1x64x1x1xf32>) -> tensor<1x64x112x112xf32>
         %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>) -> tensor<1x64x112x112xf32>

--- a/mlir/test/fusion/e2e/mixr-mbcast-add-relu-align-tiling-collapse-expand-chains.mlir
+++ b/mlir/test/fusion/e2e/mixr-mbcast-add-relu-align-tiling-collapse-expand-chains.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-opt --rock-fold-transpose -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise -rock-linalg-align | FileCheck %s
 
 module {
-    // CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)> by [<PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1, 1, 1} ["dim0", "dim2", "dim3"] at [0, 2, 3] -> ["dim0", "dim2", "dim3"] at [0, 2, 3]>] bounds = [4, 4, 1, 1] -> [1, 4, 1, 1]>
+    // CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)> by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>, <Broadcast{1} ["dim3"] at [3] -> ["dim3"] at [3]>] bounds = [4, 4, 1, 1] -> [1, 4, 1, 1]>
     // CHECK: rock.transforming_for{{.*}}#[[MAP]]
     // CHECK-NEXT: %[[ldVal:.*]] = rock.global_load{{.*}}: memref<1x4x1x1xf32> -> f32
     // CHECK-NEXT: rock.in_bounds_store %[[ldVal]]{{.*}}: f32 -> memref<1xf32, 5>, index

--- a/mlir/test/fusion/multi-collapse-expand-chains.mlir
+++ b/mlir/test/fusion/multi-collapse-expand-chains.mlir
@@ -4,7 +4,7 @@
 #transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)> by [<PassThrough ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>, <AddDim{1} ["g"] at [4] -> [] at []>] bounds = [4, 3, 3, 3, 1] -> [4, 3, 3, 3]>
 #transform_map1 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)> by [<PassThrough ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>, <AddDim{1} ["g"] at [4] -> [] at []>] bounds = [4, 4, 1, 1, 1] -> [4, 4, 1, 1]>
 module {
-    // CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)> by [<PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1, 1, 1} ["dim0", "dim2", "dim3"] at [0, 2, 3] -> ["dim0", "dim2", "dim3"] at [0, 2, 3]>] bounds = [4, 4, 1, 1] -> [1, 4, 1, 1]>
+    // CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)> by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>, <Broadcast{1} ["dim3"] at [3] -> ["dim3"] at [3]>] bounds = [4, 4, 1, 1] -> [1, 4, 1, 1]>
     // CHECK: rock.transforming_for{{.*}}#[[MAP]]
     // CHECK-NEXT: %[[ldVal:.*]] = rock.global_load{{.*}}: memref<1x4x1x1xf32> -> f32
     // CHECK-NEXT: rock.in_bounds_store %[[ldVal]]{{.*}}: f32 -> memref<1xf32, 5>, index

--- a/mlir/test/fusion/rock-bcast-exp.mlir
+++ b/mlir/test/fusion/rock-bcast-exp.mlir
@@ -1,7 +1,6 @@
 // RUN: rocmlir-opt --rock-fold-transpose -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise -rock-linalg-align %s | FileCheck %s
 
-// CHECK: #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)> by [<PassThrough ["dim4"] at [4] -> ["dim4"] at [4]>, <Broadcast{1, 1, 1, 1} ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>] bounds = [1, 1, 30, 30, 16] -> [1, 1, 1, 1, 16]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d4)> by [<PassThrough ["dim0"] at [4] -> ["dim0"] at [0]>, <AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>, <AddDim{1} ["exp2"] at [2] -> [] at []>, <AddDim{1} ["exp3"] at [3] -> [] at []>] bounds = [1, 1, 1, 1, 16] -> [16]>
+// CHECK: #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d4)> by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>, <AddDim{30} ["exp2"] at [2] -> [] at []>, <AddDim{30} ["exp3"] at [3] -> [] at []>, <PassThrough ["dim0"] at [4] -> ["dim0"] at [0]>] bounds = [1, 1, 30, 30, 16] -> [16]>
 
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4) -> (d4)>

--- a/mlir/test/fusion/rock-bcast.mlir
+++ b/mlir/test/fusion/rock-bcast.mlir
@@ -1,6 +1,6 @@
 // RUN: rocmlir-opt --rock-fold-transpose -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise -rock-linalg-align %s | FileCheck %s
 
-// CHECK:  <Broadcast{1, 1, 1, 1} ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>] bounds = [1, 1, 30, 30, 16] -> [1, 1, 1, 1, 16]>
+// CHECK:  #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d4)> by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>, <AddDim{30} ["exp2"] at [2] -> [] at []>, <AddDim{30} ["exp3"] at [3] -> [] at []>, <PassThrough ["dim0"] at [4] -> ["dim0"] at [0]>] bounds = [1, 1, 30, 30, 16] -> [16]>
 
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)>

--- a/mlir/test/fusion/tosa-to-rock-tp-add.mlir
+++ b/mlir/test/fusion/tosa-to-rock-tp-add.mlir
@@ -1,6 +1,6 @@
 // RUN: rocmlir-driver --host-pipeline highlevel %s | rocmlir-opt --rock-fold-transpose --rock-affix-params --rock-conv-to-gemm --rock-gemm-to-gridwise --rock-gridwise-gemm-to-blockwise --rock-linalg-align | FileCheck %s
 // CHECK-DAG: #[[MAP1:.*]] = #rock.transform_map<affine_map<{{.*}} by [<PassThrough ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>, <AddDim{1} ["g"] at [4] -> [] at []>] bounds = [256, 28, 28, 64, 1] -> [256, 28, 28, 64]>
-// CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<affine_map<{{.*}}> by [<PassThrough ["dim0", "dim1", "dim2", "dim3"] at [0, 3, 1, 2] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>] bounds = [256, 28, 28, 64] -> [256, 64, 28, 28]>
+// CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<affine_map<{{.*}}> by [<PassThrough ["{{.*}}", "{{.*}}", "{{.*}}", "{{.*}}"] at [0, 1, 2, 3] -> ["{{.*}}", "{{.*}}", "{{.*}}", "{{.*}}"] at [0, 2, 3, 1]>] bounds = [256, 28, 28, 64] -> [256, 64, 28, 28]>
 // CHECK: rock.transforming_for{{.*}}#[[MAP1]]
 // CHECK: rock.transforming_for
 // CHECK-SAME: [#[[MAP2]]]


### PR DESCRIPTION
This commit contains code that cleans up
AlignTiling pass to use a single place
to add transforms cater both transpose
and broadcasting.