### PR TITLE
[hotfix] Disable not unrolling load/store loops

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -366,6 +366,12 @@ PopulateParamsXDL::isValidBlockwiseGemmXDLOPS(const InitParamsXDL &param,
   if ((param.gemmNPerBlock % param.gemmNPerWave) != 0)
     return failure();
 
+  // Sledgehammer hotfix because not unrolling sometimes makes the register
+  // allocator break. This should be refined quickly.
+  if (param.gemmAThreadCopyMoreGemmK == false) {
+    return failure();
+  }
+
   // Reject invalid KPACK values.
   if (!XdlopsCodeSelection::get(dataType, param.gemmMPerWave,
                                 param.gemmNPerWave)

--- a/mlir/test/rocmlir-driver/tuning_parameter_forceunroll.mlir
+++ b/mlir/test/rocmlir-driver/tuning_parameter_forceunroll.mlir
@@ -1,3 +1,6 @@
+// Loop unrolling stubbed out by hotfix
+// XFAIL: *
+
 // RUN: rocmlir-gen --operation conv2d -t f32 --arch gfx908 --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 256 --in_channels 1024 --in_h 14 --in_w 14 --out_channels 2048 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 2 --padding_h 0 --padding_w 0 --perf_config="16,16,64,16,16,1,1,1" | rocmlir-driver  -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-gridwise-gemm-to-blockwise | FileCheck %s --check-prefix=UNROLL
 
 // UNROLL: #xdlops_gemm_params = #rock.xdlops_gemm_params<kPerBlock = 64, mPerBlock = 16, nPerBlock = 16, kpack = 1, mPerWave = 16, nPerWave = 16, forceUnroll = true>


### PR DESCRIPTION
This commit temporarily disables forceUnroll = false as a valid parameter setting for xdlops tuning, because in some cases it causes register allocator failures (we think).

Future work should be happening now to loosen this restriction.