### PR TITLE
Use percent change for regression reporting

### DIFF
--- a/mlir/utils/performance/createGemmPerformanceReports.py
+++ b/mlir/utils/performance/createGemmPerformanceReports.py
@@ -46,7 +46,7 @@ def printAllPerformance(chip, lib='rocBLAS'):
 
     with open(chip + "_" + f"MLIR_vs_{lib}.html", 'w') as htmlOutput:
         reportUtils.htmlReport(df, means, f"MLIR vs. {lib} performance",
-        toHighlight, htmlOutput)
+        toHighlight, reportUtils.colorForSpeedups, htmlOutput)
 
 # Main function.
 if __name__ == '__main__':

--- a/mlir/utils/performance/createPerformanceReports.py
+++ b/mlir/utils/performance/createPerformanceReports.py
@@ -56,7 +56,10 @@ def printAllPerformance(chip):
     means.to_csv(chip + '_' + reportUtils.PERF_STATS_REPORT_FILE)
 
     with open(chip + "_" + "MLIR_vs_MIOpen.html", 'w') as htmlOutput:
-        reportUtils.htmlReport(df, means, "MLIR vs. MIOpen performance", ["MLIR/MIOpen", "Tuned/Untuned", "Tuned/MIOpen"], htmlOutput)
+        reportUtils.htmlReport(df, means, "MLIR vs. MIOpen performance",
+          ["MLIR/MIOpen", "Tuned/Untuned", "Tuned/MIOpen"],
+          reportUtils.colorForSpeedups,
+          htmlOutput)
 
 # Main function.
 if __name__ == '__main__':


### PR DESCRIPTION
The current result / previous result metric we've been reporting is, IMO, kinda confusing, so swap to % change in regression reports instead.

Update the reporting utilities to allow customizing how cells get colored.