### PR TITLE
Fix MIGraphX to Tosa to support 2D matmul

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -41,7 +41,7 @@ static bool isBroadcastable(Operation *op, Operation *operand) {
 template <typename TosaOp, typename... Args>
 static TosaOp createOpAndInfer(mlir::PatternRewriter &rewriter,
                                mlir::Location loc, Type elemType,
-                               Args &&... args) {
+                               Args &&...args) {
   auto op =
       rewriter.create<TosaOp>(loc, UnrankedTensorType::get(elemType), args...);
   InferShapedTypeOpInterface shapeInterface =
@@ -320,7 +320,8 @@ public:
     ArrayRef<int64_t> orgOutDims = outputTy.getShape();
     RankedTensorType newOutType = RankedTensorType::get(orgOutDims, elementTy);
     size_t outRank = orgOutDims.size();
-    if (outRank > 3) { // A, B, Out have the same rank
+
+    if (outRank != 3) { // A, B, Out have the same rank. rank=2 assumes batch=1
       ArrayRef<int64_t> orgDimsA = in_A.getType().cast<ShapedType>().getShape();
       ArrayRef<int64_t> orgDimsB = in_B.getType().cast<ShapedType>().getShape();
       int64_t batchSize = 1;
@@ -354,7 +355,7 @@ public:
     if (auto attr = op->getAttrOfType<StringAttr>("perf_config"))
       mop->setAttr("perf_config", attr);
 
-    if (outRank > 3) {
+    if (outRank != 3) {
       auto rop = rewriter.create<tosa::ReshapeOp>(
           loc, outputTy, mop, rewriter.getI64ArrayAttr(orgOutDims));
       rewriter.replaceOp(op, {rop});

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -15,6 +15,13 @@ module  {
      return %0 : tensor<2x16x256x768xf32>
   }
 
+  // CHECK-LABEL: func.func @matmul_rank2
+  // CHECK: tosa.matmul
+  func.func @matmul_rank2(%arg0: tensor<32x72xf32>, %arg1: tensor<72x64xf32>) -> tensor<32x64xf32> {
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<32x72xf32>, tensor<72x64xf32>) -> tensor<32x64xf32>
+     return %0 : tensor<32x64xf32>
+  }
+
   // CHECK-LABEL: func.func @func_power
   // CHECK: tosa.pow
   func.func @func_power(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf32> {


### PR DESCRIPTION
Turns out tosa always requires batch dimension.