### PR TITLE
Use llvm.assume to encode bounds on block and grid sizes

### DIFF
--- a/mlir/include/mlir/Conversion/RocMLIRPasses.td
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.td
@@ -32,7 +32,9 @@ def ConvertRockToGPUPass : Pass<"convert-rock-to-gpu", "ModuleOp"> {
     "amdgpu::AMDGPUDialect",
     "cf::ControlFlowDialect",
     "func::FuncDialect",
-    "gpu::GPUDialect"
+    "gpu::GPUDialect",
+    "arith::ArithmeticDialect",
+    "LLVM::LLVMDialect",
   ];
 }
 

--- a/mlir/test/Conversion/RockToGPU/misc_ops.mlir
+++ b/mlir/test/Conversion/RockToGPU/misc_ops.mlir
@@ -17,7 +17,30 @@ module {
     // CHECK: %{{.*}} = gpu.thread_id x
     %tid = rock.workitem_id : index
 
+    // CHECK-NOT: llvm.intr.assume
     %idx = arith.muli %bid, %tid : index
+
+    %val = memref.load %arg0[%idx] : memref<?xf32>
+
+    memref.store %val, %arg1[%idx] : memref<?xf32>
+    return
+  }
+
+  // CHECK-LABEL: func @launch_dims
+  func.func @launch_dims(%arg0: memref<?xf32>, %arg1: memref<?xf32>) attributes {kernel = 0 : i32, block_size = 64 : i32, grid_size = 512 : i32} {
+    // CHECK-DAG: %[[c64:.*]] = arith.constant 64 : index
+    // CHECK-DAG: %[[c512:.*]] = arith.constant 512 : index
+    // CHECK: %[[bid:.*]] = gpu.block_id x
+    // CHECK: %[[cmpGroup:.*]] = arith.cmpi ult, %[[bid]], %[[c512]]
+    // CHECK: "llvm.intr.assume"(%[[cmpGroup]]) : (i1) -> ()
+    %bid = rock.workgroup_id : index
+
+    // CHECK: %[[tid:.*]] = gpu.thread_id x
+    // CHECK: %[[cmpBlock:.*]] = arith.cmpi ult, %[[tid]], %[[c64]]
+    // CHECK: "llvm.intr.assume"(%[[cmpBlock]]) : (i1) -> ()
+    %tid = rock.workitem_id : index
+
+   %idx = arith.muli %bid, %tid : index
 
     %val = memref.load %arg0[%idx] : memref<?xf32>
 


### PR DESCRIPTION
Since our rock kernels know their launch dimensions, we can bound the workgroup and workitem IDs from above by those dimensions. LLVM has an assume intrinsic that is, in effect, an assert() that doesn't actually generate code. The manual does warn that you shouldn't use this to annotate thing the optimizer could infer, but the launch dimensions of a kernel are not such a piece of information.

Performance measurements for Navi21 and comparisons of the generated assembly will be added as comments to the PR once I have them.