### PR TITLE
Enabling looped execution for xdlops gemm

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1116,16 +1116,18 @@ def Rock_ThreadwiseGemmOp:
 // xdlops_gemm_V2
 def Rock_XdlopsGemmV2Op:
     Rock_Op<"xdlops_gemm_v2">,
-    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8,
-                      VectorOfLengthAndType<[2, 4], [F32]>,
-                      VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [2]>:$matrixA,
+    Arguments<(ins Index:$mRepeat,
+                   Index:$nRepeat,
                    MemRefRankOf<[F32, F16, BF16, I8,
                       VectorOfLengthAndType<[2, 4], [F32]>,
                       VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [2]>:$matrixB,
+                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [1]>:$matrixA,
+                   MemRefRankOf<[F32, F16, BF16, I8,
+                      VectorOfLengthAndType<[2, 4], [F32]>,
+                      VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                      VectorOfLengthAndType<[4, 8, 16], [I8]>], [1]>:$matrixB,
                    MemRefRankOf<[F32, F16, BF16, I32,
-                      VectorOf<[F32, F16, BF16, I32]>], [3]>:$matrixC,
+                      VectorOf<[F32, F16, BF16, I32]>], [1]>:$matrixC,
                    Rock_XdlopsGemmParamsAttr:$params)> {
   let summary = "XDLOPS GEMM V2";
   let description = [{
@@ -1135,7 +1137,7 @@ def Rock_XdlopsGemmV2Op:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    $matrixC `+` `` `=` $matrixA `*` $matrixB attr-dict
+    $matrixC `+` `` `=` $matrixA`[`$mRepeat`]` `*` $matrixB`[`$nRepeat`]` attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
   let hasVerifier = 1;

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1436,15 +1436,10 @@ LogicalResult ThreadwiseGemmOp::verify() {
 //===----------------------------------------------------------------------===//
 LogicalResult XdlopsGemmV2Op::verify() {
   ArrayRef<int64_t> aShape = getMatrixA().getType().getShape(),
-                    bShape = getMatrixB().getType().getShape(),
-                    cShape = getMatrixC().getType().getShape();
+                    bShape = getMatrixB().getType().getShape();
 
-  if (aShape[1] != bShape[1])
+  if (aShape != bShape)
     return emitOpError("K dimensions don't match");
-  if (aShape[0] != cShape[0])
-    return emitOpError("M dimensions don't match");
-  if (bShape[0] != cShape[1])
-    return emitOpError("N dimensions don't match");
   return success();
 }
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1188,12 +1188,13 @@ struct GridwiseGemmV2RewritePattern
     // Logic to setup buffers for blockwise_gemm_v2.
 
     bool isKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
-    int64_t arrayASize =
-        (!isKReduction) ? (kpacksPerBlock * mRepeats)
-                        : (kpacksPerBlock / inputSpansPerMfmaIn * mRepeats);
-    int64_t arrayBSize =
-        (!isKReduction) ? (kpacksPerBlock * nRepeats)
-                        : (kpacksPerBlock / inputSpansPerMfmaIn * nRepeats);
+    int64_t arrayASize = (!isKReduction)
+                             ? (kpacksPerBlock)
+                             : (kpacksPerBlock / inputSpansPerMfmaIn);
+    int64_t arrayBSize = (!isKReduction)
+                             ? (kpacksPerBlock)
+                             : (kpacksPerBlock / inputSpansPerMfmaIn);
+
     Type arrayAType, arrayBType;
     if (kpack > 1) {
       arrayAType =

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
@@ -1,22 +1,13 @@
 // RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
-#transform_map0 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 2 + d1)> by [<Embed{2, 1} ["m", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [2, 2] -> [4]>
-#transform_map1 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 2 + d1)> by [<Embed{2, 1} ["n", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [1, 2] -> [2]>
-#transform_map2 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0 * 2 + d1 + d2)> by [<Embed{2, 1, 1} ["m", "n", "v"] at [0, 1, 2] -> ["raw"] at [0]>] bounds = [2, 1, 1] -> [2]>
-
-#map0 = affine_map<(d0, d1) -> (d0 * 8 + d1)>
-#map1 = affine_map<(d0, d1, d2) -> (d0 * 2 + d1 * 2 + d2)>
-
-func.func @rock_xdlops_gemm_v2_reduction_nokpack(%matrixA : memref<4xf32, 5>,
-                                                      %matrixB : memref<2xf32, 5>,
-                                                      %matrixC : memref<2xvector<16xf32>, 5>) {
+func.func @rock_xdlops_gemm_v2_reduction_nokpack(%matrixA : memref<2xf32, 5>,
+                                                 %matrixB : memref<2xf32, 5>,
+                                                 %matrixC : memref<2xvector<16xf32>, 5>) {
+  %c0 = arith.constant 0 : index
   // CHECK-LABEL: func.func @rock_xdlops_gemm_v2_reduction_nokpack
   // CHECK: rock.in_bounds_load
   // CHECK: rock.in_bounds_load
   // CHECK: amdgpu.mfma
-  %A = rock.transform %matrixA by #transform_map0 : memref<4xf32, 5> to memref<2x2xf32, #map0, 5>
-  %B = rock.transform %matrixB by #transform_map1 : memref<2xf32, 5> to memref<1x2xf32, #map0, 5>
-  %C = rock.transform %matrixC by #transform_map2 : memref<2xvector<16xf32>, 5> to memref<2x1x1xvector<16xf32>, #map1, 5>
-  rock.xdlops_gemm_v2 %C += %A * %B {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
        kPerBlock = 8,
        kpack = 1,
@@ -25,29 +16,19 @@ func.func @rock_xdlops_gemm_v2_reduction_nokpack(%matrixA : memref<4xf32, 5>,
        nPerBlock = 64,
        nPerWave = 32,
        forceUnroll = true>
-     } : memref<2x1x1xvector<16xf32>, #map1, 5> += memref<2x2xf32, #map0, 5> * memref<1x2xf32, #map0, 5>
+     } : memref<2xvector<16xf32>, 5> += memref<2xf32, 5> * memref<2xf32, 5>
   return
 }
 
-#transform_map3 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 2 + d1)> by [<Embed{2, 1} ["m", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [2, 1] -> [2]>
-#transform_map4 = #rock.transform_map<affine_map<(d0, d1) -> (d0 * 2 + d1)> by [<Embed{2, 1} ["n", "k"] at [0, 1] -> ["raw"] at [0]>] bounds = [2, 1] -> [2]>
-#transform_map5 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0 * 2 + d1 + d2)> by [<Embed{2, 2, 1} ["m", "n", "v"] at [0, 1, 2] -> ["raw"] at [0]>] bounds = [2, 2, 1] -> [2]>
-
-#map2 = affine_map<(d0, d1) -> (d0 * 2 + d1)>
-#map3 = affine_map<(d0, d1, d2) -> (d0 * 2 + d1 + d2)>
-
 func.func @rock_xdlops_gemm_v2_reduction_kpack_f32(%matrixA : memref<2xvector<2xf32>, 5>,
-                                                    %matrixB : memref<2xvector<2xf32>, 5>,
-                                                    %matrixC : memref<4xvector<16xf32>, 5>) {
+                                                   %matrixB : memref<2xvector<2xf32>, 5>,
+                                                   %matrixC : memref<4xvector<16xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK-LABEL: func.func @rock_xdlops_gemm_v2_reduction_kpack_f32
   // CHECK: rock.extract_slice
   // CHECK: rock.extract_slice
   // CHECK: amdgpu.mfma
-  %A = rock.transform %matrixA by #transform_map3 : memref<2xvector<2xf32>, 5> to memref<2x1xvector<2xf32>, #map2, 5>
-  %B = rock.transform %matrixB by #transform_map4 : memref<2xvector<2xf32>, 5> to memref<2x1xvector<2xf32>, #map2, 5>
-  %C = rock.transform %matrixC by #transform_map5 : memref<4xvector<16xf32>, 5> to memref<2x2x1xvector<16xf32>, #map3, 5>
-  rock.xdlops_gemm_v2 %C += %A * %B {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 2,
       kpack = 2,
@@ -56,7 +37,7 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_f32(%matrixA : memref<2xvector<2x
       nPerBlock = 128,
       nPerWave = 64,
       forceUnroll = true>
-  } : memref<2x2x1xvector<16xf32>, #map3, 5> += memref<2x1xvector<2xf32>, #map2, 5> * memref<2x1xvector<2xf32>, #map2, 5>
+  } : memref<4xvector<16xf32>, 5> += memref<2xvector<2xf32>, 5> * memref<2xvector<2xf32>, 5>
   return
 }
 
@@ -69,10 +50,7 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<2xvector<8xi
   // CHECK: rock.extract_slice
   // CHECK: amdgpu.mfma
   // CHECK-NOT: amdgpu.mfma
-  %A = rock.transform %matrixA by #transform_map3 : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
-  %B = rock.transform %matrixB by #transform_map4 : memref<2xvector<8xi8>, 5> to memref<1x2xvector<8xi8>, #map2, 5>
-  %C = rock.transform %matrixC by #transform_map5 : memref<1xvector<16xi32>, 5> to memref<1x1x1xvector<16xi32>, #map3, 5>
-  rock.xdlops_gemm_v2 %C += %A * %B {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 4,
       kpack = 8,
@@ -81,6 +59,6 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<2xvector<8xi
       mPerBlock = 64,
       nPerBlock = 64,
       forceUnroll = true>
-  } : memref<1x1x1xvector<16xi32>, #map3, 5> += memref<1x2xvector<8xi8>, #map2, 5> * memref<1x2xvector<8xi8>, #map2, 5>
+  } : memref<1xvector<16xi32>, 5> += memref<2xvector<8xi8>, 5> * memref<2xvector<8xi8>, 5>
   return
 }

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -474,11 +474,11 @@ func.func @rock_threadwise_gemm(%lhs : memref<4x8x1xf32, 5>, %rhs : memref<4x8x1
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<2x16xf32, 5>,
-                                            %matrixB : memref<1x16xf32, 5>,
-                                            %matrixC : memref<2x1x1xvector<32xf32>, 5>) {
+func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<16xf32, 5>,
+                                            %matrixB : memref<16xf32, 5>,
+                                            %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -487,7 +487,7 @@ func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<2x16xf32, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf32>, 5> += memref<2x16xf32, 5> * memref<1x16xf32, 5>
+  } : memref<1xvector<32xf32>, 5> += memref<16xf32, 5> * memref<16xf32, 5>
   return
 }
 
@@ -496,11 +496,11 @@ func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<2x16xf32, 5>,
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_two_results(%matrixA : memref<2x16xf32, 5>,
-                                             %matrixB : memref<1x16xf32, 5>,
-                                             %matrixC : memref<2x1x1xvector<32xf32>, 5>) {
+func.func @rock_xdlops_gemm_v2_two_results(%matrixA : memref<16xf32, 5>,
+                                             %matrixB : memref<16xf32, 5>,
+                                             %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -509,7 +509,7 @@ func.func @rock_xdlops_gemm_v2_two_results(%matrixA : memref<2x16xf32, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf32>, 5> += memref<2x16xf32, 5> * memref<1x16xf32, 5>
+  } : memref<1xvector<32xf32>, 5> += memref<16xf32, 5> * memref<16xf32, 5>
   return
 }
 

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -22,11 +22,11 @@ func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x12
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<2x16xf16, 5>,
-                                                %matrixB : memref<1x16xf16, 5>,
-                                                %matrixC : memref<2x1x1xvector<32xf16>, 5>) {
+func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<16xf16, 5>,
+                                                %matrixB : memref<16xf16, 5>,
+                                                %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -35,7 +35,7 @@ func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<2x16xf16, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf16>, 5> += memref<2x16xf16, 5> * memref<1x16xf16, 5>
+  } : memref<1xvector<32xf16>, 5> += memref<16xf16, 5> * memref<16xf16, 5>
   return
 }
 
@@ -44,11 +44,11 @@ func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<2x16xf16, 5>,
 
 // ----
 
-func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<2x16xf16, 5>,
-                                                 %matrixB: memref<1x16xf16, 5>,
-                                                 %matrixC : memref<2x1x1xvector<32xf16>, 5>) {
+func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<16xf16, 5>,
+                                               %matrixB : memref<16xf16, 5>,
+                                               %matrixC : memref<1xvector<32xf16>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.xdlops_gemm_v2 %matrixC += %matrixA * %matrixB {
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -57,7 +57,7 @@ func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<2x16xf16, 5>,
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<2x1x1xvector<32xf16>, 5> += memref<2x16xf16, 5> * memref<1x16xf16, 5>
+  } : memref<1xvector<32xf16>, 5> += memref<16xf16, 5> * memref<16xf16, 5>
   return
 }
 


### PR DESCRIPTION
This is second attempt after https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/942. The loop iteration style will change to the following (according to CK style):

```
for m = 0 : mRepeat
 a = load(A)
  for n = 0 : nRepeat
   b = load(B)
    for k = 0 : K   
      c = a * b
```

Will run this through with tuning for the second time to confirm the issue bumped with broadcast is work-arounded.