### PR TITLE
Add a feature for the presence of the gfx940 MFMAs

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -290,11 +290,14 @@ def Rock_GemmFeatures_Mfma : I32BitEnumAttrCaseBit<"mfma", 0>;
 def Rock_GemmFeatures_Dot : I32BitEnumAttrCaseBit<"dot", 1>;
 def Rock_GemmFeatures_AtomicAdd : I32BitEnumAttrCaseBit<"atomic_add", 2>;
 def Rock_GemmFeatures_AtomicFmaxF32 : I32BitEnumAttrCaseBit<"atomic_fmax_f32", 4>;
+// Has the MFMA intrinsics introduced on Gfx940
+def Rock_GemmFeatures_Gfx940Mfma : I32BitEnumAttrCaseBit<"gfx940_mfma", 5>;
 
 def Rock_GemmFeatures : I32BitEnumAttr<"GemmFeatures",
     "Features that can be enabled on GEMM-based operations",
     [Rock_GemmFeatures_None, Rock_GemmFeatures_Mfma,
-     Rock_GemmFeatures_Dot, Rock_GemmFeatures_AtomicAdd, Rock_GemmFeatures_AtomicFmaxF32]> {
+     Rock_GemmFeatures_Dot, Rock_GemmFeatures_AtomicAdd, Rock_GemmFeatures_AtomicFmaxF32,
+     Rock_GemmFeatures_Gfx940Mfma]> {
   let cppNamespace = "::mlir::rock";
   let genSpecializedAttr = 0;
 }

--- a/mlir/lib/Dialect/Rock/Generator/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/AmdArchDb.cpp
@@ -18,6 +18,8 @@ using namespace mlir::rock;
 static constexpr AmdArchInfo gcnInfo(GemmFeatures::none, /*waveSize=*/64),
     cdnaInfo(GemmFeatures::mfma | GemmFeatures::dot | GemmFeatures::atomic_add,
              /*waveSize=*/64),
+    cdna3Info(cdnaInfo.defaultFeatures | GemmFeatures::gfx940_mfma,
+              /*waveSize=*/64),
     rdnaNoDotInfo(GemmFeatures::atomic_fmax_f32, /*waveSize=*/32),
     rdnaInfo(GemmFeatures::dot | GemmFeatures::atomic_fmax_f32,
              /*waveSize=*/32),
@@ -39,7 +41,8 @@ AmdArchInfo mlir::rock::lookupArchInfo(StringRef arch) {
   StringRef major = chip.slice(0, chip.size() - 2);
   if (major == "gfx9") {
     return llvm::StringSwitch<AmdArchInfo>(minor)
-        .Cases("08", "0a", "40", cdnaInfo)
+        .Cases("08", "0a", cdnaInfo)
+        .Case("40", cdna3Info)
         // gfx906 has the dot product instructions, uniquely
         .Case("06", AmdArchInfo(GemmFeatures::dot, /*waveSize=*/64))
         .Default(gcnInfo);

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -323,6 +323,16 @@ static llvm::cl::opt<FeatureToggle> atomicFMaxF32Feature(
                                 "remove atomic_add from the feature list")),
     llvm::cl::init(FeatureToggle::infer));
 
+static llvm::cl::opt<FeatureToggle> gfx940MfmaFeature(
+    "gfx940_mfma", llvm::cl::desc("toggle gfx940_mfma feature"),
+    llvm::cl::values(clEnumValN(FeatureToggle::infer, "infer",
+                                "use the default value provided by the chip"),
+                     clEnumValN(FeatureToggle::on, "on",
+                                "force gfx940_mfma into the feature list"),
+                     clEnumValN(FeatureToggle::off, "off",
+                                "remove gfx940_mfma from the feature list")),
+    llvm::cl::init(FeatureToggle::infer));
+
 // data type
 static llvm::cl::opt<std::string>
     tensorDataType("t", llvm::cl::desc("Data type for convolution"),
@@ -2812,6 +2822,10 @@ int main(int argc, char **argv) {
         enabledFeatures =
             bitEnumSet(enabledFeatures, rock::GemmFeatures::atomic_fmax_f32,
                        atomicFMaxF32Feature == FeatureToggle::on);
+      if (gfx940MfmaFeature != FeatureToggle::infer)
+        enabledFeatures =
+            bitEnumSet(enabledFeatures, rock::GemmFeatures::gfx940_mfma,
+                       gfx940MfmaFeature == FeatureToggle::on);
       genParams.operation = operation;
       genParams.features = enabledFeatures;
       genParams.arch = arch;


### PR DESCRIPTION
This feature currently isn't hooked up to anything, but at least it's there so we can use it in the future.