### PR TITLE
Fix missing CK driver nightly failure

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -58,10 +58,19 @@ void getAndBuildMIGraphX(String cmakeOpts) {
     buildMIGraphX(cmakeOpts)
 }
 
+CKBuilt = false
 void getAndBuildCK(String cmakeOpts) {
     git branch: params.CKBranch, poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/composable_kernel.git'
     buildCK(cmakeOpts)
+}
+
+String getGEMMBenchmarkDrivers(){
+    if (CKBuilt == true){
+        return "rocblas-benchmark-driver ck-benchmark-driver"
+    } else {
+        return "rocblas-benchmark-driver"
+    }
 }
 
 void buildMIOpenWithMLIR() {
@@ -815,7 +824,7 @@ pipeline {
                         steps {
                             sh 'rm -rf composable_kernel'
                             dir('composable_kernel') {
-                                catchError (buildResult: null) {
+                                try {
                                     getAndBuildCK('''
                                         -DGPU_TARGETS="gfx1030;gfx908;gfx90a"
                                         -DCMAKE_CXX_FLAGS="-O3"
@@ -824,6 +833,10 @@ pipeline {
                                         -DCMAKE_BUILD_TYPE=Release
                                         ''')
                                     sh 'cd build/library; make install; cp ../composable_kernelConfig*.cmake ${WORKSPACE}/composable_kernel/build/CKInstallDir/lib/cmake/composable_kernel'
+                                    CKBuilt = true
+                                } catch (err) {
+                                    currentBuild.result = null
+                                    CKBuilt = false
                                 }
                             }
                         }
@@ -833,7 +846,7 @@ pipeline {
                             // Clean up build settings to disable static library and allow
                             // ROCm testing
                             sh 'rm build/CMakeCache.txt'
-                            buildProject('check-rocmlir-build-only ci-performance-scripts rocblas-benchmark-driver',
+                            buildProject("check-rocmlir-build-only ci-performance-scripts ${getGEMMBenchmarkDrivers()}",
                                          '''-DCMAKE_PREFIX_PATH=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                             -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
                                             -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang''')
@@ -848,7 +861,7 @@ pipeline {
                                 sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
 					--configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
 					--tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv"""
-                            catchError (buildResult: null) { // Might error if the CK driver has not been built
+                            if (CKBuilt == true) {
                                     sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
                         --configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
                         --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
@@ -872,7 +885,7 @@ pipeline {
                                 sh 'ls -l'
                                 sh 'python3 ./bin/createPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP}'
-                                catchError (buildResult: null) { // Might error if the CK driver has noot been built
+                                if (CKBuilt == true) {
                                     sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
                                 }
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -58,19 +58,10 @@ void getAndBuildMIGraphX(String cmakeOpts) {
     buildMIGraphX(cmakeOpts)
 }
 
-CKBuilt = false
 void getAndBuildCK(String cmakeOpts) {
     git branch: params.CKBranch, poll: false,\
         url: 'https://github.com/ROCmSoftwarePlatform/composable_kernel.git'
     buildCK(cmakeOpts)
-}
-
-String getGEMMBenchmarkDrivers(){
-    if (CKBuilt == true){
-        return "rocblas-benchmark-driver ck-benchmark-driver"
-    } else {
-        return "rocblas-benchmark-driver"
-    }
 }
 
 void buildMIOpenWithMLIR() {
@@ -820,57 +811,14 @@ pipeline {
                             }
                         }
                     }
-                    stage("Build Composable Kernels") {
-                        steps {
-                            sh 'rm -rf composable_kernel'
-                            dir('composable_kernel') {
-                                script{
-                                    try {
-                                        getAndBuildCK('''
-                                            -DGPU_TARGETS="gfx1030;gfx908;gfx90a"
-                                            -DCMAKE_CXX_FLAGS="-O3"
-                                            -DCMAKE_PREFIX_PATH="/opt/rocm"
-                                            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
-                                            -DCMAKE_BUILD_TYPE=Release
-                                            ''')
-                                        sh 'cd build/library; make install; cp ../composable_kernelConfig*.cmake ${WORKSPACE}/composable_kernel/build/CKInstallDir/lib/cmake/composable_kernel'
-                                        CKBuilt = true
-                                    } catch (err) {
-                                        currentBuild.result = null
-                                        CKBuilt = false
-                                    }
-                                }
-                            }
-                        }
-                    }
                     stage("Build MLIR") {
                         steps {
                             // Clean up build settings to disable static library and allow
                             // ROCm testing
                             sh 'rm build/CMakeCache.txt'
-                            buildProject("check-rocmlir-build-only ci-performance-scripts ${getGEMMBenchmarkDrivers()}",
-                                         '''-DCMAKE_PREFIX_PATH=${WORKSPACE}/composable_kernel/build/CKInstallDir
-                                            -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+                            buildProject("check-rocmlir-build-only ci-performance-scripts rocblas-benchmark-driver",
+                                         ''' -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
                                             -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang''')
-                        }
-                    }
-                    stage("Test MLIR vs MIOpen") {
-                        steps {
-                            dir('build') {
-                                sh 'date --utc +%Y-%m-%d > perf-run-date'
-                                // Run MLIR perf benchmarks
-                                sh 'python3 ./bin/perfRunner.py'
-                                sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
-					--configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
-					--tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv"""
-                            script{
-                                if (CKBuilt == true) {
-                                        sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
-                            --configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
-                            --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
-                                    }
-                                }
-                            }
                         }
                     }
                     stage("Copy earlier performance results") {
@@ -883,17 +831,54 @@ pipeline {
                                 target: 'build/oldData'
                         }
                     }
+                    stage("Test MLIR vs MIOpen") {
+                        steps {
+                            dir('build') {
+                                sh 'date --utc +%Y-%m-%d > perf-run-date'
+                                // Run MLIR perf benchmarks
+                                sh 'python3 ./bin/perfRunner.py'
+                                sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
+					--configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
+					--tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv"""
+                            }
+                        }
+                    }
+                    stage("Test MLIR vs CK") {
+                        steps {
+                            catchError (buildResult: null) { // This is an optional stage
+                                dir('composable_kernel') {
+                                    sh 'rm -rf composable_kernel'
+                                    getAndBuildCK('''
+                                        -DGPU_TARGETS="gfx1030;gfx908;gfx90a"
+                                        -DCMAKE_CXX_FLAGS="-O3"
+                                        -DCMAKE_PREFIX_PATH="/opt/rocm"
+                                        -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
+                                        -DCMAKE_BUILD_TYPE=Release
+                                        ''')
+                                    sh 'cd build/library; make install; cp ../composable_kernelConfig*.cmake ${WORKSPACE}/composable_kernel/build/CKInstallDir/lib/cmake/composable_kernel'
+                                    sh 'echo `git rev-parse HEAD`'
+                                }
+                                sh 'rm build/CMakeCache.txt'
+                                buildProject("ck-benchmark-driver",
+                                             '''-DCMAKE_PREFIX_PATH=${WORKSPACE}/composable_kernel/build/CKInstallDir
+                                                -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+                                                -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang''')
+
+                                dir('build') {
+                                    sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
+                                --configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
+                                --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
+                                    sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
+                                }
+                            }
+                        }
+                    }
                     stage("Create performance reports") {
                         steps {
                             dir('build') {
                                 sh 'ls -l'
                                 sh 'python3 ./bin/createPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP}'
-                                script{
-                                    if (CKBuilt == true) {
-                                        sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
-                                    }
-                                }
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
                                 sh 'mkdir -p reports && cp ./*.html reports'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -848,9 +848,11 @@ pipeline {
                                 sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
 					--configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
 					--tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv"""
-                                sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
-                    --configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
-                    --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
+                            catchError (buildResult: null) { // Might error if the CK driver has not been built
+                                    sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
+                        --configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
+                        --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
+                                }
                             }
                         }
                     }
@@ -870,7 +872,9 @@ pipeline {
                                 sh 'ls -l'
                                 sh 'python3 ./bin/createPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP}'
-                                sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
+                                catchError (buildResult: null) { // Might error if the CK driver has noot been built
+                                    sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
+                                }
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
                                 sh 'mkdir -p reports && cp ./*.html reports'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -824,19 +824,21 @@ pipeline {
                         steps {
                             sh 'rm -rf composable_kernel'
                             dir('composable_kernel') {
-                                try {
-                                    getAndBuildCK('''
-                                        -DGPU_TARGETS="gfx1030;gfx908;gfx90a"
-                                        -DCMAKE_CXX_FLAGS="-O3"
-                                        -DCMAKE_PREFIX_PATH="/opt/rocm"
-                                        -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
-                                        -DCMAKE_BUILD_TYPE=Release
-                                        ''')
-                                    sh 'cd build/library; make install; cp ../composable_kernelConfig*.cmake ${WORKSPACE}/composable_kernel/build/CKInstallDir/lib/cmake/composable_kernel'
-                                    CKBuilt = true
-                                } catch (err) {
-                                    currentBuild.result = null
-                                    CKBuilt = false
+                                script{
+                                    try {
+                                        getAndBuildCK('''
+                                            -DGPU_TARGETS="gfx1030;gfx908;gfx90a"
+                                            -DCMAKE_CXX_FLAGS="-O3"
+                                            -DCMAKE_PREFIX_PATH="/opt/rocm"
+                                            -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
+                                            -DCMAKE_BUILD_TYPE=Release
+                                            ''')
+                                        sh 'cd build/library; make install; cp ../composable_kernelConfig*.cmake ${WORKSPACE}/composable_kernel/build/CKInstallDir/lib/cmake/composable_kernel'
+                                        CKBuilt = true
+                                    } catch (err) {
+                                        currentBuild.result = null
+                                        CKBuilt = false
+                                    }
                                 }
                             }
                         }
@@ -861,10 +863,12 @@ pipeline {
                                 sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
 					--configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
 					--tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv"""
-                            if (CKBuilt == true) {
-                                    sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
-                        --configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
-                        --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
+                            script{
+                                if (CKBuilt == true) {
+                                        sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
+                            --configs_file=${WORKSPACE}/mlir/utils/performance/bert-configs \
+                            --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
+                                    }
                                 }
                             }
                         }
@@ -885,8 +889,10 @@ pipeline {
                                 sh 'ls -l'
                                 sh 'python3 ./bin/createPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP}'
-                                if (CKBuilt == true) {
-                                    sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
+                                script{
+                                    if (CKBuilt == true) {
+                                        sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
+                                    }
                                 }
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -353,6 +353,8 @@ pipeline {
                      description: 'Run the performance testing stage')
         booleanParam(name: 'checkMIGraphX', defaultValue: false,
                      description: 'Run the MIGraphX integration tests')
+        booleanParam(name: 'checkCK', defaultValue: true,
+                     description: 'Compare performance against CK')
 
         // choose the codepath for testing
         choice(name: 'codepath',
@@ -844,6 +846,10 @@ pipeline {
                         }
                     }
                     stage("Test MLIR vs CK") {
+                        when {
+                            beforeAgent true;
+                            equals expected: true, actual: params.checkCK;
+                        }
                         steps {
                             catchError (buildResult: null) { // This is an optional stage
                                 dir('composable_kernel') {

--- a/mlir/utils/performance/common/benchmarkUtils.cpp
+++ b/mlir/utils/performance/common/benchmarkUtils.cpp
@@ -195,11 +195,11 @@ BenchmarkArgs parseCommandLine(const std::string &name, int argc, char **argv) {
     } else if (arg == "-t") {
       res.dataType = strToDataType(argv[++i]);
     } else if (arg.rfind("-transA=", 0) == 0) {
-      const int lenTransA = 9;
+      const int lenTransA = std::string("-transA=").length();
       std::string value = arg.substr(lenTransA);
       res.transposeA = atob(value);
     } else if (arg.rfind("-transB=", 0) == 0) {
-      const int lenTransB = 9;
+      const int lenTransB = std::string("-transB=").length();
       std::string value = arg.substr(lenTransB);
       res.transposeB = atob(value);
     } else if (arg == "--perf_config=" || arg == "--arch" ||


### PR DESCRIPTION
CK is still under heavy development and might happen that CK doesn't get build. We already disabled the driver, but we also need to disable later stages of the performance pipeline to ensure that problems in CK don't affect benchmark report generation