### PR TITLE
Fixing bugs coming from PR #941

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -41,14 +41,16 @@ struct InitParams {
   int64_t gemmMPerBlock;
   int64_t gemmNPerBlock;
   int64_t gemmKPerBlock;
+  int64_t gemmKPack;
 };
 
 struct InitParamsNonXDL : InitParams, Serializable<InitParamsNonXDL> {
   constexpr InitParamsNonXDL(uint32_t bSize, int64_t mPerBlock,
                              int64_t nPerBlock, int64_t kPerBlock,
                              int64_t mPerThread, int64_t nPerThread)
-      : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerThread(mPerThread),
-        gemmNPerThread(nPerThread), blockSize(bSize) {}
+      : InitParams{mPerBlock, nPerBlock, kPerBlock, int64_t(1)},
+        gemmMPerThread(mPerThread), gemmNPerThread(nPerThread),
+        blockSize(bSize) {}
   int64_t gemmMPerThread;
   int64_t gemmNPerThread;
   uint32_t blockSize;
@@ -71,8 +73,8 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
                           int64_t kPerBlock, int64_t mPerWave, int64_t nPerWave,
                           int64_t kPack, bool aThreadCopyMoreGemmK,
                           bool bThreadCopyMoreGemmKPack)
-      : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerWave(mPerWave),
-        gemmNPerWave(nPerWave), gemmKPack(kPack),
+      : InitParams{mPerBlock, nPerBlock, kPerBlock, kPack},
+        gemmMPerWave(mPerWave), gemmNPerWave(nPerWave),
         gemmAThreadCopyMoreGemmK(aThreadCopyMoreGemmK),
         gemmBThreadCopyMoreGemmKPack(bThreadCopyMoreGemmKPack) {}
 
@@ -81,7 +83,6 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
 
   int64_t gemmMPerWave;
   int64_t gemmNPerWave;
-  int64_t gemmKPack;
   bool gemmAThreadCopyMoreGemmK;
   bool gemmBThreadCopyMoreGemmKPack;
 

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -185,7 +185,7 @@ private:
   // if can't select config from above , use this config to do
   // padding kernel for example , GemmK/block is 16 , if your gemmK is  13 , we
   // add more 3 gemmk
