### PR TITLE
Extend the fusion/e2e tests to f16 and bf16.

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -115,9 +115,11 @@ endif()
 
 # Enable the ROCK E2E tests if -DROCK_E2E_TEST_ENABLED=1
 if(ROCK_E2E_TEST_ENABLED OR ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED)
-  list(APPEND ROCMLIR_TEST_DEPENDS e2e_tests)
+  list(APPEND ROCMLIR_TEST_DEPENDS e2e_tests fusion-e2e-tests)
   add_subdirectory(e2e)
+  add_subdirectory(fusion)
 endif()
+
 
 add_custom_target(check-rocmlir-build-only
   DEPENDS ${ROCMLIR_TEST_DEPENDS})
@@ -143,4 +145,12 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_BINARY_DIR}/e2e/lit.site.cfg.py
   MAIN_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/e2e/lit.cfg.py
+)
+
+# Update the configs for fusion E2E tests
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/fusion/e2e/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/fusion/e2e/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/fusion/e2e/lit.cfg.py
 )

--- a/mlir/test/fusion/CMakeLists.txt
+++ b/mlir/test/fusion/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(e2e)
+add_subdirectory(xdlops)

--- a/mlir/test/fusion/e2e/CMakeLists.txt
+++ b/mlir/test/fusion/e2e/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Dependencies for the E2E test only
+set(FUSION_E2E_DEPENDS
+  FileCheck count not
+  rocmlir-opt
+  rocmlir-gen
+  rocmlir-driver
+  mlir-cpu-runner
+  xmir-runner
+  mlir_rocm_runtime
+  mlir_runner_utils
+  mlir_c_runner_utils
+  conv-validation-wrappers
+  fusion-e2e-tests
+)
+
+set(E2E_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(E2E_GEN_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/generate-fusion-tests.py")
+set(CONFIG_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(LOCAL_CONFIG_FILE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/lit.local.cfg)
+set(LOCAL_CONFIG_FILE_BIN ${CMAKE_CURRENT_BINARY_DIR}/lit.local.cfg)
+
+# Add a command to copy lit.local.cfg
+add_custom_command(OUTPUT ${LOCAL_CONFIG_FILE_BIN}
+  COMMAND ${CMAKE_COMMAND} -E copy ${LOCAL_CONFIG_FILE_SRC} ${LOCAL_CONFIG_FILE_BIN}
+  COMMENT "Copying lit.local.cfg"
+)
+
+# Add a target to trigger E2E tests generation unconditionally
+add_custom_target(fusion-e2e-tests)
+add_custom_command(TARGET fusion-e2e-tests
+    COMMAND ${Python3_EXECUTABLE} ${E2E_GEN_SCRIPT} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating fusion E2E tests"
+  )
+
+# Add a new target to run the E2E test only
+add_lit_testsuite(check-fusion-e2e "Running fusion e2e tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${FUSION_E2E_DEPENDS}
+)

--- a/mlir/test/fusion/e2e/generate-fusion-tests.py
+++ b/mlir/test/fusion/e2e/generate-fusion-tests.py
@@ -25,7 +25,7 @@ def generate_option_list(table, key1, key2):
         combinations.append(opt);
     return combinations
 
-def generate_tosa_to_rock_test(indir, outdir, type, file, opspec):
+def generate_op_variants_test(indir, outdir, type, file, opspec):
     opname,op = opspec
     with open(f"{indir}/{file}.e2e.template") as f:
         template = f.read()
@@ -56,9 +56,9 @@ def toml_loop(toml, indir, outdir):
     for suite in toml['suite']:
         combinations = generate_option_list(suite, 'axis', 'values')
         for test in combinations:
-            if suite['name'] == "tosa-to-rock tests":
-                generate_tosa_to_rock_test(indir, outdir, *test)
-            elif suite['name'] == "type-only tests":
+            if suite['kind'] == "op-variants":
+                generate_op_variants_test(indir, outdir, *test)
+            elif suite['kind'] == "type-only":
                 generate_type_only_test(indir, outdir, *test)
             else:
                 raise Exception("unknown test suite")

--- a/mlir/test/fusion/e2e/generate-fusion-tests.py
+++ b/mlir/test/fusion/e2e/generate-fusion-tests.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import shutil
+import glob
+import itertools
+import tomli
+
+RANDTYPE = {'f32' : 'float',
+            'f16' : 'float',
+            'bf16' : 'float',
+            'i32' : 'int',
+            'i8' : 'int'}
+
+def generate_option_list(table, key1, key2):
+    options_list=[]
+    for item in table[key1]:
+        options=[]
+        for value in item[key2]:
+            options.append(value)
+        options_list.append(options)
+    combinations=[]
+    for opt in itertools.product(*options_list):
+        combinations.append(opt);
+    return combinations
+
+def generate_tosa_to_rock_test(indir, outdir, type, file, opspec):
+    opname,op = opspec
+    with open(f"{indir}/{file}.e2e.template") as f:
+        template = f.read()
+    outfile = f"{outdir}/{file}-{opname}-{type}.e2e.mlir"
+    with open(outfile, 'w') as f:
+        # The instruction operand is in the middle for clamp, so we can't simply
+        # substitute.  With a regexp replace we could capture the actual operand
+        # but for now we'll just "know" what we have.
+        op = op.format(operand='(%0)')
+        f.write(template.format(op=op, type=type,
+                                randtype=RANDTYPE[type],
+                                randkind='fixed' if opname != 'rsqrt' else '1',
+                                # So far clone-verification only works with f32.  Also, tanh
+                                # fails it because math.tanh is converted by gpu-to-rocdl pass
+                                # which isn't run on the cloned function.
+                                disablep='-DISABLE' if type != 'f32' or opname == 'tanh' else ''))
+
+def generate_type_only_test(indir, outdir, type, file):
+    with open(f"{indir}/{file}.e2e.template") as f:
+        template = f.read()
+    outfile = f"{outdir}/{file}-{type}.e2e.mlir"
+    with open(outfile, 'w') as f:
+        f.write(template.format(type=type,
+                                # So far clone-verification only works with f32.
+                                disablep='-DISABLE' if type != 'f32' else ''))
+
+def toml_loop(toml, indir, outdir):
+    for suite in toml['suite']:
+        combinations = generate_option_list(suite, 'axis', 'values')
+        for test in combinations:
+            if suite['name'] == "tosa-to-rock tests":
+                generate_tosa_to_rock_test(indir, outdir, *test)
+            elif suite['name'] == "type-only tests":
+                generate_type_only_test(indir, outdir, *test)
+            else:
+                raise Exception("unknown test suite")
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('indir', default=os.getcwd())
+parser.add_argument('outdir', default=os.getcwd())
+args = parser.parse_args()
+
+def run():
+    indir = args.indir
+    outdir = args.outdir
+
+#     # shutil.copytree isn't recursively copying in some circumstances.
+#     for dir,*_ in os.walk(indir):
+#         if dir == indir:
+#             dir = '.'
+#         elif dir.startswith(indir):
+#             dir = dir[len(indir):].lstrip('/')
+#         outsubdir = os.path.join(outdir, dir)
+#         os.makedirs(outsubdir, exist_ok=True)
+#         for file in glob.glob(os.path.join(indir, '*.mlir')):
+#             shutil.copy(file, outsubdir)
+
+    def ignore_not_mlir(dir, files):
+        return [f for f in files if not f.endswith('.mlir')
+                                    and not os.path.isdir(os.path.join(dir, f))]
+    shutil.copytree(indir, outdir, ignore=ignore_not_mlir, dirs_exist_ok=True)
+    shutil.copy(os.path.join(indir, "lit.local.cfg"), outdir)
+
+    with open(os.path.join(indir, "tests.toml"), 'rb') as f:
+        toml = tomli.load(f)
+    toml_loop(toml, indir, outdir)
+
+
+if __name__ == '__main__':
+    run()
+    print("DONE!")

--- a/mlir/test/fusion/e2e/lit.cfg.py
+++ b/mlir/test/fusion/e2e/lit.cfg.py
@@ -16,7 +16,7 @@ from lit.llvm.subst import FindTool
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'ROCK E2E'
+config.name = 'Fusion E2E'
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
@@ -24,7 +24,7 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.suffixes = ['.mlir']
 
 # test_source_root: The root path where tests are located.
-config.test_source_root = os.path.join(config.mlir_obj_root, 'mlir/test/e2e')
+config.test_source_root = os.path.join(config.mlir_obj_root, 'mlir/test/fusion/e2e')
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.mlir_obj_root, 'test')
 
@@ -83,8 +83,7 @@ tools.extend([
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
     ToolSubst('%linalg_test_lib_dir', config.linalg_test_lib_dir, unresolved='ignore'),
     ToolSubst('%mlir_runner_utils_dir', config.mlir_runner_utils_dir, unresolved='ignore'),
-    ToolSubst('%conv_validation_wrapper_library_dir',
-              config.conv_validation_wrapper_library_dir, unresolved='fatal'),
+    ToolSubst('%conv_validation_wrapper_library_dir', config.conv_validation_wrapper_library_dir, unresolved='fatal'),
 ])
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/mlir/test/fusion/e2e/lit.local.cfg
+++ b/mlir/test/fusion/e2e/lit.local.cfg
@@ -1,0 +1,4 @@
+# This'll run whenever we're not building a fat library build, and isn't
+# controlled by the e2e test switches.
+if not config.enable_rock_driver_any_e2e_test or config.no_AMD_GPU:
+  config.unsupported = True

--- a/mlir/test/fusion/e2e/lit.site.cfg.py.in
+++ b/mlir/test/fusion/e2e/lit.site.cfg.py.in
@@ -1,0 +1,75 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+import subprocess
+
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_shlib_dir = "@SHLIBDIR@"
+config.llvm_shlib_ext = "@SHLIBEXT@"
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.python_executable = "@Python3_EXECUTABLE@"
+config.mlir_src_root = "@MLIR_SOURCE_DIR@"
+config.mlir_obj_root = "@MLIR_BINARY_DIR@"
+config.mlir_runner_utils_dir = "@MLIR_RUNNER_UTILS_DIR@"
+config.mlir_tools_dir = "@MLIR_TOOLS_DIR@"
+config.mlir_rock_tools_dir = "@ROCMLIR_TOOLS_DIR@"
+config.linalg_test_lib_dir = "@MLIR_DIALECT_LINALG_INTEGRATION_TEST_LIB_DIR@"
+config.mlir_lib_dir = "@MLIR_LIB_DIR@"
+config.conv_validation_wrapper_library_dir = "@MLIR_CONV_VALIDATION_WRAPPER_LIBRARY_DIR@"
+config.allow_e2e_tests = @ROCK_E2E_TEST_ENABLED@ or @ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED@
+config.enable_rocm_runner = @MLIR_ENABLE_ROCM_RUNNER@
+if config.enable_rocm_runner:
+    config.available_features.add('rocm-runner')
+config.enable_rock_driver_e2e_test = @ROCMLIR_DRIVER_E2E_TEST_ENABLED@
+config.enable_rock_driver_pr_e2e_test = @ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED@
+config.enable_rock_driver_any_e2e_test = config.enable_rock_driver_pr_e2e_test or config.enable_rock_driver_e2e_test
+if config.enable_rock_driver_any_e2e_test:
+    config.available_features.add('rock-any-e2e')
+config.enable_bindings_python = @MLIR_BINDINGS_PYTHON_ENABLED@
+config.random_data = "@MLIR_RANDOM_DATA@"
+config.rocmlir_gen_flags = "@ROCMLIR_GEN_FLAGS@"
+config.populate_validation = "@MLIR_POPULATE_VALIDATION@"
+config.rocm_path = "@ROCM_PATH@"
+
+# Support substitution of the tools_dir with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_shlib_dir = config.llvm_shlib_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# If rocm_agent_enumerator shows no viable GPUs, skip tests that need one,
+# because the default target will lead to compilation failures.
+config.no_AMD_GPU = False
+config.arch = ""
+config.arch_support_mfma = False
+if config.rocm_path:
+    try:
+        p = subprocess.run([config.rocm_path + "/bin/rocm_agent_enumerator", "-name"],
+                           check=True, stdout=subprocess.PIPE)
+        agents = set(x.decode("utf-8") for x in p.stdout.split())
+        if not agents:
+            # TODO: Remove this workaround for a bug in rocm_agent_enumerator -name
+            # Once https://github.com/RadeonOpenCompute/rocminfo/pull/59 lands
+            q = subprocess.run([config.rocm_path + "/bin/rocm_agent_enumerator"],
+                                check=True, stdout=subprocess.PIPE)
+            agents = set(x.decode("utf-8") for x in q.stdout.split() if x != b"gfx000")
+        config.arch = ','.join(agents)
+        for x in agents:
+            if "gfx908" in x or "gfx90a" in x:
+                config.arch_support_mfma = True
+            # Check other features here
+        if not config.arch:
+            config.no_AMD_GPU = True
+    except subprocess.CalledProcessError:
+        config.no_AMD_GPU = True
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@MLIR_SOURCE_DIR@/test/fusion/e2e/lit.cfg.py")

--- a/mlir/test/fusion/e2e/mixr-bcast-add.e2e.template
+++ b/mlir/test/fusion/e2e/mixr-bcast-add.e2e.template
@@ -1,0 +1,12 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+
+// CHECK:  6,     6,     6,     6
+module {{
+  func.func @main0(%arg0: tensor<1x5x4x4x{type}>, %arg1: tensor<4x5x1x1x{type}>, %arg2: tensor<4x{type}>) -> tensor<1x4x4x4x{type}> attributes{{kernel, arch = ""}} {{
+    %0 = "migraphx.convolution"(%arg0, %arg1) {{padding = [0:i64, 0:i64, 0:i64, 0:i64], stride = [1:i64, 1:i64], dilation = [1:i64, 1:i64], group = 1:i64}} : (tensor<1x5x4x4x{type}>, tensor<4x5x1x1x{type}>) -> tensor<1x4x4x4x{type}>
+    %1 = "migraphx.broadcast"(%arg2) {{axis = 1:i64, out_lens= [1:i64, 4:i64, 4:i64, 4:i64] }} : (tensor<4x{type}>)-> tensor<1x4x4x4x{type}>
+    %2 = "migraphx.add"(%0, %1) {{}} : (tensor<1x4x4x4x{type}>, tensor<1x4x4x4x{type}>)-> tensor<1x4x4x4x{type}>
+    return %2 : tensor<1x4x4x4x{type}>
+  }}
+}}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-add.e2e.template
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-add.e2e.template
@@ -1,0 +1,18 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN{disablep}: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_add --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+module {{
+  // CHECK:  [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_add(%arg0: tensor<1x5x4x{type}>, %arg1: tensor<1x4x3x{type}>, %arg2: tensor<1x5x3x{type}>) -> tensor<1x5x3x{type}> attributes{{kernel, arch = ""}} {{
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4x{type}>, tensor<1x4x3x{type}>) -> tensor<1x5x3x{type}>
+    %2 = "migraphx.add"(%0, %arg2) {{}} : (tensor<1x5x3x{type}>, tensor<1x5x3x{type}>)-> tensor<1x5x3x{type}>
+    return %2 : tensor<1x5x3x{type}>
+  }}
+}}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-bcast-add.e2e.template
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-bcast-add.e2e.template
@@ -1,0 +1,20 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN{disablep}: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_broadcast_add --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+
+module {{
+  // CHECK:  [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5],
+  // CHECK-NEXT: [5,     5,     5]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_broadcast_add(%arg0: tensor<1x5x4x{type}>, %arg1: tensor<1x4x3x{type}>, %arg2: tensor<3x{type}>) -> tensor<1x5x3x{type}> attributes{{kernel, arch = ""}} {{
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4x{type}>, tensor<1x4x3x{type}>) -> tensor<1x5x3x{type}>
+    %1 = "migraphx.broadcast"(%arg2) {{axis = 2:i64, out_lens= [1:i64, 5:i64, 3:i64] }} : (tensor<3x{type}>)-> tensor<1x5x3x{type}>
+    %2 = "migraphx.add"(%0, %1) {{}} : (tensor<1x5x3x{type}>, tensor<1x5x3x{type}>)-> tensor<1x5x3x{type}>
+    return %2 : tensor<1x5x3x{type}>
+  }}
+}}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case1.e2e.template
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case1.e2e.template
@@ -1,0 +1,13 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN{disablep}: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_reshape_1 --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+
+module {{
+  // CHECK:  [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+  func.func @dot_reshape_1(%arg0: tensor<1x5x4x{type}>, %arg1: tensor<1x4x3x{type}>, %arg2: tensor<1x5x3x{type}>) -> tensor<1x15x{type}> attributes{{kernel, arch = ""}} {{
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4x{type}>, tensor<1x4x3x{type}>) -> tensor<1x5x3x{type}>
+    %2 = "migraphx.reshape"(%0) {{dims = [1:i64, 15:i64]}} : (tensor<1x5x3x{type}>)-> tensor<1x15x{type}>
+    return %2 : tensor<1x15x{type}>
+  }}
+}}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case2.e2e.template
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case2.e2e.template
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN{disablep}: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_reshape_2 --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+
+module {{
+  // CHECK:  [4, 4, 4, 4, 4],
+  // CHECK-NEXT: [4, 4, 4, 4, 4],
+  // CHECK-NEXT: [4, 4, 4, 4, 4]
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+  func.func @dot_reshape_2(%arg0: tensor<1x5x4x{type}>, %arg1: tensor<1x4x3x{type}>, %arg2: tensor<1x5x3x{type}>) -> tensor<1x3x5x{type}> attributes{{kernel, arch = ""}} {{
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4x{type}>, tensor<1x4x3x{type}>) -> tensor<1x5x3x{type}>
+    %2 = "migraphx.reshape"(%0) {{dims = [1:i64, 3:i64, 5:i64]}} : (tensor<1x5x3x{type}>)-> tensor<1x3x5x{type}>
+    return %2 : tensor<1x3x5x{type}>
+  }}
+}}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-transpose.e2e.template
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-transpose.e2e.template
@@ -1,0 +1,15 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN{disablep}: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_transpose --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+
+module {{
+  // CHECK:  [4, 4, 4, 4, 4],
+  // CHECK-NEXT: [4, 4, 4, 4, 4],
+  // CHECK-NEXT: [4, 4, 4, 4, 4]
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+  func.func @dot_transpose(%arg0: tensor<1x5x4x{type}>, %arg1: tensor<1x4x3x{type}>) -> tensor<1x3x5x{type}> attributes{{kernel, arch = ""}} {{
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4x{type}>, tensor<1x4x3x{type}>) -> tensor<1x5x3x{type}>
+    %2 = "migraphx.transpose"(%0) {{permutation = [0:i64, 2:i64, 1:i64]}} : (tensor<1x5x3x{type}>)-> tensor<1x3x5x{type}>
+    return %2 : tensor<1x3x5x{type}>
+  }}
+}}

