### PR TITLE
Adding QuantConvolution and consolidate with MIGraphX Conv

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -172,26 +172,20 @@ def MIGraphX_QuantizeLinearOp :
 }
 
 // Convolution operations
+class MIGraphX_ConvOpBase<string mnemonic, list<Type> inputTypes=[], list<Type> outputTypes=[]> :
+    MIGraphX_Op<mnemonic>{
+    let arguments = (ins TensorOf<inputTypes>:$input,
+                         TensorOf<inputTypes>:$filter,
 
-def MIGraphX_ConvolutionOp :
-    MIGraphX_Op<"convolution">,
-    Arguments<(ins AnyRankedTensor:$input,
-                   AnyRankedTensor:$filter,
-
-                   I64ArrayAttr:$padding,
-                   I64ArrayAttr:$stride,
-                   I64ArrayAttr:$dilation,
-                   I64Attr:$group,
-                   OptionalAttr<I64Attr>:$padding_mode,
-                   OptionalAttr<BoolAttr>:$xdlopsV2,
-                   OptionalAttr<StrAttr>:$perf_config
-                   )>,
-	  Results<(outs AnyRankedTensor:$output)> {
-  let summary = "convolution forward";
-  let description = [{
-    The `migraphx.convolution` op computes convolution forward.
-  }];
-  let builders = [
+                         I64ArrayAttr:$padding,
+                         I64ArrayAttr:$stride,
+                         I64ArrayAttr:$dilation,
+                         I64Attr:$group,
+                         OptionalAttr<I64Attr>:$padding_mode,
+                         OptionalAttr<BoolAttr>:$xdlopsV2,
+                         OptionalAttr<StrAttr>:$perf_config);
+	  let results = (outs TensorOf<outputTypes>:$output);
+    let builders = [
     OpBuilder<(ins "::mlir::Value":$input, "::mlir::Value":$filter, "::mlir::ArrayAttr":$padding,
       "::mlir::ArrayAttr":$stride, "::mlir::ArrayAttr":$dilation, "::mlir::IntegerAttr":$group,
       "::mlir::migraphx::padding_mode_tAttr":$padding_mode,
@@ -211,6 +205,22 @@ def MIGraphX_ConvolutionOp :
     }]>];
 
   let assemblyFormat = "`(`$input `,` $filter`)` attr-dict `:` `(`type($input) `,` type($filter) `)` `->` type($output)";
+}
+
+def MIGraphX_QuantConvolutionOp :
+    MIGraphX_ConvOpBase<"quant_convolution", [I8], [I32]>{
+  let summary = "quantized convolution forward";
+  let description = [{
+    The `migraphx.quant_convolution` op computes quantized convolution forward.
+  }];
+}
+
+def MIGraphX_ConvolutionOp :
+    MIGraphX_ConvOpBase<"convolution", [F32, F16, BF16], [F32, F16, BF16]>{
+  let summary = "convolution forward";
+  let description = [{
+    The `migraphx.convolution` op computes convolution forward.
+  }];
 }
 
 def MIGraphX_BatchNormOp :

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -66,9 +66,10 @@ static tosa::CastOp createCastOp(PatternRewriter &rewriter, Location loc,
   return op;
 }
 
-template <typename T> class ConvConverter : public OpConversionPattern<T> {
+template <typename ConvType>
+class ConvConverter : public OpConversionPattern<ConvType> {
 public:
-  using OpConversionPattern<T>::OpConversionPattern;
+  using OpConversionPattern<ConvType>::OpConversionPattern;
 
   Value getZeroBias(Location loc, Type elemType, int64_t filterOutputChannels,
                     ConversionPatternRewriter &rewriter) const {
@@ -97,8 +98,14 @@ public:
     return newOp;
   }
 
+  // Note, this lowering pattern works for both migraphx.convolution and
+  // migraphx.quant_convolution. The only difference between the two ops
+  // is that quant_convolution allows convolution input and output to be
+  // different types. Because of this, we use same lowering pattern but
+  // different tablegen to capture the difference between the two ops.
   LogicalResult
-  matchAndRewrite(T op, typename OpConversionPattern<T>::OpAdaptor adaptor,
+  matchAndRewrite(ConvType op,
+                  typename OpConversionPattern<ConvType>::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     auto input_t = op.getInput();

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
@@ -46,13 +46,13 @@ public:
     ConversionTarget target(ctx);
     target.addLegalDialect<tosa::TosaDialect, migraphx::MIGraphXDialect,
                            func::FuncDialect>();
-    target.addIllegalOp<migraphx::AddOp, migraphx::ConstantOp,
-                        migraphx::ConvolutionOp, migraphx::RsqrtOp,
-                        migraphx::ReluOp, migraphx::TransposeOp,
-                        migraphx::BroadcastOp, migraphx::MultiBroadcastOp,
-                        migraphx::ReshapeOp, migraphx::DotOp, migraphx::PowOp,
-                        migraphx::RecipOp, migraphx::SoftmaxOp,
-                        migraphx::ReduceMeanOp, migraphx::QuantizeLinearOp>();
+    target.addIllegalOp<
+        migraphx::AddOp, migraphx::ConstantOp, migraphx::ConvolutionOp,
+        migraphx::QuantConvolutionOp, migraphx::RsqrtOp, migraphx::ReluOp,
+        migraphx::TransposeOp, migraphx::BroadcastOp,
+        migraphx::MultiBroadcastOp, migraphx::ReshapeOp, migraphx::DotOp,
+        migraphx::PowOp, migraphx::RecipOp, migraphx::SoftmaxOp,
+        migraphx::ReduceMeanOp, migraphx::QuantizeLinearOp>();
 
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -23,7 +23,7 @@ module  {
   // CHECK: tosa.mul
   // CHECK: tosa.cast
   func.func @conv_with_quant(%arg1: tensor<1x3x224x224xi8>, %arg2: tensor<64x3x7x7xi8>, %scale: tensor<1x64x1x1xf32>, %bias: tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xi8> attributes {kernel = "mixr"} {
-    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xi8>, tensor<64x3x7x7xi8>) -> tensor<1x64x112x112xi32>
+    %1 = migraphx.quant_convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xi8>, tensor<64x3x7x7xi8>) -> tensor<1x64x112x112xi32>
     %2 = "migraphx.quantizelinear"(%1, %scale, %bias) : (tensor<1x64x112x112xi32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xi8>
     return %2 : tensor<1x64x112x112xi8>
 }

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1-int8.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1-int8.mlir
@@ -4,7 +4,7 @@
 
 module {
   func.func @test(%arg0: tensor<1x128x1x1xi32>, %arg1: tensor<1x128x56x56xi8>, %arg2: tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi32> {
-    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x128x56x56xi8>, tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi32>
+    %1 = migraphx.quant_convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x128x56x56xi8>, tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi32>
     %2 = migraphx.add(%1, %arg0) : (tensor<1x128x28x28xi32>, tensor<1x128x1x1xi32>) -> tensor<1x128x28x28xi32>
     return %2 : tensor<1x128x28x28xi32>
   }

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1-quantization.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1-quantization.mlir
@@ -4,7 +4,7 @@
 
 module {
   func.func @test(%arg0: tensor<1x128x1x1xf32>, %arg1: tensor<1x128x56x56xi8>, %arg2: tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi8> {
-    %1 = migraphx.convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x128x56x56xi8>, tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi32>
+    %1 = migraphx.quant_convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x128x56x56xi8>, tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi32>
     %2 = "migraphx.quantizelinear"(%1, %arg0) : (tensor<1x128x28x28xi32>, tensor<1x128x1x1xf32>) -> tensor<1x128x28x28xi8>
     return %2 : tensor<1x128x28x28xi8>
   }


### PR DESCRIPTION
In MIGraphX, a default op doesn't allow input and output type to be different. Therefore below is invalid MIGraphX IR:

```
%1 = migraphx.convolution(%arg1, %arg2) : (tensor<1x128x56x56xi8>, tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi32>
```

I created the QuantConvolution Op and make it consolidate with the original convolution Op. This allow our MIGraphX `quant_convolution` to be captured and lowered correctly in our end.