### PR TITLE
Fix address-sanitiser errors and a compile warning

### DIFF
--- a/mlir/include/mlir-c/Dialect/Rock.h
+++ b/mlir/include/mlir-c/Dialect/Rock.h
@@ -88,8 +88,9 @@ void mlirRockTuningTableDestroy(MlirRockTuningTable table);
 // the best performing tuning parameter to simplify the underlying
 // implementation, which can be revisited in the future.
 MLIR_CAPI_EXPORTED
-bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable, char *probCStr,
-                               char *perfCStr, float time);
+bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable,
+                               const char *probCStr, const char *perfCStr,
+                               float time);
 
 // Search the tuning table and get the stored best value for the given problem.
 // The definition of the tuning problem is internally described and opaque to

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -223,14 +223,13 @@ def Rock_GeneralGemmParamsAttr : Rock_Attr<"GeneralGemmParams", [RockTuningParam
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(std::string &perfStr){
-      const Twine paramsConcat =
-        Twine(getBlockSize()) + ","
+      perfStr =
+       (Twine(getBlockSize()) + ","
       + Twine(getMPerBlock()) + ","
       + Twine(getNPerBlock()) + ","
       + Twine(getKPerBlock()) + ","
       + Twine(getMPerThread()) + ","
-      + Twine(getNPerThread());
-      perfStr = paramsConcat.str();
+      + Twine(getNPerThread())).str();
     }
   }];
 
@@ -258,16 +257,16 @@ def Rock_XdlopsGemmParamsAttr : Rock_Attr<"XdlopsGemmParams", [RockTuningParamAt
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(std::string &perfStr){
-      const Twine paramsConcat = 
-          Twine(getMPerBlock()) + ","
+      perfStr =
+         (Twine(getMPerBlock()) + ","
         + Twine(getNPerBlock()) + ","
         + Twine(getKPerBlock()) + ","
         + Twine(getMPerWave()) + ","
         + Twine(getNPerWave()) + ","
         + Twine(getKpack()) + ","
         + Twine(getForceUnroll()) + ","
-        + "1"; /* *ThreadCopyMore* */
-      perfStr = paramsConcat.str();
+          + "1") /* *ThreadCopyMore* */
+        .str();
     }
   }];
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -223,13 +223,14 @@ def Rock_GeneralGemmParamsAttr : Rock_Attr<"GeneralGemmParams", [RockTuningParam
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(std::string &perfStr){
-      perfStr =
-        std::to_string(getBlockSize()) + ","
-      + std::to_string(getMPerBlock()) + ","
-      + std::to_string(getNPerBlock()) + ","
-      + std::to_string(getKPerBlock()) + ","
-      + std::to_string(getMPerThread()) + ","
-      + std::to_string(getNPerThread());
+      const Twine paramsConcat =
+        Twine(getBlockSize()) + ","
+      + Twine(getMPerBlock()) + ","
+      + Twine(getNPerBlock()) + ","
+      + Twine(getKPerBlock()) + ","
+      + Twine(getMPerThread()) + ","
+      + Twine(getNPerThread());
+      perfStr = paramsConcat.str();
     }
   }];
 
@@ -257,15 +258,16 @@ def Rock_XdlopsGemmParamsAttr : Rock_Attr<"XdlopsGemmParams", [RockTuningParamAt
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(std::string &perfStr){
-      perfStr =
-          std::to_string(getMPerBlock()) + ","
-        + std::to_string(getNPerBlock()) + ","
-        + std::to_string(getKPerBlock()) + ","
-        + std::to_string(getMPerWave()) + ","
-        + std::to_string(getNPerWave()) + ","
-        + std::to_string(getKpack()) + ","
-        + std::to_string(getForceUnroll()) + ","
+      const Twine paramsConcat = 
+          Twine(getMPerBlock()) + ","
+        + Twine(getNPerBlock()) + ","
+        + Twine(getKPerBlock()) + ","
+        + Twine(getMPerWave()) + ","
+        + Twine(getNPerWave()) + ","
+        + Twine(getKpack()) + ","
+        + Twine(getForceUnroll()) + ","
         + "1"; /* *ThreadCopyMore* */
+      perfStr = paramsConcat.str();
     }
   }];
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -223,14 +223,13 @@ def Rock_GeneralGemmParamsAttr : Rock_Attr<"GeneralGemmParams", [RockTuningParam
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(std::string &perfStr){
-      const Twine paramsConcat =
-        Twine(getBlockSize()) + ","
-      + Twine(getMPerBlock()) + ","
-      + Twine(getNPerBlock()) + ","
-      + Twine(getKPerBlock()) + ","
-      + Twine(getMPerThread()) + ","
-      + Twine(getNPerThread());
-      perfStr = paramsConcat.str();
+      perfStr =
+        std::to_string(getBlockSize()) + ","
+      + std::to_string(getMPerBlock()) + ","
+      + std::to_string(getNPerBlock()) + ","
+      + std::to_string(getKPerBlock()) + ","
+      + std::to_string(getMPerThread()) + ","
+      + std::to_string(getNPerThread());
     }
   }];
 
