### PR TITLE
Fixing benchmark/tuner issues

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
+++ b/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
@@ -67,7 +67,4 @@ set_property(TARGET rocmlir-tuning-driver
   target_link_libraries(rocmlir-tuning-driver PRIVATE ${LIBS})
   target_link_libraries(rocmlir-tuning-driver PUBLIC benchmark-driver-utils)
   target_link_libraries(rocmlir-tuning-driver PUBLIC hip::host hip::amdhip64)
-  target_include_directories(rocmlir-tuning-driver PUBLIC
-   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
-  )
 endif()

--- a/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
+++ b/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
@@ -67,4 +67,7 @@ set_property(TARGET rocmlir-tuning-driver
   target_link_libraries(rocmlir-tuning-driver PRIVATE ${LIBS})
   target_link_libraries(rocmlir-tuning-driver PUBLIC benchmark-driver-utils)
   target_link_libraries(rocmlir-tuning-driver PUBLIC hip::host hip::amdhip64)
+  target_include_directories(rocmlir-tuning-driver PUBLIC
+   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
+  )
 endif()

--- a/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
+++ b/mlir/tools/rocmlir-tuning-driver/CMakeLists.txt
@@ -65,5 +65,6 @@ set_property(TARGET rocmlir-tuning-driver
 
   llvm_update_compile_flags(rocmlir-tuning-driver)
   target_link_libraries(rocmlir-tuning-driver PRIVATE ${LIBS})
+  target_link_libraries(rocmlir-tuning-driver PUBLIC benchmark-driver-utils)
   target_link_libraries(rocmlir-tuning-driver PUBLIC hip::host hip::amdhip64)
 endif()

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -42,7 +42,7 @@
 #include <cstdlib>
 
 // Utilities to allocate buffers
-#include "mlir/utils/performance/common/benchmarkUtils.h"
+#include "../utils/performance/common/benchmarkUtils.h"
 
 #if !defined(_HIP_CLANG_ONLY__)
 // GCC complains if we don't do this

--- a/mlir/utils/performance/common/CMakeLists.txt
+++ b/mlir/utils/performance/common/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 if (hip_FOUND)
   set(EXCLUDE_FROM_ALL TRUE)
   add_library(benchmark-driver-utils benchmarkUtils.cpp)
-  target_link_libraries(benchmark-driver-utils hip::device)
+  target_link_libraries(benchmark-driver-utils PUBLIC hip::host hip::amdhip64)
   set_target_properties(benchmark-driver-utils
     PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"

--- a/mlir/utils/performance/common/benchmarkUtils.cpp
+++ b/mlir/utils/performance/common/benchmarkUtils.cpp
@@ -264,7 +264,7 @@ void *allocAndFill(DataType dataType, size_t byteSize, bool isOut) {
   size_t bytesPerElem = getBytesPerElement(dataType, isOut);
   size_t elems = byteSize / bytesPerElem;
   for (size_t i = 0; i < elems; ++i) {
-    for (size_t byte = 0; i < bytesPerElem; ++i) {
+    for (size_t byte = 0; byte < bytesPerElem; ++byte) {
       int elem = pattern[(i % patternLen) * bytesPerElem];
       ret[bytesPerElem * i + byte] = elem;
     }

--- a/mlir/utils/performance/common/benchmarkUtils.cpp
+++ b/mlir/utils/performance/common/benchmarkUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "benchmarkUtils.h"
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -162,8 +163,8 @@ std::string dataTypeToStr(DataType dataType) {
 // Utility function to convert "true"/"false" to boolean true/false
 bool atob(const std::string &arg) {
   auto lowercaseArg = arg;
-  transform(lowercaseArg.begin(), lowercaseArg.end(), lowercaseArg.begin(),
-            ::tolower);
+  std::transform(lowercaseArg.begin(), lowercaseArg.end(), lowercaseArg.begin(),
+                 ::tolower);
   return (lowercaseArg == "true" ? true : false);
 }
 


### PR DESCRIPTION
This is fixing discrepancies between the tuner, the driver and `rocmlir-gen`. The main issues were:
- The benchmark driver was not filling the input
- The tuner was filling the input uniformly
This meant that tuner and benchmark driver were faster than `rocmlir-gen` (since the latter was using a fixed pattern, filling the tensors with actual data). 