### PR TITLE
[DO NOT MERGE] Use COMgr to compile our GPU binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,9 +86,9 @@ else()
 
   # We need the native target for JIT reasons
   if(ROCMLIR_ENABLE_COMGR)
-    set(LLVM_TARGETS_TO_BUILD "native" CACHE STRING "")
+    set(LLVM_TARGETS_TO_BUILD "X86" CACHE STRING "")
   else()
-    set(LLVM_TARGETS_TO_BUILD "native;AMDGPU" CACHE STRING "")
+    set(LLVM_TARGETS_TO_BUILD "X86;AMDGPU" CACHE STRING "")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,17 +24,18 @@ endif()
 cmake_policy(SET CMP0057 NEW)
 
 # Rock dialect.
+set(ROCMLIR_ENABLE_COMGR ON CACHE BOOL
+  "Use comgr to compile kernels insteadd of building our own LLVM")
+
 set(ROCMLIR_DRIVER_ENABLED 1 CACHE BOOL "Enable build Rock driver")
 set(ROCMLIR_DRIVER_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build E2E tests for Rock driver")
 set(ROCMLIR_DRIVER_RANDOM_DATA_SEED "none" CACHE STRING "Enable E2E tests using random data")
 set(ROCMLIR_GEN_FLAGS "" CACHE BOOL "Set feature flag for rocmlir-gen")
 set(ROCMLIR_DRIVER_TEST_GPU_VALIDATION 1 CACHE BOOL "Enable E2E tests with GPU validation")
-set(LLVM_ENABLE_ZLIB "OFF" CACHE STRING "")
-set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
 set(ROCK_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build rock E2E tests")
 
-# LLVM settings that have an effect on the MLIR dialect
-set(LLVM_TARGETS_TO_BUILD "X86;AMDGPU" CACHE STRING "")
+set(LLVM_ENABLE_ZLIB OFF CACHE BOOL "")
+set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
 
 # Pointers to: 1) external LLVM bins/libs, and 2) Rock Dialect bins/libs
 set(LLVM_MAIN_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project/llvm" CACHE PATH "Path to LLVM sources")
@@ -68,6 +69,13 @@ if( BUILD_FAT_LIBROCKCOMPILER )
   set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
   # Note, this is a hack to ignore Pytorch added conda path
   list(APPEND CMAKE_IGNORE_PATH /opt/conda)
+
+  # We don't need the x86 target since there won't be JIT
+  if(ROCMLIR_ENABLE_COMGR)
+    set(LLVM_TARGETS_TO_BUILD "" CACHE STRING "")
+  else()
+    set(LLVM_TARGETS_TO_BUILD "AMDGPU" CACHE STRING "")
+  endif()
 else()
   set(BUILD_SHARED_LIBS ON CACHE BOOL "")
   set(LLVM_BUILD_LLVM_DYLIB ON CACHE BOOL "")
@@ -75,6 +83,13 @@ else()
   set(MLIR_ENABLE_ROCM_RUNNER 1 CACHE BOOL "")
   set(MLIR_INCLUDE_INTEGRATION_TESTS ON CACHE BOOL "")
   set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 1 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
+
+  # We need the native target for JIT reasons
+  if(ROCMLIR_ENABLE_COMGR)
+    set(LLVM_TARGETS_TO_BUILD "native" CACHE STRING "")
+  else()
+    set(LLVM_TARGETS_TO_BUILD "native;AMDGPU" CACHE STRING "")
+  endif()
 endif()
 
 # Set up the build for the LLVM/MLIR git-submodule

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -9,7 +9,15 @@ set(MLIR_CMAKE_CONFIG_DIR
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
 # LLVM settings
-set(LLVM_ENABLE_PROJECTS "mlir;lld" CACHE STRING "List of default llvm targets")
+if(ROCMLIR_ENABLE_COMGR)
+  set(LLVM_ENABLE_PROJECTS "mlir" CACHE STRING "List of default llvm targets")
+  set(MLIR_ENABLE_ROCM_CONVERSIONS_COMGR ON CACHE BOOL
+    "Enable compiling for ROCm targets using the COMgr library")
+else()
+  set(LLVM_ENABLE_PROJECTS "mlir;lld" CACHE STRING "List of default llvm targets")
+  set(MLIR_ENABLE_ROCM_CONVERSIONS_COMGR OFF CACHE BOOL
+    "Enable compiling for ROCm targets using the COMgr library")
+endif()
 set(LLVM_BUILD_EXAMPLES ON CACHE BOOL "")
 set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")

--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/lit.local.cfg
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/lit.local.cfg
@@ -1,4 +1,4 @@
-if not config.enable_rocm_runner or not config.rocm_test_chipset:
+if not config.run_rocm_tests or not config.enable_rocm_runner or not config.rocm_test_chipset:
   config.unsupported = True
 
 config.substitutions.append(('%chip', config.rocm_test_chipset))

--- a/mlir/include/mlir/CMakeLists.txt
+++ b/mlir/include/mlir/CMakeLists.txt
@@ -3,4 +3,5 @@ add_subdirectory(Dialect)
 #add_subdirectory(IR)
 #add_subdirectory(Interfaces)
 #add_subdirectory(Reducer)
-#add_subdirectory(Transforms)
+# TODO: Once we've moved to rocmlir/ instead of mlir/, just name this Transforms
+add_subdirectory(RocmlirTransforms)

--- a/mlir/include/mlir/InitRocMLIRPasses.h
+++ b/mlir/include/mlir/InitRocMLIRPasses.h
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Dialect/Vector/Transforms/Passes.h"
 #include "mlir/Dialect/XModel/Transforms/Passes.h"
+#include "mlir/RocmlirTransforms/Passes.h"
 #include "mlir/Transforms/Passes.h"
 
 #include <cstdlib>
@@ -47,6 +48,7 @@ inline void registerUpstreamPasses() {
   registerConvertAMDGPUToROCDL();
   registerArithToLLVMConversionPass();
   registerConvertFuncToLLVM();
+  registerGpuToLLVMConversionPass();
   registerConvertGpuOpsToROCDLOps();
   registerConvertMathToLLVM();
   registerMemRefToLLVMConversionPass();
@@ -87,6 +89,7 @@ inline void registerRocMLIRPasses() {
   migraphx::registerPasses();
   rock::registerPasses();
   rock::registerPipelines();
+  rocmlir::registerPasses();
 
   registerUpstreamPasses();
 }

--- a/mlir/include/mlir/RocmlirTransforms/CMakeLists.txt
+++ b/mlir/include/mlir/RocmlirTransforms/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(RocMLIRTransformsPassIncGen)
+
+add_mlir_doc(Passes RocMLIRTransformsPasses ./ -gen-pass-doc)

--- a/mlir/include/mlir/RocmlirTransforms/Passes.h
+++ b/mlir/include/mlir/RocmlirTransforms/Passes.h
@@ -1,0 +1,26 @@
+//===- Passes.h - rocMLIR passes not tied to dialects -------*- C++ -*-===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 ADvanced Micro Devices Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_ROCMLIRTRANSFORMS_PASSES_H_
+#define MLIR_ROCMLIRTRANSFORMS_PASSES_H_
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace mlir {
+namespace rocmlir {
+#define GEN_PASS_DECL_COMPILEGPUWITHCOMGRPASS
+#define GEN_PASS_REGISTRATION
+#include "mlir/RocmlirTransforms/Passes.h.inc"
+} // namespace rocmlir
+} // namespace mlir
+
+#endif // MLIR_ROCMLIRTRANSFORMS_PASSES_H

--- a/mlir/include/mlir/RocmlirTransforms/Passes.td
+++ b/mlir/include/mlir/RocmlirTransforms/Passes.td
@@ -1,0 +1,31 @@
+//===-- Passes.td - RocMLIR general pass definitions ---*- tablegen -*-===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Advanced Micro Devices Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ROCMLIR_TRANSFORMS_PASSES
+#define ROCMLIR_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def CompileGpuWithComgrPass : Pass<"compile-gpu-with-comgr", "::mlir::gpu::GPUModuleOp"> {
+  let summary = "compile gpu.module's of IR to HSACO with Comgr";
+  let dependentDialects = ["ROCDL::ROCDLDialect", "LLVM::LLVMDialect", "gpu::GPUDialect"];
+  let options = [
+    Option<"triple", "triple", "std::string", "",
+      "Target triple to compile">,
+    Option<"chip", "chip", "std::string", "",
+      "Target chipset">,
+    Option<"chipFeatures", "feaduters", "std::string", "",
+      "Target chipset features">,
+    Option<"optLevel", "opt-evel", "uint64_t", "3",
+      "Optimization level to use during compilation">
+  ];
+}
+
+#endif // ROCMLIR_TRANSFORMS_PASSES

--- a/mlir/lib/CMakeLists.txt
+++ b/mlir/lib/CMakeLists.txt
@@ -16,5 +16,6 @@ add_subdirectory(ExecutionEngine)
 #add_subdirectory(Support)
 #add_subdirectory(TableGen)
 #add_subdirectory(Target)
-#add_subdirectory(Transforms)
+# TODO Rename this to just "Transforms" when we've changed mlir/ to rocmlir/
+add_subdirectory(RocmlirTransforms)
 add_subdirectory(Translation)

--- a/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
@@ -13,4 +13,12 @@ add_rocmlir_dialect_library(MLIRRockPipeline
   MLIRRockToGPU
   MLIRRockOps
   MLIRRockTransforms
+  RocMLIRTransforms
 )
+
+if (ROCMLIR_ENABLE_COMGR)
+  target_compile_definitions(obj.MLIRRockPipeline
+  PRIVATE
+  ROCMLIR_ENABLE_COMGR=1
+  )
+endif()

--- a/mlir/lib/RocmlirTransforms/CMakeLists.txt
+++ b/mlir/lib/RocmlirTransforms/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 add_rocmlir_dialect_library(RocMLIRTransforms
   CompileGpuWithComgr.cpp
 
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/RocmlirTransforms
+
   LINK_COMPONENTS
   ${COMGR_PASS_COMPONENTS}
 

--- a/mlir/lib/RocmlirTransforms/CMakeLists.txt
+++ b/mlir/lib/RocmlirTransforms/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Instead of using the LLVM and LLD living next to MLIR, use the COMGR interface
+# to invoke the versions of these tools shipped with ROCm. This is used to
+# avoid packaging a separate copy of the compiler when creating MLIR-based tools
+# targetting ROCm, espcecially those living inside the ROCm distribution itself.
+if (ROCMLIR_ENABLE_COMGR)
+  find_package(amd_comgr REQUIRED PATHS /opt/rocm)
+  set(COMGR_PASS_COMPONENTS
+    Core
+  )
+  set(COMGR_PASS_LIBS)
+endif()
+
+add_rocmlir_dialect_library(RocMLIRTransforms
+  CompileGpuWithComgr.cpp
+
+  LINK_COMPONENTS
+  ${COMGR_PASS_COMPONENTS}
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRGPUOps
+  MLIRLLVMDialect
+  MLIRLLVMToLLVMIRTranslation
+  MLIRROCDLToLLVMIRTranslation
+  MLIRPass
+  ${COMGR_PASS_LIBS}
+
+  DEPENDS
+  RocMLIRTransformsPassIncGen
+)
+
+if (ROCMLIR_ENABLE_COMGR)
+  target_compile_definitions(obj.RocMLIRTransforms
+  PRIVATE
+  ROCMLIR_COMPILE_GPU_WITH_COMGR_PASS_ENABLE=1
+  )
+
+  target_link_libraries(RocMLIRTransforms PUBLIC amd_comgr)
+endif()
+

--- a/mlir/lib/RocmlirTransforms/CompileGpuWithComgr.cpp
+++ b/mlir/lib/RocmlirTransforms/CompileGpuWithComgr.cpp
@@ -1,0 +1,368 @@
+//===- CompileGpuWithComgr.cpp - Compile kernelsto HSACO with COMGR --===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Advanced Micro Devices Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass that serializes a gpu module into HSAco blob and
+// adds that blob as a string attribute of the module. Unlike the main
+// SeralizeToHsaco, this uses AMD's COMGR interface to call an external LLVM.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/RocmlirTransforms/Passes.h"
+
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+
+#ifdef ROCMLIR_COMPILE_GPU_WITH_COMGR_PASS_ENABLE
+#include "mlir/Dialect/GPU/Transforms/Passes.h"
+
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Regex.h"
+
+#include <memory>
+#include <string>
+
+#include <amd_comgr/amd_comgr.h>
+#endif
+
+namespace mlir {
+namespace rocmlir {
+#define GEN_PASS_DEF_COMPILEGPUWITHCOMGRPASS
+#include "mlir/RocmlirTransforms/Passes.h.inc"
+} // namespace rocmlir
+} // namespace mlir
+
+using namespace mlir;
+
+#define DEBUG_TYPE "compile-gpu-with-comgr"
+
+namespace {
+#ifdef ROCMLIR_COMPILE_GPU_WITH_COMGR_PASS_ENABLE
+class CompileGpuWithComgrPass
+    : public rocmlir::impl::CompileGpuWithComgrPassBase<
+          CompileGpuWithComgrPass> {
+public:
+  using rocmlir::impl::CompileGpuWithComgrPassBase<
+      CompileGpuWithComgrPass>::CompileGpuWithComgrPassBase;
+
+  void runOnOperation() override;
+
+private:
+  void getDependentDialects(DialectRegistry &registry) const override;
+
+  /// Adjusts the target string we've been passed to how comgr likes them,
+  /// namely, instead of triple:cpu[:feature:feature], we go for
+  // triple--cpu[:feature].
+  FailureOr<std::string> getComgrTarget();
+
+  /// Scan a module to see what device libraries are needed.
+  /// Returns the target backend.
+  amd_comgr_language_t getDeviceLibList(const llvm::Module &module,
+                                        SmallVectorImpl<const char *> &libs);
+
+  /// Whereas the comgr LLVM is behind the one we use to print the IR, use this
+  /// callback to do any "downgrades" needed for the serialized form of the IR.
+  void downgradeIrForBackcompat(SmallVectorImpl<char> &ir);
+
+  LogicalResult compileModule(gpu::GPUModuleOp mlirMod,
+                              SmallVectorImpl<char> &binary);
+};
+} // end anonymous namespace
+
+void CompileGpuWithComgrPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  registerROCDLDialectTranslation(registry);
+  registerLLVMDialectTranslation(registry);
+  rocmlir::impl::CompileGpuWithComgrPassBase<
+      CompileGpuWithComgrPass>::getDependentDialects(registry);
+}
+
+FailureOr<std::string> CompileGpuWithComgrPass::getComgrTarget() {
+  Location loc = getOperation()->getLoc();
+  if (triple.empty() || chip.empty())
+    return emitError(loc, "must specify a target triple and chipset");
+  std::string retVal;
+  llvm::raw_string_ostream ret(retVal);
+
+  ret << triple << "--" << chip;
+  // COMGR wants features clang-style (:bar+:foo-) features but SerializeToHsaco
+  // wants llc-style (+bar,-foo). We expect llc-style features to be passed in,
+  // but account for both.
+  if (chipFeatures.empty()) {
+    // do nothing
+  } else if (chipFeatures.find(':') != std::string::npos)
+    ret << ':' << chipFeatures;
+  else {
+    for (StringRef feature : llvm::split(chipFeatures, ',')) {
+      ret << ':' << feature.substr(1) << feature.take_front(1);
+    }
+  }
+  return retVal;
+}
+
+amd_comgr_language_t
+CompileGpuWithComgrPass::getDeviceLibList(const llvm::Module &module,
+                                          SmallVectorImpl<const char *> &libs) {
+  amd_comgr_language_t ret = AMD_COMGR_LANGUAGE_LAST;
+
+  // Walk the LLVM module in order to determine if we need to link in device
+  // libs.
+  bool needOpenCl = false;
+  bool needOckl = false;
+  bool needOcml = false;
+  for (const llvm::Function &f : module.functions()) {
+    if (f.hasExternalLinkage() && f.hasName() && !f.hasExactDefinition()) {
+      StringRef funcName = f.getName();
+      if ("printf" == funcName)
+        needOpenCl = true;
+      if (funcName.startswith("__ockl_"))
+        needOckl = true;
+      if (funcName.startswith("__ocml_"))
+        needOcml = true;
+    }
+  }
+
+  if (!(needOpenCl || needOcml || needOckl))
+    // Return _NONE to indicate that no device libraries are needed.
+    return AMD_COMGR_LANGUAGE_NONE;
+
+  if (needOpenCl) {
+    ret = AMD_COMGR_LANGUAGE_OPENCL_2_0;
+    needOcml = needOckl = true;
+  } else {
+    ret = AMD_COMGR_LANGUAGE_HIP;
+  }
+  if (needOcml) {
+    libs.push_back("correctly_rounded_sqrt");
+  }
+  if (needOcml || needOckl) {
+    libs.push_back("wavefrontsize64");
+    // This constant must always match the default code object ABI version
+    // of the AMDGPU backend.
+    libs.push_back("code_object_v4");
+  }
+  return ret;
+}
+
+static std::string subAll(const llvm::Regex &regex, StringRef rep,
+                          std::string orig) {
+  while (regex.match(orig)) {
+    orig = regex.sub(rep, orig);
+  }
+  return orig;
+}
+
+void CompileGpuWithComgrPass::downgradeIrForBackcompat(
+    SmallVectorImpl<char> &ir) {
+  llvm::Regex memoryNone("memory\\(none\\)");
+  std::string original(ir.data(), ir.size());
+  std::string memoryNoneRep = subAll(memoryNone, "readnone", original);
+  llvm::Regex memoryRead("memory\\(read\\)");
+  std::string memoryReadRep = subAll(memoryRead, "readonly", memoryNoneRep);
+  llvm::Regex memoryWrite("memory\\(write\\)");
+  std::string memoryWriteRep = subAll(memoryWrite, "writeonly", memoryReadRep);
+  ir.assign(memoryWriteRep.begin(), memoryWriteRep.end());
+}
+
+LogicalResult
+CompileGpuWithComgrPass::compileModule(gpu::GPUModuleOp mlirMod,
+                                       SmallVectorImpl<char> &binary) {
+#define CHECK_COMGR_CALL(call)                                                 \
+  do {                                                                         \
+    status = (call);                                                           \
+    if (AMD_COMGR_STATUS_SUCCESS != status) {                                  \
+      const char *statusName;                                                  \
+      amd_comgr_status_string(status, &statusName);                            \
+      return mlirMod->emitOpError("Failed comgr call: " #call " with status ") \
+             << statusName;                                                    \
+    }                                                                          \
+  } while (0)
+
+  amd_comgr_status_t status = AMD_COMGR_STATUS_SUCCESS;
+  FailureOr<std::string> maybeTargetIsa = getComgrTarget();
+  if (failed(maybeTargetIsa))
+    return failure();
+  std::string targetIsa = std::move(*maybeTargetIsa);
+
+  StringRef name = mlirMod.getNameAttr().getValue();
+  if (name.empty())
+    name = "GPUKernels";
+  SmallString<32> pointableName(name);
+  // needed to make the compiler do the right thing
+  pointableName.append(".ll");
+
+  llvm::LLVMContext ctx;
+  std::unique_ptr<llvm::Module> llvmMod =
+      translateModuleToLLVMIR(mlirMod, ctx, name);
+  if (!llvmMod) {
+    return mlirMod.emitOpError("Could not translate module to LLVM IR");
+  }
+  llvmMod->setTargetTriple(triple);
+
+  SmallVector<const char *> libraries;
+  amd_comgr_language_t inputLanguage = getDeviceLibList(*llvmMod, libraries);
+
+  llvm::SmallVector<char, 0> irBuf;
+  llvm::raw_svector_ostream irStream(irBuf);
+  llvmMod->print(irStream, nullptr);
+  downgradeIrForBackcompat(irBuf);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "LLVM IR for module " << name << "\n" << irBuf;
+    llvm::dbgs().flush();
+  });
+
+  amd_comgr_action_info_t actionInfo;
+  CHECK_COMGR_CALL(amd_comgr_create_action_info(&actionInfo));
+  CHECK_COMGR_CALL(
+      amd_comgr_action_info_set_isa_name(actionInfo, targetIsa.c_str()));
+
+  amd_comgr_data_t irData;
+  CHECK_COMGR_CALL(amd_comgr_create_data(AMD_COMGR_DATA_KIND_BC, &irData));
+  CHECK_COMGR_CALL(amd_comgr_set_data(irData, irBuf.size(), irBuf.data()));
+  CHECK_COMGR_CALL(amd_comgr_set_data_name(irData, pointableName.c_str()));
+
+  amd_comgr_data_set_t inputIrSet, targetBcSet;
+  CHECK_COMGR_CALL(amd_comgr_create_data_set(&inputIrSet));
+  CHECK_COMGR_CALL(amd_comgr_create_data_set(&targetBcSet));
+  CHECK_COMGR_CALL(amd_comgr_data_set_add(inputIrSet, irData));
+
+  // HACK: "compile" needs a language set, and HIP will get us into offload-arch
+  // so we claim to be OpenCL for a hot second.
+  amd_comgr_action_info_t actionInfoHack;
+  CHECK_COMGR_CALL(amd_comgr_create_action_info(&actionInfoHack));
+  CHECK_COMGR_CALL(
+      amd_comgr_action_info_set_isa_name(actionInfoHack, targetIsa.c_str()));
+  CHECK_COMGR_CALL(amd_comgr_action_info_set_language(
+      actionInfoHack, AMD_COMGR_LANGUAGE_OPENCL_2_0));
+  const char *hackArgs[] = {"-x", "ir"};
+  CHECK_COMGR_CALL(
+      amd_comgr_action_info_set_option_list(actionInfoHack, hackArgs, 2));
+
+  CHECK_COMGR_CALL(amd_comgr_do_action(AMD_COMGR_ACTION_COMPILE_SOURCE_TO_BC,
+                                       actionInfoHack, inputIrSet,
+                                       targetBcSet));
+  CHECK_COMGR_CALL(amd_comgr_destroy_action_info(actionInfoHack));
+  CHECK_COMGR_CALL(amd_comgr_release_data(irData));
+  CHECK_COMGR_CALL(amd_comgr_destroy_data_set(inputIrSet));
+
+  if (!libraries.empty()) {
+    // We do this down here (and temporarily) in order to prevent
+    // issuse where setting the language affects some of how COMgr handles
+    // setting up Clang, namely that setting the language to HIP implies that
+    // architecture should be handled by way of offload-arch.
+    CHECK_COMGR_CALL(
+        amd_comgr_action_info_set_language(actionInfo, inputLanguage));
+
+    amd_comgr_data_set_t withDeviceLibsSet, linkedBcSet;
+    CHECK_COMGR_CALL(amd_comgr_create_data_set(&withDeviceLibsSet));
+    CHECK_COMGR_CALL(amd_comgr_create_data_set(&linkedBcSet));
+
+    CHECK_COMGR_CALL(amd_comgr_action_info_set_option_list(
+        actionInfo, libraries.data(), libraries.size()));
+    CHECK_COMGR_CALL(amd_comgr_do_action(AMD_COMGR_ACTION_ADD_DEVICE_LIBRARIES,
+                                         actionInfo, targetBcSet,
+                                         withDeviceLibsSet));
+    CHECK_COMGR_CALL(
+        amd_comgr_action_info_set_option_list(actionInfo, nullptr, 0));
+    CHECK_COMGR_CALL(amd_comgr_do_action(AMD_COMGR_ACTION_LINK_BC_TO_BC,
+                                         actionInfo, withDeviceLibsSet,
+                                         linkedBcSet));
+    // Free data we're about to lose references to.
+    CHECK_COMGR_CALL(amd_comgr_destroy_data_set(targetBcSet));
+    CHECK_COMGR_CALL(amd_comgr_destroy_data_set(withDeviceLibsSet));
+    targetBcSet = linkedBcSet;
+
+    // Hack: go back to the NONE language to make sure arch flags are handled
+    // correctly.
+    CHECK_COMGR_CALL(amd_comgr_action_info_set_language(
+        actionInfo, AMD_COMGR_LANGUAGE_NONE));
+  }
+
+  // Set up compiler options.
+  llvm::SmallString<4> optOption;
+  ("-O" + Twine(optLevel)).toVector(optOption);
+  SmallVector<const char *, 0> options;
+  options.push_back(optOption.c_str());
+  CHECK_COMGR_CALL(amd_comgr_action_info_set_option_list(
+      actionInfo, options.data(), options.size()));
+
+  // Codegen (opt + llc) to .o files.
+  amd_comgr_data_set_t objectsSet;
+  amd_comgr_action_info_set_logging(actionInfo, true);
+  CHECK_COMGR_CALL(amd_comgr_create_data_set(&objectsSet));
+  CHECK_COMGR_CALL(
+      amd_comgr_do_action(AMD_COMGR_ACTION_CODEGEN_BC_TO_RELOCATABLE,
+                          actionInfo, targetBcSet, objectsSet));
+
+  // Link into a loadable executable.
+  amd_comgr_data_set_t hsacoSet;
+  CHECK_COMGR_CALL(amd_comgr_create_data_set(&hsacoSet));
+  CHECK_COMGR_CALL(
+      amd_comgr_do_action(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE,
+                          actionInfo, objectsSet, hsacoSet));
+  CHECK_COMGR_CALL(amd_comgr_destroy_data_set(objectsSet));
+
+  size_t resultCount = 0;
+  CHECK_COMGR_CALL(amd_comgr_action_data_count(
+      hsacoSet, AMD_COMGR_DATA_KIND_EXECUTABLE, &resultCount));
+  if (resultCount != 1)
+    return mlirMod.emitOpError("couldn't compile LLVM IR");
+
+  amd_comgr_data_t hsaco;
+  CHECK_COMGR_CALL(amd_comgr_action_data_get_data(
+      hsacoSet, AMD_COMGR_DATA_KIND_EXECUTABLE, 0, &hsaco));
+  size_t numBytes = 0;
+  CHECK_COMGR_CALL(amd_comgr_get_data(hsaco, &numBytes, nullptr));
+  binary.resize_for_overwrite(numBytes);
+  CHECK_COMGR_CALL(amd_comgr_get_data(hsaco, &numBytes, binary.data()));
+
+  CHECK_COMGR_CALL(amd_comgr_release_data(hsaco));
+  CHECK_COMGR_CALL(amd_comgr_destroy_data_set(hsacoSet));
+  CHECK_COMGR_CALL(amd_comgr_destroy_action_info(actionInfo));
+
+  return success();
+}
+
+void CompileGpuWithComgrPass::runOnOperation() {
+  gpu::GPUModuleOp mlirMod = getOperation();
+  SmallVector<char, 0> binary;
+
+  if (failed(compileModule(mlirMod, binary)))
+    return signalPassFailure();
+
+  MLIRContext *ctx = mlirMod->getContext();
+  auto binaryAttr =
+      StringAttr::get(ctx, StringRef(binary.data(), binary.size()));
+  // Hard-code this to avoid depending on SerializeToBlob, which we're trying to
+  // avoid pulling in.
+  mlirMod->setAttr("gpu.binary", binaryAttr);
+}
+
+#else
+class CompileGpuWithComgrPass
+    : public rocmlir::impl::CompileGpuWithComgrPassBase<
+          CompileGpuWithComgrPass> {
+  void runOnOperation() override {
+    gpu::GPUModuleOp mod = getOperation();
+    mod.emitOpError("Cannot use COMGR because it is not linked in. Try "
+                    "serialize-to-hsaco instead\n");
+    signalPassFailure();
+  }
+};
+#endif

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -5,9 +5,7 @@ set(LLVM_OPTIONAL_SOURCES
   mixr_full.c
 )
 
-set(LLVM_LINK_COMPONENTS
-  X86
-)
+set(LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD})
 
 add_llvm_executable(mlir-mixr-capi-test
   mixrir.c
@@ -32,8 +30,6 @@ target_link_libraries(mlir-tosa-miir-test
   MLIRCAPIIR
   MLIRCAPIRegisterRocMLIR
   MLIRRockPipeline
-  LLVMAMDGPUAsmParser
-  LLVMX86AsmParser
 )
 
 add_llvm_executable(mlir-mixr-full-test
@@ -50,8 +46,6 @@ target_link_libraries(mlir-mixr-full-test
   MLIRCAPIGPU
   MLIRMIGraphXPipeline
   MLIRRockPipeline
-  LLVMAMDGPUAsmParser
-  LLVMX86AsmParser
 )
 
 add_llvm_executable(mlir-mixr-fullc-test

--- a/mlir/test/CAPI/lit.local.cfg
+++ b/mlir/test/CAPI/lit.local.cfg
@@ -1,4 +1,1 @@
-if not config.enable_rocm_runner:
-  config.unsupported = True
-
 config.suffixes.add('.c')

--- a/mlir/test/CAPI/lit.local.cfg
+++ b/mlir/test/CAPI/lit.local.cfg
@@ -1,1 +1,4 @@
+if not config.enable_rocm_runner:
+  config.unsupported = True
+
 config.suffixes.add('.c')

--- a/mlir/test/CAPI/mixr_cobj.cpp
+++ b/mlir/test/CAPI/mixr_cobj.cpp
@@ -181,14 +181,11 @@ static bool constructAndTraverseIr(MlirContext ctx) {
 
   auto module = unwrap(moduleOp1);
 
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetInfos();
+  llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmParsers();
   llvm::InitializeAllAsmPrinters();
-
-  // Initialize LLVM AMDGPU backend.
-  LLVMInitializeAMDGPUTarget();
-  LLVMInitializeAMDGPUTargetInfo();
-  LLVMInitializeAMDGPUTargetMC();
-  LLVMInitializeAMDGPUAsmPrinter();
 
   const char *triple = "amdgcn-amd-amdhsa";
   const char *chip = "gfx908";

--- a/mlir/test/CAPI/tosa_miir.cpp
+++ b/mlir/test/CAPI/tosa_miir.cpp
@@ -215,14 +215,11 @@ static bool constructAndTraverseIr(MlirContext ctx) {
 
   auto module = unwrap(moduleOp1);
 
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetInfos();
+  llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmParsers();
   llvm::InitializeAllAsmPrinters();
-
-  // Initialize LLVM AMDGPU backend.
-  LLVMInitializeAMDGPUTarget();
-  LLVMInitializeAMDGPUTargetInfo();
-  LLVMInitializeAMDGPUTargetMC();
-  LLVMInitializeAMDGPUAsmPrinter();
 
   const char *triple = "amdgcn-amd-amdhsa";
   const char *chip = "gfx908";

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(CAPI)
+if (MLIR_ENABLE_ROCM_RUNNER)
+  add_subdirectory(CAPI)
+endif()
 add_subdirectory(lib)
 
 llvm_canonicalize_cmake_booleans(
@@ -70,21 +72,23 @@ set(ROCMLIR_TEST_DEPENDS
   rocmlir-opt
   rocmlir-translate
   rocmlir-lsp-server
-  mlir-mixr-capi-test
-  mlir-mixr-full-test
-  mlir-mixr-fullc-test
-  mlir-tosa-miir-test
-  mlir_runner_utils
-  mlir_c_runner_utils
-  mlir_async_runtime
 )
 
 list(APPEND ROCMLIR_TEST_DEPENDS RocMLIRUnitTests)
 
 if(MLIR_ENABLE_ROCM_RUNNER)
   list(APPEND ROCMLIR_TEST_DEPENDS
+    mlir-mixr-capi-test
+    mlir-mixr-full-test
+    mlir-mixr-fullc-test
+    mlir-tosa-miir-test
+
+    mlir_runner_utils
+    mlir_c_runner_utils
+    mlir_async_runtime
     mlir_rocm_runtime
     conv-validation-wrappers
+
     mlir-cpu-runner
     xmir-runner
     # Not strictly a test dependency, included so we don't break it during compiles

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -72,17 +72,17 @@ set(ROCMLIR_TEST_DEPENDS
   rocmlir-opt
   rocmlir-translate
   rocmlir-lsp-server
+
+  mlir-mixr-capi-test
+  mlir-mixr-full-test
+  mlir-mixr-fullc-test
+  mlir-tosa-miir-test
 )
 
 list(APPEND ROCMLIR_TEST_DEPENDS RocMLIRUnitTests)
 
 if(MLIR_ENABLE_ROCM_RUNNER)
   list(APPEND ROCMLIR_TEST_DEPENDS
-    mlir-mixr-capi-test
-    mlir-mixr-full-test
-    mlir-mixr-fullc-test
-    mlir-tosa-miir-test
-
     mlir_runner_utils
     mlir_c_runner_utils
     mlir_async_runtime

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -1,6 +1,4 @@
-if (MLIR_ENABLE_ROCM_RUNNER)
-  add_subdirectory(CAPI)
-endif()
+add_subdirectory(CAPI)
 add_subdirectory(lib)
 
 llvm_canonicalize_cmake_booleans(
@@ -9,6 +7,7 @@ llvm_canonicalize_cmake_booleans(
   MLIR_ENABLE_ROCM_CONVERSIONS
   MLIR_ENABLE_ROCM_RUNNER
 
+  ROCMLIR_ENABLE_COMGR
   ROCMLIR_DRIVER_ENABLED
   ROCMLIR_DRIVER_E2E_TEST_ENABLED
   ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED

--- a/mlir/test/Integration/ROCmComgr/compile-gpu-with-comgr.mlir
+++ b/mlir/test/Integration/ROCmComgr/compile-gpu-with-comgr.mlir
@@ -1,0 +1,40 @@
+// RUN: rocmlir-opt %s \
+// RUN: | rocmlir-opt -gpu-kernel-outlining \
+// RUN: | rocmlir-opt -pass-pipeline='builtin.module(gpu.module(strip-debuginfo,convert-gpu-to-rocdl,compile-gpu-with-comgr{triple=amdgcn-amd-amdhsa chip=%chip}))' \
+// RUN: | rocmlir-opt -gpu-to-llvm \
+// RUN: | mlir-cpu-runner \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext \
+// RUN:   --entry-point-result=void \
+// RUN: | FileCheck %s
+
+func.func @other_func(%arg0 : f32, %arg1 : memref<?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %block_dim = memref.dim %arg1, %c0 : memref<?xf32>
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %block_dim, %block_y = %c1, %block_z = %c1) {
+    memref.store %arg0, %arg1[%tx] : memref<?xf32>
+    gpu.terminator
+  }
+  return
+}
+
+// CHECK: [1, 1, 1, 1, 1]
+func.func @main() {
+  %arg0 = memref.alloc() : memref<5xf32>
+  %21 = arith.constant 5 : i32
+  %22 = memref.cast %arg0 : memref<5xf32> to memref<?xf32>
+  %cast = memref.cast %22 : memref<?xf32> to memref<*xf32>
+  gpu.host_register %cast : memref<*xf32>
+  %23 = memref.cast %22 : memref<?xf32> to memref<*xf32>
+  call @printMemrefF32(%23) : (memref<*xf32>) -> ()
+  %24 = arith.constant 1.0 : f32
+  %25 = call @mgpuMemGetDeviceMemRef1dFloat(%22) : (memref<?xf32>) -> (memref<?xf32>)
+  call @other_func(%24, %25) : (f32, memref<?xf32>) -> ()
+  call @printMemrefF32(%23) : (memref<*xf32>) -> ()
+  return
+}
+
+func.func private @mgpuMemGetDeviceMemRef1dFloat(%ptr : memref<?xf32>) -> (memref<?xf32>)
+func.func private @printMemrefF32(%ptr : memref<*xf32>)

--- a/mlir/test/Integration/ROCmComgr/lit.local.cfg
+++ b/mlir/test/Integration/ROCmComgr/lit.local.cfg
@@ -1,0 +1,4 @@
+if not config.rocmlir_enable_comgr or not config.enable_rocm_runner or config.no_AMD_GPU:
+  config.unsupported = True
+
+config.substitutions.append(('%chip', config.arch.split(':')[0]))

--- a/mlir/test/Integration/ROCmComgr/printf.mlir
+++ b/mlir/test/Integration/ROCmComgr/printf.mlir
@@ -1,0 +1,29 @@
+// RUN: rocmlir-opt %s \
+// RUN: | rocmlir-opt -pass-pipeline='builtin.module(gpu.module(strip-debuginfo,convert-gpu-to-rocdl{index-bitwidth=32 runtime=HIP},compile-gpu-with-comgr{triple=amdgcn-amd-amdhsa chip=%chip}))' \
+// RUN: | rocmlir-opt -gpu-to-llvm \
+// RUN: | mlir-cpu-runner \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext \
+// RUN:   --entry-point-result=void \
+// RUN: | FileCheck %s
+
+// CHECK: Hello from 0
+// CHECK: Hello from 1
+module attributes {gpu.container_module} {
+    gpu.module @kernels {
+        gpu.func @hello() kernel {
+            %0 = gpu.thread_id x
+            gpu.printf "Hello from %d\n" %0 : index
+            gpu.return
+        }
+    }
+
+    func.func @main() {
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        gpu.launch_func @kernels::@hello
+            blocks in (%c1, %c1, %c1)
+            threads in (%c2, %c1, %c1)
+        return
+    }
+}

--- a/mlir/test/Integration/ROCmComgr/two-modules.mlir
+++ b/mlir/test/Integration/ROCmComgr/two-modules.mlir
@@ -1,0 +1,38 @@
+// RUN: rocmlir-opt %s \
+// RUN: | rocmlir-opt -gpu-kernel-outlining \
+// RUN: | rocmlir-opt -pass-pipeline='builtin.module(gpu.module(strip-debuginfo,convert-gpu-to-rocdl,compile-gpu-with-comgr{triple=amdgcn-amd-amdhsa chip=%chip}))' \
+// RUN: | rocmlir-opt -gpu-to-llvm \
+// RUN: | mlir-cpu-runner \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext \
+// RUN:   --entry-point-result=void \
+// RUN: | FileCheck %s
+
+// CHECK: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+func.func @main() {
+  %arg = memref.alloc() : memref<13xi32>
+  %dst = memref.cast %arg : memref<13xi32> to memref<?xi32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %sx = memref.dim %dst, %c0 : memref<?xi32>
+  %cast_dst = memref.cast %dst : memref<?xi32> to memref<*xi32>
+  gpu.host_register %cast_dst : memref<*xi32>
+  %dst_device = call @mgpuMemGetDeviceMemRef1dInt32(%dst) : (memref<?xi32>) -> (memref<?xi32>)
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %sx, %block_y = %c1, %block_z = %c1) {
+    %t0 = arith.index_cast %tx : index to i32
+    memref.store %t0, %dst_device[%tx] : memref<?xi32>
+    gpu.terminator
+  }
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %sx, %block_y = %c1, %block_z = %c1) {
+    %t0 = arith.index_cast %tx : index to i32
+    memref.store %t0, %dst_device[%tx] : memref<?xi32>
+    gpu.terminator
+  }
+  call @printMemrefI32(%cast_dst) : (memref<*xi32>) -> ()
+  return
+}
+
+func.func private @mgpuMemGetDeviceMemRef1dInt32(%ptr : memref<?xi32>) -> (memref<?xi32>)
+func.func private @printMemrefI32(%ptr : memref<*xi32>)

--- a/mlir/test/Integration/ROCmComgr/vecadd.mlir
+++ b/mlir/test/Integration/ROCmComgr/vecadd.mlir
@@ -1,0 +1,62 @@
+// RUN: rocmlir-opt %s \
+// RUN: | rocmlir-opt -convert-scf-to-cf \
+// RUN: | rocmlir-opt -gpu-kernel-outlining \
+// RUN: | rocmlir-opt -pass-pipeline='builtin.module(gpu.module(strip-debuginfo,convert-gpu-to-rocdl{use-bare-ptr-memref-call-conv=true},compile-gpu-with-comgr{triple=amdgcn-amd-amdhsa chip=%chip}))' \
+// RUN: | rocmlir-opt -gpu-to-llvm=use-bare-pointers-for-kernels=true \
+// RUN: | mlir-cpu-runner \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext \
+// RUN:   --entry-point-result=void \
+// RUN: | FileCheck %s
+
+func.func @vecadd(%arg0 : memref<5xf32>, %arg1 : memref<5xf32>, %arg2 : memref<5xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %block_dim = arith.constant 5 : index
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %block_dim, %block_y = %c1, %block_z = %c1) {
+    %a = memref.load %arg0[%tx] : memref<5xf32>
+    %b = memref.load %arg1[%tx] : memref<5xf32>
+    %c = arith.addf %a, %b : f32
+    memref.store %c, %arg2[%tx] : memref<5xf32>
+    gpu.terminator
+  }
+  return
+}
+
+// CHECK: [2.46, 2.46, 2.46, 2.46, 2.46]
+func.func @main() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  %cf1dot23 = arith.constant 1.23 : f32
+  %0 = memref.alloc() : memref<5xf32>
+  %1 = memref.alloc() : memref<5xf32>
+  %2 = memref.alloc() : memref<5xf32>
+  %3 = memref.cast %0 : memref<5xf32> to memref<?xf32>
+  %4 = memref.cast %1 : memref<5xf32> to memref<?xf32>
+  %5 = memref.cast %2 : memref<5xf32> to memref<?xf32>
+  scf.for %i = %c0 to %c5 step %c1 {
+    memref.store %cf1dot23, %3[%i] : memref<?xf32>
+    memref.store %cf1dot23, %4[%i] : memref<?xf32>
+  }
+  %6 = memref.cast %3 : memref<?xf32> to memref<*xf32>
+  %7 = memref.cast %4 : memref<?xf32> to memref<*xf32>
+  %8 = memref.cast %5 : memref<?xf32> to memref<*xf32>
+  gpu.host_register %6 : memref<*xf32>
+  gpu.host_register %7 : memref<*xf32>
+  gpu.host_register %8 : memref<*xf32>
+  %9 = call @mgpuMemGetDeviceMemRef1dFloat(%3) : (memref<?xf32>) -> (memref<?xf32>)
+  %10 = call @mgpuMemGetDeviceMemRef1dFloat(%4) : (memref<?xf32>) -> (memref<?xf32>)
+  %11 = call @mgpuMemGetDeviceMemRef1dFloat(%5) : (memref<?xf32>) -> (memref<?xf32>)
+  %12 = memref.cast %9 : memref<?xf32> to memref<5xf32>
+  %13 = memref.cast %10 : memref<?xf32> to memref<5xf32>
+  %14 = memref.cast %11 : memref<?xf32> to memref<5xf32>
+
+  call @vecadd(%12, %13, %14) : (memref<5xf32>, memref<5xf32>, memref<5xf32>) -> ()
+  call @printMemrefF32(%8) : (memref<*xf32>) -> ()
+  return
+}
+
+func.func private @mgpuMemGetDeviceMemRef1dFloat(%ptr : memref<?xf32>) -> (memref<?xf32>)
+func.func private @printMemrefF32(%ptr : memref<*xf32>)

--- a/mlir/test/Integration/ROCmComgr/vector-transferops.mlir
+++ b/mlir/test/Integration/ROCmComgr/vector-transferops.mlir
@@ -1,0 +1,90 @@
+// RUN: rocmlir-opt %s \
+// RUN: | rocmlir-opt -convert-scf-to-cf \
+// RUN: | rocmlir-opt -gpu-kernel-outlining \
+// RUN: | rocmlir-opt -pass-pipeline='builtin.module(gpu.module(strip-debuginfo,convert-gpu-to-rocdl{chipset=%chip index-bitwidth=32},compile-gpu-with-comgr{triple=amdgcn-amd-amdhsa chip=%chip}))' \
+// RUN: | rocmlir-opt -gpu-to-llvm \
+// RUN: | mlir-cpu-runner \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext \
+// RUN:   --shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext \
+// RUN:   --entry-point-result=void \
+// RUN: | FileCheck %s
+
+// TODO: swap for vector transfer reads if we ever create a --vector-to-amdgpu
+func.func @vectransferx2(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>) {
+  %cst = arith.constant 1 : index
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %cst, %grid_y = %cst, %grid_z = %cst)
+             threads(%tx, %ty, %tz) in (%block_x = %cst, %block_y = %cst, %block_z = %cst) {
+    %f0 = arith.constant 0.0: f32
+    %base = arith.constant 0 : i32
+    %f = amdgpu.raw_buffer_load {boundsCheck = true } %arg0[%base]
+      : memref<?xf32>, i32 -> vector<2xf32>
+
+    %c = arith.addf %f, %f : vector<2xf32>
+
+    %base1 = arith.constant 1 : i32
+    amdgpu.raw_buffer_store { boundsCheck = false } %c -> %arg1[%base1]
+      : vector<2xf32> -> memref<?xf32>, i32
+
+    gpu.terminator
+  }
+  return
+}
+
+func.func @vectransferx4(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>) {
+  %cst = arith.constant 1 : index
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %cst, %grid_y = %cst, %grid_z = %cst)
+             threads(%tx, %ty, %tz) in (%block_x = %cst, %block_y = %cst, %block_z = %cst) {
+    %f0 = arith.constant 0.0: f32
+    %base = arith.constant 0 : i32
+    %f = amdgpu.raw_buffer_load { boundsCheck = false } %arg0[%base]
+      : memref<?xf32>, i32 -> vector<4xf32>
+
+    %c = arith.addf %f, %f : vector<4xf32>
+
+    amdgpu.raw_buffer_store { boundsCheck = false } %c -> %arg1[%base]
+      : vector<4xf32> -> memref<?xf32>, i32
+
+    gpu.terminator
+  }
+  return
+}
+
+func.func @main() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %cf1 = arith.constant 1.0 : f32
+  %cf1dot23 = arith.constant 1.23 : f32
+
+  %arg0 = memref.alloc() : memref<4xf32>
+  %arg1 = memref.alloc() : memref<4xf32>
+
+  %22 = memref.cast %arg0 : memref<4xf32> to memref<?xf32>
+  %23 = memref.cast %arg1 : memref<4xf32> to memref<?xf32>
+
+  scf.for %i = %c0 to %c4 step %c1 {
+    memref.store %cf1dot23, %22[%i] : memref<?xf32>
+    memref.store %cf1dot23, %23[%i] : memref<?xf32>
+  }
+
+  %cast0 = memref.cast %22 : memref<?xf32> to memref<*xf32>
+  %cast1 = memref.cast %23 : memref<?xf32> to memref<*xf32>
+
+  gpu.host_register %cast0 : memref<*xf32>
+  gpu.host_register %cast1 : memref<*xf32>
+
+  %24 = call @mgpuMemGetDeviceMemRef1dFloat(%22) : (memref<?xf32>) -> (memref<?xf32>)
+  %26 = call @mgpuMemGetDeviceMemRef1dFloat(%23) : (memref<?xf32>) -> (memref<?xf32>)
+
+  // CHECK: [1.23, 2.46, 2.46, 1.23]
+  call @vectransferx2(%24, %26) : (memref<?xf32>,  memref<?xf32>) -> ()
+  call @printMemrefF32(%cast1) : (memref<*xf32>) -> ()
+
+  // CHECK: [2.46, 2.46, 2.46, 2.46]
+  call @vectransferx4(%24, %26) : (memref<?xf32>,  memref<?xf32>) -> ()
+  call @printMemrefF32(%cast1) : (memref<*xf32>) -> ()
+  return
+}
+
+func.func private @mgpuMemGetDeviceMemRef1dFloat(%ptr : memref<?xf32>) -> (memref<?xf32>)
+func.func private @printMemrefF32(%ptr : memref<*xf32>)

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -90,8 +90,10 @@ tools.extend([
     ToolSubst('%conv_validation_wrapper_library_dir', config.conv_validation_wrapper_library_dir, unresolved='fatal'),
 ])
 
+if config.rocmlir_enable_comgr:
+    # Send `llc` to `true` so that we don't have to deal with LLVM IR mangling
+    tools.append(ToolSubst('llc', '/bin/cat >/dev/null | true'))
 llvm_config.add_tool_substitutions(tools, tool_dirs)
-
 
 # FileCheck -enable-var-scope is enabled by default in MLIR test
 # This option avoids to accidentally reuse variable across -LABEL match,

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -43,6 +43,7 @@ config.run_rocm_tests = @MLIR_ENABLE_ROCM_CONVERSIONS@
 config.conv_validation_wrapper_library_dir = "@MLIR_CONV_VALIDATION_WRAPPER_LIBRARY_DIR@"
 config.enable_rocm_runner = @MLIR_ENABLE_ROCM_RUNNER@
 config.enable_rock_driver = @ROCMLIR_DRIVER_ENABLED@
+config.rocmlir_enable_comgr = @ROCMLIR_ENABLE_COMGR@
 if config.enable_rock_driver:
     config.available_features.add('rock-driver')
 config.enable_rock_driver_e2e_test = @ROCMLIR_DRIVER_E2E_TEST_ENABLED@

--- a/mlir/tools/rocmlir-driver/CMakeLists.txt
+++ b/mlir/tools/rocmlir-driver/CMakeLists.txt
@@ -10,9 +10,12 @@ set(LIBS
   ${rocmlir_dialect_libs}
   ${rocmlir_conversion_libs}
   ${rocmlir_test_libs}
-  MLIRExecutionEngine
   MLIRXModelPipeline
   )
+
+if (MLIR_ENABLE_EXECUTION_ENGINE)
+  list(APPEND LIBS MLIRExecutionEngine)
+endif()
 
 add_llvm_executable(rocmlir-driver
   PARTIAL_SOURCES_INTENDED

--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -7,6 +7,14 @@ set(LIBS
   LLVMX86AsmParser
 )
 
+if (NOT ROCMLIR_ENABLE_COMGR)
+  list(APPEND libs LLVMX86AsmParser)
+  set(COMPONENTS
+  X86CodeGen
+  X86Desc
+  X86Info
+  )
+endif()
 set(CMAKE_BUILD_RPATH ${CMAKE_BUILD_DIR}/external/llvm-project/llvm/lib)
 
 llvm_add_library(MLIRRockThin
@@ -18,9 +26,7 @@ PARTIAL_SOURCES_INTENDED
   ${LIBS}
 
   LINK_COMPONENTS
-  X86CodeGen
-  X86Desc
-  X86Info
+  ${COMPONENTS}
   )
 
 add_llvm_executable(rocmlir-lib-test

--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -4,16 +4,11 @@ get_property(rocmlir_capi_libs GLOBAL PROPERTY ROCMLIR_PUBLIC_C_API_LIBS)
 set(LIBS
   ${rocmlir_dialect_libs}
   ${rocmlir_capi_libs}
-  LLVMX86AsmParser
 )
 
-if (NOT ROCMLIR_ENABLE_COMGR)
-  list(APPEND libs LLVMX86AsmParser)
-  set(COMPONENTS
-  X86CodeGen
-  X86Desc
-  X86Info
-  )
+if("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
+  list(APPEND libs LLVMAMDGPUAsmParser)
+  set(COMPONENTS AMDGPU)
 endif()
 set(CMAKE_BUILD_RPATH ${CMAKE_BUILD_DIR}/external/llvm-project/llvm/lib)
 
@@ -28,6 +23,10 @@ PARTIAL_SOURCES_INTENDED
   LINK_COMPONENTS
   ${COMPONENTS}
   )
+
+if ("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
+  target_compile_definitions(MLIRRockThin PRIVATE AMDGPU_BACKEND_NEEDS_INIT=1)
+endif()
 
 add_llvm_executable(rocmlir-lib-test
   PARTIAL_SOURCES_INTENDED

--- a/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
+++ b/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
@@ -86,10 +86,12 @@ void miirLazyInit() {
   static std::once_flag once;
   std::call_once(once, []() {
     // Initialize LLVM AMDGPU backend.
+#ifdef AMDGPU_BACKEND_NEEDS_INIT
     LLVMInitializeAMDGPUTarget();
     LLVMInitializeAMDGPUTargetInfo();
     LLVMInitializeAMDGPUTargetMC();
     LLVMInitializeAMDGPUAsmPrinter();
+#endif
   });
 }
 

--- a/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
+++ b/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
@@ -85,7 +85,7 @@ private:
 void miirLazyInit() {
   static std::once_flag once;
   std::call_once(once, []() {
-    // Initialize LLVM AMDGPU backend.
+  // Initialize LLVM AMDGPU backend.
 #ifdef AMDGPU_BACKEND_NEEDS_INIT
     LLVMInitializeAMDGPUTarget();
     LLVMInitializeAMDGPUTargetInfo();

--- a/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
+++ b/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
@@ -85,12 +85,6 @@ private:
 void miirLazyInit() {
   static std::once_flag once;
   std::call_once(once, []() {
-    llvm::InitializeAllTargets();
-    llvm::InitializeAllTargetInfos();
-    llvm::InitializeAllTargetMCs();
-    llvm::InitializeAllAsmParsers();
-    llvm::InitializeAllAsmPrinters();
-
     // Initialize LLVM AMDGPU backend.
     LLVMInitializeAMDGPUTarget();
     LLVMInitializeAMDGPUTargetInfo();


### PR DESCRIPTION
Since we're considering shipping as a ROCm package, I've investigated if it's possible to use COMgr instead of shipping our own copy of LLVM.

This branch shows that it's possible, but I'm not convinced we want to merge it.

The good news is that the setup works.

The bad news is that, because our LLVM copy is *newer* than the one shipped in ROCm 5.4 (which is what we're using for our CI) we'll sometimes need to **downgrade** the LLVM IR we produce to be acceptable input to ROCm's LLVM. If theirs were newer, it'd be fine, because LLVM has strong backwards compatibility guarantees, but this is the other direction.

On top of that, I had to do a few ugly hacks to make COMgr do the compiler invocations we want.

So ... yeah.

(I also should add some tests to make sure printf() works, but that's a tomorrow me problem - I wanted to get this PR out)