### PR TITLE
[DO NOT SQUASH] Adds slice op input fusion support

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -117,6 +117,17 @@ bool isTransposeOp(Operation *op) {
   return isa<tosa::TransposeOp, tosa::ReshapeOp>(op);
 }
 
+bool isSliceOp(Operation *op) { return isa<tosa::SliceOp>(op); }
+
+bool isConstSplatOp(Operation *op) {
+  if (tosa::ConstOp constOp = dyn_cast<tosa::ConstOp>(op)) {
+    if (constOp.getValue().isSplat()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool isTransposeConfigConstant(Operation *op) {
   return op->hasTrait<OpTrait::ConstantLike>() &&
          llvm::any_of(op->getUsers(), [&](Operation *u) {
@@ -125,8 +136,8 @@ bool isTransposeConfigConstant(Operation *op) {
 }
 
 bool isAlwaysLeadingOp(Operation *op) {
-  return isConstantZero(op) || isTransposeOp(op) ||
-         isTransposeConfigConstant(op);
+  return isConstantZero(op) || isTransposeOp(op) || isSliceOp(op) ||
+         isConstSplatOp(op) || isTransposeConfigConstant(op);
 }
 
 bool isLeadingOp(Operation *op, bool trailingOnly) {

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
@@ -3,6 +3,7 @@
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
 // CHECK: tosa.transpose
 // CHECK: tosa.transpose
@@ -10,6 +11,7 @@
 // CHECK-NEXT: tosa.transpose
 // CHECK: return
 // CHECK-LABEL: func private @forward__part_1
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -109,6 +109,12 @@ TransformMapAttr transformExpandShape(OpBuilder &b, Location loc,
                                       ArrayRef<int64_t> outShape,
                                       ArrayRef<ReassociationIndices> reassocs);
 
+TransformMapAttr transformExtractSlice(OpBuilder &b, Location loc,
+                                       ArrayRef<int64_t> inpShape,
+                                       ArrayRef<int64_t> outShape,
+                                       ArrayRef<int64_t> offsets,
+                                       ArrayRef<int64_t> sizes);
+
 } // end namespace rock
 } // end namespace mlir
 #endif

--- a/mlir/test/fusion/e2e/mixr-slice-dot.mlir
+++ b/mlir/test/fusion/e2e/mixr-slice-dot.mlir
@@ -1,0 +1,22 @@
+// RUN: rocmlir-opt --migraphx-transform --canonicalize --migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut mlir_dot --verifier clone - | rocmlir-driver -host-pipeline xmodel -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK-NEXT: Unranked Memref base
+  func.func @mlir_dot(%arg0: tensor<1x1x1x1xf32>, %arg1: tensor<1x384x2304xf32>, %arg2: tensor<1x384x2304xf32>) -> tensor<1x12x384x384xf32> {
+    %0 = "tosa.const"() {value = dense<1.250000e-01> : tensor<1xf32>} : () -> tensor<1xf32>
+    %1 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1x1x1x1xf32>) -> tensor<1x12x384x384xf32>
+    %2 = migraphx.reshape(%arg1) {dims = [1, 384, 36, 64]} : (tensor<1x384x2304xf32>) -> tensor<1x384x36x64xf32>
+    %3 = migraphx.transpose(%2) {permutation = [0, 2, 1, 3]} : (tensor<1x384x36x64xf32>) -> tensor<1x36x384x64xf32>
+    %4 = migraphx.slice(%3) {axes = [1], ends = [12], starts = [0]} : (tensor<1x36x384x64xf32>) -> tensor<1x12x384x64xf32>
+    %5 = migraphx.reshape(%arg2) {dims = [1, 384, 36, 64]} : (tensor<1x384x2304xf32>) -> tensor<1x384x36x64xf32>
+    %6 = migraphx.transpose(%5) {permutation = [0, 2, 1, 3]} : (tensor<1x384x36x64xf32>) -> tensor<1x36x384x64xf32>
+    %7 = migraphx.slice(%6) {axes = [1], ends = [24], starts = [12]} : (tensor<1x36x384x64xf32>) -> tensor<1x12x384x64xf32>
+    %8 = migraphx.transpose(%7) {permutation = [0, 1, 3, 2]} : (tensor<1x12x384x64xf32>) -> tensor<1x12x64x384xf32>
+    %9 = migraphx.dot(%4, %8) : tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32> -> tensor<1x12x384x384xf32>
+    %10 = migraphx.multibroadcast(%0) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1xf32>) -> tensor<1x12x384x384xf32>
+    %11 = migraphx.mul(%9, %10) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
+    %12 = migraphx.add(%11, %1) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
+    return %12 : tensor<1x12x384x384xf32>
+  }
+}


### PR DESCRIPTION
This commit adds lowering of slice op fused to
gemm-like ops by converting the eventually lowered
tensor.extract_slice op to rock.transform by slice.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/863