### PR TITLE
Adds multiple output fusion support

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/XModel/Transforms/AsyncGraph.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/XModel/Transforms/AsyncGraph.cpp
@@ -73,8 +73,10 @@ class XModelAsyncGraphPass
     // Insert host sync before operation that reads an async::value
     for (auto operand : op->getOperands()) {
       if (auto itoken = res2tokens.lookup(operand)) {
-        createWaitOp(op, itoken);
-        currentTokens.erase(itoken);
+        if (currentTokens.contains(itoken)) {
+          createWaitOp(op, itoken);
+          currentTokens.erase(itoken);
+        }
       }
     }
     // Insert host synchronization before terminator or op with side effects.

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -173,7 +173,7 @@ static Operation *traceToNonViewDef(Operation *op) {
 // This function checks the results of the current operation
 // is copied to a block argument output, hence needs to be
 // preserved.
-static bool isLeadingToBlockArg(Operation *op) {
+static bool leadsToUnwrittenBlockArg(Operation *op) {
   Operation *nonViewDef = traceToNonViewDef(op);
   for (Value result : nonViewDef->getResults()) {
     if (result.isa<BlockArgument>()) {
@@ -383,7 +383,7 @@ LAGenericRewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
   // op or linalg block) will be written to the internal memref alloca. If that
   // is not copied as an output, it is not an actual output. Therefore, we dont
   // need clone the gemmStore.
-  if (isLeadingToBlockArg(gemmStoreOp.getDest().getDefiningOp())) {
+  if (leadsToUnwrittenBlockArg(gemmStoreOp.getDest().getDefiningOp())) {
     gemmStoreOp =
         static_cast<ThreadwiseWriteAllOp>(b.clone(*gemmStoreOp.getOperation()));
   }

--- a/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
@@ -275,7 +275,7 @@ struct PushTransformsUpRewritePattern
             auto top = rw.create<rock::TransformOp>(loc, val, itx);
             val = top.getResult();
           }
-          writer->replaceUsesOfWith(alloc, val);
+          rw.replaceOp(alloc, val);
 
           lres = success();
         }

--- a/mlir/test/fusion/e2e/migraphx-multi-output.mlir
+++ b/mlir/test/fusion/e2e/migraphx-multi-output.mlir
@@ -1,0 +1,13 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -fut test_mo -verifier clone - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK:  [1 1 1]
+module {
+    func.func @test_mo(%arg0: tensor<1x256x768xf32>, %arg1: tensor<1x768x768xf32>, %arg2: tensor<1x256x1xf32>, %arg3: tensor<1x256x768xf32>) -> (tensor<1x256x768xf32>, tensor<1x256x768xf32>) {
+        %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x256x768xf32>, tensor<1x768x768xf32>) -> tensor<1x256x768xf32>
+        %1 = "migraphx.multibroadcast"(%arg2) {out_lens = [1, 768, 768]} : (tensor<1x256x1xf32>) -> (tensor<1x256x768xf32>)
+        %2 = "migraphx.add"(%0, %1) : (tensor<1x256x768xf32>, tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+        %3 = "migraphx.add"(%2, %arg3) : (tensor<1x256x768xf32>, tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+        %4 = "migraphx.relu"(%3) : (tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+        return %3, %4 : tensor<1x256x768xf32>, tensor<1x256x768xf32>
+    }
+}

--- a/mlir/test/fusion/e2e/multiple-outputs/migraphx-mbcast-two-outputs.mlir
+++ b/mlir/test/fusion/e2e/multiple-outputs/migraphx-mbcast-two-outputs.mlir
@@ -1,6 +1,6 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -fut test_mo -verifier clone - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
-// CHECK:  [1 1 1]
+// CHECK-COUNT-2:  [1 1 1]
 module {
     func.func @test_mo(%arg0: tensor<1x256x768xf32>, %arg1: tensor<1x768x768xf32>, %arg2: tensor<1x256x1xf32>, %arg3: tensor<1x256x768xf32>) -> (tensor<1x256x768xf32>, tensor<1x256x768xf32>) {
         %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x256x768xf32>, tensor<1x768x768xf32>) -> tensor<1x256x768xf32>

--- a/mlir/test/fusion/e2e/multiple-outputs/tosa-three-outputs.mlir
+++ b/mlir/test/fusion/e2e/multiple-outputs/tosa-three-outputs.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | rocmlir-gen -ph -print-results -fut test_mo -verifier clone - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK-COUNT-2:  [1 1 1]
+module {
+  func.func @test_mo(%arg0: tensor<1x256x768xf32>, %arg1: tensor<1x768x768xf32>, %arg2: tensor<1x256x1xf32>, %arg3: tensor<1x256x768xf32>, %arg4: tensor<1x256x768xf32>) -> (tensor<1x256x768xf32>, tensor<1x256x768xf32>, tensor<1x256x768xf32>) {
+    %0 = "tosa.reshape"(%arg0) {new_shape = array<i64: 1, 256, 768>} : (tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %1 = "tosa.reshape"(%arg1) {new_shape = array<i64: 1, 768, 768>} : (tensor<1x768x768xf32>) -> tensor<1x768x768xf32>
+    %2 = "tosa.matmul"(%0, %1) : (tensor<1x256x768xf32>, tensor<1x768x768xf32>) -> tensor<1x256x768xf32>
+    %3 = "tosa.reshape"(%2) {new_shape = array<i64: 1, 256, 768>} : (tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %4 = "tosa.add"(%3, %arg2) : (tensor<1x256x768xf32>, tensor<1x256x1xf32>) -> tensor<1x256x768xf32>
+    %5 = "tosa.add"(%4, %arg3) : (tensor<1x256x768xf32>, tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %6 = "tosa.clamp"(%5) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %7 = "tosa.sub"(%6, %arg4) : (tensor<1x256x768xf32>, tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    return %5, %6, %7 : tensor<1x256x768xf32>, tensor<1x256x768xf32>, tensor<1x256x768xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/multiple-outputs/tosa-two-outputs.mlir
+++ b/mlir/test/fusion/e2e/multiple-outputs/tosa-two-outputs.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | rocmlir-gen -ph -print-results -fut test_mo -verifier clone - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK-COUNT-2:  [1 1 1]
+module {
+  func.func @test_mo(%arg0: tensor<1x256x768xf32>, %arg1: tensor<1x768x768xf32>, %arg2: tensor<1x256x1xf32>, %arg3: tensor<1x256x768xf32>) -> (tensor<1x256x768xf32>, tensor<1x256x768xf32>) {
+    %0 = "tosa.reshape"(%arg0) {new_shape = array<i64: 1, 256, 768>} : (tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %1 = "tosa.reshape"(%arg1) {new_shape = array<i64: 1, 768, 768>} : (tensor<1x768x768xf32>) -> tensor<1x768x768xf32>
+    %2 = "tosa.matmul"(%0, %1) : (tensor<1x256x768xf32>, tensor<1x768x768xf32>) -> tensor<1x256x768xf32>
+    %3 = "tosa.reshape"(%2) {new_shape = array<i64: 1, 256, 768>} : (tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %4 = "tosa.add"(%3, %arg2) : (tensor<1x256x768xf32>, tensor<1x256x1xf32>) -> tensor<1x256x768xf32>
+    %5 = "tosa.add"(%4, %arg3) : (tensor<1x256x768xf32>, tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %6 = "tosa.clamp"(%5) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    return %5, %6 : tensor<1x256x768xf32>, tensor<1x256x768xf32>
+  }
+}

--- a/mlir/test/rocmlir-driver/populate_conv_config.mlir
+++ b/mlir/test/rocmlir-driver/populate_conv_config.mlir
@@ -2,7 +2,7 @@
 
 //PV: [[FIL1:%.*]] = memref.alloc() : memref<1x2048x1024x1x1xf32>
 //PV: [[FIL2:%.*]] = memref.alloc() : memref<1x2048x1024x1x1xf32>
-//PV: call @mlir_gen_igemm_conv2d_v4r4_wrw_xdlops_0_verify([[FIL1]], [[FIL2]])
+//PV: call @mlir_gen_igemm_conv2d_v4r4_wrw_xdlops_0_verify0([[FIL1]], [[FIL2]])
 //PV: @conv2d_bwd_weight_cpu
 //PV: %[[f32_0:.*]] = arith.constant 0.000000e+00 : f32
 //PV: vector.insertelement %[[f32_0]]
@@ -36,7 +36,7 @@
 
 //PVCPP: [[FIL1:%.*]] = memref.alloc() : memref<1x2048x1024x1x1xf32>
 //PVCPP: [[FIL2:%.*]] = memref.alloc() : memref<1x2048x1024x1x1xf32>
-//PVCPP: call @mlir_gen_igemm_conv2d_v4r4_wrw_xdlops_0_verify([[FIL1]], [[FIL2]])
+//PVCPP: call @mlir_gen_igemm_conv2d_v4r4_wrw_xdlops_0_verify0([[FIL1]], [[FIL2]])
 //PVCPP: %{{.*}} = memref.cast %{{.*}} : memref<256x1x2048x8x8xf32> to memref<*xf32>
 //PVCPP-NEXT: [[S1:%.*]] = arith.constant 2 : i32
 //PVCPP-NEXT: [[S2:%.*]] = arith.constant 2 : i32


### PR DESCRIPTION
This commit adds support selectively clone
threadswise write all depending on whether
the intermediaries are copied to output buffers
( > 1).

I also needed to change AsyncGraph pass as it creates
awaits for each output although they could align
to a single token (i.e multiple outputs from a single kernel)

I also needed to change rocmlir-gen test harness creation
as it assumed that there will be only one output in the 
kernel.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/803