### PR TITLE
Improve default performance by adding up-to-date default configs

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -216,7 +216,7 @@ public:
 
 class PopulateParamsXDL : public BasePopulateParams<InitParamsXDL> {
 private:
-  static constexpr size_t nInitParameters = 4;
+  static constexpr size_t nInitParameters = 5;
   // Initial tuning parameters for forward convolution and backward
   // convolution.
   static const InitParamsXDL initParameters[nInitParameters];

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -216,14 +216,10 @@ public:
 
 class PopulateParamsXDL : public BasePopulateParams<InitParamsXDL> {
 private:
-  static constexpr size_t nInitParameters = 9;
+  static constexpr size_t nInitParameters = 15;
   // Initial tuning parameters for forward convolution and backward
   // convolution.
   static const InitParamsXDL initParameters[nInitParameters];
-
-  static constexpr size_t nInitParametersForwardI8 = 12;
-  // Tuning parameters for i8 convolutions.
-  static const InitParamsXDL initParametersForwardI8[nInitParametersForwardI8];
 
   static constexpr int64_t waveSize = 64;
 

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -216,10 +216,18 @@ public:
 
 class PopulateParamsXDL : public BasePopulateParams<InitParamsXDL> {
 private:
-  static constexpr size_t nInitParameters = 15;
+  static constexpr size_t nInitParameters = 4;
   // Initial tuning parameters for forward convolution and backward
   // convolution.
   static const InitParamsXDL initParameters[nInitParameters];
+
+  static constexpr size_t nInitParametersFp16 = 3;
+  // Tuning parameters for fp16/bf16 convolutions.
+  static const InitParamsXDL initParametersFp16[nInitParametersFp16];
+
+  static constexpr size_t nInitParametersForwardI8 = 5;
+  // Tuning parameters for i8 convolutions.
+  static const InitParamsXDL initParametersForwardI8[nInitParametersForwardI8];
 
   static constexpr int64_t waveSize = 64;
 

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -229,24 +229,29 @@ PopulateParamsXDL::calculatePaddingAmount(const InitParamsXDL &params,
 const InitParamsXDL
 PopulateParamsXDL::initParameters[PopulateParamsXDL::nInitParameters] = {
   // M/block N/block K/block M/wave N/wave kPack forceUnroll bCopyMore
-  {256, 128, 8, 128, 128, 1,true, true},
-  {128, 64, 4, 64, 32, 4, true, true},
   {128, 128, 4, 64, 64, 4, true, true},
-  {128, 128, 8, 64, 64, 4, true, true},
-  {256, 128, 4, 128, 64, 4, true, true},
-  {64, 128, 8, 64, 32, 4, true, true},
-  {32, 128, 2, 32, 32, 4, true, true},
+  {64, 64, 8, 32, 32, 4, true, true},
   {32, 64, 4, 32, 64, 4, true, true},
-  {4, 64, 8, 4, 64, 4, true, true},
-  {256, 256, 4, 128, 128, 8, true, true},
-  {128, 128, 8, 128, 128, 8, true, true},
-  {128, 128, 4, 64, 128, 8, true, true},
-  {16, 32, 8, 16, 16, 8, true, true},
-  {128, 128, 8, 64, 64, 8, true, true},
-  {64, 64, 8, 32, 32, 16, true, true},
-  {16, 32, 16, 16, 16, 16, true, true},
+  {32, 64, 2, 8, 64, 4, true, true},
 };
 
+const InitParamsXDL
+PopulateParamsXDL::initParametersFp16[PopulateParamsXDL::nInitParametersFp16] = {
+  // M/block N/block K/block M/wave N/wave kPack forceUnroll bCopyMore
+  {128,  128,  4,  64,  64,  8,  true,  true},
+  {32,  128,  4,  32,  32,  8,  true,  true},
+  {32, 64, 4, 32, 64, 4, true, true},
+};
+
+const InitParamsXDL
+PopulateParamsXDL::initParametersForwardI8[
+  PopulateParamsXDL::nInitParametersForwardI8] = {
+  {128, 128, 8, 64, 64, 8, true, true},
+  {64, 64, 8, 32, 32, 8, true, true},
+  {64, 64, 8, 32, 32, 4, true, true},
+  {32, 32, 8, 16, 16, 8, true, true},
+  {32, 32, 8, 16, 16, 4, true, true},
+};
 // clang-format on
 
 const InitParamsXDL PopulateParamsXDL::universalParameters = {32, 64, 4, 32,
@@ -439,7 +444,17 @@ LogicalResult PopulateParamsXDL::obtainTuningParameters(
 
 std::vector<InitParamsXDL>
 PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataType) const {
-  ArrayRef<InitParamsXDL> params = {initParameters, nInitParameters};
+  ArrayRef<InitParamsXDL> params;
+  switch (dataType.getIntOrFloatBitWidth()) {
+  case 8:
+    params = {initParametersForwardI8, nInitParametersForwardI8};
+    break;
+  case 16:
+    params = {initParametersFp16, nInitParametersFp16};
+    break;
+  default:
+    params = {initParameters, nInitParameters};
+  }
   std::vector<InitParamsXDL> res;
   // Only return valid XDLOp params
   std::copy_if(

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -233,6 +233,7 @@ PopulateParamsXDL::initParameters[PopulateParamsXDL::nInitParameters] = {
   {64, 64, 8, 32, 32, 4, true, true},
   {32, 64, 4, 32, 64, 4, true, true},
   {32, 64, 2, 8, 64, 4, true, true},
+  {4, 64, 16, 4, 64, 1, true, true}
 };
 
 const InitParamsXDL

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -229,39 +229,24 @@ PopulateParamsXDL::calculatePaddingAmount(const InitParamsXDL &params,
 const InitParamsXDL
 PopulateParamsXDL::initParameters[PopulateParamsXDL::nInitParameters] = {
   // M/block N/block K/block M/wave N/wave kPack forceUnroll bCopyMore
+  {256, 128, 8, 128, 128, 1,true, true},
+  {128, 64, 4, 64, 32, 4, true, true},
   {128, 128, 4, 64, 64, 4, true, true},
+  {128, 128, 8, 64, 64, 4, true, true},
+  {256, 128, 4, 128, 64, 4, true, true},
+  {64, 128, 8, 64, 32, 4, true, true},
+  {32, 128, 2, 32, 32, 4, true, true},
   {32, 64, 4, 32, 64, 4, true, true},
-
-  {128, 128, 8, 64, 64, 1, true, true},
-  {128, 128, 16, 64, 64, 1, true, true},
-  {8, 64, 8, 8, 64, 1, true, true},
-  {4, 64, 16, 4, 64, 1, true, true},
-  {32, 64, 4, 32, 64, 1, true, true},
-  {16, 16, 16, 16, 16, 1, true, true},
-  {16, 16, 4, 16, 16, 1, true, true},
+  {4, 64, 8, 4, 64, 4, true, true},
+  {256, 256, 4, 128, 128, 8, true, true},
+  {128, 128, 8, 128, 128, 8, true, true},
+  {128, 128, 4, 64, 128, 8, true, true},
+  {16, 32, 8, 16, 16, 8, true, true},
+  {128, 128, 8, 64, 64, 8, true, true},
+  {64, 64, 8, 32, 32, 16, true, true},
+  {16, 32, 16, 16, 16, 16, true, true},
 };
 
-const InitParamsXDL
-PopulateParamsXDL::initParametersForwardI8[
-  PopulateParamsXDL::nInitParametersForwardI8] = {
-  // M/block N/block K/block M/wave N/wave kPack forceUnroll bCopyMore
-  // kpack for int8 must be larger than kbase, which means
-  // kpack must be at least 4, once enabled.
-  {64, 64, 8, 32, 32, 8, true, true},
-  {64, 64, 8, 32, 32, 4, true, true},
-  {32, 32, 8, 16, 16, 8, true, true},
-  {32, 32, 8, 16, 16, 4, true, true},
-  // The 32 x 32 xdlops k/block must be at least 8
-  {64, 64, 16, 32, 32, 1, true, true},
-  {64, 64, 8, 32, 32, 1, true, true},
-  {32, 32, 16, 32, 32, 1, true, true},
-  {32, 32, 8, 32, 32, 1, true, true},
-  // The 16 x 16 xdlops k/block must be at least 16
-  {32, 32, 32, 16, 16, 1, true, true},
-  {32, 32, 16, 16, 16, 1, true, true},
-  {16, 16, 32, 16, 16, 1, true, true},
-  {16, 16, 16, 16, 16, 1, true, true},
-};
 // clang-format on
 
 const InitParamsXDL PopulateParamsXDL::universalParameters = {32, 64, 4, 32,
@@ -454,12 +439,7 @@ LogicalResult PopulateParamsXDL::obtainTuningParameters(
 
 std::vector<InitParamsXDL>
 PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataType) const {
-  ArrayRef<InitParamsXDL> params;
-  if (dataType.isInteger(8)) {
-    params = {initParametersForwardI8, nInitParametersForwardI8};
-  } else {
-    params = {initParameters, nInitParameters};
-  }
+  ArrayRef<InitParamsXDL> params = {initParameters, nInitParameters};
   std::vector<InitParamsXDL> res;
   // Only return valid XDLOp params
   std::copy_if(

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -10,13 +10,13 @@
 // CHECK-DAG: #[[$GENERAL_PARAMS_2:.*]] = #rock.general_gemm_params<blockSize = 64, kPerBlock = 4, mPerBlock = 32, nPerBlock = 64, kPerThread = 1, mPerThread = 2, nPerThread = 4, kpack = 1>
 // CHECK-DAG: #[[$GENERAL_PARAMS_3:.*]] = #rock.general_gemm_params<blockSize = 64, kPerBlock = 16, mPerBlock = 64, nPerBlock = 32, kPerThread = 1, mPerThread = 4, nPerThread = 2, kpack = 1>
 // CHECK-DAG: #[[$GENERAL_PARAMS_4:.*]] = #rock.general_gemm_params<blockSize = 64, kPerBlock = 4, mPerBlock = 32, nPerBlock = 32, kPerThread = 1, mPerThread = 2, nPerThread = 2, kpack = 1>
-// CHECK-DAG: #[[$XDLOPS_PARAMS_0:.*]] = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, forceUnroll = true>
+// CHECK-DAG: #[[$XDLOPS_PARAMS_0:.*]] = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 64, nPerBlock = 64, kpack = 4, mPerWave = 32, nPerWave = 32, forceUnroll = true>
 // CHECK-DAG: #[[$XDLOPS_PARAMS_1:.*]] = #rock.xdlops_gemm_params<kPerBlock = 4, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 64, nPerWave = 64, forceUnroll = true>
-// CHECK-DAG: #[[$XDLOPS_PARAMS_2:.*]] = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 64, nPerBlock = 256, kpack = 1, mPerWave = 64, nPerWave = 64, forceUnroll = true>
-// CHECK-DAG: #[[$XDLOPS_PARAMS_3:.*]] = #rock.xdlops_gemm_params<kPerBlock = 4, mPerBlock = 32, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 64, forceUnroll = true>
-// CHECK-DAG: #[[$XDLOPS_PARAMS_4:.*]] = #rock.xdlops_gemm_params<kPerBlock = 16, mPerBlock = 16, nPerBlock = 16, kpack = 1, mPerWave = 16, nPerWave = 16, forceUnroll = true>
+// CHECK-DAG: #[[$XDLOPS_PARAMS_2:.*]] = #rock.xdlops_gemm_params<kPerBlock = 4, mPerBlock = 128, nPerBlock = 128, kpack = 8, mPerWave = 64, nPerWave = 64, forceUnroll = true>
+// CHECK-DAG: #[[$XDLOPS_PARAMS_3:.*]] = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 64, nPerBlock = 256, kpack = 1, mPerWave = 64, nPerWave = 64, forceUnroll = true>
+// CHECK-DAG: #[[$XDLOPS_PARAMS_4:.*]] = #rock.xdlops_gemm_params<kPerBlock = 2, mPerBlock = 32, nPerBlock = 64, kpack = 4, mPerWave = 8, nPerWave = 64, forceUnroll = true>
 // CHECK-DAG: #[[$XDLOPS_PARAMS_5:.*]] = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 16, nPerBlock = 128, kpack = 1, mPerWave = 16, nPerWave = 64, forceUnroll = true>
-// CHECK-DAG: #[[$XDLOPS_PARAMS_6:.*]] = #rock.xdlops_gemm_params<kPerBlock = 16, mPerBlock = 4, nPerBlock = 64, kpack = 1, mPerWave = 4, nPerWave = 64, forceUnroll = true>
+// CHECK-DAG: #[[$XDLOPS_PARAMS_6:.*]] = #rock.xdlops_gemm_params<kPerBlock = 4, mPerBlock = 32, nPerBlock = 64, kpack = 4, mPerWave = 32, nPerWave = 64, forceUnroll = true>
 
 // CHECK-LABEL: @rock_conv2d
 func.func @rock_conv2d(%filter : memref<1x128x8x3x3xf32>, %input : memref<128x1x8x32x32xf32>, %output : memref<128x1x128x30x30xf32>) {
@@ -94,7 +94,7 @@ func.func @rock_conv2d_bwd_data_f16(%filter: memref<1x1024x1024x1x1xf16>, %input
   // CHECK: rock.conv2d_bwd_data
   // CHECK-SAME: derivedBlockSize = 256
   // CHECK-SAME: gridSize = 1568
-  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_1]]
+  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_2]]
   rock.conv2d_bwd_data(%filter, %input, %output) features = mfma|dot|atomic_add {
     arch = "amdgcn-amd-amdhsa:gfx908",
     dilations = [1 : i32, 1 : i32],
@@ -221,7 +221,7 @@ func.func @rock_conv2d_7x7_tuning(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<2
   // CHECK: rock.conv2d
   // CHECK-SAME: derivedBlockSize = 256
   // CHECK-SAME: gridSize = 12544
-  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_2]]
+  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_3]]
   rock.conv2d(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add {
     arch = "amdgcn-amd-amdhsa:gfx908",
     dilations = [1 : i32, 1 : i32],
@@ -240,9 +240,9 @@ func.func @rock_conv2d_7x7_tuning(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<2
 // CHECK-LABEL: @rock_conv2d_7x7
 func.func @rock_conv2d_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x230x230xf32>, %arg2: memref<256x1x64x112x112xf32>) {
   // CHECK: rock.conv2d
-  // CHECK-SAME: derivedBlockSize = 64
+  // CHECK-SAME: derivedBlockSize = 256
   // CHECK-SAME: gridSize = 100352
-  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_3]]
+  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_4]]
   rock.conv2d(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add {
     arch = "amdgcn-amd-amdhsa:gfx908",
     dilations = [1 : i32, 1 : i32],
@@ -258,9 +258,9 @@ func.func @rock_conv2d_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x
 // CHECK-LABEL: @rock_conv2d_bwd_weight_7x7
 func.func @rock_conv2d_bwd_weight_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x230x230xf32>, %arg2: memref<256x1x64x112x112xf32>) attributes {kernel = 0 : i32} {
   // CHECK: rock.conv2d_bwd_weight
-  // CHECK-SAME: derivedBlockSize = 64
-  // CHECK-SAME: gridSize = 40
-  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_4]]
+  // CHECK-SAME: derivedBlockSize = 256
+  // CHECK-SAME: gridSize = 3
+  // CHECK-SAME: params = #[[$XDLOPS_PARAMS_0]]
   rock.conv2d_bwd_weight(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add {
     arch = "amdgcn-amd-amdhsa:gfx908",
     dilations = [1 : i32, 1 : i32],

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -16,7 +16,7 @@
 // CHECK-DAG: #[[$XDLOPS_PARAMS_3:.*]] = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 64, nPerBlock = 256, kpack = 1, mPerWave = 64, nPerWave = 64, forceUnroll = true>
 // CHECK-DAG: #[[$XDLOPS_PARAMS_4:.*]] = #rock.xdlops_gemm_params<kPerBlock = 2, mPerBlock = 32, nPerBlock = 64, kpack = 4, mPerWave = 8, nPerWave = 64, forceUnroll = true>
 // CHECK-DAG: #[[$XDLOPS_PARAMS_5:.*]] = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 16, nPerBlock = 128, kpack = 1, mPerWave = 16, nPerWave = 64, forceUnroll = true>
-// CHECK-DAG: #[[$XDLOPS_PARAMS_6:.*]] = #rock.xdlops_gemm_params<kPerBlock = 4, mPerBlock = 32, nPerBlock = 64, kpack = 4, mPerWave = 32, nPerWave = 64, forceUnroll = true>
+// CHECK-DAG: #[[$XDLOPS_PARAMS_6:.*]] = #rock.xdlops_gemm_params<kPerBlock = 16, mPerBlock = 4, nPerBlock = 64, kpack = 1, mPerWave = 4, nPerWave = 64, forceUnroll = true>
 
 // CHECK-LABEL: @rock_conv2d
 func.func @rock_conv2d(%filter : memref<1x128x8x3x3xf32>, %input : memref<128x1x8x32x32xf32>, %output : memref<128x1x128x30x30xf32>) {

--- a/mlir/test/Dialect/Rock/lowering_wrw_atomic_transform.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wrw_atomic_transform.mlir
@@ -6,17 +6,13 @@ module  {
   }
 }
 
-// CHECK-DAG: #[[map:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d4, d5)>
-// CHECK-DAG: #[[map1:.*]] = affine_map<(d0, d1, d2) -> (0, d0, d1, d2 floordiv 9, (d2 mod 9) floordiv 3, d2 mod 3)>
-// CHECK-DAG: #[[map2:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0 * 16 + d1, d2, d3, d4 - 2, d5 - 2)>
-// CHECK-DAG: #[[map3:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4 + d5, d6 + d7)>
-// CHECK-DAG: #[[map4:.*]] = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 81, 0, d2 floordiv 9, (d2 mod 9) floordiv 3, (d1 mod 81) floordiv 9, d2 mod 3, d1 mod 9)>
-// CHECK-DAG: #[[map5:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0 * 16 + d1, d2, d3, d4, d5)>
-// CHECK-DAG: #[[map6:.*]] = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 81, 0, d2, (d1 mod 81) floordiv 9, d1 mod 9)>
-// CHECK-DAG: #rock.transform_map<#[[map]] by [<PassThrough ["g"] at [0] -> ["g"] at [0]>, <AddDim{2} ["kBlock"] at [1] -> [] at []>, <PassThrough ["k", "c", "y", "x"] at [2, 3, 4, 5] -> ["k", "c", "y", "x"] at [1, 2, 3, 4]>] bounds = [1, 2, 32, 32, 3, 3] -> [1, 32, 32, 3, 3]>
-// CHECK-DAG: #rock.transform_map<#[[map1]] by [<Merge{1, 2} ["gemmG"] at [0] -> ["g", "kBlock"] at [0, 1]>, <PassThrough ["gemmM"] at [1] -> ["k"] at [2]>, <Merge{32, 3, 3} ["gemmN"] at [2] -> ["c", "y", "x"] at [3, 4, 5]>] bounds = [2, 32, 288] -> [1, 2, 32, 32, 3, 3]>
-// CHECK-DAG: #rock.transform_map<#[[map2]] by [<PassThrough ["gi"] at [2] -> ["gi"] at [1]>, <Unmerge{2, 16} ["n0", "n1"] at [0, 1] -> ["ni"] at [0]>, <PassThrough ["ci"] at [3] -> ["ci"] at [2]>, <Pad{2, 2, 2, 2} ["hipad", "wipad"] at [4, 5] -> ["hi", "wi"] at [3, 4]>] bounds = [2, 16, 1, 32, 11, 11] -> [32, 1, 32, 7, 7]>
-// CHECK-DAG: #rock.transform_map<#[[map3]] by [<PassThrough ["gi", "n0", "n1", "ci"] at [2, 0, 1, 3] -> ["gi", "n0", "n1", "ci"] at [2, 0, 1, 3]>, <Embed{1, 1} ["y", "ho"] at [4, 5] -> ["hipad"] at [4]>, <Embed{1, 1} ["x", "wo"] at [6, 7] -> ["wipad"] at [5]>] bounds = [2, 16, 1, 32, 3, 9, 3, 9] -> [2, 16, 1, 32, 11, 11]>
-// CHECK-DAG: #rock.transform_map<#[[map4]] by [<Merge{1, 2} ["gemmG"] at [0] -> ["gi", "n0"] at [2, 0]>, <Merge{16, 9, 9} ["gemmK"] at [1] -> ["n1", "ho", "wo"] at [1, 5, 7]>, <Merge{32, 3, 3} ["gemmN"] at [2] -> ["ci", "y", "x"] at [3, 4, 6]>] bounds = [2, 1296, 288] -> [2, 16, 1, 32, 3, 9, 3, 9]>
-// CHECK-DAG: #rock.transform_map<#[[map5]] by [<PassThrough ["go"] at [2] -> ["go"] at [1]>, <Unmerge{2, 16} ["n0", "n1"] at [0, 1] -> ["no"] at [0]>, <PassThrough ["ko", "ho", "wo"] at [3, 4, 5] -> ["ko", "ho", "wo"] at [2, 3, 4]>] bounds = [2, 16, 1, 32, 9, 9] -> [32, 1, 32, 9, 9]>
-// CHECK-DAG: #rock.transform_map<#[[map6]] by [<Merge{1, 2} ["gemmG"] at [0] -> ["go", "n0"] at [2, 0]>, <Merge{16, 9, 9} ["gemmK"] at [1] -> ["n1", "ho", "wo"] at [1, 4, 5]>, <PassThrough ["gemmM"] at [2] -> ["ko"] at [3]>] bounds = [2, 1296, 32] -> [2, 16, 1, 32, 9, 9]>
+// CHECK-DAG: #[[map:.*]] = affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 9, (d2 mod 9) floordiv 3, d2 mod 3)>
+// CHECK-DAG: #[[map1:.*]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 - 2, d4 - 2)>
+// CHECK-DAG: #[[map2:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3 + d4, d5 + d6)>
+// CHECK-DAG: #[[map3:.*]] = affine_map<(d0, d1, d2) -> (d1 floordiv 81, d0, d2 floordiv 9, (d2 mod 9) floordiv 3, (d1 mod 81) floordiv 9, d2 mod 3, d1 mod 9)>
+// CHECK-DAG: #[[map4:.*]] = affine_map<(d0, d1, d2) -> (d1 floordiv 81, d0, d2, (d1 mod 81) floordiv 9, d1 mod 9)>
+// CHECK-DAG: #rock.transform_map<#[[map]] by [<PassThrough ["gemmG"] at [0] -> ["g"] at [0]>, <PassThrough ["gemmM"] at [1] -> ["k"] at [1]>, <Merge{32, 3, 3} ["gemmN"] at [2] -> ["c", "y", "x"] at [2, 3, 4]>] bounds = [1, 32, 288] -> [1, 32, 32, 3, 3]>
+// CHECK-DAG: #rock.transform_map<#[[map1]] by [<PassThrough ["ni"] at [0] -> ["ni"] at [0]>, <PassThrough ["gi"] at [1] -> ["gi"] at [1]>, <PassThrough ["ci"] at [2] -> ["ci"] at [2]>, <Pad{2, 2, 2, 2} ["hipad", "wipad"] at [3, 4] -> ["hi", "wi"] at [3, 4]>] bounds = [32, 1, 32, 11, 11] -> [32, 1, 32, 7, 7]>
+// CHECK-DAG: #rock.transform_map<#[[map2]] by [<PassThrough ["ni", "gi", "ci"] at [0, 1, 2] -> ["ni", "gi", "ci"] at [0, 1, 2]>, <Embed{1, 1} ["y", "ho"] at [3, 4] -> ["hipad"] at [3]>, <Embed{1, 1} ["x", "wo"] at [5, 6] -> ["wipad"] at [4]>] bounds = [32, 1, 32, 3, 9, 3, 9] -> [32, 1, 32, 11, 11]>
+// CHECK-DAG: #rock.transform_map<#[[map3]] by [<PassThrough ["gemmG"] at [0] -> ["gi"] at [1]>, <Merge{32, 9, 9} ["gemmK"] at [1] -> ["ni", "ho", "wo"] at [0, 4, 6]>, <Merge{32, 3, 3} ["gemmN"] at [2] -> ["ci", "y", "x"] at [2, 3, 5]>] bounds = [1, 2592, 288] -> [32, 1, 32, 3, 9, 3, 9]>
+// CHECK-DAG: #rock.transform_map<#[[map4]] by [<PassThrough ["gemmG"] at [0] -> ["go"] at [1]>, <Merge{32, 9, 9} ["gemmK"] at [1] -> ["no", "ho", "wo"] at [0, 3, 4]>, <PassThrough ["gemmM"] at [2] -> ["ko"] at [2]>] bounds = [1, 2592, 32] -> [32, 1, 32, 9, 9]>

--- a/mlir/test/Dialect/Rock/lowering_wrw_atomic_transform_nhwc.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wrw_atomic_transform_nhwc.mlir
@@ -6,17 +6,13 @@ module  {
   }
 }
 
-// CHECK-DAG: #[[map:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d4, d5)>
-// CHECK-DAG: #[[map1:.*]] = affine_map<(d0, d1, d2) -> (0, d0, d1, d2 floordiv 96, (d2 mod 96) floordiv 32, d2 mod 32)>
-// CHECK-DAG: #[[map2:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0 * 16 + d1, d2, d3 - 2, d4 - 2, d5)>
-// CHECK-DAG: #[[map3:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3 + d4, d5 + d6, d7)>
-// CHECK-DAG: #[[map4:.*]] = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 81, 0, d2 floordiv 96, (d1 mod 81) floordiv 9, (d2 mod 96) floordiv 32, d1 mod 9, d2 mod 32)>
-// CHECK-DAG: #[[map5:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0 * 16 + d1, d2, d3, d4, d5)>
-// CHECK-DAG: #[[map6:.*]] = affine_map<(d0, d1, d2) -> (d0, d1 floordiv 81, 0, (d1 mod 81) floordiv 9, d1 mod 9, d2)>
-// CHECK-DAG: #rock.transform_map<#[[map]] by [<PassThrough ["g"] at [0] -> ["g"] at [0]>, <AddDim{2} ["kBlock"] at [1] -> [] at []>, <PassThrough ["k", "c", "y", "x"] at [2, 5, 3, 4] -> ["k", "c", "y", "x"] at [1, 4, 2, 3]>] bounds = [1, 2, 32, 3, 3, 32] -> [1, 32, 3, 3, 32]>
-// CHECK-DAG: #rock.transform_map<#[[map1]] by [<Merge{1, 2} ["gemmG"] at [0] -> ["g", "kBlock"] at [0, 1]>, <PassThrough ["gemmM"] at [1] -> ["k"] at [2]>, <Merge{3, 3, 32} ["gemmN"] at [2] -> ["y", "x", "c"] at [3, 4, 5]>] bounds = [2, 32, 288] -> [1, 2, 32, 3, 3, 32]>
-// CHECK-DAG: #rock.transform_map<#[[map2]] by [<PassThrough ["gi"] at [2] -> ["gi"] at [1]>, <Unmerge{2, 16} ["n0", "n1"] at [0, 1] -> ["ni"] at [0]>, <PassThrough ["ci"] at [5] -> ["ci"] at [4]>, <Pad{2, 2, 2, 2} ["hipad", "wipad"] at [3, 4] -> ["hi", "wi"] at [2, 3]>] bounds = [2, 16, 1, 11, 11, 32] -> [32, 1, 7, 7, 32]>
-// CHECK-DAG: #rock.transform_map<#[[map3]] by [<PassThrough ["gi", "n0", "n1", "ci"] at [2, 0, 1, 7] -> ["gi", "n0", "n1", "ci"] at [2, 0, 1, 5]>, <Embed{1, 1} ["y", "ho"] at [3, 4] -> ["hipad"] at [3]>, <Embed{1, 1} ["x", "wo"] at [5, 6] -> ["wipad"] at [4]>] bounds = [2, 16, 1, 3, 9, 3, 9, 32] -> [2, 16, 1, 11, 11, 32]>
-// CHECK-DAG: #rock.transform_map<#[[map4]] by [<Merge{1, 2} ["gemmG"] at [0] -> ["gi", "n0"] at [2, 0]>, <Merge{16, 9, 9} ["gemmK"] at [1] -> ["n1", "ho", "wo"] at [1, 4, 6]>, <Merge{3, 3, 32} ["gemmN"] at [2] -> ["y", "x", "ci"] at [3, 5, 7]>] bounds = [2, 1296, 288] -> [2, 16, 1, 3, 9, 3, 9, 32]>
-// CHECK-DAG: #rock.transform_map<#[[map5]] by [<PassThrough ["go"] at [2] -> ["go"] at [1]>, <Unmerge{2, 16} ["n0", "n1"] at [0, 1] -> ["no"] at [0]>, <PassThrough ["ko", "ho", "wo"] at [5, 3, 4] -> ["ko", "ho", "wo"] at [4, 2, 3]>] bounds = [2, 16, 1, 9, 9, 32] -> [32, 1, 9, 9, 32]>
-// CHECK-DAG: #rock.transform_map<#[[map6]] by [<Merge{1, 2} ["gemmG"] at [0] -> ["go", "n0"] at [2, 0]>, <Merge{16, 9, 9} ["gemmK"] at [1] -> ["n1", "ho", "wo"] at [1, 3, 4]>, <PassThrough ["gemmM"] at [2] -> ["ko"] at [5]>] bounds = [2, 1296, 32] -> [2, 16, 1, 9, 9, 32]>
+// CHECK-DAG: #[[map:.*]] =  affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 96, (d2 mod 96) floordiv 32, d2 mod 32)>
+// CHECK-DAG: #[[map1:.*]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2 - 2, d3 - 2, d4)>
+// CHECK-DAG: #[[map2:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2 + d3, d4 + d5, d6)>
+// CHECK-DAG: #[[map3:.*]] = affine_map<(d0, d1, d2) -> (d1 floordiv 81, d0, d2 floordiv 96, (d1 mod 81) floordiv 9, (d2 mod 96) floordiv 32, d1 mod 9, d2 mod 32)>
+// CHECK-DAG: #[[map4:.*]] = affine_map<(d0, d1, d2) -> (d1 floordiv 81, d0, (d1 mod 81) floordiv 9, d1 mod 9, d2)>
+// CHECK-DAG: #rock.transform_map<#[[map]]  by [<PassThrough ["gemmG"] at [0] -> ["g"] at [0]>, <PassThrough ["gemmM"] at [1] -> ["k"] at [1]>, <Merge{3, 3, 32} ["gemmN"] at [2] -> ["y", "x", "c"] at [2, 3, 4]>] bounds = [1, 32, 288] -> [1, 32, 3, 3, 32]>
+// CHECK-DAG: #rock.transform_map<#[[map1]] by [<PassThrough ["ni"] at [0] -> ["ni"] at [0]>, <PassThrough ["gi"] at [1] -> ["gi"] at [1]>, <PassThrough ["ci"] at [4] -> ["ci"] at [4]>, <Pad{2, 2, 2, 2} ["hipad", "wipad"] at [2, 3] -> ["hi", "wi"] at [2, 3]>] bounds = [32, 1, 11, 11, 32] -> [32, 1, 7, 7, 32]>
+// CHECK-DAG: #rock.transform_map<#[[map2]] by [<PassThrough ["ni", "gi", "ci"] at [0, 1, 6] -> ["ni", "gi", "ci"] at [0, 1, 4]>, <Embed{1, 1} ["y", "ho"] at [2, 3] -> ["hipad"] at [2]>, <Embed{1, 1} ["x", "wo"] at [4, 5] -> ["wipad"] at [3]>] bounds = [32, 1, 3, 9, 3, 9, 32] -> [32, 1, 11, 11, 32]>
+// CHECK-DAG: #rock.transform_map<#[[map3]] by [<PassThrough ["gemmG"] at [0] -> ["gi"] at [1]>, <Merge{32, 9, 9} ["gemmK"] at [1] -> ["ni", "ho", "wo"] at [0, 3, 5]>, <Merge{3, 3, 32} ["gemmN"] at [2] -> ["y", "x", "ci"] at [2, 4, 6]>] bounds = [1, 2592, 288] -> [32, 1, 3, 9, 3, 9, 32]>
+// CHECK-DAG: #rock.transform_map<#[[map4]] by [<PassThrough ["gemmG"] at [0] -> ["go"] at [1]>, <Merge{32, 9, 9} ["gemmK"] at [1] -> ["no", "ho", "wo"] at [0, 2, 3]>, <PassThrough ["gemmM"] at [2] -> ["ko"] at [4]>] bounds = [1, 2592, 32] -> [32, 1, 9, 9, 32]>


### PR DESCRIPTION
In PR https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/983 we extended the tiling values supported for `int8` (which were need since we were limiting the vectorization). 

This PR takes a step forward to update the default tuning configs using the ones that were found fastest on the bert database ( [I used the results obtained from PR #983](https://github.com/ROCmSoftwarePlatform/rocMLIR/files/10786432/results.zip)). 


Since now everything is a reduction, I thought also of unifying `int8` vs non-`int8` default configs. 

I am marking this dependent on #983 so that I can test default performance (i.e., `--perf_conifg=`) once #983 has been merged. 