### PR TITLE
[DO NOT SQUASH] MLIR#807: add tosa.cast to fusable elementwise ops in tosa-partition

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -66,7 +66,7 @@ def TosaPartition : Pass<"tosa-partition", "ModuleOp"> {
                "llvm::cl::ZeroOrMore">,
     Option<"partitionTagOpt", "partition-tag", "std::string",
            /*default=*/"\"kernel\"", "Attribute for outlined functions">,
-    Option<"trailingOnly", "trailing-only", "bool", /*default=*/"false",
+    Option<"trailingOnly", "trailing-only", "bool", /*default=*/"true",
            "Don't gather ops ahead of anchor op">
   ];
   let dependentDialects = ["tosa::TosaDialect"];

--- a/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
@@ -63,6 +63,29 @@ static mlir::Value applyPad(Location loc, Value input, ArrayRef<int64_t> pad,
       highIndices, padValue);
 }
 
+static mlir::Value makeIntBiasAdd(PatternRewriter &rewriter, Location loc,
+                                  ShapedType resultTy, Value bias, Value conv,
+                                  Value result,
+                                  ArrayRef<AffineMap> indexingMaps) {
+  result = rewriter
+               .create<linalg::GenericOp>(
+                   loc, resultTy, ValueRange({bias, conv}), result,
+                   indexingMaps, getNParallelLoopsAttrs(resultTy.getRank()),
+                   [](OpBuilder &builder, Location loc, ValueRange args) {
+                     Value biasVal = args[0];
+                     Type resType = args[1].getType();
+                     if (resType != biasVal.getType()) {
+                       biasVal = builder.create<arith::ExtSIOp>(loc, resType,
+                                                                biasVal);
+                     }
+                     Value added =
+                         builder.create<arith::AddIOp>(loc, biasVal, args[1]);
+                     builder.create<linalg::YieldOp>(loc, added);
+                   })
+               .getResult(0);
+  return result;
+}
+
 static mlir::Value reifyConstantDim(int64_t attr,
                                     ImplicitLocOpBuilder &builder) {
   return builder.createOrFold<arith::IndexCastOp>(
@@ -290,19 +313,8 @@ public:
                   loc, resultTy, ValueRange{input, weight, iZpVal, kZpVal},
                   ValueRange{zeroTensor}, strideAttr, dilationAttr)
               ->getResult(0);
-
-      Value result =
-          rewriter
-              .create<linalg::GenericOp>(
-                  loc, resultTy, ValueRange({bias, conv}), biasEmptyTensor,
-                  indexingMaps, getNParallelLoopsAttrs(resultTy.getRank()),
-                  [&](OpBuilder &nestedBuilder, Location nestedLoc,
-                      ValueRange args) {
-                    Value added = nestedBuilder.create<arith::AddIOp>(
-                        loc, args[0], args[1]);
-                    nestedBuilder.create<linalg::YieldOp>(nestedLoc, added);
-                  })
-              .getResult(0);
+      Value result = makeIntBiasAdd(rewriter, loc, resultTy, bias, conv,
+                                    biasEmptyTensor, indexingMaps);
       rewriter.replaceOp(op, result);
       return success();
     }
@@ -479,19 +491,8 @@ public:
       createDepthwiseConvCollapseMap(resultRank, reassociationMap, rewriter);
       Value convReshape = rewriter.create<tensor::CollapseShapeOp>(
           loc, resultTy, conv, reassociationMap);
-      Value result =
-          rewriter
-              .create<linalg::GenericOp>(
-                  loc, resultTy, ValueRange({bias, convReshape}),
-                  biasEmptyTensor, indexingMaps,
-                  getNParallelLoopsAttrs(resultRank),
-                  [&](OpBuilder &nestedBuilder, Location nestedLoc,
-                      ValueRange args) {
-                    Value added = nestedBuilder.create<arith::AddIOp>(
-                        loc, args[0], args[1]);
-                    nestedBuilder.create<linalg::YieldOp>(nestedLoc, added);
-                  })
-              .getResult(0);
+      Value result = makeIntBiasAdd(rewriter, loc, resultTy, bias, convReshape,
+                                    biasEmptyTensor, indexingMaps);
       rewriter.replaceOp(op, result);
     }
     return success();
@@ -624,11 +625,8 @@ public:
     Value transposedWeight = rewriter.create<tosa::TransposeOp>(
         loc, newWeightTy, weight, permutationValue);
 
