### PR TITLE
Remove swizzles from lowering pipeline

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1141,7 +1141,9 @@ def Rock_XdlopsGemmV2Op:
   let hasVerifier = 1;
 }
 
-// TODO(kdrewnia): upstream these
+/// ONLY NEEDEF FOR in_warp_transpose BELOW. DEAD BUT LEFT IN FOR FUTURE
+/// USE, JUST LIKE in_warp_transpose ITSELF.
+
 // Whether the vector's length is divisible by `divisor`
 class IsVectorOfDivisibleLengthPred<int divisor> :
   And<[IsVectorTypePred,
@@ -1174,7 +1176,11 @@ def Rock_InWarpTransposeOp :
     Results<(outs VectorOfDivisibleLengthAndType<swizzleGroupSize, [F32, I32]>:$res)> {
   let summary = "Transpose blocks of data distributed accross a warp";
   let description = [{
-    `Rock.in_warp_transpose` takes a vector representing a matrix of values
+    NOTE: THIS IS CURRENTLY DEAD CODE LEFT IN IN CASE WE FIND A USE FOR IT
+    AND TO PROVIDE TESTCASES FOR A PLANNED amdgpu.dpp. YOU CAN, IF NEED
+    BE, REMOVE THIS and gpu.warp_swizzle.
+
+    `rock.in_warp_transpose` takes a vector representing a matrix of values
     stored accross the threads in a warp and transposes `size`x`size` blocks
     of this matrix. The rows of the output (if we regard each thread's vector
     as a row in the matrix) are further permuted with the `inGroupPerm`

--- a/mlir/test/fusion/e2e/mixr-mbcast-scalar-conv-align-tiling.mlir
+++ b/mlir/test/fusion/e2e/mixr-mbcast-scalar-conv-align-tiling.mlir
@@ -3,11 +3,11 @@
 module {
   // CHECK-DAG: #[[MAP1:.*]] = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (d0, d1, 0, 0)> by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>, <Broadcast{1} ["dim3"] at [3] -> ["dim3"] at [3]>] bounds = [1, 1, 28, 28] -> [1, 1, 1, 1]>
   // CHECK: rock.transforming_for {{.*}} (%[[loadCoord:.*]]) = {{.*}}#[[MAP1]]
-  // CHECK-SAME: bounds [1, 1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1, 1]
   // CHECK-SAME: strides [1, 1, 1, 1]
   // CHECK-NEXT: arith.andi
   // CHECK-NEXT: rock.global_load %arg0[%[[loadCoord]]]
-  // CHECK: linalg.generic{{.*}} outs(%[[outBuf:.*]] : memref<4xf32, 5>)
+  // CHECK: linalg.generic{{.*}} outs(%[[outBuf:.*]] : memref<1xf32, 5>)
   // CHECK: global_store %[[outBuf]]{{.*}} -> %arg3
   func.func @main(%arg0: tensor<1x1x1x1xf32>, %arg1: tensor<1x3x32x32xf32>, %arg2: tensor<1x3x5x5xf32>) -> tensor<1x1x28x28xf32> attributes {arch = "gfx908:sramecc+:xnack-", kernel = "mixr"} {
     %0 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 1, 28, 28]} : (tensor<1x1x1x1xf32>) -> tensor<1x1x28x28xf32>


### PR DESCRIPTION
Per https://github.com/ROCmSoftwarePlatform/rocMLIR/discussions/957, swizzles are bad for performance on MI-200, especially when
dealing with GEMMs (which don't have a lot of address calculations to
hide the data movement in), and never really gave us much to begin
with.

They were probably OK on MI-100 because of the agpr->vgpr movements.

They also make delaying vectorization analysis until after fusion
complicated.

We're keeping the `in_warp_transpose` op, though, it's a good example and might be a useful testcase for `amdgpu.dpp`.