### PR TITLE
Amend API to use tuned data

### DIFF
--- a/mlir/include/mlir-c/Dialect/Rock.h
+++ b/mlir/include/mlir-c/Dialect/Rock.h
@@ -88,7 +88,7 @@ void mlirRockTuningTableDestroy(MlirRockTuningTable table);
 // the best performing tuning parameter to simplify the underlying
 // implementation, which can be revisited in the future.
 MLIR_CAPI_EXPORTED
-bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable, MlirModule module,
+bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable, char *probCStr,
                                char *perfCStr, float time);
 
 // Search the tuning table and get the stored best value for the given problem.

--- a/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
@@ -46,7 +46,7 @@ struct TuningTable {
 TuningTable *tuningTableCreate();
 size_t getTuningHash(ModuleOp &mod);
 std::string getTuningProblemStr(ModuleOp &mod);
-bool tuningTableUpdate(TuningTable *perfTable, ModuleOp &mod,
+bool tuningTableUpdate(TuningTable *perfTable, std::string problem,
                        std::string perfConfig, float time);
 std::string tuningTableLookup(TuningTable *perfTable, ModuleOp &mod);
 

--- a/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
@@ -35,6 +35,8 @@ struct TunableParams {
 };
 
 TunableParams *createTunableParamSpace(ModuleOp &mod);
+bool tuningGetParam(TunableParams *tuningSpace, int pos,
+                    ParamEntry *paramEntry);
 bool tuningSetParam(ModuleOp &mod, ParamEntry *paramEntry);
 bool tuningSetStr(ModuleOp &mod, std::string perfConfig);
 

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -121,6 +121,8 @@ bool mlirRockTuningSetFromTable(MlirRockTuningTable perfTable,
   auto pTable = unwrap(perfTable);
   auto mod = unwrap(module);
   std::string perfConfig = rock::tuningTableLookup(pTable, mod);
+  if (perfConfg.empty())
+    return false;
   return rock::tuningSetStr(mod, perfConfig);
 }
 

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -105,13 +105,14 @@ void mlirRockTuningTableDestroy(MlirRockTuningTable table) {
 }
 
 MLIR_CAPI_EXPORTED
-bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable, MlirModule module,
+bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable, char *probCStr,
                                char *perfCStr, float time) {
+  MlirStringRef probStringRef = mlirStringRefCreateFromCString(probCStr);
   MlirStringRef perfStringRef = mlirStringRefCreateFromCString(perfCStr);
+  std::string problem = unwrap(probStringRef).str();
   std::string perfConfig = unwrap(perfStringRef).str();
   auto pTable = unwrap(perfTable);
-  auto mod = unwrap(module);
-  return rock::tuningTableUpdate(pTable, mod, perfConfig, time);
+  return rock::tuningTableUpdate(pTable, problem, perfConfig, time);
 }
 
 MLIR_CAPI_EXPORTED

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -121,7 +121,7 @@ bool mlirRockTuningSetFromTable(MlirRockTuningTable perfTable,
   auto pTable = unwrap(perfTable);
   auto mod = unwrap(module);
   std::string perfConfig = rock::tuningTableLookup(pTable, mod);
-  if (perfConfg.empty())
+  if (perfConfig.empty())
     return false;
   return rock::tuningSetStr(mod, perfConfig);
 }

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -64,11 +64,7 @@ bool mlirRockTuningParamGet(MlirRockTuningSpace params, int pos,
                             MlirRockTuningParam param) {
   auto tuningSpace = unwrap(params);
   auto paramEntry = unwrap(param);
-  // out of bound check.
-  if (pos < 0 || (unsigned int)pos > tuningSpace->tuningRange.size() - 1)
-    return false;
-  paramEntry->param = tuningSpace->tuningRange[pos];
-  return true;
+  return rock::tuningGetParam(tuningSpace, pos, paramEntry);
 }
 
 MLIR_CAPI_EXPORTED

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -186,21 +186,6 @@ std::string getTuningProblemStr(ModuleOp &mod) {
     return std::string();
   }
 
-  // Data type
-  problemOS << "-t ";
-  Type elemType = gemmIF.getInputType();
-  if (elemType.isF32()) {
-    problemOS << "f32";
-  } else if (elemType.isF16()) {
-    problemOS << "f16";
-  } else if (elemType.isInteger(8)) {
-    problemOS << "i8";
-  } else {
-    // Unknown data type
-    return std::string();
-  }
-  problemOS << sep;
-
   if (opType == KernelType::Conv2D || opType == KernelType::Conv2DBwdData ||
       opType == KernelType::Conv2DBwdWeight) { // conv cases
     RockConvInterface convIF = dyn_cast<RockConvInterface>(gemmOp);
@@ -316,6 +301,20 @@ std::string getTuningProblemStr(ModuleOp &mod) {
     problemOS << "-k " << gemmIF.getGemmSize().k << sep;
   } else {
     // Unknown op type, unreachable.
+    return std::string();
+  }
+
+  // Data type
+  problemOS << "-t ";
+  Type elemType = gemmIF.getInputType();
+  if (elemType.isF32()) {
+    problemOS << "f32";
+  } else if (elemType.isF16()) {
+    problemOS << "f16";
+  } else if (elemType.isInteger(8)) {
+    problemOS << "i8";
+  } else {
+    // Unknown data type
     return std::string();
   }
 

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -322,9 +322,8 @@ std::string getTuningProblemStr(ModuleOp &mod) {
   return problemStr;
 }
 
-bool tuningTableUpdate(TuningTable *perfTable, ModuleOp &mod,
+bool tuningTableUpdate(TuningTable *perfTable, std::string problem,
                        std::string perfConfig, float time) {
-  std::string problem = getTuningProblemStr(mod);
   if (problem.empty())
     return false;
   auto search = perfTable->tuningMap.find(problem);

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -116,6 +116,15 @@ TunableParams *createTunableParamSpace(ModuleOp &mod) {
   return newSpace;
 }
 
+bool tuningGetParam(TunableParams *tuningSpace, int pos,
+                    ParamEntry *paramEntry) {
+  // out of bound check.
+  if (pos < 0 || (unsigned int)pos > tuningSpace->tuningRange.size() - 1)
+    return false;
+  paramEntry->param = tuningSpace->tuningRange[pos];
+  return true;
+}
+
 bool tuningSetParam(ModuleOp &mod, ParamEntry *paramEntry) {
   WalkResult setPrimary =
       mod->walk([&](rock::RockGemmWrapperInterface op) -> WalkResult {

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -74,7 +74,8 @@ MlirModule makeAndDumpMIXR(MlirContext ctx, MlirLocation location) {
       func, mlirStringRefCreateFromCString("kernel"), mlirUnitAttrGet(ctx));
   mlirOperationSetAttributeByName(
       func, mlirStringRefCreateFromCString("arch"),
-      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("gfx908:sramecc+:xnack-")));
+      mlirStringAttrGet(
+          ctx, mlirStringRefCreateFromCString("gfx908:sramecc+:xnack-")));
   mlirBlockInsertOwnedOperation(moduleBody, 0, func);
 
   //-------------- conv0 = migraphx.convolution
@@ -186,9 +187,12 @@ static bool constructAndTraverseIr(MlirContext ctx) {
     float fakeTime = (float)(i + 1);
     char *paramStr = strdup(mlirRockTuningGetParamStr(tuningParam));
     char *problemKey = strdup(mlirRockTuningGetKey(tuningTable, module));
-    printf("Update perfconfig for the problem string(%s): \"%s\" with time %f\n",
-           problemKey, paramStr, fakeTime);
-    if (!mlirRockTuningUpdateTable(tuningTable, module, paramStr, fakeTime)) {
+    printf(
+        "Update perfconfig for the problem string(%s): \"%s\" with time %f\n",
+        problemKey, paramStr, fakeTime);
+    if (!mlirRockTuningUpdateTable(tuningTable,
+                                   mlirRockTuningGetKey(tuningTable, module),
+                                   paramStr, fakeTime)) {
       printf("fails to update table, maybe existing config is faster\n");
     }
     free(paramStr);


### PR DESCRIPTION
Found some change required while implementing the client side code.
- when the tuned data entry comes from file, it only has serialized form of the problem, not the original problem.
- modify the problem  serialization format to match with the string currently generated by the performance script.