### PR TITLE
Remove Tosa layerwise constant folding to avoid mixed layout in Rock

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/XModel/Pipelines/Pipelines.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/XModel/Pipelines/Pipelines.cpp
@@ -58,13 +58,10 @@ void xmodel::buildGraphPipeline(OpPassManager &pm,
                                 const xmodel::GraphOptions &options) {
   // TOSA partitioning pass
   // make 'kernel' funcs with tosa dataflow
-  /* mlir-opt --tosa-layerwise-constant-fold --tosa-make-broadcastable
+  /* mlir-opt --tosa-make-broadcastable
          --tosa-partition
    */
-  pm.addNestedPass<func::FuncOp>(tosa::createTosaLayerwiseConstantFoldPass());
   pm.addNestedPass<func::FuncOp>(tosa::createTosaMakeBroadcastablePass());
-
-  // Canonicalizer applies constant/transpose folding
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
   SmallVector<std::string, 4> anchors{"tosa.conv2d", "tosa.depthwise_conv2d",


### PR DESCRIPTION
We had this pass added early in our Tosa pipeline for reasons I'm not entirely clear on. The tosa to linalg passes will run this transformation, and those passes run after tosa-to-rock, and so therefore we don't lose the fact that constant tensors are NCHW. We also won't have to go through a lot of dramatics to un-transpose the constants.