### PR TITLE
Exclude ck driver build to WA CI failure

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -833,7 +833,7 @@ pipeline {
                             // Clean up build settings to disable static library and allow
                             // ROCm testing
                             sh 'rm build/CMakeCache.txt'
-                            buildProject('check-rocmlir-build-only ci-performance-scripts rocblas-benchmark-driver ck-benchmark-driver',
+                            buildProject('check-rocmlir-build-only ci-performance-scripts rocblas-benchmark-driver',
                                          '''-DCMAKE_PREFIX_PATH=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                             -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
                                             -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang''')


### PR DESCRIPTION
Current CK code keep failing to build and cannot find any stable branch.
exclude building ck driver until we find a solution for it.