### PR TITLE
Allow rock.buffer_{load,store} to support scalar memrefs

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/AMDGPU.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/AMDGPU.td
@@ -87,7 +87,7 @@ def AMDGPU_RawBufferLoadOp :
   let assemblyFormat = [{
     attr-dict $memref `[` $indices `]`
       (`sgprOffset` $sgprOffset^)? `:`
-      type($memref) `,` type($indices) `->` type($value)
+      type($memref) (`,` type($indices)^)? `->` type($value)
   }];
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
@@ -130,7 +130,7 @@ def AMDGPU_RawBufferStoreOp :
   let assemblyFormat = [{
     attr-dict $value `->` $memref `[` $indices `]`
       (`sgprOffset` $sgprOffset^)? `:`
-      type($value) `->` type($memref) `,` type($indices)
+      type($value) `->` type($memref) (`,` type($indices)^)?
   }];
   let hasCanonicalizer = 1;
   let hasVerifier = 1;

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -199,7 +199,7 @@ struct RawBufferOpLowering : public ConvertOpToLLVMPattern<GpuOp> {
     args.push_back(resource);
 
     // Indexing (voffset)
-    Value voffset;
+    Value voffset = createI32Constant(rewriter, loc, 0);
     for (auto &pair : llvm::enumerate(adaptor.getIndices())) {
       size_t i = pair.index();
       Value index = pair.value();
@@ -212,8 +212,7 @@ struct RawBufferOpLowering : public ConvertOpToLLVMPattern<GpuOp> {
             createI32Constant(rewriter, loc, strides[i] * elementByteWidth);
       }
       index = rewriter.create<LLVM::MulOp>(loc, index, strideOp);
-      voffset =
-          voffset ? rewriter.create<LLVM::AddOp>(loc, voffset, index) : index;
+      voffset = rewriter.create<LLVM::AddOp>(loc, voffset, index);
     }
     if (adaptor.getIndexOffset()) {
       int32_t indexOffset = *gpuOp.getIndexOffset() * elementByteWidth;

--- a/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
@@ -18,6 +18,13 @@ func.func @raw_buffer_load_f32_from_rank_4(%src : memref<128x64x32x16xf32>, %off
   func.return %0 : f32
 }
 
+// CHECK-LABEL: func @raw_buffer_load_scalar
+func.func @raw_buffer_load_scalar(%src : memref<f32>) -> f32 {
+  // CHECK: amdgpu.raw_buffer_load {indexOffset = 1 : i32} %{{.*}}[] : memref<f32> -> f32
+  %0 = amdgpu.raw_buffer_load {indexOffset = 1 : i32} %src[] : memref<f32> -> f32
+  func.return %0 : f32
+}
+
 // CHECK-LABEL: func @raw_buffer_load_4xf32_from_rank_4
 func.func @raw_buffer_load_4xf32_from_rank_4(%src : memref<128x64x32x16xf32>, %offset : i32, %idx0 : i32, %idx1 : i32, %idx2 : i32, %idx3 : i32) -> vector<4xf32> {
   // CHECK: amdgpu.raw_buffer_load {indexOffset = 1 : i32} %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}] sgprOffset %{{.*}} : memref<128x64x32x16xf32>, i32, i32, i32, i32 -> vector<4xf32>
@@ -43,6 +50,13 @@ func.func @raw_buffer_store_f32_to_rank_4(%value : f32, %dst : memref<128x64x32x
 func.func @raw_buffer_store_4xf32_to_rank_4(%value : vector<4xf32>, %dst : memref<128x64x32x16xf32>, %offset : i32, %idx0 : i32, %idx1 : i32, %idx2 : i32, %idx3 : i32) {
   // CHECK: amdgpu.raw_buffer_store {indexOffset = 1 : i32} %{{.*}} -> %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}] sgprOffset %{{.*}} : vector<4xf32> -> memref<128x64x32x16xf32>, i32, i32, i32, i32
   amdgpu.raw_buffer_store {boundsCheck = true, indexOffset = 1 : i32} %value -> %dst[%idx0, %idx1, %idx2, %idx3] sgprOffset %offset : vector<4xf32> -> memref<128x64x32x16xf32>, i32, i32, i32, i32
+  func.return
+}
+
+// CHECK-LABEL: func @raw_buffer_store_scalar
+func.func @raw_buffer_store_scalar(%value : f32, %dst : memref<f32>) {
+  // CHECK: amdgpu.raw_buffer_store {indexOffset = 1 : i32} %{{.*}} -> %{{.*}}[] : f32 -> memref<f32>
+  amdgpu.raw_buffer_store {indexOffset = 1 : i32} %value -> %dst[] : f32 -> memref<f32>
   func.return
 }
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -764,7 +764,7 @@ def Rock_BufferLoadOp :
   }];
   let assemblyFormat = [{
     $source `[` $coords `]` `if` $valid attr-dict
-    `:` type($source) `,` type($coords) `->` type($result)
+    `:` type($source) (`,` type($coords)^)? `->` type($result)
   }];
   let hasVerifier = 1;
 }
@@ -803,7 +803,7 @@ def Rock_BufferStoreOp :
   }];
   let assemblyFormat = [{
     $storeMethod $data `->` $dest `[` $coords `]` `if` $valid `features` `=` $features attr-dict
-    `:` type($data) `->` type($dest) `,` type($coords)
+    `:` type($data) `->` type($dest) (`,` type($coords)^)?
   }];
   let hasVerifier = 1;
 }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1294,8 +1294,6 @@ LogicalResult BufferLoadOp::verify() {
   MemRefType sourceType = getSource().getType();
   size_t nDims = sourceType.getRank();
 
-  if (nDims == 0)
-    return emitOpError("buffer load from scalar memrefs doesn't work");
   if (getCoords().size() != nDims)
     return emitOpError("Expected " + Twine(nDims) + " coordinates for load");
   Attribute memSpaceAttr = sourceType.getMemorySpace();
@@ -1315,8 +1313,6 @@ LogicalResult BufferLoadOp::verify() {
 LogicalResult BufferStoreOp::verify() {
   MemRefType destType = getDest().getType();
   size_t nDims = destType.getRank();
-  if (nDims == 0)
-    return emitOpError("buffer store to scalar memrefs doesn't work");
   if (getCoords().size() != nDims)
     return emitOpError("Expected " + Twine(nDims) + " coordinates for store");
   Attribute memSpaceAttr = destType.getMemorySpace();

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -863,7 +863,8 @@ struct BufferLoadRewritePattern : public OpRewritePattern<BufferLoadOp> {
 
     llvm::APInt validConst = APInt::getZero(1);
     bool needOobChecks =
-        !matchPattern(valid, m_ConstantInt(&validConst)) || validConst.isZero();
+        !coords.empty() && (!matchPattern(valid, m_ConstantInt(&validConst)) ||
+                            validConst.isZero());
     if (needOobChecks) {
       Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
       Value numElements = computeMemRefNumElements(b, loc, source);
@@ -984,7 +985,8 @@ struct BufferStoreRewritePattern : public OpRewritePattern<BufferStoreOp> {
 
     llvm::APInt validConst = APInt::getZero(1);
     bool needOobChecks =
-        !matchPattern(valid, m_ConstantInt(&validConst)) || validConst.isZero();
+        !coords.empty() && (!matchPattern(valid, m_ConstantInt(&validConst)) ||
+                            validConst.isZero());
     if (needOobChecks) {
       Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
       Value numElements = computeMemRefNumElements(b, loc, dest);

--- a/mlir/test/fusion/e2e/tosa-to-rock-bcast-add.scalar.e2e.mlir
+++ b/mlir/test/fusion/e2e/tosa-to-rock-bcast-add.scalar.e2e.mlir
@@ -1,0 +1,14 @@
+// RUN:  rocmlir-driver -host-pipeline highlevel,partition -targets %arch %s| rocmlir-gen -ph -rand 1 -rand_type float -fut test_fusion  --verifier clone - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full |xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+
+// CHECK: [1 1 1]
+func.func @test_fusion(%arg0: tensor<1x8x8x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg3: tensor<f32>) -> tensor<1x8x8x8xf32> attributes {kernel, arch = ""} {
+  %zero = arith.constant dense<0.0> : tensor<8xf32>
+  %0 = "tosa.conv2d"(%arg0, %arg1, %zero) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x8x8x4xf32>, tensor<8x1x1x4xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>
+  %2 = "tosa.add"(%0, %arg3) {} : (tensor<1x8x8x8xf32>, tensor<f32>) -> tensor<1x8x8x8xf32>
+
+  return %2 : tensor<1x8x8x8xf32>
+}
+
+// -----
+


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/827