-  static const InitParams universalParameters;
+  static const InitParamsNonXDL universalParameters;
 
   LogicalResult
   calculateBlockGemmPerformanceParameters(const InitParamsNonXDL &param,
@@ -205,9 +205,7 @@ public:
   std::vector<InitParamsNonXDL> getTuningParameters(KernelType opType,
                                                     Type dataType) const;
 
-  const InitParams &getUniversalParameters() const;
-
-  int64_t getUniversalKPack() const;
+  const InitParamsNonXDL &getUniversalParameters() const;
 
   LogicalResult isValidGemm(const InitParamsNonXDL &param,
                             const GemmSize &gemmSize) const override;
@@ -232,7 +230,7 @@ private:
   // if can't select config from above , use this config to do
   // padding kernel for example , GEMMK/block is 16 , if your gemmK is  13 , we
   // add more 3 gemmk.
-  static const InitParams universalParameters;
+  static const InitParamsXDL universalParameters;
 
   uint32_t obtainBlockSize(const InitParamsXDL &params, int64_t waveSize);
 
@@ -264,9 +262,7 @@ public:
 
   std::vector<InitParamsXDL> getTuningParameters(KernelType opType,
                                                  Type dataType) const;
-  const InitParams &getUniversalParameters() const;
-
-  int64_t getUniversalKPack() const;
+  const InitParamsXDL &getUniversalParameters() const;
 
   LogicalResult isValidGemm(const InitParamsXDL &param,
                             const GemmSize &gemmSize) const override;

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -41,22 +41,22 @@ struct InitParams {
   int64_t gemmMPerBlock;
   int64_t gemmNPerBlock;
   int64_t gemmKPerBlock;
-  int64_t gemmKPack;
 };
 
 struct InitParamsNonXDL : InitParams, Serializable<InitParamsNonXDL> {
   constexpr InitParamsNonXDL(uint32_t bSize, int64_t mPerBlock,
                              int64_t nPerBlock, int64_t kPerBlock,
                              int64_t mPerThread, int64_t nPerThread)
-      : InitParams{mPerBlock, nPerBlock, kPerBlock, int64_t(1)},
-        gemmMPerThread(mPerThread), gemmNPerThread(nPerThread),
-        blockSize(bSize) {}
+      : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerThread(mPerThread),
+        gemmNPerThread(nPerThread), blockSize(bSize) {}
   int64_t gemmMPerThread;
   int64_t gemmNPerThread;
   uint32_t blockSize;
 
   constexpr InitParamsNonXDL()
       : InitParamsNonXDL(0U, 0LL, 0LL, 0LL, 0LL, 0LL) {}
+
+  int64_t getKPack() { return 1; }
 
   template <class Self, class F> static void visit(Self &&self, F f) {
     f(self.blockSize);
@@ -73,16 +73,19 @@ struct InitParamsXDL : InitParams, Serializable<InitParamsXDL> {
                           int64_t kPerBlock, int64_t mPerWave, int64_t nPerWave,
                           int64_t kPack, bool aThreadCopyMoreGemmK,
                           bool bThreadCopyMoreGemmKPack)
-      : InitParams{mPerBlock, nPerBlock, kPerBlock, kPack},
-        gemmMPerWave(mPerWave), gemmNPerWave(nPerWave),
+      : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerWave(mPerWave),
+        gemmNPerWave(nPerWave), gemmKPack(kPack),
         gemmAThreadCopyMoreGemmK(aThreadCopyMoreGemmK),
         gemmBThreadCopyMoreGemmKPack(bThreadCopyMoreGemmKPack) {}
 
   constexpr InitParamsXDL()
       : InitParamsXDL(0LL, 0LL, 0LL, 0LL, 0LL, 0LL, false, false) {}
 
+  int64_t getKPack() { return gemmKPack; }
+
   int64_t gemmMPerWave;
   int64_t gemmNPerWave;
+  int64_t gemmKPack;
   bool gemmAThreadCopyMoreGemmK;
   bool gemmBThreadCopyMoreGemmKPack;
 
@@ -204,6 +207,8 @@ public:
 
   const InitParams &getUniversalParameters() const;
 
+  int64_t getUniversalKPack() const;
+
   LogicalResult isValidGemm(const InitParamsNonXDL &param,
                             const GemmSize &gemmSize) const override;
 
@@ -260,6 +265,8 @@ public:
   std::vector<InitParamsXDL> getTuningParameters(KernelType opType,
                                                  Type dataType) const;
   const InitParams &getUniversalParameters() const;
+
+  int64_t getUniversalKPack() const;
 
   LogicalResult isValidGemm(const InitParamsXDL &param,
                             const GemmSize &gemmSize) const override;

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -351,45 +351,24 @@ template <typename T>
 static Optional<GemmSize>
 calculatePaddingKernelSize(GemmSize gemmSize, ConvOpType dir, Type dataType,
                            T populateParams) {
-  bool needExtraPad = false;
-  int64_t gemmMExtra, gemmNExtra, gemmKExtra;
-  gemmMExtra = gemmNExtra = gemmKExtra = 0;
-
   auto configParams = populateParams.getTuningParameters(
       kernelTypeFromConvOpType(dir), dataType);
   size_t numOfFailedConfigs = 0;
   for (auto &params : configParams) {
     if (gemmSize.m % params.gemmMPerBlock == 0 &&
-        gemmSize.k % params.gemmKPerBlock == 0 &&
+        gemmSize.k % (params.gemmKPerBlock * params.gemmKPack) == 0 &&
         gemmSize.n % params.gemmNPerBlock == 0) {
       break;
     }
     numOfFailedConfigs++;
   }
 
-  auto extraParams = populateParams.getUniversalParameters();
   if (numOfFailedConfigs == configParams.size()) {
-    needExtraPad = true;
-    int64_t gemmMRemain, gemmKRemain, gemmNRemain;
-
-    gemmMRemain = gemmSize.m % extraParams.gemmMPerBlock;
-    if (gemmMRemain != 0)
-      gemmMExtra = extraParams.gemmMPerBlock - gemmMRemain;
-
-    gemmNRemain = gemmSize.n % extraParams.gemmNPerBlock;
-    if (gemmNRemain != 0)
-      gemmNExtra = extraParams.gemmNPerBlock - gemmNRemain;
-
-    gemmKRemain = gemmSize.k % extraParams.gemmKPerBlock;
-    if (gemmKRemain != 0)
-      gemmKExtra = extraParams.gemmKPerBlock - gemmKRemain;
-
-    // llvm::errs() << "gemmMExtra: " << gemmMExtra << "gemmNExtra: " <<
-    // gemmNExtra << "gemmKExtra: " << gemmKExtra << "\n";
+    auto extraParams = populateParams.getUniversalParameters();
+    return calculatePadding(
+        extraParams.gemmKPerBlock, extraParams.gemmMPerBlock,
+        extraParams.gemmNPerBlock, gemmSize, extraParams.gemmKPack);
   }
-
-  if (needExtraPad)
-    return GemmSize(gemmSize.g, gemmMExtra, gemmKExtra, gemmNExtra);
   return llvm::None;
 }
 

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -356,7 +356,7 @@ calculatePaddingKernelSize(GemmSize gemmSize, ConvOpType dir, Type dataType,
   size_t numOfFailedConfigs = 0;
   for (auto &params : configParams) {
     if (gemmSize.m % params.gemmMPerBlock == 0 &&
-        gemmSize.k % (params.gemmKPerBlock * params.gemmKPack) == 0 &&
+        gemmSize.k % (params.gemmKPerBlock * params.getKPack()) == 0 &&
         gemmSize.n % params.gemmNPerBlock == 0) {
       break;
     }
@@ -365,9 +365,10 @@ calculatePaddingKernelSize(GemmSize gemmSize, ConvOpType dir, Type dataType,
 
   if (numOfFailedConfigs == configParams.size()) {
     auto extraParams = populateParams.getUniversalParameters();
-    return calculatePadding(
-        extraParams.gemmKPerBlock, extraParams.gemmMPerBlock,
-        extraParams.gemmNPerBlock, gemmSize, extraParams.gemmKPack);
+    return calculatePadding(extraParams.gemmKPerBlock,
+                            extraParams.gemmMPerBlock,
+                            extraParams.gemmNPerBlock, gemmSize,
+                            populateParams.getUniversalKPack());
   }
   return llvm::None;
 }

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -365,10 +365,9 @@ calculatePaddingKernelSize(GemmSize gemmSize, ConvOpType dir, Type dataType,
 
   if (numOfFailedConfigs == configParams.size()) {
     auto extraParams = populateParams.getUniversalParameters();
-    return calculatePadding(extraParams.gemmKPerBlock,
-                            extraParams.gemmMPerBlock,
-                            extraParams.gemmNPerBlock, gemmSize,
-                            populateParams.getUniversalKPack());
+    return calculatePadding(
+        extraParams.gemmKPerBlock, extraParams.gemmMPerBlock,
+        extraParams.gemmNPerBlock, gemmSize, extraParams.getKPack());
   }
   return llvm::None;
 }

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -420,7 +420,7 @@ struct BlockwiseGemmV2RewritePattern
         sourceOffset = mnb.create<AddIOp>(
             loc, sourceOffset, mnb.create<MulIOp>(loc, mnPerMfmaGroup, mn_i));
         sourceOffset = kb.create<AddIOp>(loc, sourceOffset,
-                                         mnb.create<MulIOp>(loc, MN, mn_i));
+                                         kb.create<MulIOp>(loc, MN, k_i));
       } else {
         // srcOffset = (k_i * input_span_per_mfma + blk_id) * MN + blk_td + mn_i
         // * input_span_length;

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -64,7 +64,7 @@ PopulateParams::initParameters[PopulateParams::nInitParameters] = {
   {64, 32, 32, 4, 2, 2}};
 // clang-format on
 
-const InitParams PopulateParams::universalParameters = {64, 64, 16, 1};
+const InitParams PopulateParams::universalParameters = {64, 64, 16};
 
 LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
     const InitParamsNonXDL &param, RockGemmWrapperInterface op) {
@@ -181,6 +181,8 @@ const InitParams &PopulateParams::getUniversalParameters() const {
   return universalParameters;
 }
 
+int64_t PopulateParams::getUniversalKPack() const { return 1; }
+
 LogicalResult PopulateParams::isValidGemm(const InitParamsNonXDL &param,
                                           const GemmSize &gemmSize) const {
   if (!(gemmSize.m % param.gemmMPerBlock == 0 &&
@@ -263,7 +265,7 @@ PopulateParamsXDL::initParametersForwardI8[
 };
 // clang-format on
 
-const InitParams PopulateParamsXDL::universalParameters = {32, 64, 4, 4};
+const InitParams PopulateParamsXDL::universalParameters = {32, 64, 4};
 
 uint32_t PopulateParamsXDL::obtainBlockSize(const InitParamsXDL &params,
                                             int64_t waveSize) {
@@ -492,6 +494,15 @@ PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataType) const {
 
 const InitParams &PopulateParamsXDL::getUniversalParameters() const {
   return universalParameters;
+}
+
+int64_t PopulateParamsXDL::getUniversalKPack() const {
+  // TODO(grossini): this is because we are using universal parameters
+  // to establish if backward weight convolution needs padding. What we
+  // are saying is that the 32,64,4,*,*,1 is not valid anymore, but we
+  // need a 32,64,4,*,*,4 at least. We should remove this hack and get rid
+  // of the universal parameters
+  return 4;
 }
 
 LogicalResult PopulateParamsXDL::isValidGemm(const InitParamsXDL &param,

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -64,7 +64,7 @@ PopulateParams::initParameters[PopulateParams::nInitParameters] = {
   {64, 32, 32, 4, 2, 2}};
 // clang-format on
 
-const InitParams PopulateParams::universalParameters = {64, 64, 16};
+const InitParams PopulateParams::universalParameters = {64, 64, 16, 1};
 
 LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
     const InitParamsNonXDL &param, RockGemmWrapperInterface op) {
@@ -263,7 +263,7 @@ PopulateParamsXDL::initParametersForwardI8[
 };
 // clang-format on
 
-const InitParams PopulateParamsXDL::universalParameters = {32, 64, 4};
+const InitParams PopulateParamsXDL::universalParameters = {32, 64, 4, 4};
 
 uint32_t PopulateParamsXDL::obtainBlockSize(const InitParamsXDL &params,
                                             int64_t waveSize) {
@@ -437,6 +437,7 @@ LogicalResult PopulateParamsXDL::obtainTuningParameters(
   LogicalResult res = failure();
   std::vector<InitParamsXDL> paramSets =
       getTuningParameters(op.getKernelType(), op.getInputType());
+
   for (const auto &params : orderInitParams(paramSets, gemmSize)) {
     blockSize = obtainBlockSize(params, waveSize);
     // We have an override on the blockSize, only loop through the

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -64,7 +64,8 @@ PopulateParams::initParameters[PopulateParams::nInitParameters] = {
   {64, 32, 32, 4, 2, 2}};
 // clang-format on
 
-const InitParams PopulateParams::universalParameters = {64, 64, 16};
+const InitParamsNonXDL PopulateParams::universalParameters = {64, 64, 64,
+                                                              16, 4,  4};
 
 LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
     const InitParamsNonXDL &param, RockGemmWrapperInterface op) {
@@ -177,11 +178,9 @@ PopulateParams::getTuningParameters(KernelType opType, Type dataType) const {
   return std::vector<InitParamsNonXDL>(params);
 }
 
-const InitParams &PopulateParams::getUniversalParameters() const {
+const InitParamsNonXDL &PopulateParams::getUniversalParameters() const {
   return universalParameters;
 }
-
-int64_t PopulateParams::getUniversalKPack() const { return 1; }
 
 LogicalResult PopulateParams::isValidGemm(const InitParamsNonXDL &param,
                                           const GemmSize &gemmSize) const {
@@ -265,7 +264,8 @@ PopulateParamsXDL::initParametersForwardI8[
 };
 // clang-format on
 
-const InitParams PopulateParamsXDL::universalParameters = {32, 64, 4};
+const InitParamsXDL PopulateParamsXDL::universalParameters = {32, 64, 4, 32,
+                                                              64, 4,  1, 1};
 
 uint32_t PopulateParamsXDL::obtainBlockSize(const InitParamsXDL &params,
                                             int64_t waveSize) {
@@ -492,17 +492,8 @@ PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataType) const {
   return res;
 }
 
-const InitParams &PopulateParamsXDL::getUniversalParameters() const {
+const InitParamsXDL &PopulateParamsXDL::getUniversalParameters() const {
   return universalParameters;
-}
-
-int64_t PopulateParamsXDL::getUniversalKPack() const {
-  // TODO(grossini): this is because we are using universal parameters
-  // to establish if backward weight convolution needs padding. What we
-  // are saying is that the 32,64,4,*,*,1 is not valid anymore, but we
-  // need a 32,64,4,*,*,4 at least. We should remove this hack and get rid
-  // of the universal parameters
-  return 4;
 }
 
 LogicalResult PopulateParamsXDL::isValidGemm(const InitParamsXDL &param,


### PR DESCRIPTION
This PR is fixing 2 bugs stemming from the introduction of reductions in PR #941 . 

1. The first bug is trivial, and it is mostly a typo in the non-reduction code (which is now not much tested as it used to be). This is the simple fix in `mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp`

3. The second bug is nastier. The problem is that, using reductions, the "universal" configuration we used to compute padding (when the `perf_config` was not passed) is not suitable anymore for reductions, because it has `KPerBlock=4 and KPack==1`. This meant that we were padding in the wrong way, which resulted in failures. My solution was to add a KPack set to 4 for the `UniversalParameters` in the XDL case. 