@@ -258,16 +257,15 @@ def Rock_XdlopsGemmParamsAttr : Rock_Attr<"XdlopsGemmParams", [RockTuningParamAt
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(std::string &perfStr){
-      const Twine paramsConcat = 
-          Twine(getMPerBlock()) + ","
-        + Twine(getNPerBlock()) + ","
-        + Twine(getKPerBlock()) + ","
-        + Twine(getMPerWave()) + ","
-        + Twine(getNPerWave()) + ","
-        + Twine(getKpack()) + ","
-        + Twine(getForceUnroll()) + ","
+      perfStr =
+          std::to_string(getMPerBlock()) + ","
+        + std::to_string(getNPerBlock()) + ","
+        + std::to_string(getKPerBlock()) + ","
+        + std::to_string(getMPerWave()) + ","
+        + std::to_string(getNPerWave()) + ","
+        + std::to_string(getKpack()) + ","
+        + std::to_string(getForceUnroll()) + ","
         + "1"; /* *ThreadCopyMore* */
-      perfStr = paramsConcat.str();
     }
   }];
 

--- a/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
@@ -44,8 +44,8 @@ public:
   void getEndNames(SmallVectorImpl<StringRef> &names);
   void getStartNames(SmallVectorImpl<StringRef> &names);
 
-  SmallString<8> startName(uint32_t dim);
-  SmallString<8> endName(uint32_t dim);
+  StringRef startName(uint32_t dim);
+  StringRef endName(uint32_t dim);
   uint32_t startIndex(StringRef name);
   uint32_t endIndex(StringRef name);
 

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -101,8 +101,9 @@ void mlirRockTuningTableDestroy(MlirRockTuningTable table) {
 }
 
 MLIR_CAPI_EXPORTED
-bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable, char *probCStr,
-                               char *perfCStr, float time) {
+bool mlirRockTuningUpdateTable(MlirRockTuningTable perfTable,
+                               const char *probCStr, const char *perfCStr,
+                               float time) {
   MlirStringRef probStringRef = mlirStringRefCreateFromCString(probCStr);
   MlirStringRef perfStringRef = mlirStringRefCreateFromCString(perfCStr);
   std::string problem = unwrap(probStringRef).str();

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -211,11 +211,11 @@ void TransformMapBuilder::getStartNames(SmallVectorImpl<StringRef> &names) {
   }
 }
 
-SmallString<8> TransformMapBuilder::startName(uint32_t dim) {
+StringRef TransformMapBuilder::startName(uint32_t dim) {
   return startNames[dim];
 }
 
-SmallString<8> TransformMapBuilder::endName(uint32_t dim) {
+StringRef TransformMapBuilder::endName(uint32_t dim) {
   assert(endNames.count(dim) == 1 &&
          "Dimension not defined in ending dimension space");
   return endNames[dim];

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -215,7 +215,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
   // ranks, dimensions of each arguments and kernel name.
   int argSize = 0;
   mlirGetKernelInfo(module, &argSize, NULL);
-  void *argInfo = malloc(argSize+1);
+  void *argInfo = malloc(argSize + 1);
   // get the data
   mlirGetKernelInfo(module, NULL, (void *)argInfo);
   int *argData = (int *)argInfo;
@@ -233,7 +233,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
 
   // The last part of the retrieved data contains the kernel name.
   char *nameData = (char *)(argData + idx);
-  ((char*)argInfo)[argSize] = '\0';
+  ((char *)argInfo)[argSize] = '\0';
   printf("kernel name : %s\n", nameData);
 
   // 2nd pipeline to call

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -215,7 +215,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
   // ranks, dimensions of each arguments and kernel name.
   int argSize = 0;
   mlirGetKernelInfo(module, &argSize, NULL);
-  void *argInfo = malloc(argSize);
+  void *argInfo = malloc(argSize+1);
   // get the data
   mlirGetKernelInfo(module, NULL, (void *)argInfo);
   int *argData = (int *)argInfo;
@@ -233,6 +233,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
 
   // The last part of the retrieved data contains the kernel name.
   char *nameData = (char *)(argData + idx);
+  ((char*)argInfo)[argSize] = '\0';
   printf("kernel name : %s\n", nameData);
 
   // 2nd pipeline to call


### PR DESCRIPTION
When debugging something of mine, I built with the address sanitiser (-DLLVM_USE_SANITIZER=Address) and stumbled across several errors, which are fixed here.  Also fixed one compiler warning because it bugged me.

Still one other compiler warning, and still one ASAN error in TosaPartition.cpp that I'm working on eliminating while making the pass generic.