### PR TITLE
Phase 1 of making the tosa-partition pass into a generic utility.

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Transforms/OutlinerUtils.h
+++ b/external/llvm-project/mlir/include/mlir/Transforms/OutlinerUtils.h
@@ -1,0 +1,66 @@
+//===- OutlinerUtils.h ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Replace conv2d followed by elementwise op with call to function containing
+// them.  Generalised, outline any anchor op, all its trailing elementwise ops,
+// and all its leading elementwise ops.  (Where "elementwise" itself is
+// generalised to include transpose and reshape ops.)
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "mlir/Transforms/TopologicalSortUtils.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include <algorithm>
+#include <deque>
+#include <iostream>
+
+using llvm::SmallVector;
+
+namespace mlir {
+
+bool isConstantZero(Operation *op);
+
+////////////////////////////////////////////////////////////////////////////////
+
+class Outliner {
+public:
+  Outliner(function_ref<bool(Operation *)> isAnchorOp,
+           function_ref<bool(Operation *)> isLeadingOp,
+           function_ref<bool(Operation *)> isTrailingOp, StringRef outlineTag)
+      : isAnchorOp(isAnchorOp), isLeadingOp(isLeadingOp),
+        isTrailingOp(isTrailingOp), outlineTag(outlineTag) {}
+
+  void outline(ModuleOp module);
+
+private:
+  function_ref<bool(Operation *)> isAnchorOp;
+  function_ref<bool(Operation *)> isLeadingOp;
+  function_ref<bool(Operation *)> isTrailingOp;
+  StringRef outlineTag;
+  void traceInputs(Operation *op, Operation *ignoreOp,
+                   SetVector<Operation *> &predecessors,
+                   SetVector<Value> &inputNodes);
+};
+
+} // namespace mlir

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -27,8 +27,10 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/OutlinerUtils.h"
 #include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/RegionUtils.h"
