### PR TITLE
Matching quant and dequant ops from MIGraphX

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -166,7 +166,8 @@ def MIGraphX_QuantizeLinearOp :
 	  Results<(outs TensorOf<[I8]>:$output)> {
   let summary = "Channelwise quantization";
   let description = [{
-    Quantization tensor elementwise
+    Quantization tensor channelwise. It computes the following:
+    tensor[n,c,h,w] = tensor[n,c,h,w] / quantScale[c] + quantBias[c]
   }];
   let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
 }
@@ -179,7 +180,8 @@ def MIGraphX_DeQuantizeLinearOp :
 	  Results<(outs TensorOf<[F32]>:$output)> {
   let summary = "Channelwise dequantization";
   let description = [{
-    De-Quantization tensor elementwise
+    De-Quantization tensor channelwise. It computes the following:
+    tensor[n,c,h,w] = (tensor[n,c,h,w] - quantBias[c]) * quantScale[c]
   }];
   let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
 }

--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -160,7 +160,7 @@ def MIGraphX_FloorOp :
 
 def MIGraphX_QuantizeLinearOp :
     MIGraphX_Op<"quantizelinear">,
-    Arguments<(ins TensorOf<[I32]>:$input,
+    Arguments<(ins TensorOf<[F32]>:$input,
                    TensorOf<[F32]>:$scale,
                    Optional<TensorOf<[I32]>>:$bias)>,
 	  Results<(outs TensorOf<[I8]>:$output)> {
@@ -168,7 +168,20 @@ def MIGraphX_QuantizeLinearOp :
   let description = [{
     Quantization tensor elementwise
   }];
-  let assemblyFormat = "`(` operands `)` attr-dict `:` type(operands) `->` type(results)";
+  let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
+}
+
+def MIGraphX_DeQuantizeLinearOp :
+    MIGraphX_Op<"dequantizelinear">,
+    Arguments<(ins TensorOf<[I32]>:$input,
+                   TensorOf<[F32]>:$scale,
+                   Optional<TensorOf<[I32]>>:$bias)>,
+	  Results<(outs TensorOf<[F32]>:$output)> {
+  let summary = "Channelwise dequantization";
+  let description = [{
+    De-Quantization tensor elementwise
+  }];
+  let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
 }
 
 // Convolution operations

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -75,7 +75,7 @@ static tosa::CastOp createCastOp(PatternRewriter &rewriter, Location loc,
   return op;
 }
 
-static Type getShapedElementTy(const Value &v) {
+static Type getShapedElementTy(Value v) {
   return v.getType().cast<ShapedType>().getElementType();
 }
 

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -485,6 +485,10 @@ class QuantizeLinearConverter final
 public:
   using OpConversionPattern<migraphx::QuantizeLinearOp>::OpConversionPattern;
 
+  // MIGraphX pseudo code:
+  // int64_t quantized = static_cast<int32>(
+  //      std::round(input[i] / scales[i])) + zero_pts[i];
+  // output[i] = std::max(-128, std::min(127, quantized));
   LogicalResult
   matchAndRewrite(migraphx::QuantizeLinearOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
@@ -520,6 +524,8 @@ class DeQuantizeLinearConverter final
 public:
   using OpConversionPattern<migraphx::DeQuantizeLinearOp>::OpConversionPattern;
 
+  // MIGraphX pseudo code:
+  // output[i] = static_cast<fp32>(input[i] - zero_pts[i]) * scales[i];
   LogicalResult
   matchAndRewrite(migraphx::DeQuantizeLinearOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
@@ -52,7 +52,8 @@ public:
         migraphx::TransposeOp, migraphx::BroadcastOp,
         migraphx::MultiBroadcastOp, migraphx::ReshapeOp, migraphx::DotOp,
         migraphx::PowOp, migraphx::RecipOp, migraphx::SoftmaxOp,
-        migraphx::ReduceMeanOp, migraphx::QuantizeLinearOp>();
+        migraphx::ReduceMeanOp, migraphx::QuantizeLinearOp,
+        migraphx::DeQuantizeLinearOp>();
 
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 

--- a/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1-quantization.mlir
+++ b/mlir/test/fusion/e2e/resnet50/mixr-resnet-fusion-case-1-quantization.mlir
@@ -5,7 +5,9 @@
 module {
   func.func @test(%arg0: tensor<1x128x1x1xf32>, %arg1: tensor<1x128x56x56xi8>, %arg2: tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi8> {
     %1 = migraphx.quant_convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x128x56x56xi8>, tensor<128x128x3x3xi8>) -> tensor<1x128x28x28xi32>
-    %2 = "migraphx.quantizelinear"(%1, %arg0) : (tensor<1x128x28x28xi32>, tensor<1x128x1x1xf32>) -> tensor<1x128x28x28xi8>
-    return %2 : tensor<1x128x28x28xi8>
+    %2 = migraphx.dequantizelinear(%1, %arg0) : (tensor<1x128x28x28xi32>, tensor<1x128x1x1xf32>) -> tensor<1x128x28x28xf32>
+    %3 = migraphx.quantizelinear(%2, %arg0) : (tensor<1x128x28x28xf32>, tensor<1x128x1x1xf32>) -> tensor<1x128x28x28xi8>
+    return %3 : tensor<1x128x28x28xi8>
   }
 }
+

--- a/mlir/test/fusion/quantization.mlir
+++ b/mlir/test/fusion/quantization.mlir
@@ -15,48 +15,20 @@ func.func @test_conv_with_cast(
     return %output_cast : tensor<1x8x8x8xf32>
 }
 
-// CHECK-LABEL: test_quantization_ck
+// CHECK-LABEL: test_dequantization_migraphx
 // CHECK: arith.sitofp {{.*}} : i32 to f32
-// CHECK: arith.minf {{.*}} : f32
-// CHECK: arith.maxf {{.*}} : f32
-// CHECK: arith.fptosi {{.*}} : f32 to i8
-// N, H, W, C = 1, 8, 8, 4
-// K, Y, X, C = 8, 1, 1, 4
-// N, H, W, K = 1, 8, 8, 8
-func.func @test_quantization_ck(
+func.func @test_dequantization_migraphx(
     %input: tensor<1x8x8x4xi8>, 
     %filter: tensor<8x1x1x4xi8>, 
     %scale: tensor<8xf32>,
-    %bias: tensor<8xi32>) -> tensor<1x8x8x8xi8> 
+    %bias: tensor<8xi32>) -> tensor<1x8x8x8xf32> 
 {
     %zero = arith.constant dense<0> : tensor<8xi8>  
     %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  
-    %shifted = "tosa.add"(%output, %bias) {} : (tensor<1x8x8x8xi32>, tensor<8xi32>) -> tensor<1x8x8x8xi32>  
-    %output_cast = "tosa.cast"(%shifted) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xf32>
-    %scaled = "tosa.mul"(%output_cast, %scale) {shift = 0 : i32} : (tensor<1x8x8x8xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>  
-    %scale_cast = "tosa.cast"(%scaled) : (tensor<1x8x8x8xf32>) -> tensor<1x8x8x8xi8>
-    return %scale_cast : tensor<1x8x8x8xi8>
-}
 
-// CHECK-LABEL: test_quantization_migraphx
-// CHECK: arith.sitofp {{.*}} : i32 to f32
-// CHECK: arith.minf {{.*}} : f32
-// CHECK: arith.maxf {{.*}} : f32
-// CHECK: arith.fptosi {{.*}} : f32 to i32
-// CHECK: arith.trunci {{.*}} : i32 to i8
-func.func @test_quantization_migraphx(
-    %input: tensor<1x8x8x4xi8>, 
-    %filter: tensor<8x1x1x4xi8>, 
-    %scale: tensor<8xf32>,
-    %bias: tensor<8xi32>) -> tensor<1x8x8x8xi8> 
-{
-    %zero = arith.constant dense<0> : tensor<8xi8>  
-    %output = "tosa.conv2d"(%input, %filter, %zero) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, arch = "gfx906", dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x8x8x4xi8>, tensor<8x1x1x4xi8>, tensor<8xi8>) -> tensor<1x8x8x8xi32>  
-    %output_cast = "tosa.cast"(%output) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xf32>
-    %scaled = "tosa.mul"(%output_cast, %scale) {shift = 0 : i32} : (tensor<1x8x8x8xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>  
-    %scaled_cast = "tosa.cast"(%scaled) : (tensor<1x8x8x8xf32>) -> tensor<1x8x8x8xi32>
-    %shifted = "tosa.add"(%scaled_cast, %bias) {} : (tensor<1x8x8x8xi32>, tensor<8xi32>) -> tensor<1x8x8x8xi32>  
-    %scale_cast = "tosa.cast"(%shifted) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xi8>
-    return %scale_cast : tensor<1x8x8x8xi8>
+    %shifted = "tosa.sub"(%output, %bias) {} : (tensor<1x8x8x8xi32>, tensor<8xi32>) -> tensor<1x8x8x8xi32>  
+    %shifted_cast = "tosa.cast"(%shifted) : (tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xf32>
+    %scaled = "tosa.mul"(%shifted_cast, %scale) {shift = 0 : i32} : (tensor<1x8x8x8xf32>, tensor<8xf32>) -> tensor<1x8x8x8xf32>  
+    return %scaled : tensor<1x8x8x8xf32>
 }
 


### PR DESCRIPTION
MIGraphX provided us with correct kernel prototype with both ops as following:

Dequantizelinear op:
```cpp
output[i] = static_cast<fp32>(input[i] - zero_pts[i]) * scales[i];
```

Quantizelinear op:
```cpp
int64_t quantized = static_cast<int32>(std::round(input[i] / scales[i])) + zero_pts[i];
output[i] = std::max(-128, std::min(127, quantized));
```

MLIR's implementation will not be identical to MIGraphx's because of the abstraction mismatch mentioned in https://github.com/ROCmSoftwarePlatform/rocMLIR/discussions/981. The math between using TOSA corresponding ops will be more or less similar.

We will explore to expose MIGraphX specific ops in TOSA extensions, but for the short term of this release, we continue choose to converge on the high level op.