### PR TITLE
Add rock.threadwise_write_all to abstract writeback loop, help fusion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-const-correctness,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,readability-identifier-naming'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
@@ -6,6 +6,10 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.FunctionCase
     value:           camelBack
+  # Exclude from scanning as this is an exported symbol used for fuzzing
+  # throughout the code base.
+  - key:             readability-identifier-naming.FunctionIgnoredRegexp
+    value:           "LLVMFuzzerTestOneInput"
   - key:             readability-identifier-naming.MemberCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterCase
@@ -16,4 +20,7 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.IgnoreMainLikeFunctions
     value:           1
-
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           1
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           1

--- a/mlir/.clang-tidy
+++ b/mlir/.clang-tidy
@@ -1,19 +1,60 @@
-# Almost identical to the top-level .clang-tidy, except that {Member,Parameter,Variable}Case use camelBack.
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+InheritParentConfig: true
+Checks: >
+        -misc-const-correctness,
+        bugprone-argument-comment,
+        bugprone-assert-side-effect,
+        bugprone-branch-clone,
+        bugprone-copy-constructor-init,
+        bugprone-dangling-handle,
+        bugprone-dynamic-static-initializers,
+        bugprone-macro-parentheses,
+        bugprone-macro-repeated-side-effects,
+        bugprone-misplaced-widening-cast,
+        bugprone-move-forwarding-reference,
+        bugprone-multiple-statement-macro,
+        bugprone-suspicious-semicolon,
+        bugprone-swapped-arguments,
+        bugprone-terminating-continue,
+        bugprone-unused-raii,
+        bugprone-unused-return-value,
+        misc-redundant-expression,
+        misc-static-assert,
+        misc-unused-using-decls,
+        modernize-use-bool-literals,
+        modernize-loop-convert,
+        modernize-make-unique,
+        modernize-raw-string-literal,
+        modernize-use-equals-default,
+        modernize-use-default-member-init,
+        modernize-use-emplace,
+        modernize-use-nullptr,
+        modernize-use-override,
+        modernize-use-using,
+        performance-for-range-copy,
+        performance-implicit-conversion-in-loop,
+        performance-inefficient-algorithm,
+        performance-inefficient-vector-operation,
+        performance-move-const-arg,
+        performance-no-automatic-move,
+        performance-trivially-destructible,
+        performance-unnecessary-copy-initialization,
+        performance-unnecessary-value-param,
+        readability-avoid-const-params-in-decls,
+        readability-const-return-type,
+        readability-container-size-empty,
+        readability-inconsistent-declaration-parameter-name,
+        readability-misleading-indentation,
+        readability-redundant-control-flow,
+        readability-redundant-smartptr-get,
+        readability-simplify-boolean-expr,
+        readability-simplify-subscript-expr,
+        readability-use-anyofallof
+
+
 CheckOptions:
-  - key:             readability-identifier-naming.ClassCase
-    value:           CamelCase
-  - key:             readability-identifier-naming.EnumCase
-    value:           CamelCase
-  - key:             readability-identifier-naming.FunctionCase
-    value:           camelBack
   - key:             readability-identifier-naming.MemberCase
     value:           camelBack
   - key:             readability-identifier-naming.ParameterCase
     value:           camelBack
-  - key:             readability-identifier-naming.UnionCase
-    value:           CamelCase
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack
-  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
-    value:           1

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -862,6 +862,69 @@ def Rock_GlobalStoreOp :
   }];
 }
 
+// threadwise_write_all
+def Rock_ThreadwiseWriteAllOp :
+    Rock_Op<"threadwise_write_all">,
+    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I32], [1]>:$source,
+      AnyMemRef:$dest,
+      TransformMapArrayAttr:$extraViews,
+      StoreMethodAttr:$storeMethod,
+      UnitAttr:$forceUnroll,
+      UnitAttr:$useIndexDiffs
+    )> {
+  let summary = "Write out values in registers to transformed destination";
+
+  let description = [{
+    A high-level representation of a register -> somewhere write loop that
+    accounts for coordinate transformations.
+
+    If `%dest = rock.transform #transform_mapN %buffer`
+    (with the one transformation representing an entire sequence),
+    and `%buffer` is in global memory, the operation
+
+    ```mlir
+    rock.threadwise_write_all [#transform_mapM](%source) -> %dest by set
+    ```
+
+    will lower to
+    ```mlir
+    %bid = rock.workgroup_id
+    %tid = rock.workitem_id
+    rock.transforming_for (%_, %_, %i) = [](%c0, %c0, %c0)
+      (%args, ...) = MAPS(%bid, %tid, %c0)
+      bounds = [1, 1, L], strides = [1, 1, V] {
+        rock.global_store set {length = V, oobDims=...} %source[%i] -> %buffer[%args]
+    }
+    ```
+    where MAPS is `[#transform_mapM, #transform_mapN]`,
+    L is the length of `%source`, V is the maximum vectorization computed
+    for MAPS, and the oob dimensions are those combputed on MAPS.
+
+    The input to extraViews ; (the transforms on %dest) must have the form
+    (workgroup_id, workitem_id, iteration_number)
+
+    This is used during fusion to allow rewriting
+    ```mlir
+    %tmp = memref.alloc()
+    ...
+    rock.threadwise_write_all [...](%result) -> %tmp
+    linalg.generic (%tmp) -> (%output) { ... }
+    ```
+
+    to
+    ```mlir
+    linalg.generic (%result) -> (%result_2) { ... }
+    rock.thredawise_write_all [...](%result_2) -> %out
+    ```
+  }];
+
+  let assemblyFormat = [{
+    attr-dict $extraViews `(` $source `)` `->` $dest `by` $storeMethod
+    `:` type($source) `->` type($dest)
+  }];
+  let hasVerifier = 1;
+}
+
 // blockwise_gemm
 def Rock_BlockwiseGemmOp:
     Rock_Op<"blockwise_gemm">,

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1344,6 +1344,25 @@ LogicalResult InBoundsStoreOp::verify() {
   return success();
 }
 
