### PR TITLE
[CI] Ignore third-party files in clang-tidy

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -121,7 +121,12 @@ void preMergeCheck(String codepath) {
           ln -s build/compile_commands.json compile_commands.json
         fi
         '''
-        sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
+        if (params.ignoreExternalLinting == true) {
+            sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --ignore-external'
+        }
+        else {
+            sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
+        }
     } else {
         echo "Static Test step skipped"
     }
@@ -363,6 +368,10 @@ pipeline {
         // option to disable navi21 cells in case nodes are offline
         booleanParam(name: 'disableNavi21', defaultValue: false,
                      description: 'Disable testing on Navi21')
+
+        // option only to be used with upstream merges
+        booleanParam(name: 'ignoreExternalLinting', defaultValue: false,
+                     description: 'Ignore linting on files in external/')
     }
     stages {
         stage("Set System Property") {


### PR DESCRIPTION
This commit adds a filter to filter out clang-tidy warning originate outside our repo.

Summary of changes : 
* We had been using opt/rocm/bin/git-clang-format with clang-format-10 and this PR changes that to be opt/rocm/bin/git-clang-format with opt/rocm/bin/clang-format (aka clang-format-15'ish)
* Adds a third-party files ignore pattern to clang-tidy checks
* Adds a switch enable/disable linting of external/ folder from Jenkins -- only to be used with upstream merges.