### PR TITLE
Add migraphx.mul to illegal ops

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
@@ -44,17 +44,8 @@ public:
     auto &ctx = getContext();
     RewritePatternSet patterns(&ctx);
     ConversionTarget target(ctx);
-    target.addLegalDialect<tosa::TosaDialect, migraphx::MIGraphXDialect,
-                           func::FuncDialect>();
-    target.addIllegalOp<
-        migraphx::AddOp, migraphx::ConstantOp, migraphx::ConvolutionOp,
-        migraphx::QuantConvolutionOp, migraphx::RsqrtOp, migraphx::ReluOp,
-        migraphx::TransposeOp, migraphx::BroadcastOp,
-        migraphx::MultiBroadcastOp, migraphx::ReshapeOp, migraphx::DotOp,
-        migraphx::PowOp, migraphx::RecipOp, migraphx::SoftmaxOp,
-        migraphx::ReduceMeanOp, migraphx::QuantizeLinearOp,
-        migraphx::DeQuantizeLinearOp>();
-
+    target.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
+    target.addIllegalDialect<migraphx::MIGraphXDialect>();
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
     func::FuncOp func = getOperation();

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -210,6 +210,15 @@ module  {
     %0 = "migraphx.reduce_mean"(%arg0) {axes = [2 : i64]} : (tensor<1x64x112x112xi8>) -> tensor<1x64x1x112xi8>
     return %0 : tensor<1x64x1x112xi8>
   }
+
+  // CHECK-LABEL: func.func @func_dot_mul
+  // CHECK: tosa.matmul
+  // CHECK: tosa.mul
+  func.func @func_dot_mul(%arg0: tensor<1x5x4xf32>, %arg1: tensor<1x4x3xf32>, %arg2: tensor<1x5x3xf32>) -> tensor<1x5x3xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4xf32>, tensor<1x4x3xf32>) -> tensor<1x5x3xf32>
+    %2 = "migraphx.mul"(%0, %arg2) {} : (tensor<1x5x3xf32>, tensor<1x5x3xf32>)-> tensor<1x5x3xf32>
+    return %2 : tensor<1x5x3xf32>
+  }
 }
 
 

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-mbcast-mul-add.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-mbcast-mul-add.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut mlir_dot --verifier clone - | rocmlir-driver -host-pipeline xmodel,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+func.func @mlir_dot(%arg0: tensor<1x1x1x1xf32>, %arg1: tensor<1x1x1x1xf32>, %arg2: tensor<1x12x384x64xf32>, %arg3: tensor<1x12x384x64xf32>) -> tensor<1x12x384x384xf32> attributes{kernel, arch = ""} {
+    %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1x1x1x1xf32>) -> tensor<1x12x384x384xf32>
+    %1 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1x1x1x1xf32>) -> tensor<1x12x384x384xf32>
+    %2 = migraphx.transpose(%arg3) {permutation = [0, 1, 3, 2]} : (tensor<1x12x384x64xf32>) -> tensor<1x12x64x384xf32>
+    %3 = migraphx.dot(%arg2, %2) : tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32> -> tensor<1x12x384x384xf32>
+    %4 = migraphx.mul(%3, %1) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
+    %5 = migraphx.add(%4, %0) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
+    return %5 : tensor<1x12x384x384xf32>
+  }
+}


### PR DESCRIPTION
Currently the dialect transformation does not
define mul as an illegal op. Hence the tablegen
define lowering is not taking place. This commit
fixes that and tests to assure that.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/849