+//===-----------------------------------------------------===//
+// ThreadwiseWriteAllOp
+//===-----------------------------------------------------===//
+LogicalResult ThreadwiseWriteAllOp::verify() {
+  MemRefType sourceType = getSource().getType();
+  if (sourceType.getMemorySpaceAsInt() != 5)
+    return emitOpError("source must be private registers");
+  ArrayAttr extraViews = getExtraViews();
+  ArrayRef<int64_t> inputShape;
+  if (extraViews.empty())
+    inputShape = getDest().getType().getShape();
+  else
+    inputShape = extraViews[0].cast<TransformMapAttr>().getUpperBounds();
+
+  if (inputShape.size() != 3)
+    return emitOpError("input must accept (bid, tid, iter) coordinates");
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // BlockwiseGemmOp
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/Rock/lowering_threadwise_write_all.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_write_all.mlir
@@ -1,0 +1,33 @@
+// Note: this should be in a post-fusion pass
+// RUN: rocmlir-opt -rock-gridwise-gemm-to-blockwise %s | FileCheck --enable-var-scope %s
+
+// CHECK-DAG: #[[$ON_OP:transform_map.+]] = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG: #[[$IN_FUNC:transform_map.+]] = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2 - 2)>
+#transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+  by [<PassThrough ["x", "y", "z"] at [0, 1, 2] -> ["x", "y", "z"] at [0, 1, 2]>]
+  bounds = [2, 64, 32] -> [2, 64, 32]>
+#transform_map1 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2 - 2)>
+  by [<PassThrough ["x", "y"] at [0, 1]  -> ["x", "y"] at [0, 1]>,
+    <Pad{2, 0} ["z"] at [2] -> ["z"] at [2]>]
+  bounds = [2, 64, 32] -> [2, 64, 30]>
+
+// CHECK-LABEL: func @threadwise_write_all
+// CHECK-SAME: [[source:%.+]]: memref<32xf32, 5>, [[dest:%.+]]: memref<2x64x30xf32>
+func.func @threadwise_write_all(%source: memref<32xf32, 5>, %dest: memref<2x64x30xf32>) {
+  // CHECK-DAG: [[zero:%.+]] = arith.constant 0
+  // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
+  // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
+  // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
+  // CHECK-SAME: ({{%.*}}, {{%.*}}, [[i:%.+]]) = []([[bid]], [[tid]], [[zero]])
+  // CHECK-SAME: ([[args:%.+, %.+, %.+]]) = [#[[$ON_OP]], #[[$IN_FUNC]]]([[bid]], [[tid]], [[zero]])
+  // CHECK-SAME: bounds [1, 1, 32]
+  // CHECK-SAME: strides [1, 1, 2]
+  // CHECK-NEXT: rock.global_store [[source]][[[i]]] -> [[dest]][[[args]]]
+  // CHECK-SAME: leftOobDims = [2 : i32], length = 2 : index, rightOobDims = []
+
+  %view = rock.transform %dest by #transform_map1 : memref<2x64x30xf32> to memref<2x64x32xf32>
+  rock.threadwise_write_all {forceUnroll, useIndexDiffs}
+    [#transform_map0](%source) -> %view by set
+    : memref<32xf32, 5> -> memref<2x64x32xf32>
+  func.return
+}


### PR DESCRIPTION
In order to simplify an upcoming fusion refactoring, define rock.threadwise_write_all, which expands to a transforming_for loop that stores values from a memref of registers to a global buffer after peeling the rock.transform operations off of said buffer.

This operation is currently lowered within
-rock-gridwise-gemm-to-blockwise in order to not disturb the existing fusion code, but that should change in the future.

Also merge in upstream's clang-tidy config while I'm here because with ROCm 5.4.0 I was getting a bunch of complaints about const that weren't actually meant to be showing up.