### PR TITLE
Get rid of universal parameters

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/Rock/Generator/Conv2dGenerator.h
@@ -77,7 +77,7 @@ public:
   const Config &getConfig() const { return config; }
   void setKernelName(const std::string &newName);
 
-  int getKernelCount(OpBuilder &builder) const;
+  LogicalResult getKernelCount(OpBuilder &builder, int &kernelCount) const;
 
   Type getDataType(OpBuilder &builder) const;
 
@@ -126,10 +126,10 @@ public:
   LogicalResult isApplicable(bool checkChip = true) const;
 
   // Utility function to query if a config requires additional workspace.
-  bool hasWorkspace(OpBuilder &builder) const;
+  LogicalResult hasWorkspace(OpBuilder &builder, bool &needWorkspace) const;
 
   // Utility function to fetch the size of workspace.
-  int getWorkspaceSize(ModuleOp &module) const;
+  LogicalResult getWorkspaceSize(ModuleOp &module, int &workspaceSize) const;
 
 private:
   template <typename Vector>
@@ -144,8 +144,10 @@ private:
     return permutation;
   }
   int getBwdDataKernelCount() const;
-  int getBwdWeightKernelCount(OpBuilder &builder) const;
-  bool needExtraPadBwdWeight(OpBuilder &builder) const;
+  LogicalResult getBwdWeightKernelCount(OpBuilder &builder,
+                                        int &kernelCount) const;
+  LogicalResult needExtraPadBwdWeight(OpBuilder &builder,
+                                      bool &needExtraPad) const;
   LogicalResult hasValidDimension() const;
   LogicalResult hasValidChip() const;
 

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -257,7 +257,7 @@ private:
   // add more 3 gemmk.
   uint32_t obtainBlockSize(const InitParamsXDL &params, int64_t waveSize);
 
