### PR TITLE
Adding migraphx quantize linear op and its TOSA lowering

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -160,10 +160,10 @@ def MIGraphX_FloorOp :
 
 def MIGraphX_QuantizeLinearOp :
     MIGraphX_Op<"quantizelinear">,
-    Arguments<(ins AnyRankedTensor:$input,
-                   AnyRankedTensor:$scale,
-                   Optional<AnyRankedTensor>:$bias)>,
-	  Results<(outs AnyRankedTensor:$output)> {
+    Arguments<(ins TensorOf<[I32]>:$input,
+                   TensorOf<[F32]>:$scale,
+                   Optional<TensorOf<[I32]>>:$bias)>,
+	  Results<(outs TensorOf<[I8]>:$output)> {
   let summary = "Channelwise quantization";
   let description = [{
     Quantization tensor elementwise

--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -160,7 +160,7 @@ def MIGraphX_FloorOp :
 
 def MIGraphX_QuantizeLinearOp :
     MIGraphX_Op<"quantizelinear">,
-    Arguments<(ins AnyRankedTensor:$inA,
+    Arguments<(ins AnyRankedTensor:$input,
                    AnyRankedTensor:$scale,
                    Optional<AnyRankedTensor>:$bias)>,
 	  Results<(outs AnyRankedTensor:$output)> {

--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -158,6 +158,19 @@ def MIGraphX_FloorOp :
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
 
+def MIGraphX_QuantizeLinearOp :
+    MIGraphX_Op<"quantizelinear">,
+    Arguments<(ins AnyRankedTensor:$inA,
+                   AnyRankedTensor:$scale,
+                   Optional<AnyRankedTensor>:$bias)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Channelwise quantization";
+  let description = [{
+    Quantization tensor elementwise
+  }];
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type(operands) `->` type(results)";
+}
+
 // Convolution operations
 
 def MIGraphX_ConvolutionOp :

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Dialect/Tosa/Utils/QuantUtils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -54,6 +55,19 @@ static TosaOp createOpAndInfer(mlir::PatternRewriter &rewriter,
   Type newOutTy = RankedTensorType::get({returnShape[0].getDims()}, elemType);
   auto result = op->getResult(0);
   result.setType(newOutTy);
+  return op;
+}
+
+static tosa::CastOp createCastOp(mlir::PatternRewriter &rewriter,
+                                 mlir::Location loc, Type resElementType,
+                                 Value input) {
+  ShapedType inputType = input.getType().cast<ShapedType>();
+  auto elementType = inputType.getElementType();
+  Type resType = inputType.cloneWith({}, resElementType);
+
+  auto op = rewriter.create<tosa::CastOp>(loc, elementType, input);
+  auto result = op->getResult(0);
+  result.setType(resType);
   return op;
 }
 
@@ -149,6 +163,12 @@ public:
       cop->setAttr("xdlopsV2", attr);
     if (auto attr = op->getAttrOfType<StringAttr>("perf_config"))
       cop->setAttr("perf_config", attr);
+
+    if (elementTy.isInteger(8)) {
+      auto quantAttr = rewriter.getAttr<tosa::ConvOpQuantizationAttr>(
+          /*inputZp =*/0, /*weightZp =*/0);
+      cop->setAttr("quantization_info", quantAttr);
+    }
 
     // transpose the output back to NCHW so that it can match following
     // operators.
@@ -478,11 +498,47 @@ public:
   }
 };
 
+class QuantizeLinearConverter final
+    : public OpConversionPattern<migraphx::QuantizeLinearOp> {
+public:
+  using OpConversionPattern<migraphx::QuantizeLinearOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(migraphx::QuantizeLinearOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto input = op.getOperand(0);
+    auto scale = op.getOperand(1);
+    ShapedType inputType = input.getType().cast<ShapedType>();
+    auto elementType = inputType.getElementType();
+    Location loc = op->getLoc();
+
+    assert(!elementType.isInteger(8) &&
+           "quantlinear op Only supporting int8 elementType now");
+
+    Value shifted = input;
+    if (op.getNumOperands() == 3) {
+      auto bias = op.getOperand(2);
+      shifted = createOpAndInfer<tosa::AddOp>(rewriter, loc, elementType, input,
+                                              bias);
+    }
+
+    Type intermediateElementType = rewriter.getF32Type();
+    Value upCast =
+        createCastOp(rewriter, loc, intermediateElementType, shifted);
+    Value scaled = createOpAndInfer<tosa::MulOp>(
+        rewriter, loc, intermediateElementType, upCast, scale, /*shift=*/0);
+
+    Type destElementType = rewriter.getIntegerType(8);
+    Value downCast = createCastOp(rewriter, loc, destElementType, scaled);
+    rewriter.replaceOp(op, {downCast});
+    return success();
+  }
+};
 } // namespace
 
 void migraphx::populateMIGraphXToTosaConversionPatterns(
     MLIRContext *context, RewritePatternSet &patterns) {
   patterns.add<ConvConverter, BroadcastConverter, MultiBroadcastConverter,
                ReshapeConverter, SoftmaxConverter, DotConverter,
-               ReduceMeanConverter>(context);
+               ReduceMeanConverter, QuantizeLinearConverter>(context);
 }

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -41,7 +41,7 @@ static bool isBroadcastable(Operation *op, Operation *operand) {
 
 template <typename TosaOp, typename... Args>
 static TosaOp createOpAndInfer(PatternRewriter &rewriter, Location loc,
-                               Type elemType, Args &&... args) {
+                               Type elemType, Args &&...args) {
   auto op =
       rewriter.create<TosaOp>(loc, UnrankedTensorType::get(elemType), args...);
   InferShapedTypeOpInterface shapeInterface =

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -515,11 +515,6 @@ public:
     auto elementType = inputType.getElementType();
     Location loc = op->getLoc();
 
-    if (!elementType.isInteger(32)) {
-      return rewriter.notifyMatchFailure(
-          loc, "quantlinear op Only supporting int32 elementType now");
-    }
-
     Value shifted = input;
     if (auto bias = op.getBias()) {
       shifted = createOpAndInfer<tosa::AddOp>(rewriter, loc, elementType, input,

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Conversion/MIGraphXToTosa/MIGraphXToTosa.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Dialect/Tosa/Utils/QuantUtils.h"
 #include "mlir/IR/PatternMatch.h"
@@ -45,12 +46,13 @@ public:
     ConversionTarget target(ctx);
     target.addLegalDialect<tosa::TosaDialect, migraphx::MIGraphXDialect,
                            func::FuncDialect>();
-    target.addIllegalOp<
-        migraphx::AddOp, migraphx::ConstantOp, migraphx::ConvolutionOp,
-        migraphx::RsqrtOp, migraphx::ReluOp, migraphx::TransposeOp,
-        migraphx::BroadcastOp, migraphx::MultiBroadcastOp, migraphx::ReshapeOp,
-        migraphx::DotOp, migraphx::PowOp, migraphx::RecipOp,
-        migraphx::SoftmaxOp, migraphx::ReduceMeanOp>();
+    target.addIllegalOp<migraphx::AddOp, migraphx::ConstantOp,
+                        migraphx::ConvolutionOp, migraphx::RsqrtOp,
+                        migraphx::ReluOp, migraphx::TransposeOp,
+                        migraphx::BroadcastOp, migraphx::MultiBroadcastOp,
+                        migraphx::ReshapeOp, migraphx::DotOp, migraphx::PowOp,
+                        migraphx::RecipOp, migraphx::SoftmaxOp,
+                        migraphx::ReduceMeanOp, migraphx::QuantizeLinearOp>();
 
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -1,6 +1,33 @@
 // RUN: rocmlir-opt --migraphx-transform --canonicalize --migraphx-to-tosa %s -verify-diagnostics -o -| FileCheck %s
 
 module  {
+  // CHECK-LABEL: func @quantization_scale
+  // CHECK-NOT: tosa.add
+  // CHECK: tosa.mul
+  func.func @quantization_scale(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf32>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
+    %2 = "migraphx.quantizelinear"(%arg, %scale) : (tensor<1x112x112x64xi32>, tensor<64xf32>) -> tensor<1x112x112x64xi8>
+    return %2 : tensor<1x112x112x64xi8>
+}
+
+  // CHECK-LABEL: func @quantization_scale_bias
+  // CHECK: tosa.add
+  // CHECK: tosa.mul
+  func.func @quantization_scale_bias(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf32>, %bias: tensor<64xi32>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
+    %2 = "migraphx.quantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xi32>, tensor<64xf32>, tensor<64xi32>) -> tensor<1x112x112x64xi8>
+    return %2 : tensor<1x112x112x64xi8>
+}
+
+  // CHECK-LABEL: func @conv_with_quant
+  // CHECK: tosa.conv2d{{.*}} quantization_info
+  // CHECK: tosa.add
+  // CHECK: tosa.mul
+  // CHECK: tosa.cast
+  func.func @conv_with_quant(%arg1: tensor<1x3x224x224xi8>, %arg2: tensor<64x3x7x7xi8>, %scale: tensor<1x64x1x1xf32>, %bias: tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xi8> attributes {kernel = "mixr"} {
+    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xi8>, tensor<64x3x7x7xi8>) -> tensor<1x64x112x112xi32>
+    %2 = "migraphx.quantizelinear"(%1, %scale, %bias) : (tensor<1x64x112x112xi32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xi8>
+    return %2 : tensor<1x64x112x112xi8>
+}
+
   // CHECK-LABEL: func.func @matmul
   // CHECK: tosa.matmul
   func.func @matmul(%arg0: tensor<2x256x384xf32>, %arg1: tensor<2x384x768xf32>) -> tensor<2x256x768xf32> {


### PR DESCRIPTION
I added the quantize linear op lowering implemented according to most recent meeting with MIGraphX and CK.

```cpp
__host__ __device__ constexpr void
operator()(int8_t& y, const int32_t& x, const int32_t& bias) const
{
    float y_fp32 = ck::type_convert<float>(x + bias);
    y_fp32 = math::clamp(round(requantScale_ * y_fp32), -128.f, 127.f);
    y      = ck::type_convert<int8_t>(y_fp32);
}

```

This sample implementation match perfectly with the original prototype:
 - The int32 to fp32 type cast is aligned with tosa.cast
 - The fp32 to int32 type cast includes: rounding, clamp and type convert, also aligned with tosa.cast