### PR TITLE
[MIGraphXToTosa] Enable broadcast input to matmul when possible.

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -317,7 +317,7 @@ public:
 
     // check batch dimension. Tosa matmul only allow a single dimension for it,
     // add reshape ops to flatten and restore the original dimension.
-    SmallVector<int64_t, 5> orgOutDims = outputTy.getShape();
+    SmallVector<int64_t, 5> orgOutDims(outputTy.getShape());
     RankedTensorType newOutType = RankedTensorType::get(orgOutDims, elementTy);
     size_t outRank = orgOutDims.size();
 

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -339,12 +339,12 @@ public:
 
       if (batchSizeA != batchSizeB) {
         // support when batchB dimension is broadcast
-        if (RankB == 3 && orgDimsB[0] == 1) {
+        if (rankB == 3 && orgDimsB[0] == 1) {
           // modify [g, m, k, n] to [1, g*m, k, n]
           batchSizeA = 1;
-          batchSize = 1;
+          batchSizeC = 1;
           orgDimsA[rankA - 2] *= batchSizeA;
-          orgOutDims[outRank - 2] *= batchSize;
+          orgOutDims[outRank - 2] *= batchSizeC;
         } else {
           // currently not supporting the other case, broadcast A could be
           // supported with an additional transpose.
@@ -355,7 +355,7 @@ public:
                              orgDimsA[outRank - 1]};
       int64_t newDimsB[3] = {batchSizeB, orgDimsB[outRank - 2],
                              orgDimsB[outRank - 1]};
-      int64_t newDimsOut[3] = {batchSize, orgOutDims[outRank - 2],
+      int64_t newDimsOut[3] = {batchSizeC, orgOutDims[outRank - 2],
                                orgOutDims[outRank - 1]};
       RankedTensorType newAType = RankedTensorType::get(newDimsA, elementTy);
       RankedTensorType newBType = RankedTensorType::get(newDimsB, elementTy);

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -322,8 +322,8 @@ public:
     size_t outRank = orgOutDims.size();
 
     if (outRank != 3) { // A, B, Out have the same rank. rank=2 assumes batch=1
-      ArrayRef<int64_t> orgDimsA = in_A.getType().cast<ShapedType>().getShape();
-      ArrayRef<int64_t> orgDimsB = in_B.getType().cast<ShapedType>().getShape();
+      SmallVector orgDimsA(in_A.getType().cast<ShapedType>().getShape());
+      SmallVector orgDimsB(in_B.getType().cast<ShapedType>().getShape());
       size_t rankA = orgDimsA.size();
       size_t rankB = orgDimsB.size();
       int64_t batchSizeA = 1, batchSizeB = 1, batchSizeC = 1;

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -317,13 +317,11 @@ public:
 
     // check batch dimension. Tosa matmul only allow a single dimension for it,
     // add reshape ops to flatten and restore the original dimension.
-    SmallVector<int64_t, 5> orgOutDims(outputTy.getShape());
+    ArrayRef<int64_t> orgOutDims = outputTy.getShape();
     RankedTensorType newOutType = RankedTensorType::get(orgOutDims, elementTy);
     size_t outRank = orgOutDims.size();
-    SmallVector<int64_t, 5> orgDimsA(
-        in_A.getType().cast<ShapedType>().getShape());
-    SmallVector<int64_t, 5> orgDimsB(
-        in_B.getType().cast<ShapedType>().getShape());
+    ArrayRef<int64_t> orgDimsA = in_A.getType().cast<ShapedType>().getShape();
+    ArrayRef<int64_t> orgDimsB = in_B.getType().cast<ShapedType>().getShape();
     size_t rankA = orgDimsA.size();
     size_t rankB = orgDimsB.size();
 
@@ -359,7 +357,7 @@ public:
         } else {
           // currently not supporting the other case, broadcast A could be
           // supported with an additional transpose.
-          return failure();
+          return op->emitError("tosa.matmul can't broadcast input.");
         }
       }
       RankedTensorType newAType = RankedTensorType::get(newDimsA, elementTy);

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -348,7 +348,7 @@ public:
                                orgOutDims[outRank - 1]};
       if (batchSizeA != batchSizeB) {
         // support when batchB dimension is broadcast
-        if (rankB == 3 && orgDimsB[0] == 1) {
+        if (batchSizeB == 1) {
           // modify [g, m, k, n] to [1, g*m, k, n]
           newDimsA[0] = 1;
           newDimsA[1] *= batchSizeA;

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -317,13 +317,15 @@ public:
 
     // check batch dimension. Tosa matmul only allow a single dimension for it,
     // add reshape ops to flatten and restore the original dimension.
-    ArrayRef<int64_t> orgOutDims = outputTy.getShape();
+    SmallVector<int64_t, 5> orgOutDims = outputTy.getShape();
     RankedTensorType newOutType = RankedTensorType::get(orgOutDims, elementTy);
     size_t outRank = orgOutDims.size();
 
     if (outRank != 3) { // A, B, Out have the same rank. rank=2 assumes batch=1
-      SmallVector orgDimsA(in_A.getType().cast<ShapedType>().getShape());
-      SmallVector orgDimsB(in_B.getType().cast<ShapedType>().getShape());
+      SmallVector<int64_t, 5> orgDimsA(
+          in_A.getType().cast<ShapedType>().getShape());
+      SmallVector<int64_t, 5> orgDimsB(
+          in_B.getType().cast<ShapedType>().getShape());
       size_t rankA = orgDimsA.size();
       size_t rankB = orgDimsB.size();
       int64_t batchSizeA = 1, batchSizeB = 1, batchSizeC = 1;

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -346,10 +346,10 @@ public:
         // support when batchB dimension is broadcast
         if (rankB == 3 && orgDimsB[0] == 1) {
           // modify [g, m, k, n] to [1, g*m, k, n]
-          batchSizeA = 1;
-          batchSizeC = 1;
           orgDimsA[rankA - 2] *= batchSizeA;
           orgOutDims[outRank - 2] *= batchSizeC;
+          batchSizeA = 1;
+          batchSizeC = 1;
         } else {
           // currently not supporting the other case, broadcast A could be
           // supported with an additional transpose.

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -320,14 +320,17 @@ public:
     SmallVector<int64_t, 5> orgOutDims(outputTy.getShape());
     RankedTensorType newOutType = RankedTensorType::get(orgOutDims, elementTy);
     size_t outRank = orgOutDims.size();
+    SmallVector<int64_t, 5> orgDimsA(
+        in_A.getType().cast<ShapedType>().getShape());
+    SmallVector<int64_t, 5> orgDimsB(
+        in_B.getType().cast<ShapedType>().getShape());
+    size_t rankA = orgDimsA.size();
+    size_t rankB = orgDimsB.size();
 
-    if (outRank != 3) { // A, B, Out have the same rank. rank=2 assumes batch=1
-      SmallVector<int64_t, 5> orgDimsA(
-          in_A.getType().cast<ShapedType>().getShape());
-      SmallVector<int64_t, 5> orgDimsB(
-          in_B.getType().cast<ShapedType>().getShape());
-      size_t rankA = orgDimsA.size();
-      size_t rankB = orgDimsB.size();
+    // A, B, Out have the same rank. rank=2 assumes batch=1.
+    // Here handling special cases.
+    if (outRank != 3 || rankA != rankB ||
+        (outRank == 3 && orgDimsA != orgDimsB)) {
       int64_t batchSizeA = 1, batchSizeB = 1, batchSizeC = 1;
       for (size_t i = 0; i < outRank - 2; i++) {
         batchSizeC *= orgOutDims[i];

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -383,7 +383,8 @@ public:
     if (auto attr = op->getAttrOfType<StringAttr>("perf_config"))
       mop->setAttr("perf_config", attr);
 
-    if (outRank != 3) {
+    if (outRank != 3 || rankA != rankB ||
+        (outRank == 3 && orgDimsA != orgDimsB)) {
       auto rop = rewriter.create<tosa::ReshapeOp>(
           loc, outputTy, mop, rewriter.getI64ArrayAttr(orgOutDims));
       rewriter.replaceOp(op, {rop});

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -342,26 +342,26 @@ public:
         batchSizeB *= orgDimsB[i];
       }
 
-      if (batchSizeA != batchSizeB) {
-        // support when batchB dimension is broadcast
-        if (rankB == 3 && orgDimsB[0] == 1) {
-          // modify [g, m, k, n] to [1, g*m, k, n]
-          orgDimsA[rankA - 2] *= batchSizeA;
-          orgOutDims[outRank - 2] *= batchSizeC;
-          batchSizeA = 1;
-          batchSizeC = 1;
-        } else {
-          // currently not supporting the other case, broadcast A could be
-          // supported with an additional transpose.
-          return failure();
-        }
-      }
       int64_t newDimsA[3] = {batchSizeA, orgDimsA[outRank - 2],
                              orgDimsA[outRank - 1]};
       int64_t newDimsB[3] = {batchSizeB, orgDimsB[outRank - 2],
                              orgDimsB[outRank - 1]};
       int64_t newDimsOut[3] = {batchSizeC, orgOutDims[outRank - 2],
                                orgOutDims[outRank - 1]};
+      if (batchSizeA != batchSizeB) {
+        // support when batchB dimension is broadcast
+        if (rankB == 3 && orgDimsB[0] == 1) {
+          // modify [g, m, k, n] to [1, g*m, k, n]
+          newDimsA[0] = 1;
+          newDimsA[1] *= batchSizeA;
+          newDimsOut[0] = 1;
+          newDimsOut[1] *= batchSizeC;
+        } else {
+          // currently not supporting the other case, broadcast A could be
+          // supported with an additional transpose.
+          return failure();
+        }
+      }
       RankedTensorType newAType = RankedTensorType::get(newDimsA, elementTy);
       RankedTensorType newBType = RankedTensorType::get(newDimsB, elementTy);
       newOutType = RankedTensorType::get(newDimsOut, elementTy);

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -34,6 +34,18 @@ module  {
     return %2 : tensor<64x64x2304xf16>
   }
 
+  // CHECK-LABEL: func.func @matmul_broadcast_R5
+  func.func @matmul_broadcast_R5(%arg0: tensor<2x4x8x64x2304xf16>, %arg1: tensor<2x4x8x64x768xf16>, %arg2: tensor<1x1x1x768x2304xf16>) -> tensor<2x4x8x64x2304xf16> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
+    %0 = migraphx.multibroadcast(%arg2) {out_dyn_dims = [], out_lens = [1, 1, 64, 768, 2304]} : (tensor<1x1x1x768x2304xf16>) -> tensor<1x1x64x768x2304xf16>
+    // CHECK-DAG: %[[RESHAPE0:.*]] = "tosa.reshape"(%arg1) {new_shape = [1, 4096, 768]}
+    // CHECK-DAG: %[[RESHAPE1:.*]] = "tosa.reshape"(%arg2) {new_shape = [1, 768, 2304]}
+    %1 = migraphx.dot(%arg1, %0) : tensor<2x4x8x64x768xf16>, tensor<1x1x64x768x2304xf16> -> tensor<2x4x8x64x2304xf16>
+    // CHECK-DAG: %[[MATMUL:.*]] = "tosa.matmul"(%[[RESHAPE0]], %[[RESHAPE1]]
+    // CHECK: %[[RESHAPE2:.*]] = "tosa.reshape"(%[[MATMUL]]) {new_shape = [2, 4, 8, 64, 2304]}
+    %2 = migraphx.add(%1, %arg0) : (tensor<2x4x8x64x2304xf16>, tensor<2x4x8x64x2304xf16>) -> tensor<2x4x8x64x2304xf16>
+    return %2 : tensor<2x4x8x64x2304xf16>
+  }
+
   // CHECK-LABEL: func.func @func_power
   // CHECK: tosa.pow
   func.func @func_power(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf32> {

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -36,10 +36,10 @@ module  {
 
   // CHECK-LABEL: func.func @matmul_broadcast_R5
   func.func @matmul_broadcast_R5(%arg0: tensor<2x4x8x64x2304xf16>, %arg1: tensor<2x4x8x64x768xf16>, %arg2: tensor<1x1x1x768x2304xf16>) -> tensor<2x4x8x64x2304xf16> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
-    %0 = migraphx.multibroadcast(%arg2) {out_dyn_dims = [], out_lens = [1, 1, 64, 768, 2304]} : (tensor<1x1x1x768x2304xf16>) -> tensor<1x1x64x768x2304xf16>
+    %0 = migraphx.multibroadcast(%arg2) {out_dyn_dims = [], out_lens = [2, 4, 8, 768, 2304]} : (tensor<1x1x1x768x2304xf16>) -> tensor<2x4x8x768x2304xf16>
     // CHECK-DAG: %[[RESHAPE0:.*]] = "tosa.reshape"(%arg1) {new_shape = [1, 4096, 768]}
     // CHECK-DAG: %[[RESHAPE1:.*]] = "tosa.reshape"(%arg2) {new_shape = [1, 768, 2304]}
-    %1 = migraphx.dot(%arg1, %0) : tensor<2x4x8x64x768xf16>, tensor<1x1x64x768x2304xf16> -> tensor<2x4x8x64x2304xf16>
+    %1 = migraphx.dot(%arg1, %0) : tensor<2x4x8x64x768xf16>, tensor<2x4x8x768x2304xf16> -> tensor<2x4x8x64x2304xf16>
     // CHECK-DAG: %[[MATMUL:.*]] = "tosa.matmul"(%[[RESHAPE0]], %[[RESHAPE1]]
     // CHECK: %[[RESHAPE2:.*]] = "tosa.reshape"(%[[MATMUL]]) {new_shape = [2, 4, 8, 64, 2304]}
     %2 = migraphx.add(%1, %arg0) : (tensor<2x4x8x64x2304xf16>, tensor<2x4x8x64x2304xf16>) -> tensor<2x4x8x64x2304xf16>

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -25,11 +25,11 @@ module  {
   // CHECK-LABEL: func.func @matmul_broadcast
   func.func @matmul_broadcast(%arg0: tensor<64x64x2304xf16>, %arg1: tensor<64x64x768xf16>, %arg2: tensor<1x768x2304xf16>) -> tensor<64x64x2304xf16> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
     %0 = migraphx.multibroadcast(%arg2) {out_dyn_dims = [], out_lens = [64, 768, 2304]} : (tensor<1x768x2304xf16>) -> tensor<64x768x2304xf16>
-    // CHECK: [[INIT:%.+]] = tosa.reshape %arg1 {new_shape = [1, 4096, 768]}
-    // CHECK: [[RESHAPE1:%.+]] = tosa.reshape %arg2 {new_shape = [1, 768, 2304]}
+    // CHECK-DAG: %[[RESHAPE0:.*]] = "tosa.reshape"(%arg1) {new_shape = [1, 4096, 768]}
+    // CHECK-DAG: %[[RESHAPE1:.*]] = "tosa.reshape"(%arg2) {new_shape = [1, 768, 2304]}
     %1 = migraphx.dot(%arg1, %0) : tensor<64x64x768xf16>, tensor<64x768x2304xf16> -> tensor<64x64x2304xf16>
-    // CHECK: [[MATMUL:%.+]] = tosa.matmul [[INIT]], [[RESHAPE1]]
-    // CHECK: [[RESHAPE2:%.+]] = tosa.reshape [[MATMUL]] {new_shape = [64, 64, 2304]}
+    // CHECK-DAG: %[[MATMUL:.*]] = "tosa.matmul"(%[[RESHAPE0]], %[[RESHAPE1]]
+    // CHECK: %[[RESHAPE2:.*]] = "tosa.reshape"(%[[MATMUL]]) {new_shape = [64, 64, 2304]}
     %2 = migraphx.add(%1, %arg0) : (tensor<64x64x2304xf16>, tensor<64x64x2304xf16>) -> tensor<64x64x2304xf16>
     return %2 : tensor<64x64x2304xf16>
   }

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -25,10 +25,11 @@ module  {
   // CHECK-LABEL: func.func @matmul_broadcast
   func.func @matmul_broadcast(%arg0: tensor<64x64x2304xf16>, %arg1: tensor<64x64x768xf16>, %arg2: tensor<1x768x2304xf16>) -> tensor<64x64x2304xf16> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
     %0 = migraphx.multibroadcast(%arg2) {out_dyn_dims = [], out_lens = [64, 768, 2304]} : (tensor<1x768x2304xf16>) -> tensor<64x768x2304xf16>
-    // CHECK: [[RESHAPE1:%.+]] = tosa.reshape
+    // CHECK: [[INIT:%.+]] = tosa.reshape %arg1 {new_shape = [1, 4096, 768]}
+    // CHECK: [[RESHAPE1:%.+]] = tosa.reshape %arg2 {new_shape = [1, 768, 2304]}
     %1 = migraphx.dot(%arg1, %0) : tensor<64x64x768xf16>, tensor<64x768x2304xf16> -> tensor<64x64x2304xf16>
-    // CHECK: [[MATMUL:%.+]] = tosa.matmul [[RESHAPE1]], %arg2
-    // CHECK: [[RESHAPE2:%.+]] = tosa.reshape [[MATMUL]]
+    // CHECK: [[MATMUL:%.+]] = tosa.matmul [[INIT]], [[RESHAPE1]]
+    // CHECK: [[RESHAPE2:%.+]] = tosa.reshape [[MATMUL]] {new_shape = [64, 64, 2304]}
     %2 = migraphx.add(%1, %arg0) : (tensor<64x64x2304xf16>, tensor<64x64x2304xf16>) -> tensor<64x64x2304xf16>
     return %2 : tensor<64x64x2304xf16>
   }


### PR DESCRIPTION
support converting
migraphx.dot(A, broadcast(B)) to tosa, where it only support implicit  broadcast for elementwise operators.

This only support the case when the batch dimension of B is broadcast,
e.g.
A : [g, m, k]
B : [1,  k, n]
broadcast(B) : [g, k, n]

by reshaping A -> [1, gxm, k]

