### PR TITLE
Fixing pytorch build by ignore conda build path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ if( BUILD_FAT_LIBROCKCOMPILER )
   set(MLIR_INCLUDE_INTEGRATION_TESTS OFF CACHE BOOL "")
   set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "")
   set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
+  # Note, this is a hack to ignore Pytorch added conda path
+  list(APPEND CMAKE_IGNORE_PATH /opt/conda)
 else()
   set(BUILD_SHARED_LIBS ON CACHE BOOL "")
   set(LLVM_BUILD_LLVM_DYLIB ON CACHE BOOL "")


### PR DESCRIPTION
To be reverted when corresponding fix is pushed to pytorch