+#include "mlir/Transforms/TopologicalSortUtils.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
@@ -52,22 +54,6 @@ using namespace mlir;
 using namespace mlir::tosa;
 
 namespace {
-
-class TosaPartitionPass
-    : public tosa::impl::TosaPartitionBase<TosaPartitionPass> {
-public:
-  using tosa::impl::TosaPartitionBase<TosaPartitionPass>::TosaPartitionBase;
-
-  bool isAnchorOp(Operation *op);
-  bool isTransposeOp(Operation *op) const;
-  bool isLeadingOp(Operation *op) const;
-  bool isTrailingOp(Operation *op) const;
-  StringRef partitionTag() const;
-  void traceInputs(Operation *op, Operation *ignoreOp,
-                   SetVector<Operation *> &predecessors,
-                   SetVector<Value> &inputNodes);
-  void runOnOperation() override;
-};
 
 // Tosa ops can broadcast values along axes, which allows for
 // element-wise operations without fully-matching dimensions.  The
@@ -120,525 +106,53 @@ bool isElementwiseOp(Operation *op) {
 
 bool isFuseableOp(Operation *op) { return isElementwiseOp(op); }
 
-bool isZeroAttribute(Attribute value) {
-  if (auto intValue = value.dyn_cast<IntegerAttr>())
-    return intValue.getValue().isNullValue();
-  if (auto fpValue = value.dyn_cast<FloatAttr>())
-    return fpValue.getValue().isZero();
-  if (auto splatValue = value.dyn_cast<SplatElementsAttr>())
-    return isZeroAttribute(splatValue.getSplatValue<Attribute>());
-  if (auto elementsValue = value.dyn_cast<ElementsAttr>())
-    return llvm::all_of(elementsValue.getValues<Attribute>(), isZeroAttribute);
-  if (auto arrayValue = value.dyn_cast<ArrayAttr>())
-    return llvm::all_of(arrayValue.getValue(), isZeroAttribute);
-  return false;
-}
-
-bool isConstantZero(Operation *op) {
-  // test for zero
-  // test for zero
-  if (auto cst = dyn_cast<arith::ConstantOp>(op))
-    return isZeroAttribute(cst.getValue());
-  else if (auto cst = dyn_cast<tosa::ConstOp>(op))
-    return isZeroAttribute(cst->getAttr("value"));
-  return false;
-}
-
-bool isSmallishConstant(Operation *op) {
-  if (op->hasTrait<OpTrait::ConstantLike>())
-    // In TOSA, should always be tensor and thus shaped, but just in case.
-    if (auto cstType = op->getResult(0).getType().dyn_cast<ShapedType>())
-      if (cstType.hasStaticShape() && cstType.getNumElements() <= 8)
-        return true;
-  return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-// Inspired by / adapted from outlineIfOp() in SCF/Transforms/Utils.cpp
-// and mergeIdenticalBlocks() in Utils/RegionUtils.cpp.
-
-struct OutliningCandidate {
-  OutliningCandidate(Operation *anchorOp_, ArrayRef<Operation *> &trailingOps_,
-                     ArrayRef<Operation *> &leadingOps_,
-                     ArrayRef<Value> &params_, ArrayRef<Value> &returnVals_,
-                     StringRef partFnName_);
-
-  unsigned addOp(Operation *op, unsigned orderIt);
-
-  Operation *anchorOp;
-  SmallVector<Operation *> trailingOps;
-  SmallVector<Operation *> leadingOps;
-  SmallVector<Value> params;
-  SmallVector<Value> returnVals;
-  std::string partFnName;
-  llvm::hash_code hash;
-  func::FuncOp function;
-
-  /// Return the order index for the given value that is within the block of
-  /// this data.
-  unsigned getOrderOf(Value value) const;
-
-  /// A map of result producing operations to their relative orders within this
-  /// block. The order of an operation is the number of defined values that are
-  /// produced within the block before this operation.
-  DenseMap<Operation *, unsigned> opOrderIndex;
-};
-
-unsigned OutliningCandidate::addOp(Operation *op, unsigned orderIt) {
-  if (unsigned numResults = op->getNumResults()) {
-    opOrderIndex.try_emplace(op, orderIt);
-    orderIt += numResults;
-  }
-
-  auto opHash = OperationEquivalence::computeHash(
-      op, OperationEquivalence::ignoreHashValue,
-      OperationEquivalence::ignoreHashValue,
-      OperationEquivalence::IgnoreLocations);
-  hash = llvm::hash_combine(hash, opHash);
-
-  return orderIt;
-}
-
-OutliningCandidate::OutliningCandidate(Operation *anchorOp_,
-                                       ArrayRef<Operation *> &trailingOps_,
-                                       ArrayRef<Operation *> &leadingOps_,
-                                       ArrayRef<Value> &params_,
-                                       ArrayRef<Value> &returnVals_,
-                                       StringRef partFnName_)
-    : anchorOp(anchorOp_), partFnName(partFnName_), hash(0), function(nullptr) {
-  // We'll need to grab the cloned ops to avoid use-after-free.
-  for (auto *op : trailingOps_) {
-    trailingOps.push_back(op);
-  }
-  for (auto *op : leadingOps_) {
-    leadingOps.push_back(op);
-  }
-  for (auto val : params_) {
-    params.push_back(val);
-  }
-  for (auto val : returnVals_) {
-    returnVals.push_back(val);
-  }
-
-  unsigned orderIt = params.size();
-  for (auto *op : leadingOps) {
-    orderIt = addOp(op, orderIt);
-  }
-  orderIt = addOp(anchorOp, orderIt);
-  for (auto *op : trailingOps) {
-    orderIt = addOp(op, orderIt);
-  }
-}
-
-unsigned OutliningCandidate::getOrderOf(Value value) const {
-  // Arguments use the argument number as the order index.
-  if (BlockArgument arg = value.dyn_cast<BlockArgument>())
-    return arg.getArgNumber();
-  for (unsigned i = 0; i < params.size(); i++) {
-    if (params[i] == value)
-      return i;
-  }
-
-  // Otherwise, the result order is offset from the parent op's order.
-  auto *definingOp = value.getDefiningOp();
-  if (definingOp) {
-    auto opOrderIt = opOrderIndex.find(definingOp);
-    // Candidate arguments will have a definingOp that won't be in opOrderIndex.
-    assert(opOrderIt != opOrderIndex.end() && "expected op to have an order");
-    return opOrderIt->second + value.cast<OpResult>().getResultNumber();
-  }
-
-  return 0;
-}
-
-bool opsMatch(Operation *lhs, Operation *rhs, OutliningCandidate &one,
-              OutliningCandidate &two) {
-  // Check that the operations are equivalent.
-  if (!OperationEquivalence::isEquivalentTo(
-          lhs, rhs, OperationEquivalence::ignoreValueEquivalence,
-          OperationEquivalence::ignoreValueEquivalence,
-          OperationEquivalence::Flags::IgnoreLocations))
-    return false;
-
-  // Compare the operands of the two operations. If the operand is within
-  // the block, it must refer to the same operation.
-  auto lhsOperands = lhs->getOperands(), rhsOperands = rhs->getOperands();
-  if (lhs->getNumOperands() != rhs->getNumOperands()) {
-    return false;
-  }
-  for (int operand : llvm::seq<int>(0, lhs->getNumOperands())) {
-    Value lhsOperand = lhsOperands[operand];
-    Value rhsOperand = rhsOperands[operand];
-    if (lhsOperand == rhsOperand)
-      continue;
-    // Check that the types of the operands match.
-    if (lhsOperand.getType() != rhsOperand.getType())
-      return false;
-
-    // Otherwise, these operands must have the same logical order within the
-    // parent block.
-    if (one.getOrderOf(lhsOperand) != two.getOrderOf(rhsOperand)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-bool outliningCandidatesEquivalent(OutliningCandidate &one,
-                                   OutliningCandidate &two) {
-  if (one.hash != two.hash) {
-    return false;
-  }
-
-  if (one.params.size() != two.params.size()) {
-    return false;
-  }
-  for (unsigned i = 0; i < one.params.size(); i++) {
-    if (one.params[i].getType() != two.params[i].getType()) {
-      return false;
-    }
-  }
-
-  for (auto ops : llvm::zip(one.leadingOps, two.leadingOps)) {
-    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
-      return false;
-    }
-  }
-  if (!opsMatch(one.anchorOp, two.anchorOp, one, two)) {
-    return false;
-  }
-  for (auto ops : llvm::zip(one.trailingOps, two.trailingOps)) {
-    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-OutliningCandidate *
-findOutliningCandidate(OutliningCandidate &newCandidate,
-                       std::vector<OutliningCandidate> &candidates) {
-  for (auto &candidate : candidates) {
-    if (outliningCandidatesEquivalent(candidate, newCandidate)) {
-      return &candidate;
-    }
-  }
-  return nullptr;
-}
-
-// Given a convolution op and its fuse-able trailing (second) and leading
-// (front) ops, remove them into a separate function.
-void outlinePartitionOps(Operation *anchorOp, ArrayRef<Operation *> trailingOps,
-                         ArrayRef<Operation *> leadingOps,
-                         ArrayRef<Value> params, ArrayRef<Value> returnVals,
-                         StringRef partFnName, StringRef attrName,
-                         std::vector<OutliningCandidate> &candidates) {
-  ValueRange values(params);
-  OpBuilder b(anchorOp);
-  Location loc = anchorOp->getLoc();
-  func::FuncOp outlinedFunc;
-
-  // ------------------------------------------------------------
-  // Merging part.
-
-  OutliningCandidate newCandidate(anchorOp, trailingOps, leadingOps, params,
-                                  returnVals, partFnName);
-
-  if (OutliningCandidate *found =
-          findOutliningCandidate(newCandidate, candidates)) {
-    // Matches one we already have.
-    outlinedFunc = found->function;
-  } else {
-    // ------------------------------------------------------------
-    // Construction part.
-
-    // Insert outlined function before current function.
-    OpBuilder::InsertionGuard g(b);
-    b.setInsertionPoint(anchorOp->getParentOfType<func::FuncOp>());
-
-    // Make FuncOp from anchorOp's operand types and trailingOp's result type.
-    MLIRContext *ctx = anchorOp->getContext();
-    ValueRange results(returnVals);
-    FunctionType type =
-        FunctionType::get(ctx, values.getTypes(), results.getTypes());
-    SmallVector<NamedAttribute, 1> kernelAttrs{
-        b.getNamedAttr(attrName, b.getUnitAttr()),
-    };
-    outlinedFunc = b.create<func::FuncOp>(
-        loc, partFnName, type, ArrayRef<NamedAttribute>(kernelAttrs));
-    outlinedFunc->setAttr("sym_visibility", StringAttr::get(ctx, "private"));
-    newCandidate.function = outlinedFunc;
-
-    // Add access modes for parameters: read-only, write-only, read-write
-    // All MemRef params are marked as 'read-write'
-    // Non-MemRef inputs are added as 'read-only'
-    auto readAccessAttr =
-        b.getNamedAttr(func::FuncOp::getReadAccessAttrName(), b.getUnitAttr());
-    auto writeAccessAttr =
-        b.getNamedAttr(func::FuncOp::getWriteAccessAttrName(), b.getUnitAttr());
-    for (auto pair : llvm::enumerate(values)) {
-      auto vtype = pair.value().getType();
-      if (vtype.isa<VectorType, RankedTensorType, UnrankedTensorType>())
-        outlinedFunc.setArgAttrs(pair.index(),
-                                 b.getDictionaryAttr({readAccessAttr}));
-      else if (vtype.isa<MemRefType>())
-        outlinedFunc.setArgAttrs(
-            pair.index(),
-            b.getDictionaryAttr({readAccessAttr, writeAccessAttr}));
-    }
-    // Non-MemRef results are added as 'write-only'
-    for (auto pair : llvm::enumerate(results)) {
-      auto vtype = pair.value().getType();
-      if (vtype.isa<VectorType, RankedTensorType, UnrankedTensorType>())
-        outlinedFunc.setResultAttrs(pair.index(),
-                                    b.getDictionaryAttr({writeAccessAttr}));
-      else if (vtype.isa<MemRefType>())
-        outlinedFunc.setResultAttrs(
-            pair.index(),
-            b.getDictionaryAttr({readAccessAttr, writeAccessAttr}));
-    }
-
-    // Clone leadingOps, anchorOp, and trailingOps into the body of the new
-    // function, while also updating the comparison details for future
-    // candidates.
-    b.setInsertionPointToStart(outlinedFunc.addEntryBlock());
-    IRMapping bvm;
-    for (auto it : llvm::zip(values, outlinedFunc.getArguments()))
-      bvm.map(std::get<0>(it), std::get<1>(it));
-
-    newCandidate.leadingOps.clear();
-    for (auto *op : llvm::reverse(leadingOps)) {
-      newCandidate.leadingOps.push_back(b.clone(*op, bvm));
-      newCandidate.opOrderIndex[newCandidate.leadingOps.back()] =
-          newCandidate.opOrderIndex[op];
-    }
-    std::reverse(newCandidate.leadingOps.begin(),
-                 newCandidate.leadingOps.end());
-
-    newCandidate.anchorOp = b.clone(*anchorOp, bvm);
-    newCandidate.opOrderIndex[newCandidate.anchorOp] =
-        newCandidate.opOrderIndex[anchorOp];
-
-    newCandidate.trailingOps.clear();
-    for (auto *op : trailingOps) {
-      // All operands should already be in bvm.
-      assert(llvm::all_of(op->getOperands(),
-                          [&](Value v) { return bvm.lookupOrNull(v); }));
-      newCandidate.trailingOps.push_back(b.clone(*op, bvm));
-      newCandidate.opOrderIndex[newCandidate.trailingOps.back()] =
-          newCandidate.opOrderIndex[op];
-    }
-
-    // Make ReturnOp from trailingOps' results.
-    SmallVector<Value> returnOperands;
-    for (auto op : returnVals) {
-      returnOperands.push_back(bvm.lookup(op));
-    }
-    // Can't also supply return types, because it'll see a mismatch
-    // in numbers where there isn't one.
-    b.create<func::ReturnOp>(loc, returnOperands);
-
-    candidates.push_back(newCandidate);
-  }
-
-  // ------------------------------------------------------------
-  // Replacement part.
-
-  // Replace anchorOp, trailingOps, and leadingOps with CallOp to new function.
-  Operation *lastOp = anchorOp;
-  if (!trailingOps.empty())
-    lastOp = trailingOps[trailingOps.size() - 1];
-  b.setInsertionPointAfter(lastOp);
-  func::CallOp callOp = b.create<func::CallOp>(loc, outlinedFunc, values);
-
-  for (auto it : llvm::zip(returnVals, callOp->getResults())) {
-    std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
-  }
-
-  // Erase the ops we outlined, which should be safe now.
-  for (auto &op : llvm::make_early_inc_range(llvm::reverse(trailingOps))) {
-    if (op->use_empty()) {
-      op->erase();
-    }
-  }
-  assert(anchorOp->use_empty() && "expected 'op' to have no uses");
-  anchorOp->erase();
-  for (auto &op : llvm::make_early_inc_range(leadingOps)) {
-    if (op->use_empty()) {
-      op->erase();
-    }
-  }
-}
-
-} // namespace
-
-bool TosaPartitionPass::isAnchorOp(Operation *op) {
+bool isAnchorOp(Operation *op, Pass::ListOption<std::string> &anchorOps) {
   if (anchorOps.empty()) // ListOption doesn't have a default value.
     anchorOps = {"tosa.conv2d", "tosa.matmul", "tosa.depthwise_conv2d",
                  "tosa.fully_connected"};
   return llvm::is_contained(anchorOps, op->getName().getIdentifier().str());
 }
 
-bool TosaPartitionPass::isTransposeOp(Operation *op) const {
+bool isTransposeOp(Operation *op) {
   return isa<tosa::TransposeOp, tosa::ReshapeOp>(op);
 }
 
-bool TosaPartitionPass::isLeadingOp(Operation *op) const {
-  return isConstantZero(op) || isSmallishConstant(op) || isTransposeOp(op) ||
-         (!trailingOnly && isFuseableOp(op));
+bool isTransposeConfigConstant(Operation *op) {
+  return op->hasTrait<OpTrait::ConstantLike>() &&
+         llvm::any_of(op->getUsers(), [&](Operation *u) {
+           return isTransposeOp(u) && u->getOperand(1) == op->getResult(0);
+         });
 }
 
-bool TosaPartitionPass::isTrailingOp(Operation *op) const {
+bool isAlwaysLeadingOp(Operation *op) {
+  return isConstantZero(op) || isTransposeOp(op) ||
+         isTransposeConfigConstant(op);
+}
+
+bool isLeadingOp(Operation *op, bool trailingOnly) {
+  return isAlwaysLeadingOp(op) || (!trailingOnly && isFuseableOp(op));
+}
+
+bool isTrailingOp(Operation *op) {
   return isTransposeOp(op) || isFuseableOp(op);
 }
 
-StringRef TosaPartitionPass::partitionTag() const { return partitionTagOpt; }
+class TosaPartitionPass
+    : public tosa::impl::TosaPartitionBase<TosaPartitionPass> {
+public:
+  using tosa::impl::TosaPartitionBase<TosaPartitionPass>::TosaPartitionBase;
 
-void TosaPartitionPass::traceInputs(Operation *op, Operation *ignoreOp,
-                                    SetVector<Operation *> &predecessors,
-                                    SetVector<Value> &inputNodes) {
-  for (const auto &opnd : op->getOperands()) {
-    Operation *usedOp = opnd.getDefiningOp();
-    if (usedOp != ignoreOp) {
-      if (usedOp && (isTransposeOp(op) ? isSmallishConstant(usedOp)
-                                       : isLeadingOp(usedOp))) {
-        if (predecessors.contains(
-                usedOp)) // If already present, move it for new use.
-          predecessors.remove(usedOp);
-        predecessors.insert(usedOp);
-        if (!usedOp->hasTrait<OpTrait::ConstantLike>()) {
-          // depth first
-          traceInputs(usedOp, op, predecessors, inputNodes);
-        }
-      } else if (!usedOp || !predecessors.contains(
-                                usedOp)) { // special-case consts aren't inputs
-        inputNodes.insert(opnd);
-      }
-    }
-  }
-}
+  void runOnOperation() override;
+};
 
-// Inspired by / adapted from TestSCFIfUtilsPass in
-// test/lib/Transforms/TestSCFUtils.cpp.
 void TosaPartitionPass::runOnOperation() {
   ModuleOp module = getOperation();
-  auto funcOps = module.getOps<func::FuncOp>();
-  for (auto func : llvm::make_early_inc_range(funcOps)) {
-    // Don't partition a kernel;  it may be already partitioned.
-    if (func->hasAttr(partitionTag()))
-      continue;
-
-    int count = 0;
-    // (Problems with node mismatches and unexpected uses if we have the
-    // candidates list at module level.)
-    std::vector<OutliningCandidate> candidates;
-    auto callback = [&](Operation *op) {
-      if (!isAnchorOp(op))
-        return false;
-      Operation *anchorOp = op;
-      auto strCount = std::string("__part_") + std::to_string(count++);
-
-      // Given a Conv2DOp (or other anchor op), gather all the
-      // element-wise ops that are reachable from its results,
-      // contiguously.
-      //
-      // The ops after the anchor are "trailing" ops.
-      //
-      // inputNodes gathers what will become the parameters of the
-      // outlined function;  initially it's the anchor's arguments,
-      // and it accumulates arguments to other ops that don't come
-      // from inside the outlined function.
-      //
-      // resultNodes will become the results of the outlined function.
-      // It starts with the anchor's result(s) and gains the results
-      // of each new trailingOp.  When all a resultNode's users can be
-      // determined to lie within the outlined function, it's removed
-      // from the set.
-      //
-      // These are SetVectors because we test with contains() a lot,
-      // but still want to preserve order.
-      SetVector<Operation *> trailingOps;
-      SetVector<Value> inputNodes;
-      SetVector<Value> resultNodes(anchorOp->getResults().begin(),
-                                   anchorOp->getResults().end());
-
-      // Grab a useful set of leading ops, like we do for trailing.
-      SetVector<Operation *> leadingOps;
-      traceInputs(anchorOp, anchorOp, leadingOps, inputNodes);
-
-      DominanceInfo domInfo(func);
-      std::deque<Operation *> worklist; // cuz I want to pull from the front.
-
-      worklist.push_back(anchorOp);
-      while (!worklist.empty()) {
-        Operation *op = worklist.front();
-        worklist.pop_front();
-        for (auto *userOp : op->getUsers()) {
-          if (isTrailingOp(userOp)) {
-            bool skip = false;
-            // First criterion is that the op is element-wise.  Second
-            // criterion is that the op dominates all the users of the
-            // accumulated results of the outlined function.  In other words,
-            // we can't take an op that comes "after" a user of the result
-            // from the eventual call, because the call needs to dominate all
-            // its users.
-            for (const Value &val : resultNodes) {
-              for (auto *user : val.getDefiningOp()->getUsers()) {
-                if (user != userOp &&
-                    !domInfo.properlyDominates(userOp, user)) {
-                  skip = true;
-                }
-              }
-            }
-
-            // userOp is acceptable.  Keep it as a trailingOp, put it on the
-            // worklist.  Add its operands to inputNodes unless they come
-            // from other trailingOps (indicated by being in resultNodes).
-            // If all the users of any resultNode are in trailingOps, there's
-            // no need to return it so remove from resultNodes.  Finally,
-            // add all userOp's results to resultNodes.
-            if (!skip) {
-              // Also accept small constant inputs to userOp.
-              traceInputs(userOp, op, leadingOps, inputNodes);
-              // General case.
-              trailingOps.insert(userOp);
-              worklist.push_back(userOp);
-              for (const Value &val : resultNodes)
-                if (llvm::all_of(val.getUsers(), [&](Operation *u) {
-                      return trailingOps.contains(u);
-                    }))
-                  resultNodes.remove(val);
-              for (auto res : userOp->getResults())
-                resultNodes.insert(res);
-            }
-          }
-        }
-      }
-
-      // Make the outlined function from the ops we've gathered.
-      outlinePartitionOps(anchorOp, trailingOps.getArrayRef(),
-                          leadingOps.getArrayRef(), inputNodes.getArrayRef(),
-                          resultNodes.getArrayRef(),
-                          std::string(func.getSymName()) + strCount,
-                          partitionTag(), candidates);
-      // Outlining will erase nodes and thus perturb the walk, so
-      // signal interrupted to exit it and restart.
-      return true;
-    };
-
-    // Walk until we've outlined all the anchor ops we can.
-    auto walkBackward = [&](Block &b) -> bool {
-      for (auto it = b.rbegin(); it != b.rend(); ++it) {
-        if (callback(&*it))
-          return true;
-      }
-      return false;
-    };
-    for (auto &block : func.getBody()) {
-      while (walkBackward(block)) {
-      }
-    }
-  }
+  auto anchorPred = [&](Operation *op) { return isAnchorOp(op, anchorOps); };
+  auto leadingPred = [&](Operation *op) {
+    return isLeadingOp(op, trailingOnly);
+  };
+  Outliner p(anchorPred, leadingPred, isTrailingOp, partitionTagOpt);
+  p.outline(module);
 }
+
+} // namespace

--- a/external/llvm-project/mlir/lib/Transforms/Utils/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Transforms/Utils/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_library(MLIRTransformUtils
   GreedyPatternRewriteDriver.cpp
   InliningUtils.cpp
   LoopInvariantCodeMotionUtils.cpp
+  OutlinerUtils.cpp
   RegionUtils.cpp
   TopologicalSortUtils.cpp
 
@@ -17,4 +18,5 @@ add_mlir_library(MLIRTransformUtils
   MLIRLoopLikeInterface
   MLIRSideEffectInterfaces
   MLIRRewrite
+  MLIRFuncDialect
   )

--- a/external/llvm-project/mlir/lib/Transforms/Utils/OutlinerUtils.cpp
+++ b/external/llvm-project/mlir/lib/Transforms/Utils/OutlinerUtils.cpp
@@ -1,0 +1,501 @@
+//===- OutlinerUtils.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Replace conv2d followed by elementwise op with call to function containing
+// them.  Generalised, outline any anchor op, all its trailing elementwise ops,
+// and all its leading elementwise ops.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Transforms/OutlinerUtils.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "mlir/Transforms/TopologicalSortUtils.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include <algorithm>
+#include <deque>
+#include <iostream>
+
+using llvm::SmallVector;
+using namespace mlir;
+
+static bool isZeroAttribute(Attribute value) {
+  if (auto intValue = value.dyn_cast<IntegerAttr>())
+    return intValue.getValue().isNullValue();
+  if (auto fpValue = value.dyn_cast<FloatAttr>())
+    return fpValue.getValue().isZero();
+  if (auto splatValue = value.dyn_cast<SplatElementsAttr>())
+    return isZeroAttribute(splatValue.getSplatValue<Attribute>());
+  if (auto elementsValue = value.dyn_cast<ElementsAttr>())
+    return llvm::all_of(elementsValue.getValues<Attribute>(), isZeroAttribute);
+  if (auto arrayValue = value.dyn_cast<ArrayAttr>())
+    return llvm::all_of(arrayValue.getValue(), isZeroAttribute);
+  return false;
+}
+
+bool mlir::isConstantZero(Operation *op) {
+  // Cheating, by assuming that constants will have "value" attribute.
+  if (op->hasTrait<OpTrait::ConstantLike>() && op->hasAttr("value"))
+    return isZeroAttribute(op->getAttr("value"));
+  return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Inspired by / adapted from outlineIfOp() in SCF/Transforms/Utils.cpp
+// and mergeIdenticalBlocks() in Utils/RegionUtils.cpp.
+
+struct OutliningCandidate {
+  OutliningCandidate(Operation *anchorOp, ArrayRef<Operation *> &trailingOps,
+                     ArrayRef<Operation *> &leadingOps, ArrayRef<Value> &params,
+                     ArrayRef<Value> &returnVals, StringRef partFnName);
+
+  unsigned addOp(Operation *op, unsigned orderIt);
+
+  Operation *anchorOp;
+  SmallVector<Operation *> trailingOps;
+  SmallVector<Operation *> leadingOps;
+  SmallVector<Type> params;
+  SmallVector<Value> returnVals;
+  std::string partFnName;
+  llvm::hash_code hash;
+  func::FuncOp function;
+
+  /// Return the order index for the given value that is within the block of
+  /// this data.
+  unsigned getOrderOf(Value value) const;
+
+  /// A map of result producing operations to their relative orders within this
+  /// block. The order of an operation is the number of defined values that are
+  /// produced within the block before this operation.
+  DenseMap<Operation *, unsigned> opOrderIndex;
+};
+
+unsigned OutliningCandidate::addOp(Operation *op, unsigned orderIt) {
+  if (unsigned numResults = op->getNumResults()) {
+    opOrderIndex.try_emplace(op, orderIt);
+    orderIt += numResults;
+  }
+
+  auto opHash = OperationEquivalence::computeHash(
+      op, OperationEquivalence::ignoreHashValue,
+      OperationEquivalence::ignoreHashValue,
+      OperationEquivalence::IgnoreLocations);
+  hash = llvm::hash_combine(hash, opHash);
+
+  return orderIt;
+}
+
+OutliningCandidate::OutliningCandidate(Operation *anchorOp_,
+                                       ArrayRef<Operation *> &trailingOps_,
+                                       ArrayRef<Operation *> &leadingOps_,
+                                       ArrayRef<Value> &params_,
+                                       ArrayRef<Value> &returnVals_,
+                                       StringRef partFnName_)
+    : anchorOp(anchorOp_), trailingOps(trailingOps_), leadingOps(leadingOps_),
+      returnVals(returnVals_), partFnName(partFnName_), hash(0),
+      function(nullptr) {
+  for (auto val : params_) {
+    params.push_back(val.getType());
+  }
+  unsigned orderIt = params.size();
+  for (auto *op : leadingOps) {
+    orderIt = addOp(op, orderIt);
+  }
+  orderIt = addOp(anchorOp, orderIt);
+  for (auto *op : trailingOps) {
+    orderIt = addOp(op, orderIt);
+  }
+}
+
+unsigned OutliningCandidate::getOrderOf(Value value) const {
+  // Otherwise, the result order is offset from the parent op's order.
+  auto *definingOp = value.getDefiningOp();
+  if (definingOp) {
+    auto opOrderIt = opOrderIndex.find(definingOp);
+    // Candidate arguments will have a definingOp that won't be in opOrderIndex.
+    if (opOrderIt != opOrderIndex.end())
+      return opOrderIt->second + value.cast<OpResult>().getResultNumber();
+
+    for (unsigned i = 0; i < params.size(); i++) {
+      if (params[i] == value.getType())
+        return i;
+    }
+  }
+
+  return 0;
+}
+
+static bool opsMatch(Operation *lhs, Operation *rhs, OutliningCandidate &one,
+                     OutliningCandidate &two) {
+  // Check that the operations are equivalent.
+  if (!OperationEquivalence::isEquivalentTo(
+          lhs, rhs, OperationEquivalence::ignoreValueEquivalence,
+          OperationEquivalence::ignoreValueEquivalence,
+          OperationEquivalence::Flags::IgnoreLocations))
+    return false;
+
+  // Compare the operands of the two operations. If the operand is within
+  // the block, it must refer to the same operation.
+  auto lhsOperands = lhs->getOperands(), rhsOperands = rhs->getOperands();
+  if (lhs->getNumOperands() != rhs->getNumOperands()) {
+    return false;
+  }
+  for (auto opnds : llvm::zip(lhsOperands, rhsOperands)) {
+    Value lhsOperand = std::get<0>(opnds);
+    Value rhsOperand = std::get<1>(opnds);
+    if (lhsOperand == rhsOperand)
+      continue;
+    // Check that the types of the operands match.
+    if (lhsOperand.getType() != rhsOperand.getType())
+      return false;
+
+    // Otherwise, these operands must have the same logical order within the
+    // parent block.
+    if (one.getOrderOf(lhsOperand) != two.getOrderOf(rhsOperand)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool outliningCandidatesEquivalent(OutliningCandidate &one,
+                                          OutliningCandidate &two) {
+  if (one.hash != two.hash) {
+    return false;
+  }
+
+  if (one.params.size() != two.params.size()) {
+    return false;
+  }
+  for (auto params : llvm::zip(one.params, two.params)) {
+    if (std::get<0>(params) != std::get<1>(params)) {
+      return false;
+    }
+  }
+
+  for (auto ops : llvm::zip(one.leadingOps, two.leadingOps)) {
+    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
+      return false;
+    }
+  }
+  if (!opsMatch(one.anchorOp, two.anchorOp, one, two)) {
+    return false;
+  }
+  for (auto ops : llvm::zip(one.trailingOps, two.trailingOps)) {
+    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static OutliningCandidate *
+findOutliningCandidate(OutliningCandidate &newCandidate,
+                       std::vector<OutliningCandidate> &candidates) {
+  for (auto &candidate : candidates) {
+    if (outliningCandidatesEquivalent(candidate, newCandidate)) {
+      return &candidate;
+    }
+  }
+  return nullptr;
+}
+
+// Given an op and its fuse-able trailing (second) and leading
+// (front) ops, remove them into a separate function.
+static void outlineOps(Operation *anchorOp, ArrayRef<Operation *> trailingOps,
+                       ArrayRef<Operation *> leadingOps, ArrayRef<Value> params,
+                       ArrayRef<Value> returnVals, StringRef partFnName,
+                       StringRef attrName,
+                       std::vector<OutliningCandidate> &candidates) {
+  ValueRange values(params);
+  OpBuilder b(anchorOp);
+  Location loc = anchorOp->getLoc();
+  func::FuncOp outlinedFunc;
+
+  // ------------------------------------------------------------
+  // Merging part.
+
+  OutliningCandidate newCandidate(anchorOp, trailingOps, leadingOps, params,
+                                  returnVals, partFnName);
+
+  if (OutliningCandidate *found =
+          findOutliningCandidate(newCandidate, candidates)) {
+    // Matches one we already have.
+    outlinedFunc = found->function;
+  } else {
+    // ------------------------------------------------------------
+    // Construction part.
+
+    // Insert outlined function before current function.
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(anchorOp->getParentOfType<func::FuncOp>());
+
+    // Make FuncOp from anchorOp's operand types and trailingOp's result type.
+    MLIRContext *ctx = anchorOp->getContext();
+    ValueRange results(returnVals);
+    FunctionType type =
+        FunctionType::get(ctx, values.getTypes(), results.getTypes());
+    SmallVector<NamedAttribute, 1> kernelAttrs{
+        b.getNamedAttr(attrName, b.getUnitAttr()),
+    };
+    outlinedFunc = b.create<func::FuncOp>(
+        loc, partFnName, type, ArrayRef<NamedAttribute>(kernelAttrs));
+    outlinedFunc->setAttr("sym_visibility", StringAttr::get(ctx, "private"));
+    newCandidate.function = outlinedFunc;
+
+    // Add access modes for parameters: read-only, write-only, read-write
+    // All MemRef params are marked as 'read-write'
+    // Non-MemRef inputs are added as 'read-only'
+    auto readAccessAttr =
+        b.getNamedAttr(func::FuncOp::getReadAccessAttrName(), b.getUnitAttr());
+    auto writeAccessAttr =
+        b.getNamedAttr(func::FuncOp::getWriteAccessAttrName(), b.getUnitAttr());
+    for (auto pair : llvm::enumerate(values)) {
+      auto vtype = pair.value().getType();
+      if (vtype.isa<VectorType, RankedTensorType, UnrankedTensorType>())
+        outlinedFunc.setArgAttrs(pair.index(),
+                                 b.getDictionaryAttr({readAccessAttr}));
+      else if (vtype.isa<MemRefType>())
+        outlinedFunc.setArgAttrs(
+            pair.index(),
+            b.getDictionaryAttr({readAccessAttr, writeAccessAttr}));
+    }
+    // Non-MemRef results are added as 'write-only'
+    for (auto pair : llvm::enumerate(results)) {
+      auto vtype = pair.value().getType();
+      if (vtype.isa<VectorType, RankedTensorType, UnrankedTensorType>())
+        outlinedFunc.setResultAttrs(pair.index(),
+                                    b.getDictionaryAttr({writeAccessAttr}));
+      else if (vtype.isa<MemRefType>())
+        outlinedFunc.setResultAttrs(
+            pair.index(),
+            b.getDictionaryAttr({readAccessAttr, writeAccessAttr}));
+    }
+
+    // Clone leadingOps, anchorOp, and trailingOps into the body of the new
+    // function, while also updating the comparison details for future
+    // candidates.
+    b.setInsertionPointToStart(outlinedFunc.addEntryBlock());
+    IRMapping bvm;
+    for (auto it : llvm::zip(values, outlinedFunc.getArguments()))
+      bvm.map(std::get<0>(it), std::get<1>(it));
+
+    newCandidate.leadingOps.clear();
+    for (auto *op : llvm::reverse(leadingOps)) {
+      newCandidate.leadingOps.push_back(b.clone(*op, bvm));
+      newCandidate.opOrderIndex[newCandidate.leadingOps.back()] =
+          newCandidate.opOrderIndex[op];
+    }
+    std::reverse(newCandidate.leadingOps.begin(),
+                 newCandidate.leadingOps.end());
+
+    newCandidate.anchorOp = b.clone(*anchorOp, bvm);
+    newCandidate.opOrderIndex[newCandidate.anchorOp] =
+        newCandidate.opOrderIndex[anchorOp];
+
+    newCandidate.trailingOps.clear();
+    for (auto *op : trailingOps) {
+      // All operands should already be in bvm.
+      assert(llvm::all_of(op->getOperands(),
+                          [&](Value v) { return bvm.lookupOrNull(v); }));
+      newCandidate.trailingOps.push_back(b.clone(*op, bvm));
+      newCandidate.opOrderIndex[newCandidate.trailingOps.back()] =
+          newCandidate.opOrderIndex[op];
+    }
+
+    // Make ReturnOp from trailingOps' results.
+    SmallVector<Value> returnOperands;
+    for (auto op : returnVals) {
+      returnOperands.push_back(bvm.lookup(op));
+    }
+    // Can't also supply return types, because it'll see a mismatch
+    // in numbers where there isn't one.
+    b.create<func::ReturnOp>(loc, returnOperands);
+
+    candidates.push_back(newCandidate);
+  }
+
+  // ------------------------------------------------------------
+  // Replacement part.
+
+  // Replace anchorOp, trailingOps, and leadingOps with CallOp to new function.
+  Operation *lastOp = anchorOp;
+  if (!trailingOps.empty())
+    lastOp = trailingOps[trailingOps.size() - 1];
+  b.setInsertionPointAfter(lastOp);
+  func::CallOp callOp = b.create<func::CallOp>(loc, outlinedFunc, values);
+
+  for (auto it : llvm::zip(returnVals, callOp->getResults())) {
+    std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
+  }
+
+  // Erase the ops we outlined, which should be safe now.
+  for (auto &op : llvm::make_early_inc_range(llvm::reverse(trailingOps))) {
+    if (op->use_empty()) {
+      op->erase();
+    }
+  }
+  assert(anchorOp->use_empty() && "expected 'op' to have no uses");
+  anchorOp->erase();
+  for (auto &op : llvm::make_early_inc_range(leadingOps)) {
+    if (op->use_empty()) {
+      op->erase();
+    }
+  }
+}
+
+void Outliner::traceInputs(Operation *op, Operation *ignoreOp,
+                           SetVector<Operation *> &predecessors,
+                           SetVector<Value> &inputNodes) {
+  for (const auto &opnd : op->getOperands()) {
+    Operation *usedOp = opnd.getDefiningOp();
+    if (usedOp == ignoreOp)
+      continue;
+    if (usedOp && isLeadingOp(usedOp)) {
+      if (predecessors.contains(
+              usedOp)) // If already present, move it for new use.
+        predecessors.remove(usedOp);
+      predecessors.insert(usedOp);
+      if (!usedOp->hasTrait<OpTrait::ConstantLike>()) {
+        // depth first
+        traceInputs(usedOp, op, predecessors, inputNodes);
+      }
+    } else if (!predecessors.contains(
+                   usedOp)) { // special-case consts aren't inputs
+      inputNodes.insert(opnd);
+    }
+  }
+}
+
+// Inspired by / adapted from TestSCFIfUtilsPass in
+// test/lib/Transforms/TestSCFUtils.cpp.
+void Outliner::outline(ModuleOp module) {
+  auto funcOps = module.getOps<func::FuncOp>();
+  for (auto func : llvm::make_early_inc_range(funcOps)) {
+    // Don't outline a kernel;  it may already have been outlined.
+    if (func->hasAttr(outlineTag))
+      continue;
+
+    std::vector<Operation *> anchors;
+    auto callback = [&](Operation *op) {
+      if (isAnchorOp(op))
+        anchors.push_back(op);
+    };
+    // Gather the anchor ops so we can process them back-to-front.
+    func.walk(callback);
+
+    int count = 0;
+    // (Problems with node mismatches and unexpected uses if we have the
+    // candidates list at module level.)
+    std::vector<OutliningCandidate> candidates;
+    for (auto &anchorOp : llvm::make_early_inc_range(llvm::reverse(anchors))) {
+      auto strCount = std::string("__part_") + std::to_string(count++);
+
+      // Given a Conv2DOp (or other anchor op), gather all the
+      // element-wise ops that are reachable from its results,
+      // contiguously.
+      //
+      // The ops after the anchor are "trailing" ops.
+      //
+      // inputNodes gathers what will become the parameters of the
+      // outlined function;  initially it's the anchor's arguments,
+      // and it accumulates arguments to other ops that don't come
+      // from inside the outlined function.
+      //
+      // resultNodes will become the results of the outlined function.
+      // It starts with the anchor's result(s) and gains the results
+      // of each new trailingOp.  When all a resultNode's users can be
+      // determined to lie within the outlined function, it's removed
+      // from the set.
+      //
+      // These are SetVectors because we test with contains() a lot,
+      // but still want to preserve order.
+      SetVector<Operation *> trailingOps;
+      SetVector<Value> inputNodes;
+      SetVector<Value> resultNodes(anchorOp->getResults().begin(),
+                                   anchorOp->getResults().end());
+
+      // Grab a useful set of leading ops, like we do for trailing.
+      SetVector<Operation *> leadingOps;
+      traceInputs(anchorOp, anchorOp, leadingOps, inputNodes);
+
+      DominanceInfo domInfo(func);
+      std::deque<Operation *> worklist; // cuz I want to pull from the front.
+
+      worklist.push_back(anchorOp);
+      while (!worklist.empty()) {
+        Operation *op = worklist.front();
+        worklist.pop_front();
+        for (auto *userOp : op->getUsers()) {
+          if (isTrailingOp(userOp)) {
+            bool skip = false;
+            // First criterion is that the op is element-wise.  Second
+            // criterion is that the op dominates all the users of the
+            // accumulated results of the outlined function.  In other words,
+            // we can't take an op that comes "after" a user of the result
+            // from the eventual call, because the call needs to dominate all
+            // its users.
+            for (const Value &val : resultNodes) {
+              for (auto *user : val.getDefiningOp()->getUsers()) {
+                if (user != userOp &&
+                    !domInfo.properlyDominates(userOp, user)) {
+                  skip = true;
+                }
+              }
+            }
+
+            // userOp is acceptable.  Keep it as a trailingOp, put it on
+            // the worklist.  Add its operands to inputNodes unless
+            // they're suitable as leading ops or come from other
+            // trailingOps (indicated by being in resultNodes).  If all
+            // the users of any resultNode are in trailingOps, there's
+            // no need to return it so remove from resultNodes.
+            // Finally, add all userOp's results to resultNodes.
+            if (!skip) {
+              // Also accept inputs to userOp.
+              // Put traced ops in leadingOps so they're always ahead of op.
+              traceInputs(userOp, op, leadingOps, inputNodes);
+              // General case.
+              trailingOps.insert(userOp);
+              worklist.push_back(userOp);
+              for (const Value &val : resultNodes)
+                if (llvm::all_of(val.getUsers(), [&](Operation *u) {
+                      return trailingOps.contains(u);
+                    }))
+                  resultNodes.remove(val);
+              for (auto res : userOp->getResults())
+                resultNodes.insert(res);
+            }
+          }
+        }
+      }
+
+      // Make the outlined function from the ops we've gathered.
+      outlineOps(anchorOp, trailingOps.getArrayRef(), leadingOps.getArrayRef(),
+                 inputNodes.getArrayRef(), resultNodes.getArrayRef(),
+                 std::string(func.getSymName()) + strCount, outlineTag,
+                 candidates);
+    }
+  }
+}

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-options.mlir
@@ -10,11 +10,11 @@
 // RUN: mlir-opt --test-tosa-partition-options=attr-one %s | FileCheck %s --check-prefix=ONE
 // RUN: mlir-opt --test-tosa-partition-options=nofront-arg %s | FileCheck %s --check-prefix=THREE
 
-// CHECK: func private @test_fusion8__part_0
+// CHECK-LABEL: func private @test_fusion8__part_0
 // CHECK-NEXT: tosa.conv2d
 // CHECK-NEXT: tosa.add
 // CHECK-NEXT: return
-// CHECK-LABEL: func private @test_fusion8__part_1
+// CHECK: func private @test_fusion8__part_1
 // CHECK-SAME: attributes {{{.*}}kernel}
 // CHECK-NEXT: arith.constant
 // CHECK-NEXT: tosa.transpose

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
@@ -1,28 +1,21 @@
-// RUN: mlir-opt --tosa-partition %s | FileCheck %s
+// RUN: mlir-opt --tosa-partition='trailing-only=false' %s | FileCheck %s
 // CHECK-LABEL: func private @forward__part_0
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
-// CHECK-NEXT: tosa.transpose
+// CHECK: tosa.transpose
+// CHECK: tosa.transpose
 // CHECK-NEXT: tosa.conv2d
 // CHECK-NEXT: tosa.transpose
 // CHECK: return
 // CHECK-LABEL: func private @forward__part_1
-// CHECK-NEXT: tosa.reshape
-// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.conv2d
-// CHECK-NEXT: tosa.transpose
-// CHECK-NEXT: tosa.sub
-// CHECK-NEXT: tosa.mul
-// CHECK-NEXT: tosa.mul
-// CHECK-NEXT: tosa.add
-// CHECK-NEXT: tosa.clamp
-// CHECK-NEXT: return
+// CHECK: return
 
 module attributes {torch.debug_module_name = "ResNet"} {
   func.func @forward(%arg0: tensor<1x64x56x56xf32>) -> tensor<1x64x56x56xf32> {

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt --split-input-file --tosa-partition %s -verify-each=0 -o - | FileCheck %s
+// RUN: mlir-opt --split-input-file --tosa-partition='trailing-only=false' %s -verify-each=0 -o - | FileCheck %s
 
 // CHECK-LABEL: func private @test_fusion__part_0
 // CHECK: tosa.conv2d
@@ -57,12 +57,12 @@ func.func @test_fusion4(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3x
 
 
 // CHECK-LABEL: func private @test_fusion5__part_0
+// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: tosa.conv2d
 // CHECK-NEXT: tosa.add
 // CHECK-NEXT: return
 // CHECK: func private @test_fusion5__part_1
 // CHECK-NEXT: tosa.conv2d
-// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: return
 // CHECK: func @test_fusion5
 // CHECK-NEXT: call @test_fusion5__part_1
@@ -88,10 +88,10 @@ func.func @test_fusion6(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3x
 }
 
 // CHECK-LABEL: func private @test_fusion7__part_0
+// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: tosa.conv2d
 // CHECK-NEXT: return
 // CHECK: func @test_fusion7
-// CHECK-NEXT: tosa.abs
 // CHECK-NEXT: call @test_fusion7__part_0
 // CHECK-NEXT: return
 func.func @test_fusion7(%arg0: tensor<128x8x32x32xf32>, %arg1: tensor<128x8x3x3xf32>, %arg2: tensor<8xf32>) -> tensor<128x128x30x30xf32> {

--- a/mlir/test/xmir/mobilenetv1.mid.mlir
+++ b/mlir/test/xmir/mobilenetv1.mid.mlir
@@ -1,14 +1,10 @@
 // RUN: rocmlir-driver -host-pipeline partition,highlevel -targets gfx908 %s | FileCheck %s
 
 module {
-
-// CHECK:  func.func private @mobilenetv1__part_4(%arg0: memref<1x224x224x3xf32> {func.read_access}, %arg1: memref<32x3x3x3xf32> {func.read_access}, %arg2: memref<1x112x112x32xf32> {func.write_access}) {
-
-// CHECK: func.func @mobilenetv1(%arg0: memref<1x224x224x3xf32>, %arg1: memref<32x3x3x3xf32>, %arg2: memref<3x3x32x1xf32>, %arg3: memref<64x1x1x32xf32>, %arg4: memref<3x3x64x1xf32>, %arg5: memref<128x1x1x64xf32>, %arg6: memref<1x56x56x128xf32>) {
-// CHECK:   %[[TOKEN0:.*]] = async.launch @mobilenetv1__part_4 (%arg0, %arg1, %{{.*}}) : (memref<1x224x224x3xf32>, memref<32x3x3x3xf32>, memref<1x112x112x32xf32>)
-
-// CHECK-DIS:   %[[TOKEN1:.*]] = async.launch @mobilenetv1__part_3 (%{{.*}}, %arg2, %{{.*}}) : (memref<1x112x112x32xf32>, memref<3x3x32x1xf32>, memref<12544x32xf32>)
-
+// CHECK:  func.func private @mobilenetv1__part_1(%arg0: memref<1x112x112x64xf32> {func.read_access}, %arg1: memref<3x3x64x1xf32> {func.read_access}, %arg2: memref<1x56x56x64xf32> {func.write_access}) {
+// CHECK:  func.func @mobilenetv1(%arg0: memref<1x224x224x3xf32>, %arg1: memref<32x3x3x3xf32>, %arg2: memref<3x3x32x1xf32>, %arg3: memref<64x1x1x32xf32>, %arg4: memref<3x3x64x1xf32>, %arg5: memref<128x1x1x64xf32>, %arg6: memref<1x56x56x128xf32>) {
+// CHECK:  %[[TOKEN0:.*]] = async.launch @mobilenetv1__part_4 (%arg0, %arg1, %{{.*}}) : (memref<1x224x224x3xf32>, memref<32x3x3x3xf32>, memref<1x112x112x32xf32>)
+// CHECK-DIS:   %[[TOKEN1:.*]] = async.launch @mobilenetv1__part_3 %[[TOKEN0:.*]] (%{{.*}}, %arg2, %{{.*}}) : (memref<1x112x112x32xf32>, memref<3x3x32x1xf32>, memref<1x112x112x32xf32>)
 // CHECK:   async.await %token_{{.*}} : !async.token
 
   func.func @mobilenetv1(%input_image: tensor<1x224x224x3xf32>, %f0: tensor<32x3x3x3xf32>, %f1: tensor<3x3x32x1xf32>, %f2: tensor<64x1x1x32xf32>, %f3: tensor<3x3x64x1xf32>, %f4: tensor<128x1x1x64xf32>) -> tensor<1x56x56x128xf32> {

--- a/mlir/test/xmir/mobilenetv1.small.mlir
+++ b/mlir/test/xmir/mobilenetv1.small.mlir
@@ -7,7 +7,7 @@ module {
 // CHECK:  func.func @mobilenetv1(%arg0: tensor<1x112x112x32xf32>, %arg1: tensor<32x3x3x3xf32>, %arg2: tensor<3x3x32x1xf32>, %arg3: tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32> {
 // CHECK:    %[[T0:.*]], %[[RES0:.*]] = async.launch @mobilenetv1__part_1 (%arg0, %arg2) : (tensor<1x112x112x32xf32>, tensor<3x3x32x1xf32>) -> tensor<1x112x112x32xf32>
 // CHECK:    %[[T1:.*]], %[[RES1:.*]] = async.launch @mobilenetv1__part_0
-// CHECK-SAME:[%[[T0]]] 
+// CHECK-SAME:[%[[T0]]]
 // CHECK-SAME:(%[[RES0]]
 // CHECK-SAME: %arg3) : (tensor<1x112x112x32xf32>, tensor<64x1x1x32xf32>) -> tensor<1x112x112x64xf32>
 

--- a/mlir/test/xmir/resnet50_blk.async.mlir
+++ b/mlir/test/xmir/resnet50_blk.async.mlir
@@ -24,4 +24,3 @@ module {
     return %4 : tensor<1x32x32x64xf32>
   }
 }
-

--- a/mlir/test/xmir/resnet50_blk.bin.mlir
+++ b/mlir/test/xmir/resnet50_blk.bin.mlir
@@ -21,4 +21,3 @@ module {
     return %4 : tensor<1x32x32x64xf32>
   }
 }
-


### PR DESCRIPTION
Simplify isConstantZero() and make it more general.

Restructure partition walk to collect anchors then process them back-to-front, and drop transpose special case.

Update rocmlir tests that are perturbed by the partitioning rearrangement.

Rearranged the code to make a stub TosaPartitionPass with all the action in a tosa-free Partition class.  Adjusted one test for different behavior with tosa::transpose.

This is a state that incorporates most of Simon's pull request, but not the traceInputs() change to the partitioner.  It does pass all the Dialect/Tosa tests. In sum:  generic partitioning, Tosa implementation, some of Simon's changes.

Tweak traceInputs() and use it on trailing-op operands like Simon does, and some cleanup.

First cut at separating the partitioner into a separate utility, used by tosa-partition.

IS NOT:  partition passes for dialects other than Tosa;  terminating ops as a special class (they can still be addressed in the trailing-op predicate).