### PR TITLE
[DO NOT MERGE] Move the second LDS barrier

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -554,6 +554,10 @@ struct BlockwiseGemmV2RewritePattern
       lklb.create<memref::StoreOp>(loc, valueB, bufferB, ValueRange{lkliv});
     }
 
+    // LDS barrier: LDS_fence and WG_barrier to ensure all data has been read
+    // out from LDS.
+    b.create<LDSBarrierOp>(loc);
+
     // Workload of either MPerWave and NPerWave that are larger
     // than wave size of 64 will be executed by repeats
     // TODO: amend this for tuning parameter selection as well

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1282,7 +1282,8 @@ struct GridwiseGemmV2RewritePattern
               .getBeginOperandIndex(),
           iv);
 
-      // LDS barrier.
+      // LDS barrier : LDS_fence and WG_barrier to guarantee LDS updates are
+      // completed.
       b.create<LDSBarrierOp>(loc);
 
       // Emit blockwise GEMM.
@@ -1291,10 +1292,6 @@ struct GridwiseGemmV2RewritePattern
           b.getIndexAttr(ldsBlockBOffset), mMyWaveOffsetA, mMyWaveOffsetB,
           arrayA, arrayB, regCAllocOp, op.getBlockSizeAttr(),
           op.getParamsAttr());
-
-      // LDS barrier.
-      // This barrier prevents halo part of outputs having weird values.
-      b.create<LDSBarrierOp>(loc);
 
       // Emit blockwise stores
       BlockAndValueMapping storeAUpdates, storeBUpdates;


### PR DESCRIPTION
I might be forgetting something but reviewed the barrier again and wonder this can be reschduled as this.

The point is, MFMA instruction itself doesn't really resolve or set any LDS/WG related dependency. Accumulator register is not shared across waves and only LDS-to-(acc)register data read needs to be fenced.

Local test looks fine but need more tests and performance numbers.