### PR TITLE
[DO NOT SQUASH] Remove certain CMake crimes around CMAKE_PREFIX_PATH

### DIFF
--- a/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -197,8 +197,14 @@ if(MLIR_ENABLE_ROCM_RUNNER)
       set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which ROCm has been installed")
     endif()
   endif()
+  # A lot of the ROCm CMake files expect to find their own dependencies in
+  # CMAKE_PREFIX_PATH and don't respect PATHS or HINTS :( .
+  # Therefore, temporarily add the ROCm path to CMAKE_PREFIX_PATH so we can
+  # load HIP, then remove it
+  set(REAL_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
   find_package(hip REQUIRED)
+  set(CMAKE_PREFIX_PATH "${REAL_CMAKE_PREFIX_PATH}")
 
   if (NOT DEFINED ROCM_TEST_CHIPSET)
     execute_process(COMMAND "${ROCM_PATH}/bin/rocm_agent_enumerator"

--- a/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
+++ b/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
@@ -25,9 +25,14 @@ if (NOT DEFINED ROCM_PATH)
     set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which ROCm has been installed")
   endif()
 endif()
+# A lot of the ROCm CMake files expect to find their own dependencies in
+# CMAKE_PREFIX_PATH and don't respect PATHS or HINTS :( .
+# Therefore, temporarily add the ROCm path to CMAKE_PREFIX_PATH so we can
+# load HIP, then remove it
+set(REAL_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
 find_package(hip REQUIRED)
-
+set(CMAKE_PREFIX_PATH "${REAL_CMAKE_PREFIX_PATH}")
 
 # Supress compiler warnings from HIP headers
 check_cxx_compiler_flag(-Wno-c++98-compat-extra-semi


### PR DESCRIPTION
HIP needs /opt/rocm in CMAKE_PREFIX_PATH, setting that globally is bad practice, compromise by temporarily setting it just for finding HIP.