### PR TITLE
Bugfixes found in the process of creating PR #903

### DIFF
--- a/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
+++ b/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
@@ -101,6 +101,11 @@ static llvm::cl::opt<std::string>
     arch("arch", llvm::cl::desc("Arch (ignored, MLIR compat)"),
          llvm::cl::init("gemm"));
 
+static llvm::cl::opt<std::string>
+    perfConfig("perf_config",
+               llvm::cl::desc("Perf config (ignored, MLIR compat)"),
+               llvm::cl::init(""));
+
 static size_t getByteSize(size_t elems, bool isOut) {
   switch (dataType) {
   case DataType::F32:


### PR DESCRIPTION
1. Add a perf_config option that's ignored to the rocblas driver so that rocblas benchmarks actually run
2. Change the xdlops tuning ranges to match MIOpen, including the different KPerBlock for int32, with the exception that we now also include kPack=1 in the xdlops range to prevent another "tuning made things slower" situation.