### PR TITLE
Update the Int8 verifier to handle overflow

### DIFF
--- a/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
@@ -563,13 +563,13 @@ extern "C" void mcpuVerifyInt32(int32_t *gpuAllocated, int32_t *gpuAligned,
   for (int64_t i = 0; i < valSize; ++i) {
     if (gpuAligned[i] != valAligned[i]) {
       if (printDebug)
-        printf("gpu=%d val=%d\n", gpuAligned[i], valAligned[i]);
-      printf("[%d %d %d]\n", 0, 0, 0);
+        printf("%ld: gpu=%d val=%d\n", i, gpuAligned[i], valAligned[i]);
+      printf("[-1]");
       return;
     }
   }
 
-  printf("[%d %d %d]\n", 1, 1, 1);
+  printf("[1 1 1]\n");
   return;
 }
 
@@ -587,12 +587,12 @@ extern "C" void mcpuVerifyInt32Int64(int32_t *gpuAllocated, int32_t *gpuAligned,
         printf("gpu results overflow \n");
     } else if (gpuAligned[i] != valAligned[i]) {
       if (printDebug)
-        printf("gpu=%d val=%ld\n", gpuAligned[i], valAligned[i]);
-      printf("[%d %d %d]\n", 0, 0, 0);
+        printf("%ld: gpu=%d val=%ld\n", i, gpuAligned[i], valAligned[i]);
+      printf("[-1]\n");
       return;
     }
   }
 
-  printf("[%d %d %d]\n", 1, 1, 1);
+  printf("[1 1 1]\n");
   return;
 }

--- a/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
@@ -425,6 +425,13 @@ void printDebugVerifyResults(int64_t dataSize, float maxAbsDiff,
   }
 }
 