-  LogicalResult getKBlocks(int64_t convGroupSize, const GemmSize &gemmSize,
+  LogicalResult getKBlocks(int64_t batchSize, const GemmSize &gemmSize,
                            const InitParamsXDL &params, int64_t &gemmKBlocks,
                            uint32_t numCu);
 

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -43,6 +43,30 @@ struct InitParams {
   int64_t gemmKPerBlock;
 };
 
+/// Store information useful for populating perf configurations
+struct PopulateParamsInfo {
+  GemmSize gemmSize;
+  GemmFeatures gemmFeatures;
+  Type inputType;
+  KernelType kernelType;
+  int64_t batchSize;
+  uint32_t numCu;
+
+  PopulateParamsInfo(GemmSize gemmSize, GemmFeatures gemmFeatures,
+                     Type inputType, KernelType kernelType)
+      : gemmSize(gemmSize), gemmFeatures(gemmFeatures), inputType(inputType),
+        kernelType(kernelType) {}
+
+  PopulateParamsInfo(GemmSize gemmSize, GemmFeatures gemmFeatures,
+                     Type inputType, KernelType kernelType, int64_t batchSize,
+                     uint32_t numCu)
+      : gemmSize(gemmSize), gemmFeatures(gemmFeatures), inputType(inputType),
+        kernelType(kernelType), batchSize(batchSize), numCu(numCu) {}
+
+  /// Extract the relevant information from a RockGemmWrapperInterface operation
+  static PopulateParamsInfo fromOp(RockGemmWrapperInterface op);
+};
+
 struct InitParamsNonXDL : InitParams, Serializable<InitParamsNonXDL> {
   constexpr InitParamsNonXDL(uint32_t bSize, int64_t mPerBlock,
                              int64_t nPerBlock, int64_t kPerBlock,
@@ -185,14 +209,11 @@ private:
   // if can't select config from above , use this config to do
   // padding kernel for example , GemmK/block is 16 , if your gemmK is  13 , we
   // add more 3 gemmk
-  static const InitParamsNonXDL universalParameters;
 
   LogicalResult
-  calculateBlockGemmPerformanceParameters(const InitParamsNonXDL &param,
-                                          RockGemmWrapperInterface op);
+  calculateBlockGemmPerformanceParameters(const InitParamsNonXDL &param);
 
-  LogicalResult populateDerived(RockGemmWrapperInterface op,
-                                const InitParamsNonXDL &validParams,
+  LogicalResult populateDerived(const InitParamsNonXDL &validParams,
                                 GemmSize &gemmSize, uint32_t &gridSize);
 
 public:
@@ -202,10 +223,14 @@ public:
                                        InitParamsNonXDL &validParams,
                                        uint32_t &gridSize);
 
+  LogicalResult obtainTuningParameters(const PopulateParamsInfo &info,
+                                       uint32_t blockSizeOverride,
+                                       const std::string &perfConfig,
+                                       InitParamsNonXDL &validParams,
+                                       uint32_t &gridSize);
+
   std::vector<InitParamsNonXDL> getTuningParameters(KernelType opType,
                                                     Type dataType) const;
-
-  const InitParamsNonXDL &getUniversalParameters() const;
 
   LogicalResult isValidGemm(const InitParamsNonXDL &param,
                             const GemmSize &gemmSize) const override;
@@ -230,19 +255,17 @@ private:
   // if can't select config from above , use this config to do
   // padding kernel for example , GEMMK/block is 16 , if your gemmK is  13 , we
   // add more 3 gemmk.
-  static const InitParamsXDL universalParameters;
-
   uint32_t obtainBlockSize(const InitParamsXDL &params, int64_t waveSize);
 
-  LogicalResult getKBlocks(Conv2DBwdWeightOp op, const GemmSize &gemmSize,
-                           const InitParamsXDL &params, int64_t &gemmKBlocks);
+  LogicalResult getKBlocks(int64_t convGroupSize, const GemmSize &gemmSize,
+                           const InitParamsXDL &params, int64_t &gemmKBlocks,
+                           uint32_t numCu);
 
   LogicalResult isValidBlockwiseGemmXDLOPS(const InitParamsXDL &param,
-                                           RockGemmWrapperInterface op,
-                                           uint32_t blockSize);
+                                           Type dataType, uint32_t blockSize);
 
-  LogicalResult populateDerived(RockGemmWrapperInterface op,
-                                const InitParamsXDL &validParams,
+  LogicalResult populateDerived(const InitParamsXDL &validParams,
+                                const PopulateParamsInfo &info,
                                 GemmSize &gemmSize, uint32_t &blockSize,
                                 uint32_t &gridSize, int64_t &gemmKBlocks);
 
@@ -260,9 +283,15 @@ public:
                                        uint32_t &blockSize, uint32_t &gridSize,
                                        int64_t &gemmKBlocks);
 
+  LogicalResult obtainTuningParameters(PopulateParamsInfo info,
+                                       uint32_t blockSizeOverride,
+                                       const std::string &perfConfig,
+                                       InitParamsXDL &validParams,
+                                       uint32_t &blockSize, uint32_t &gridSize,
+                                       int64_t &gemmKBlocks);
+
   std::vector<InitParamsXDL> getTuningParameters(KernelType opType,
                                                  Type dataType) const;
-  const InitParamsXDL &getUniversalParameters() const;
 
   LogicalResult isValidGemm(const InitParamsXDL &param,
                             const GemmSize &gemmSize) const override;

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -40,7 +40,7 @@ bool isWrWAtomicKernel(GemmFeatures features, const Type &dataType,
 // reasonable reduction of GemmK after splitting, without incurring too much
 // overheads on atomic adds. One potential future work is to make this value be
 // tunable.
-LogicalResult calculateKBlockNum(const ConvolutionDims &convDims,
+LogicalResult calculateKBlockNum(const int64_t convGroupSize,
                                  const GemmSize &gemmSize, int64_t MPerBlock,
                                  int64_t NPerBlock, int64_t KPerBlock,
                                  int64_t KPack, int64_t num_cu,

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -40,7 +40,7 @@ bool isWrWAtomicKernel(GemmFeatures features, const Type &dataType,
 // reasonable reduction of GemmK after splitting, without incurring too much
 // overheads on atomic adds. One potential future work is to make this value be
 // tunable.
-LogicalResult calculateKBlockNum(const int64_t convGroupSize,
+LogicalResult calculateKBlockNum(const int64_t batchSize,
                                  const GemmSize &gemmSize, int64_t MPerBlock,
                                  int64_t NPerBlock, int64_t KPerBlock,
                                  int64_t KPack, int64_t num_cu,

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -269,28 +269,39 @@ LogicalResult Conv2dGenerator::hasValidChip() const {
   return success();
 }
 
-int Conv2dGenerator::getKernelCount(OpBuilder &builder) const {
+LogicalResult Conv2dGenerator::getKernelCount(OpBuilder &builder,
+                                              int &kernelCount) const {
   if (config.kernelId > 0) { // generate only 1 specified kernel
-    return 1;
+    kernelCount = 1;
+    return success();
   }
   assert(config.operation.has_value());
   switch (config.operation.value()) {
   case ConvOpType::BwdData:
-    return getBwdDataKernelCount();
+    kernelCount = getBwdDataKernelCount();
+    return success();
   case ConvOpType::Fwd:
-    return 1;
+    kernelCount = 1;
+    return success();
   case ConvOpType::BwdWeight:
-    return getBwdWeightKernelCount(builder);
+    LogicalResult res = getBwdWeightKernelCount(builder, kernelCount);
+    return res;
   }
   llvm_unreachable("Invalid conv2d operation");
 }
 
-int Conv2dGenerator::getBwdWeightKernelCount(OpBuilder &builder) const {
+LogicalResult Conv2dGenerator::getBwdWeightKernelCount(OpBuilder &builder,
+                                                       int &kernelCount) const {
   assert(config.operation.value() == ConvOpType::BwdWeight);
 
+  kernelCount = 1;
   if (bitEnumContainsAll(config.features, GemmFeatures::mfma)) {
     Type dataType = getDataType(builder);
-    if (!needExtraPadBwdWeight(builder)) {
+    bool needExtraPad = false;
+    if (failed(needExtraPadBwdWeight(builder, needExtraPad))) {
+      return failure();
+    }
+    if (!needExtraPad) {
       if (dataType == builder.getF32Type()) {
         // For the following case, use 2 kernels:
         // - backward weight
@@ -300,7 +311,7 @@ int Conv2dGenerator::getBwdWeightKernelCount(OpBuilder &builder) const {
         // The first kernel will 0-initialize the output (filter tensor).
         // The second kernel will conduct the actual backward weight
         // convolution, using atomic add instructions.
-        return 2;
+        kernelCount = 2;
       } else if (dataType == builder.getF16Type()) {
         // For the following case, use 3 kernels:
         // - backward weight
@@ -312,11 +323,11 @@ int Conv2dGenerator::getBwdWeightKernelCount(OpBuilder &builder) const {
         // convolution, using atomic add instructions. The third kernel will do
         // elementwise conversion from fp32 in the workspace to fp16 in the
         // actual output (filter tensor).
-        return 3;
+        kernelCount = 3;
       }
     }
   }
-  return 1;
+  return success();
 }
 
 int Conv2dGenerator::getBwdDataKernelCount() const {
@@ -340,7 +351,8 @@ Type Conv2dGenerator::getDataType(OpBuilder &builder) const {
   return dataType;
 }
 
-bool Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder) const {
+LogicalResult Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder,
+                                                     bool &needExtraPad) const {
   Type dataType = getDataType(builder);
   ConvOpType dir = config.operation.value();
   assert(dir == ConvOpType::BwdWeight &&
@@ -349,7 +361,7 @@ bool Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder) const {
   ConvolutionDims convDims = getConvolutionDims();
   GemmSize gemmSize = GemmSize::fromConvolution(dir, convDims);
 
-  bool needExtraPad = false;
+  needExtraPad = false;
   PopulateParamsInfo info{/*gemmSize=*/gemmSize,
                           /*gemmFeatures=*/config.features,
                           /*inputType=*/dataType,
@@ -363,9 +375,12 @@ bool Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder) const {
     uint32_t gridSize;
     auto res = populateParams.obtainTuningParameters(info, 0, config.perfConfig,
                                                      validParams, gridSize);
-    needExtraPad =
-        succeeded(res) &&
-        (populateParams.calculatePaddingAmount(validParams, gemmSize) != 0);
+
+    if (succeeded(res)) {
+      needExtraPad =
+          (populateParams.calculatePaddingAmount(validParams, gemmSize) != 0);
+      return success();
+    }
 
   } else {
     PopulateParamsXDL populateParamsXDL;
@@ -376,22 +391,24 @@ bool Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder) const {
     auto res = populateParamsXDL.obtainTuningParameters(
         info, 0, config.perfConfig, validParams, blockSize, gridSize,
         gemmKBlocks);
-    needExtraPad =
-        succeeded(res) &&
-        (populateParamsXDL.calculatePaddingAmount(validParams, gemmSize) != 0);
+    if (succeeded(res)) {
+      needExtraPad = (populateParamsXDL.calculatePaddingAmount(validParams,
+                                                               gemmSize) != 0);
+      return success();
+    }
   }
-  return needExtraPad;
+  return failure();
 }
 
-bool Conv2dGenerator::hasWorkspace(OpBuilder &builder) const {
+LogicalResult Conv2dGenerator::hasWorkspace(OpBuilder &builder,
+                                            bool &needWorkspace) const {
   // Decide if a workspace is needed.
   // Preconditions:
   // - data type: fp16
   // - operation: backward weight conv2d.
   // - use XDLOPS.
   // - No need to pad along Gemm M/N/K dimension.
-  bool result = false;
-
+  needWorkspace = false;
   if (config.operation.has_value()) {
     Type dataType = getDataType(builder);
     ConvOpType dir = config.operation.value();
@@ -399,28 +416,36 @@ bool Conv2dGenerator::hasWorkspace(OpBuilder &builder) const {
         bitEnumContainsAll(config.features, GemmFeatures::mfma) &&
         (dataType == builder.getF16Type())) {
       // In case we need extra padding, do not use workspace.
-      result = (needExtraPadBwdWeight(builder) == false);
+      bool needPadding = false;
+      if (failed(needExtraPadBwdWeight(builder, needPadding))) {
+        return failure();
+      }
+      needWorkspace = !needPadding;
     }
   }
-  return result;
+  return success();
 }
 
-int Conv2dGenerator::getWorkspaceSize(ModuleOp &module) const {
+LogicalResult Conv2dGenerator::getWorkspaceSize(ModuleOp &module,
+                                                int &workspaceSize) const {
   // Currently onlt in the following condition would a workspace is needed.
   // - data type: fp16
   // - operation: backward weight conv2d.
   // - use XDLOPS.
   // - No need to pad along Gemm M/N/K dimension.
   // Workspace size is the same as the filter dimension, with fp32 type.
-  int result = 0;
+  bool needWorkspace = false;
   OpBuilder builder(module.getContext());
-  if (hasWorkspace(builder)) {
-    result = std::accumulate(config.filterDimension.begin(),
-                             config.filterDimension.end(), 1,
-                             std::multiplies<int>()) *
-             builder.getF32Type().getWidth() / 8;
+  if (failed(hasWorkspace(builder, needWorkspace))) {
+    return failure();
   }
-  return result;
+  if (needWorkspace) {
+    workspaceSize = std::accumulate(config.filterDimension.begin(),
+                                    config.filterDimension.end(), 1,
+                                    std::multiplies<int>()) *
+                    builder.getF32Type().getWidth() / 8;
+  }
+  return success();
 }
 
 LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
@@ -677,7 +702,10 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module, int rawKernelId,
                                         config.outputDimension.end()),
                       outputDataType);
 
-  bool hasWorkspace = this->hasWorkspace(builder);
+  bool hasWorkspace = false;
+  if (failed(this->hasWorkspace(builder, hasWorkspace))) {
+    return failure();
+  }
   Type workspaceArgType;
   if (hasWorkspace) {
     workspaceArgType =
@@ -843,7 +871,11 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module, int rawKernelId,
     }
   } break;
   case ConvOpType::BwdWeight: {
-    bool hasUtilities = getBwdWeightKernelCount(builder) > 1;
+    int kernelCount = 0;
+    if (failed(getBwdWeightKernelCount(builder, kernelCount))) {
+      return failure();
+    }
+    bool hasUtilities = (kernelCount > 1);
     if (hasUtilities && kernelId == 0) {
       // If there is a workspace, zero-init it, otherwise fill the filter tensor
       auto zeroInitOp = builder.create<ZeroInitKernelOp>(

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -24,7 +24,7 @@ bool mlir::rock::isWrWAtomicKernel(GemmFeatures features, const Type &dataType,
          (dataType.isF32() || dataType.isF16()) && !requiredPadding;
 }
 
-LogicalResult mlir::rock::calculateKBlockNum(const ConvolutionDims &convDims,
+LogicalResult mlir::rock::calculateKBlockNum(const int64_t batchSize,
                                              const GemmSize &gemmSize,
                                              int64_t MPerBlock,
                                              int64_t NPerBlock,
@@ -41,14 +41,14 @@ LogicalResult mlir::rock::calculateKBlockNum(const ConvolutionDims &convDims,
     return failure();
 
   const int64_t gridSize =
-      convDims.g * (gemmM / MPerBlock) * (gemmN / NPerBlock);
+      gemmSize.g * (gemmM / MPerBlock) * (gemmN / NPerBlock);
   const int64_t maxGridSize = 20 * num_cu;
 
   gemmKBlock = std::max(maxGridSize / gridSize, static_cast<int64_t>(1));
-  gemmKBlock = std::min(gemmKBlock, convDims.n);
+  gemmKBlock = std::min(gemmKBlock, batchSize);
 
   for (; gemmKBlock > 1; --gemmKBlock) {
-    if (convDims.n % gemmKBlock != 0)
+    if (batchSize % gemmKBlock != 0)
       continue;
 
     if (gemmK % (gemmKBlock * KPerBlock * KPack) != 0)
@@ -57,7 +57,7 @@ LogicalResult mlir::rock::calculateKBlockNum(const ConvolutionDims &convDims,
     break;
   }
   // not more than n
-  gemmKBlock = std::min(convDims.n, gemmKBlock);
+  gemmKBlock = std::min(batchSize, gemmKBlock);
   // not less than 1
   gemmKBlock = std::max((__int64_t)1, gemmKBlock);
 

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1688,7 +1688,10 @@ createCPUConvFunc(ModuleOp module,
   // Create conv2d_host function
   rock::Conv2dGenerator conv2dGenerator(genConfig);
 
-  bool hasWorkspace = conv2dGenerator.hasWorkspace(b);
+  bool hasWorkspace = false;
+  if (failed(conv2dGenerator.hasWorkspace(b, hasWorkspace))) {
+    assert(genConfig.operation.value() == rock::ConvOpType::Fwd);
+  }
   Type workspaceArgType;
   if (hasWorkspace) {
     workspaceArgType = MemRefType::get(
@@ -2288,7 +2291,12 @@ static void insertValidationCalls(const GenParams &genParams, OpBuilder &b,
         conv2dGenerator.setDataType("f32");
 
       int kernelStart = genConfig.kernelId;
-      int kernelCount = conv2dGenerator.getKernelCount(b);
+      int kernelCount = 0;
+      if (failed(conv2dGenerator.getKernelCount(b, kernelCount))) {
+        llvm::errs() << "Getting kernel count failed.\n";
+        exit(1);
+      }
+      llvm::errs() << kernelCount << "\n";
       if (kernelStart < 0) {
         kernelStart = 0;
       } else {
@@ -2311,8 +2319,16 @@ static void insertValidationCalls(const GenParams &genParams, OpBuilder &b,
         // Decide whether to trim the last workspace argument to the verifier
         // GPU kernel.
         rock::Conv2dGenerator originalConv2dGenerator(genConfig);
-        bool originalHasWorkspace = originalConv2dGenerator.hasWorkspace(b);
-        bool verifierHasWorkspace = conv2dGenerator.hasWorkspace(b);
+        bool originalHasWorkspace = false, verifierHasWorkspace = false;
+        if (failed(originalConv2dGenerator.hasWorkspace(
+                b, originalHasWorkspace))) {
+          llvm::errs() << "Getting workspace failed.\n";
+          exit(1);
+        }
+        if (failed(conv2dGenerator.hasWorkspace(b, verifierHasWorkspace))) {
+          llvm::errs() << "Getting workspace failed.\n";
+          exit(1);
+        }
         if (originalHasWorkspace && !verifierHasWorkspace) {
           valVars.resize(valVars.size() - 1);
         }
@@ -2819,7 +2835,12 @@ int main(int argc, char **argv) {
     } else {
       // Populate the module.
       int kernelStart = genConfig.kernelId;
-      int kernelCount = conv2dGenerator.getKernelCount(builder);
+      int kernelCount = 0;
+      if (failed(conv2dGenerator.getKernelCount(builder, kernelCount))) {
+        llvm::errs() << "Getting kernel count failed.\n";
+        exit(1);
+      }
+      llvm::errs() << kernelCount << "\n";
       if (kernelStart < 0) {
         kernelStart = 0;
       } else {

--- a/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
+++ b/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
@@ -129,8 +129,14 @@ extern "C" MiirHandle miirCreateHandle(const char *arguments) {
 
   ModuleOp module = handle->getModule();
   OpBuilder builder(module.getContext());
-  handle->kernelCount = conv2dGenerator.getKernelCount(builder);
-  handle->workspace = conv2dGenerator.getWorkspaceSize(module);
+
+  if (failed(conv2dGenerator.getKernelCount(builder, handle->kernelCount))) {
+    return nullptr;
+  }
+
+  if (failed(conv2dGenerator.getWorkspaceSize(module, handle->workspace))) {
+    return nullptr;
+  }
 
   if (failed(conv2dGenerator.genConvModule(module, config.kernelId))) {
     return nullptr;


### PR DESCRIPTION
This is a refactor to get rid of the `universalParameters` used by the `Conv2DGenerator` to decide workspace size during wrw convolution. 

Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/800