### PR TITLE
Allow Resnet50 fusion tests to run on nightly testing

### DIFF
--- a/mlir/test/fusion/e2e/resnet50/lit.local.cfg
+++ b/mlir/test/fusion/e2e/resnet50/lit.local.cfg
@@ -1,0 +1,2 @@
+if not config.enable_rock_driver_e2e_test or config.no_AMD_GPU:
+  config.unsupported = True


### PR DESCRIPTION
This commits adds the config to only allow resnet50 tests run where e2e tests are allowed (i.e. nightly).