### PR TITLE
[DO NOT SQUASH] Make LDS buffers vector-typed

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -1346,6 +1346,95 @@ def MemRef_ReinterpretCastOp
 }
 
 //===----------------------------------------------------------------------===//
+// ReinterpretElementsOp
+//===----------------------------------------------------------------------===//
+def MemRef_ReinterpretElementsOp : MemRef_Op<"reinterpret_elements", [
+      DeclareOpInterfaceMethods<CastOpInterface>,
+      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+      MemRefsNormalizable,
+      Pure,
+      ViewLikeOpInterface
+    ]> {
+  let summary = "reinterpret the elements of a memref";
+  let description = [{
+    The `memref.reinterpret_elements` operation changes the element type of a
+    memref when it would be safe to do so. This operation is meant to allow
+    for type punning, such as interpreting a memref<?xf32> as a memref<?xi32>
+    and to enable shrinking the element types of a memref,
+    such as by reinterpreting a memref<Nxvector<KxT>> as a memref<NxKxT>
+    or a memref<?xi32> as a memref<?x2xi16>.
+
+    Unless the `unsafeSkipSizeAndAlignmentCompatibilityChecks` attribute is present,
+    both the source and dest element types must be scalars, 0D vectors, or 1D vectors
+    whose bitwidth is a power of 2. This condition ensures that the source
+    element type be stored without padding, and that the dest elements will form
+    even, densely packed subdivisions of each source element (assuming
+    that loads of the source and  dest type are permitted on a target).
+
+    The reinterpretation is restricted to viewing larger types
+    as smaller ones.
+
+    For "pure" reinterpretations (for example, f32 <-> i32), the layout
+    must not change. For expansions (where a dimension is added), the layout
+    must be the identity layout. (As with `memref.view`, this is not an
+    inherent restriction on the operation, but a simplification used to ensure
+    implementation simplicity. It could be lifted in the future.)
+
+    The reinterpretation is only valid when:
+    1. The source and dest element types have the same bitwidth, and the dest
+    memref's shape is identical to the source's.
+    Example:
+
+    ```mlir
+    // View integers as floats.
+    %2 = memref.reinterpret_elements %1 : memref<4xi32> to memref<4xf32>
+
+    // View 0D vectors as scalars.
+    %4 = memref.reinterpret_elements %3 : memref<?xvector<i32>> to memref<?xi32>
+
+    // View scalars as length-1 vectors
+    %6 = memref.reinterpret_elements %5 : memref<32x32xi32> to memref<32x32xvector<1xi32>>
+
+    ```
+
+    2. The cast is from memref<...xT> to memref<...xBxU> where B
+    is the bitwidth of T divided by the bitwidth of U. When
+    `unsafeSkipSizeAndAlignmentCompatibilityChecks` is enabled, the value of `B` given
+    at the type level is assumed to be correct.
+    Example:
+
+    ```mlir
+    // View vectors as scalars.
+    %2 = memref.reinterpret_elements %1 : memref<?x?xvector<4xf32>> to memref<?x?x4xf32>
+
+    // View scalars as bytes.
+    %4 = memref.reinterpret_elements %3 : memref<?x?xf32> to memref<?x?x4xi8>
+
+    // View vectors as smaller vectors.
+    %6 = memref.reinterpret_elements %5 : memref<?x?xvector<4xf32>> to memref<?x?x2xvector<2xf32>>
+
+    // View vectors as scalars, relying on low-level knowledge of memory layout on a target.
+    %8 = memref.reinterpret_elements %7 {unsafeSkipSizeAndAlignmentCompatibilityChecks}
+      : memref<6xvector<6xi32>> to memref<6x6xi32>
+    ```
+  }];
+
+  let arguments = (ins AnyMemRef:$source,
+                   UnitAttr:$unsafeSkipSizeAndAlignmentCompatibilityChecks);
+  let results = (outs AnyMemRef:$dest);
+  let assemblyFormat = "$source attr-dict `:` type($source) `to` type($dest)";
+
+  let builders = [OpBuilder<(ins "Value":$source, "Type":$newElementType)>];
+
+  let extraClassDeclaration = [{
+    Value getViewSource() { return getSource(); }
+  }];
+
+  let hasFolder = 1;
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // RankOp
 //===----------------------------------------------------------------------===//
 

--- a/external/llvm-project/mlir/test/Dialect/MemRef/invalid.mlir
+++ b/external/llvm-project/mlir/test/Dialect/MemRef/invalid.mlir
@@ -291,6 +291,102 @@ func.func @memref_reshape_result_affine_map_is_not_identity(
 
 // -----
 
+func.func @reinterpret_elements_memory_spaces(%in : memref<4xf32, #gpu.address_space<workgroup>>) -> memref<4xi32> {
+  // expected-error @+1 {{operand type 'memref<4xf32, #gpu.address_space<workgroup>>' and result type 'memref<4xi32>' are cast incompatible}}
+  %out = memref.reinterpret_elements %in : memref<4xf32, #gpu.address_space<workgroup>> to memref<4xi32>
+  return %out : memref<4xi32>
+}
+
+// -----
+
+func.func @reinterpret_elements_too_many_dims(%in : memref<4xvector<4xf32>>) -> memref<4x2x2xf32> {
+  // expected-error @+1 {{operand type 'memref<4xvector<4xf32>>' and result type 'memref<4x2x2xf32>' are cast incompatible}}
+  %out = memref.reinterpret_elements %in : memref<4xvector<4xf32>> to memref<4x2x2xf32>
+  return %out : memref<4x2x2xf32>
+}
+
+// -----
+
+func.func @reinterpret_elements_dynamic_new_dim(%in : memref<4xvector<4xf32>>) -> memref<4x?xf32> {
+  // expected-error @+1 {{operand type 'memref<4xvector<4xf32>>' and result type 'memref<4x?xf32>' are cast incompatible}}
+  %out = memref.reinterpret_elements %in : memref<4xvector<4xf32>> to memref<4x?xf32>
+  return %out : memref<4x?xf32>
+}
+
+// -----
+
+func.func @reinterpret_elements_shape_change(%in : memref<4xi32>) -> memref<2xi64> {
+  // expected-error @+1 {{operand type 'memref<4xi32>' and result type 'memref<2xi64>' are cast incompatible}}
+  %out = memref.reinterpret_elements %in : memref<4xi32> to memref<2xi64>
+  return %out : memref<2xi64>
+}
+
+// -----
+
+func.func @reinterpret_elements_2D_vector(%in : memref<4xvector<2x2xf32>>) -> memref<4x4xf32> {
+  // expected-error @+1 {{source element type must be a fixed-width integer, a float, or a 0- or 1-D vector of such types}}
+  %out = memref.reinterpret_elements %in : memref<4xvector<2x2xf32>> to memref<4x4xf32>
+  return %out : memref<4x4xf32>
+}
+
+// -----
+
+func.func @reinterpret_elements_index_in(%in : memref<4xindex>) -> memref<4xi32> {
+  // expected-error @+1 {{source element type must be a fixed-width integer, a float, or a 0- or 1-D vector of such types}}
+  %out = memref.reinterpret_elements %in : memref<4xindex> to memref<4xi32>
+  return %out : memref<4xi32>
+}
+
+// -----
+
+func.func @reinterpret_elements_index_out(%in : memref<4xi32>) -> memref<4xindex> {
+  // expected-error @+1 {{result element type must be a fixed-width integer, a float, or a 0- or 1-D vector of such types}}
+  %out = memref.reinterpret_elements %in : memref<4xi32> to memref<4xindex>
+  return %out : memref<4xindex>
+}
+
+// -----
+
+func.func @reinterpret_elements_bad_width(%in : memref<4xi48>) -> memref<4x3xi16> {
+  // expected-error @+1 {{'memref.reinterpret_elements' op source element type bitwidth must be a power of 2}}
+  %out = memref.reinterpret_elements %in : memref<4xi48> to memref<4x3xi16>
+  return %out : memref<4x3xi16>
+}
+
+// -----
+
+func.func @reinterpret_elements_bad_result_width(%in : memref<4xi64>) -> memref<4x3xi21> {
+  // expected-error @+1 {{'memref.reinterpret_elements' op result element type bitwidth must be a power of 2}}
+  %out = memref.reinterpret_elements %in : memref<4xi64> to memref<4x3xi21>
+  return %out : memref<4x3xi21>
+}
+
+// -----
+
+func.func @reinterpret_elements_bad_width(%in : memref<4xi32>) -> memref<4xi64> {
+  // expected-error @+1 {{'memref.reinterpret_elements' op result element type bitwidth must evenly divide source element type bitwidth}}
+  %out = memref.reinterpret_elements %in : memref<4xi32> to memref<4xi64>
+  return %out : memref<4xi64>
+}
+
+// -----
+
+func.func @reinterpret_elements_wrong_expansion(%in : memref<4xvector<4xf32>>) -> memref<4x2xf32> {
+  // expected-error @+1 {{'memref.reinterpret_elements' op expected additional trailing dimension of length 4 but got 2 elements}}
+  %out = memref.reinterpret_elements %in : memref<4xvector<4xf32>> to memref<4x2xf32>
+  return %out : memref<4x2xf32>
+}
+
+// -----
+
+func.func @reinterpret_elements_missing_expansion(%in : memref<4xi32>) -> memref<4xi16> {
+  // expected-error @+1 {{'memref.reinterpret_elements' op cast to a shorter bitwidth (from 32 to 16 bits) requires adding a trailing dimension of length 2}}
+  %out = memref.reinterpret_elements %in : memref<4xi32> to memref<4xi16>
+  return %out : memref<4xi16>
+}
+
+// -----
+
 // expected-error @+1 {{type should be static shaped memref}}
 memref.global @foo : i32
 

--- a/external/llvm-project/mlir/test/Dialect/MemRef/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/MemRef/ops.mlir
@@ -42,6 +42,54 @@ func.func @memref_reshape(%unranked: memref<*xf32>, %shape1: memref<1xi32>,
   return %new_unranked : memref<*xf32>
 }
 
+// CHECK-LABEL: func @reinterpret_elements_scalar_to_scalar
+func.func @reinterpret_elements_scalar_to_scalar(%in : memref<4xf32>) -> memref<4xi32> {
+  %out = memref.reinterpret_elements %in : memref<4xf32> to memref<4xi32>
+  return %out : memref<4xi32>
+}
+
+// CHECK-LABEL: func @reinterpret_elements_0D_to_scalar
+func.func @reinterpret_elements_0D_to_scalar(%in : memref<?xvector<i32>>) -> memref<?xi32> {
+  %out = memref.reinterpret_elements %in : memref<?xvector<i32>> to memref<?xi32>
+  return %out : memref<?xi32>
+}
+
+// CHECK-LABEL: func @reinterpret_elements_scalar_to_1D
+func.func @reinterpret_elements_scalar_to_1D(%in : memref<32x32xi32>) -> memref<32x32xvector<1xi32>> {
+  %out = memref.reinterpret_elements %in : memref<32x32xi32> to memref<32x32xvector<1xi32>>
+  return %out : memref<32x32xvector<1xi32>>
+}
+
+// CHECK-LABEL: func @reinterpret_elements_vectors_to_scalars
+func.func @reinterpret_elements_vectors_to_scalars(%in : memref<4xvector<4xf32>>) -> memref<4x4xf32> {
+  %out = memref.reinterpret_elements %in : memref<4xvector<4xf32>> to memref<4x4xf32>
+  return %out : memref<4x4xf32>
+}
+
+// CHECK-LABEL: func @reinterpret_elements_scalars_to_bytes
+func.func @reinterpret_elements_scalars_to_bytes(%in : memref<4xi32>) -> memref<4x4xi8> {
+  %out = memref.reinterpret_elements %in : memref<4xi32> to memref<4x4xi8>
+  return %out : memref<4x4xi8>
+}
+
+// CHECK-LABEL: func @reinterpret_elements_vectors_to_smaller_vectors
+func.func @reinterpret_elements_vectors_to_smaller_vectors(%in : memref<4xvector<4xf32>>) -> memref<4x2xvector<2xf32>> {
+  %out = memref.reinterpret_elements %in : memref<4xvector<4xf32>> to memref<4x2xvector<2xf32>>
+  return %out : memref<4x2xvector<2xf32>>
+}
+
+// CHECK-LABEL: func @reinterpret_elements_vectors_to_themselves
+func.func @reinterpret_elements_vectors_to_themselves(%in : memref<4xvector<4xf32>>) -> memref<4x1xvector<4xf32>> {
+  %out = memref.reinterpret_elements %in : memref<4xvector<4xf32>> to memref<4x1xvector<4xf32>>
+  return %out : memref<4x1xvector<4xf32>>
+}
+
+// CHECK-LABEL: func @reinterpret_elements_vectors_to_smaller_vectors_unsafe
+func.func @reinterpret_elements_vectors_to_smaller_vectors_unsafe(%in : memref<4xvector<6xf32>>) -> memref<4x2xvector<3xf32>> {
+  %out = memref.reinterpret_elements %in {unsafeSkipSizeAndAlignmentCompatibilityChecks} : memref<4xvector<6xf32>> to memref<4x2xvector<3xf32>>
+  return %out : memref<4x2xvector<3xf32>>
+}
+
 // CHECK-LABEL: memref.global @memref0 : memref<2xf32>
 memref.global @memref0 : memref<2xf32>
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1027,6 +1027,8 @@ def Rock_ThreadwiseWriteAllOp :
   let hasVerifier = 1;
 }
 
+defvar LdsBufferTypes = GemmInputTypes # [VectorOfRankAndType<[1], GemmInputTypes>];
+
 // blockwise_gemm
 def Rock_BlockwiseGemmOp:
     Rock_Op<"blockwise_gemm">,
@@ -1039,8 +1041,9 @@ def Rock_BlockwiseGemmOp:
   let description = [{
     The `rock.blockwise_gemm` op does gemm at the blockwise level without xdlops.
 
-    Matrix A resides in LDS and has dimensions [k, m_c * mRepeatStride, kPack].
-    Matrix B resides in LDS and has dimensions [k, n_c * nRepeatStride, kPack].
+    Matrix A resides in LDS and has dimensions [k, m_c * mRepeatStride, kpack].
+    Matrix B resides in LDS and has dimensions [k, n_c * nRepeatStride, kpack].
+
     Matrix C resides in registers and has dimensions [m_c, n_c].
 
     The two index arguments specify a given threads's offset into the LDS buffer..
@@ -1067,8 +1070,8 @@ defvar MfmaResTypes = [VectorOfLengthAndType<[4, 16, 32], [F32, I32]>];
 // blockwise_gemm_v2
 def Rock_BlockwiseGemmV2Op:
     Rock_Op<"blockwise_gemm_v2">,
-    Arguments<(ins MemRefOf<GemmInputTypes>:$matrixA,
-                   MemRefOf<GemmInputTypes>:$matrixB,
+    Arguments<(ins MemRefOf<LdsBufferTypes>:$matrixA,
+                   MemRefOf<LdsBufferTypes>:$matrixB,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
                    MemRefOf<MfmaArgTypes>:$bufferA,
@@ -1079,12 +1082,12 @@ def Rock_BlockwiseGemmV2Op:
                    Rock_XdlopsGemmParamsAttr:$params)>{
   let summary = "Blockwise GEMM XDLOPS version";
   let description = [{
-    The `rock.block_gemm` op does GEMM at workgroup (block) level.
+    The `rock.block_gemm_v2` op does GEMM at workgroup (block) level.
     - Matrix A and Matrix B shall reside on LDS (naive tensor).
     - Matrix C shall be vectors.
 
-    There are only two slots for argument transforms since the buffers are
-    not slices of a larger object.
+    The elements of matrices A and B should be vectors of length kpack, or
+    scalars when kpack is 1.
   }];
   let assemblyFormat = [{
     $matrixC `+` `` `=` $bufferA `from` $matrixA `[` $waveOffsetA `]` `*`

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -45,9 +45,15 @@ TransformOp reshapeBuffer(OpBuilder &b, Location loc, Value buffer,
 /// dimension, returns the largest stride `s` such that length-`s` slices of
 /// `dim` correspond to contiguous slices of the underlying memory the
 /// `transforms` will be applied to, which is assumed to have shape
-/// `outputShape`.
+/// `outputShape`. `implicitStride` is used for vector-valued buffers whose
+/// indexing functions are scalar-valued. It scales the implicit
+/// index linearization at the end of the vectorization analysis by
+/// `implicitStride`, so that the low-order bits of the scalar index that are
+/// discarded do not cause incorrect conclusions. The returned vectorization
+/// length is scaled by `implicitStride`.
 int64_t getMaxVectorization(ArrayAttr transforms, uint32_t dim, int64_t len,
-                            ArrayRef<int64_t> outputShape);
+                            ArrayRef<int64_t> outputShape,
+                            int64_t implicitStride = 1);
 
 /// Returns the maximum vectorization constrained by the `dataType` we are
 /// vectorizing for

--- a/mlir/test/Dialect/Rock/gridwise_gemm_v2_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_gemm_v2_lowering.mlir
@@ -4,8 +4,8 @@
 // CHECK-LABEL: @fp8_bf8_xdlops
 func.func @fp8_bf8_xdlops(%arg0: memref<1x128x128xf8E4M3FNUZ>, %arg1: memref<1x128x115200xf8E5M2FNUZ>, %arg2: memref<1x128x115200xf32>) attributes {block_size = 256 : i32, grid_size = 900 : i32} {
   // The tuning testcase leads to padded buffers, we simplify here.
-  // CHECK: %[[ldsA:.+]] = rock.alloc() : memref<8192xf8E4M3FNUZ, #gpu.address_space<workgroup>>
-  // CHECK: %[[ldsB:.+]] = rock.alloc() : memref<8192xf8E5M2FNUZ, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsA:.+]] = rock.alloc() : memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsB:.+]] = rock.alloc() : memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
   // CHECK: rock.blockwise_gemm_v2
   // CHECK-SAME %[[ldsA]]
   // CHECK-SAME: %[[ldsB]]


### PR DESCRIPTION
In order to properly communicate size and alignment information to the
backend when using kpack > 1, change the LDS buffer types
from (kpacksPerBlock * dPerBlock * kpack) x T to
(kpacksPerBlock * dPerBlock) x vector<kpack x T>.

This required the creation of a memref.reinterpret_elements operation.

The LDS matrix wrapping and LDS store loop wrapping functionality has
been merged into one larger function, and a special-purpose function
for handling the requirements of the non-xdlops pipeline has been
added.

There's also a minor extension to the vectorizer to handle the fact
that we have a scalar iteration map but vector-valued buffers.