### PR TITLE
Allocates LDS buffers as bytes and view them as appropriate vectors

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1027,6 +1027,8 @@ def Rock_ThreadwiseWriteAllOp :
   let hasVerifier = 1;
 }
 
+defvar LdsBufferTypes = GemmInputTypes # [VectorOfRankAndType<[1], GemmInputTypes>];
+
 // blockwise_gemm
 def Rock_BlockwiseGemmOp:
     Rock_Op<"blockwise_gemm">,
@@ -1039,8 +1041,9 @@ def Rock_BlockwiseGemmOp:
   let description = [{
     The `rock.blockwise_gemm` op does gemm at the blockwise level without xdlops.
 
-    Matrix A resides in LDS and has dimensions [k, m_c * mRepeatStride, kPack].
-    Matrix B resides in LDS and has dimensions [k, n_c * nRepeatStride, kPack].
+    Matrix A resides in LDS and has dimensions [k, m_c * mRepeatStride, kpack].
+    Matrix B resides in LDS and has dimensions [k, n_c * nRepeatStride, kpack].
+
     Matrix C resides in registers and has dimensions [m_c, n_c].
 
     The two index arguments specify a given threads's offset into the LDS buffer..
@@ -1067,8 +1070,8 @@ defvar MfmaResTypes = [VectorOfLengthAndType<[4, 16, 32], [F32, I32]>];
 // blockwise_gemm_v2
 def Rock_BlockwiseGemmV2Op:
     Rock_Op<"blockwise_gemm_v2">,
-    Arguments<(ins MemRefOf<GemmInputTypes>:$matrixA,
-                   MemRefOf<GemmInputTypes>:$matrixB,
+    Arguments<(ins MemRefOf<LdsBufferTypes>:$matrixA,
+                   MemRefOf<LdsBufferTypes>:$matrixB,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
                    MemRefOf<MfmaArgTypes>:$bufferA,
@@ -1079,12 +1082,12 @@ def Rock_BlockwiseGemmV2Op:
                    Rock_XdlopsGemmParamsAttr:$params)>{
   let summary = "Blockwise GEMM XDLOPS version";
   let description = [{
-    The `rock.block_gemm` op does GEMM at workgroup (block) level.
+    The `rock.block_gemm_v2` op does GEMM at workgroup (block) level.
     - Matrix A and Matrix B shall reside on LDS (naive tensor).
     - Matrix C shall be vectors.
 
-    There are only two slots for argument transforms since the buffers are
-    not slices of a larger object.
+    The elements of matrices A and B should be vectors of length kpack, or
+    scalars when kpack is 1.
   }];
   let assemblyFormat = [{
     $matrixC `+` `` `=` $bufferA `from` $matrixA `[` $waveOffsetA `]` `*`

--- a/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
@@ -26,6 +26,9 @@ Value createTypeConversionOp(OpBuilder &b, Location loc, Value source,
 /// Utility function to collapse an multi-dimensional memref to 1D.
 Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source);
 
+/// Utility function to get the number of bytes a value of type `type` takes up.
+int64_t getByteWidth(Type type);
+
 } // namespace rock
 } // namespace mlir
 

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -45,9 +45,15 @@ TransformOp reshapeBuffer(OpBuilder &b, Location loc, Value buffer,
 /// dimension, returns the largest stride `s` such that length-`s` slices of
 /// `dim` correspond to contiguous slices of the underlying memory the
 /// `transforms` will be applied to, which is assumed to have shape
-/// `outputShape`.
+/// `outputShape`. `implicitStride` is used for vector-valued buffers whose
+/// indexing functions are scalar-valued. It scales the implicit
+/// index linearization at the end of the vectorization analysis by
+/// `implicitStride`, so that the low-order bits of the scalar index that are
+/// discarded do not cause incorrect conclusions. The returned vectorization
+/// length is scaled by `implicitStride`.
 int64_t getMaxVectorization(ArrayAttr transforms, uint32_t dim, int64_t len,
-                            ArrayRef<int64_t> outputShape);
+                            ArrayRef<int64_t> outputShape,
+                            int64_t implicitStride = 1);
 
 /// Returns the maximum vectorization constrained by the `dataType` we are
 /// vectorizing for

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -150,5 +150,10 @@ Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source) {
   return result;
 }
 
+int64_t getByteWidth(Type type) {
+  if (auto vecType = type.dyn_cast<VectorType>())
+    return (vecType.getElementTypeBitWidth() * vecType.getNumElements()) / 8;
+  return type.getIntOrFloatBitWidth() / 8;
+}
 } // namespace rock
 } // namespace mlir

--- a/mlir/test/Dialect/Rock/gridwise_gemm_v2_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_gemm_v2_lowering.mlir
@@ -4,11 +4,17 @@
 // CHECK-LABEL: @fp8_bf8_xdlops
 func.func @fp8_bf8_xdlops(%arg0: memref<1x128x128xf8E4M3FNUZ>, %arg1: memref<1x128x115200xf8E5M2FNUZ>, %arg2: memref<1x128x115200xf32>) attributes {block_size = 256 : i32, grid_size = 900 : i32} {
   // The tuning testcase leads to padded buffers, we simplify here.
-  // CHECK: %[[ldsA:.+]] = rock.alloc() : memref<8192xf8E4M3FNUZ, #gpu.address_space<workgroup>>
-  // CHECK: %[[ldsB:.+]] = rock.alloc() : memref<8192xf8E5M2FNUZ, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsA:.+]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsB:.+]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewAStore:.+]] = memref.view %[[ldsA]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewBStore:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: memref.store %{{.*}}, %[[viewAStore]]
+  // CHECK: memref.store %{{.*}}, %[[viewBStore]]
+  // CHECK: %[[viewAGemm:.+]] = memref.view %[[ldsA]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewBGemm:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
   // CHECK: rock.blockwise_gemm_v2
-  // CHECK-SAME %[[ldsA]]
-  // CHECK-SAME: %[[ldsB]]
+  // CHECK-SAME %[[viewAGemm]]
+  // CHECK-SAME: %[[viewBGemm]]
   rock.gridwise_gemm_v2(%arg0, %arg1, %arg2) storeMethod( set) features =  mfma|dot|atomic_add {arch = "amdgcn-amd-amdhsa:gfx940", blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params} : memref<1x128x128xf8E4M3FNUZ>, memref<1x128x115200xf8E5M2FNUZ>, memref<1x128x115200xf32>
   return
 }


### PR DESCRIPTION
In order to generate more vectorized reads from LDS (using things like ds_read2_b64), we need LLVM to be using simpler address computation logic, namely, we need the getelementpointer operations we're doing to be vector-typed. This doesn't necessarily mean we need to allocate our LDS buffers as vector-typed values, but it does mean that we need to do the view conversion instead of calling vector.transfer_read / vector.load , as this leads to computing a scalar index and then loading a vector based off of it.

Since we don't need to actually make the buffer vector-typed, we can instead use a buffer of bytes and the existing `memref.view` op, which is intended for exactly this sort of situation (and may have been motivated by similar LDS-using code in someone else's kernel).

Since our kernels have a bunch of nice powers of 2 running around, we don't necessarily need to explicitly pass the alignment of the global to LLVM, but I'm fixing to do that in a followup commit anyway.

The LDS matrix wrapping and LDS store loop wrapping functionality has been merged into one larger function to make this work - partly because that's how the previous PR did it.

There's also a minor extension to the vectorizer to handle the fact that we have a scalar iteration map but vector-valued buffers.

Superscedes PR #1037, for which see more info on what this changes about our output (there doesn't seem to be much difference in the ultimate effects)

(@zhanglx13 , you're on this because it might be relevant to Triton integration stuff, even if the code changes from this change shouldn't be much )