### PR TITLE
Make MFMA selection chipset-dependent

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
@@ -124,8 +124,8 @@ private:
   MfmaInsnGroupAttr groupAttr;
 
 public:
-  static FailureOr<MfmaInsnGroup> select(Type elementType, int64_t mPerWave,
-                                         int64_t nPerWave);
+  static FailureOr<MfmaInsnGroup> select(Type elementType, StringRef arch,
+                                         int64_t mPerWave, int64_t nPerWave);
   MfmaInsnGroup(Type elementType, const MfmaInsn &insn,
                 const MfmaInsnGroupAttr &groupAttr);
   int64_t getMRepeats(int64_t mPerWave);

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -359,6 +359,7 @@ def Rock_GridwiseGemmV2Op :
     Arguments<(ins MemRefRankOf<GemmInputTypes, [3]>:$a,
                    MemRefRankOf<GemmInputTypes, [3]>:$b,
                    MemRefRankOf<GemmOutputTypes, [3]>:$c,
+                   StrAttr:$arch,
                    Rock_GemmFeaturesAttr:$features,
                    StoreMethodAttr:$storeMethod,
                    I32Attr:$blockSize,
@@ -1076,6 +1077,7 @@ def Rock_BlockwiseGemmV2Op:
                    MemRefOf<MfmaArgTypes>:$bufferA,
                    MemRefOf<MfmaArgTypes>:$bufferB,
                    MemRefOf<MfmaResTypes>:$matrixC,
+                   StrAttr:$arch,
                    I32Attr:$blockSize,
                    Rock_XdlopsGemmParamsAttr:$params)>{
   let summary = "Blockwise GEMM XDLOPS version";
@@ -1125,6 +1127,7 @@ def Rock_XdlopsGemmV2Op:
                    MemRefRankOf<MfmaArgTypes, [1]>:$matrixA,
                    MemRefRankOf<MfmaArgTypes, [1]>:$matrixB,
                    MemRefRankOf<MfmaResTypes , [1]>:$matrixC,
+                   StrAttr:$arch,
                    Rock_XdlopsGemmParamsAttr:$params)> {
   let summary = "XDLOPS GEMM V2";
   let description = [{

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -46,22 +46,25 @@ struct InitParams {
 /// Store information useful for populating perf configurations
 struct PopulateParamsInfo {
   GemmSize gemmSize;
+  SmallString<32> arch;
   GemmFeatures gemmFeatures;
   Type inputType;
   KernelType kernelType;
   int64_t batchSize;
   uint32_t numCu;
 
-  PopulateParamsInfo(GemmSize gemmSize, GemmFeatures gemmFeatures,
-                     Type inputType, KernelType kernelType)
-      : gemmSize(gemmSize), gemmFeatures(gemmFeatures), inputType(inputType),
-        kernelType(kernelType) {}
+  PopulateParamsInfo(GemmSize gemmSize, StringRef arch,
+                     GemmFeatures gemmFeatures, Type inputType,
+                     KernelType kernelType)
+      : gemmSize(gemmSize), arch(arch), gemmFeatures(gemmFeatures),
+        inputType(inputType), kernelType(kernelType) {}
 
-  PopulateParamsInfo(GemmSize gemmSize, GemmFeatures gemmFeatures,
-                     Type inputType, KernelType kernelType, int64_t batchSize,
-                     uint32_t numCu)
-      : gemmSize(gemmSize), gemmFeatures(gemmFeatures), inputType(inputType),
-        kernelType(kernelType), batchSize(batchSize), numCu(numCu) {}
+  PopulateParamsInfo(GemmSize gemmSize, StringRef arch,
+                     GemmFeatures gemmFeatures, Type inputType,
+                     KernelType kernelType, int64_t batchSize, uint32_t numCu)
+      : gemmSize(gemmSize), arch(arch), gemmFeatures(gemmFeatures),
+        inputType(inputType), kernelType(kernelType), batchSize(batchSize),
+        numCu(numCu) {}
 
   /// Extract the relevant information from a RockGemmWrapperInterface operation
   static PopulateParamsInfo fromOp(RockGemmWrapperInterface op);
@@ -266,7 +269,8 @@ private:
                            uint32_t numCu);
 
   LogicalResult isValidBlockwiseGemmXDLOPS(const InitParamsXDL &param,
-                                           Type dataType, uint32_t blockSize);
+                                           Type dataType, StringRef arch,
+                                           uint32_t blockSize);
 
   LogicalResult populateDerived(const InitParamsXDL &validParams,
                                 const PopulateParamsInfo &info,
@@ -287,15 +291,15 @@ public:
                                        uint32_t &blockSize, uint32_t &gridSize,
                                        int64_t &gemmKBlocks);
 
-  LogicalResult obtainTuningParameters(PopulateParamsInfo info,
+  LogicalResult obtainTuningParameters(const PopulateParamsInfo &info,
                                        uint32_t blockSizeOverride,
                                        const std::string &perfConfig,
                                        InitParamsXDL &validParams,
                                        uint32_t &blockSize, uint32_t &gridSize,
                                        int64_t &gemmKBlocks);
 
-  std::vector<InitParamsXDL> getTuningParameters(KernelType opType,
-                                                 Type dataType) const;
+  std::vector<InitParamsXDL>
+  getTuningParameters(KernelType opType, Type dataType, StringRef arch) const;
 
   LogicalResult isValidGemm(const InitParamsXDL &param,
                             const GemmSize &gemmSize) const override;

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -363,6 +363,7 @@ LogicalResult Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder,
 
   needExtraPad = false;
   PopulateParamsInfo info{/*gemmSize=*/gemmSize,
+                          /*arch*=*/config.arch,
                           /*gemmFeatures=*/config.features,
                           /*inputType=*/dataType,
                           /*kernelType=*/KernelType::Conv2DBwdWeight,

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -346,7 +346,7 @@ struct BlockwiseGemmV2RewritePattern
                          b.create<ConstantIndexOp>(loc, ldsOffsetB / KPack));
 
     auto maybeMfmaInsnGroup =
-        MfmaInsnGroup::select(dataType, mPerWave, nPerWave);
+        MfmaInsnGroup::select(dataType, arch, mPerWave, nPerWave);
     if (failed(maybeMfmaInsnGroup)) {
       return emitError(loc) << "Failed to select xdlops instruction group.\n";
     }

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -311,6 +311,7 @@ struct BlockwiseGemmV2RewritePattern
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
 
+    StringAttr arch = op.getArchAttr();
     XdlopsGemmParamsAttr tuningParams = op.getParams();
     int64_t M = tuningParams.getMPerBlock();
     int64_t N = tuningParams.getNPerBlock();
@@ -531,7 +532,7 @@ struct BlockwiseGemmV2RewritePattern
     olnb.create<XdlopsGemmV2Op>(loc, outerLoopM.getInductionVar(),
                                 outerLoopN.getInductionVar(),
                                 adaptor.getBufferA(), adaptor.getBufferB(),
-                                adaptor.getMatrixC(), tuningParams);
+                                adaptor.getMatrixC(), arch, tuningParams);
     return success();
   }
 };

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -159,8 +159,9 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
     return op.emitOpError("grid size must be set at lowering");
   if (isXdlops) {
     // Onne the attribute copies are gone, make this a replaceOp
-    rw.create<GridwiseGemmV2Op>(loc, a, b, c, op.getFeaturesAttr(),
-                                op.getStoreMethodAttr(), blockSize, gridSize,
+    rw.create<GridwiseGemmV2Op>(loc, a, b, c, op.getArchAttr(),
+                                op.getFeaturesAttr(), op.getStoreMethodAttr(),
+                                blockSize, gridSize,
                                 params.cast<XdlopsGemmParamsAttr>());
     rw.eraseOp(op);
   } else {

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1171,7 +1171,7 @@ struct GridwiseGemmV2RewritePattern
 
     // Mfma instruction group selection.
     auto maybeMfmaInsnGroup =
-        MfmaInsnGroup::select(elementType, mPerWave, nPerWave);
+        MfmaInsnGroup::select(elementType, arch, mPerWave, nPerWave);
     if (failed(maybeMfmaInsnGroup)) {
       return emitError(loc) << "Failed to select xdlops instruction group.\n";
     }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -965,6 +965,7 @@ struct GridwiseGemmV2RewritePattern
     int64_t N = bShape[2];
 
     // Obtain critical tuning parameters.
+    StringRef arch = op.getArch();
     uint32_t blockSize = op.getBlockSize();
     uint32_t gridSize = op.getGridSize();
     XdlopsGemmParamsAttr tuningParams = op.getParams();
@@ -1290,7 +1291,7 @@ struct GridwiseGemmV2RewritePattern
       blockwiseGemmV2Op = b.create<BlockwiseGemmV2Op>(
           loc, ldsGpuAllocOp, ldsGpuAllocOp, b.getIndexAttr(ldsBlockAOffset),
           b.getIndexAttr(ldsBlockBOffset), mMyWaveOffsetA, mMyWaveOffsetB,
-          arrayA, arrayB, regCAllocOp, op.getBlockSizeAttr(),
+          arrayA, arrayB, regCAllocOp, op.getArchAttr(), op.getBlockSizeAttr(),
           op.getParamsAttr());
 
       // LDS barrier.

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -193,7 +193,7 @@ struct XdlopsGemmV2RewritePattern : public OpConversionPattern<XdlopsGemmV2Op> {
     }
 
     auto maybeMfmaInsnGroup =
-        MfmaInsnGroup::select(dataType, mPerWave, nPerWave);
+        MfmaInsnGroup::select(dataType, op.getArch(), mPerWave, nPerWave);
     if (failed(maybeMfmaInsnGroup)) {
       return emitError(loc) << "Failed to select xdlops instruction group.\n";
     }

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_v2.mlir
@@ -6,6 +6,7 @@ func.func @rock_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
   %c0 = arith.constant 0 : index
   // CHECK:  rock.xdlops_gemm_v2
   rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize= 256 : i32,
     params = #rock.xdlops_gemm_params<
       kPerBlock = 2,
@@ -27,6 +28,7 @@ func.func @rock_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>,
   %c0 = arith.constant 0 : index
   // CHECK:  rock.xdlops_gemm_v2
   rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
       kPerBlock = 2,

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
@@ -13,6 +13,7 @@ func.func @rock_xdlops_gemm_v2_reduction_nokpack(%matrixA : memref<2xf32, 5>,
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
        kPerBlock = 4,
        kpack = 1,
@@ -38,6 +39,7 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_f32(%matrixA : memref<2xf32, 5>,
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kPerBlock = 2,
       kpack = 2,
@@ -64,6 +66,7 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<4xvector<4xi
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kPerBlock = 4,
       kpack = 8,

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm_v2.mlir
@@ -78,3 +78,103 @@ func.func @rock_xdlops_gemm_v2_reduction_kpack_i8(%matrixA : memref<4xvector<4xi
   } : memref<1xvector<16xi32>, 5> += memref<4xvector<4xi8>, 5> * memref<4xvector<4xi8>, 5>
   return
 }
+
+/// Tests for navigating the differences between the available MFMA instructions
+/// on different CDNA generations.
+
+func.func @xdlops_gemm_gfx90a_i8(%matrixA : memref<4xvector<4xi8>, 5>,
+                                                 %matrixB : memref<4xvector<4xi8>, 5>,
+                                                 %matrixC : memref<1xvector<16xi32>, 5>) {
+  // CHECK-LABEL: func.func @xdlops_gemm_gfx90a_i8
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [4]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
+    params = #rock.xdlops_gemm_params<
+      kPerBlock = 4,
+      kpack = 8,
+      mPerWave = 32,
+      nPerWave = 32,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      forceUnroll = true>
+  } : memref<1xvector<16xi32>, 5> += memref<4xvector<4xi8>, 5> * memref<4xvector<4xi8>, 5>
+  return
+}
+
+func.func @xdlops_gemm_gfx940_i8(%matrixA : memref<4xvector<8xi8>, 5>,
+                                                 %matrixB : memref<4xvector<8xi8>, 5>,
+                                                 %matrixC : memref<1xvector<16xi32>, 5>) {
+  // CHECK-LABEL: func.func @xdlops_gemm_gfx940_i8
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [4]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 16 : i32, m = 32 : i32, n = 32 : i32
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx940",
+    params = #rock.xdlops_gemm_params<
+      kPerBlock = 4,
+      kpack = 16,
+      mPerWave = 32,
+      nPerWave = 32,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      forceUnroll = true>
+  } : memref<1xvector<16xi32>, 5> += memref<4xvector<8xi8>, 5> * memref<4xvector<8xi8>, 5>
+  return
+}
+
+func.func @xdlops_gemm_gfx908_bf16(%matrixA : memref<4xvector<2xbf16>, 5>,
+                                                 %matrixB : memref<4xvector<2xbf16>, 5>,
+                                                 %matrixC : memref<1xvector<16xf32>, 5>) {
+  // CHECK-LABEL: func.func @xdlops_gemm_gfx908_bf16
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [4]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 4 : i32, m = 32 : i32, n = 32 : i32
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx908",
+    params = #rock.xdlops_gemm_params<
+      kPerBlock = 4,
+      kpack = 4,
+      mPerWave = 32,
+      nPerWave = 32,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      forceUnroll = true>
+  } : memref<1xvector<16xf32>, 5> += memref<4xvector<2xbf16>, 5> * memref<4xvector<2xbf16>, 5>
+  return
+}
+
+func.func @xdlops_gemm_gfx90a_bf16(%matrixA : memref<4xvector<4xbf16>, 5>,
+                                                 %matrixB : memref<4xvector<4xbf16>, 5>,
+                                                 %matrixC : memref<1xvector<16xf32>, 5>) {
+  // CHECK-LABEL: func.func @xdlops_gemm_gfx90a_bf16
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [4]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
+    params = #rock.xdlops_gemm_params<
+      kPerBlock = 4,
+      kpack = 8,
+      mPerWave = 32,
+      nPerWave = 32,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      forceUnroll = true>
+  } : memref<1xvector<16xf32>, 5> += memref<4xvector<4xbf16>, 5> * memref<4xvector<4xbf16>, 5>
+  return
+}
+

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -480,6 +480,7 @@ func.func @rock_xdlops_gemm_v2_one_result(%matrixA : memref<16xf32, 5>,
                                             %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -502,6 +503,7 @@ func.func @rock_xdlops_gemm_v2_two_results(%matrixA : memref<16xf32, 5>,
                                              %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -524,6 +526,7 @@ func.func @rock_blockwise_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, %m
                                               %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -549,6 +552,7 @@ func.func @rock_blockwise_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>, %
                                                 %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -27,6 +27,7 @@ func.func @rock_xdlops_gemm_v2_one_result_f16(%matrixA : memref<4xvector<4xf16>,
                                                 %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -49,6 +50,7 @@ func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<4xvector<4xf16>
                                                %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -72,6 +74,7 @@ func.func @rock_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
   %c0 = arith.constant 0 : index
   %c0f = arith.constant 0.0 : f16
   rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -97,6 +100,7 @@ func.func @rock_blockwise_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 3>
                                                %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,

--- a/mlir/test/Dialect/Rock/regularize.mlir
+++ b/mlir/test/Dialect/Rock/regularize.mlir
@@ -9,7 +9,7 @@ func.func private @bert_part_11__part_0(%arg0: memref<1x12x12x32xf32> {func.read
   %4 = rock.transform %3 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemmK"] at [1] -> ["gemmK"] at [1]>, <Pad{0, 4} ["gemmMPad"] at [2] -> ["gemmM"] at [2]>] bounds = [12, 32, 16] -> [12, 32, 12]> : memref<12x32x12xf32> to memref<12x32x16xf32>
   %5 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemmK"] at [1] -> ["gemmK"] at [1]>, <Pad{0, 4} ["gemmNPad"] at [2] -> ["gemmN"] at [2]>] bounds = [12, 32, 16] -> [12, 32, 12]> : memref<12x32x12xf32> to memref<12x32x16xf32>
   %6 = rock.transform %2 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 4} ["gemmMPad"] at [1] -> ["gemmM"] at [1]>, <Pad{0, 4} ["gemmNPad"] at [2] -> ["gemmN"] at [2]>] bounds = [12, 16, 16] -> [12, 12, 12]> : memref<12x12x12xf32> to memref<12x16x16xf32>
-  rock.gridwise_gemm_v2(%4, %5, %6) storeMethod( set) features = mfma {blockSize = 64 : i32, gridSize = 12 : i32, params = #rock.xdlops_gemm_params<kPerBlock = 16, mPerBlock = 16, nPerBlock = 16, kpack = 1, mPerWave = 16, nPerWave = 16, forceUnroll = true>} : memref<12x32x16xf32>, memref<12x32x16xf32>, memref<12x16x16xf32>
+  rock.gridwise_gemm_v2(%4, %5, %6) storeMethod( set) features = mfma {arch = "amdgcn-amd-amdhsa:gfx90a", blockSize = 64 : i32, gridSize = 12 : i32, params = #rock.xdlops_gemm_params<kPerBlock = 16, mPerBlock = 16, nPerBlock = 16, kpack = 1, mPerWave = 16, nPerWave = 16, forceUnroll = true>} : memref<12x32x16xf32>, memref<12x32x16xf32>, memref<12x16x16xf32>
   %7 = rock.transform %2 by <affine_map<(d0, d1, d2, d3) -> (d0 * 12 + d1, d2, d3)> by [<Unmerge{1, 12} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [3] -> ["dim2"] at [2]>] bounds = [1, 12, 12, 12] -> [12, 12, 12]> : memref<12x12x12xf32> to memref<1x12x12x12xf32>
   %8 = memref.collapse_shape %7 [[0, 1], [2], [3]] : memref<1x12x12x12xf32> into memref<12x12x12xf32>
   %9 = memref.collapse_shape %arg2 [] : memref<1x1x1x1xf32> into memref<f32>
@@ -41,4 +41,4 @@ func.func private @bert_part_11__part_0(%arg0: memref<1x12x12x32xf32> {func.read
 // CHECK: linalg.generic {indexing_maps = [[[MAP0]], [[MAP0]], [[MAP0]], [[MAP0]]], iterator_types = ["parallel", "parallel", "parallel"]} ins([[ALLOC0]], [[ARG2_TR2]], [[ARG3_TR2]] : memref<12x12x12xf32>, memref<12x12x12xf32>, memref<12x12x12xf32>) outs([[ARG4_TR:.*]] : memref<12x12x12xf32>)
 
 // CHECK: memref.copy [[ALLOC1]], [[ARG4]] : memref<1x12x12x12xf32> to memref<1x12x12x12xf32>
-    
+


### PR DESCRIPTION
Whereas
- The upcoming gfx940 deprecates certain int8-related instructions, namely the 32x32x8 and 16x16x16 ones, in favor of the 32x32x16 and 16x16x32 ones, respectively, and;
- New, more efficient bfloat16 operations were introduced in gfx90a, and the older versions have been removed in gfx940, and;
- FP8-based MFMAs are only introduced in gfx940, and the future PR to add support for FP8 should be able to reject requests for these kernels on older architectures, and;
- Trying to add features describing all this variation really won't buy us much, as per discussion on #1009 

This PR
- Threads the `arch` attribute back through `gridwise_gemm_v2`, `blockwise_gemm_v2`, and `xdlops_gemm_v2`
- Extends the MFMA instruction group selection system to accept an `arch` parameter
- Uses the passed-in `arch` to choose the sets of tables that will be queried for MFMA groups
- Extends the tuning info structure with an `arch` field
- Cleans up some of the MFMA database implementation to avoid pointless copies
- Adds tests
