### PR TITLE
Add ConstDim operator

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -75,10 +75,12 @@ def Merge : I32EnumAttrCase<"Merge", 5>;
 def Unfold : I32EnumAttrCase<"Unfold", 6>;
 def AddDim : I32EnumAttrCase<"AddDim", 7>;
 def Broadcast : I32EnumAttrCase<"Broadcast", 8>;
+def ConstDim : I32EnumAttrCase<"ConstDim", 9>;
 
 def TransformType : Rock_I32Enum<"TransformType",
     "The operation type for a coordinate transformation",
-    [PassThrough, Pad, Slice, Embed, Unmerge, Merge, Unfold, AddDim, Broadcast]>;
+    [PassThrough, Pad, Slice, Embed, Unmerge, Merge, Unfold, AddDim, Broadcast,
+     ConstDim]>;
 
 /// StoreMethod
 
@@ -258,7 +260,7 @@ def Rock_XdlopsGemmParamsAttr : Rock_Attr<"XdlopsGemmParams", [RockTuningParamAt
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(std::string &perfStr){
-      const Twine paramsConcat = 
+      const Twine paramsConcat =
           Twine(getMPerBlock()) + ","
         + Twine(getNPerBlock()) + ","
         + Twine(getKPerBlock()) + ","

--- a/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
@@ -150,7 +150,15 @@ public:
   // that your start dimension is already sliced so you need to pass the full
   // length
 
+  // Drop `dim`, making it disappear from the underlying view.
   void ignore(StringRef dim);
+
+  // Defines dimension(s) that have a constan value and some particular size.
+  void constDim(StringRef lowerName, uint32_t lowerDim, int64_t constantVal,
+                int64_t lowerSize);
+  void constDim(ArrayRef<StringRef> lowerNames, ArrayRef<uint32_t> lowerDims,
+                ArrayRef<int64_t> constantVals, ArrayRef<int64_t> lowerSizes);
+
   void embed(StringRef lowerName, uint32_t lowerDim, int64_t lowerSize,
              ArrayRef<StringRef> upperNames, ArrayRef<int64_t> coefficients);
   void unmerge(StringRef lowerName, uint32_t lowerDim,
@@ -187,6 +195,10 @@ struct TopDownTMBottomDimsWrapper {
 
   void pad(ArrayRef<StringRef> outNames, ArrayRef<StringRef> inNames,
            ArrayRef<int64_t> params);
+
+  void constDim(StringRef lowerName, int64_t constantVal, int64_t lowerSize);
+  void constDim(ArrayRef<StringRef> lowerNames, ArrayRef<int64_t> constantVals,
+                ArrayRef<int64_t> lowerSizes);
 
   void embed(StringRef lowerName, int64_t lowerSize,
              ArrayRef<StringRef> upperNames, ArrayRef<int64_t> coefficients);
@@ -230,6 +242,12 @@ public:
 
   // Defines a dimension that is not mapped to any coordinates in the output
   void addDim(StringRef name, uint32_t dim, int64_t size);
+
+  // NOTE: there is no builder for constDim but you can add one if you really
+  // want to. If you do so, put some sort of warning in the name, like
+  // assumeDimIsConst(), because, when working from the bottom up,
+  // that transformation is an assertion that a given dimension has a particular
+  // constant value.
 
   void broadcast(ArrayRef<uint32_t> endDims, ArrayRef<int64_t> endSizes);
 

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -684,6 +684,12 @@ struct IndexDiffUpdateRewritePattern
           lowerIndicesDiffMap[q[i]] = lowerDiff;
           lowerIndicesUpdatedMap[q[i]] = newLower;
         }
+      } else if (transformation == TransformType::ConstDim) {
+        for (uint32_t i = 0; i < q.size(); ++i) {
+          // A constant dimension has its original value and no difference
+          lowerIndicesDiffMap[q[i]] = zeroConstantOp;
+          lowerIndicesUpdatedMap[q[i]] = lowerIndicesOriginal[q[i]];
+        }
       }
     } // for (auto mapping : transforms.getOps())
 

--- a/mlir/test/Dialect/Rock/index_diff_update.mlir
+++ b/mlir/test/Dialect/Rock/index_diff_update.mlir
@@ -27,6 +27,11 @@
         #rock.transform<PassThrough ["y"] at [1] -> ["y"] at [0]>]
     bounds = [16, 4] -> [4]>
 
+#transform_map6 = #rock.transform_map<affine_map<(d0) -> (d0, 1)>
+    by [<PassThrough ["x"] at [0] -> ["x"] at [0]>,
+        <ConstDim{1, 8} [] at [] -> ["y"] at [1]>]
+    bounds = [64] -> [64, 8]>
+
 module {
     // CHECK-LABEL: func.func @index_diff_passthrough
     // CHECK-SAME: ({{.*}}%[[l0:.*]]: index, %[[l1:.*]]: index)
@@ -123,6 +128,16 @@ module {
         %i0, %d0 = rock.index_diff_update #transform_map5(%dx, %c1) + (%l0) : index
         // CHECK-NEXT: memref.store {{.*}}%[[i0]]
         memref.store %v, %mem[%i0] : memref<4xf32>
+        return
+    }
+
+    // CHECK-LABEL: func.func @index_diff_const_dim
+    // CHECK-SAME: ({{.*}}, %[[l0:.*]]: index, %[[l1:.*]]: index, %[[dx:.*]]: index)
+    func.func @index_diff_const_dim(%mem: memref<64x8xf32>, %v: f32, %l0: index, %l1: index, %dx: index) {
+        // CHECK-NEXT: %[[i0:.*]] = arith.addi %[[l0]], %[[dx]]
+        %i0, %i1, %d0, %d1 = rock.index_diff_update #transform_map6(%dx) + (%l0, %l1) : index, index
+        // CHECK-NEXT: memref.store {{.*}}%[[i0]], %[[l1]]
+        memref.store %v, %mem[%i0, %i1] : memref<64x8xf32>
         return
     }
 

--- a/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
+++ b/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
@@ -161,6 +161,10 @@
   by [<Embed{1, 3} ["a", "c"] at [0, 1] -> ["x"] at [0]>]
   bounds = [3, 8] -> [24]>
 
+#transform_inject_unit_const = #rock.transform_map<affine_map<(d0, d1) -> (d0, 0, d1)>
+  by [<PassThrough ["a", "b"] at [0, 1] -> ["a", "c"] at [0, 2]>,
+    <ConstDim{0, 1} [] at [] -> ["b"] at [1]>]
+  bounds = [8, 3] -> [8, 1, 3]>
 
 // CHECK-LABEL: func.func @test
 func.func @test_vectorization() {
@@ -277,9 +281,8 @@ func.func @test_vectorization() {
   %37 = "get_length"() {transforms = [#transform_merge_7, #transform_shuffle_5, #transform_unmerge_8], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
   // CHECK-NEXT: result = 4
   %38 = "get_length"() {transforms = [#transform_merge_9, #transform_shuffle_6, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
-
-
-
+  // CHECK-NEXT: result = 4
+  %39 = "get_length"() {transforms = [#transform_merge, #transform_inject_unit_const, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
  func.return
 }
 

--- a/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
+++ b/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
@@ -166,6 +166,15 @@
     <ConstDim{0, 1} [] at [] -> ["b"] at [1]>]
   bounds = [8, 3] -> [8, 1, 3]>
 
+#transform_inject_non_unit_const = #rock.transform_map<affine_map<(d0, d1) -> (d0, 0, d1)>
+  by [<PassThrough ["a", "b"] at [0, 1] -> ["a", "c"] at [0, 2]>,
+    <ConstDim{0, 2} [] at [] -> ["b"] at [1]>]
+  bounds = [8, 3] -> [8, 2, 3]>
+
+#transform_unmerge_injected_non_unit = #rock.transform_map<affine_map<(d0, d1, d2) -> (d2 + 3 * (d1 + d0 * 2))>
+  by [<Unmerge{8, 2, 3} ["a", "b", "c"] at [0, 1, 2] -> ["x"] at [0]>]
+  bounds = [8, 2, 3] -> [48]>
+
 // CHECK-LABEL: func.func @test
 func.func @test_vectorization() {
   // CHECK-NEXT: result = 4
@@ -283,6 +292,9 @@ func.func @test_vectorization() {
   %38 = "get_length"() {transforms = [#transform_merge_9, #transform_shuffle_6, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
   // CHECK-NEXT: result = 4
   %39 = "get_length"() {transforms = [#transform_merge, #transform_inject_unit_const, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
+  // Even though we injected a 0, it _could_ have been a 1.
+  // CHECK-NEXT: result = 1
+  %40 = "get_length"() {transforms = [#transform_merge, #transform_inject_non_unit_const, #transform_unmerge_injected_non_unit], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<48xf32>)
  func.return
 }
 

--- a/mlir/unittests/Dialect/Rock/TransformMapBuilderTests.cpp
+++ b/mlir/unittests/Dialect/Rock/TransformMapBuilderTests.cpp
@@ -195,6 +195,20 @@ TEST_F(TMBuilderTest, AddDim) {
   EXPECT_EQ(resUp, resDown);
 }
 
+TEST_F(TMBuilderTest, ConstDim) {
+  auto buildDown = makeTopDown({}, {});
+
+  buildDown.constDim("a", 0, 0, 1);
+  buildDown.constDim({"b", "c"}, {1, 2}, {1, 2}, {2, 3});
+
+  TransformMapAttr resDown = buildDown.get();
+
+  EXPECT_EQ(resDown.getMap().getAffineMap(),
+            AffineMap::get(0, 0, {affC(0), affC(1), affC(2)}, &context));
+  SmallVector<int64_t> expectedLowerBounds = {1, 2, 3};
+  EXPECT_ARRAY_EQ(int64_t, resDown.getLowerBounds(), expectedLowerBounds);
+}
+
 TEST_F(TMBuilderTest, Broadcast) {
   auto buildUp = makeBottomUp({"a", "b"}, {1, 3});
 


### PR DESCRIPTION
This operator takes no inputs (no dimensions in the view) and adds constant-valued dimensions into the output (underlying tensor/next view).

The operator is parameterized by {constant_value, dimension_length, constant_value, dimension_length, ...}.

The point of all this is to allow us to nicely represent certain maps, like "() -> (0, 0, 0, 0)", that you find in various fusion scenarios.

A commit that uses this may or may not be upcoming.