### PR TITLE
Make threadwise_write_all a writer in regularization

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
@@ -214,6 +214,8 @@ struct PushTransformsUpRewritePattern
       return rgop.getC() == result;
     } else if (auto rgop = dyn_cast<rock::GridwiseGemmV2Op>(forwOp)) {
       return rgop.getC() == result;
+    } else if (auto rgop = dyn_cast<rock::ThreadwiseWriteAllOp>(forwOp)) {
+      return rgop.getDest() == result;
     }
     LLVM_DEBUG(llvm::dbgs() << "unsupported op\n" << *forwOp);
     return false;


### PR DESCRIPTION
In the tuning loop, and probably in the MIOpen context, the applicability section of the kernel pipeline (GridwiseGemmToBlockwise and before) may be run multiple times. The first run stops at GridwiseGemmToBlockwise, and errors at or before this point are deemed to be the fault of the tuning config.

Then, when the compilation pipeline is run, the steps that were run as part of the applicability test are run again. What this means is that Regularize may receive as its input the result of
GridwiseGemmToBlockwise. Since that IR was already reguralized, the pass should be a noop.

However, because threadwise_write_all wasn't on the list of writers, the regularizer would treat it as a reader and go looking for another writer, not find one, and leave the IR in some very weird state. This patch fixes the problem, allowing us to tune kernels with fusions in them.

Thanks to @yiqian1  for substantial initial debugging effort.