### PR TITLE
Bump rocMLIR supported minor version up ROCm5.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15.1)
 
 # Allow VERSION for projects, as expected in CMake 3.0+
 cmake_policy(SET CMP0048 NEW)
-project(rocMLIR VERSION 1.0.0 LANGUAGES CXX C)
+project(rocMLIR VERSION 1.1.0 LANGUAGES CXX C)
 
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
 if(POLICY CMP0116)


### PR DESCRIPTION
Backports https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/929, after discussion with MIOpen.

As it turns out we'd need to remember to bump this version for every ROCm release if we supported new capabilities. For the ROCm 5.5 release, we added support to Navi architecture therefore it is necessary.