### PR TITLE
Rocmlir package

### DIFF
--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -247,6 +247,6 @@ if(BUILD_FAT_LIBROCKCOMPILER)
   rocm_create_package(
     NAME ${PACKAGE_NAME}
     DESCRIPTION "MLIR packages"
-    MAINTAINER "rocMLIR"
+    MAINTAINER "rocMLIR Dev Team dl.dl-mlir@amd.com"
   )
 endif()

--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -144,11 +144,11 @@ if(BUILD_FAT_LIBROCKCOMPILER)
     if(ARG_EXTRA_INCLUDES)
       set(EXTRA_INCLUDES ${ARG_EXTRA_INCLUDES})
     endif()
+    set(ROCM_INSTALL_LIBDIR lib/${package_name})
     rocm_install(TARGETS ${lib_name}
       EXPORT ${export_set}
-      ARCHIVE DESTINATION lib/${package_name}
-      INCLUDES DESTINATION ${INCLUDE_DIR} ${EXTRA_INCLUDES}
       COMPONENT ${component_name}
+      INCLUDES DESTINATION ${INCLUDE_DIR} ${EXTRA_INCLUDES}
     )
 
     # Generate package config and version file

--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -40,6 +40,13 @@ mlir_check_link_libraries(rocmlir-lib-test)
 llvm_canonicalize_cmake_booleans(BUILD_FAT_LIBROCKCOMPILER)
 # Static library target, enabled only when building static libs
 if(BUILD_FAT_LIBROCKCOMPILER)
+  find_package(ROCM 0.8 REQUIRED PATHS /opt/rocm)
+  include(ROCMInstallTargets)
+  include(ROCMCreatePackage)
+
+  set(ROCMCHECKS_WARN_TOOLCHAIN_VAR OFF)
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+
   set(PACKAGE_NAME ${CMAKE_PROJECT_NAME})
   set(LIBRARY_NAME rockCompiler)
   function(combine_archives output_archive)
@@ -76,9 +83,18 @@ if(BUILD_FAT_LIBROCKCOMPILER)
     ${LIBRARY_NAME}
   )
 
+  rocm_package_setup_component(lib${LIBRARY_NAME}
+        LIBRARY_NAME lib${LIBRARY_NAME}
+        PACKAGE_NAME ${PACKAGE_NAME}
+  )
+
+  rocm_install(FILES LICENSE
+    DESTINATION share/doc/${PACKAGE_NAME}
+    COMPONENT lib${LIBRARY_NAME})
+
   # Install Miir.h to ${CMAKE_INSTALL_PREFIX}/include/${PACKAGE_NAME}/
   # as part of component libroCompiler
