### PR TITLE
Fix globalLoadOp lowering to not use vector magic if it isn't needed

### DIFF
--- a/mlir/test/Dialect/Rock/lowering_global_moves.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_moves.mlir
@@ -59,10 +59,9 @@ func.func @rock_global_load(%source2D : memref<32x32xf32>) -> vector<4xf32> {
   %c0 = arith.constant 0 : index
   %true = arith.constant true
   // CHECK: %[[loaded:.*]] = rock.buffer_load {{.*}}: memref<32x32xf32>, index, index -> vector<4xf32>
-  // CHECK: %[[ret:.*]] = rock.insert_slice %[[loaded]]
   %loaded = rock.global_load %source2D[%c0, %c0] if %true
     : memref<32x32xf32> -> vector<4xf32>
-  // CHECK: return %[[ret]]
+  // CHECK: return %[[loaded]]
   func.return %loaded : vector<4xf32>
 }
 


### PR DESCRIPTION
@krzysz00 we discussed this fix last week. While overall it does not bring performance uplift, it makes some configurations work better :
For instance, consider this sequence of commands:
```
$ echo "./bin/rocmlir-gen -ph -operation gemm --arch gfx90a -t i8 --transA --transB -g 64 -m 1024 -k 1024 -n 384 --perf_config=128,64,4,64,32,16,1,1 | ./bin/rocmlir-driver -c  |  ../mlir/utils/widgets/rocm-run" > toprofile.sh
$ rocprof --stats toprofile.sh && cat results.stats.csv
```
With current `rocMLIR`

```
"Name","Calls","TotalDurationNs","AverageNs","Percentage"
"rock_gemm.kd",5,3917131,783426,100.0
```

With this PR:
```
"Name","Calls","TotalDurationNs","AverageNs","Percentage"
"rock_gemm.kd",5,2332965,466593,100.0
```
So, it is about 84% improvement. Again, when tuned there is very little improvement, because the tuner is smart and selects a configuration that gives about the same performance. 

