### PR TITLE
Fixing redundant archive by moving to the reports folder

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -131,7 +131,7 @@ void postProcessPerfRes(String chip) {
         allowMissing: false,
         alwaysLinkToLastBuild: false,
         keepAll: true,
-        reportDir: 'build',
+        reportDir: 'build/reports',
         reportFiles: "${chip}_MLIR_Performance_Changes.html,${chip}_MLIR_vs_MIOpen.html,${chip}_MLIR_Performance_Changes_Gemm.html,${chip}_MLIR_vs_rocBLAS.html",
         reportName: "Performance report for ${chip}"
     ])
@@ -828,6 +828,7 @@ pipeline {
                                 sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
+                                sh 'mkdir -p reports && cp ./*.html reports'
                             }
                             postProcessPerfRes("${CHIP}")
                         }


### PR DESCRIPTION
The jenkins HTML publisher plugin has the side effect of archiving too much (undocumented from its [reference page](https://www.jenkins.io/doc/pipeline/steps/htmlpublisher/)). This entire build folder was archived, causing disk running out of space.

After a couple of attempt to fix it, I figured that the easy way is to give it a folder where no redundant build files exists. @okakarpa confirmed in a test run that this will no longer store the useless intermediate files and make nightly archive size fall to reasonable size.