-  install(FILES Miir.h
+  rocm_install(FILES Miir.h
     DESTINATION include/${PACKAGE_NAME}
     COMPONENT lib${LIBRARY_NAME})
 
@@ -128,11 +144,11 @@ if(BUILD_FAT_LIBROCKCOMPILER)
     if(ARG_EXTRA_INCLUDES)
       set(EXTRA_INCLUDES ${ARG_EXTRA_INCLUDES})
     endif()
-    install(TARGETS ${lib_name}
+    rocm_install(TARGETS ${lib_name}
       EXPORT ${export_set}
       ARCHIVE DESTINATION lib/${package_name}
-      COMPONENT ${component_name}
       INCLUDES DESTINATION ${INCLUDE_DIR} ${EXTRA_INCLUDES}
+      COMPONENT ${component_name}
     )
 
     # Generate package config and version file
@@ -152,14 +168,14 @@ if(BUILD_FAT_LIBROCKCOMPILER)
     )
 
     # Generate Targets.cmake file for the export-set to contain imported targets
-    install(EXPORT ${export_set}
+    rocm_install(EXPORT ${export_set}
       NAMESPACE ${package_name}::
       DESTINATION ${LIB_CMAKE_DIR}
       COMPONENT ${component_name}
     )
 
     # Install package configuration and version files
-    install(
+    rocm_install(
       FILES
       "${CMAKE_CURRENT_BINARY_DIR}/${pkg_config_file}"
       "${CMAKE_CURRENT_BINARY_DIR}/${pkg_version_file}"
@@ -171,7 +187,11 @@ if(BUILD_FAT_LIBROCKCOMPILER)
   set(extra_include_dir "")
 
   if ((NOT LLVM_INSTALL_TOOLCHAIN_ONLY) AND EXPORT_ALL_HEADERS)
-    install(DIRECTORY
+  rocm_package_setup_component(${LIBRARY_NAME}-headers
+        LIBRARY_NAME ${LIBRARY_NAME}-headers
+        PACKAGE_NAME ${PACKAGE_NAME}
+  )
+    rocm_install(DIRECTORY
       ${PROJECT_SOURCE_DIR}/mlir/include/mlir
       ${PROJECT_SOURCE_DIR}/mlir/include/mlir-c
       DESTINATION include/${PACKAGE_NAME}
@@ -184,7 +204,7 @@ if(BUILD_FAT_LIBROCKCOMPILER)
       PATTERN "LICENSE.TXT"
     )
 
-    install(DIRECTORY ${MLIR_INCLUDE_DIRS}
+    rocm_install(DIRECTORY ${MLIR_INCLUDE_DIRS}
       DESTINATION include/${PACKAGE_NAME}/external
       COMPONENT ${LIBRARY_NAME}-headers
       FILES_MATCHING
@@ -197,7 +217,7 @@ if(BUILD_FAT_LIBROCKCOMPILER)
       PATTERN "config.h" EXCLUDE
     )
 
-    install(DIRECTORY ${PROJECT_BINARY_DIR}/mlir/include
+    rocm_install(DIRECTORY ${PROJECT_BINARY_DIR}/mlir/include
       DESTINATION include/${PACKAGE_NAME}/build
       COMPONENT ${LIBRARY_NAME}-headers
       FILES_MATCHING
@@ -220,5 +240,11 @@ if(BUILD_FAT_LIBROCKCOMPILER)
     lib${LIBRARY_NAME}          # component name
     EXTRA_INCLUDES              # extra include directories
     ${extra_include_dir}
+  )
+
+  rocm_create_package(
+    NAME ${PACKAGE_NAME}
+    DESCRIPTION "MLIR packages"
+    MAINTAINER "rocMLIR"
   )
 endif()

--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -144,9 +144,11 @@ if(BUILD_FAT_LIBROCKCOMPILER)
     if(ARG_EXTRA_INCLUDES)
       set(EXTRA_INCLUDES ${ARG_EXTRA_INCLUDES})
     endif()
-    set(ROCM_INSTALL_LIBDIR lib/${package_name})
-    rocm_install(TARGETS ${lib_name}
+    # Call install() instead of rocm_install() here in order to install
+    # the package in a specific direcotry. 
+    install(TARGETS ${lib_name}
       EXPORT ${export_set}
+      ARCHIVE DESTINATION lib/${package_name}
       COMPONENT ${component_name}
       INCLUDES DESTINATION ${INCLUDE_DIR} ${EXTRA_INCLUDES}
     )

--- a/mlir/tools/rocmlir-lib/LICENSE
+++ b/mlir/tools/rocmlir-lib/LICENSE
@@ -1,0 +1,20 @@
+SPDX-License-Identifier: MIT
+Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -119,6 +119,11 @@ RUN apt-get update && rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+# Install the new rocm-cmake version
+RUN git clone -b master https://github.com/RadeonOpenCompute/rocm-cmake.git  && \
+  cd rocm-cmake && mkdir build && cd build && \
+  cmake  .. && cmake --build . && cmake --build . --target install
+
 # --------------------- Section 3: MIOpen dependencies ---------------
 WORKDIR /MIOpenDepsWork
 RUN wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/MIOpen/develop/requirements.txt \

--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -119,11 +119,6 @@ RUN apt-get update && rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# Install the new rocm-cmake version
-RUN git clone -b master https://github.com/RadeonOpenCompute/rocm-cmake.git  && \
-  cd rocm-cmake && mkdir build && cd build && \
-  cmake  .. && cmake --build . && cmake --build . --target install
-
 # --------------------- Section 3: MIOpen dependencies ---------------
 WORKDIR /MIOpenDepsWork
 RUN wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/MIOpen/develop/requirements.txt \

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -141,10 +141,12 @@ pipeline {
                         stage("Igemm build") {
                             steps {
                                 checkout scm
-                                buildProject('librockCompiler',
-                                             '-DBUILD_FAT_LIBROCKCOMPILER=ON')
-                                cmake arguments: "--install . --component librockCompiler --prefix ${WORKSPACE}/MIOpenDeps",\
-                                installation: 'InSearchPath', workingDir: 'build'
+                                buildProject('package',
+                                             "-DBUILD_FAT_LIBROCKCOMPILER=ON -DCPACK_INSTALL_PREFIX=${WORKSPACE}/MIOpenDeps")
+                                dir('build'){
+                                    sh "cat install_manifest_librockCompiler.txt"
+                                    sh "dpkg -i librockcompiler-rocmlir_1.1.0_amd64.deb"
+                                }
                             }
                         }
                         // Note: setting cxxflags here works around https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1604

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -145,7 +145,9 @@ pipeline {
                                              "-DBUILD_FAT_LIBROCKCOMPILER=ON -DCPACK_INSTALL_PREFIX=${WORKSPACE}/MIOpenDeps")
                                 dir('build'){
                                     sh "cat install_manifest_librockCompiler.txt"
-                                    sh "dpkg -i librockcompiler-rocmlir_1.1.0_amd64.deb"
+                                    // Cannot use 'dpkg -i' because it requires superuser privilege
+                                    // Ignore an error due to the system call utime
+                                    sh "dpkg -x librockcompiler-rocmlir_1.1.0_amd64.deb / || true"
                                 }
                             }
                         }


### PR DESCRIPTION
Use rocm-cmake to create a deb package for librockcompiler.

To create the package:
cmake -G Ninja .. -DBUILD_FAT_LIBROCKCOMPILER=ON -DCPACK_INSTALL_PREFIX=instdir [-DEXPORT_ALL_HEADERS=ON]
cmake --build . --target package

This will generate librockcompiler-rocmlir_1.1.0_amd64.deb and rockcompiler-headers-rocmlir_1.1.0_amd64.deb if EXPORT_ALL_HEADERS=ON.

To install
dpkg -i librockcompiler-rocmlir_1.1.0_amd64.deb

If CPACK_INSTALL_PREFIX is not defined, the package will be installed at /usr/local.