### PR TITLE
Adding script to convert from hsaco to StringAttribute

### DIFF
--- a/mlir/utils/widgets/hsacoToStringAttr.py
+++ b/mlir/utils/widgets/hsacoToStringAttr.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import os
+
+# https://github.com/llvm/llvm-project/blob/dc37dc824aabbbe3d029519f43f0b348dcad7027/llvm/include/llvm/ADT/StringExtras.h#L125-L128
+def isPrint(C: str) -> bool:
+    UC = ord(C)
+    return 0x20 <= UC <= 0x7E
+
+# https://github.com/llvm/llvm-project/blob/dc37dc824aabbbe3d029519f43f0b348dcad7027/llvm/lib/Support/StringExtras.cpp#L62-L71
+def printEscapedString(data, out):
+    for val in data:
+        c = chr(val)
+        if c == '\\':
+            out.write('\\' + c)
+        elif isPrint(c) and c != '"':
+            out.write(c)
+        else:
+            out.write('\\' + hex(ord(c) >> 4)[2:] + hex(ord(c) & 0x0F)[2:])
+    print("mlir type: array<" + str(len(data)) + ", i8>")
+
+def genAttrFromHsaco(args):
+    with open(args.i, 'rb') as f:
+        # Read the entire contents of the file into a bytes object
+        data = f.read()
+
+    with open(args.o, 'w') as out:
+        printEscapedString(data, out)
+
+def add_args():
+    parser = argparse.ArgumentParser(
+        description="Convert hsaco elf to rocMLIR serialized text.")
+
+    parser.add_argument("-i", help="Input hsaco kernel file", required=True)
+    parser.add_argument("-o", help="Output kernel text file", default=None)
+
+    args = parser.parse_args()
+    return args
+
+def main(args):
+    if (args.o == None):
+        args.o = args.i.rsplit('.', maxsplit=1)[0] + ".attr"
+    print("Converting from " + args.i + " to " + args.o)
+    genAttrFromHsaco(args)
+
+if __name__ == "__main__":
+    arguments = add_args()
+    main(arguments)

--- a/mlir/utils/widgets/hsacoToStringAttr.py
+++ b/mlir/utils/widgets/hsacoToStringAttr.py
@@ -19,6 +19,7 @@ def printEscapedString(data, out):
             out.write('\\' + hex(ord(c) >> 4)[2:] + hex(ord(c) & 0x0F)[2:])
     print("mlir type: array<" + str(len(data)) + ", i8>")
 
+# This convert generate hsaco as attribute from args.i to args.o
 def genAttrFromHsaco(args):
     with open(args.i, 'rb') as f:
         # Read the entire contents of the file into a bytes object
@@ -40,7 +41,6 @@ def add_args():
 def main(args):
     if (args.o == None):
         args.o = args.i.rsplit('.', maxsplit=1)[0] + ".attr"
-    print("Converting from " + args.i + " to " + args.o)
     genAttrFromHsaco(args)
 
 if __name__ == "__main__":


### PR DESCRIPTION
It took me some effort to figure out what the actual text format of our elf binary is. I rewrite the serialization functions into a standalone python program. With this script, the developer can easily manipulate the populated IR or ISA and then re-inject it back to the same host code and run using the jit runner.

This script take two arguments:
 - -i where you specify the hsaco file
 - Optional -o where by default it will generate a file ended with `.attr`
 - In executing this script, it will also print out the type of the string attribute such that a developer can conveniently swap the type from the printed mlir global type