-    auto biasEmptyTensor =
-        rewriter
-            .create<tensor::EmptyOp>(loc, outputTy.getShape(), outputETy,
-                                     filteredDims)
-            ->getResults();
+    Value biasEmptyTensor = rewriter.create<tensor::EmptyOp>(
+        loc, outputTy.getShape(), outputETy, filteredDims);
 
     if (!op.getQuantizationInfo()) {
       Value matmul = rewriter
@@ -665,18 +663,8 @@ public:
                 ValueRange{input, transposedWeight, inputZp, outputZp},
                 zeroTensor)
             ->getResult(0);
-    Value result =
-        rewriter
-            .create<linalg::GenericOp>(
-                loc, outputTy, ValueRange({bias, matmul}), biasEmptyTensor,
-                indexingMaps, getNParallelLoopsAttrs(outputTy.getRank()),
-                [&](OpBuilder &nestedBuilder, Location nestedLoc,
-                    ValueRange args) {
-                  Value added = nestedBuilder.create<arith::AddIOp>(
-                      loc, args[0], args[1]);
-                  nestedBuilder.create<linalg::YieldOp>(nestedLoc, added);
-                })
-            .getResult(0);
+    Value result = makeIntBiasAdd(rewriter, loc, outputTy, bias, matmul,
+                                  biasEmptyTensor, indexingMaps);
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/external/llvm-project/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg-named.mlir
+++ b/external/llvm-project/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg-named.mlir
@@ -345,6 +345,28 @@ func.func @avg_pool_i16(%arg0 : tensor<1x128x128x2xi16>) -> () {
 // CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3)>
 // CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 
+// CHECK-LABEL: @conv2d_i8
+func.func @conv2d_i8(%input: tensor<1x49x42x27xi8>, %weights: tensor<28x1x1x27xi8>, %bias: tensor<28xi8>) -> () {
+  // CHECK: %[[PERM:.+]] = arith.constant dense<[1, 2, 3, 0]>
+  // CHECK: %[[W:.+]] = "tosa.transpose"(%arg1, %[[PERM]])
+  // CHECK: %[[M_IN:.+]] = tensor.empty()
+  // CHECK: %[[CST:.+]] = arith.constant 0
+  // CHECK: %[[FILL:.+]] = linalg.fill
+  // CHECK: %[[B_IN:.+]] = tensor.empty()
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<[2, 1]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %[[W]], %c0_i32_0, %c0_i32_1 : tensor<1x49x42x27xi8>, tensor<1x1x27x28xi8>, i32, i32) outs(%[[FILL]] : tensor<1x45x40x28xi32>) -> tensor<1x45x40x28xi32>
+  // CHECK: %[[B:.+]] = linalg.generic {indexing_maps = [#[[$MAP1]], #[[$MAP2]], #[[$MAP2]]], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2, %[[CONV]] : tensor<28xi8>, tensor<1x45x40x28xi32>) outs(%[[B_IN]] : tensor<1x45x40x28xi32>)
+  // CHECK:   arith.extsi
+  // CHECK:   arith.addi
+  // CHECK:   linalg.yield
+  %0 = "tosa.conv2d"(%input, %weights, %bias) {dilation = array<i64: 2, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>} : (tensor<1x49x42x27xi8>, tensor<28x1x1x27xi8>, tensor<28xi8>)  -> (tensor<1x45x40x28xi32>)
+  return
+}
+
+// -----
+
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+
 // CHECK-LABEL: @conv2d_f32
 func.func @conv2d_f32(%input: tensor<1x49x42x27xf32>, %weights: tensor<28x3x3x27xf32>, %bias: tensor<28xf32>) -> () {
   // CHECK: %[[PERM:.+]] = arith.constant dense<[1, 2, 3, 0]>

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
@@ -10,28 +10,27 @@
 // RUN: mlir-opt --test-tosa-partition-options=attr-one %s | FileCheck %s --check-prefix=ONE
 // RUN: mlir-opt --test-tosa-partition-options=nofront-arg %s | FileCheck %s --check-prefix=THREE
 
-// CHECK-LABEL: func private @test_fusion8__part_0
+// CHECK: func private @test_fusion8__part_0
+// CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: tosa.add
+// CHECK-NEXT: return
+// CHECK-LABEL: func private @test_fusion8__part_1
 // CHECK-SAME: attributes {{{.*}}kernel}
 // CHECK-NEXT: arith.constant
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.depthwise_conv2d
 // CHECK-NEXT: tosa.abs
-// CHECK-NEXT: tosa.add
-// CHECK-NEXT: return
-// CHECK: func private @test_fusion8__part_1
-// CHECK-NEXT: tosa.conv2d
 // CHECK-NEXT: return
 // CHECK: func @test_fusion8
 // CHECK: call @test_fusion8__part_1
 // CHECK: call @test_fusion8__part_0
 
-// ONE-LABEL: func private @test_fusion8__part_0
+// ONE-LABEL: func private @test_fusion8__part_1
 // ONE-SAME: attributes {{{.*}}one}
 // ONE-NEXT: arith.constant
 // ONE-NEXT: tosa.transpose
 // ONE-NEXT: tosa.depthwise_conv2d
 // ONE-NEXT: tosa.abs
-// ONE-NEXT: tosa.add
 // ONE-NEXT: return
 // ONE: func @test_fusion8
 // ONE: call @test_fusion8__part_0

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
@@ -2,20 +2,26 @@
 // CHECK-LABEL: func private @forward__part_0
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.conv2d
-// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
 // CHECK: return
 // CHECK-LABEL: func private @forward__part_1
+// CHECK-NEXT: tosa.reshape
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.conv2d
-// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
+// CHECK-NEXT: tosa.sub
+// CHECK-NEXT: tosa.mul
+// CHECK-NEXT: tosa.mul
+// CHECK-NEXT: tosa.add
+// CHECK-NEXT: tosa.clamp
 // CHECK-NEXT: return
 
 module attributes {torch.debug_module_name = "ResNet"} {

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
@@ -58,11 +58,11 @@ func.func @test_fusion4(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3x
 
 // CHECK-LABEL: func private @test_fusion5__part_0
 // CHECK-NEXT: tosa.conv2d
-// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: tosa.add
 // CHECK-NEXT: return
 // CHECK: func private @test_fusion5__part_1
 // CHECK-NEXT: tosa.conv2d
+// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: return
 // CHECK: func @test_fusion5
 // CHECK-NEXT: call @test_fusion5__part_1
@@ -88,10 +88,10 @@ func.func @test_fusion6(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3x
 }
 
 // CHECK-LABEL: func private @test_fusion7__part_0
-// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: tosa.conv2d
 // CHECK-NEXT: return
 // CHECK: func @test_fusion7
+// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: call @test_fusion7__part_0
 // CHECK-NEXT: return
 func.func @test_fusion7(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -196,7 +196,7 @@ def Rock_TransformMapAttr : Rock_Attr<"TransformMap"> {
     ];
 
     let assemblyFormat = [{
-        `<` $map `by` ` ` `[` $ops `]` `bounds` `=` ($upperBounds^) : (`[` `]`)? `->` $lowerBounds `>`
+        `<` $map `by` ` ` `[` $ops `]` `bounds` `=` ($upperBounds^) : (`[` `]`)? `->` ($lowerBounds^) : (`[` `]`)? `>`
     }];
     let genVerifyDecl = 1;
 }

--- a/mlir/test/fusion/quantization.mlir
+++ b/mlir/test/fusion/quantization.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-driver -host-pipeline highlevel -kernel-pipeline gpu -arch gfx906 %s | FileCheck %s
+// RUN: rocmlir-driver -host-pipeline partition,highlevel -arch gfx906 %s | FileCheck %s
 
 // CHECK-LABEL: test_conv_with_cast
 // CHECK: arith.sitofp {{.*}} : i32 to f32
@@ -8,7 +8,6 @@ func.func @test_conv_with_cast(
     %filter: tensor<8x1x1x4xi8>, 
     %scale: tensor<8xf32>,
     %bias: tensor<8xi32>) -> tensor<1x8x8x8xf32> 
-    attributes {kernel, arch = ""} 
 {
     %zero = arith.constant dense<0> : tensor<8xi8>  
     %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  
@@ -29,7 +28,6 @@ func.func @test_quantization_ck(
     %filter: tensor<8x1x1x4xi8>, 
     %scale: tensor<8xf32>,
     %bias: tensor<8xi32>) -> tensor<1x8x8x8xi8> 
-    attributes {kernel, arch = ""} 
 {
     %zero = arith.constant dense<0> : tensor<8xi8>  
     %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  
@@ -51,7 +49,6 @@ func.func @test_quantization_migraphx(
     %filter: tensor<8x1x1x4xi8>, 
     %scale: tensor<8xf32>,
     %bias: tensor<8xi32>) -> tensor<1x8x8x8xi8> 
-    attributes {kernel, arch = ""} 
 {
     %zero = arith.constant dense<0> : tensor<8xi8>  
     %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  

--- a/mlir/test/xmir/mobilenetv1.mid.mlir
+++ b/mlir/test/xmir/mobilenetv1.mid.mlir
@@ -2,12 +2,12 @@
 
 module {
 
-// CHECK:  func.func private @mobilenetv1__part_0(%arg0: memref<1x224x224x3xf32> {func.read_access}, %arg1: memref<32x3x3x3xf32> {func.read_access}, %arg2: memref<1x112x112x32xf32> {func.write_access}) {
+// CHECK:  func.func private @mobilenetv1__part_4(%arg0: memref<1x224x224x3xf32> {func.read_access}, %arg1: memref<32x3x3x3xf32> {func.read_access}, %arg2: memref<1x112x112x32xf32> {func.write_access}) {
 
 // CHECK: func.func @mobilenetv1(%arg0: memref<1x224x224x3xf32>, %arg1: memref<32x3x3x3xf32>, %arg2: memref<3x3x32x1xf32>, %arg3: memref<64x1x1x32xf32>, %arg4: memref<3x3x64x1xf32>, %arg5: memref<128x1x1x64xf32>, %arg6: memref<1x56x56x128xf32>) {
-// CHECK:   %[[TOKEN0:.*]] = async.launch @mobilenetv1__part_0 (%arg0, %arg1, %{{.*}}) : (memref<1x224x224x3xf32>, memref<32x3x3x3xf32>, memref<1x112x112x32xf32>)
+// CHECK:   %[[TOKEN0:.*]] = async.launch @mobilenetv1__part_4 (%arg0, %arg1, %{{.*}}) : (memref<1x224x224x3xf32>, memref<32x3x3x3xf32>, memref<1x112x112x32xf32>)
 
-// CHECK-DIS:   %[[TOKEN1:.*]] = async.launch @mobilenetv1__part_1 (%{{.*}}, %arg2, %{{.*}}) : (memref<1x112x112x32xf32>, memref<3x3x32x1xf32>, memref<12544x32xf32>)
+// CHECK-DIS:   %[[TOKEN1:.*]] = async.launch @mobilenetv1__part_3 (%{{.*}}, %arg2, %{{.*}}) : (memref<1x112x112x32xf32>, memref<3x3x32x1xf32>, memref<12544x32xf32>)
 
 // CHECK:   async.await %token_{{.*}} : !async.token
 

--- a/mlir/test/xmir/mobilenetv1.small.mlir
+++ b/mlir/test/xmir/mobilenetv1.small.mlir
@@ -2,11 +2,11 @@
 
 
 module {
-// CHECK:  func.func private @mobilenetv1__part_0(%arg0: tensor<1x112x112x32xf32> {func.read_access}, %arg1: tensor<3x3x32x1xf32> {func.read_access}) -> (tensor<1x112x112x32xf32> {func.write_access}) {
-// CHECK:  func.func private @mobilenetv1__part_1(%arg0: tensor<1x112x112x32xf32> {func.read_access}, %arg1: tensor<64x1x1x32xf32> {func.read_access}) -> (tensor<1x112x112x64xf32> {func.write_access}) {
+// CHECK:  func.func private @mobilenetv1__part_0(%arg0: tensor<1x112x112x32xf32> {func.read_access}, %arg1: tensor<64x1x1x32xf32> {func.read_access}) -> (tensor<1x112x112x64xf32> {func.write_access}) {
+// CHECK:  func.func private @mobilenetv1__part_1(%arg0: tensor<1x112x112x32xf32> {func.read_access}, %arg1: tensor<3x3x32x1xf32> {func.read_access}) -> (tensor<1x112x112x32xf32> {func.write_access}) {
 // CHECK:  func.func @mobilenetv1(%arg0: tensor<1x112x112x32xf32>, %arg1: tensor<32x3x3x3xf32>, %arg2: tensor<3x3x32x1xf32>, %arg3: tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32> {
-// CHECK:    %[[T0:.*]], %[[RES0:.*]] = async.launch @mobilenetv1__part_0 (%arg0, %arg2) : (tensor<1x112x112x32xf32>, tensor<3x3x32x1xf32>) -> tensor<1x112x112x32xf32>
-// CHECK:    %[[T1:.*]], %[[RES1:.*]] = async.launch @mobilenetv1__part_1
+// CHECK:    %[[T0:.*]], %[[RES0:.*]] = async.launch @mobilenetv1__part_1 (%arg0, %arg2) : (tensor<1x112x112x32xf32>, tensor<3x3x32x1xf32>) -> tensor<1x112x112x32xf32>
+// CHECK:    %[[T1:.*]], %[[RES1:.*]] = async.launch @mobilenetv1__part_0
 // CHECK-SAME:[%[[T0]]] 
 // CHECK-SAME:(%[[RES0]]
 // CHECK-SAME: %arg3) : (tensor<1x112x112x32xf32>, tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32>

--- a/mlir/test/xmir/resnet50_blk.async.mlir
+++ b/mlir/test/xmir/resnet50_blk.async.mlir
@@ -3,8 +3,8 @@
 module {
 // CHECK: func.func @resnet50(%[[ARG0:.*]]: memref<1x32x32x64xf32>, %[[ARG1:.*]]: memref<64x3x3x64xf32>, %[[ARG2:.*]]: memref<64x3x3x64xf32>, %[[ARG3:.*]]: memref<1x32x32x64xf32>)
 // CHECK: %[[MEM0:.*]] = memref.alloc
-// CHECK: %[[TOKEN0:.*]] = async.launch @resnet50__part_0 (%{{.*}}, %{{.*}}, %[[MEM0]])
-// CHECK: %[[TOKEN1:.*]] = async.launch @resnet50__part_1 [%[[TOKEN0]]] (%[[MEM0]], %{{.*}}, %{{.*}}, %{{.*}})
+// CHECK: %[[TOKEN0:.*]] = async.launch @resnet50__part_1 (%{{.*}}, %{{.*}}, %[[MEM0]])
+// CHECK: %[[TOKEN1:.*]] = async.launch @resnet50__part_0 [%[[TOKEN0]]] (%[[MEM0]], %{{.*}}, %{{.*}}, %{{.*}})
 // CHECK: async.await %[[TOKEN1]] : !async.token
 
   func.func @resnet50(%arg0: tensor<1x32x32x64xf32>, %arg1: tensor<64x3x3x64xf32>, %arg2: tensor<64x3x3x64xf32>) -> tensor<1x32x32x64xf32> {

--- a/mlir/test/xmir/resnet50_blk.bin.mlir
+++ b/mlir/test/xmir/resnet50_blk.bin.mlir
@@ -1,8 +1,8 @@
 // RUN: rocmlir-driver -host-pipeline partition,highlevel,xmodel -kernel-pipeline full -targets gfx908 %s | FileCheck %s
 
 module {
-// CHECK: func.func private @resnet50__part_0(%arg0: memref<1x32x32x64xf32> {func.read_access}, %arg1: memref<64x3x3x64xf32> {func.read_access}, %arg2: memref<1x32x32x64xf32> {func.write_access}) attributes {xmodel.targets = [{{.*}}]}
-// CHECK: func.func private @resnet50__part_1(%arg0: memref<1x32x32x64xf32> {func.read_access}, %arg1: memref<64x3x3x64xf32> {func.read_access}, %arg2: memref<1x32x32x64xf32> {func.read_access}, %arg3: memref<1x32x32x64xf32> {func.write_access}) attributes {xmodel.targets = [{{.*}}]}
+// CHECK: func.func private @resnet50__part_0(%arg0: memref<1x32x32x64xf32> {func.read_access}, %arg1: memref<64x3x3x64xf32> {func.read_access}, %arg2: memref<1x32x32x64xf32> {func.read_access}, %arg3: memref<1x32x32x64xf32> {func.write_access}) attributes {xmodel.targets = [{{.*}}]}
+// CHECK: func.func private @resnet50__part_1(%arg0: memref<1x32x32x64xf32> {func.read_access}, %arg1: memref<64x3x3x64xf32> {func.read_access}, %arg2: memref<1x32x32x64xf32> {func.write_access}) attributes {xmodel.targets = [{{.*}}]}
 
   func.func @resnet50(%arg0: tensor<1x32x32x64xf32>, %arg1: tensor<64x3x3x64xf32>, %arg2: tensor<64x3x3x64xf32>) -> tensor<1x32x32x64xf32> {
 


### PR DESCRIPTION
MLIR#812: fixed bug in tosa-to-linalg-named for quantized bias add
* added test
    
    https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/812

MLIR#813: fuse all subsequent transpose/reshape ops in tosa-partition
* also make tosa-partition run bottom-up (should use a pass instead)
* changed tosa-partition=trailing-only to default true
* updated tosa-partition tests
MLIR#807: add tosa.cast to fusable elementwise ops in tosa-partition
    
    https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/807
    https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/813

* fixed rock.transform_map for empty lowerBounds
* updated test for quantization kernel in partitioning
