### PR TITLE
Add timeouts to shared library tests

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -453,7 +453,9 @@ pipeline {
                         steps {
                             build_fixedE2ETests("${CODEPATH}")
                             preMergeCheck("${CODEPATH}")
-                            sh 'cd build; ninja check-mlir check-rocmlir'
+                            timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                sh 'cd build; ninja check-mlir check-rocmlir'
+                            }
                         }
                     }
                     stage("Shared Library: random E2E tests") {
@@ -966,11 +968,13 @@ pipeline {
                     stage("Verify MIGraphX with MLIR") {
                         steps {
                             dir('MIGraphX/build') {
-                                // Verify MLIR unit tests
-                                sh 'make -j$(nproc) test_gpu_mlir'
-                                sh 'ctest -R test_gpu_mlir'
-                                // Verify ResNet50
-                                sh './bin/driver verify --onnx /MIGraphXDeps/resnet50-v1-7.onnx'
+                                timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                    // Verify MLIR unit tests
+                                    sh 'make -j$(nproc) test_gpu_mlir'
+                                    sh 'ctest -R test_gpu_mlir'
+                                    // Verify ResNet50
+                                    sh './bin/driver verify --onnx /MIGraphXDeps/resnet50-v1-7.onnx'
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
As can/could be seen in
http://rocmhead:8080/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-993/6/pipeline/132 , a CI refactor led to the removal of the "60 minutes of no activity is a fail" timeout that was used to catch GPU driver hangs. This commit restores the said timeout and adds it to the MIGraphX tests.