### PR TITLE
Limit the amount of vectorization

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -49,6 +49,13 @@ TransformOp reshapeBuffer(OpBuilder &b, Location loc, Value buffer,
 int64_t getMaxVectorization(ArrayAttr transforms, uint32_t dim, int64_t len,
                             ArrayRef<int64_t> outputShape);
 
+/// Returns the maximum vectorization constrained by the `dataType` we are
+/// vectorizing for
+int64_t getMaxVectorizationForDatatype(ArrayAttr transforms, uint32_t dim,
+                                       int64_t len,
+                                       ArrayRef<int64_t> outputShape,
+                                       Type dataType);
+
 /// Rewrites the given array of transformations to (under the assumption that
 /// they will target a space of size outputShape) collapse contiguous merge
 /// dimensions. That is, if we begin with (x, y, z) <- Merge{A, B, C}(s)

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -218,6 +218,8 @@ auto getMfmaInsnGroupAttrMap = []() {
                     {ROCDL::mfma_f32_32x32x4bf16::getOperationName()}},
                    {{MfmaTypeId::Bf16TyId, 16, 16},
                     {ROCDL::mfma_f32_16x16x8bf16::getOperationName()}},
+                   {{MfmaTypeId::I8TyId, 64, 64},
+                    {ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
                    {{MfmaTypeId::I8TyId, 32, 32},
                     {ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
                    {{MfmaTypeId::I8TyId, 16, 16},

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -158,6 +158,7 @@ auto getMfmaInsnGroupAttrMap = []() {
   using amdgpu::MFMAPermB;
   static llvm::DenseMap<MfmaInsnGroupSelectKey, MfmaInsnGroupAttr,
                         MfmaInsnGroupSelectKeyInfo>
+      // f32
       groupAttrMap{{{MfmaTypeId::Fp32TyId, 64, 64},
                     {ROCDL::mfma_f32_32x32x2f32::getOperationName()}},
                    {{MfmaTypeId::Fp32TyId, 64, 32},
@@ -178,6 +179,7 @@ auto getMfmaInsnGroupAttrMap = []() {
                     {ROCDL::mfma_f32_32x32x2f32::getOperationName()}},
                    {{MfmaTypeId::Fp32TyId, 16, 16},
                     {ROCDL::mfma_f32_16x16x4f32::getOperationName()}},
+                   // f16
                    {{MfmaTypeId::Fp16TyId, 64, 64},
                     {ROCDL::mfma_f32_32x32x8f16::getOperationName()}},
                    {{MfmaTypeId::Fp16TyId, 64, 32},
@@ -198,6 +200,7 @@ auto getMfmaInsnGroupAttrMap = []() {
                     {ROCDL::mfma_f32_32x32x8f16::getOperationName()}},
                    {{MfmaTypeId::Fp16TyId, 16, 16},
                     {ROCDL::mfma_f32_16x16x16f16::getOperationName()}},
+                   // bf16
                    {{MfmaTypeId::Bf16TyId, 64, 64},
                     {ROCDL::mfma_f32_32x32x4bf16::getOperationName()}},
                    {{MfmaTypeId::Bf16TyId, 64, 32},
@@ -218,10 +221,19 @@ auto getMfmaInsnGroupAttrMap = []() {
                     {ROCDL::mfma_f32_32x32x4bf16::getOperationName()}},
                    {{MfmaTypeId::Bf16TyId, 16, 16},
                     {ROCDL::mfma_f32_16x16x8bf16::getOperationName()}},
+                   // Int8
                    {{MfmaTypeId::I8TyId, 64, 64},
+                    {ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
+                   {{MfmaTypeId::I8TyId, 64, 32},
+                    {ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
+                   {{MfmaTypeId::I8TyId, 32, 64},
                     {ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
                    {{MfmaTypeId::I8TyId, 32, 32},
                     {ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
+                   {{MfmaTypeId::I8TyId, 64, 16},
+                    {ROCDL::mfma_i32_16x16x16i8::getOperationName()}},
+                   {{MfmaTypeId::I8TyId, 16, 64},
+                    {ROCDL::mfma_i32_16x16x16i8::getOperationName()}},
                    {{MfmaTypeId::I8TyId, 16, 16},
                     {ROCDL::mfma_i32_16x16x16i8::getOperationName()}}};
 

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -675,13 +675,13 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
       buffer.getType().cast<ShapedType>().getShape();
 
   // We are vectorizing in the iter dimension, not block ID or thread ID
-  int64_t vectorLen =
-      getMaxVectorization(transforms, /*dim=*/2, numValues, bufferShape);
+  auto elementType = sourceView.getType().getElementType();
+  int64_t vectorLen = getMaxVectorizationForDatatype(
+      transforms, /*dim=*/2, numValues, bufferShape, elementType);
   LLVM_DEBUG(llvm::dbgs() << "Max vectorization for read_into = " << vectorLen
                           << "\n");
 
-  Type loadType =
-      vectorTypeOrSelf(sourceView.getType().getElementType(), vectorLen);
+  Type loadType = vectorTypeOrSelf(elementType, vectorLen);
   bool forceUnroll = op.getForceUnroll();
   bool useIndexDiffs = op.getUseIndexDiffs();
 
@@ -720,6 +720,8 @@ LogicalResult ThreadwiseWriteAllRewritePattern::matchAndRewrite(
   TypedValue<MemRefType> source = adaptor.getSource();
   TypedValue<MemRefType> destView = adaptor.getDest();
 
+  auto elementType = destView.getType().getElementType();
+
   auto [buffer, transforms] = untransform(b, destView, op.getExtraViews());
 
   int64_t numValues = source.getType().getNumElements();
@@ -727,8 +729,8 @@ LogicalResult ThreadwiseWriteAllRewritePattern::matchAndRewrite(
       buffer.getType().cast<ShapedType>().getShape();
 
   // We are vectorizing in the iter dimension, not block ID or thread ID
-  int64_t vectorLen =
-      getMaxVectorization(transforms, /*dim=*/2, numValues, bufferShape);
+  int64_t vectorLen = getMaxVectorizationForDatatype(
+      transforms, /*dim=*/2, numValues, bufferShape, elementType);
   LLVM_DEBUG(llvm::dbgs() << "Max vectorization for write_all = " << vectorLen
                           << "\n");
 

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -91,7 +91,7 @@ static Type obtainAccumulatorType(OpBuilder &b, Type &elementType,
 static std::pair<GemmDimension, int64_t>
 bestVectorization(OpBuilder &b, Value matrix, int64_t dataPerThread,
                   GemmDimension tiebreaker, int64_t kPerBlock,
-                  int64_t dPerBlock) {
+                  int64_t dPerBlock, Type elementType) {
   Value tensor;
   ArrayAttr transforms;
   std::tie(tensor, transforms) = untransform(b, matrix);
@@ -104,6 +104,15 @@ bestVectorization(OpBuilder &b, Value matrix, int64_t dataPerThread,
   int64_t dVectorLen = getMaxVectorization(
       transforms, static_cast<uint32_t>(GemmDimension::MorN),
       math_util::gcd(dataPerThread, dPerBlock), tensorShape);
+
+  // Vectorizing more than the physical vector length (128 bits) might
+  // be harmful for coalescence and other metrics. Let's limit the maximum
+  // amount of data to load to the maximum vector length. This means a
+  // warp will issue, if possible, a global_load_dwordx4 instruction
+  const int64_t maxVectorLenBits = 128;
+  auto bwidth = elementType.getIntOrFloatBitWidth();
+  kVectorLen = std::min(maxVectorLenBits / bwidth, kVectorLen);
+  dVectorLen = std::min(maxVectorLenBits / bwidth, dVectorLen);
 
   if (kVectorLen > dVectorLen)
     return {GemmDimension::K, kVectorLen};
@@ -648,10 +657,12 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         (kpack > 1) ? GemmDimension::K : GemmDimension::MorN;
     int64_t aVectorLen, bVectorLen;
     GemmDimension aVectorDim, bVectorDim;
-    std::tie(aVectorDim, aVectorLen) = bestVectorization(
-        b, op.getA(), aCopyPerThread, vectorTiebreaker, kPerBlock, mPerBlock);
-    std::tie(bVectorDim, bVectorLen) = bestVectorization(
-        b, op.getB(), bCopyPerThread, vectorTiebreaker, kPerBlock, nPerBlock);
+    std::tie(aVectorDim, aVectorLen) =
+        bestVectorization(b, op.getA(), aCopyPerThread, vectorTiebreaker,
+                          kPerBlock, mPerBlock, elementType);
+    std::tie(bVectorDim, bVectorLen) =
+        bestVectorization(b, op.getB(), bCopyPerThread, vectorTiebreaker,
+                          kPerBlock, nPerBlock, elementType);
 
     LLVM_DEBUG(llvm::dbgs()
                << "aCopyPerThread: " << aCopyPerThread << "\n"
@@ -973,19 +984,12 @@ struct GridwiseGemmV2RewritePattern
 
     GemmDimension vectorTiebreaker =
         (kpack > 1) ? GemmDimension::K : GemmDimension::MorN;
-    std::tie(aVectorDim, aVectorLen) = bestVectorization(
-        b, matA, aCopyPerThread, vectorTiebreaker, kPerBlock, mPerBlock);
-    std::tie(bVectorDim, bVectorLen) = bestVectorization(
-        b, matB, bCopyPerThread, vectorTiebreaker, kPerBlock, nPerBlock);
-
-    // Vectorizing more than the physical vector length (128 bits) might
-    // be harmful for coalescence and other metrics. Let's limit the maximum
-    // amount of data to load to the maximum vector length. This means a
-    // warp will issue, if possible, a global_load_dwordx4 instruction
-    const int64_t maxVectorLenBits = 128;
-    auto bwidth = elementType.getIntOrFloatBitWidth();
-    aVectorLen = std::min(maxVectorLenBits / bwidth, aVectorLen);
-    bVectorLen = std::min(maxVectorLenBits / bwidth, bVectorLen);
+    std::tie(aVectorDim, aVectorLen) =
+        bestVectorization(b, matA, aCopyPerThread, vectorTiebreaker, kPerBlock,
+                          mPerBlock, elementType);
+    std::tie(bVectorDim, bVectorLen) =
+        bestVectorization(b, matB, bCopyPerThread, vectorTiebreaker, kPerBlock,
+                          nPerBlock, elementType);
 
     LLVM_DEBUG(llvm::dbgs()
                << "gridSize: " << gridSize << "\n"

--- a/mlir/lib/Dialect/Rock/Transforms/LowerRockReduce.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/LowerRockReduce.cpp
@@ -125,17 +125,17 @@ LogicalResult ReduceRewritePattern::matchAndRewrite(
   std::tie(source, sourceTransformsFromOp) =
       untransform(rewriter, op.getIn(), trMaps);
 
+  Type elementType = source.getType().cast<MemRefType>().getElementType();
   ArrayRef<int64_t> threadViewShape =
       trMaps[0].cast<TransformMapAttr>().getUpperBounds();
-  int64_t vectorLength =
-      getMaxVectorization(sourceTransformsFromOp, /*dim=*/1, threadViewShape[1],
-                          source.getType().cast<MemRefType>().getShape());
+  int64_t vectorLength = getMaxVectorizationForDatatype(
+      sourceTransformsFromOp, /*dim=*/1, threadViewShape[1],
+      source.getType().cast<MemRefType>().getShape(), elementType);
   SmallVector<int64_t> bounds(threadViewShape.size(), 1LL);
   // Setting iter dimension bounds to threadViewShape size
   bounds[1] = threadViewShape[1];
   SmallVector<int64_t> strides(threadViewShape.size(), 1LL);
   strides[1] = vectorLength;
-  Type elementType = source.getType().cast<MemRefType>().getElementType();
   Type vectorType = vectorTypeOrSelf(elementType, vectorLength);
 
   // Get current workgroup ID.

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -299,6 +299,8 @@ PopulateParamsXDL::isValidBlockwiseGemmXDLOPS(const InitParamsXDL &param,
     // clang-format off
     validWaveGemmSize = {
       std::make_tuple(32, 32, 2),
+      std::make_tuple(64, 64, 2),
+      std::make_tuple(128, 128, 2),
       std::make_tuple(16, 16, 4)};
     // clang-format on
   } else {

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -288,43 +288,28 @@ LogicalResult
 PopulateParamsXDL::isValidBlockwiseGemmXDLOPS(const InitParamsXDL &param,
                                               RockGemmWrapperInterface op,
                                               uint32_t blockSize) {
-  // TBD: support fp16/bf16
-
   Type dataType = op.getInputType();
-  std::vector<std::tuple<int, int, int>> validWaveGemmSize;
 
-  if (dataType.isInteger(8)) {
-    // Note: we only support two reduction xdlops in i8 therefore the
-    // limited selection below
-    // clang-format off
-    validWaveGemmSize = {
-      std::make_tuple(32, 32, 2),
-      std::make_tuple(64, 64, 2),
-      std::make_tuple(128, 128, 2),
-      std::make_tuple(16, 16, 4)};
-    // clang-format on
-  } else {
-    // clang-format off
-    validWaveGemmSize = {
-      std::make_tuple(128, 128, 1),
-      std::make_tuple(128, 64, 1),
-      // std::make_tuple(128, 32, 1),
-      // std::make_tuple(128, 16, 1),
-      std::make_tuple(64, 128, 1),
-      std::make_tuple(64, 64, 1),
-      std::make_tuple(64, 32, 1),
-      std::make_tuple(64, 16, 1),
-      // std::make_tuple(32, 128, 1),
-      std::make_tuple(32, 64, 1),
-      std::make_tuple(32, 32, 2),
-      // std::make_tuple(16, 128, 1),
-      std::make_tuple(16, 64, 1),
-      std::make_tuple(16, 16, 4),
-      // std::make_tuple(8, 128, 1),
-      std::make_tuple(8, 64, 1),
-      // std::make_tuple(4, 128, 1),
-      std::make_tuple(4, 64, 1)};
-    // clang-format on
+  // clang-format off
+  std::vector<std::tuple<int, int, int>> validWaveGemmSize =
+  {
+    std::make_tuple(128, 128, 2),
+    std::make_tuple(128, 64, 2),
+    std::make_tuple(64, 128, 2),
+    std::make_tuple(64, 64, 2),
+    std::make_tuple(64, 32, 2),
+    std::make_tuple(32, 64, 2),
+    std::make_tuple(32, 32, 2),
+    std::make_tuple(64, 16, 4),
+    std::make_tuple(16, 64, 4),
+    std::make_tuple(16, 16, 4),
+  };
+  // clang-format on
+
+  // Add broadcasts for floating point types
+  if (!dataType.isInteger(8)) {
+    validWaveGemmSize.emplace_back(8, 64, 1);
+    validWaveGemmSize.emplace_back(4, 64, 1);
   }
 
   if (!std::any_of(validWaveGemmSize.cbegin(), validWaveGemmSize.cend(),

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -42,7 +42,7 @@ void createGemmTuningRangeBF(struct TunableParams *newSpace,
       {8, 16, 32},
       {4, 8, 16, 32, 64, 128},
       {4, 8, 16, 32, 64, 128},
-      {1, 4, 8},
+      {1, 4, 8, 16},
       {0, 1}};
 
   OpBuilder b(gemmOp.getContext());


### PR DESCRIPTION
This PR is a stab to start improving GEMM performance.
- **Limit vectorization to the hardware vector length**. Vectorizing more than 128 bits is detrimental for performance, since we ask too much from a thread. 
- **Extend the tilings we use for `int8`**. Limiting the tiles to `32,32` (m/n repeats = 1) jointly with limiting the vectorization means we ask too few from the warps. Since we can now support bigger tiles, I added them and also added a case for KPack=16. 

This patch improve performance from 2% to 90% across the board

The improvement is attached. In any test I did, I always saw this sort of improvement. 

[results.zip](https://github.com/ROCmSoftwarePlatform/rocMLIR/files/10785464/results.zip)