+enum class PrintOption : char {
+  Always = 3,  // always print debug info
+  Failure = 2, // print elem-wise diff + summary only if the test fails
+  Summary = 1, // print summary info only if the test fails
+  Off = 0      // do not print debug info
+};
+
 template <typename T>
 void mcpuVerify(T *gpuResults, T *validationResults, int64_t dataSize,
                 float thr_RMS, float thr_absDiff, float thr_relDiff,
@@ -465,12 +472,6 @@ void mcpuVerify(T *gpuResults, T *validationResults, int64_t dataSize,
   constexpr size_t NUM_BUCKETS = NUM_BOUNDARIES + 3;
   int hist_relDiff[NUM_BUCKETS] = {0};
   // Obtain print debug info option
-  enum class PrintOption : char {
-    Always = 3,  // always print debug info
-    Failure = 2, // print elem-wise diff + summary only if the test fails
-    Summary = 1, // print summary info only if the test fails
-    Off = 0      // do not print debug info
-  };
   PrintOption print_option = static_cast<PrintOption>(printDebug);
 
   for (int64_t i = 0; i < dataSize; ++i) {
@@ -553,24 +554,69 @@ extern "C" void mcpuVerifyFloat(float *gpuAllocated, float *gpuAligned,
 }
 
 // Compare the results in int32
-extern "C" void mcpuVerifyInt32(int32_t *gpuAllocated, int32_t *gpuAligned,
-                                int64_t gpuOffset, int64_t gpuSize,
-                                int64_t gpuStride, int32_t *valAllocated,
-                                int32_t *valAligned, int64_t valOffset,
-                                int64_t valSize, int64_t valStride,
-                                char printDebug) {
-  assert(gpuSize == valSize);
-  for (int64_t i = 0; i < valSize; ++i) {
-    if (gpuAligned[i] != valAligned[i]) {
-      if (printDebug)
-        printf("%ld: gpu=%d val=%d\n", i, gpuAligned[i], valAligned[i]);
-      printf("[-1]");
-      return;
+template <typename VALTYPE>
+void mcpuVerifyInt(int32_t *gpuAligned, VALTYPE *valAligned, int64_t dataSize,
+                   char printDebug) {
+  int64_t failure_count = 0;  // the number of incorrect elements
+  int64_t overflow_count = 0; // the number of overflow elements
+  int64_t maxAbsDiff = 0;
+
+  PrintOption print_option = static_cast<PrintOption>(printDebug);
+  for (int64_t i = 0; i < dataSize; ++i) {
+    int64_t valNum = static_cast<int64_t>(valAligned[i]);
+    int32_t gpuNum = gpuAligned[i];
+    if (valNum > INT32_MAX || valNum < INT32_MIN) {
+      overflow_count++;
+      if (print_option == PrintOption::Always)
+        printf("overflow at element : %ld, gpu=%d, val=%ld\n", i, gpuNum,
+               valNum);
+    }
+
+    if (gpuNum != valNum) {
+      failure_count++;
+      int64_t absDiff = abs(valNum - gpuNum);
+      if (absDiff > maxAbsDiff)
+        maxAbsDiff = absDiff;
+
+      // Print out individual failing elements if print mode is Always||Failure
+      if (print_option == PrintOption::Always ||
+          print_option == PrintOption::Failure) {
+        printf("%ld: gpu=%d val=%ld absDiff=%ld\n", i, gpuNum, valNum, absDiff);
+      }
     }
   }
 
-  printf("[1 1 1]\n");
+  if (failure_count == 0) {
+    if ((print_option == PrintOption::Always ||
+         print_option == PrintOption::Summary) &&
+        overflow_count > 0) {
+      printf("Number of elements: %ld\n", dataSize);
+      printf("Number of overflow elements: %ld\n", overflow_count);
+    }
+    printf("[1 1 1]\n");
+  } else {
+    if (print_option == PrintOption::Always ||
+        print_option == PrintOption::Failure ||
+        print_option == PrintOption::Summary) {
+      printf("Number of elements: %ld\n", dataSize);
+      printf("Number of incorrect elements: %ld\n", failure_count);
+      printf("maxAbsDiff: %ld\n", maxAbsDiff);
+      printf("Number of overflow elements: %ld\n", overflow_count);
+    }
+    printf("[0 0 0]");
+  }
   return;
+}
+
+extern "C" void mcpuVerifyInt32(int32_t *gpuAllocated, int32_t *gpuAligned,
+                                int64_t gpuOffset, int64_t gpuSize,
+                                int64_t gpuStride, int32_t *valAllocated,
+                                int32_t *valAligned, int32_t valOffset,
+                                int64_t valSize, int64_t valStride,
+                                char printDebug) {
+
+  assert(gpuSize == valSize);
+  mcpuVerifyInt<int32_t>(gpuAligned, valAligned, valSize, printDebug);
 }
 
 extern "C" void mcpuVerifyInt32Int64(int32_t *gpuAllocated, int32_t *gpuAligned,
@@ -581,18 +627,5 @@ extern "C" void mcpuVerifyInt32Int64(int32_t *gpuAllocated, int32_t *gpuAligned,
                                      char printDebug) {
 
   assert(gpuSize == valSize);
-  for (int64_t i = 0; i < valSize; ++i) {
-    if (valAligned[i] > INT32_MAX || valAligned[i] < INT32_MIN) {
-      if (printDebug)
-        printf("gpu results overflow \n");
-    } else if (gpuAligned[i] != valAligned[i]) {
-      if (printDebug)
-        printf("%ld: gpu=%d val=%ld\n", i, gpuAligned[i], valAligned[i]);
-      printf("[-1]\n");
-      return;
-    }
-  }
-
-  printf("[1 1 1]\n");
-  return;
+  mcpuVerifyInt<int64_t>(gpuAligned, valAligned, valSize, printDebug);
 }

--- a/mlir/test/rocmlir-driver/populate_host_convert.mlir
+++ b/mlir/test/rocmlir-driver/populate_host_convert.mlir
@@ -1,13 +1,13 @@
 // RUN: rocmlir-gen --arch %arch -p -ph -pr | FileCheck %s --check-prefix=F32
 // RUN: rocmlir-gen --arch %arch -p -ph -pr -t f16 | FileCheck %s --check-prefixes=F16,CHECK
 // RUN: rocmlir-gen --arch %arch -p -ph -pr -t bf16 | FileCheck %s --check-prefixes=BF16,CHECK
-// RUN: rocmlir-gen --arch %arch -p -ph -pr -t i8 | FileCheck %s --check-prefixes=I8,CHECK
+// RUN: rocmlir-gen --arch %arch -p -ph -pr -t i8 | FileCheck %s --check-prefixes=I8
 
 // F32-NOT: func.func @_memcpy_
+// I8-NOT: func.func @_memcpy_
 
 // F16: func.func @_memcpy_[[type:f16]]_f32_[[n:[0-9]+]]
 // BF16: func.func @_memcpy_[[type:bf16]]_f32_[[n:[0-9]+]]
-// I8: func.func @_memcpy_[[type:i32]]_f32_[[n:[0-9]+]]
 // CHECK-SAME: (%[[arg0:.*]]: memref<[[n]]x[[type]]>, %[[arg1:.*]]: memref<[[n]]xf32>)
 
 // CHECK-NEXT: %[[c0:.*]] = arith.constant 0 : index
@@ -17,7 +17,6 @@
 // CHECK-NEXT:   %[[load:.*]] = memref.load %[[arg0]][%[[arg2]]]
 // F16-NEXT:     %[[converted:.*]] = arith.extf %[[load]] : f16 to f32
 // BF16-NEXT:    %[[converted:.*]] = arith.extf %[[load]] : bf16 to f32
-// I8-NEXT:      %[[converted:.*]] = arith.sitofp %[[load]] : i32 to f32
 // CHECK-NEXT:   memref.store %[[converted]], %[[arg1]][%[[arg2]]]
 // CHECK-NEXT: }
 // CHECK-NEXT: return

--- a/mlir/test/rocmlir-driver/populate_host_print.mlir
+++ b/mlir/test/rocmlir-driver/populate_host_print.mlir
@@ -65,8 +65,8 @@
 // F16: call @_memcpy_f16_f32_{{[0-9]+}}(%{{.*}}, %{{.*}})
 // BF16: memref.alloc() : memref<{{.*}}>
 // BF16: call @_memcpy_bf16_f32_{{[0-9]+}}(%{{.*}}, %{{.*}})
-// I8: memref.alloc() : memref<{{.*}}>
-// I8: call @_memcpy_i32_f32_{{[0-9]+}}(%{{.*}}, %{{.*}})
+// I8: memref.cast %{{.*}} : memref<{{.*}}> to memref<*xi32>
+// I8: call @printMemrefI32(%{{.*}}) : (memref<*xi32>) -> ()
 // F16: memref.dealloc {{.*}} : memref<{{.*}}>
 // BF16: memref.dealloc {{.*}} : memref<{{.*}}>
 // I8: memref.dealloc {{.*}} : memref<{{.*}}>

--- a/mlir/test/rocmlir-driver/populate_prc.mlir
+++ b/mlir/test/rocmlir-driver/populate_prc.mlir
@@ -21,6 +21,5 @@
 // RUN: rocmlir-gen --arch %arch -p -prc -t i8 | FileCheck %s --check-prefix=INT8
 
 // INT8: func.func @main()
-// INT8:  call @_memcpy_i32_f32_{{[0-9]+}}(%{{.*}}, %{{.*}}) : (memref<{{.*}}>, memref<{{.*}}>) -> ()
-// INT8-NEXT:  [[RES:%.*]] = memref.cast {{.*}} : memref<{{.*}}> to memref<*xf32>
-// INT8-NEXT:    call @printMemrefF32([[RES]]) : (memref<*xf32>) -> ()
+// INT8:  [[RES:%.*]] = memref.cast {{.*}} : memref<{{.*}}> to memref<*xi32>
+// INT8-NEXT:    call @printMemrefI32([[RES]]) : (memref<*xi32>) -> ()

--- a/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
+++ b/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
@@ -8,7 +8,7 @@
 
 // CHECK-LABEL: func @host_naive_gemm
 // F16-SAME: (%{{.*}}: memref<3x1024x769xf32>, %{{.*}}: memref<3x769x512xf32>, %{{.*}}: memref<3x1024x512xf32>)
-// I8-SAME: (%{{.*}}: memref<3x1024x769xi8>, %{{.*}}: memref<3x769x512xi8>, %{{.*}}: memref<3x1024x512xi32>)
+// I8-SAME: (%{{.*}}: memref<3x1024x769xi8>, %{{.*}}: memref<3x769x512xi8>, %{{.*}}: memref<3x1024x512xi64>)
 
 // F16: arith.mulf
 // F16-NEXT: arith.addf


### PR DESCRIPTION
- Implement CPU validation functions for int8 conv and gemm in int64_t in order to detect overflow.
- Change the int8 verifier to use integer comparisons instead of float comparisons.
- Print integer results as integers instead of floats. 