### PR TITLE
Adds support for gemm input broadcasting.

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -296,7 +296,7 @@ def MIGraphX_FlattenOp :
 def MIGraphX_TransposeOp :
     MIGraphX_Op<"transpose">,
     Arguments<(ins AnyRankedTensor:$input,
-                   I64ArrayAttr:$dims
+                   I64ArrayAttr:$permutation
                    )>,
 	Results<(outs AnyRankedTensor:$output)> {
   let summary = "transpose dimensions";

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -27,18 +27,6 @@ using namespace mlir;
 
 namespace {
 
-static bool isBroadcastable(Operation *op, Operation *operand) {
-  // tosa only broadcast implicitly on the second input of the binary operators.
-  if (op->getNumOperands() != 2)
-    return false;
-  if (op->getOperand(1) != operand->getResult(0)) {
-    // swap, if possible
-    op->setOperand(0, op->getOperand(1));
-    op->setOperand(1, operand->getResult(0));
-  }
-  return true;
-}
-
 template <typename TosaOp, typename... Args>
 static TosaOp createOpAndInfer(PatternRewriter &rewriter, Location loc,
                                Type elemType, Args &&...args) {
@@ -55,6 +43,27 @@ static TosaOp createOpAndInfer(PatternRewriter &rewriter, Location loc,
   auto result = op->getResult(0);
   result.setType(newOutTy);
   return op;
+}
+
+static bool assignExpandedShapeVal(Operation *use, Operation *originalOp,
+                                   Value maybeExpandedVal) {
+  if (isa<migraphx::DotOp>(use)) {
+    use->replaceUsesOfWith(originalOp->getResult(0), maybeExpandedVal);
+    return true;
+  }
+  if (use->getNumOperands() != 2) {
+    return false;
+  }
+  // tosa only broadcast implicitly on the second input of the binary
+  // elementwise operators.
+  if (use->getOperand(1) != originalOp->getResult(0)) {
+    // swap, if possible
+    use->setOperand(0, use->getOperand(1));
+    use->setOperand(1, maybeExpandedVal);
+  } else {
+    use->setOperand(1, maybeExpandedVal);
+  }
+  return true;
 }
 
 static tosa::CastOp createCastOp(PatternRewriter &rewriter, Location loc,
@@ -189,50 +198,29 @@ public:
   LogicalResult
   matchAndRewrite(migraphx::BroadcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto operands = adaptor.getOperands();
     Location loc = op->getLoc();
-    auto input_t = operands[0];
-    auto axis = op->getAttr("axis").cast<IntegerAttr>().getInt();
+    ArrayRef<int64_t> inShape = op.getInput().getType().getShape();
+    uint32_t outRank = op.getOutput().getType().getRank();
+    Type elemType = op.getOutput().getType().getElementType();
+    int64_t axis = op->getAttr("axis").cast<IntegerAttr>().getInt();
 
-    // get shape of the use
-    auto outShape = op->getResultTypes()[0].cast<ShapedType>().getShape();
-    auto outElemType =
-        op->getResultTypes()[0].cast<ShapedType>().getElementType();
-    uint32_t outRank = outShape.size();
-    auto inShape = input_t.getType().cast<ShapedType>().getShape();
-
-    Value newOperand = input_t;
-    if (outRank != inShape.size()) {
-      SmallVector<int64_t, 5> newShape;
-
-      // align the dimensions - by the given axis
-      for (uint32_t i = 0; i < outRank; i++) {
+    SmallVector<int64_t, 5> newShape;
+    for (uint32_t i = 0; i < outRank; i++) {
+      if (i == axis) {
+        newShape.push_back(inShape[0]);
+      } else {
         newShape.push_back(1);
       }
-      newShape[axis] = inShape[0];
-
-      // reshape
-      auto outType = RankedTensorType::get(newShape, outElemType);
-      newOperand = rewriter.create<tosa::ReshapeOp>(
-          loc, outType, input_t, rewriter.getDenseI64ArrayAttr(newShape));
     }
-
-    for (auto &use : op->getResult(0).getUses()) {
-      auto expandedOp = use.getOwner();
-      // isa binary operation,
-      if (isBroadcastable(expandedOp, op)) {
-        // replace the uses
-        for (auto &operand : expandedOp->getOpOperands()) {
-          if (operand.get() == op) {
-            operand.set(newOperand);
-            break;
-          }
-        }
-      } else {
-        return failure();
+    tosa::ReshapeOp sameRankReshapedOp = createOpAndInfer<tosa::ReshapeOp>(
+        rewriter, loc, elemType, op.getInput(),
+        rewriter.getDenseI64ArrayAttr(newShape));
+    for (Operation *use : op.getOutput().getUsers()) {
+      if (!assignExpandedShapeVal(use, op, sameRankReshapedOp.getResult())) {
+        return op.emitError() << use << " does not support broadcasting\n";
       }
     }
-    // erase broadcast
+
     rewriter.eraseOp(op);
     return success();
   }
@@ -246,56 +234,34 @@ public:
   LogicalResult
   matchAndRewrite(migraphx::MultiBroadcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto operands = adaptor.getOperands();
     Location loc = op->getLoc();
-    auto input_t = operands[0];
-    auto inShape = input_t.getType().cast<ShapedType>().getShape();
-    uint32_t inRank = inShape.size();
+    ArrayRef<int64_t> inShape = op.getInput().getType().getShape();
+    uint32_t inRank = op.getInput().getType().getRank();
+    uint32_t outRank = op.getOutput().getType().getRank();
+    Type elemType = op.getOutput().getType().getElementType();
 
-    for (auto &use : op->getResult(0).getUses()) {
-      auto expandedOp = use.getOwner();
-      if (expandedOp == op)
-        continue;
-      // isa binary operation,
-      if (isBroadcastable(expandedOp, op)) {
-        // get shape of the use
-        auto outShape =
-            expandedOp->getResultTypes()[0].cast<ShapedType>().getShape();
-        auto outElemType =
-            expandedOp->getResultTypes()[0].cast<ShapedType>().getElementType();
-        uint32_t outRank = outShape.size();
+    if (outRank < inRank) {
+      return op.emitError("MultiBroadcastOp shouldn't reduce rank.\n");
+    }
 
-        Value newOperand = input_t;
-        if (outRank != inShape.size()) {
-          SmallVector<int64_t, 5> newShape;
+    Value replacingValue = op.getInput();
+    if (outRank > inRank) {
+      SmallVector<int64_t, 5> newShape = llvm::to_vector<5>(inShape);
+      for (uint32_t i = inRank; i < outRank; i++) {
+        newShape.push_back(i);
+      }
+      tosa::ReshapeOp sameRankReshapedOp = createOpAndInfer<tosa::ReshapeOp>(
+          rewriter, loc, elemType, op.getInput(),
+          rewriter.getDenseI64ArrayAttr(newShape));
+      replacingValue = sameRankReshapedOp.getResult();
+    }
 
-          // align the dimensions - by the given in/out shape
-          uint32_t i = 0;
-          for (; i < outRank - inRank; i++) {
-            newShape.push_back(inShape[i]);
-          }
-          for (; i < outRank; i++) {
-            newShape.push_back(1);
-          }
-
-          // reshape
-          auto outType = RankedTensorType::get(newShape, outElemType);
-          newOperand = rewriter.create<tosa::ReshapeOp>(
-              loc, outType, input_t, rewriter.getDenseI64ArrayAttr(newShape));
-        }
-
-        // replace the uses
-        for (auto &operand : expandedOp->getOpOperands()) {
-          if (operand.get() == op) {
-            operand.set(newOperand);
-            break;
-          }
-        }
-      } else {
-        return failure();
+    for (Operation *use : op.getOutput().getUsers()) {
+      if (!assignExpandedShapeVal(use, op, replacingValue) && use != op) {
+        return op.emitError() << use << " does not support broadcasting\n";
       }
     }
-    // erase broadcast
+
     rewriter.eraseOp(op);
     return success();
   }
@@ -308,10 +274,9 @@ public:
   LogicalResult
   matchAndRewrite(migraphx::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto operands = adaptor.getOperands();
     Location loc = op->getLoc();
-    auto in_A = operands[0];
-    auto in_B = operands[1];
+    TypedValue<TensorType> in_A = op.getInA();
+    TypedValue<TensorType> in_B = op.getInB();
     auto results = op->getResults();
     auto elementTy =
         op->getOperand(0).getType().cast<ShapedType>().getElementType();
@@ -322,8 +287,8 @@ public:
     ArrayRef<int64_t> orgOutDims = outputTy.getShape();
     RankedTensorType newOutType = RankedTensorType::get(orgOutDims, elementTy);
     size_t outRank = orgOutDims.size();
-    ArrayRef<int64_t> orgDimsA = in_A.getType().cast<ShapedType>().getShape();
-    ArrayRef<int64_t> orgDimsB = in_B.getType().cast<ShapedType>().getShape();
+    ArrayRef<int64_t> orgDimsA = in_A.getType().getShape();
+    ArrayRef<int64_t> orgDimsB = in_B.getType().getShape();
     size_t rankA = orgDimsA.size();
     size_t rankB = orgDimsB.size();
 

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -323,7 +323,6 @@ public:
     rock::GemmFeatures features;
     std::tie(arch, num_cu, features) = getArchAttributes(op);
 
-    int64_t dims = outputType.getRank();
     auto [mDim, nDim] = getLastDims(transposeC, outputType);
 
     int64_t kDimOfA;

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
@@ -3,10 +3,10 @@
 module {
   // CHECK:  {{.*}}[4, 4, 4, 4],
   // CHECK-NEXT:   [4, 4, 4, 4]{{.*}}
-  func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x4x3xf32>) -> tensor<1x2x4xf32> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
+  func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x4x3xf32>) -> tensor<1x2x4xf32> attributes{kernel, arch = ""} {
     %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 2, 3]} : (tensor<1x1x1xf32>) -> tensor<1x2x3xf32>
     %arg2tp = migraphx.transpose(%arg2) {permutation = [0:i64, 2:i64, 1:i64]} : (tensor<1x4x3xf32>)-> tensor<1x3x4xf32>
-    %1 = migraphx.dot(%0, %arg2tp) {xdlopsV2 = true} : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
+    %1 = migraphx.dot(%0, %arg2tp) : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
     %2 = migraphx.add(%1, %arg0) : (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
     return %2 : tensor<1x2x4xf32>
   }

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
@@ -1,0 +1,13 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+module {
+  // CHECK:  {{.*}}[4, 4, 4, 4],
+  // CHECK-NEXT:   [4, 4, 4, 4]{{.*}}
+  func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x4x3xf32>) -> tensor<1x2x4xf32> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
+    %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 2, 3]} : (tensor<1x1x1xf32>) -> tensor<1x2x3xf32>
+    %arg2tp = migraphx.transpose(%arg2) {dims = [0:i64, 2:i64, 1:i64]} : (tensor<1x4x3xf32>)-> tensor<1x3x4xf32>
+    %1 = migraphx.dot(%0, %arg2tp) {xdlopsV2 = true} : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
+    %2 = migraphx.add(%1, %arg0) : (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
+    return %2 : tensor<1x2x4xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
@@ -5,7 +5,7 @@ module {
   // CHECK-NEXT:   [4, 4, 4, 4]{{.*}}
   func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x4x3xf32>) -> tensor<1x2x4xf32> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
     %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 2, 3]} : (tensor<1x1x1xf32>) -> tensor<1x2x3xf32>
-    %arg2tp = migraphx.transpose(%arg2) {dims = [0:i64, 2:i64, 1:i64]} : (tensor<1x4x3xf32>)-> tensor<1x3x4xf32>
+    %arg2tp = migraphx.transpose(%arg2) {permutation = [0:i64, 2:i64, 1:i64]} : (tensor<1x4x3xf32>)-> tensor<1x3x4xf32>
     %1 = migraphx.dot(%0, %arg2tp) {xdlopsV2 = true} : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
     %2 = migraphx.add(%1, %arg0) : (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
     return %2 : tensor<1x2x4xf32>

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast.e2e.mlir
@@ -1,0 +1,12 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+module {
+  // CHECK:  {{.*}}[4, 4, 4, 4],
+  // CHECK-NEXT:   [4, 4, 4, 4]{{.*}}
+  func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x3x4xf32>) -> tensor<1x2x4xf32> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
+    %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 2, 3]} : (tensor<1x1x1xf32>) -> tensor<1x2x3xf32>
+    %1 = migraphx.dot(%0, %arg2) {xdlopsV2 = true} : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
+    %2 = migraphx.add(%1, %arg0) : (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
+    return %2 : tensor<1x2x4xf32>
+  }
+}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast.e2e.mlir
@@ -3,9 +3,9 @@
 module {
   // CHECK:  {{.*}}[4, 4, 4, 4],
   // CHECK-NEXT:   [4, 4, 4, 4]{{.*}}
-  func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x3x4xf32>) -> tensor<1x2x4xf32> attributes {arch = "gfx90a:sramecc+:xnack-", kernel = "mixr"} {
+  func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x3x4xf32>) -> tensor<1x2x4xf32> attributes{kernel, arch = ""} {
     %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 2, 3]} : (tensor<1x1x1xf32>) -> tensor<1x2x3xf32>
-    %1 = migraphx.dot(%0, %arg2) {xdlopsV2 = true} : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
+    %1 = migraphx.dot(%0, %arg2) : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
     %2 = migraphx.add(%1, %arg0) : (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
     return %2 : tensor<1x2x4xf32>
   }

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-transpose.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-transpose.e2e.mlir
@@ -10,7 +10,7 @@ module {
   // CLONE-NEXT: Unranked Memref base
   func.func @dot_transpose(%arg0: tensor<1x5x4xf32>, %arg1: tensor<1x4x3xf32>) -> tensor<1x3x5xf32> attributes{kernel, arch = ""} {
     %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4xf32>, tensor<1x4x3xf32>) -> tensor<1x5x3xf32>
-    %2 = "migraphx.transpose"(%0) {dims = [0:i64, 2:i64, 1:i64]} : (tensor<1x5x3xf32>)-> tensor<1x3x5xf32>
+    %2 = "migraphx.transpose"(%0) {permutation = [0:i64, 2:i64, 1:i64]} : (tensor<1x5x3xf32>)-> tensor<1x3x5xf32>
     return %2 : tensor<1x3x5xf32>
   }
 }


### PR DESCRIPTION
Currently, we assume rock.gemm inputs to
conform to m,k,n sizes. However, one of the inputs could be broadcasted coming from tosa.

This commit adds support to insert broadcast transforms to such inputs.

Also cleans up migraphx broadcast lowering.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/840