### PR TITLE
Amending quantized ops type requirement according to migraphx

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -160,30 +160,32 @@ def MIGraphX_FloorOp :
 
 def MIGraphX_QuantizeLinearOp :
     MIGraphX_Op<"quantizelinear">,
-    Arguments<(ins TensorOf<[F32]>:$input,
+    Arguments<(ins TensorOf<[F32, F16]>:$input,
                    TensorOf<[F32]>:$scale,
-                   Optional<TensorOf<[I32]>>:$bias)>,
-	  Results<(outs TensorOf<[I8]>:$output)> {
+                   Optional<TensorOf<[AnyInteger]>>:$bias)>,
+	  Results<(outs TensorOf<[AnyInteger]>:$output)> {
   let summary = "Channelwise quantization";
   let description = [{
     Quantization tensor channelwise. It computes the following:
     tensor[n,c,h,w] = tensor[n,c,h,w] / quantScale[c] + quantBias[c]
   }];
   let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
+  let hasVerifier = 1;
 }
 
 def MIGraphX_DeQuantizeLinearOp :
     MIGraphX_Op<"dequantizelinear">,
-    Arguments<(ins TensorOf<[I32]>:$input,
+    Arguments<(ins TensorOf<[AnyInteger]>:$input,
                    TensorOf<[F32]>:$scale,
-                   Optional<TensorOf<[I32]>>:$bias)>,
-	  Results<(outs TensorOf<[F32]>:$output)> {
+                   Optional<TensorOf<[AnyInteger]>>:$bias)>,
+	  Results<(outs TensorOf<[F32, F16]>:$output)> {
   let summary = "Channelwise dequantization";
   let description = [{
     De-Quantization tensor channelwise. It computes the following:
     tensor[n,c,h,w] = (tensor[n,c,h,w] - quantBias[c]) * quantScale[c]
   }];
   let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
+  let hasVerifier = 1;
 }
 
 // Convolution operations

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -30,8 +30,8 @@ module  {
   // CHECK: tosa.reciprocal
   // CHECK: tosa.mul
   // CHECK: tosa.add
-  func.func @quantize_scale_bias(%arg: tensor<1x112x112x64xf32>, %scale: tensor<64xf32>, %bias: tensor<64xi32>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
-    %1 = "migraphx.quantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xf32>, tensor<64xf32>, tensor<64xi32>) -> tensor<1x112x112x64xi8>
+  func.func @quantize_scale_bias(%arg: tensor<1x112x112x64xf32>, %scale: tensor<64xf32>, %bias: tensor<64xi8>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
+    %1 = "migraphx.quantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xf32>, tensor<64xf32>, tensor<64xi8>) -> tensor<1x112x112x64xi8>
     return %1 : tensor<1x112x112x64xi8>
 }
 
@@ -42,10 +42,10 @@ module  {
   // CHECK: tosa.reciprocal
   // CHECK: tosa.mul
   // CHECK: tosa.add
-  func.func @conv_with_quant(%arg1: tensor<1x3x224x224xi8>, %arg2: tensor<64x3x7x7xi8>, %scale: tensor<1x64x1x1xf32>, %bias: tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xi8> attributes {kernel = "mixr"} {
+  func.func @conv_with_quant(%arg1: tensor<1x3x224x224xi8>, %arg2: tensor<64x3x7x7xi8>, %scale: tensor<1x64x1x1xf32>, %bias: tensor<1x64x1x1xi32>, %bias2: tensor<1x64x1x1xi8>) -> tensor<1x64x112x112xi8> attributes {kernel = "mixr"} {
     %1 = migraphx.quant_convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xi8>, tensor<64x3x7x7xi8>) -> tensor<1x64x112x112xi32>
     %2 = "migraphx.dequantizelinear"(%1, %scale, %bias) : (tensor<1x64x112x112xi32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xf32>
-    %3 = "migraphx.quantizelinear"(%2, %scale, %bias) : (tensor<1x64x112x112xf32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xi8>
+    %3 = "migraphx.quantizelinear"(%2, %scale, %bias2) : (tensor<1x64x112x112xf32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi8>) -> tensor<1x64x112x112xi8>
     return %3 : tensor<1x64x112x112xi8>
 }
 


### PR DESCRIPTION
This is to help conform to migraphx/onnx standard. Quotes from @pfultz2 : 

- for migraphx quantizelinear, the bias and output type must be the same, so if its int8 output then it needs to be int8 bias. this also matches the onnx spec.
- For dequantizelinear the inputs and bias must be the same type, so if the input is int32 then the bias needs to be int32. That also matches the onnx spec.