### PR TITLE
Fixes tuning key vs perfRunner arg mismatches

### DIFF
--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -226,7 +226,7 @@ def main(args=None):
     if parsed_args.config:
         configs = parsed_args.config
     elif opType == Operation.CONV:
-        configs = perfRunner.getConvConfigurations(paths.configuration_file_path, do_sweep=False)
+        configs = perfRunner.getConvConfigurations(paths.configuration_file_path)
     elif opType == Operation.GEMM:
         configs = perfRunner.getGemmConfigurations(paths.configuration_file_path)
     else:

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -226,7 +226,7 @@ def main(args=None):
     if parsed_args.config:
         configs = parsed_args.config
     elif opType == Operation.CONV:
-        configs = perfRunner.getConvConfigurations(paths.configuration_file_path)
+        configs = perfRunner.getConvConfigurations(paths.configuration_file_path, do_sweep=False)
     elif opType == Operation.GEMM:
         configs = perfRunner.getGemmConfigurations(paths.configuration_file_path)
     else:


### PR DESCRIPTION
This commit fixes the issue the tuning hooks in rocMLIR generates args that are not consistent with perfRunner.py that is used to tune the said problem config.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/825