### PR TITLE
Adds tosa reduce_sum to rock reduce conversion

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -294,4 +294,9 @@ def Rock_GemmFeatures : I32BitEnumAttr<"GemmFeatures",
 }
 
 def Rock_GemmFeaturesAttr : EnumAttr<Rock_Dialect, Rock_GemmFeatures, "GemmFeatures">;
+
+// Misc Attrs
+def Rock_PrefillAttr : Rock_Attr<"Prefill"> {
+  let mnemonic = "rock.prefill";
+}
 #endif

--- a/mlir/include/mlir/InitRocMLIRPasses.h
+++ b/mlir/include/mlir/InitRocMLIRPasses.h
@@ -33,6 +33,7 @@
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Dialect/Vector/Transforms/Passes.h"
+#include "mlir/Dialect/XModel/Transforms/Passes.h"
 #include "mlir/Transforms/Passes.h"
 
 #include <cstdlib>
@@ -71,6 +72,7 @@ inline void registerUpstreamPasses() {
   tensor::registerTensorPasses();
   tosa::registerTosaOptPasses();
   vector::registerVectorPasses();
+  xmodel::registerPasses();
 }
 
 // This function may be called to register the rocMLIR passes with the

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -426,11 +426,73 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
   }
 };
 
+class ReduceSumConverter final : public OpConversionPattern<tosa::ReduceSumOp> {
+public:
+  using OpConversionPattern<tosa::ReduceSumOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(tosa::ReduceSumOp op,
+                                tosa::ReduceSumOp::Adaptor adaptor,
+                                ConversionPatternRewriter &rw) const final {
+    Location loc = op->getLoc();
+    auto outputType = op.getType().cast<RankedTensorType>();
+    Value output =
+        rw.create<bufferization::AllocTensorOp>(loc, outputType, ValueRange{});
+
+    StringAttr arch;
+    Optional<uint32_t> num_cu;
+    rock::GemmFeatures features;
+    std::tie(arch, num_cu, features) = getArchAttributes(op);
+    if (!rock::bitEnumContainsAll(features, rock::GemmFeatures::atomic_add)) {
+      op.emitError("Currently, we only support ReduceSum operators on GPUs "
+                   "with atomic add support.!.");
+    }
+
+    int32_t blockSize = 256;
+    auto elementCount =
+        op.getInput().getType().cast<ShapedType>().getNumElements();
+    int32_t gridSize = (elementCount + blockSize - 1) / blockSize;
+    if (num_cu.has_value()) {
+      gridSize = std::max((int32_t)(20 * num_cu.value()), gridSize);
+    }
+
+    auto rockReduce = rw.create<rock::ReduceOp>(
+        loc, outputType, op.getInput(), output,
+        rw.getAttr<rock::GemmFeaturesAttr>(features),
+        rw.getAttr<rock::ReduceMethodAttr>(rock::ReduceMethod::Sum),
+        rw.getIndexAttr(op.getAxis()), rw.getI32IntegerAttr(blockSize),
+        rw.getI32IntegerAttr(gridSize),
+        /*useLDS=*/nullptr,
+        /*useDPP=*/nullptr);
+
+    func::FuncOp func = op->getParentOfType<func::FuncOp>();
+    func.setResultAttr(0, rock::PrefillAttr::getMnemonic(),
+                       rw.getF32FloatAttr(0.0000));
+    func.setResultAttr(0, func::FuncOp::getReadAccessAttrName(),
+                       rw.getUnitAttr());
+    // The original function also need the read access attr for the output.
+    if (func->hasAttr("original_func")) {
+      if (ModuleOp rootMod =
+              func->getParentOfType<ModuleOp>()->getParentOfType<ModuleOp>()) {
+        SymbolTable symTable(rootMod);
+        SymbolRefAttr originalFuncAttr =
+            func->getAttrOfType<SymbolRefAttr>("original_func");
+        if (func::FuncOp originalFunc = dyn_cast<func::FuncOp>(
+                symTable.lookupSymbolIn(rootMod, originalFuncAttr))) {
+          originalFunc.setResultAttr(0, func::FuncOp::getReadAccessAttrName(),
+                                     rw.getUnitAttr());
+        }
+      }
+    }
+    rw.replaceOp(op, rockReduce.getResult());
+    return success();
+  }
+};
+
 } // namespace
 
 void tosa::populateTosaToRockConversionPatterns(MLIRContext *context,
                                                 RewritePatternSet &patterns) {
-  patterns.add<ConvConverter, MatMulConverter>(context);
+  patterns.add<ConvConverter, MatMulConverter, ReduceSumConverter>(context);
 }
 
 void tosa::populateTosaToRockTensorConversionPatterns(

--- a/mlir/lib/Conversion/TosaToRock/TosaToRockPass.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRockPass.cpp
@@ -53,7 +53,7 @@ public:
     target.addLegalDialect<rock::RockDialect, tosa::TosaDialect,
                            tensor::TensorDialect,
                            bufferization::BufferizationDialect>();
-    target.addIllegalOp<tosa::Conv2DOp, tosa::MatMulOp>();
+    target.addIllegalOp<tosa::Conv2DOp, tosa::MatMulOp, tosa::ReduceSumOp>();
 
     mlir::tosa::populateTosaToRockConversionPatterns(func->getContext(),
                                                      patterns);

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -58,6 +58,13 @@ void AffixTuningParameters::runOnOperation() {
 
   func.walk(
       [&](RockGemmWrapperInterface op) { affixTuningParametersImpl(op); });
+  func.walk([&](ReduceOp op) {
+    func::FuncOp funcOp = getOperation();
+    if (!funcOp->hasAttr("block_size")) {
+      funcOp->setAttr("block_size", op.getBlockSizeAttr());
+      funcOp->setAttr("grid_size", op.getGridSizeAttr());
+    }
+  });
   func.walk(
       [&](ZeroInitKernelOp op) { setUtilityKernelSizes(op.getBuffer(), op); });
   func.walk([&](ConvertingCopyKernelOp op) {

--- a/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ add_rocmlir_dialect_library(MLIRRockTransforms
   MLIRBufferizationTransforms
   MLIRDialect
   MLIRXModel
+  MLIRXModelTransforms
   MLIRFuncDialect
   MLIRIR
   MLIRPass

--- a/mlir/test/Conversion/TosaToRock/reductions/lit.local.cfg
+++ b/mlir/test/Conversion/TosaToRock/reductions/lit.local.cfg
@@ -1,0 +1,7 @@
+supported_archs = ["gfx90a", "gfx908", "gfx940"]
+is_supported = False
+for arch in supported_archs:
+  if arch in config.arch:
+    is_supported = True
+    break
+config.unsupported = ~is_supported

--- a/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce-e2e.mlir
+++ b/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce-e2e.mlir
@@ -1,0 +1,9 @@
+// RUN: rocmlir-opt --tosa-partition="anchor-ops=tosa.reduce_sum" --xmodel-async-graph --xmodel-target-kernels="targets=%arch" %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut test_basic --verifier clone - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// cat %s | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// CLONE: [1 1 1]
+// CLONE-NEXT: Unranked Memref base
+
+func.func @test_basic(%arg0: tensor<200x100xf32>) -> tensor<200x1xf32> {
+  %1 = "tosa.reduce_sum"(%arg0) {axis = 1 : i64} : (tensor<200x100xf32>) -> tensor<200x1xf32>
+  return %1 : tensor<200x1xf32>
+}

--- a/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce.mlir
+++ b/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce.mlir
@@ -1,0 +1,22 @@
+// RUN: rocmlir-opt --tosa-to-rock %s -o -| FileCheck %s
+
+module attributes {kernel.module, xmodel.arch = "amdgcn-amd-amdhsa:gfx906"} {
+// CHECK-LABEL: @test_basic
+// CHECK-SAME: -> (tensor<2x10x1xf32> {func.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_basic(%arg0: tensor<2x10x100xf32>) -> tensor<2x10x1xf32> attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x10x1xf32>
+  // CHECK: rock.reduce  sum %arg0 into %[[outBuf]] {axis = 2 : index, blockSize = 256 : i32, gridSize = 8 : i32} : tensor<2x10x100xf32> into tensor<2x10x1xf32> -> tensor<2x10x1xf32>
+  %1 = "tosa.reduce_sum"(%arg0) {axis = 2 : i64} : (tensor<2x10x100xf32>) -> tensor<2x10x1xf32>
+  return %1 : tensor<2x10x1xf32>
+}
+
+// CHECK-LABEL: @test_middle_axis_reduction
+// CHECK-SAME: -> (tensor<4x1x20xf32> {func.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_middle_axis_reduction(%arg0: tensor<4x300x20xf32>) -> tensor<4x1x20xf32> attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<4x1x20xf32>
+  // CHECK: rock.reduce  sum %arg0 into %[[outBuf]] {axis = 1 : index, blockSize = 256 : i32, gridSize = 94 : i32} : tensor<4x300x20xf32> into tensor<4x1x20xf32> -> tensor<4x1x20xf32>
+  %1 = "tosa.reduce_sum"(%arg0) {axis = 1 : i64} : (tensor<4x300x20xf32>) -> tensor<4x1x20xf32>
+  return %1 : tensor<4x1x20xf32>
+}
+
+}


### PR DESCRIPTION
This commit adds support for converting tosa.reduce_sum to rock reduce.

Moreover, a new rock attribute (maybe temporary) to indicate args of kernels where it requires to be initialized to some value prior to launch. It is verified by doing the same in the clone verification flow by adding linalg.fills.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/791