### PR TITLE
Add warning when float random inputs have both positive and negative numbers

### DIFF
--- a/mlir/test/e2e/conv2d_regression_bwd.toml
+++ b/mlir/test/e2e/conv2d_regression_bwd.toml
@@ -1,6 +1,6 @@
 directory = "conv2d_regression_bwd"
 prefix = "rocmlir-gen"
-suffix = "-rand_type float -rand_min 1 -rand_max 3 -relDiff_threshold 0.000035 -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "-rand_type float -relDiff_threshold 0.00004 -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"

--- a/mlir/test/e2e/conv2d_regression_fwd.toml
+++ b/mlir/test/e2e/conv2d_regression_fwd.toml
@@ -1,6 +1,6 @@
 directory = "conv2d_regression_fwd"
 prefix = "rocmlir-gen"
-suffix = "-rand_type float -rand_min 1 -rand_max 3 -relDiff_threshold 0.00001 -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "-rand_type float -relDiff_threshold 0.00001 -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"

--- a/mlir/test/xmir/e2e/resnet18_blk3.mlir
+++ b/mlir/test/xmir/e2e/resnet18_blk3.mlir
@@ -1,6 +1,6 @@
 // RUN: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | rocmlir-gen -ph -print-results -rand 1 -rand_type float -verifier clone -fut forward - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 
-// CHECK: RMS = {{.*}}e-08
+// CHECK: RMS = {{.*}}e-07
 // COM: CHECK: RMS = {{.*}}e-0[[#%d,RMS:]]
 // COM: how to check min(7, RMS) == 7
 // CHECK: [1 1 0]

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1943,9 +1943,24 @@ static void emitPrintTensor(OpBuilder &b, Value var) {
   }
 }
 
+static void checkRandomInputsE2E() {
+  if (randomSeed != "none" && randomSeed != "fixed" &&
+      randomDataType == "float") {
+    int min = randMin.getValue();
+    int max = randMax.getValue();
+    if ((-1 <= min && min < 1) || (-1 < max && max <= 1)) {
+      llvm::outs() << "WARNING: E2E tests with float random inputs within ";
+      llvm::outs() << "[-1, 1] may fail\n";
+      llvm::outs() << "         Try range [1, 3] by setting ";
+      llvm::outs() << "\"-rand_min 1 -rand_max 3\"\n";
+    }
+  }
+}
+
 static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
                                        MemRefType testType,
                                        MemRefType valType) {
+  checkRandomInputsE2E();
   auto kfunc = kernel.func;
   std::string funcName = kfunc.getName().str() + "_verify";
   func::FuncOp func = module.lookupSymbol<func::FuncOp>(funcName);

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1948,11 +1948,12 @@ static void checkRandomInputsE2E() {
       randomDataType == "float") {
     int min = randMin.getValue();
     int max = randMax.getValue();
-    if ((-1 <= min && min < 1) || (-1 < max && max <= 1)) {
-      llvm::outs() << "WARNING: E2E tests with float random inputs within ";
-      llvm::outs() << "[-1, 1] may fail\n";
-      llvm::outs() << "         Try range [1, 3] by setting ";
-      llvm::outs() << "\"-rand_min 1 -rand_max 3\"\n";
+    if (min < 0 && max > 0) {
+      llvm::errs() << "WARNING: E2E tests with float random inputs within ";
+      llvm::errs() << "WARNING: E2E tests may fail with both positive and ";
+      llvm::errs() << "negative float random inputs\n";
+      llvm::errs() << "         Try range [1, 3] by setting ";
+      llvm::errs() << "\"-rand_min 1 -rand_max 3\"\n";
     }
   }
 }

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -475,7 +475,7 @@ static llvm::cl::opt<std::string> randomSide(
 // float random inputs range
 static llvm::cl::opt<int>
     randMin("rand_min", llvm::cl::desc("lower bound for float random input"),
-            llvm::cl::value_desc("range"), llvm::cl::init(-1));
+            llvm::cl::value_desc("range"), llvm::cl::init(0));
 
 static llvm::cl::opt<int>
     randMax("rand_max", llvm::cl::desc("upper bound for float random input"),


### PR DESCRIPTION
This PR prints a warning message when float random inputs within [-1, 1] are used for E2E tests. It suggests to use [1,3] as the range for float random inputs.