### PR TITLE
Adding quantization unit test and fix fold transpose pass

### DIFF
--- a/mlir/test/fusion/quantization.mlir
+++ b/mlir/test/fusion/quantization.mlir
@@ -1,0 +1,68 @@
+// RUN: rocmlir-driver -host-pipeline highlevel -arch gfx906 %s | FileCheck %s
+
+// CHECK-LABEL: test_conv_with_cast
+// CHECK-COUNT-1: linalg.generic
+// CHECK: arith.sitofp {{.*}} : i32 to f32
+
+func.func @test_conv_with_cast(
+    %input: tensor<1x8x8x4xi8>, 
+    %filter: tensor<8x1x1x4xi8>, 
+    %scale: tensor<8xf32>,
+    %bias: tensor<8xi32>) -> tensor<1x8x8x8xf32> 
+    attributes {kernel, arch = ""} 
+{
+    %zero = arith.constant dense<0> : tensor<8xi8>  
+    %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  
+    %output_cast = "tosa.cast"(%output) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xf32>
+    return %output_cast : tensor<1x8x8x8xf32>
+}
+
+// CHECK-LABEL: test_quantization_ck
+// CHECK-COUNT-1: linalg.generic
+// CHECK: arith.sitofp {{.*}} : i32 to f32
+// CHECK: arith.minf {{.*}} : f32
+// CHECK: arith.maxf {{.*}} : f32
+// CHECK: arith.fptosi {{.*}} : f32 to i8
+// N, H, W, C = 1, 8, 8, 4
+// K, Y, X, C = 8, 1, 1, 4
+// N, H, W, K = 1, 8, 8, 8
+func.func @test_quantization_ck(
+    %input: tensor<1x8x8x4xi8>, 
+    %filter: tensor<8x1x1x4xi8>, 
+    %scale: tensor<8xf32>,
+    %bias: tensor<8xi32>) -> tensor<1x8x8x8xi8> 
+    attributes {kernel, arch = ""} 
+{
+    %zero = arith.constant dense<0> : tensor<8xi8>  
+    %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  
+    %shifted = "tosa.add"(%output, %bias) {} : (tensor<1x8x8x8xi32>, tensor<8xi32>) -> tensor<1x8x8x8xi32>  
+    %output_cast = "tosa.cast"(%shifted) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xf32>
+    %scaled = "tosa.mul"(%output_cast, %scale) {shift = 0 : i32} : (tensor<1x8x8x8xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>  
+    %scale_cast = "tosa.cast"(%scaled) : (tensor<1x8x8x8xf32>) -> tensor<1x8x8x8xi8>
+    return %scale_cast : tensor<1x8x8x8xi8>
+}
+
+// CHECK-LABEL: test_quantization_migraphx
+// CHECK-COUNT-1: linalg.generic
+// CHECK: arith.sitofp {{.*}} : i32 to f32
+// CHECK: arith.minf {{.*}} : f32
+// CHECK: arith.maxf {{.*}} : f32
+// CHECK: arith.fptosi {{.*}} : f32 to i32
+// CHECK: arith.trunci {{.*}} : i32 to i8
+func.func @test_quantization_migraphx(
+    %input: tensor<1x8x8x4xi8>, 
+    %filter: tensor<8x1x1x4xi8>, 
+    %scale: tensor<8xf32>,
+    %bias: tensor<8xi32>) -> tensor<1x8x8x8xi8> 
+    attributes {kernel, arch = ""} 
+{
+    %zero = arith.constant dense<0> : tensor<8xi8>  
+    %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  
+    %output_cast = "tosa.cast"(%output) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xf32>
+    %scaled = "tosa.mul"(%output_cast, %scale) {shift = 0 : i32} : (tensor<1x8x8x8xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>  
+    %scaled_cast = "tosa.cast"(%scaled) : (tensor<1x8x8x8xf32>) -> tensor<1x8x8x8xi32>
+    %shifted = "tosa.add"(%scaled_cast, %bias) {} : (tensor<1x8x8x8xi32>, tensor<8xi32>) -> tensor<1x8x8x8xi32>  
+    %scale_cast = "tosa.cast"(%shifted) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xi8>
+    return %scale_cast : tensor<1x8x8x8xi8>
+}
+


### PR DESCRIPTION
I'm adding the tentative quantization unit test and fixing the high level pipeline that doesn't converge for those examples.

Background context: MIGraphX and CK has different implementation for quantization and I don't want to wait till they get uniformed. So I'm posting this review to clear the roadblock from our end first.
 - MIGraphX implementation: [here](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/src/include/migraphx/op/quantizelinear.hpp#L69-L74)
 - CK implementation: [here](https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/ad541ad6b9de9b0579d5254f82e9d5b86103d309/include/ck/tensor_operation/gpu/element/quantization_operation.hpp#L66-L73)

Once the standard implementation is uniformed, I'll delete the one that doesn't match.

Regarding on `FoldTranspose` fix. Our Tosa pipeline cannot handle `Tosa.cast` operator because it will continually amend the `linalg.generic` input since it is non-trivial transform. Then when it tried to push the transform map to `rock.transform`, it always ended yielding a same `rock.alloc()` + `rock.transform()`, making the fold transpose pass not able to converge after ten runs. I added an additional check and delete the redundant `rock.alloc()` when this happens such that it can converge to finish running through the high level pipelines.

Next step: work through the kernel pipeline and fix any issues there.