### PR TITLE
Add support for fp8 gemm/conv inside our dialect (no hookups)

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
@@ -22,7 +22,16 @@
 namespace mlir {
 namespace rock {
 
-enum class MfmaTypeId : uint32_t { Fp32TyId = 0, Fp16TyId, Bf16TyId, I8TyId };
+enum class MfmaTypeId : uint32_t {
+  Fp32TyId = 0,
+  Fp16TyId,
+  Bf16TyId,
+  I8TyId,
+  Fp8Fp8TyId,
+  Fp8Bf8TyId,
+  Bf8Fp8TyId,
+  Bf8Bf8TyId
+};
 
 struct MfmaInsnInfo {
   MfmaTypeId type;
@@ -58,7 +67,7 @@ public:
   MfmaInsn(const MfmaInsnAttr &mfmaInsnAttr);
 
   MfmaInsnAttr getAttr();
-  Type getArgType(Type elementType);
+  Type getArgTypeFor(Type elementTypeA);
   VectorType getRetType(Type elementType);
   bool isCoherentWithK(int64_t kPack, int64_t kPerBlock);
 };
@@ -119,14 +128,16 @@ struct MfmaInsnGroupAttr {
 
 class MfmaInsnGroup {
 private:
-  Type elementType;
+  Type elementTypeA;
+  Type elementTypeB;
   MfmaInsn insn;
   MfmaInsnGroupAttr groupAttr;
 
 public:
-  static FailureOr<MfmaInsnGroup> select(Type elementType, StringRef arch,
-                                         int64_t mPerWave, int64_t nPerWave);
-  MfmaInsnGroup(Type elementType, const MfmaInsn &insn,
+  static FailureOr<MfmaInsnGroup> select(Type elementTypeA, Type elementTypeB,
+                                         StringRef arch, int64_t mPerWave,
+                                         int64_t nPerWave);
+  MfmaInsnGroup(Type elementTypeA, Type elementTypeB, const MfmaInsn &insn,
                 const MfmaInsnGroupAttr &groupAttr);
   int64_t getMRepeats(int64_t mPerWave);
   int64_t getNRepeats(int64_t nPerWave);
@@ -134,7 +145,8 @@ public:
   SmallVector<mlir::rock::MFMAParams, 2> getImms();
 
   MfmaInsnAttr getInsnAttr();
-  Type getArgType();
+  Type getArgTypeA();
+  Type getArgTypeB();
   VectorType getRetType();
   bool isCoherentWithK(int64_t kPack, int64_t kPerBlock);
 };

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td
@@ -72,16 +72,23 @@ def RockGemmWrapperInterface : OpInterface<"RockGemmWrapperInterface"> {
       >,
     InterfaceMethod<
         /*desc=*/[{
-          Return the element type of the input to this operation.
+          Return the element type of [what will become] matrix A for this operation.
         }],
         /*retType=*/"::mlir::Type",
-        /*methodName=*/"getInputType",
+        /*methodName=*/"getAType",
         /*args=*/(ins),
         /*methodBody=*/"",
-        /*defaultImplementation=*/[{
-          return $_op->getOperand(1).getType().template cast<::mlir::ShapedType>()
-            .getElementType();
-        }]
+        /*defaultImplementation=*/""
+      >,
+      InterfaceMethod<
+        /*desc=*/[{
+          Return the element type of [what will become] matrix B for this operation.
+        }],
+        /*retType=*/"::mlir::Type",
+        /*methodName=*/"getBType",
+        /*args=*/(ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/""
       >,
     InterfaceMethod<
         /*desc=*/[{
@@ -151,7 +158,7 @@ def RockGemmWrapperInterface : OpInterface<"RockGemmWrapperInterface"> {
       >,
     InterfaceMethod<
         /*desc=*/[{
-          Return the block size this operation will execute with if it has been selected 
+          Return the block size this operation will execute with if it has been selected
           or None otherwise. Prioritizes the block size defined in tuning parameters
         }],
         /*retType=*/"uint32_t",

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -131,8 +131,7 @@ def Rock_Conv2DBwdWeightOp : Rock_Conv2DOpBase<"conv2d_bwd_weight">
 }
 
 def Rock_GemmOp :
-    Rock_Op<"gemm", [AllElementTypesMatch<["a", "b"]>,
-                     DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
+    Rock_Op<"gemm", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
     Arguments<(ins Arg<TensorOrMemRefRankOf<GemmInputTypes, [2, 3]>,
                        "matrix A", [MemRead]>:$a,
                    Arg<TensorOrMemRefRankOf<GemmInputTypes, [2, 3]>,
@@ -1070,8 +1069,6 @@ def Rock_BlockwiseGemmV2Op:
     Rock_Op<"blockwise_gemm_v2">,
     Arguments<(ins MemRefOf<GemmInputTypes>:$matrixA,
                    MemRefOf<GemmInputTypes>:$matrixB,
-                   IndexAttr:$ldsBufferOffsetA,
-                   IndexAttr:$ldsBufferOffsetB,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
                    MemRefOf<MfmaArgTypes>:$bufferA,

--- a/mlir/include/mlir/Dialect/Rock/Tuning/ConvContext.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/ConvContext.h
@@ -37,17 +37,19 @@ struct ConvolutionContext {
   llvm::SmallVector<int64_t, 2> dilationVal;
   llvm::SmallVector<int64_t, 4> paddingVal;
   int gemmId;
-  Type dataType;
+  Type dataTypeA;
+  Type dataTypeB;
 
   ConvolutionContext(const llvm::SmallString<8> &architecture, int numCu,
                      ConvOpType op, llvm::StringMap<DimIndexAndSize> dim,
                      ArrayRef<int64_t> stride, ArrayRef<int64_t> dilation,
-                     ArrayRef<int64_t> padding, int gemmid, Type type)
+                     ArrayRef<int64_t> padding, int gemmid, Type typeA,
+                     Type typeB)
       : arch(architecture), num_cu(numCu), opType(op), dimIndexAndSize(dim),
         strideVal(stride.begin(), stride.end()),
         dilationVal(dilation.begin(), dilation.end()),
         paddingVal(padding.begin(), padding.end()), gemmId(gemmid),
-        dataType(type) {}
+        dataTypeA(typeA), dataTypeB(typeB) {}
 
   llvm::StringMap<DimIndexAndSize> getDimIndexAndSize() const {
     return dimIndexAndSize;
@@ -58,7 +60,8 @@ struct ConvolutionContext {
   ArrayRef<int64_t> getStrideVal() const { return strideVal; }
   ArrayRef<int64_t> getDilationVal() const { return dilationVal; }
   ConvOpType getOpType() const { return opType; }
-  Type getDataType() const { return dataType; }
+  Type getDataTypeA() const { return dataTypeA; }
+  Type getDataTypeB() const { return dataTypeB; }
 };
 
 // Populate ConvContext from a given Convolution Op.

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -48,23 +48,24 @@ struct PopulateParamsInfo {
   GemmSize gemmSize;
   SmallString<32> arch;
   GemmFeatures gemmFeatures;
-  Type inputType;
+  Type gemmAType;
+  Type gemmBType;
   KernelType kernelType;
   int64_t batchSize;
   uint32_t numCu;
 
   PopulateParamsInfo(GemmSize gemmSize, StringRef arch,
-                     GemmFeatures gemmFeatures, Type inputType,
+                     GemmFeatures gemmFeatures, Type gemmAType, Type gemmBType,
                      KernelType kernelType)
       : gemmSize(gemmSize), arch(arch), gemmFeatures(gemmFeatures),
-        inputType(inputType), kernelType(kernelType) {}
+        gemmAType(gemmAType), gemmBType(gemmBType), kernelType(kernelType) {}
 
   PopulateParamsInfo(GemmSize gemmSize, StringRef arch,
-                     GemmFeatures gemmFeatures, Type inputType,
+                     GemmFeatures gemmFeatures, Type gemmAType, Type gemmBType,
                      KernelType kernelType, int64_t batchSize, uint32_t numCu)
       : gemmSize(gemmSize), arch(arch), gemmFeatures(gemmFeatures),
-        inputType(inputType), kernelType(kernelType), batchSize(batchSize),
-        numCu(numCu) {}
+        gemmAType(gemmAType), gemmBType(gemmBType), kernelType(kernelType),
+        batchSize(batchSize), numCu(numCu) {}
 
   /// Extract the relevant information from a RockGemmWrapperInterface operation
   static PopulateParamsInfo fromOp(RockGemmWrapperInterface op);
@@ -232,8 +233,8 @@ public:
                                        InitParamsNonXDL &validParams,
                                        uint32_t &gridSize);
 
-  std::vector<InitParamsNonXDL> getTuningParameters(KernelType opType,
-                                                    Type dataType) const;
+  std::vector<InitParamsNonXDL>
+  getTuningParameters(KernelType opType, Type dataTypeA, Type dataTypeB) const;
 
   LogicalResult isValidGemm(const InitParamsNonXDL &param,
                             const GemmSize &gemmSize) const override;
@@ -253,9 +254,10 @@ private:
   // Tuning parameters for fp16/bf16 convolutions.
   static const InitParamsXDL initParametersFp16[nInitParametersFp16];
 
-  static constexpr size_t nInitParametersForwardI8 = 5;
+  static constexpr size_t nInitParametersForward8Bit = 5;
   // Tuning parameters for i8 convolutions.
-  static const InitParamsXDL initParametersForwardI8[nInitParametersForwardI8];
+  static const InitParamsXDL
+      initParametersForward8Bit[nInitParametersForward8Bit];
 
   static constexpr int64_t waveSize = 64;
 
@@ -269,8 +271,8 @@ private:
                            uint32_t numCu);
 
   LogicalResult isValidBlockwiseGemmXDLOPS(const InitParamsXDL &param,
-                                           Type dataType, StringRef arch,
-                                           uint32_t blockSize);
+                                           Type dataTypeA, Type dataTypeB,
+                                           StringRef arch, uint32_t blockSize);
 
   LogicalResult populateDerived(const InitParamsXDL &validParams,
                                 const PopulateParamsInfo &info,
@@ -298,8 +300,9 @@ public:
                                        uint32_t &blockSize, uint32_t &gridSize,
                                        int64_t &gemmKBlocks);
 
-  std::vector<InitParamsXDL>
-  getTuningParameters(KernelType opType, Type dataType, StringRef arch) const;
+  std::vector<InitParamsXDL> getTuningParameters(KernelType opType,
+                                                 Type dataTypeA, Type dataTypeB,
+                                                 StringRef arch) const;
 
   LogicalResult isValidGemm(const InitParamsXDL &param,
                             const GemmSize &gemmSize) const override;

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -22,7 +22,7 @@ namespace rock {
 struct ConvolutionDims;
 struct GemmSize;
 
-bool isWrWAtomicKernel(GemmFeatures features, const Type &dataType,
+bool isWrWAtomicKernel(GemmFeatures features, Type dataType,
                        bool requiredPadding);
 
 // Heuristic logic to compute KBlock for backward weight atomic add kernel.

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -362,10 +362,12 @@ LogicalResult Conv2dGenerator::needExtraPadBwdWeight(OpBuilder &builder,
   GemmSize gemmSize = GemmSize::fromConvolution(dir, convDims);
 
   needExtraPad = false;
+  // TODO: support mixed-type fp8 here too.
   PopulateParamsInfo info{/*gemmSize=*/gemmSize,
                           /*arch*=*/config.arch,
                           /*gemmFeatures=*/config.features,
-                          /*inputType=*/dataType,
+                          /*gemmAType=*/dataType,
+                          /*gemmBType=*/dataType,
                           /*kernelType=*/KernelType::Conv2DBwdWeight,
                           /*batchSize=*/convDims.n,
                           /*numCu=*/static_cast<uint32_t>(config.num_cu)};

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -78,7 +78,25 @@ auto getMfmaInsnInfoMap = []() -> const llvm::StringMap<MfmaInsnInfo> & {
       {ROCDL::mfma_i32_32x32x16_i8::getOperationName(),
        {MfmaTypeId::I8TyId, 32, 16, 1}},
       {ROCDL::mfma_i32_16x16x32_i8::getOperationName(),
-       {MfmaTypeId::I8TyId, 16, 32, 1}}};
+       {MfmaTypeId::I8TyId, 16, 32, 1}},
+
+      // fp8
+      {ROCDL::mfma_f32_32x32x16_fp8_fp8::getOperationName(),
+       {MfmaTypeId::Fp8Fp8TyId, 32, 16, 1}},
+      {ROCDL::mfma_f32_16x16x32_fp8_fp8::getOperationName(),
+       {MfmaTypeId::Fp8Fp8TyId, 16, 32, 1}},
+      {ROCDL::mfma_f32_32x32x16_fp8_bf8::getOperationName(),
+       {MfmaTypeId::Fp8Bf8TyId, 32, 16, 1}},
+      {ROCDL::mfma_f32_16x16x32_fp8_bf8::getOperationName(),
+       {MfmaTypeId::Fp8Bf8TyId, 16, 32, 1}},
+      {ROCDL::mfma_f32_32x32x16_bf8_fp8::getOperationName(),
+       {MfmaTypeId::Bf8Fp8TyId, 32, 16, 1}},
+      {ROCDL::mfma_f32_16x16x32_bf8_fp8::getOperationName(),
+       {MfmaTypeId::Bf8Fp8TyId, 16, 32, 1}},
+      {ROCDL::mfma_f32_32x32x16_bf8_bf8::getOperationName(),
+       {MfmaTypeId::Bf8Bf8TyId, 32, 16, 1}},
+      {ROCDL::mfma_f32_16x16x32_bf8_bf8::getOperationName(),
+       {MfmaTypeId::Bf8Bf8TyId, 16, 32, 1}}};
   return insnInfo;
 };
 
@@ -319,7 +337,71 @@ auto getMfmaInsnGroupAttrMapGfx940Plus = []() {
                    {{MfmaTypeId::I8TyId, 16, 64},
                     {ROCDL::mfma_i32_16x16x32_i8::getOperationName()}},
                    {{MfmaTypeId::I8TyId, 16, 16},
-                    {ROCDL::mfma_i32_16x16x32_i8::getOperationName()}}};
+                    {ROCDL::mfma_i32_16x16x32_i8::getOperationName()}},
+
+                   // fp8 * fp8
+                   {{MfmaTypeId::Fp8Fp8TyId, 64, 64},
+                    {ROCDL::mfma_f32_32x32x16_fp8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Fp8TyId, 64, 32},
+                    {ROCDL::mfma_f32_32x32x16_fp8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Fp8TyId, 32, 64},
+                    {ROCDL::mfma_f32_32x32x16_fp8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Fp8TyId, 32, 32},
+                    {ROCDL::mfma_f32_32x32x16_fp8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Fp8TyId, 64, 16},
+                    {ROCDL::mfma_f32_16x16x32_fp8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Fp8TyId, 16, 64},
+                    {ROCDL::mfma_f32_16x16x32_fp8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Fp8TyId, 16, 16},
+                    {ROCDL::mfma_f32_16x16x32_fp8_fp8::getOperationName()}},
+
+                   // fp8 * bf8
+                   {{MfmaTypeId::Fp8Bf8TyId, 64, 64},
+                    {ROCDL::mfma_f32_32x32x16_fp8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Bf8TyId, 64, 32},
+                    {ROCDL::mfma_f32_32x32x16_fp8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Bf8TyId, 32, 64},
+                    {ROCDL::mfma_f32_32x32x16_fp8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Bf8TyId, 32, 32},
+                    {ROCDL::mfma_f32_32x32x16_fp8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Bf8TyId, 64, 16},
+                    {ROCDL::mfma_f32_16x16x32_fp8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Bf8TyId, 16, 64},
+                    {ROCDL::mfma_f32_16x16x32_fp8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Fp8Bf8TyId, 16, 16},
+                    {ROCDL::mfma_f32_16x16x32_fp8_bf8::getOperationName()}},
+
+                   // bf8 * fp8
+                   {{MfmaTypeId::Bf8Fp8TyId, 64, 64},
+                    {ROCDL::mfma_f32_32x32x16_bf8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Fp8TyId, 64, 32},
+                    {ROCDL::mfma_f32_32x32x16_bf8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Fp8TyId, 32, 64},
+                    {ROCDL::mfma_f32_32x32x16_bf8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Fp8TyId, 32, 32},
+                    {ROCDL::mfma_f32_32x32x16_bf8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Fp8TyId, 64, 16},
+                    {ROCDL::mfma_f32_16x16x32_bf8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Fp8TyId, 16, 64},
+                    {ROCDL::mfma_f32_16x16x32_bf8_fp8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Fp8TyId, 16, 16},
+                    {ROCDL::mfma_f32_16x16x32_bf8_fp8::getOperationName()}},
+
+                   // bf8 * bf8
+                   {{MfmaTypeId::Bf8Bf8TyId, 64, 64},
+                    {ROCDL::mfma_f32_32x32x16_bf8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Bf8TyId, 64, 32},
+                    {ROCDL::mfma_f32_32x32x16_bf8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Bf8TyId, 32, 64},
+                    {ROCDL::mfma_f32_32x32x16_bf8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Bf8TyId, 32, 32},
+                    {ROCDL::mfma_f32_32x32x16_bf8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Bf8TyId, 64, 16},
+                    {ROCDL::mfma_f32_16x16x32_bf8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Bf8TyId, 16, 64},
+                    {ROCDL::mfma_f32_16x16x32_bf8_bf8::getOperationName()}},
+                   {{MfmaTypeId::Bf8Bf8TyId, 16, 16},
+                    {ROCDL::mfma_f32_16x16x32_bf8_bf8::getOperationName()}}};
   ;
   return groupAttrMap;
 };
@@ -336,7 +418,7 @@ MfmaInsn::MfmaInsn(const MfmaInsnAttr &mfmaInsnAttr) : attr(mfmaInsnAttr) {}
 
 MfmaInsnAttr MfmaInsn::getAttr() { return attr; }
 
-Type MfmaInsn::getArgType(Type elementType) {
+Type MfmaInsn::getArgTypeFor(Type elementType) {
   return attr.nInputsToMfma == 1
              ? elementType
              : VectorType::get({attr.nInputsToMfma}, elementType);
@@ -385,27 +467,41 @@ bool MfmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
   }
 }
 
-MfmaTypeId convertTypeToId(mlir::Type dataType) {
-  if (dataType.isF32()) {
+static MfmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
+  if (dataTypeA.isF32() && dataTypeB.isF32()) {
     return MfmaTypeId::Fp32TyId;
   }
-  if (dataType.isF16()) {
+  if (dataTypeA.isF16() && dataTypeB.isF16()) {
     return MfmaTypeId::Fp16TyId;
   }
-  if (dataType.isBF16()) {
+  if (dataTypeA.isBF16() && dataTypeB.isBF16()) {
     return MfmaTypeId::Bf16TyId;
   }
-  if (dataType.isInteger(8)) {
+  if (dataTypeA.isInteger(8) && dataTypeB.isInteger(8)) {
     return MfmaTypeId::I8TyId;
+  }
+  if (dataTypeA.isFloat8E4M3FNUZ() && dataTypeB.isFloat8E4M3FNUZ()) {
+    return MfmaTypeId::Fp8Fp8TyId;
+  }
+  if (dataTypeA.isFloat8E4M3FNUZ() && dataTypeB.isFloat8E5M2FNUZ()) {
+    return MfmaTypeId::Fp8Bf8TyId;
+  }
+  if (dataTypeA.isFloat8E5M2FNUZ() && dataTypeB.isFloat8E4M3FNUZ()) {
+    return MfmaTypeId::Bf8Fp8TyId;
+  }
+  if (dataTypeA.isFloat8E5M2FNUZ() && dataTypeB.isFloat8E5M2FNUZ()) {
+    return MfmaTypeId::Bf8Bf8TyId;
   }
   llvm_unreachable("Unsupported input argument type.");
 }
 
-FailureOr<MfmaInsnGroup> MfmaInsnGroup::select(mlir::Type elementType,
+FailureOr<MfmaInsnGroup> MfmaInsnGroup::select(Type elementTypeA,
+                                               Type elementTypeB,
                                                StringRef arch, int64_t mPerWave,
                                                int64_t nPerWave) {
   LLVM_DEBUG(llvm::dbgs() << "Invoke Mfma group selection:\n"
-                          << "elementType: " << elementType << "\n"
+                          << "elementType A: " << elementTypeA << "\n"
+                          << "elementType B: " << elementTypeB << "\n"
                           << "arch: " << arch << "\n"
                           << "mPerWave: " << mPerWave << "\n"
                           << "nPerWave: " << nPerWave << "\n");
@@ -414,8 +510,8 @@ FailureOr<MfmaInsnGroup> MfmaInsnGroup::select(mlir::Type elementType,
   int64_t mPerMfmaGroup = getLenPerMfmaGroup(mPerWave);
   int64_t nPerMfmaGroup = getLenPerMfmaGroup(nPerWave);
 
-  MfmaInsnGroupSelectKey key = {convertTypeToId(elementType), mPerMfmaGroup,
-                                nPerMfmaGroup};
+  MfmaInsnGroupSelectKey key = {convertTypesToId(elementTypeA, elementTypeB),
+                                mPerMfmaGroup, nPerMfmaGroup};
 
   FailureOr<MfmaInsnGroup> result = failure();
   auto selectFrom = [&](const MfmaInsnGroupMap &groupMap) {
@@ -432,12 +528,12 @@ FailureOr<MfmaInsnGroup> MfmaInsnGroup::select(mlir::Type elementType,
         result = failure();
         return;
       }
-      result = MfmaInsnGroup(elementType, *maybeInsn, groupAttr);
+      result = MfmaInsnGroup(elementTypeA, elementTypeB, *maybeInsn, groupAttr);
     }
   };
   bool hasOldBf16 = arch.contains("gfx908");
   bool isPreGfx940 = arch.contains("gfx908") || arch.contains("gfx90a");
-  if (elementType.isBF16())
+  if (elementTypeA.isBF16())
     selectFrom(hasOldBf16 ? getMfmaInsnGroupAttrMapGfx908Bf16()
                           : getMfmaInsnGroupAttrMapGfx90aPlusBf16());
   selectFrom(isPreGfx940 ? getMfmaInsnGroupAttrMapPreGfx940Int8()
@@ -449,9 +545,11 @@ FailureOr<MfmaInsnGroup> MfmaInsnGroup::select(mlir::Type elementType,
   return result;
 }
 
-MfmaInsnGroup::MfmaInsnGroup(Type elementType, const MfmaInsn &mfmaInsn,
+MfmaInsnGroup::MfmaInsnGroup(Type elementTypeA, Type elementTypeB,
+                             const MfmaInsn &mfmaInsn,
                              const MfmaInsnGroupAttr &groupAttr)
-    : elementType(elementType), insn(mfmaInsn), groupAttr(groupAttr) {}
+    : elementTypeA(elementTypeA), elementTypeB(elementTypeB), insn(mfmaInsn),
+      groupAttr(groupAttr) {}
 
 int64_t MfmaInsnGroup::getMRepeats(int64_t mPerWave) {
   auto mfmaInsnAttr = getInsnAttr();
@@ -473,9 +571,13 @@ int64_t MfmaInsnGroup::getLenPerMfmaGroup(int64_t lenPerWave) {
 
 MfmaInsnAttr MfmaInsnGroup::getInsnAttr() { return insn.getAttr(); }
 
-Type MfmaInsnGroup::getArgType() { return insn.getArgType(elementType); }
+Type MfmaInsnGroup::getArgTypeA() { return insn.getArgTypeFor(elementTypeA); }
 
-VectorType MfmaInsnGroup::getRetType() { return insn.getRetType(elementType); }
+Type MfmaInsnGroup::getArgTypeB() { return insn.getArgTypeFor(elementTypeB); }
+
+/// Note: Since this only returns i32 or f32, we don't need to do anything
+/// particularly clever here.
+VectorType MfmaInsnGroup::getRetType() { return insn.getRetType(elementTypeA); }
 
 SmallVector<mlir::rock::MFMAParams, 2> MfmaInsnGroup::getImms() {
   return groupAttr.imms;

--- a/mlir/lib/Dialect/Rock/Tuning/ConvContext.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/ConvContext.cpp
@@ -75,8 +75,9 @@ ConvolutionContext mlir::rock::populateConvContext(Operation *op) {
       op->getOperand(2).getType().template cast<MemRefType>().getShape(),
       dimIndexAndSize);
 
-  Type dataType = cast<RockGemmWrapperInterface>(op).getInputType();
+  auto gemmIface = cast<RockGemmWrapperInterface>(op);
+  Type dataTypeA = gemmIface.getAType(), dataTypeB = gemmIface.getBType();
 
   return {archVal,     numCu,      opType, dimIndexAndSize, strideVal,
-          dilationVal, paddingVal, gemmId, dataType};
+          dilationVal, paddingVal, gemmId, dataTypeA,       dataTypeB};
 }

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -17,7 +17,7 @@
 using namespace mlir;
 using namespace mlir::rock;
 
-bool mlir::rock::isWrWAtomicKernel(GemmFeatures features, const Type &dataType,
+bool mlir::rock::isWrWAtomicKernel(GemmFeatures features, Type dataType,
                                    bool requiredPadding) {
   return bitEnumContainsAll(features,
                             GemmFeatures::mfma | GemmFeatures::atomic_add) &&

--- a/mlir/test/Dialect/Rock/gridwise_gemm_v2_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_gemm_v2_lowering.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-opt -split-input-file -rock-gridwise-gemm-to-blockwise %s | FileCheck %s
+
+#xdlops_gemm_params = #rock.xdlops_gemm_params<kPerBlock = 8, mPerBlock = 128, nPerBlock = 128, kpack = 8, mPerWave = 64, nPerWave = 64, forceUnroll = true>
+// CHECK-LABEL: @fp8_bf8_xdlops
+func.func @fp8_bf8_xdlops(%arg0: memref<1x128x128xf8E4M3FNUZ>, %arg1: memref<1x128x115200xf8E5M2FNUZ>, %arg2: memref<1x128x115200xf32>) attributes {block_size = 256 : i32, grid_size = 900 : i32} {
+  // The tuning testcase leads to padded buffers, we simplify here.
+  // CHECK: %[[ldsA:.+]] = rock.alloc() : memref<8192xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsB:.+]] = rock.alloc() : memref<8192xf8E5M2FNUZ, #gpu.address_space<workgroup>>
+  // CHECK: rock.blockwise_gemm_v2
+  // CHECK-SAME %[[ldsA]]
+  // CHECK-SAME: %[[ldsB]]
+  rock.gridwise_gemm_v2(%arg0, %arg1, %arg2) storeMethod( set) features =  mfma|dot|atomic_add {arch = "amdgcn-amd-amdhsa:gfx940", blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params} : memref<1x128x128xf8E4M3FNUZ>, memref<1x128x115200xf8E5M2FNUZ>, memref<1x128x115200xf32>
+  return
+}
+
+// -----

--- a/mlir/test/Dialect/Rock/invalid.mlir
+++ b/mlir/test/Dialect/Rock/invalid.mlir
@@ -45,7 +45,7 @@ func.func @gemm_c_too_big(%a: memref<2048x2048x2048xf32>,
 func.func @gridwise_gemm_no_mixed_ab(%a: memref<1x16x16xf16>,
                         %b: memref<1x16x16xf32>,
                         %c: memref<1x16x16xf32>) {
-  // expected-error@+1 {{'rock.gridwise_gemm' op cannot mix element types for A and B}}
+  // expected-error@+1 {{'rock.gridwise_gemm' op mixed input types ('f16' and 'f32') are only supported for 8-bit floats}}
   rock.gridwise_gemm %c = %a * %b features = dot {
     gridSize = 1 : i32,
     numCu = 64 : i32,
@@ -60,7 +60,7 @@ func.func @gridwise_gemm_no_mixed_ab(%a: memref<1x16x16xf16>,
 func.func @gridwise_gemm_i32_wants_i8(%a: memref<1x16x16xf32>,
                         %b: memref<1x16x16xf32>,
                         %c: memref<1x16x16xi32>) {
-  // expected-error@+1 {{'rock.gridwise_gemm' op i32 output requires i8 input}}
+  // expected-error@+1 {{'rock.gridwise_gemm' op floating-point input type 'f32' requires a floating-point output type, but the output type is 'i32'}}
   rock.gridwise_gemm %c = %a * %b features = dot {
     gridSize = 1 : i32,
     numCu = 64 : i32,
@@ -75,7 +75,7 @@ func.func @gridwise_gemm_i32_wants_i8(%a: memref<1x16x16xf32>,
 func.func @gridwise_gemm_i8_wants_i32(%a: memref<1x16x16xi8>,
                         %b: memref<1x16x16xi8>,
                         %c: memref<1x16x16xf32>) {
-  // expected-error@+1 {{'rock.gridwise_gemm' op i8 input requires i32 output}}
+  // expected-error@+1 {{'rock.gridwise_gemm' op integer input type 'i8' requires an integer output type, but the output type is 'f32'}}
   rock.gridwise_gemm %c = %a * %b features = dot {
     gridSize = 1 : i32,
     numCu = 64 : i32,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_v2.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_v2.mlir
@@ -1,11 +1,12 @@
 // RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise %s | FileCheck %s
 
-func.func @rock_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
+// CHECK-LABEL: @rock_blockwise_gemm_v2_two_results
+func.func @rock_blockwise_gemm_v2_two_results(%matrixA : memref<512xf32, 3>, %matrixB : memref<512xf32, 3>,
                                                 %bufferA : memref<4xf32, 5>, %bufferB : memref<4xf32, 5>,
                                                 %matrixC : memref<4xvector<16xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK:  rock.xdlops_gemm_v2
-  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize= 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -15,19 +16,18 @@ func.func @rock_blockwise_gemm_v2_two_results(%matrix : memref<1024xf32, 3>,
       mPerWave = 64,
       nPerBlock = 128,
       nPerWave = 64,
-      forceUnroll = true>,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 512 : index
-  } : memref<4xvector<16xf32>, 5> += memref<4xf32, 5> from memref<1024xf32, 3> * memref<4xf32, 5> from memref<1024xf32, 3>
+      forceUnroll = true>
+  } : memref<4xvector<16xf32>, 5> += memref<4xf32, 5> from memref<512xf32, 3> * memref<4xf32, 5> from memref<512xf32, 3>
   return
 }
 
-func.func @rock_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>,
+// CHECK-LABEL: @rock_blockwise_gemm_v2_one_result
+func.func @rock_blockwise_gemm_v2_one_result(%matrixA : memref<1024xi8, 3>, %matrixB : memref<1024xi8, 3>,
                                                %bufferA : memref<1xvector<4xi8>, 5>, %bufferB : memref<1xvector<4xi8>, 5>,
                                                %matrixC : memref<1xvector<16xi32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK:  rock.xdlops_gemm_v2
-  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -37,9 +37,30 @@ func.func @rock_blockwise_gemm_v2_one_result(%matrix : memref<2048xi8, 3>,
       mPerWave = 32,
       nPerBlock = 64,
       nPerWave = 32,
-      forceUnroll = true>,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 1024 : index
-  } : memref<1xvector<16xi32>, 5> += memref<1xvector<4xi8>, 5> from memref<2048xi8, 3> * memref<1xvector<4xi8>, 5> from memref<2048xi8, 3>
+      forceUnroll = true>
+  } : memref<1xvector<16xi32>, 5> += memref<1xvector<4xi8>, 5> from memref<1024xi8, 3> * memref<1xvector<4xi8>, 5> from memref<1024xi8, 3>
+  return
+}
+
+// CHECK-LABEL: @rock_blockwise_gemm_v2_fp8_bf8
+func.func @rock_blockwise_gemm_v2_fp8_bf8(%matrixA : memref<8192xf8E4M3FNUZ, #gpu.address_space<workgroup>>,
+                                          %matrixB : memref<8192xf8E5M2FNUZ, #gpu.address_space<workgroup>>,
+                                          %bufferA : memref<4xvector<8xf8E4M3FNUZ>, #gpu.address_space<private>>,
+                                          %bufferB : memref<4xvector<8xf8E5M2FNUZ>, #gpu.address_space<private>>,
+                                          %matrixC : memref<4xvector<16xf32>, #gpu.address_space<private>>) {
+  // CHECK:  rock.xdlops_gemm_v2
+  %c0 = arith.constant 0 : index
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+    arch = "amdgcn-amd-amdhsa:gfx940",
+    blockSize = 256 : i32,
+    params = #rock.xdlops_gemm_params<
+      kPerBlock = 8,
+      mPerBlock = 128,
+      nPerBlock = 128,
+      kpack = 8,
+      mPerWave = 64,
+      nPerWave = 64,
+      forceUnroll = true>
+  } : memref<4xvector<16xf32>, #gpu.address_space<private>> += memref<4xvector<8xf8E4M3FNUZ>, #gpu.address_space<private>> from memref<8192xf8E4M3FNUZ, #gpu.address_space<workgroup>> * memref<4xvector<8xf8E5M2FNUZ>, #gpu.address_space<private>> from memref<8192xf8E5M2FNUZ, #gpu.address_space<workgroup>>
   return
 }

--- a/mlir/test/Dialect/Rock/ops.mlir
+++ b/mlir/test/Dialect/Rock/ops.mlir
@@ -33,6 +33,21 @@ func.func @rock_conv2d_f16(%filter : memref<?x?x?x?x?xf16>, %input : memref<?x?x
 // CHECK-LABEL: func.func @rock_conv2d_f16
 // CHECK-NEXT: rock.conv2d
 
+func.func @rock_conv2d_fp8_mixed(%filter : memref<?x?x?x?x?xf8E4M3FNUZ>, %input : memref<?x?x?x?x?xf8E5M2FNUZ>, %output : memref<?x?x?x?x?xf32>) {
+  rock.conv2d(%filter, %input, %output) features = mfma {
+    arch = "amdgcn-amd-amdhsa:gfx940",
+    filter_layout = ["g", "k", "c", "y", "x"],
+    input_layout = ["n", "gi", "c", "hi", "wi"],
+    output_layout = ["n", "go", "k", "ho", "wo"],
+    dilations = [1 : i32,  1 : i32],
+    strides = [1 : i32,  1 : i32],
+    padding = [0 : i32,  0 : i32,  0 : i32,  0 : i32]
+  } : memref<?x?x?x?x?xf8E4M3FNUZ>, memref<?x?x?x?x?xf8E5M2FNUZ>, memref<?x?x?x?x?xf32>
+  return
+}
+// CHECK-LABEL: func.func @rock_conv2d_fp8_mixed
+// CHECK-NEXT: rock.conv2d
+
 func.func @rock_conv2d_bwd_data(%filter : memref<?x?x?x?x?xf32>, %input : memref<?x?x?x?x?xf32>, %output : memref<?x?x?x?x?xf32>) {
   rock.conv2d_bwd_data(%filter, %input, %output) features = none {
     arch = "amdgcn-amd-amdhsa:gfx906",

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -535,9 +535,7 @@ func.func @rock_blockwise_gemm_v2_one_result(%matrixA : memref<12288xf32, 3>, %m
       mPerWave = 128,
       nPerWave = 64,
       kpack = 1,
-      forceUnroll = true>,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 0 : index
+      forceUnroll = true>
   } : memref<1xvector<32xf32>, 5> += memref<32xf32, 5> from memref<12288xf32, 3> * memref<16xf32, 5> from memref<12288xf32, 3>
   return
 }
@@ -561,9 +559,7 @@ func.func @rock_blockwise_gemm_v2_two_results(%matrixA : memref<12288xf32, 3>, %
       mPerWave = 128,
       nPerWave = 64,
       kpack = 1,
-      forceUnroll = true>,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index
+      forceUnroll = true>
   } : memref<2xvector<32xf32>, 5> += memref<32xf32, 5> from memref<12288xf32, 3> * memref<16xf32, 5> from memref<12288xf32, 3>
   return
 }

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -68,12 +68,12 @@ func.func @rock_xdlops_gemm_v2_two_results_f16(%matrixA : memref<4xvector<4xf16>
 
 // ----
 
-func.func @rock_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
+func.func @rock_blockwise_gemm_v2_one_result_f16(%matrixA : memref<8192xf16, 3>, %matrixB : memref<4096xf16, 3>,
                                           %bufferA : memref<4xvector<4xf16>, 5>, %bufferB : memref<4xvector<4xf16>, 5>,
                                           %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   %c0f = arith.constant 0.0 : f16
-  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -83,10 +83,8 @@ func.func @rock_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
       mPerWave = 16,
       nPerWave = 16,
       kpack = 1,
-      forceUnroll = true>,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index
-  } : memref<1xvector<32xf32>, 5> +=  memref<4xvector<4xf16>, 5> from memref<12288xf16, 3> * memref<4xvector<4xf16>, 5> from memref<12288xf16, 3>
+      forceUnroll = true>
+  } : memref<1xvector<32xf32>, 5> +=  memref<4xvector<4xf16>, 5> from memref<8192xf16, 3> * memref<4xvector<4xf16>, 5> from memref<4096xf16, 3>
   return
 }
 
@@ -95,11 +93,11 @@ func.func @rock_blockwise_gemm_v2_one_result_f16(%matrix : memref<12288xf16, 3>,
 
 // ----
 
-func.func @rock_blockwise_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 3>,
+func.func @rock_blockwise_gemm_v2_two_results_f16(%matrixA : memref<8192xf16, 3>, %matrixB : memref<4096xf16, 3>,
                                                %bufferA : memref<4xvector<4xf16>, 5>, %bufferB : memref<4xvector<4xf16>, 5>,
                                                %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrix[%c0] * %bufferB from %matrix[%c0] {
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -109,10 +107,8 @@ func.func @rock_blockwise_gemm_v2_two_results_f16(%matrix : memref<12288xf16, 3>
       mPerWave = 128,
       nPerWave = 64,
       kpack = 1,
-      forceUnroll = true>,
-    ldsBufferOffsetA = 0 : index,
-    ldsBufferOffsetB = 8192 : index
-  } : memref<2xvector<32xf32>, 5> += memref<4xvector<4xf16>, 5> from memref<12288xf16, 3> * memref<4xvector<4xf16>, 5> from memref<12288xf16, 3>
+      forceUnroll = true>
+  } : memref<2xvector<32xf32>, 5> += memref<4xvector<4xf16>, 5> from memref<8192xf16, 3> * memref<4xvector<4xf16>, 5> from memref<4096xf16, 3>
   return
 }
 

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -192,7 +192,9 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   if (failed(maybeToTune))
     return failure();
   rock::RockGemmWrapperInterface toTune = std::move(*maybeToTune);
-  benchmark::DataType dataType = getDataType(toTune.getInputType());
+  // Provisionally use the type of input A to set up the init value - this
+  // should be a per-buffer value in the futurue.
+  benchmark::DataType dataType = getDataType(toTune.getAType());
 
   auto kernelFunc = toTune->getParentOfType<func::FuncOp>();
   if (!kernelFunc || !kernelFunc->hasAttr("kernel"))


### PR DESCRIPTION
This commit allows our operations (rock.conv2d, rock.gemm, rock.xdlops_gemm_v2, and so on) to work with the two 8-bit float types that will be available on gfx940.

This commit does not enable generating or testing these kernels, nor does it allow for a non-xdlops fp8 path (which would require some sort of software float8 pass).

Unlike the other MFMA instructions, the fp8 instructions support mixed-format inputs: we can freely mix-and-match fp8 (aka Float8E4M3FNUZ) and bf8 (Float8E5M2FNUZ) within GEMMs.

Therefore:
- Various structures (such as the tuning parameter information, MFMA selection, and the GemmWrapperInterface) have been extended to distinguish between the types of matrix A and matrix B.
- gridwise_gemm[_v2] has been updated to use two LDS buffers, one for matrix A and one for matrix B, instead of one large buffer. The compiler folks assured me this was fine - I'll give it a perf check tomorrow.
- As a consequence, the static LDS buffer offsets have been removed from blockwise_gemm_v2.
- In the few places it was needed (creating constants), fp8 and bf8 have been added as cases
- This _ought_ to hook up fine to the AMDGPU dialect and below, but I haven't been in a position to run an e2e test.

Future work includes some some flavor of non-xdlops path, hooking up rocmlir-gen, and CPU verification.