### PR TITLE
Decouple kpack and xdlops private buffers

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1203,9 +1203,9 @@ struct GridwiseGemmV2RewritePattern
     // Logic to setup buffers for blockwise_gemm_v2.
 
     bool isKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
-    int64_t inputBufferSize = kpacksPerBlock /
-                              (isKReduction ? inputSpansPerMfmaIn : 1) *
-                              std::max(kpack / k_base, 1L);
+    int64_t inputBufferSize =
+        (kpacksPerBlock * kpack) /
+        ((isKReduction ? inputSpansPerMfmaIn : 1) * k_base);
 
     Type arrayAType, arrayBType;
     auto privateMemoryAddressSpace = b.getAttr<gpu::AddressSpaceAttr>(

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -182,8 +182,7 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
 
     XdlopsGemmParamsAttr tuningParams = op.getParams();
     // Obtain critical information.
-    int64_t KPack = tuningParams.getKpack();
-    int64_t K = tuningParams.getKPerBlock();
+    int64_t K = tuningParams.getKPerBlock() * tuningParams.getKpack();
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();
 
@@ -217,12 +216,9 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
     Value bufferA = adaptor.getMatrixA();
     Value bufferB = adaptor.getMatrixB();
     Value bufferC = adaptor.getMatrixC();
-    auto matrixAType = bufferA.getType().cast<MemRefType>();
-    auto matrixBType = bufferB.getType().cast<MemRefType>();
-    Type matrixAElementType = matrixAType.getElementType();
-    Type matrixBElementType = matrixBType.getElementType();
 
-    int64_t KPerThread = IsKReduction ? K / inputSpansPerMfmaIn : K;
+    int64_t kBasePerThread =
+        (IsKReduction ? K / inputSpansPerMfmaIn : K) / k_base;
     Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
     SmallVector<Value, 4> startCoords(4, zeroConstantOp);
 
@@ -248,88 +244,22 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
 
     auto generateMfmaOnKDim = [&](Value &regAOffset, Value &regBOffset,
                                   Value &regCOffset) {
-      if (KPack == 1) {
-        auto mfmaLoop = b.create<TransformingForOp>(
-            loc, ArrayRef<ValueRange>{{zeroConstantOp}},
-            ArrayRef<Attribute>{b.getArrayAttr({})},
-            /*bounds=*/ArrayRef<int64_t>{KPerThread},
-            /*strides=*/ArrayRef<int64_t>{k_base},
-            /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-        {
-          OpBuilder::InsertionGuard guard(b);
-          b.setInsertionPointToStart(mfmaLoop.getBody());
-          Value coord = mfmaLoop.getLowerCoords(/*domain=*/0)[0];
+      auto mfmaLoop = b.create<TransformingForOp>(
+          loc, ArrayRef<ValueRange>{{zeroConstantOp}},
+          ArrayRef<Attribute>{b.getArrayAttr({})},
+          /*bounds=*/ArrayRef<int64_t>{kBasePerThread},
+          /*strides=*/ArrayRef<int64_t>{1},
+          /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+      {
+        OpBuilder::InsertionGuard guard(b);
+        b.setInsertionPointToStart(mfmaLoop.getBody());
+        Value coord = mfmaLoop.getLowerCoords(/*domain=*/0)[0];
 
-          auto loadArg = [&](Value regOffset, Value matrix) {
-            Value regIdx = b.create<AddIOp>(loc, regOffset, coord);
-            Value arg;
-            if (k_base == 1) {
-              // xdlops needs only 1 element, load directly from buffer.
-              arg = b.create<InBoundsLoadOp>(loc, argType, matrix,
-                                             ValueRange{regIdx});
-            } else {
-              // k_base > 1, use transferRead to load a vector length equivalent
-              // with a xdlops argument.
-              arg = b.create<vector::TransferReadOp>(
-                  loc, argType.cast<VectorType>(), matrix, ValueRange{regIdx},
-                  /*InBounds*/ ArrayRef<bool>(true));
-            }
-            return arg;
-          };
-
-          Value argA = loadArg(regAOffset, bufferA);
-          Value argB = loadArg(regBOffset, bufferB);
-          populateMfma(b, argA, argB, regCOffset);
-        };
-      } else {
-        // for(index_t k_i = 0; k_i < KPerThread; ++k_i) {
-        //   matrixAElement = a[k_i];
-        //   matrixBElement = b[k_i];
-        //   // Loop within a kpack
-        //   for(index_t ki_i = 0; ki_i < k_base * KRepeats; ki_i += k_base)
-        //     argA = &matrixAElement[ki_i];
-        //     argB = &matrixAElement[ki_i];
-        //     p_c_thread = mfma_type.template run<MPerXlops * mRepeats,
-        //                                         NPerXdlops * nRepeats,
-        //                                         AStride,
-        //                                         BStride>(argA, argB,
-        //       p_c_thread);
-        // }
-        int64_t outerLoopUpperBound = KPerThread;
-        int64_t KRepeats = KPack / k_base;
-
-        auto outerLoop = b.create<AffineForOp>(loc, 0, outerLoopUpperBound);
-        auto outerLoopb = ConversionPatternRewriter::atBlockBegin(
-            outerLoop.getBody(), b.getListener());
-        auto outerLoopiv = outerLoop.getInductionVar();
-
-        auto loadSingleKPack = [&](Value regOffset, Type elementType,
-                                   Value matrix) {
-          Value regIdx = outerLoopb.create<AddIOp>(loc, regOffset, outerLoopiv);
-          Value element = outerLoopb.create<memref::LoadOp>(
-              loc, elementType, matrix, ValueRange{regIdx});
-          return element;
-        };
-
-        Value matrixAElement =
-            loadSingleKPack(regAOffset, matrixAElementType, bufferA);
-        Value matrixBElement =
-            loadSingleKPack(regBOffset, matrixBElementType, bufferB);
-
-        auto innerLoop =
-            outerLoopb.create<AffineForOp>(loc, 0, KRepeats * k_base, k_base);
-        auto innerLoopb = ConversionPatternRewriter::atBlockBegin(
-            innerLoop.getBody(), outerLoopb.getListener());
-        auto innerLoopiv = innerLoop.getInductionVar();
-
-        // At this point, we are guaranteed that buffer element vectorization
-        // length (kPack) must be a multiple of k_base. Use extractsliceop
-        // to handle a independent data slice at a time.
-        Value argA = innerLoopb.create<ExtractSliceOp>(
-            loc, argType, matrixAElement, innerLoopiv);
-        Value argB = innerLoopb.create<ExtractSliceOp>(
-            loc, argType, matrixBElement, innerLoopiv);
-        populateMfma(innerLoopb, argA, argB, regCOffset);
+        Value regIdxA = b.create<arith::AddIOp>(loc, coord, regAOffset);
+        Value regIdxB = b.create<arith::AddIOp>(loc, coord, regBOffset);
+        Value argA = b.create<memref::LoadOp>(loc, argType, bufferA, regIdxA);
+        Value argB = b.create<memref::LoadOp>(loc, argType, bufferB, regIdxB);
+        populateMfma(b, argA, argB, regCOffset);
       }
     };
 

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_v2.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise %s | FileCheck %s
 
 func.func @rock_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
-                                                %bufferA : memref<2xvector<2xf32>, 5>, %bufferB : memref<2xvector<2xf32>, 5>,
+                                                %bufferA : memref<4xf32, 5>, %bufferB : memref<4xf32, 5>,
                                                 %matrixC : memref<4xvector<16xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK:  rock.xdlops_gemm_v2
@@ -17,7 +17,7 @@ func.func @rock_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
       forceUnroll = true>,
     ldsBufferOffsetA = 0 : index,
     ldsBufferOffsetB = 512 : index
-  } : memref<4xvector<16xf32>, 5> += memref<2xvector<2xf32>, 5> from memref<1024xf32, 3> * memref<2xvector<2xf32>, 5> from memref<1024xf32, 3>
+  } : memref<4xvector<16xf32>, 5> += memref<4xf32, 5> from memref<1024xf32, 3> * memref<4xf32, 5> from memref<1024xf32, 3>
   return
 }
 

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
@@ -10,7 +10,7 @@ func.func @rock_xdlops_gemm_v2_reduction_nokpack(%matrixA : memref<2xf32, 5>,
   // CHECK: [[a:%.+]] = memref.load [[ABuf]]
   // CHECK: [[b:%.+]] = memref.load [[BBuf]]
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
-  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, vector<16xf32>
+  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
@@ -35,7 +35,7 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_f32(%matrixA : memref<2xf32, 5>,
   // CHECK: [[a:%.+]] = memref.load [[ABuf]]
   // CHECK: [[b:%.+]] = memref.load [[BBuf]]
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
-  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, vector<16xf32>
+  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
@@ -60,7 +60,7 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<4xvector<4xi
   // CHECK: [[a:%.+]] = memref.load [[ABuf]]
   // CHECK: [[b:%.+]] = memref.load [[BBuf]]
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
-  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : vector<4xi8>, vector<16xi32>
+  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : vector<4xi8>, vector<4xi8>, vector<16xi32>
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
@@ -1,15 +1,20 @@
 // RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
+
 func.func @rock_xdlops_gemm_v2_reduction_nokpack(%matrixA : memref<2xf32, 5>,
                                                  %matrixB : memref<2xf32, 5>,
                                                  %matrixC : memref<2xvector<16xf32>, 5>) {
-  %c0 = arith.constant 0 : index
   // CHECK-LABEL: func.func @rock_xdlops_gemm_v2_reduction_nokpack
-  // CHECK: rock.in_bounds_load
-  // CHECK: rock.in_bounds_load
-  // CHECK: amdgpu.mfma
+  // CHECK-SAME: ([[ABuf:%.+]]: memref<2xf32, 5>, [[BBuf:%.+]]: memref<2xf32, 5>, [[CBuf:%.+]]: memref<2xvector<16xf32>, 5>)
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [2]
+  // CHECK: [[a:%.+]] = memref.load [[ABuf]]
+  // CHECK: [[b:%.+]] = memref.load [[BBuf]]
+  // CHECK: [[c:%.+]] = memref.load [[CBuf]]
+  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, vector<16xf32>
+  %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
-       kPerBlock = 8,
+       kPerBlock = 4,
        kpack = 1,
        mPerBlock = 128,
        mPerWave = 64,
@@ -20,14 +25,18 @@ func.func @rock_xdlops_gemm_v2_reduction_nokpack(%matrixA : memref<2xf32, 5>,
   return
 }
 
-func.func @rock_xdlops_gemm_v2_reduction_kpack_f32(%matrixA : memref<2xvector<2xf32>, 5>,
-                                                   %matrixB : memref<2xvector<2xf32>, 5>,
+func.func @rock_xdlops_gemm_v2_reduction_kpack_f32(%matrixA : memref<2xf32, 5>,
+                                                   %matrixB : memref<2xf32, 5>,
                                                    %matrixC : memref<4xvector<16xf32>, 5>) {
-  %c0 = arith.constant 0 : index
   // CHECK-LABEL: func.func @rock_xdlops_gemm_v2_reduction_kpack_f32
-  // CHECK: rock.extract_slice
-  // CHECK: rock.extract_slice
-  // CHECK: amdgpu.mfma
+  // CHECK-SAME: ([[ABuf:%.+]]: memref<2xf32, 5>, [[BBuf:%.+]]: memref<2xf32, 5>, [[CBuf:%.+]]: memref<4xvector<16xf32>, 5>)
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [2]
+  // CHECK: [[a:%.+]] = memref.load [[ABuf]]
+  // CHECK: [[b:%.+]] = memref.load [[BBuf]]
+  // CHECK: [[c:%.+]] = memref.load [[CBuf]]
+  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, vector<16xf32>
+  %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 2,
@@ -37,19 +46,23 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_f32(%matrixA : memref<2xvector<2x
       nPerBlock = 128,
       nPerWave = 64,
       forceUnroll = true>
-  } : memref<4xvector<16xf32>, 5> += memref<2xvector<2xf32>, 5> * memref<2xvector<2xf32>, 5>
+  } : memref<4xvector<16xf32>, 5> += memref<2xf32, 5> * memref<2xf32, 5>
   return
 }
 
-func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<2xvector<8xi8>, 5>,
-                                                 %matrixB : memref<2xvector<8xi8>, 5>,
+func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<4xvector<4xi8>, 5>,
+                                                 %matrixB : memref<4xvector<4xi8>, 5>,
                                                  %matrixC : memref<1xvector<16xi32>, 5>) {
-  %c0 = arith.constant 0 : index
   // CHECK-LABEL: func.func @rock_xdlops_gemm_v2_reduction_kpack_i8
-  // CHECK: rock.extract_slice
-  // CHECK: rock.extract_slice
-  // CHECK: amdgpu.mfma
+  // CHECK-SAME: ([[ABuf:%.+]]: memref<4xvector<4xi8>, 5>, [[BBuf:%.+]]: memref<4xvector<4xi8>, 5>, [[CBuf:%.+]]: memref<1xvector<16xi32>, 5>)
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [4]
+  // CHECK: [[a:%.+]] = memref.load [[ABuf]]
+  // CHECK: [[b:%.+]] = memref.load [[BBuf]]
+  // CHECK: [[c:%.+]] = memref.load [[CBuf]]
+  // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : vector<4xi8>, vector<16xi32>
   // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
     params = #rock.xdlops_gemm_params<
       kPerBlock = 4,
@@ -59,6 +72,6 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<2xvector<8xi
       mPerBlock = 64,
       nPerBlock = 64,
       forceUnroll = true>
-  } : memref<1xvector<16xi32>, 5> += memref<2xvector<8xi8>, 5> * memref<2xvector<8xi8>, 5>
+  } : memref<1xvector<16xi32>, 5> += memref<4xvector<4xi8>, 5> * memref<4xvector<4xi8>, 5>
   return
 }


### PR DESCRIPTION
Storing vectors of length kpack in the buffers passed to the threadwise gemm is awkward and isn't what threadwise gemm actually needs. However, to avoid blowups during MemToReg, we probably still want the values in those arrays to be vectors. Therefore, change blockwise gemm to construct vectors of the argument type of the underlying MFMA and to pass those into xdlops_gemm_v2.

This should not have any correctness effect, and is extremely likely to have performance impact.

It also enables, for example, xpack=8 for f32, in case that ends up being useful.