### PR TITLE
Fixing vectorization decision with gcd of per block length

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -96,15 +96,13 @@ bestVectorization(OpBuilder &b, Value matrix, int64_t dataPerThread,
   std::tie(tensor, transforms) = untransform(b, matrix);
   ArrayRef<int64_t> tensorShape =
       tensor.getType().cast<MemRefType>().getShape();
-  int64_t kVectorLen =
-      getMaxVectorization(transforms, static_cast<uint32_t>(GemmDimension::K),
-                          dataPerThread, tensorShape);
-  kVectorLen = std::min(kVectorLen, kPerBlock);
+  int64_t kVectorLen = getMaxVectorization(
+      transforms, static_cast<uint32_t>(GemmDimension::K),
+      math_util::gcd(dataPerThread, kPerBlock), tensorShape);
 
   int64_t dVectorLen = getMaxVectorization(
-      transforms, static_cast<uint32_t>(GemmDimension::MorN), dataPerThread,
-      tensorShape);
-  dVectorLen = std::min(dVectorLen, dPerBlock);
+      transforms, static_cast<uint32_t>(GemmDimension::MorN),
+      math_util::gcd(dataPerThread, dPerBlock), tensorShape);
 
   if (kVectorLen > dVectorLen)
     return {GemmDimension::K, kVectorLen};


### PR DESCRIPTION
This fixed the previous review comments here: https://github.com/ROCmSoftwarePlatform/rocMLIR/commit/ef3f98f23bd6657d79daf0fbbc5b73800c5723f6#comments