--- a/mlir/test/fusion/e2e/rock-bcast-exp.e2e.template
+++ b/mlir/test/fusion/e2e/rock-bcast-exp.e2e.template
@@ -1,0 +1,19 @@
+// RUN: rocmlir-gen -ph -print-results -rand none %s | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+
+
+// CHECK:  73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
+module {{
+  func.func @test_fusion(%arg0: memref<1x1x32x32x8x{type}>, %arg1: memref<1x16x3x3x8x{type}>, %arg2: memref<16x{type}>, %arg3: memref<1x1x30x30x16x{type}>) attributes {{kernel, arch = ""}} {{
+    %0 = memref.alloc() : memref<1x1x30x30x16x{type}>
+    rock.conv2d(%arg1, %arg0, %0) features = dot {{arch = "amdgcn-amd-amdhsa:gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]}} : memref<1x16x3x3x8x{type}>, memref<1x1x32x32x8x{type}>, memref<1x1x30x30x16x{type}>
+    linalg.generic {{indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}} ins(%0, %arg2 : memref<1x1x30x30x16x{type}>, memref<16x{type}>) outs(%arg3 : memref<1x1x30x30x16x{type}>) {{
+    ^bb0(%arg4: {type}, %arg5: {type}, %arg6: {type}):
+      %8 = arith.addf %arg4, %arg5 : {type}
+      linalg.yield %8 : {type}
+    }}
+    return
+  }}
+}}

--- a/mlir/test/fusion/e2e/rock-bcast-idxmap.e2e.template
+++ b/mlir/test/fusion/e2e/rock-bcast-idxmap.e2e.template
@@ -1,0 +1,20 @@
+// RUN: rocmlir-gen -ph -print-results -rand none %s | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+
+// CHECK: 65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65,      65
+
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)>
+module {{
+  func.func @test_fusion(%arg0: memref<1x64x64x64x64x{type}>, %arg1: memref<1x64x1x1x64x{type}>, %arg2: memref<64x{type}>, %arg3: memref<1x64x64x64x64x{type}>) attributes {{kernel, arch = ""}} {{
+    %0 = memref.alloc() : memref<1x64x64x64x64x{type}>
+    rock.conv2d(%arg1, %arg0, %0) features = none {{arch = "", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]}} : memref<1x64x1x1x64x{type}>, memref<1x64x64x64x64x{type}>, memref<1x64x64x64x64x{type}>
+    %4 = memref.expand_shape %arg2 [[0, 1, 2, 3, 4]] : memref<64x{type}> into memref<1x1x1x1x64x{type}>
+    linalg.generic {{indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}} ins(%0, %4 : memref<1x64x64x64x64x{type}>, memref<1x1x1x1x64x{type}>) outs(%arg3 : memref<1x64x64x64x64x{type}>) {{
+    ^bb0(%arg4: {type}, %arg5: {type}, %arg6: {type}):
+      %8 = arith.addf %arg4, %arg5 : {type}
+      linalg.yield %8 : {type}
+    }}
+    return
+  }}
+}}

