### PR TITLE
Disable HIPRTC for MIGraphX builds

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -961,7 +961,7 @@ pipeline {
                         steps {
                             sh 'rm -rf MIGraphX'
                             dir('MIGraphX') {
-                                getAndBuildMIGraphX("-DCMAKE_PREFIX_PATH='/MIGraphXDeps;${WORKSPACE}/MIGraphXDeps' -DMIGRAPHX_ENABLE_MLIR=On -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++")
+                                getAndBuildMIGraphX("-DCMAKE_PREFIX_PATH='/MIGraphXDeps;${WORKSPACE}/MIGraphXDeps' -DMIGRAPHX_ENABLE_MLIR=On -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DMIGRAPHX_USE_HIPRTC=Off")
                             }
                         }
                     }


### PR DESCRIPTION
MIGraphX recently enabled hiprtc by default.
However, MIGraphX requires >= ROCm 5.5.

Thus, currently disabling hiprtc in our tests
until we move onto 5.5.