### PR TITLE
[cmake] Fixed submoduling for mlir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 include(cmake/llvm-project.cmake)
 
 # Update the build-tree RPATH
-set(CMAKE_BUILD_RPATH "${ROCMLIR_LIB_DIR};${LLVM_LIB_DIR}")
+set(CMAKE_BUILD_RPATH "${ROCMLIR_LIB_DIR};${LLVM_EXTERNAL_LIB_DIR}")
 message(STATUS "CMAKE_BUILD_RPATH: ${CMAKE_BUILD_RPATH}")
 
 # Set up the build for the rocMLIR dialects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 include(cmake/llvm-project.cmake)
 
 # Update the build-tree RPATH
-set(CMAKE_BUILD_RPATH "${ROCMLIR_LIB_DIR};${LLVM_EXTERNAL_LIB_DIR}")
+set(CMAKE_BUILD_RPATH "${ROCMLIR_LIB_DIR};${LLVM_LIB_DIR}")
 message(STATUS "CMAKE_BUILD_RPATH: ${CMAKE_BUILD_RPATH}")
 
 # Set up the build for the rocMLIR dialects

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -1,16 +1,14 @@
 message(STATUS "Adding LLVM git-submodule src dependency")
 
-# LLVM settings that have an effect on the MLIR dialect
-set(LLVM_ENABLE_ZLIB "OFF" CACHE STRING "")
-set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
-set(LLVM_TARGETS_TO_BUILD "X86;AMDGPU" CACHE STRING "")
+set(LLVM_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project")
+set(LLVM_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project")
 
-message(STATUS "LLVM_EXTERNAL_BIN_DIR: ${LLVM_EXTERNAL_BIN_DIR}")
+# Pointers to: external LLVM bins/libs
+set(LLVM_BIN_DIR "${LLVM_BINARY_DIR}/llvm/bin" CACHE PATH "")
+set(LLVM_LIB_DIR "${LLVM_BINARY_DIR}/llvm/lib" CACHE PATH "")
 
-# Pointers to: 1) external LLVM bins/libs, and 2) Rock Dialect bins/libs
-set(LLVM_MAIN_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project/llvm" CACHE PATH "Path to LLVM sources")
-set(LLVM_EXTERNAL_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/bin" CACHE PATH "")
-set(LLVM_EXTERNAL_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/lib" CACHE PATH "")
+message(STATUS "LLVM_BIN_DIR: ${LLVM_BIN_DIR}")
+message(STATUS "LLVM_LIB_DIR: ${LLVM_LIB_DIR}")
 
 # Passed to lit.site.cfg.py.so that the out of tree Standalone dialect test
 # can find MLIR's CMake configuration
@@ -20,13 +18,14 @@ set(MLIR_CMAKE_CONFIG_DIR
 # MLIR settings
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
-# LLVM settings
+# LLVM settings that have an effect on the MLIR dialect
+set(LLVM_ENABLE_ZLIB "OFF" CACHE STRING "")
+set(LLVM_TARGETS_TO_BUILD "X86;AMDGPU" CACHE STRING "")
 set(LLVM_ENABLE_PROJECTS "mlir;lld" CACHE STRING "List of default llvm targets")
 set(LLVM_BUILD_EXAMPLES ON CACHE BOOL "")
 set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
 set(LLVM_ENABLE_ASSERTIONS ON CACHE BOOL "")
-set(LLVM_PROJ_SRC "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project")
 
 # Configure ROCm support.
 if (NOT DEFINED ROCM_PATH)
@@ -43,26 +42,26 @@ list(APPEND CMAKE_MODULE_PATH
   "${ROCM_PATH}/hip/cmake"
 )
 list(APPEND CMAKE_MODULE_PATH
-  "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/mlir"
+  "${CMAKE_BINARY_DIR}/lib/cmake/mlir"
 )
 list(APPEND CMAKE_MODULE_PATH
-  "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/lib/cmake/llvm/"
+  "${LLVM_BINARY_DIR}/llvm/lib/cmake/llvm/"
 )
 
 # Include dirs for MLIR and LLVM
 list(APPEND MLIR_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project/mlir/include
-  ${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/tools/mlir/include
+  ${LLVM_PROJECT_DIR}/mlir/include
+  ${LLVM_BINARY_DIR}/llvm/tools/mlir/include
 )
 list(APPEND LLVM_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project/llvm/include
-  ${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/include
+  ${LLVM_PROJECT_DIR}/llvm/include
+  ${LLVM_BINARY_DIR}/llvm/include
 )
 
 # Linker flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project/llvm/lib")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,${LLVM_BINARY_DIR}/llvm/lib")
 
-add_subdirectory("${LLVM_PROJ_SRC}/llvm" "external/llvm-project/llvm" EXCLUDE_FROM_ALL)
+add_subdirectory("${LLVM_PROJECT_DIR}/llvm" "external/llvm-project/llvm" EXCLUDE_FROM_ALL)
 
 function(add_rocmlir_dialect_library name)
   set_property(GLOBAL APPEND PROPERTY ROCMLIR_DIALECT_LIBS ${name})

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -4,11 +4,11 @@ set(LLVM_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project")
 set(LLVM_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project")
 
 # Pointers to: external LLVM bins/libs
-set(LLVM_BIN_DIR "${LLVM_BINARY_DIR}/llvm/bin" CACHE PATH "")
-set(LLVM_LIB_DIR "${LLVM_BINARY_DIR}/llvm/lib" CACHE PATH "")
+set(LLVM_EXTERNAL_BIN_DIR "${LLVM_BINARY_DIR}/llvm/bin" CACHE PATH "")
+set(LLVM_EXTERNAL_LIB_DIR "${LLVM_BINARY_DIR}/llvm/lib" CACHE PATH "")
 
-message(STATUS "LLVM_BIN_DIR: ${LLVM_BIN_DIR}")
-message(STATUS "LLVM_LIB_DIR: ${LLVM_LIB_DIR}")
+message(STATUS "LLVM_EXTERNAL_BIN_DIR: ${LLVM_EXTERNAL_BIN_DIR}")
+message(STATUS "LLVM_EXTERNAL_LIB_DIR: ${LLVM_EXTERNAL_LIB_DIR}")
 
 # Passed to lit.site.cfg.py.so that the out of tree Standalone dialect test
 # can find MLIR's CMake configuration


### PR DESCRIPTION
* upstream still has at least one CMAKE_BINARY_DIR
  * see https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/861
* also some general cleanup