--- a/mlir/test/fusion/e2e/rock-bcast.e2e.template
+++ b/mlir/test/fusion/e2e/rock-bcast.e2e.template
@@ -1,0 +1,20 @@
+// RUN: rocmlir-gen -ph -print-results -rand none %s | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+
+
+// CHECK:  73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73,      73
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (0, 0, 0, 0, d4)>
+module {{
+  func.func @test_fusion(%arg0: memref<1x1x32x32x8x{type}>, %arg1: memref<1x16x3x3x8x{type}>, %arg2: memref<16x{type}>, %arg3: memref<1x1x30x30x16x{type}>) attributes {{kernel, arch = ""}} {{
+    %0 = memref.alloc() : memref<1x1x30x30x16x{type}>
+    rock.conv2d(%arg1, %arg0, %0) features = dot {{arch = "amdgcn-amd-amdhsa:gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "y", "x", "c"], input_layout = ["gi", "ni", "hi", "wi", "ci"], output_layout = ["go", "no", "ho", "wo", "ko"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]}} : memref<1x16x3x3x8x{type}>, memref<1x1x32x32x8x{type}>, memref<1x1x30x30x16x{type}>
+    %4 = memref.expand_shape %arg2 [[0, 1, 2, 3, 4]] : memref<16x{type}> into memref<1x1x1x1x16x{type}>
+    linalg.generic {{indexing_maps = [#map1, #map2, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}} ins(%0, %4 : memref<1x1x30x30x16x{type}>, memref<1x1x1x1x16x{type}>) outs(%arg3 : memref<1x1x30x30x16x{type}>) {{
+    ^bb0(%arg4: {type}, %arg5: {type}, %arg6: {type}):
+      %8 = arith.addf %arg4, %arg5 : {type}
+      linalg.yield %8 : {type}
+    }}
+    return
+  }}
+}}

--- a/mlir/test/fusion/e2e/tests.toml
+++ b/mlir/test/fusion/e2e/tests.toml
@@ -1,0 +1,45 @@
+[[suite]]
+name = "type-only tests"
+
+[[suite.axis]]
+name = "data type"
+values = ["f32", "f16", "bf16"]
+
+[[suite.axis]]
+name = "test files"
+values = ["mixr-bcast-add",
+          "rock-bcast",
+          "rock-bcast-exp",
+          "rock-bcast-idxmap",
+          "tosa-to-rock-bias",
+          "tosa-to-rock-bcast-add",
+          "mixr-gemm/mixr-gemm-add",
+          "mixr-gemm/mixr-gemm-bcast-add",
+          "mixr-gemm/mixr-gemm-reshape-case1",
+          "mixr-gemm/mixr-gemm-reshape-case2",
+          "mixr-gemm/mixr-gemm-transpose"]
+
+[[suite]]
+name = "tosa-to-rock tests"
+
+[[suite.axis]]
+name = "data type"
+values = ["f32", "f16"]
+
+[[suite.axis]]
+name = "test files"
+values = ["tosa-to-rock"]
+
+[[suite.axis]]
+name = "ops"
+values = [["clamp", '''"tosa.clamp"{operand} {{
+               min_fp = 0.0 : f32,
+               max_fp = 6.0 : f32,
+               min_int = 0 : i64,
+               max_int = 6 : i64
+             }}
+          '''],
+          ["exp", '"tosa.exp"{operand}'],
+          ["rsqrt", '"tosa.rsqrt"{operand}'],
+          ["sigmoid", '"tosa.sigmoid"{operand}'],
+          ["tanh", '"tosa.tanh"{operand}']]

--- a/mlir/test/fusion/e2e/tests.toml
+++ b/mlir/test/fusion/e2e/tests.toml
@@ -1,5 +1,6 @@
 [[suite]]
 name = "type-only tests"
+kind = "type-only"
 
 [[suite.axis]]
 name = "data type"
@@ -21,6 +22,7 @@ values = ["mixr-bcast-add",
 
 [[suite]]
 name = "tosa-to-rock tests"
+kind = "op-variants"
 
 [[suite.axis]]
 name = "data type"

--- a/mlir/test/fusion/e2e/tosa-to-rock-bcast-add.e2e.template
+++ b/mlir/test/fusion/e2e/tosa-to-rock-bcast-add.e2e.template
@@ -1,0 +1,17 @@
+// RUN: rocmlir-driver -host-pipeline highlevel %s | rocmlir-gen -ph -print-inputs -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+
+// CHECK: Unranked Memref base
+// CHECK: 5,     5,     5,     5,     5,     5,     5,     5
+// CHECK-COUNT-504: 5
+// Test first 8 and then remaining 504 out of total 512
+
+func.func @test_fusion(%arg0: tensor<1x8x8x4x{type}>, %arg1: tensor<8x1x1x4x{type}>, %arg3: tensor<1x1x1x8x{type}>) -> tensor<1x8x8x8x{type}> attributes {{kernel, arch = ""}} {{
+  %zero = arith.constant dense<0.0> : tensor<8x{type}>
+  %0 = "tosa.conv2d"(%arg0, %arg1, %zero) {{dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}} : (tensor<1x8x8x4x{type}>, tensor<8x1x1x4x{type}>, tensor<8x{type}>) -> tensor<1x8x8x8x{type}>
+  %2 = "tosa.add"(%0, %arg3) {{}} : (tensor<1x8x8x8x{type}>, tensor<1x1x1x8x{type}>) -> tensor<1x8x8x8x{type}>
+
+  return %2 : tensor<1x8x8x8x{type}>
+}}
+
+// -----

--- a/mlir/test/fusion/e2e/tosa-to-rock-bias.e2e.template
+++ b/mlir/test/fusion/e2e/tosa-to-rock-bias.e2e.template
@@ -1,0 +1,12 @@
+// RUN: rocmlir-driver -host-pipeline highlevel %s | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext -entry-point-result=void | FileCheck %s
+// RUN{disablep}: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut test_fusion --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CHECK: Unranked Memref base
+// CLONE: [1 1 1]
+// CLONE-NEXT: Unranked Memref base
+func.func @test_fusion(%arg0: tensor<1x32x32x8x{type}>, %arg1: tensor<16x3x3x8x{type}>, %arg2: tensor<16x{type}>) -> tensor<1x30x30x16x{type}> attributes {{kernel, arch = ""}} {{
+  %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {{dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}} : (tensor<1x32x32x8x{type}>, tensor<16x3x3x8x{type}>, tensor<16x{type}>) -> tensor<1x30x30x16x{type}>
+
+  return %0 : tensor<1x30x30x16x{type}>
+}}
+
+// -----

--- a/mlir/test/fusion/e2e/tosa-to-rock.e2e.template
+++ b/mlir/test/fusion/e2e/tosa-to-rock.e2e.template
@@ -1,0 +1,24 @@
+// RUN: rocmlir-driver -host-pipeline highlevel %s | rocmlir-gen -ph -print-results -rand 1 -rand_type {randtype} - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN{disablep}: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | rocmlir-gen -ph -print-results -rand fixed -rand_type {randtype} -fut test_fusion --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+
+module {{
+// CHECK: Unranked Memref base
+// CLONE: [1 1 1]
+// CLONE-NEXT: Unranked Memref base
+  func.func @test_fusion(%arg0: tensor<128x32x32x8x{type}>, %arg1: tensor<128x3x3x8x{type}>) -> tensor<128x30x30x128x{type}> attributes {{kernel, arch = ""}} {{
+
+    %zero = arith.constant dense<0.0> : tensor<128x{type}>
+    %0 = "tosa.conv2d"(%arg0, %arg1, %zero) {{
+      dilation = array<i64: 1, 1>,
+      pad = array<i64: 0, 0, 0, 0>,
+      stride = array<i64: 1, 1>
+    }}
+     : (tensor<128x32x32x8x{type}>, tensor<128x3x3x8x{type}>, tensor<128x{type}>) -> tensor<128x30x30x128x{type}>
+
+    %1 = {op}
+     : (tensor<128x30x30x128x{type}>) -> tensor<128x30x30x128x{type}>
+
+    return %1 : tensor<128x30x30x128x{type}>
+  }}
+
+}}


### PR DESCRIPTION
Modify most of the tests in fusion/e2e and fusion/e2e/mixr-gemm to make them into templates, into which the generate-fusion-tests.py script will substitute the element type and a couple of other fields.

In the general case, only the type is varied, plus the clone-verification run is disabled if the type isn't f32, because its underlying mcpuVerify() doesn't support f16 and bf16 yet.

Several tosa-to-rock tests are built from one template, because the test differs only in a single op;  in those cases, type, op, and a couple supporting fields are varied.

The script is run by cmake, and there's a lot of boilerplate in there to connect it to the check-rocmlir target and to make sure that its environment is correct.