### PR TITLE
Enabling 128x128 wave size

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
@@ -125,6 +125,7 @@ public:
                 const MfmaInsnGroupAttr &groupAttr);
   int64_t getMRepeats();
   int64_t getNRepeats();
+  static int64_t getLenPerMfmaGroup(int64_t lenPerWave);
   SmallVector<mlir::rock::MFMAParams, 2> getImms();
 
   MfmaInsnAttr getInsnAttr();

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -396,8 +396,8 @@ FailureOr<MfmaInsnGroup> MfmaInsnGroup::select(mlir::Type elementType,
                           << "nPerWave: " << nPerWave << "\n");
 
   // Use 64x64 as base unit in large waves
-  int64_t mPerMfmaGroup = (mPerWave > 64) ? 64 : mPerWave;
-  int64_t nPerMfmaGroup = (nPerWave > 64) ? 64 : nPerWave;
+  int64_t mPerMfmaGroup = getLenPerMfmaGroup(mPerWave);
+  int64_t nPerMfmaGroup = getLenPerMfmaGroup(nPerWave);
 
   MfmaInsnGroupSelectKey key = {convertTypeToId(elementType), mPerMfmaGroup,
                                 nPerMfmaGroup};
@@ -434,6 +434,10 @@ MfmaInsnGroup::MfmaInsnGroup(Type dataType, const MfmaInsn &mfmaInsn,
 int64_t MfmaInsnGroup::getMRepeats() { return groupAttr.mRepeats; }
 
 int64_t MfmaInsnGroup::getNRepeats() { return groupAttr.nRepeats; }
+
+int64_t MfmaInsnGroup::getLenPerMfmaGroup(int64_t lenPerWave) {
+  return (lenPerWave > 64) ? 64 : lenPerWave;
+}
 
 MfmaInsnAttr MfmaInsnGroup::getInsnAttr() { return insn.getAttr(); }
 

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -158,23 +158,7 @@ auto getMfmaInsnGroupAttrMap = []() {
   using amdgpu::MFMAPermB;
   static llvm::DenseMap<MfmaInsnGroupSelectKey, MfmaInsnGroupAttr,
                         MfmaInsnGroupSelectKeyInfo>
-      groupAttrMap{{{MfmaTypeId::Fp32TyId, 128, 64},
-                    {ROCDL::mfma_f32_32x32x1f32::getOperationName(),
-                     2,
-                     1,
-                     {{1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none},
-                      {1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none}}}},
-                   {{MfmaTypeId::Fp32TyId, 64, 128},
-                    {ROCDL::mfma_f32_32x32x1f32::getOperationName(),
-                     1,
-                     2,
-                     {{1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none},
-                      {1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none}}}},
-                   {{MfmaTypeId::Fp32TyId, 64, 64},
+      groupAttrMap{{{MfmaTypeId::Fp32TyId, 64, 64},
                     {ROCDL::mfma_f32_32x32x1f32::getOperationName(),
                      1,
                      1,
@@ -220,22 +204,6 @@ auto getMfmaInsnGroupAttrMap = []() {
                      1,
                      {{0, 0, MFMAPermB::none}}}},
 
-                   {{MfmaTypeId::Fp16TyId, 128, 64},
-                    {ROCDL::mfma_f32_32x32x4f16::getOperationName(),
-                     2,
-                     1,
-                     {{1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none},
-                      {1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none}}}},
-                   {{MfmaTypeId::Fp16TyId, 64, 128},
-                    {ROCDL::mfma_f32_32x32x4f16::getOperationName(),
-                     1,
-                     2,
-                     {{1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none},
-                      {1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none}}}},
                    {{MfmaTypeId::Fp16TyId, 64, 64},
                     {ROCDL::mfma_f32_32x32x4f16::getOperationName(),
                      1,
@@ -282,22 +250,6 @@ auto getMfmaInsnGroupAttrMap = []() {
                      1,
                      {{0, 0, MFMAPermB::none}}}},
 
-                   {{MfmaTypeId::Bf16TyId, 128, 64},
-                    {ROCDL::mfma_f32_32x32x2bf16::getOperationName(),
-                     2,
-                     1,
-                     {{1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none},
-                      {1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none}}}},
-                   {{MfmaTypeId::Bf16TyId, 64, 128},
-                    {ROCDL::mfma_f32_32x32x2bf16::getOperationName(),
-                     1,
-                     2,
-                     {{1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none},
-                      {1, 0, MFMAPermB::none},
-                      {1, 1, MFMAPermB::none}}}},
                    {{MfmaTypeId::Bf16TyId, 64, 64},
                     {ROCDL::mfma_f32_32x32x2bf16::getOperationName(),
                      1,
@@ -443,12 +395,25 @@ FailureOr<MfmaInsnGroup> MfmaInsnGroup::select(mlir::Type elementType,
                           << "mPerWave: " << mPerWave << "\n"
                           << "nPerWave: " << nPerWave << "\n");
 
-  MfmaInsnGroupSelectKey key = {convertTypeToId(elementType), mPerWave,
-                                nPerWave};
+  // Use 64x64 as base unit in large waves
+  int64_t mPerMfmaGroup = (mPerWave > 64) ? 64 : mPerWave;
+  int64_t nPerMfmaGroup = (nPerWave > 64) ? 64 : nPerWave;
+
+  MfmaInsnGroupSelectKey key = {convertTypeToId(elementType), mPerMfmaGroup,
+                                nPerMfmaGroup};
   auto mfmaInsnGroupAttrMap = getMfmaInsnGroupAttrMap();
   auto it = mfmaInsnGroupAttrMap.find(key);
   if (it != mfmaInsnGroupAttrMap.end()) {
     MfmaInsnGroupAttr groupAttr = (*it).second;
+    // Override the repeat information in case this is for larger wave
+    if (mPerWave > 64) {
+      groupAttr.mRepeats = mPerWave / 64;
+    }
+
+    if (nPerWave > 64) {
+      groupAttr.nRepeats = nPerWave / 64;
+    }
+
     auto maybeInsn = MfmaInsn::select(groupAttr.insn);
     if (failed(maybeInsn)) {
       LLVM_DEBUG(llvm::dbgs()

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -564,8 +564,7 @@ struct BlockwiseGemmV2RewritePattern
     // Workload of either mPerWave and nPerWave that are larger
     // than wave size of 64 will be executed by repeats
     // TODO: amend this for tuning parameter selection as well
-    maybeMfmaInsnGroup =
-        MfmaInsnGroup::select(dataType, MPerXdlops, NPerXdlops);
+    maybeMfmaInsnGroup = MfmaInsnGroup::select(dataType, mPerWave, nPerWave);
     if (failed(maybeMfmaInsnGroup)) {
       return emitError(loc) << "Failed to select xdlops instruction group.\n";
     }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1185,7 +1185,7 @@ struct GridwiseGemmV2RewritePattern
     int64_t nRepeats = mfmaGroup.getNRepeats();
     auto imms = mfmaGroup.getImms();
 
-    int64_t nResultVectors = imms.size();
+    int64_t nResultVectors = imms.size() * mRepeats * nRepeats;
     int64_t mPerRepeat = mPerWave / mRepeats;
     int64_t nPerRepeat = nPerWave / nRepeats;
 

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -186,13 +186,6 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();
 
-    // Workload of either mPerWave and nPerWave that are larger
-    // than wave size of 64 will be executed by repeats
-    // TODO: amend this for tuning parameter selection as well
-    int64_t waveSize = 64;
-    int64_t MPerXdlops = (mPerWave > waveSize) ? waveSize : mPerWave;
-    int64_t NPerXdlops = (nPerWave > waveSize) ? waveSize : nPerWave;
-
     auto dataType =
         adaptor.getMatrixA().getType().cast<MemRefType>().getElementType();
     if (dataType.isa<VectorType>()) {

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -200,7 +200,7 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
     }
 
     auto maybeMfmaInsnGroup =
-        MfmaInsnGroup::select(dataType, MPerXdlops, NPerXdlops);
+        MfmaInsnGroup::select(dataType, mPerWave, nPerWave);
     if (failed(maybeMfmaInsnGroup)) {
       return emitError(loc) << "Failed to select xdlops instruction group.\n";
     }

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -324,7 +324,7 @@ PopulateParamsXDL::isValidBlockwiseGemmXDLOPS(const InitParamsXDL &param,
   } else {
     // clang-format off
     validWaveGemmSize = {
-      // std::make_tuple(128, 128, 1),
+      std::make_tuple(128, 128, 1),
       std::make_tuple(128, 64, 1),
       // std::make_tuple(128, 32, 1),
       // std::make_tuple(128, 16, 1),


### PR DESCRIPTION
Tested and can verify for 128x128 wave size. Sample config:

> --operation conv2d -t f32 --arch gfx90a:sramecc+:xnack- --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 8192 --in_channels 8192 --in_h 1 --in_w 1 --out_channels 8192 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h_l 0 --padding_h_r 0 --padding_w_l 0 --padding_w_r 0 -mfma=on -dot=on -atomic_add=on --perf_config 256,256,4,128,128,2,1,1