### PR TITLE
Enabling looped load/execution for xdlops gemm

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1017,16 +1017,19 @@ def Rock_ThreadwiseGemmOp:
 // xdlops_gemm_V2
 def Rock_XdlopsGemmV2Op:
     Rock_Op<"xdlops_gemm_v2">,
-    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8,
-                      VectorOfLengthAndType<[2, 4], [F32]>,
-                      VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [2]>:$matrixA,
+    Arguments<(ins 
+                   Index:$mRepeat,
+                   Index:$nRepeat,
                    MemRefRankOf<[F32, F16, BF16, I8,
                       VectorOfLengthAndType<[2, 4], [F32]>,
                       VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [2]>:$matrixB,
+                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [1]>:$matrixA,
+                   MemRefRankOf<[F32, F16, BF16, I8,
+                      VectorOfLengthAndType<[2, 4], [F32]>,
+                      VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [1]>:$matrixB,
                    MemRefRankOf<[F32, F16, BF16, I32,
-                      VectorOf<[F32, F16, BF16, I32]>], [3]>:$matrixC,
+                      VectorOf<[F32, F16, BF16, I32]>], [1]>:$matrixC,
                    Rock_XdlopsGemmParamsAttr:$params)> {
   let summary = "XDLOPS GEMM V2";
   let description = [{
@@ -1036,7 +1039,7 @@ def Rock_XdlopsGemmV2Op:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    $matrixC `+` `` `=` $matrixA `*` $matrixB attr-dict
+    $matrixC `+` `` `=` $matrixA`[`$mRepeat`]` `*` $matrixB`[`$nRepeat`]` attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
   let hasVerifier = 1;

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1406,15 +1406,10 @@ LogicalResult ThreadwiseGemmOp::verify() {
 //===----------------------------------------------------------------------===//
 LogicalResult XdlopsGemmV2Op::verify() {
   ArrayRef<int64_t> aShape = getMatrixA().getType().getShape(),
-                    bShape = getMatrixB().getType().getShape(),
-                    cShape = getMatrixC().getType().getShape();
+                    bShape = getMatrixB().getType().getShape();
 
-  if (aShape[1] != bShape[1])
+  if (aShape != bShape)
     return emitOpError("K dimensions don't match");
-  if (aShape[0] != cShape[0])
-    return emitOpError("M dimensions don't match");
-  if (bShape[0] != cShape[1])
-    return emitOpError("N dimensions don't match");
   return success();
 }
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
@@ -1,11 +1,4 @@
 // RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
-#transform_map0 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 8 + d1)> by [<Embed{8, 1} ["m", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [1, 8] -> [8]>
-#transform_map1 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 8 + d1)> by [<Embed{8, 1} ["n", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [1, 8] -> [8]>
-#transform_map2 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0 * 2 + d1 * 2 + d2)> by [<Embed{2, 2, 1} ["m", "n", "v"] at [0, 1, 2] -> ["raw"] at [0]>] bounds = [1, 1, 2] -> [2]>
-
-#map0 = affine_map<(d0, d1) -> (d0 * 8 + d1)>
-#map1 = affine_map<(d0, d1, d2) -> (d0 * 2 + d1 * 2 + d2)>
-
 func.func @rock_xdlops_gemm_v2_nonreduction_nokpack(%matrixA : memref<8xf32, 5>,
                                                       %matrixB : memref<8xf32, 5>,
                                                       %matrixC : memref<2xvector<32xf32>, 5>) {
@@ -13,10 +6,8 @@ func.func @rock_xdlops_gemm_v2_nonreduction_nokpack(%matrixA : memref<8xf32, 5>,
   // CHECK: rock.in_bounds_load
   // CHECK: rock.in_bounds_load
   // CHECK: amdgpu.mfma
-  %A = rock.transform %matrixA by #transform_map0 : memref<8xf32, 5> to memref<1x8xf32, #map0, 5>
-  %B = rock.transform %matrixB by #transform_map1 : memref<8xf32, 5> to memref<1x8xf32, #map0, 5>
-  %C = rock.transform %matrixC by #transform_map2 : memref<2xvector<32xf32>, 5> to memref<1x1x2xvector<32xf32>, #map1, 5>
-  rock.xdlops_gemm_v2 %C += %A * %B {
+  %c0 = arith.constant 0 : index
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
        kPerBlock = 8,
        kpack = 1,
@@ -25,16 +16,9 @@ func.func @rock_xdlops_gemm_v2_nonreduction_nokpack(%matrixA : memref<8xf32, 5>,
        nPerBlock = 64,
        nPerWave = 32,
        forceUnroll = true>
-     } : memref<1x1x2xvector<32xf32>, #map1, 5> += memref<1x8xf32, #map0, 5> * memref<1x8xf32, #map0, 5>
+     } : memref<2xvector<32xf32>, 5> += memref<8xf32, 5> * memref<8xf32, 5>
   return
 }
-
-#transform_map3 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 2 + d1)> by [<Embed{2, 1} ["m", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [1, 2] -> [2]>
-#transform_map4 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 2 + d1)> by [<Embed{2, 1} ["n", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [1, 2] -> [2]>
-#transform_map5 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0 * 2 + d1 * 2 + d2)> by [<Embed{2, 2, 1} ["m", "n", "v"] at [0, 1, 2] -> ["raw"] at [0]>] bounds = [1, 1, 2] -> [2]>
-
-#map2 = affine_map<(d0, d1) -> (d0 * 2 + d1)>
-#map3 = affine_map<(d0, d1, d2) -> (d0 * 2 + d1 * 2 + d2)>
 
 func.func @rock_xdlops_gemm_v2_nonreduction_kpack(%matrixA : memref<2xvector<2xf32>, 5>,
                                                     %matrixB : memref<2xvector<2xf32>, 5>,
@@ -45,10 +29,7 @@ func.func @rock_xdlops_gemm_v2_nonreduction_kpack(%matrixA : memref<2xvector<2xf
   // CHECK: rock.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK: amdgpu.mfma
-  %A = rock.transform %matrixA by #transform_map3 : memref<2xvector<2xf32>, 5> to memref<1x2xvector<2xf32>, #map2, 5>
-  %B = rock.transform %matrixB by #transform_map4 : memref<2xvector<2xf32>, 5> to memref<1x2xvector<2xf32>, #map2, 5>
-  %C = rock.transform %matrixC by #transform_map5 : memref<2xvector<32xf32>, 5> to memref<1x1x2xvector<32xf32>, #map3, 5>
-  rock.xdlops_gemm_v2 %C += %A * %B {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 2,
       kpack = 2,
@@ -57,7 +38,7 @@ func.func @rock_xdlops_gemm_v2_nonreduction_kpack(%matrixA : memref<2xvector<2xf
       nPerBlock = 128,
       nPerWave = 64,
       forceUnroll = true>
-  } : memref<1x1x2xvector<32xf32>, #map3, 5> += memref<1x2xvector<2xf32>, #map2, 5> * memref<1x2xvector<2xf32>, #map2, 5>
+  } : memref<2xvector<32xf32>, 5> += memref<2xvector<2xf32>, 5> * memref<2xvector<2xf32>, 5>
   return
 }
 
@@ -70,10 +51,7 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack(%matrixA : memref<2xvector<8xi8>,
   // CHECK: rock.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK-NOT: amdgpu.mfma
-  %A = rock.transform %matrixA by #transform_map3 : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
-  %B = rock.transform %matrixB by #transform_map4 : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
-  %C = rock.transform %matrixC by #transform_map5 : memref<1xvector<16xi32>, 5> to memref<1x1x1xvector<16xi32>, #map3, 5>
-  rock.xdlops_gemm_v2 %C += %A * %B {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 4,
       kpack = 8,
@@ -82,6 +60,6 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack(%matrixA : memref<2xvector<8xi8>,
       mPerBlock = 64,
       nPerBlock = 64,
       forceUnroll = true>
-  } : memref<1x1x1xvector<16xi32>, #map3, 5> += memref<1x2xvector<8xi8>, #map2, 5> * memref<1x2xvector<8xi8>, #map2, 5>
+  } : memref<1xvector<16xi32>, 5> += memref<2xvector<8xi8>, 5> * memref<2xvector<8xi8>, 5>
   return
 }

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -490,11 +490,11 @@ func.func @rock_threadwise_gemm(%lhs : memref<4x8x1xf32, 5>, %rhs : memref<4x8x1
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<2x16xf32, 5>,
-                                            %matrixB : memref<1x16xf32, 5>,
-                                            %matrixC : memref<2x1x1xvector<32xf32>, 5>) {
+func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<16xf32, 5>,
+                                            %matrixB : memref<16xf32, 5>,
+                                            %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -503,7 +503,7 @@ func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<2x16xf32, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf32>, 5> += memref<2x16xf32, 5> * memref<1x16xf32, 5>
+  } : memref<1xvector<32xf32>, 5> += memref<16xf32, 5> * memref<16xf32, 5>
   return
 }
 
@@ -512,11 +512,11 @@ func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<2x16xf32, 5>,
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_two_results(%matrixA : memref<2x16xf32, 5>,
-                                             %matrixB : memref<1x16xf32, 5>,
-                                             %matrixC : memref<2x1x1xvector<32xf32>, 5>) {
+func.func @rock_xdlops_gemm_v2_two_results(%matrixA : memref<16xf32, 5>,
+                                             %matrixB : memref<16xf32, 5>,
+                                             %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -525,7 +525,7 @@ func.func @rock_xdlops_gemm_v2_two_results(%matrixA : memref<2x16xf32, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf32>, 5> += memref<2x16xf32, 5> * memref<1x16xf32, 5>
+  } : memref<1xvector<32xf32>, 5> += memref<16xf32, 5> * memref<16xf32, 5>
   return
 }
 

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -22,11 +22,11 @@ func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x12
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<2x16xf16, 5>,
-                                                %matrixB : memref<1x16xf16, 5>,
-                                                %matrixC : memref<2x1x1xvector<32xf16>, 5>) {
+func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<16xf16, 5>,
+                                                %matrixB : memref<16xf16, 5>,
+                                                %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -35,7 +35,7 @@ func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<2x16xf16, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf16>, 5> += memref<2x16xf16, 5> * memref<1x16xf16, 5>
+  } : memref<1xvector<32xf16>, 5> += memref<16xf16, 5> * memref<16xf16, 5>
   return
 }
 
@@ -44,11 +44,11 @@ func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<2x16xf16, 5>,
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<2x16xf16, 5>,
-                                                 %matrixB: memref<1x16xf16, 5>,
-                                                 %matrixC : memref<2x1x1xvector<32xf16>, 5>) {
+func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<16xf16, 5>,
+                                               %matrixB : memref<16xf16, 5>,
+                                               %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -57,7 +57,7 @@ func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<2x16xf16, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf16>, 5> += memref<2x16xf16, 5> * memref<1x16xf16, 5>
+  } : memref<1xvector<32xf16>, 5> += memref<16xf16, 5> * memref<16xf16, 5>
   return
 }
 


### PR DESCRIPTION
This PR convert the flat load/execution loop of blockwise and xdlops gemm from

```cpp
for m = 0 : mRepeat
  for i = 0 : K 
    a = load(A) 

for n = 0 : nRepeat
  for i = 0 : K
    b = load(B) 

for m = 0 : mRepeat
  for n = 0 : nRepeat
    for i = 0 : K 
      c = a * b 
```

to

```cpp
for m = 0 : mRepeat
  for n = 0 : nRepeat
    for k = 0 : K   
      a = load(A)
      b = load(B)
      c = a * b
```

This reduces the register to allocate at one go and increase the amount of parallelism between load and execution.

Next step of after PR, per discussion with @giuseros is to make the loop pipelined in a follow-up pass.