### PR TITLE
Add support for wmma in the rocMLIR frontend

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
@@ -56,6 +56,7 @@ struct MfmaInsnAttr {
   int64_t blocksPerMfmaOutput;
   int64_t rowGroupsPerBlock;
   int64_t blocksInOutRegs;
+  bool isKReduction;
 };
 
 class MfmaInsn {

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -285,6 +285,41 @@ def Rock_XdlopsGemmParamsAttr : Rock_Attr<"XdlopsGemmParams", [RockTuningParamAt
   }];
 }
 
+def Rock_WmmaGemmParamsAttr : Rock_Attr<"WmmaGemmParams", [RockTuningParamAttrInterface, RockAccelTuningParamAttrInterface]> {
+  let mnemonic = "wmma_gemm_params";
+  let description = [{
+    The tuning parameters for an wmma-based matrix multiplication.
+  }];
+  let parameters = (ins
+    "int64_t":$kpackPerBlock,
+    "int64_t":$mPerBlock,
+    "int64_t":$nPerBlock,
+    "int64_t":$kpack,
+    "int64_t":$mPerWave,
+    "int64_t":$nPerWave,
+    "bool":$forceUnroll
+  );
+
+  let extraClassDeclaration = [{
+    void getPerfConfigStr(std::string &perfStr){
+      perfStr =
+         (Twine(getMPerBlock()) + ","
+        + Twine(getNPerBlock()) + ","
+        + Twine(getKpackPerBlock()) + ","
+        + Twine(getMPerWave()) + ","
+        + Twine(getNPerWave()) + ","
+        + Twine(getKpack()) + ","
+        + Twine(getForceUnroll()) + ","
+          + "1") /* *ThreadCopyMore* */
+        .str();
+    }
+  }];
+
+  let assemblyFormat = [{
+    `<` struct(params) `>`
+  }];
+}
+
 
 // GEMM Features
 def Rock_GemmFeatures_None : I32BitEnumAttrCaseNone<"none">;

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -292,11 +292,12 @@ def Rock_GemmFeatures_Mfma : I32BitEnumAttrCaseBit<"mfma", 0>;
 def Rock_GemmFeatures_Dot : I32BitEnumAttrCaseBit<"dot", 1>;
 def Rock_GemmFeatures_AtomicAdd : I32BitEnumAttrCaseBit<"atomic_add", 2>;
 def Rock_GemmFeatures_AtomicFmaxF32 : I32BitEnumAttrCaseBit<"atomic_fmax_f32", 4>;
+def Rock_GemmFeatures_Wmma : I32BitEnumAttrCaseBit<"wmma", 5>;
 
 def Rock_GemmFeatures : I32BitEnumAttr<"GemmFeatures",
     "Features that can be enabled on GEMM-based operations",
     [Rock_GemmFeatures_None, Rock_GemmFeatures_Mfma,
-     Rock_GemmFeatures_Dot, Rock_GemmFeatures_AtomicAdd, Rock_GemmFeatures_AtomicFmaxF32]> {
+     Rock_GemmFeatures_Dot, Rock_GemmFeatures_AtomicAdd, Rock_GemmFeatures_AtomicFmaxF32, Rock_GemmFeatures_Wmma]> {
   let cppNamespace = "::mlir::rock";
   let genSpecializedAttr = 0;
 }

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1055,8 +1055,6 @@ def Rock_BlockwiseGemmOp:
     $matrixC `+` `` `=` $matrixA `*` $matrixB attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
-
-  let hasVerifier = 1;
 }
 
 // This is less general than the one in the AMDGPU dialect, since it only

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1063,9 +1063,9 @@ def Rock_BlockwiseGemmOp:
 // accounts for how we call these operations.
 defvar AccelArgTypes = [F32,
                     VectorOfLengthAndType<[2, 4], [F32]>,
-                    VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
-                    VectorOfLengthAndType<[4, 8], [I8, F8E5M2FNUZ, F8E4M3FNUZ]>];
-defvar AccelResTypes = [VectorOfLengthAndType<[4, 16, 32], [F32, I32]>];
+                    VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
+                    VectorOfLengthAndType<[4, 8, 16], [I8, F8E5M2FNUZ, F8E4M3FNUZ]>];
+defvar AccelResTypes = [VectorOfLengthAndType<[4, 8, 16, 32], [F32, I32]>];
 
 // blockwise_gemm_accel
 def Rock_BlockwiseGemmAccelOp:
@@ -1078,6 +1078,7 @@ def Rock_BlockwiseGemmAccelOp:
                    MemRefOf<AccelArgTypes>:$bufferB,
                    MemRefOf<AccelResTypes>:$matrixC,
                    StrAttr:$arch,
+                   Rock_GemmFeaturesAttr:$features,
                    I32Attr:$blockSize,
                    RockAccelTuningParamAttrInterface:$params)>{
   let summary = "Blockwise GEMM accelerated version";
@@ -1091,7 +1092,7 @@ def Rock_BlockwiseGemmAccelOp:
   }];
   let assemblyFormat = [{
     $matrixC `+` `` `=` $bufferA `from` $matrixA `[` $waveOffsetA `]` `*`
-                        $bufferB `from` $matrixB `[` $waveOffsetB `]` attr-dict
+                        $bufferB `from` $matrixB `[` $waveOffsetB `]` `features` `=` $features attr-dict
     `:` type($matrixC) `+` `` `=` type($bufferA) `from` type($matrixA) `*`
                                   type($bufferB) `from` type($matrixB)
   }];
@@ -1128,6 +1129,7 @@ def Rock_AccelGemmOp:
                    MemRefRankOf<AccelArgTypes, [1]>:$matrixB,
                    MemRefRankOf<AccelResTypes , [1]>:$matrixC,
                    StrAttr:$arch,
+                   Rock_GemmFeaturesAttr:$features,
                    RockAccelTuningParamAttrInterface:$params)> {
   let summary = "Accelerated GEMM";
   let description = [{
@@ -1137,7 +1139,7 @@ def Rock_AccelGemmOp:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    $matrixC `+` `` `=` $matrixA`[`$mRepeat`]` `*` $matrixB`[`$nRepeat`]` attr-dict
+    $matrixC `+` `` `=` $matrixA`[`$mRepeat`]` `*` $matrixB`[`$nRepeat`]` `features` `=` $features attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
   let hasVerifier = 1;

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1055,6 +1055,8 @@ def Rock_BlockwiseGemmOp:
     $matrixC `+` `` `=` $matrixA `*` $matrixB attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
+
+  let hasVerifier = 1;
 }
 
 // This is less general than the one in the AMDGPU dialect, since it only

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1065,7 +1065,7 @@ defvar AccelArgTypes = [F32,
                     VectorOfLengthAndType<[2, 4], [F32]>,
                     VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
                     VectorOfLengthAndType<[4, 8, 16], [I8, F8E5M2FNUZ, F8E4M3FNUZ]>];
-defvar AccelResTypes = [VectorOfLengthAndType<[4, 8, 16, 32], [F32, I32]>];
+defvar AccelResTypes = [VectorOfLengthAndType<[4, 8, 16, 32], [F32, I32, F16, BF16]>];
 
 // blockwise_gemm_accel
 def Rock_BlockwiseGemmAccelOp:

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -1,0 +1,43 @@
+//===- WmmaInsnGroup.h - MLIR to C++ for Rock conversion
+//---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// This file implements code selection logic for Wmma instructions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_WMMA_INSN_GROUP_H
+#define MLIR_WMMA_INSN_GROUP_H
+
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringMap.h"
+
+namespace mlir {
+namespace rock {
+
+struct WmmaInsn {
+  StringRef insn;
+  int64_t inputLen;
+  int64_t outputLen;
+  int64_t mRepeats;
+  int64_t nRepeats;
+  VectorType argTypeA;
+  VectorType argTypeB;
+  VectorType retType;
+
+public:
+  static FailureOr<WmmaInsn> select(Type elementTypeA, Type elementTypeB,
+                                    StringRef arch, int64_t mPerWave,
+                                    int64_t nPerWave);
+};
+} // namespace rock
+} // namespace mlir
+
+#endif // MLIR_WMMA_INSN_GROUP_H

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -26,6 +26,7 @@ struct WmmaInsn {
   StringRef insn;
   int64_t inputLen;
   int64_t outputLen;
+  int64_t outputStride;
   int64_t mRepeats;
   int64_t nRepeats;
   VectorType argTypeA;
@@ -34,8 +35,7 @@ struct WmmaInsn {
 
 public:
   static FailureOr<WmmaInsn> select(Type elementTypeA, Type elementTypeB,
-                                    StringRef arch, int64_t mPerWave,
-                                    int64_t nPerWave);
+                                    int64_t mPerWave, int64_t nPerWave);
 };
 } // namespace rock
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -35,7 +35,8 @@ struct WmmaInsn {
 
 public:
   static FailureOr<WmmaInsn> select(Type elementTypeA, Type elementTypeB,
-                                    int64_t mPerWave, int64_t nPerWave);
+                                    int64_t waveSize, int64_t mPerWave,
+                                    int64_t nPerWave);
 };
 } // namespace rock
 } // namespace mlir

--- a/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ add_rocmlir_dialect_library(MLIRRockOps
   RockTuningParamAttrInterface.cpp
   RockAccelTuningParamAttrInterface.cpp
   MfmaInsnGroup.cpp
+  WmmaInsnGroup.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Rock

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -160,21 +160,19 @@ static MfmaInsnAttr deriveAttr(MfmaInsnInfo info) {
   int64_t inputSpanLen = mfmaNonKDim * blocksPerMfmaOutput;
   int64_t inputSpansPerMfmaIn = waveSize / inputSpanLen;
 
-  return {
-      mfmaNonKDim,
-      k,
-      blocksMfma,
-      nInputsToMfma,
-      k_base,
-      inputSpanLen,
-      inputSpansPerMfmaIn,
-      nOutputsOfMfma,
-      rowGroupSize,
-      rowsPerMfmaOutput,
-      blocksPerMfmaOutput,
-      rowGroupsPerBlock,
-      blocksInOutRegs,
-  };
+  return {mfmaNonKDim,
+          k,
+          blocksMfma,
+          nInputsToMfma,
+          k_base,
+          inputSpanLen,
+          inputSpansPerMfmaIn,
+          nOutputsOfMfma,
+          rowGroupSize,
+          rowsPerMfmaOutput,
+          blocksPerMfmaOutput,
+          rowGroupsPerBlock,
+          blocksInOutRegs};
 }
 
 auto getMfmaInsnAttrMap = []() -> const llvm::StringMap<MfmaInsnAttr> & {

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -456,7 +456,8 @@ bool MfmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
                  << "When non-reduction, KPerBlock must be at least k_base\n");
       return false;
     }
-    if (attr.isKReduction && kPerBlock < attr.k_base * attr.inputSpansPerMfmaIn) {
+    if (attr.isKReduction &&
+        kPerBlock < attr.k_base * attr.inputSpansPerMfmaIn) {
       LLVM_DEBUG(llvm::dbgs()
                  << "When reduction, KPerBlock must be at least k_base * "
                     "num_input_blks\n");

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -160,6 +160,8 @@ static MfmaInsnAttr deriveAttr(MfmaInsnInfo info) {
   int64_t inputSpanLen = mfmaNonKDim * blocksPerMfmaOutput;
   int64_t inputSpansPerMfmaIn = waveSize / inputSpanLen;
 
+  bool isKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
+
   return {mfmaNonKDim,
           k,
           blocksMfma,
@@ -172,7 +174,8 @@ static MfmaInsnAttr deriveAttr(MfmaInsnInfo info) {
           rowsPerMfmaOutput,
           blocksPerMfmaOutput,
           rowGroupsPerBlock,
-          blocksInOutRegs};
+          blocksInOutRegs,
+          isKReduction};
 }
 
 auto getMfmaInsnAttrMap = []() -> const llvm::StringMap<MfmaInsnAttr> & {
@@ -433,8 +436,6 @@ VectorType MfmaInsn::getRetType(Type elementType) {
 }
 
 bool MfmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
-  bool isKReduction =
-      (attr.blocksInOutRegs == 1) && (attr.inputSpansPerMfmaIn > 1);
   if (kpack > 1) {
     if (kpack < attr.k_base) {
       LLVM_DEBUG(llvm::dbgs()
@@ -442,7 +443,7 @@ bool MfmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
                     "xdlopsgemm cycles\n");
       return false;
     }
-    if (isKReduction && kPerBlock < attr.inputSpansPerMfmaIn) {
+    if (attr.isKReduction && kPerBlock < attr.inputSpansPerMfmaIn) {
       LLVM_DEBUG(
           llvm::dbgs()
           << "When reduction, KPerBlock must be at least num_input_blks\n");
@@ -450,12 +451,12 @@ bool MfmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
     }
     return true;
   } else {
-    if (!isKReduction && kPerBlock < attr.k_base) {
+    if (!attr.isKReduction && kPerBlock < attr.k_base) {
       LLVM_DEBUG(llvm::dbgs()
                  << "When non-reduction, KPerBlock must be at least k_base\n");
       return false;
     }
-    if (isKReduction && kPerBlock < attr.k_base * attr.inputSpansPerMfmaIn) {
+    if (attr.isKReduction && kPerBlock < attr.k_base * attr.inputSpansPerMfmaIn) {
       LLVM_DEBUG(llvm::dbgs()
                  << "When reduction, KPerBlock must be at least k_base * "
                     "num_input_blks\n");

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1472,25 +1472,6 @@ LogicalResult ThreadwiseWriteAllOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// BlockwiseGemmOp
-//===----------------------------------------------------------------------===//
-LogicalResult BlockwiseGemmOp::verify() {
-  MemRefType blockAType = getMatrixA().getType(),
-             blockBType = getMatrixB().getType();
-
-  int64_t k = blockAType.getShape()[0];
-  int64_t kPack = blockAType.getShape()[2];
-
-  if (k != blockBType.getShape()[0]) {
-    return emitOpError("Mismatched k dimensions between A and B");
-  }
-  if (kPack != blockBType.getShape()[2]) {
-    return emitOpError("Mismatched kPack between A and B");
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // ThreadwiseGemmOp
 //===----------------------------------------------------------------------===//
 LogicalResult ThreadwiseGemmOp::verify() {

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -730,6 +730,7 @@ LogicalResult GemmOp::verify() {
            << " k_a = " << kA << " k_b = " << kB;
 
   bool isXdlops = bitEnumContainsAll(getFeatures(), GemmFeatures::mfma);
+  bool isWmma = bitEnumContainsAll(getFeatures(), GemmFeatures::wmma);
   if (Attribute params = this->getParams().value_or(nullptr)) {
     if (isXdlops && !params.isa<XdlopsGemmParamsAttr>())
       return emitOpError("an xdlops GEMM has non-xdlops tuning parameters");
@@ -744,11 +745,11 @@ LogicalResult GemmOp::verify() {
     }
   }
 
-  if (getStoreMethod() != StoreMethod::Set && !isXdlops) {
+  if (getStoreMethod() != StoreMethod::Set && !isXdlops && !isWmma) {
     return emitOpError("general kernels don't support non-set store methods");
   }
 
-  if (getDerivedBlockSize().has_value() && !isXdlops) {
+  if (getDerivedBlockSize().has_value() && !isXdlops && !isWmma) {
     return emitOpError(
         "general gemm kernels shouldn't have derived block size.");
   }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1472,6 +1472,25 @@ LogicalResult ThreadwiseWriteAllOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// BlockwiseGemmOp
+//===----------------------------------------------------------------------===//
+LogicalResult BlockwiseGemmOp::verify() {
+  MemRefType blockAType = getMatrixA().getType(),
+             blockBType = getMatrixB().getType();
+
+  int64_t k = blockAType.getShape()[0];
+  int64_t kPack = blockAType.getShape()[2];
+
+  if (k != blockBType.getShape()[0]) {
+    return emitOpError("Mismatched k dimensions between A and B");
+  }
+  if (kPack != blockBType.getShape()[2]) {
+    return emitOpError("Mismatched kPack between A and B");
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ThreadwiseGemmOp
 //===----------------------------------------------------------------------===//
 LogicalResult ThreadwiseGemmOp::verify() {

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -26,8 +26,8 @@ static Type getRetType(Type inputType) {
 }
 
 FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
-                                     mlir::Type elementTypeB, int64_t mPerWave,
-                                     int64_t nPerWave) {
+                                     mlir::Type elementTypeB, int64_t waveSize,
+                                     int64_t mPerWave, int64_t nPerWave) {
   LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma group selection:\n"
                           << "elementTypeA: " << elementTypeA << "\n"
                           << "elementTypeB: " << elementTypeB << "\n"
@@ -37,9 +37,10 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
   if (elementTypeA != elementTypeB)
     return failure();
 
-  int64_t inputLen = 16;
+  if (waveSize != 32)
+    return failure();
 
-  // We are assuming waveSize==32
+  int64_t inputLen = 16;
   int64_t outLen = 8;
   int64_t outStride = 2;
 

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -17,7 +17,7 @@
 using namespace mlir;
 using namespace mlir::rock;
 
-Type getRetType(Type inputType) {
+static Type getRetType(Type inputType) {
   Builder b(inputType.getContext());
   if (inputType.isInteger(8))
     return b.getI32Type();

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -1,0 +1,67 @@
+
+#include "mlir/Dialect/Rock/IR/WmmaInsnGroup.h"
+
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/Rock/utility/AmdArchDb.h"
+#include "mlir/Dialect/Rock/utility/math.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include <cstdint>
+
+#define DEBUG_TYPE "rock-wmma-insn-group"
+
+using namespace mlir;
+using namespace mlir::rock;
+
+Type getRetType(Type inputType) {
+  Builder b(inputType.getContext());
+  if (inputType.isInteger(8))
+    return b.getI32Type();
+
+  return b.getF32Type();
+}
+
+FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
+                                     mlir::Type elementTypeB, StringRef arch,
+                                     int64_t mPerWave, int64_t nPerWave) {
+  LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma group selection:\n"
+                          << "elementTypeA: " << elementTypeA << "\n"
+                          << "elementTypeB: " << elementTypeB << "\n"
+                          << "arch: " << arch << "\n"
+                          << "mPerWave: " << mPerWave << "\n"
+                          << "nPerWave: " << nPerWave << "\n");
+
+  if (!arch.contains("gfx11"))
+    return failure();
+
+  if (elementTypeA != elementTypeB)
+    return failure();
+
+  int64_t inputLen = 16;
+  int64_t outLen = 8;
+
+  int64_t mRepeats = mPerWave / inputLen;
+  int64_t nRepeats = nPerWave / inputLen;
+
+  VectorType argTypeA = VectorType::get({inputLen}, elementTypeA);
+  VectorType argTypeB = VectorType::get({inputLen}, elementTypeB);
+  VectorType retType = VectorType::get({outLen}, getRetType(elementTypeA));
+
+  StringRef insn;
+  if (elementTypeA.isF16()) {
+    insn = ROCDL::wmma_f32_16x16x16_f16::getOperationName();
+  } else if (elementTypeA.isBF16()) {
+    insn = ROCDL::wmma_f32_16x16x16_bf16::getOperationName();
+  } else if (elementTypeA.isInteger(8)) {
+    insn = ROCDL::wmma_i32_16x16x16_iu8::getOperationName();
+  } else {
+    return failure();
+  }
+
+  return WmmaInsn{insn,     inputLen, outLen,   mRepeats,
+                  nRepeats, argTypeA, argTypeB, retType};
+}

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -26,23 +26,22 @@ static Type getRetType(Type inputType) {
 }
 
 FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
-                                     mlir::Type elementTypeB, StringRef arch,
-                                     int64_t mPerWave, int64_t nPerWave) {
+                                     mlir::Type elementTypeB, int64_t mPerWave,
+                                     int64_t nPerWave) {
   LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma group selection:\n"
                           << "elementTypeA: " << elementTypeA << "\n"
                           << "elementTypeB: " << elementTypeB << "\n"
-                          << "arch: " << arch << "\n"
                           << "mPerWave: " << mPerWave << "\n"
                           << "nPerWave: " << nPerWave << "\n");
-
-  if (!arch.contains("gfx11"))
-    return failure();
 
   if (elementTypeA != elementTypeB)
     return failure();
 
   int64_t inputLen = 16;
+
+  // We are assuming waveSize==32
   int64_t outLen = 8;
+  int64_t outStride = 2;
 
   int64_t mRepeats = mPerWave / inputLen;
   int64_t nRepeats = nPerWave / inputLen;
@@ -62,6 +61,6 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
     return failure();
   }
 
-  return WmmaInsn{insn,     inputLen, outLen,   mRepeats,
+  return WmmaInsn{insn,     inputLen, outLen,   outStride, mRepeats,
                   nRepeats, argTypeA, argTypeB, retType};
 }

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -179,7 +179,8 @@ void rock::buildBackendPipeline(OpPassManager &pm,
    */
   pm.addPass(createStripDebugInfoPass());
   pm.addPass(createLowerGpuOpsToROCDLOpsPass(
-      options.chip, options.indexBitwidth, /*useBarePtrCallConv=*/true));
+      options.chip, options.indexBitwidth, /*useBarePtrCallConv=*/true,
+      gpu::amd::Runtime::HIP));
   pm.addPass(createGpuSerializeToHsacoPass(options.triple, options.chip,
                                            options.features, options.optLevel));
 }

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -179,8 +179,7 @@ void rock::buildBackendPipeline(OpPassManager &pm,
    */
   pm.addPass(createStripDebugInfoPass());
   pm.addPass(createLowerGpuOpsToROCDLOpsPass(
-      options.chip, options.indexBitwidth, /*useBarePtrCallConv=*/true,
-      gpu::amd::Runtime::HIP));
+      options.chip, options.indexBitwidth, /*useBarePtrCallConv=*/true));
   pm.addPass(createGpuSerializeToHsacoPass(options.triple, options.chip,
                                            options.features, options.optLevel));
 }

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -1,0 +1,431 @@
+#include "AccelEmitter.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Rock/utility/AmdArchDb.h"
+
+using namespace mlir;
+using namespace mlir::arith;
+using namespace mlir::rock;
+using namespace mlir::rock::accel;
+
+// ************************
+// Generic helper functions
+// ************************
+
+void AccelEmitter::validateAcceleratorProperties() {
+  if (kPack > 1 && (kPack < kBase || kPack % kBase != 0)) {
+    llvm_unreachable(
+        "Tuning parameter selection guarantees kPack is multiple of k_base,"
+        "this should never happen");
+  }
+}
+
+AccelEmitter::AccelEmitter(StringRef arch, XdlopsGemmParamsAttr tuningParams) {
+  mPerBlock = tuningParams.getMPerBlock();
+  nPerBlock = tuningParams.getNPerBlock();
+  kPerBlock = tuningParams.getKPerBlock();
+  mPerWave = tuningParams.getMPerWave();
+  nPerWave = tuningParams.getNPerWave();
+  kPack = tuningParams.getKpack();
+  waveSize = rock::lookupArchInfo(arch).waveSize;
+}
+
+// **************************
+// Mfma accelerator interface
+// **************************
+
+MfmaEmitter::MfmaEmitter(MfmaInsnGroup mfmaGroup, StringRef arch,
+                         XdlopsGemmParamsAttr tuningParams)
+    : AccelEmitter{arch, tuningParams}, mfmaGroup{mfmaGroup} {
+  MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
+
+  // Specific mfma parameters
+  int64_t K = kPerBlock * kPack;
+  int64_t blocksInOutRegs = mfmaAttr.blocksInOutRegs;
+  isKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
+  inputSpansPerMfmaIn = mfmaAttr.inputSpansPerMfmaIn;
+  inputSpanLen = mfmaAttr.inputSpanLen;
+
+  // Accelerator parameters
+  mRepeats = mfmaGroup.getMRepeats(mPerWave);
+  nRepeats = mfmaGroup.getNRepeats(nPerWave);
+  nResultVectors = mfmaGroup.getImms().size();
+  mPerAccel = mfmaGroup.getLenPerMfmaGroup(mPerWave);
+  nPerAccel = mfmaGroup.getLenPerMfmaGroup(nPerWave);
+  kPerThread = (isKReduction ? kPerBlock / inputSpansPerMfmaIn : kPerBlock);
+  numOutputVectorElements = mfmaGroup.getRetType().getNumElements() *
+                            nResultVectors * mRepeats * nRepeats;
+  kBase = mfmaAttr.k_base;
+  kBasePerThread = (isKReduction ? K / inputSpansPerMfmaIn : K) / kBase;
+  inputBufferSize = K / ((isKReduction ? inputSpansPerMfmaIn : 1) * kBase);
+
+  // Accelerator data types
+  argTypeA = mfmaGroup.getArgTypeA();
+  argTypeB = mfmaGroup.getArgTypeB();
+  accVectorType = mfmaGroup.getRetType();
+
+  validateAcceleratorProperties();
+}
+
+void MfmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
+                                     Value argB, Value bufferC,
+                                     Value regCOffset) {
+  MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
+  int64_t mfmaNonKDim = mfmaAttr.mfmaNonKDim;
+  auto imms = mfmaGroup.getImms();
+  int64_t nResultVectors = imms.size();
+  VectorType vectorType = mfmaGroup.getRetType();
+  for (int64_t i = 0; i < nResultVectors; ++i) {
+    Value offset = b.createOrFold<arith::ConstantIndexOp>(loc, i);
+    offset = b.create<AddIOp>(loc, offset, regCOffset);
+
+    auto vectorC = b.create<memref::LoadOp>(loc, vectorType, bufferC, offset);
+    auto mfma = b.create<amdgpu::MFMAOp>(
+        loc, vectorType, mfmaNonKDim, mfmaNonKDim, mfmaAttr.k,
+        mfmaAttr.blocksMfma, argA, argB, vectorC, /*cbsz=*/imms[i].cbsz,
+        /*abid=*/imms[i].abid,
+        /*blgp=*/imms[i].blgp, /*reducePrecision=*/false, /*negateA=*/false,
+        /*negateB=*/false, /*negateC=*/false);
+    auto vectorD = mfma.getDestD();
+
+    b.create<memref::StoreOp>(loc, vectorD, bufferC, offset);
+  }
+}
+
+ArrayAttr MfmaEmitter::computeOutputTransforms(
+    PatternRewriter &b, Location loc, int64_t M, int64_t N, int64_t blockSize,
+    int64_t gridSize, Value regCAllocOp, Value convertedC) {
+
+  auto mfmaAttr = mfmaGroup.getInsnAttr();
+  int64_t mPerRepeat = mPerWave / mRepeats;
+  int64_t nPerRepeat = nPerWave / nRepeats;
+  int64_t nBlocks = N / nPerBlock;
+  int64_t mBlocks = M / mPerBlock;
+  int64_t gStride = mBlocks * nBlocks;
+  int64_t nWaves = nPerBlock / nPerWave;
+  int64_t rowGroupSize = mfmaAttr.rowGroupSize;
+  int64_t rowGroupsPerBlock = mfmaAttr.rowGroupsPerBlock;
+  int64_t inputSpanLen = mfmaAttr.inputSpanLen;
+  int64_t m = mfmaAttr.mfmaNonKDim;
+
+  // Note n has the 4x4 => 4x64 behavior that necessitated
+  // inputSpansPerMfmaIn
+  int64_t n = mfmaAttr.inputSpanLen;
+  int64_t inputSpansPerMfmaIn = mfmaAttr.inputSpansPerMfmaIn;
+  int64_t blocksInOutRegs = mfmaAttr.blocksInOutRegs;
+  int64_t blocksPerRepeat = (mPerRepeat * nPerRepeat) / (m * n);
+  int64_t wavesInKernelBlock = blockSize / waveSize;
+
+  int64_t retNumElements = accVectorType.getNumElements();
+  int64_t numElements = retNumElements * mRepeats * nRepeats * nResultVectors;
+  TopDownTMBuilder splitMemoryCoords(b, {"bid", "tid", "item"},
+                                     {gridSize, blockSize, numElements}, loc);
+  splitMemoryCoords.merge({"g", "m", "n"}, {0, 1, 2}, {"bid"},
+                          {gridSize / gStride, gStride / nBlocks, nBlocks});
+  splitMemoryCoords.merge(
+      {"wave", "m_tid", "n_tid"}, {3, 4, 5}, "tid",
+      {wavesInKernelBlock, waveSize / inputSpanLen, inputSpanLen});
+  splitMemoryCoords.merge(
+      {"i", "j", "vec_group", "vec_item"}, {6, 7, 8, 9}, "item",
+      {numElements / (blocksPerRepeat * rowGroupsPerBlock * rowGroupSize),
+       blocksPerRepeat, rowGroupsPerBlock, rowGroupSize});
+  TransformMapAttr splitMemoryCoordsAttr = splitMemoryCoords.get();
+
+  // "blkMajor" and "blkMinor" are placeholder names because we don't know
+  // if they'll be column or row until we check for broadcast-ness.
+  auto toRowsAndCols =
+      TopDownTMBuilder::below(splitMemoryCoords, splitMemoryCoordsAttr);
+  llvm::StringMap<uint32_t> rowsAndColsIdxs =
+      expandNamesInPlace(splitMemoryCoords, {{"wave", {"wave_m", "wave_n"}},
+                                             {"i", {"m_i", "n_i"}},
+                                             {"j", {"blkMajor", "blkMinor"}}});
+  TopDownTMBottomDimsWrapper rowsAndColsWrap(toRowsAndCols, rowsAndColsIdxs);
+  rowsAndColsWrap.passThrough({"g", "m", "n"});
+  rowsAndColsWrap.merge({"wave_m", "wave_n"}, "wave",
+                        {wavesInKernelBlock / nWaves, nWaves});
+  rowsAndColsWrap.passThrough({"m_tid", "n_tid"});
+  rowsAndColsWrap.merge({"m_i", "n_i"}, "i",
+                        {splitMemoryCoords.endSize("i") / nRepeats, nRepeats});
+
+  // Here we use the full builder API since we want index and name control
+  bool isABroadcast = (nPerRepeat >= mPerRepeat);
+  SmallVector<StringRef, 2> rowsFirst = {"blk_row", "blk_col"};
+  SmallVector<StringRef, 2> colsFirst = {"blk_col", "blk_row"};
+  toRowsAndCols.merge(
+      isABroadcast ? rowsFirst : colsFirst,
+      {rowsAndColsIdxs["blkMajor"], rowsAndColsIdxs["blkMinor"]}, "j",
+      {splitMemoryCoords.endSize("j") / blocksInOutRegs, blocksInOutRegs});
+  toRowsAndCols.passThrough(
+      {"vec_group", "vec_item"},
+      {rowsAndColsIdxs["vec_group"], rowsAndColsIdxs["vec_item"]},
+      {"vec_group", "vec_item"});
+
+  TransformMapAttr toRowsAndColsAttr = toRowsAndCols.get();
+
+  auto toMatrixC = TopDownTMBuilder::below(toRowsAndCols, toRowsAndColsAttr);
+  toMatrixC.passThrough({"gemmG"}, {0}, {"g"});
+
+  toMatrixC.embed(
+      "gemmM", 1, M,
+      {"m", "wave_m", "m_tid", "m_i", "blk_row", "vec_group", "vec_item"},
+      {mPerBlock, mPerWave, rowGroupSize, mPerRepeat, m,
+       inputSpansPerMfmaIn * rowGroupSize, 1});
+  toMatrixC.embed("gemmN", 2, N, {"n", "wave_n", "n_i", "blk_col", "n_tid"},
+                  {nPerBlock, nPerWave, nPerRepeat, n, 1});
+  TransformMapAttr toMatrixCAttr = toMatrixC.get();
+
+  ArrayAttr idToMatrixCMaps =
+      b.getArrayAttr({splitMemoryCoordsAttr, toRowsAndColsAttr, toMatrixCAttr});
+  return idToMatrixCMaps;
+}
+
+Value MfmaEmitter::computeOutputConversion(PatternRewriter &b, Location loc,
+                                           int64_t M, int64_t N,
+                                           int64_t blockSize, int64_t gridSize,
+                                           Value regVectorOrig, Value regDest,
+                                           bool forceUnroll) {
+
+  Type destType = regDest.getType().dyn_cast<MemRefType>().getElementType();
+
+  int64_t accVectorLen = accVectorType.getNumElements();
+  int64_t numElements = accVectorLen * (mRepeats * nRepeats * nResultVectors);
+  auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
+
+  BottomUpTMBuilder toRegCScalar(b, {"scalar"}, {numElements}, loc);
+  toRegCScalar.embed({"vector"}, {0}, {mRepeats * nRepeats * nResultVectors},
+                     "scalar", {accVectorLen});
+  TransformMapAttr toRegCScalarAttr = toRegCScalar.get();
+
+  auto convertLoop = b.create<TransformingForOp>(
+      loc, ArrayRef<ValueRange>{{zeroConstantOp}, {zeroConstantOp}},
+      ArrayRef<Attribute>{b.getArrayAttr({}), b.getArrayAttr(toRegCScalarAttr)},
+      /*bounds=*/ArrayRef<int64_t>{mRepeats * nRepeats * nResultVectors},
+      /*strides=*/std::nullopt, forceUnroll, /*useIndexDiffs=*/true);
+  {
+    OpBuilder::InsertionGuard guard(b);
+    b.setInsertionPointToStart(convertLoop.getBody());
+    Value loaded =
+        b.create<memref::LoadOp>(loc, accVectorType, regVectorOrig,
+                                 convertLoop.getLowerCoords(/*domain*/ 0));
+    Value cast = loaded;
+    if (destType != accVectorType.getElementType()) {
+      VectorType destVectorType = accVectorType.clone(destType);
+      cast = createTypeConversionOp(b, loc, loaded, destVectorType);
+    }
+    b.create<InBoundsStoreOp>(loc, cast, regDest,
+                              convertLoop.getLowerCoords(/*domain*/ 1));
+  }
+  return regDest;
+}
+
+Value MfmaEmitter::computeLdsSourceOffset(OpBuilder &kb, Value k_i,
+                                          OpBuilder &mnb, Value mn_i,
+                                          OpBuilder &b, Value MN, Location loc,
+                                          Value sourceOffset, Value laneId) {
+
+  if (!isKReduction) {
+    // srcOffset = k_i * MN + laneId + mPerMfmaGroup * mn_i;
+    Value mnPerMfmaGroup = b.create<ConstantIndexOp>(loc, nPerAccel);
+    sourceOffset = b.create<AddIOp>(loc, sourceOffset, laneId);
+    sourceOffset = mnb.create<AddIOp>(
+        loc, sourceOffset, mnb.create<MulIOp>(loc, mnPerMfmaGroup, mn_i));
+    sourceOffset =
+        kb.create<AddIOp>(loc, sourceOffset, kb.create<MulIOp>(loc, MN, k_i));
+  } else {
+    // srcOffset = (k_i * input_span_per_mfma + blk_id) * MN + blk_td + mn_i
+    // * input_span_length;
+    Value inputSpanLenConstantOp = b.create<ConstantIndexOp>(loc, inputSpanLen);
+    Value inputSpansPerMfmaInConstantOp =
+        b.create<ConstantIndexOp>(loc, inputSpansPerMfmaIn);
+    Value blk_id = b.create<DivUIOp>(loc, laneId, inputSpanLenConstantOp);
+    Value blk_td = b.create<RemUIOp>(loc, laneId, inputSpanLenConstantOp);
+
+    sourceOffset = b.create<AddIOp>(loc, sourceOffset, blk_td);
+    sourceOffset = mnb.create<AddIOp>(
+        loc, sourceOffset,
+        mnb.create<MulIOp>(loc, inputSpanLenConstantOp, mn_i));
+    sourceOffset = kb.create<AddIOp>(
+        loc, sourceOffset,
+        kb.create<MulIOp>(
+            loc,
+            kb.create<AddIOp>(
+                loc, kb.create<MulIOp>(loc, k_i, inputSpansPerMfmaInConstantOp),
+                blk_id),
+            MN));
+  }
+  return sourceOffset;
+}
+
+// **************************
+// Wmma accelerator interface
+// **************************
+
+WmmaEmitter::WmmaEmitter(WmmaInsn wmmaInsn, StringRef arch,
+                         XdlopsGemmParamsAttr tuningParams)
+    : AccelEmitter{arch, tuningParams}, wmmaInsn(wmmaInsn) {
+  mRepeats = wmmaInsn.mRepeats;
+  nRepeats = wmmaInsn.nRepeats;
+  nResultVectors = 1;
+  kPerThread = kPerBlock;
+  kBase = wmmaInsn.inputLen;
+  mPerAccel = wmmaInsn.inputLen;
+  nPerAccel = wmmaInsn.inputLen;
+  kBasePerThread = kPerBlock * kPack / kBase;
+  inputBufferSize = (kPerBlock * kPack) / kBase;
+
+  argTypeA = wmmaInsn.argTypeA;
+  argTypeB = wmmaInsn.argTypeB;
+  accVectorType = wmmaInsn.retType;
+
+  numOutputVectorElements =
+      (accVectorType.getNumElements()) * nResultVectors * mRepeats * nRepeats;
+  reducedVectorType = accVectorType.cloneWith(accVectorType.getNumElements(),
+                                              accVectorType.getElementType());
+  validateAcceleratorProperties();
+}
+
+Value WmmaEmitter::computeLdsSourceOffset(OpBuilder &kb, Value k_i,
+                                          OpBuilder &mnb, Value mn_i,
+                                          OpBuilder &b, Value MN, Location loc,
+                                          Value sourceOffset, Value laneId) {
+
+  // srcOffset = k_i * MN + (laneId % wmmaInputLen) + wmmaInputLen * mn_i;
+  Value inputLen = b.create<ConstantIndexOp>(loc, wmmaInsn.inputLen);
+  sourceOffset = b.create<AddIOp>(loc, sourceOffset,
+                                  b.create<RemUIOp>(loc, laneId, inputLen));
+  sourceOffset = mnb.create<AddIOp>(loc, sourceOffset,
+                                    mnb.create<MulIOp>(loc, inputLen, mn_i));
+  sourceOffset =
+      kb.create<AddIOp>(loc, sourceOffset, kb.create<MulIOp>(loc, MN, k_i));
+  return sourceOffset;
+}
+
+void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
+                                     Value argB, Value bufferC,
+                                     Value regCOffset) {
+  VectorType vectorType = wmmaInsn.retType;
+  auto vectorC = b.create<memref::LoadOp>(loc, vectorType, bufferC, regCOffset);
+
+  auto mfma = b.create<amdgpu::WMMAOp>(loc, vectorType, argA, argB, vectorC);
+  auto vectorD = mfma.getDestD();
+
+  b.create<memref::StoreOp>(loc, vectorD, bufferC, regCOffset);
+}
+
+ArrayAttr WmmaEmitter::computeOutputTransforms(
+    PatternRewriter &b, Location loc, int64_t M, int64_t N, int64_t blockSize,
+    int64_t gridSize, Value regCAllocOp, Value convertedC) {
+
+  int64_t nBlocks = N / nPerBlock;
+  int64_t mBlocks = M / mPerBlock;
+  int64_t gStride = mBlocks * nBlocks;
+  int64_t nWaves = nPerBlock / nPerWave;
+
+  // High level code for this loop
+  // source: https://gpuopen.com/learn/wmma_on_rdna3/
+  //
+  // for (int ele = 0; ele < 8; ele++){
+  //    col = laneIdx % 16;
+  //    row = (2*ele + laneIdx / 16);
+  //    c[16 * row+col] = reg[ele];
+  // }
+  //
+  int64_t retNumElements = reducedVectorType.getNumElements();
+  TopDownTMBuilder splitMemoryCoords(
+      b, {"bid", "tid", "item"},
+      {gridSize, blockSize, mRepeats * nRepeats * retNumElements}, loc);
+  splitMemoryCoords.merge({"g", "m", "n"}, {0, 1, 2}, {"bid"},
+                          {gridSize / gStride, gStride / nBlocks, nBlocks});
+
+  int64_t wavesInKernelBlock = blockSize / waveSize;
+  splitMemoryCoords.merge({"wave_m", "wave_n", "m_tid", "n_tid"}, {3, 4, 5, 6},
+                          "tid",
+                          {wavesInKernelBlock / nWaves, nWaves,
+                           waveSize / wmmaInsn.inputLen, wmmaInsn.inputLen});
+
+  splitMemoryCoords.merge({"rep_i", "rep_j", "item_i"}, {7, 8, 9}, "item",
+                          {mRepeats, nRepeats, retNumElements});
+  TransformMapAttr splitMemoryCoordsAttr = splitMemoryCoords.get();
+
+  auto toMatrixC =
+      TopDownTMBuilder::below(splitMemoryCoords, splitMemoryCoordsAttr);
+
+  toMatrixC.passThrough({"gemmG"}, {0}, {"g"});
+
+  toMatrixC.embed("gemmM", 1, M, {"m", "wave_m", "m_tid", "rep_i", "item_i"},
+                  {mPerBlock, mPerWave, 1, wmmaInsn.inputLen, 2});
+
+  toMatrixC.embed("gemmN", 2, N, {"n", "wave_n", "n_tid", "rep_j"},
+                  {nPerBlock, nPerWave, 1, wmmaInsn.inputLen});
+
+  TransformMapAttr toMatrixCAttr = toMatrixC.get();
+
+  ArrayAttr idToMatrixCMaps =
+      b.getArrayAttr({splitMemoryCoordsAttr, toMatrixCAttr});
+  return idToMatrixCMaps;
+}
+
+Value WmmaEmitter::computeOutputConversion(PatternRewriter &b, Location loc,
+                                           int64_t M, int64_t N,
+                                           int64_t blockSize, int64_t gridSize,
+                                           Value regCAllocOp, Value convertedC,
+                                           bool forceUnroll) {
+
+  auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
+
+  Value registerC = regCAllocOp;
+  Type destType = convertedC.getType().dyn_cast<MemRefType>().getElementType();
+
+  BottomUpTMBuilder toRegCScalar(b, {"scalar"}, {numOutputVectorElements}, loc);
+  toRegCScalar.embed({"vector"}, {0}, {mRepeats * nRepeats}, "scalar",
+                     {reducedVectorType.getNumElements()});
+  TransformMapAttr toRegCScalarAttr = toRegCScalar.get();
+
+  auto convertLoop = b.create<TransformingForOp>(
+      loc, ArrayRef<ValueRange>{{zeroConstantOp}, {zeroConstantOp}},
+      ArrayRef<Attribute>{b.getArrayAttr({}), b.getArrayAttr(toRegCScalarAttr)},
+      /*bounds=*/ArrayRef<int64_t>{mRepeats * nRepeats},
+      /*strides=*/std::nullopt, forceUnroll, /*useIndexDiffs=*/true);
+  {
+    OpBuilder::InsertionGuard guard(b);
+    b.setInsertionPointToStart(convertLoop.getBody());
+    Value loaded =
+        b.create<memref::LoadOp>(loc, accVectorType, registerC,
+                                 convertLoop.getLowerCoords(/*domain*/ 0));
+    Value cast = loaded;
+    if (destType != accVectorType.getElementType()) {
+      VectorType destVectorType = accVectorType.clone(destType);
+      cast = createTypeConversionOp(b, loc, loaded, destVectorType);
+    }
+    b.create<InBoundsStoreOp>(loc, cast, convertedC,
+                              convertLoop.getLowerCoords(/*domain*/ 1));
+  }
+  return convertedC;
+}
+
+std::unique_ptr<AccelEmitter>
+AccelEmitter::select(GemmFeatures features, Type dataTypeA, Type dataTypeB,
+                     StringRef arch, XdlopsGemmParamsAttr tuningParams) {
+  bool isMfma = rock::bitEnumContainsAll(features, GemmFeatures::mfma);
+  bool isWmma = rock::bitEnumContainsAll(features, GemmFeatures::wmma);
+  if (isMfma) {
+    auto maybeMfmaInsnGroup = MfmaInsnGroup::select(dataTypeA, dataTypeB, arch,
+                                                    tuningParams.getMPerWave(),
+                                                    tuningParams.getNPerWave());
+    if (failed(maybeMfmaInsnGroup)) {
+      return nullptr;
+    }
+    return std::make_unique<MfmaEmitter>(*maybeMfmaInsnGroup, arch,
+                                         tuningParams);
+  } else if (isWmma) {
+    auto maybeWmmaInsnGroup =
+        WmmaInsn::select(dataTypeA, dataTypeB, arch, tuningParams.getMPerWave(),
+                         tuningParams.getNPerWave());
+    if (failed(maybeWmmaInsnGroup)) {
+      return nullptr;
+    }
+    return std::make_unique<WmmaEmitter>(*maybeWmmaInsnGroup, arch,
+                                         tuningParams);
+  } else {
+    return nullptr;
+  }
+}

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -1,0 +1,169 @@
+
+//===- AccelEmitter.cpp - MLIR helper to emit acceleration intrinsics
+//---------------===//
+//
+// Copyright 2020 The MLIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+//
+// This class tries to abstract away the code-generation details needed to
+// generated calls to matrix multiply accelerator intrinsics (wmma, mfma).
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_ACCEL_EMITTER_INSN_GROUP_H
+#define MLIR_ACCEL_EMITTER_INSN_GROUP_H
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Rock/IR/MfmaInsnGroup.h"
+#include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
+#include "mlir/Dialect/Rock/IR/WmmaInsnGroup.h"
+#include "mlir/Dialect/Rock/utility/builderUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+
+#include <memory>
+
+namespace mlir {
+namespace rock {
+namespace accel {
+struct AccelEmitter {
+
+  // Select the right accelerator based on the set of features and architecture
+  static std::unique_ptr<AccelEmitter>
+  select(GemmFeatures features, Type dataTypeA, Type dataTypeB, StringRef arch,
+         XdlopsGemmParamsAttr tuningParams);
+
+  AccelEmitter(StringRef arch, XdlopsGemmParamsAttr tuningParams);
+  /// Emit the actual intrinsic in the threadwise operation
+  virtual void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
+                                  Value argB, Value bufferC,
+                                  Value regCOffset) = 0;
+
+  // Compute the correct lds source offset when loading data from shared memory
+  // into registers
+  virtual Value computeLdsSourceOffset(OpBuilder &kb, Value k_i, OpBuilder &mnb,
+                                       Value mn_i, OpBuilder &b, Value MN,
+                                       Location loc, Value sourceOffset,
+                                       Value laneId) = 0;
+  // Compute the output transform map to be used to store the result of the
+  // matrix multiplication tile
+  virtual ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc,
+                                            int64_t M, int64_t N,
+                                            int64_t blockSize, int64_t gridSize,
+                                            Value regCAllocOp,
+                                            Value convertedC) = 0;
+
+  // Convert from memref<?xvector<?xT>> to memref<?xD> where the source T
+  // is the accumulator type and D is the destination type
+  virtual Value computeOutputConversion(PatternRewriter &b, Location loc,
+                                        int64_t M, int64_t N, int64_t blockSize,
+                                        int64_t gridSize, Value regCAllocOp,
+                                        Value convertedC, bool forceUnroll) = 0;
+
+  // Validate the accelerator structure
+  void validateAcceleratorProperties();
+
+  virtual ~AccelEmitter() {}
+
+public:
+  // Tuning parameters
+  int64_t mPerBlock;
+  int64_t nPerBlock;
+  int64_t kPerBlock;
+  int64_t mPerWave;
+  int64_t nPerWave;
+  int64_t kPack;
+
+  // Accelerator parameters
+  int64_t mRepeats;
+  int64_t nRepeats;
+  int64_t nResultVectors;
+  int64_t mPerAccel;
+  int64_t nPerAccel;
+  int64_t kPerThread;
+  int64_t kBase;
+  int64_t kBasePerThread;
+  int64_t inputBufferSize;
+  int64_t waveSize;
+  int64_t numOutputVectorElements;
+
+  // Accelerator data types
+  Type argTypeA;            // Type of the arguments (might be scalar or vector)
+  Type argTypeB;            // Type of the arguments (might be scalar or vector)
+  VectorType accVectorType; // Accumulator vector type (always vector type)
+};
+
+// Accel emitter implementation for mfma
+struct MfmaEmitter : public AccelEmitter {
+
+  MfmaEmitter(MfmaInsnGroup mfmaGroup, StringRef arch,
+              XdlopsGemmParamsAttr tuningParams);
+
+  void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
+                          Value bufferC, Value regCOffset) override;
+
+  Value computeLdsSourceOffset(OpBuilder &kb, Value k_i, OpBuilder &mnb,
+                               Value mn_i, OpBuilder &b, Value MN, Location loc,
+                               Value sourceOffset, Value laneId) override;
+
+  ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc, int64_t M,
+                                    int64_t N, int64_t blockSize,
+                                    int64_t gridSize, Value regCAllocOp,
+                                    Value convertedC) override;
+
+  Value computeOutputConversion(PatternRewriter &b, Location loc, int64_t M,
+                                int64_t N, int64_t blockSize, int64_t gridSize,
+                                Value regCAllocOp, Value convertedC,
+                                bool forceUnroll) override;
+
+private:
+  // Specifc mfma parameters
+  bool isKReduction;
+  int64_t inputSpansPerMfmaIn;
+  int64_t inputSpanLen;
+  MfmaInsnGroup mfmaGroup;
+};
+
+// Accel emitter implementation for wmma
+struct WmmaEmitter : public AccelEmitter {
+
+  WmmaEmitter(WmmaInsn wmmaInsn, StringRef arch,
+              XdlopsGemmParamsAttr tuningParams);
+
+  void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
+                          Value bufferC, Value regCOffset) override;
+  Value computeLdsSourceOffset(OpBuilder &kb, Value k_i, OpBuilder &mnb,
+                               Value mn_i, OpBuilder &b, Value MN, Location loc,
+                               Value sourceOffset, Value laneId) override;
+  ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc, int64_t M,
+                                    int64_t N, int64_t blockSize,
+                                    int64_t gridSize, Value regCAllocOp,
+                                    Value convertedC) override;
+
+  Value computeOutputConversion(PatternRewriter &b, Location loc, int64_t M,
+                                int64_t N, int64_t blockSize, int64_t gridSize,
+                                Value regCAllocOp, Value convertedC,
+                                bool forceUnroll) override;
+
+private:
+  // Specifc wmma parameters
+  WmmaInsn wmmaInsn;
+  VectorType reducedVectorType;
+};
+} // namespace accel
+} // namespace rock
+} // namespace mlir
+
+#endif // MLIR_ACCEL_EMITTER_INSN_GROUP_H

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -23,8 +23,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_ACCEL_EMITTER_INSN_GROUP_H
-#define MLIR_ACCEL_EMITTER_INSN_GROUP_H
+#ifndef MLIR_LIB_DIALECT_ROCK_TRANSFORMS_MLIR_ACCEL_EMITTER_H
+#define MLIR_LIB_DIALECT_ROCK_TRANSFORMS_MLIR_ACCEL_EMITTER_H
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/MfmaInsnGroup.h"
@@ -52,25 +52,33 @@ struct AccelEmitter {
                                   Value regCOffset) = 0;
 
   // Compute the correct lds source offset when loading data from shared memory
-  // into registers
-  virtual Value computeLdsSourceOffset(OpBuilder &kb, Value k_i, OpBuilder &mnb,
-                                       Value mn_i, OpBuilder &b, Value MN,
-                                       Location loc, Value sourceOffset,
+  // into registers. The pseudo-code of the lds-to-register loops is as follows
+  // for(index_t m_i = 0; m_i < mRepeats; ++m_i)
+  //   for(index_t k_i = 0; k_i < KPerThread; ++k_i)
+  //       sourceOffset = computeLdsSourceOffset(d_i, k_i, dPerBlock,
+  //       baseOffset)
+  //       ...
+  // In the above loop `d` can be either `m` or `n`.
+  virtual Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
+                                       OpBuilder &dBuilder, Value d_i,
+                                       OpBuilder &builder, Value dPerBlock,
+                                       Location loc, Value baseOffset,
                                        Value laneId) = 0;
+
   // Compute the output transform map to be used to store the result of the
   // matrix multiplication tile
   virtual ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc,
-                                            int64_t M, int64_t N,
+                                            int64_t matrixM, int64_t matrixN,
                                             int64_t blockSize, int64_t gridSize,
-                                            Value regCAllocOp,
-                                            Value convertedC) = 0;
+                                            Value regC) = 0;
 
   // Convert from memref<?xvector<?xT>> to memref<?xD> where the source T
   // is the accumulator type and D is the destination type
-  virtual Value computeOutputConversion(PatternRewriter &b, Location loc,
-                                        int64_t M, int64_t N, int64_t blockSize,
-                                        int64_t gridSize, Value regCAllocOp,
-                                        Value convertedC, bool forceUnroll) = 0;
+  Value computeOutputConversion(PatternRewriter &b, Location loc,
+                                int64_t matrixM, int64_t matrixN,
+                                int64_t blockSize, int64_t gridSize,
+                                Value regDest, Value convertedC,
+                                bool forceUnroll);
 
   // Validate the accelerator structure
   void validateAcceleratorProperties();
@@ -78,28 +86,52 @@ struct AccelEmitter {
   virtual ~AccelEmitter() {}
 
 public:
+  //
   // Tuning parameters
+  //
   int64_t mPerBlock;
   int64_t nPerBlock;
   int64_t kPerBlock;
   int64_t mPerWave;
   int64_t nPerWave;
   int64_t kPack;
+  int64_t waveSize;
 
+  //
   // Accelerator parameters
+  //
+  // `mPerAccel`/`nPerAccel` represent how many rows an accelerator intrinsic
+  // will compute, while mRepeats and nRepeats represent how many times a given
+  // wave needs to iterate to compute the `mPerWave` x `nPerWave` tile. E.g., if
+  // `mPerWave=64`, `nPerWave=64`, `mPerAccel=16` and `nPerAccel=16` we have
+  // what `mRepeats=64/16=4` and `nRepeats=64/16=4`
   int64_t mRepeats;
   int64_t nRepeats;
-  int64_t nResultVectors;
   int64_t mPerAccel;
   int64_t nPerAccel;
-  int64_t kPerThread;
+
+  // A total of `kPerThread` k values are read by each worktiem.
+  // Workitems need to read vectors of length `kBase` to compute the correct
+  // output tile, but if `kPack>kBase` each thread will read multiple `kBase`
+  // vectors.
   int64_t kBase;
+  int64_t kPerThread;
   int64_t kBasePerThread;
-  int64_t inputBufferSize;
-  int64_t waveSize;
+
+  // This takes into account the fact that we might invoke accelerators back to
+  // back and generate multiple sets of mRepeats*nRepeats vectors
+  int64_t nResultVectors;
+
+  // Each workitem invoking an accelerator receives as a result a given number
+  // of elements stored in VGPR
+  //
+  // numOutputVectorElements =
+  // nResultVectors*mRepeats*nRepeats*accVectorType.getNumElements()
   int64_t numOutputVectorElements;
 
+  //
   // Accelerator data types
+  //
   Type argTypeA;            // Type of the arguments (might be scalar or vector)
   Type argTypeB;            // Type of the arguments (might be scalar or vector)
   VectorType accVectorType; // Accumulator vector type (always vector type)
@@ -114,19 +146,16 @@ struct MfmaEmitter : public AccelEmitter {
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
                           Value bufferC, Value regCOffset) override;
 
-  Value computeLdsSourceOffset(OpBuilder &kb, Value k_i, OpBuilder &mnb,
-                               Value mn_i, OpBuilder &b, Value MN, Location loc,
-                               Value sourceOffset, Value laneId) override;
+  Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
+                               OpBuilder &dBuilder, Value d_i,
+                               OpBuilder &builder, Value dPerBlock,
+                               Location loc, Value baseOffset,
+                               Value laneId) override;
 
-  ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc, int64_t M,
-                                    int64_t N, int64_t blockSize,
-                                    int64_t gridSize, Value regCAllocOp,
-                                    Value convertedC) override;
-
-  Value computeOutputConversion(PatternRewriter &b, Location loc, int64_t M,
-                                int64_t N, int64_t blockSize, int64_t gridSize,
-                                Value regCAllocOp, Value convertedC,
-                                bool forceUnroll) override;
+  ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc,
+                                    int64_t matrixM, int64_t matrixN,
+                                    int64_t blockSize, int64_t gridSize,
+                                    Value regC) override;
 
 private:
   // Specifc mfma parameters
@@ -144,18 +173,17 @@ struct WmmaEmitter : public AccelEmitter {
 
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
                           Value bufferC, Value regCOffset) override;
-  Value computeLdsSourceOffset(OpBuilder &kb, Value k_i, OpBuilder &mnb,
-                               Value mn_i, OpBuilder &b, Value MN, Location loc,
-                               Value sourceOffset, Value laneId) override;
-  ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc, int64_t M,
-                                    int64_t N, int64_t blockSize,
-                                    int64_t gridSize, Value regCAllocOp,
-                                    Value convertedC) override;
 
-  Value computeOutputConversion(PatternRewriter &b, Location loc, int64_t M,
-                                int64_t N, int64_t blockSize, int64_t gridSize,
-                                Value regCAllocOp, Value convertedC,
-                                bool forceUnroll) override;
+  Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
+                               OpBuilder &dBuilder, Value d_i,
+                               OpBuilder &builder, Value dPerBlock,
+                               Location loc, Value baseOffset,
+                               Value laneId) override;
+
+  ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc,
+                                    int64_t matrixM, int64_t matrixN,
+                                    int64_t blockSize, int64_t gridSize,
+                                    Value regC) override;
 
 private:
   // Specifc wmma parameters
@@ -166,4 +194,4 @@ private:
 } // namespace rock
 } // namespace mlir
 
-#endif // MLIR_ACCEL_EMITTER_INSN_GROUP_H
+#endif //  MLIR_LIB_DIALECT_ROCK_TRANSFORMS_MLIR_ACCEL_EMITTER_H

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -40,7 +40,7 @@ namespace rock {
 namespace accel {
 
 //
-// Accelerator parameters
+// Accelerator parameters used throughout the GEMM lowering pipeline
 //
 struct AccelEmitterParams {
   // `mPerAccel`/`nPerAccel` represent how many rows an accelerator intrinsic
@@ -77,6 +77,10 @@ struct AccelEmitterParams {
   }
 };
 
+//
+// Accelerator emitter strategy providing helpers to lower GEMM passes using an
+// accelerator
+//
 struct AccelEmitter {
 
   /// Select the right accelerator based on the set of features and architecture

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -105,7 +105,8 @@ void AffixTuningParameters::affixTuningParametersImpl(
     perfConfig = perfConfigAttr.getValue().str();
   }
   GemmFeatures features = op.getGemmFeatures();
-  if (bitEnumContainsAll(features, GemmFeatures::mfma)) {
+  if (bitEnumContainsAll(features, GemmFeatures::mfma) ||
+      bitEnumContainsAll(features, GemmFeatures::wmma)) {
     PopulateParamsXDL populateParamsXDL;
     InitParamsXDL validParams;
     uint32_t blockSize = 0;

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -33,10 +33,11 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/Rock/IR/MfmaInsnGroup.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "AccelEmitter.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -334,45 +335,29 @@ struct BlockwiseGemmAccelRewritePattern
     Value sourceOffsetA = adaptor.getWaveOffsetA();
     Value sourceOffsetB = adaptor.getWaveOffsetB();
 
-    auto maybeMfmaInsnGroup =
-        MfmaInsnGroup::select(dataTypeA, dataTypeB, arch, mPerWave, nPerWave);
-    if (failed(maybeMfmaInsnGroup)) {
-      return emitError(loc) << "Failed to select xdlops instruction group.\n";
-    }
-    MfmaInsnGroup mfmaGroup = *maybeMfmaInsnGroup;
+    auto accelEmitterPtr = rock::accel::AccelEmitter::select(
+        op.getFeatures(), dataTypeA, dataTypeB, arch, tuningParams);
 
-    Type argTypeA = mfmaGroup.getArgTypeA();
-    Type argTypeB = mfmaGroup.getArgTypeB();
+    if (!accelEmitterPtr)
+      return op.emitOpError("Unable to emit accelerator code.");
 
-    MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
-    int64_t inputSpanLen = mfmaAttr.inputSpanLen;
-    int64_t inputSpansPerMfmaIn = mfmaAttr.inputSpansPerMfmaIn;
-    int64_t blocksInOutRegs = mfmaAttr.blocksInOutRegs;
-    int64_t k_base = mfmaAttr.k_base;
-
-    int64_t mRepeats = mfmaGroup.getMRepeats(mPerWave);
-    int64_t nRepeats = mfmaGroup.getNRepeats(nPerWave);
-
-    int64_t mPerMfmaGroup = mfmaGroup.getLenPerMfmaGroup(mPerWave);
-    int64_t nPerMfmaGroup = mfmaGroup.getLenPerMfmaGroup(nPerWave);
-
-    bool IsKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
-
-    if (KPack > 1 && (KPack < k_base || KPack % k_base != 0)) {
-      llvm_unreachable(
-          "Tuning parameter selection guarantees kPack is multiple of k_base,"
-          "this should never happen");
-    }
+    Type argTypeA = accelEmitterPtr->argTypeA;
+    Type argTypeB = accelEmitterPtr->argTypeB;
 
     auto tid = b.create<WorkitemIdOp>(loc, b.getIndexType());
     const int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
     auto laneId =
         b.create<RemUIOp>(loc, tid, b.create<ConstantIndexOp>(loc, waveSize));
+    int64_t kBase = accelEmitterPtr->kBase;
 
     LLVM_DEBUG(llvm::dbgs()
                << "argVectorType A: " << argTypeA << "\n"
                << "argVectorType B: " << argTypeB << "\n"
-               << "k_base: " << k_base << "\n"
+               << "k_base: " << accelEmitterPtr->kBase << "\n"
+               << "mPerWave: " << mPerWave << "\n"
+               << "nPerWave: " << nPerWave << "\n"
+               << "mRepeat: " << accelEmitterPtr->mRepeats << "\n"
+               << "nRepeat: " << accelEmitterPtr->nRepeats << "\n"
                << "K: " << K << "\n"
                << "bufferA type: " << adaptor.getBufferA().getType() << "\n"
                << "bufferB type: " << adaptor.getBufferB().getType() << "\n");
@@ -380,16 +365,16 @@ struct BlockwiseGemmAccelRewritePattern
     Value MConstantOp = b.create<ConstantIndexOp>(loc, M);
     Value NConstantOp = b.create<ConstantIndexOp>(loc, N);
 
-    Value mPerMfmaGroupConstantOp =
-        b.create<ConstantIndexOp>(loc, mPerMfmaGroup);
-    Value nPerMfmaGroupConstantOp =
-        b.create<ConstantIndexOp>(loc, nPerMfmaGroup);
+    Value mPerAccelConstantOp =
+        b.create<ConstantIndexOp>(loc, accelEmitterPtr->mPerAccel);
+    Value nPerAccelConstantOp =
+        b.create<ConstantIndexOp>(loc, accelEmitterPtr->nPerAccel);
 
     Value bufferA = adaptor.getBufferA();
     Value bufferB = adaptor.getBufferB();
 
-    int64_t KPerThread = IsKReduction ? K / inputSpansPerMfmaIn : K;
-    Value KPerThreadConstantOp = b.create<ConstantIndexOp>(loc, KPerThread);
+    Value KPerThreadConstantOp =
+        b.create<ConstantIndexOp>(loc, accelEmitterPtr->kPerThread);
 
     auto ldsToRegisterCopy = [&](Location loc, OpBuilder mnb, OpBuilder kb,
                                  Value sourceBase, Value mn_i, Value MN,
@@ -397,55 +382,26 @@ struct BlockwiseGemmAccelRewritePattern
                                  Type ldsBufferElemType, Type dataType,
                                  Value ldsOrig, Value regDest) {
       // Compute source offset
-      Value sourceOffset = sourceBase;
-      if (!IsKReduction) {
-        // srcOffset = k_i * MN + laneId + mPerMfmaGroup * mn_i;
-        sourceOffset = b.create<AddIOp>(loc, sourceOffset, laneId);
-        sourceOffset = mnb.create<AddIOp>(
-            loc, sourceOffset, mnb.create<MulIOp>(loc, mnPerMfmaGroup, mn_i));
-        sourceOffset = kb.create<AddIOp>(loc, sourceOffset,
-                                         kb.create<MulIOp>(loc, MN, k_i));
-      } else {
-        // srcOffset = (k_i * input_span_per_mfma + blk_id) * MN + blk_td + mn_i
-        // * input_span_length;
-        Value inputSpanLenConstantOp =
-            b.create<ConstantIndexOp>(loc, inputSpanLen);
-        Value inputSpansPerMfmaInConstantOp =
-            b.create<ConstantIndexOp>(loc, inputSpansPerMfmaIn);
-        Value blk_id = b.create<DivUIOp>(loc, laneId, inputSpanLenConstantOp);
-        Value blk_td = b.create<RemUIOp>(loc, laneId, inputSpanLenConstantOp);
-
-        sourceOffset = b.create<AddIOp>(loc, sourceOffset, blk_td);
-        sourceOffset = mnb.create<AddIOp>(
-            loc, sourceOffset,
-            mnb.create<MulIOp>(loc, inputSpanLenConstantOp, mn_i));
-        sourceOffset = kb.create<AddIOp>(
-            loc, sourceOffset,
-            kb.create<MulIOp>(
-                loc,
-                kb.create<AddIOp>(
-                    loc,
-                    kb.create<MulIOp>(loc, k_i, inputSpansPerMfmaInConstantOp),
-                    blk_id),
-                MN));
-      }
+      Value sourceOffset = accelEmitterPtr->computeLdsSourceOffset(
+          kb, k_i, mnb, mn_i, b, MN, loc, sourceBase, laneId);
 
       Value value = kb.create<memref::LoadOp>(loc, ldsBufferElemType, ldsOrig,
                                               sourceOffset);
+
       auto bufferType = regDest.getType().cast<MemRefType>();
       Type bufferElementType = bufferType.getElementType();
 
       // We're loading in units of kPack, but storing in units of k_base.
-      if (KPack == k_base) {
+      if (KPack == accelEmitterPtr->kBase) {
         Value destOffset = k_i;
         kb.create<memref::StoreOp>(loc, value, regDest, ValueRange{destOffset});
-      } else if (KPack > k_base) {
-        int64_t numStores = KPack / k_base;
+      } else if (KPack > kBase) {
+        int64_t numStores = KPack / kBase;
         Value baseDestOffset = kb.createOrFold<arith::MulIOp>(
             loc, k_i, kb.createOrFold<arith::ConstantIndexOp>(loc, numStores));
         for (int64_t i = 0; i < numStores; ++i) {
           Value sliceStart =
-              kb.createOrFold<arith::ConstantIndexOp>(loc, k_base * i);
+              kb.createOrFold<arith::ConstantIndexOp>(loc, kBase * i);
           Value slice = kb.create<ExtractSliceOp>(loc, bufferElementType, value,
                                                   sliceStart);
           Value destOffset = kb.createOrFold<arith::AddIOp>(
@@ -454,11 +410,11 @@ struct BlockwiseGemmAccelRewritePattern
           kb.create<memref::StoreOp>(loc, slice, regDest,
                                      ValueRange{destOffset});
         }
-      } else if (KPack < k_base) {
+      } else if (KPack < kBase) {
         // Here we are gathering loaded values into vectors for passing into
         // MFMAs.
         Value destValsPerKpack =
-            kb.createOrFold<arith::ConstantIndexOp>(loc, k_base / KPack);
+            kb.createOrFold<arith::ConstantIndexOp>(loc, kBase / KPack);
         // This is fine, since the inputs to MFMAs are contiguous in the k
         // dimension.
         Value destOffset =
@@ -481,7 +437,8 @@ struct BlockwiseGemmAccelRewritePattern
         [&](OpBuilder outerLoopB, AffineForOp outerLoopBodyOp, Value sourceBase,
             Value MN, Value mnPerMfmaGroup, Type ldsBufferElemType,
             Type dataType, Value ldsOrig, Value regDest) {
-          auto innerLoopK = outerLoopB.create<AffineForOp>(loc, 0, KPerThread);
+          auto innerLoopK = outerLoopB.create<AffineForOp>(
+              loc, 0, accelEmitterPtr->kPerThread);
           auto ilkb = ConversionPatternRewriter::atBlockBegin(
               innerLoopK.getBody(), outerLoopB.getListener());
           {
@@ -501,28 +458,29 @@ struct BlockwiseGemmAccelRewritePattern
     // for(index_t m_i = 0; m_i < mRepeats; ++m_i)
     //   for(index_t k_i = 0; k_i < KPerThread; ++k_i)
     //       ldsToRegisterCopy[m_i, k_i]
-    auto outerLoopM = b.create<AffineForOp>(loc, 0, mRepeats);
+    auto outerLoopM = b.create<AffineForOp>(loc, 0, accelEmitterPtr->mRepeats);
     auto olmb = ConversionPatternRewriter::atBlockBegin(outerLoopM.getBody(),
                                                         b.getListener());
     ldsToRegisterCopyKdim(olmb, outerLoopM, sourceOffsetA, MConstantOp,
-                          mPerMfmaGroupConstantOp, bufferElemTypeA, dataTypeA,
+                          mPerAccelConstantOp, bufferElemTypeA, dataTypeA,
                           op.getMatrixA(), bufferA);
 
     // load B from LDS into registers
     // for(index_t n_i = 0; n_i < mRepeats; ++n_i)
     //   for(index_t k_i = 0; k_i < KPerThread; ++k_i)
     //       ldsToRegisterCopy[n_i, k_i]
-    auto outerLoopN = olmb.create<AffineForOp>(loc, 0, nRepeats);
+    auto outerLoopN =
+        olmb.create<AffineForOp>(loc, 0, accelEmitterPtr->nRepeats);
     auto olnb = ConversionPatternRewriter::atBlockBegin(outerLoopN.getBody(),
                                                         olmb.getListener());
     ldsToRegisterCopyKdim(olnb, outerLoopN, sourceOffsetB, NConstantOp,
-                          nPerMfmaGroupConstantOp, bufferElemTypeB, dataTypeB,
+                          nPerAccelConstantOp, bufferElemTypeB, dataTypeB,
                           op.getMatrixB(), bufferB);
 
     b.eraseOp(op);
     olnb.create<AccelGemmOp>(loc, outerLoopM.getInductionVar(),
                              outerLoopN.getInductionVar(), adaptor.getBufferA(),
-                             adaptor.getBufferB(), adaptor.getMatrixC(), arch,
+                             adaptor.getBufferB(), adaptor.getMatrixC(), arch, op.getFeaturesAttr(),
                              tuningParams);
     return success();
   }
@@ -757,6 +715,7 @@ LogicalResult ThreadwiseWriteAllRewritePattern::matchAndRewrite(
   auto [buffer, transforms] = untransform(b, destView, op.getExtraViews());
 
   int64_t numValues = source.getType().getNumElements();
+
   ArrayRef<int64_t> bufferShape =
       buffer.getType().cast<ShapedType>().getShape();
 
@@ -801,7 +760,9 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
   {
     ConversionTarget writeAllTarget(*ctx);
     writeAllTarget.addIllegalOp<ThreadwiseReadIntoOp, ThreadwiseWriteAllOp>();
-    writeAllTarget.addLegalDialect<arith::ArithDialect, rock::RockDialect>();
+    writeAllTarget.addLegalDialect<arith::ArithDialect, rock::RockDialect,
+                                   memref::MemRefDialect>();
+    writeAllTarget.addLegalOp<gpu::PrintfOp>();
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns.add<ThreadwiseReadIntoRewritePattern,
                          ThreadwiseWriteAllRewritePattern>(ctx);
@@ -814,7 +775,8 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
   target.addIllegalOp<FillOp, BlockwiseGemmOp, BlockwiseGemmAccelOp,
                       GlobalLoadOp, GlobalStoreOp>();
   target.addLegalDialect<arith::ArithDialect, rock::RockDialect, AffineDialect,
-                         memref::MemRefDialect>();
+                         vector::VectorDialect, memref::MemRefDialect>();
+  target.addLegalOp<gpu::PrintfOp>();
 
   RewritePatternSet patterns(ctx);
   patterns.add<FillRewritePattern, BlockwiseGemmRewritePattern,

--- a/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_rocmlir_dialect_library(MLIRRockTransforms
+  AccelEmitter.cpp
   AffixTuningParameters.cpp
   AlignTiling.cpp
   BlockwiseGemmToThreadwise.cpp

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -150,6 +150,7 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
   c = padMatrix(c, rw, loc, "gemmM", extraPad.m, "gemmN", extraPad.n);
 
   bool isXdlops = bitEnumContainsAll(op.getFeatures(), GemmFeatures::mfma);
+  bool isWmma = bitEnumContainsAll(op.getFeatures(), GemmFeatures::wmma);
 
   IntegerAttr blockSize = op.getDerivedBlockSizeAttr();
   if (isXdlops && !blockSize)
@@ -157,7 +158,7 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
   IntegerAttr gridSize = op.getGridSizeAttr();
   if (!gridSize)
     return op.emitOpError("grid size must be set at lowering");
-  if (isXdlops) {
+  if (isXdlops || isWmma) {
     // Onne the attribute copies are gone, make this a replaceOp
     rw.create<GridwiseGemmAccelOp>(loc, a, b, c, op.getArchAttr(),
                                    op.getFeaturesAttr(),

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -158,12 +158,19 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
   IntegerAttr gridSize = op.getGridSizeAttr();
   if (!gridSize)
     return op.emitOpError("grid size must be set at lowering");
-  if (isXdlops || isWmma) {
+  if (isXdlops) {
     // Onne the attribute copies are gone, make this a replaceOp
     rw.create<GridwiseGemmAccelOp>(loc, a, b, c, op.getArchAttr(),
                                    op.getFeaturesAttr(),
                                    op.getStoreMethodAttr(), blockSize, gridSize,
                                    params.cast<XdlopsGemmParamsAttr>());
+    rw.eraseOp(op);
+  } else if (isWmma) {
+    // Onne the attribute copies are gone, make this a replaceOp
+    rw.create<GridwiseGemmAccelOp>(loc, a, b, c, op.getArchAttr(),
+                                   op.getFeaturesAttr(),
+                                   op.getStoreMethodAttr(), blockSize, gridSize,
+                                   params.cast<WmmaGemmParamsAttr>());
     rw.eraseOp(op);
   } else {
     rw.create<GridwiseGemmOp>(loc, a, b, c, op.getFeaturesAttr(), gridSize,

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1271,10 +1271,10 @@ struct GridwiseGemmAccelRewritePattern
     // Logic to setup buffers for blockwise_gemm_accel.
 
     Type arrayAType, arrayBType;
-    arrayAType = MemRefType::get({accelEmitterPtr->inputBufferSize},
+    arrayAType = MemRefType::get({accelEmitterPtr->kBasePerThread},
                                  accelEmitterPtr->argTypeA, AffineMap{},
                                  privateMemoryAddressSpace);
-    arrayBType = MemRefType::get({accelEmitterPtr->inputBufferSize},
+    arrayBType = MemRefType::get({accelEmitterPtr->kBasePerThread},
                                  accelEmitterPtr->argTypeB, AffineMap{},
                                  privateMemoryAddressSpace);
     auto arrayA = b.create<GpuAllocOp>(loc, arrayAType);
@@ -1371,7 +1371,7 @@ struct GridwiseGemmAccelRewritePattern
     Value convertedC = b.create<rock::GpuAllocOp>(loc, convertedCType);
 
     ArrayAttr idToMatrixCMaps = accelEmitterPtr->computeOutputTransforms(
-        b, loc, M, N, blockSize, gridSize, regCAllocOp, convertedC);
+        b, loc, M, N, blockSize, gridSize, regCAllocOp);
 
     Value registerC = accelEmitterPtr->computeOutputConversion(
         b, loc, M, N, blockSize, gridSize, regCAllocOp, convertedC,

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -18,7 +18,6 @@
 // This pass converts rock.gridwise_gemm[_v2] into block- and threadwise ops
 //
 //===-----------------------------------------------------===//
-#include "mlir/Dialect/Rock/IR/MfmaInsnGroup.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/Passes.h"
@@ -43,6 +42,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "AccelEmitter.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -65,7 +65,6 @@ struct RockGridwiseGemmToBlockwisePass
           RockGridwiseGemmToBlockwisePass> {
   void runOnOperation() override;
 };
-} // end anonymous namespace
 
 static Type obtainAccumulatorType(OpBuilder &b, Type elementTypeA,
                                   Type elementTypeB, Type destType) {
@@ -102,6 +101,7 @@ static TypedValue<MemRefType> viewBufferAs(OpBuilder &b, Value buffer,
                                /*dynamic dim sizes=*/ValueRange{});
   return TypedValue<MemRefType>(view.getResult());
 }
+} // end anonymous namespace
 
 /// Given a copy layout <copyDPerThread, copyKPerThread>, come up with the best
 /// vectorization strategy for the layout. For instance, if the layout is <D,K>
@@ -1002,8 +1002,6 @@ struct GridwiseGemmAccelRewritePattern
     auto elementTypeB = op.getB().getType().getElementType();
 
     // Prepare some useful constants.
-    Value zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
-
     Value matA = op.getA();
     Value matB = op.getB();
 
@@ -1153,7 +1151,7 @@ struct GridwiseGemmAccelRewritePattern
         b, loc, elementTypeB, bVectorDim, kpack, loadBufferB, storeBufferB,
         copyNPerThread, bCopyKPerThread);
 
-    // Obtain XDLOPS-related attributes.
+    // Obtain Accelerator-related attributes.
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();
     // int64_t MWaves = mPerBlock / mPerWave;
@@ -1163,12 +1161,16 @@ struct GridwiseGemmAccelRewritePattern
     auto nPerWaveConstantOp = b.create<ConstantIndexOp>(loc, nPerWave);
     auto nWavesConstantOp = b.create<ConstantIndexOp>(loc, nWaves);
 
+    auto accelEmitterPtr = accel::AccelEmitter::select(
+        op.getFeatures(), elementTypeA, elementTypeB, arch, tuningParams);
+
+    if (!accelEmitterPtr)
+      return op.emitOpError("Unable to emit accelerator code.");
+
     const int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
     auto waveSizeConstantOp = b.create<ConstantIndexOp>(loc, waveSize);
 
     bool useIndexDiffs = true;
-
-    int64_t gStride = mBlocks * nBlocks;
 
     LLVM_DEBUG(llvm::dbgs() << "M: " << M << "\n"
                             << "N: " << N << "\n"
@@ -1240,41 +1242,12 @@ struct GridwiseGemmAccelRewritePattern
     Value ldsViewForGemmB = viewBufferAs(b, ldsBufferB, ldsReadTypeB);
     // -----
 
-    // Mfma instruction group selection.
-    auto maybeMfmaInsnGroup = MfmaInsnGroup::select(elementTypeA, elementTypeB,
-                                                    arch, mPerWave, nPerWave);
-    if (failed(maybeMfmaInsnGroup)) {
-      return emitError(loc) << "Failed to select xdlops instruction group.\n";
-    }
-    MfmaInsnGroup mfmaGroup = *maybeMfmaInsnGroup;
-    if (!mfmaGroup.isCoherentWithK(kpack, kPerBlock)) {
-      return emitError(loc)
-             << "Mfma instruction group selection is not compatible with k.\n";
-    }
+    Type destType = op.getC().getType().getElementType();
 
-    int64_t mRepeats = mfmaGroup.getMRepeats(mPerWave);
-    int64_t nRepeats = mfmaGroup.getNRepeats(nPerWave);
-    auto imms = mfmaGroup.getImms();
+    int64_t nOutputVectors = accelEmitterPtr->nResultVectors *
+                             accelEmitterPtr->mRepeats *
+                             accelEmitterPtr->nRepeats;
 
-    int64_t nResultVectors = imms.size() * mRepeats * nRepeats;
-    int64_t mPerRepeat = mPerWave / mRepeats;
-    int64_t nPerRepeat = nPerWave / nRepeats;
-
-    VectorType vectorType = mfmaGroup.getRetType();
-    MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
-
-    int64_t m = mfmaAttr.mfmaNonKDim;
-    // Note n has the 4x4 => 4x64 behavior that necessitated inputSpansPerMfmaIn
-    int64_t n = mfmaAttr.inputSpanLen;
-
-    int64_t rowGroupSize = mfmaAttr.rowGroupSize;
-    int64_t rowGroupsPerBlock = mfmaAttr.rowGroupsPerBlock;
-    int64_t inputSpanLen = mfmaAttr.inputSpanLen;
-    int64_t inputSpansPerMfmaIn = mfmaAttr.inputSpansPerMfmaIn;
-    int64_t k_base = mfmaAttr.k_base;
-    int64_t blocksInOutRegs = mfmaAttr.blocksInOutRegs;
-
-    int64_t blocksPerRepeat = (mPerRepeat * nPerRepeat) / (m * n);
     // -----
 
     // Logic to setup blockwise_gemm_accel parameters.
@@ -1297,33 +1270,25 @@ struct GridwiseGemmAccelRewritePattern
 
     // Logic to setup buffers for blockwise_gemm_accel.
 
-    bool isKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
-    int64_t inputBufferSize =
-        (kpacksPerBlock * kpack) /
-        ((isKReduction ? inputSpansPerMfmaIn : 1) * k_base);
-
     Type arrayAType, arrayBType;
-    arrayAType = MemRefType::get({inputBufferSize}, mfmaGroup.getArgTypeA(),
-                                 AffineMap{}, privateMemoryAddressSpace);
-    arrayBType = MemRefType::get({inputBufferSize}, mfmaGroup.getArgTypeB(),
-                                 AffineMap{}, privateMemoryAddressSpace);
+    arrayAType = MemRefType::get({accelEmitterPtr->inputBufferSize},
+                                 accelEmitterPtr->argTypeA, AffineMap{},
+                                 privateMemoryAddressSpace);
+    arrayBType = MemRefType::get({accelEmitterPtr->inputBufferSize},
+                                 accelEmitterPtr->argTypeB, AffineMap{},
+                                 privateMemoryAddressSpace);
     auto arrayA = b.create<GpuAllocOp>(loc, arrayAType);
     auto arrayB = b.create<GpuAllocOp>(loc, arrayBType);
 
     // -----
     // Logic to allocate 0-initialized vectors for C.
-    int64_t regCVectorLen = vectorType.getNumElements();
-    Type destType = op.getC().getType().getElementType();
-    Type accumulatorType =
-        obtainAccumulatorType(b, elementTypeA, elementTypeB, destType);
-    VectorType accumulatorVectorType =
-        vectorType.cloneWith({}, accumulatorType);
-    MemRefType regCAllocType =
-        MemRefType::get(nResultVectors, accumulatorVectorType, AffineMap{},
-                        /*memorySpace=*/privateMemoryAddressSpace);
+    MemRefType regCAllocType = MemRefType::get(
+        nOutputVectors, accelEmitterPtr->accVectorType, AffineMap{},
+        /*memorySpace=*/privateMemoryAddressSpace);
     Value regCAllocOp = b.create<rock::GpuAllocOp>(loc, regCAllocType);
 
-    Value zeroConstantCOp = createZeroConstantOp(b, loc, vectorType);
+    Value zeroConstantCOp =
+        createZeroConstantOp(b, loc, accelEmitterPtr->accVectorType);
     b.create<FillOp>(loc, regCAllocOp, zeroConstantCOp);
 
     // Emit loop.
@@ -1360,8 +1325,8 @@ struct GridwiseGemmAccelRewritePattern
       // Emit blockwise GEMM.
       blockwiseGemmAccelOp = b.create<BlockwiseGemmAccelOp>(
           loc, ldsViewForGemmA, ldsViewForGemmB, mMyWaveOffsetA, mMyWaveOffsetB,
-          arrayA, arrayB, regCAllocOp, op.getArchAttr(), op.getBlockSizeAttr(),
-          op.getParamsAttr());
+          arrayA, arrayB, regCAllocOp, op.getArchAttr(), op.getFeaturesAttr(),
+          op.getBlockSizeAttr(), op.getParamsAttr());
 
       // LDS barrier.
       // This barrier prevents halo part of outputs having weird values.
@@ -1400,107 +1365,22 @@ struct GridwiseGemmAccelRewritePattern
     // -----
 
     // Matrix C write out logic.
-    int64_t wavesInKernelBlock = blockSize / waveSize;
-
-    int64_t numElements = regCVectorLen * nResultVectors;
-    TopDownTMBuilder splitMemoryCoords(b, {"bid", "tid", "item"},
-                                       {gridSize, blockSize, numElements}, loc);
-    splitMemoryCoords.merge({"g", "m", "n"}, {0, 1, 2}, {"bid"},
-                            {gridSize / gStride, gStride / nBlocks, nBlocks});
-    splitMemoryCoords.merge(
-        {"wave", "m_tid", "n_tid"}, {3, 4, 5}, "tid",
-        {wavesInKernelBlock, waveSize / inputSpanLen, inputSpanLen});
-    splitMemoryCoords.merge(
-        {"i", "j", "vec_group", "vec_item"}, {6, 7, 8, 9}, "item",
-        {numElements / (blocksPerRepeat * rowGroupsPerBlock * rowGroupSize),
-         blocksPerRepeat, rowGroupsPerBlock, rowGroupSize});
-    TransformMapAttr splitMemoryCoordsAttr = splitMemoryCoords.get();
-
-    // "blkMajor" and "blkMinor" are placeholder names because we don't know if
-    // they'll be column or row until we check for broadcast-ness.
-    auto toRowsAndCols =
-        TopDownTMBuilder::below(splitMemoryCoords, splitMemoryCoordsAttr);
-    llvm::StringMap<uint32_t> rowsAndColsIdxs = expandNamesInPlace(
-        splitMemoryCoords, {{"wave", {"wave_m", "wave_n"}},
-                            {"i", {"m_i", "n_i"}},
-                            {"j", {"blkMajor", "blkMinor"}}});
-    TopDownTMBottomDimsWrapper rowsAndColsWrap(toRowsAndCols, rowsAndColsIdxs);
-    rowsAndColsWrap.passThrough({"g", "m", "n"});
-    rowsAndColsWrap.merge({"wave_m", "wave_n"}, "wave",
-                          {wavesInKernelBlock / nWaves, nWaves});
-    rowsAndColsWrap.passThrough({"m_tid", "n_tid"});
-    rowsAndColsWrap.merge(
-        {"m_i", "n_i"}, "i",
-        {splitMemoryCoords.endSize("i") / nRepeats, nRepeats});
-
-    // Here we use the full builder API since we want index and name control
-    bool isABroadcast = (nPerRepeat >= mPerRepeat);
-    SmallVector<StringRef, 2> rowsFirst = {"blk_row", "blk_col"};
-    SmallVector<StringRef, 2> colsFirst = {"blk_col", "blk_row"};
-    toRowsAndCols.merge(
-        isABroadcast ? rowsFirst : colsFirst,
-        {rowsAndColsIdxs["blkMajor"], rowsAndColsIdxs["blkMinor"]}, "j",
-        {splitMemoryCoords.endSize("j") / blocksInOutRegs, blocksInOutRegs});
-    toRowsAndCols.passThrough(
-        {"vec_group", "vec_item"},
-        {rowsAndColsIdxs["vec_group"], rowsAndColsIdxs["vec_item"]},
-        {"vec_group", "vec_item"});
-
-    TransformMapAttr toRowsAndColsAttr = toRowsAndCols.get();
-
-    auto toMatrixC = TopDownTMBuilder::below(toRowsAndCols, toRowsAndColsAttr);
-    toMatrixC.passThrough({"gemmG"}, {0}, {"g"});
-
-    toMatrixC.embed(
-        "gemmM", 1, M,
-        {"m", "wave_m", "m_tid", "m_i", "blk_row", "vec_group", "vec_item"},
-        {mPerBlock, mPerWave, rowGroupSize, mPerRepeat, m,
-         inputSpansPerMfmaIn * rowGroupSize, 1});
-    toMatrixC.embed("gemmN", 2, N, {"n", "wave_n", "n_i", "blk_col", "n_tid"},
-                    {nPerBlock, nPerWave, nPerRepeat, n, 1});
-    TransformMapAttr toMatrixCAttr = toMatrixC.get();
-
-    ArrayAttr idToMatrixCMaps = b.getArrayAttr(
-        {splitMemoryCoordsAttr, toRowsAndColsAttr, toMatrixCAttr});
-
-    Value registerC = regCAllocOp;
-    auto convertedCType =
-        MemRefType::get(numElements, destType, AffineMap{},
-                        /*memorySpace=*/privateMemoryAddressSpace);
+    auto convertedCType = MemRefType::get(
+        accelEmitterPtr->numOutputVectorElements, destType, AffineMap{},
+        /*memorySpace=*/privateMemoryAddressSpace);
     Value convertedC = b.create<rock::GpuAllocOp>(loc, convertedCType);
 
-    BottomUpTMBuilder toRegCScalar(b, {"scalar"}, {numElements}, loc);
-    toRegCScalar.embed({"vector"}, {0}, {nResultVectors}, "scalar",
-                       {regCVectorLen});
-    TransformMapAttr toRegCScalarAttr = toRegCScalar.get();
+    ArrayAttr idToMatrixCMaps = accelEmitterPtr->computeOutputTransforms(
+        b, loc, M, N, blockSize, gridSize, regCAllocOp, convertedC);
 
-    // Convert from memref<?xvector<?xT>> to memref<?xT> where the source T
-    // is the accumulatorType and destination type is destType
-    auto convertLoop = b.create<TransformingForOp>(
-        loc, ArrayRef<ValueRange>{{zeroConstantOp}, {zeroConstantOp}},
-        ArrayRef<Attribute>{b.getArrayAttr({}),
-                            b.getArrayAttr(toRegCScalarAttr)},
-        /*bounds=*/regCAllocType.getShape(), /*strides=*/std::nullopt,
-        forceUnroll, /*useIndexDiffs=*/true);
-    {
-      OpBuilder::InsertionGuard guard(b);
-      b.setInsertionPointToStart(convertLoop.getBody());
-      Value loaded =
-          b.create<memref::LoadOp>(loc, accumulatorVectorType, registerC,
-                                   convertLoop.getLowerCoords(/*domain*/ 0));
-      Value cast = loaded;
-      if (destType != accumulatorType) {
-        VectorType destVectorType = vectorType.clone(destType);
-        cast = createTypeConversionOp(b, loc, loaded, destVectorType);
-      }
-      b.create<InBoundsStoreOp>(loc, cast, convertedC,
-                                convertLoop.getLowerCoords(/*domain*/ 1));
-    }
-    registerC = convertedC;
+    Value registerC = accelEmitterPtr->computeOutputConversion(
+        b, loc, M, N, blockSize, gridSize, regCAllocOp, convertedC,
+        forceUnroll);
 
     b.create<ThreadwiseWriteAllOp>(loc, registerC, op.getC(), idToMatrixCMaps,
                                    op.getFeatures(), op.getStoreMethod(),
                                    forceUnroll, useIndexDiffs);
+
     b.eraseOp(op);
     return success();
   }

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -24,8 +24,8 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/Rock/IR/MfmaInsnGroup.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
+#include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/Passes.h"
 #include "mlir/Dialect/Rock/utility/builderUtils.h"
@@ -36,9 +36,11 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "AccelEmitter.h"
 #include "llvm/Support/Debug.h"
 
 #include <iterator>
+#include <memory>
 #include <numeric>
 
 namespace mlir {
@@ -180,10 +182,6 @@ struct AccelGemmV2RewritePattern : public OpConversionPattern<AccelGemmOp> {
     Location loc = op.getLoc();
 
     RockAccelTuningParamAttrInterface tuningParams = op.getParams();
-    // Obtain critical information.
-    int64_t K = tuningParams.getKpackPerBlock() * tuningParams.getKpack();
-    int64_t mPerWave = tuningParams.getMPerWave();
-    int64_t nPerWave = tuningParams.getNPerWave();
 
     auto dataTypeA =
         adaptor.getMatrixA().getType().cast<MemRefType>().getElementType();
@@ -196,81 +194,46 @@ struct AccelGemmV2RewritePattern : public OpConversionPattern<AccelGemmOp> {
       dataTypeB = dataTypeB.cast<VectorType>().getElementType();
     }
 
-    auto maybeMfmaInsnGroup = MfmaInsnGroup::select(
-        dataTypeA, dataTypeB, op.getArch(), mPerWave, nPerWave);
-    if (failed(maybeMfmaInsnGroup)) {
-      return emitError(loc) << "Failed to select xdlops instruction group.\n";
-    }
-    MfmaInsnGroup mfmaGroup = *maybeMfmaInsnGroup;
-
-    VectorType vectorType = mfmaGroup.getRetType();
-    auto imms = mfmaGroup.getImms();
-    int64_t nResultVectors = imms.size();
-    Type argTypeA = mfmaGroup.getArgTypeA();
-    Type argTypeB = mfmaGroup.getArgTypeB();
-
-    MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
-
-    int64_t mfmaNonKDim = mfmaAttr.mfmaNonKDim;
-    int64_t inputSpansPerMfmaIn = mfmaAttr.inputSpansPerMfmaIn;
-    int64_t blocksInOutRegs = mfmaAttr.blocksInOutRegs;
-    int64_t k_base = mfmaAttr.k_base;
-
-    bool IsKReduction = (blocksInOutRegs == 1) && (inputSpansPerMfmaIn > 1);
-
     Value bufferA = adaptor.getMatrixA();
     Value bufferB = adaptor.getMatrixB();
     Value bufferC = adaptor.getMatrixC();
 
-    int64_t kBasePerThread =
-        (IsKReduction ? K / inputSpansPerMfmaIn : K) / k_base;
+    auto emitter = rock::accel::AccelEmitter::select(
+        op.getFeatures(), dataTypeA, dataTypeB, op.getArch(), tuningParams);
+
+    if (!emitter)
+      return emitError(loc)
+             << "Failed to select any accelerator instruction.\n";
+
     Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
     SmallVector<Value, 4> startCoords(4, zeroConstantOp);
 
-    auto populateMfma = [&](OpBuilder &b, Value argA, Value argB,
-                            Value regCOffset) {
-      for (int64_t i = 0; i < nResultVectors; ++i) {
-        Value offset = b.createOrFold<arith::ConstantIndexOp>(loc, i);
-        offset = b.create<AddIOp>(loc, offset, regCOffset);
-
-        auto vectorC =
-            b.create<memref::LoadOp>(loc, vectorType, bufferC, offset);
-        auto mfma = b.create<amdgpu::MFMAOp>(
-            loc, vectorType, mfmaNonKDim, mfmaNonKDim, mfmaAttr.k,
-            mfmaAttr.blocksMfma, argA, argB, vectorC, /*cbsz=*/imms[i].cbsz,
-            /*abid=*/imms[i].abid,
-            /*blgp=*/imms[i].blgp, /*reducePrecision=*/false, /*negateA=*/false,
-            /*negateB=*/false, /*negateC=*/false);
-        auto vectorD = mfma.getDestD();
-
-        b.create<memref::StoreOp>(loc, vectorD, bufferC, offset);
-      }
-    };
-
-    auto generateMfmaOnKDim = [&](Value regCOffset) {
-      auto mfmaLoop = b.create<TransformingForOp>(
+    auto generateAccelOnKDim = [&](Value regCOffset) {
+      auto accelLoop = b.create<TransformingForOp>(
           loc, ArrayRef<ValueRange>{{zeroConstantOp}},
           ArrayRef<Attribute>{b.getArrayAttr({})},
-          /*bounds=*/ArrayRef<int64_t>{kBasePerThread},
+          /*bounds=*/ArrayRef<int64_t>{emitter->kBasePerThread},
           /*strides=*/ArrayRef<int64_t>{1},
           /*forceUnroll=*/false, /*useIndexDiffs=*/false);
       {
         OpBuilder::InsertionGuard guard(b);
-        b.setInsertionPointToStart(mfmaLoop.getBody());
-        Value coord = mfmaLoop.getLowerCoords(/*domain=*/0)[0];
-
-        Value argA = b.create<memref::LoadOp>(loc, argTypeA, bufferA, coord);
-        Value argB = b.create<memref::LoadOp>(loc, argTypeB, bufferB, coord);
-        populateMfma(b, argA, argB, regCOffset);
+        b.setInsertionPointToStart(accelLoop.getBody());
+        Value coord = accelLoop.getLowerCoords(/*domain=*/0)[0];
+        Value argA =
+            b.create<memref::LoadOp>(loc, emitter->argTypeA, bufferA, coord);
+        Value argB =
+            b.create<memref::LoadOp>(loc, emitter->argTypeB, bufferB, coord);
+        emitter->emitThreadwiseLoop(b, loc, argA, argB, bufferC, regCOffset);
       }
     };
 
     auto mRepeat = op.getMRepeat();
     auto nRepeat = op.getNRepeat();
-    int64_t nRepeats = mfmaGroup.getNRepeats(nPerWave);
+
     Value nResultVectorsConstantOp =
-        b.createOrFold<ConstantIndexOp>(loc, nResultVectors);
-    Value nRepeatsConstantOp = b.create<ConstantIndexOp>(loc, nRepeats);
+        b.createOrFold<ConstantIndexOp>(loc, emitter->nResultVectors);
+    Value nRepeatsConstantOp =
+        b.create<ConstantIndexOp>(loc, emitter->nRepeats);
 
     Value regCOffset = b.create<MulIOp>(
         loc,
@@ -278,7 +241,7 @@ struct AccelGemmV2RewritePattern : public OpConversionPattern<AccelGemmOp> {
             loc, b.create<MulIOp>(loc, mRepeat, nRepeatsConstantOp), nRepeat),
         nResultVectorsConstantOp);
 
-    generateMfmaOnKDim(regCOffset);
+    generateAccelOnKDim(regCOffset);
 
     b.eraseOp(op);
     return success();
@@ -293,6 +256,7 @@ void RockThreadwiseGemmLoweringPass::runOnOperation() {
   target.addLegalDialect<amdgpu::AMDGPUDialect, arith::ArithDialect,
                          rock::RockDialect, AffineDialect,
                          memref::MemRefDialect, vector::VectorDialect>();
+  target.addLegalOp<gpu::PrintfOp>();
 
   RewritePatternSet patterns(ctx);
   patterns.add<ThreadwiseGemmRewritePattern, AccelGemmV2RewritePattern>(ctx);

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -9,7 +9,7 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2x
                                                 %matrixC : memref<4xvector<16xf32>, #priv>) {
   %c0 = arith.constant 0 : index
   // CHECK:  rock.accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize= 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -30,7 +30,7 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<128xvector<8xi
                                                %matrixC : memref<1xvector<16xi32>, #priv>) {
   %c0 = arith.constant 0 : index
   // CHECK:  rock.accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -53,7 +53,7 @@ func.func @rock_blockwise_gemm_accel_fp8_bf8(%matrixA : memref<1024xvector<8xf8E
                                           %matrixC : memref<4xvector<16xf32>, #gpu.address_space<private>>) {
   // CHECK:  rock.accel_gemm
   %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -1,0 +1,102 @@
+// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise %s | FileCheck %s
+#wg = #gpu.address_space<workgroup>
+#priv = #gpu.address_space<private>
+
+func.func @rock_blockwise_gemm_v2_wmma(%matrixA : memref<16xvector<16xf16>, #wg>, %matrixB : memref<16xvector<16xf16>, #wg>,
+                                               %bufferA : memref<1xvector<16xf16>, #priv>, %bufferB : memref<1xvector<16xf16>, #priv>,
+                                               %matrixC : memref<1xvector<16xf16>, #priv>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[tid:.*]] = rock.workitem_id : index
+  // CHECK: %[[wid:.*]] = arith.remui %[[tid]], %c32{{.*}} : index
+  // CHECK: {{.*}} = arith.remui %[[wid]], %c16{{.*}} : index
+  // CHECK: affine.for {{.*}} = 0 to 1
+  // CHECK: affine.for {{.*}} = 0 to 4
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<16xvector<16xf16>, #gpu.address_space<workgroup>>
+  // CHECK: memref.store
+  // CHECK: affine.for {{.*}} = 0 to 1
+  // CHECK: affine.for {{.*}} = 0 to 4
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<16xvector<16xf16>, #gpu.address_space<workgroup>>
+  // CHECK: memref.store
+  // CHECK:  rock.xdlops_gemm_v2
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    blockSize = 32 : i32,
+    params = #rock.xdlops_gemm_params<
+      kPerBlock = 4,
+      kpack = 16,
+      mPerBlock = 16,
+      mPerWave = 16,
+      nPerBlock = 16,
+      nPerWave = 16,
+      forceUnroll = true>
+  } : memref<1xvector<16xf16>, #priv> += memref<1xvector<16xf16>, #priv> from memref<16xvector<16xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<16xvector<16xf16>, #wg>
+  return
+}
+
+func.func @rock_blockwise_gemm_v2_wmma_largekpack(%matrixA : memref<32xvector<32xf16>, #wg>, %matrixB : memref<32xvector<32xf16>, #wg>,
+                                                  %bufferA : memref<1xvector<16xf16>, #priv>, %bufferB : memref<1xvector<16xf16>, #priv>,
+                                                  %matrixC : memref<1xvector<16xf16>, #priv>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[tid:.*]] = rock.workitem_id : index
+  // CHECK: %[[wid:.*]] = arith.remui %[[tid]], %c32{{.*}} : index
+  // CHECK: {{.*}} = arith.remui %[[wid]], %c16{{.*}} : index
+  // CHECK: affine.for {{.*}} = 0 to 1
+  // CHECK: affine.for {{.*}} = 0 to 4
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<32xvector<32xf16>, #gpu.address_space<workgroup>>
+  // CHECK: {{.*}} = rock.extract_slice %[[a]][{{.*}}] : vector<32xf16> -> vector<16xf16>
+  // CHECK: memref.store
+  // CHECK: {{.*}} = rock.extract_slice %[[a]][{{.*}}] : vector<32xf16> -> vector<16xf16>
+  // CHECK: memref.store
+  // CHECK: affine.for {{.*}} = 0 to 1
+  // CHECK: affine.for {{.*}} = 0 to 4
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<32xvector<32xf16>, #gpu.address_space<workgroup>>
+  // CHECK: {{.*}} = rock.extract_slice %[[b]][{{.*}}] : vector<32xf16> -> vector<16xf16>
+  // CHECK: memref.store
+  // CHECK: {{.*}} = rock.extract_slice %[[b]][{{.*}}] : vector<32xf16> -> vector<16xf16>
+  // CHECK: memref.store
+  // CHECK:  rock.xdlops_gemm_v2
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    blockSize = 128 : i32,
+    params = #rock.xdlops_gemm_params<
+      mPerBlock = 32,
+      nPerBlock = 32,
+      kPerBlock = 4,
+      mPerWave = 16,
+      nPerWave = 16,
+      kpack = 32,
+      forceUnroll = true>
+  } : memref<1xvector<16xf16>, #priv> += memref<1xvector<16xf16>, #priv> from memref<32xvector<32xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<32xvector<32xf16>, #wg>
+  return
+}
+
+func.func @rock_blockwise_gemm_v2_wmma_int8(%matrixA : memref<32xvector<16xi8>, #wg>, %matrixB : memref<32xvector<16xi8>, #wg>,
+                                            %bufferA : memref<4xvector<16xi8>, #priv>, %bufferB : memref<4xvector<16xi8>, #priv>,
+                                            %matrixC : memref<4xvector<8xi32>, #priv>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[tid:.*]] = rock.workitem_id : index
+  // CHECK: %[[wid:.*]] = arith.remui %[[tid]], %c32{{.*}} : index
+  // CHECK: {{.*}} = arith.remui %[[wid]], %c16{{.*}} : index
+  // CHECK: affine.for {{.*}} = 0 to 2
+  // CHECK: affine.for {{.*}} = 0 to 4
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<32xvector<16xi8>, #gpu.address_space<workgroup>>
+  // CHECK: memref.store
+  // CHECK: affine.for {{.*}} = 0 to 2
+  // CHECK: affine.for {{.*}} = 0 to 4
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<32xvector<16xi8>, #gpu.address_space<workgroup>>
+  // CHECK: memref.store
+  // CHECK:  rock.xdlops_gemm_v2
+  rock.blockwise_gemm_v2 %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    blockSize = 128 : i32,
+    params = #rock.xdlops_gemm_params<
+      mPerBlock = 64,
+      nPerBlock = 64,
+      kPerBlock = 4,
+      mPerWave = 32,
+      nPerWave = 32,
+      kpack = 16,
+      forceUnroll = true>
+  } : memref<4xvector<8xi32>, #priv> += memref<4xvector<16xi8>, #priv> from memref<32xvector<16xi8>, #wg> * memref<4xvector<16xi8>, #priv> from memref<32xvector<16xi8>, #wg>
+  return
+}

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
@@ -1,9 +1,9 @@
 // RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
 
-// CHECK: rock_xdlops_gemm_v2_wmma
-func.func @rock_xdlops_gemm_v2_wmma(%matrixA : memref<1xvector<16xf16>, 5>,
-                                    %matrixB : memref<1xvector<16xf16>, 5>,
-                                    %matrixC : memref<1xvector<8xf32>, 5>) {
+// CHECK: rock_accel_gemm_wmma
+func.func @rock_accel_gemm_wmma(%matrixA : memref<1xvector<16xf16>, 5>,
+                                %matrixB : memref<1xvector<16xf16>, 5>,
+                                %matrixC : memref<1xvector<8xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [4]
@@ -12,12 +12,12 @@ func.func @rock_xdlops_gemm_v2_wmma(%matrixA : memref<1xvector<16xf16>, 5>,
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1xvector<8xf32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<1xvector<8xf32>, 5>
-  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] features = wmma {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
-    params = #rock.xdlops_gemm_params<
+    params = #rock.wmma_gemm_params<
        mPerBlock = 16,
        nPerBlock = 16,
-       kPerBlock = 4,
+       kpackPerBlock = 4,
        mPerWave = 16,
        nPerWave = 16,
        kpack = 16,
@@ -26,10 +26,10 @@ func.func @rock_xdlops_gemm_v2_wmma(%matrixA : memref<1xvector<16xf16>, 5>,
   return
 }
 
-// CHECK: rock_xdlops_gemm_v2_wmma_repeats
-func.func @rock_xdlops_gemm_v2_wmma_repeats(%matrixA : memref<4xvector<16xf16>, 5>,
-                                    %matrixB : memref<4xvector<16xf16>, 5>,
-                                    %matrixC : memref<4xvector<8xf32>, 5>) {
+// CHECK: rock_accel_gemm_wmma_repeats
+func.func @rock_accel_gemm_wmma_repeats(%matrixA : memref<4xvector<16xf16>, 5>,
+                                        %matrixB : memref<4xvector<16xf16>, 5>,
+                                        %matrixC : memref<4xvector<8xf32>, 5>) {
   %c1 = arith.constant 1 : index
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [2]
@@ -38,12 +38,12 @@ func.func @rock_xdlops_gemm_v2_wmma_repeats(%matrixA : memref<4xvector<16xf16>, 
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xf32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xf32>, 5>
-  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+  rock.accel_gemm %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
-    params = #rock.xdlops_gemm_params<
+    params = #rock.wmma_gemm_params<
        mPerBlock = 32,
        nPerBlock = 32,
-       kPerBlock = 2,
+       kpackPerBlock = 2,
        mPerWave = 32,
        nPerWave = 32,
        kpack = 16,
@@ -52,10 +52,10 @@ func.func @rock_xdlops_gemm_v2_wmma_repeats(%matrixA : memref<4xvector<16xf16>, 
   return
 }
 
-// CHECK: rock_xdlops_gemm_v2_wmma_repeats_int8
-func.func @rock_xdlops_gemm_v2_wmma_repeats_int8(%matrixA : memref<4xvector<16xi8>, 5>,
-                                    %matrixB : memref<4xvector<16xi8>, 5>,
-                                    %matrixC : memref<4xvector<8xi32>, 5>) {
+// CHECK: rock_accel_gemm_wmma_repeats_int8
+func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<4xvector<16xi8>, 5>,
+                                             %matrixB : memref<4xvector<16xi8>, 5>,
+                                             %matrixC : memref<4xvector<8xi32>, 5>) {
   %c1 = arith.constant 1 : index
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [4]
@@ -64,12 +64,12 @@ func.func @rock_xdlops_gemm_v2_wmma_repeats_int8(%matrixA : memref<4xvector<16xi
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
-  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+  rock.accel_gemm %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
-    params = #rock.xdlops_gemm_params<
+    params = #rock.wmma_gemm_params<
        mPerBlock = 32,
        nPerBlock = 32,
-       kPerBlock = 4,
+       kpackPerBlock = 4,
        mPerWave = 32,
        nPerWave = 32,
        kpack = 16,
@@ -78,10 +78,10 @@ func.func @rock_xdlops_gemm_v2_wmma_repeats_int8(%matrixA : memref<4xvector<16xi
   return
 }
 
-// CHECK: rock_xdlops_gemm_v2_wmma_partial_repeats_int8
-func.func @rock_xdlops_gemm_v2_wmma_partial_repeats_int8(%matrixA : memref<2xvector<16xi8>, 5>,
-                                    %matrixB : memref<2xvector<16xi8>, 5>,
-                                    %matrixC : memref<2xvector<8xi32>, 5>) {
+// CHECK: rock_accel_gemm_wmma_partial_repeats_int8
+func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<2xvector<16xi8>, 5>,
+                                                     %matrixB : memref<2xvector<16xi8>, 5>,
+                                                     %matrixC : memref<2xvector<8xi32>, 5>) {
   %c1 = arith.constant 1 : index
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [2]
@@ -90,12 +90,12 @@ func.func @rock_xdlops_gemm_v2_wmma_partial_repeats_int8(%matrixA : memref<2xvec
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<2xvector<8xi32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<2xvector<8xi32>, 5>
-  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+  rock.accel_gemm %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
-    params = #rock.xdlops_gemm_params<
+    params = #rock.wmma_gemm_params<
        mPerBlock = 32,
        nPerBlock = 32,
-       kPerBlock = 2,
+       kpackPerBlock = 2,
        mPerWave = 32,
        nPerWave = 16,
        kpack = 16,

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
@@ -1,0 +1,105 @@
+// RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
+
+// CHECK: rock_xdlops_gemm_v2_wmma
+func.func @rock_xdlops_gemm_v2_wmma(%matrixA : memref<1xvector<16xf16>, 5>,
+                                    %matrixB : memref<1xvector<16xf16>, 5>,
+                                    %matrixC : memref<1xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [4]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1xvector<16xf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1xvector<16xf16>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1xvector<8xf32>, 5>
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c0] * %matrixB[%c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.xdlops_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kPerBlock = 4,
+       mPerWave = 16,
+       nPerWave = 16,
+       kpack = 16,
+       forceUnroll = true>
+     } : memref<1xvector<8xf32>, 5> += memref<1xvector<16xf16>, 5> * memref<1xvector<16xf16>, 5>
+  return
+}
+
+// CHECK: rock_xdlops_gemm_v2_wmma_repeats
+func.func @rock_xdlops_gemm_v2_wmma_repeats(%matrixA : memref<4xvector<16xf16>, 5>,
+                                    %matrixB : memref<4xvector<16xf16>, 5>,
+                                    %matrixC : memref<4xvector<8xf32>, 5>) {
+  %c1 = arith.constant 1 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [2]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4xvector<16xf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4xvector<16xf16>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xf32>, 5>
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.xdlops_gemm_params<
+       mPerBlock = 32,
+       nPerBlock = 32,
+       kPerBlock = 2,
+       mPerWave = 32,
+       nPerWave = 32,
+       kpack = 16,
+       forceUnroll = true>
+     } : memref<4xvector<8xf32>, 5> += memref<4xvector<16xf16>, 5> * memref<4xvector<16xf16>, 5>
+  return
+}
+
+// CHECK: rock_xdlops_gemm_v2_wmma_repeats_int8
+func.func @rock_xdlops_gemm_v2_wmma_repeats_int8(%matrixA : memref<4xvector<16xi8>, 5>,
+                                    %matrixB : memref<4xvector<16xi8>, 5>,
+                                    %matrixC : memref<4xvector<8xi32>, 5>) {
+  %c1 = arith.constant 1 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [4]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4xvector<16xi8>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4xvector<16xi8>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
+  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.xdlops_gemm_params<
+       mPerBlock = 32,
+       nPerBlock = 32,
+       kPerBlock = 4,
+       mPerWave = 32,
+       nPerWave = 32,
+       kpack = 16,
+       forceUnroll = true>
+     } : memref<4xvector<8xi32>, 5> += memref<4xvector<16xi8>, 5> * memref<4xvector<16xi8>, 5>
+  return
+}
+
+// CHECK: rock_xdlops_gemm_v2_wmma_partial_repeats_int8
+func.func @rock_xdlops_gemm_v2_wmma_partial_repeats_int8(%matrixA : memref<2xvector<16xi8>, 5>,
+                                    %matrixB : memref<2xvector<16xi8>, 5>,
+                                    %matrixC : memref<2xvector<8xi32>, 5>) {
+  %c1 = arith.constant 1 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [2]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<2xvector<16xi8>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<2xvector<16xi8>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<2xvector<8xi32>, 5>
+  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<2xvector<8xi32>, 5>
+  rock.xdlops_gemm_v2 %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.xdlops_gemm_params<
+       mPerBlock = 32,
+       nPerBlock = 32,
+       kPerBlock = 2,
+       mPerWave = 32,
+       nPerWave = 16,
+       kpack = 16,
+       forceUnroll = true>
+     } : memref<2xvector<8xi32>, 5> += memref<2xvector<16xi8>, 5> * memref<2xvector<16xi8>, 5>
+  return
+}

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
@@ -12,7 +12,7 @@ func.func @rock_accel_gemm_reduction_nokpack(%matrixA : memref<2xf32, 5>,
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
        kpackPerBlock = 4,
@@ -38,7 +38,7 @@ func.func @rock_accel_gemm_reduction_kpack_f32(%matrixA : memref<2xf32, 5>,
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
@@ -65,7 +65,7 @@ func.func @rock_accel_gemm_reduction_kpack_i8(%matrixA : memref<4xvector<4xi8>, 
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : vector<4xi8>, vector<4xi8>, vector<16xi32>
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -92,7 +92,7 @@ func.func @accel_gemm_gfx90a_i8(%matrixA : memref<4xvector<4xi8>, 5>,
   // CHECK-SAME: blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -116,7 +116,7 @@ func.func @accel_gemm_gfx940_i8(%matrixA : memref<4xvector<8xi8>, 5>,
   // CHECK-SAME: blocks = 1 : i32, k = 16 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -140,7 +140,7 @@ func.func @accel_gemm_gfx908_bf16(%matrixA : memref<4xvector<2xbf16>, 5>,
   // CHECK-SAME: blocks = 1 : i32, k = 4 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx908",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -164,7 +164,7 @@ func.func @accel_gemm_gfx90a_bf16(%matrixA : memref<4xvector<4xbf16>, 5>,
   // CHECK-SAME: blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -189,7 +189,7 @@ func.func @accel_gemm_fp8_bf8(%matrixA : memref<4xvector<8xf8E4M3FNUZ>, #gpu.add
   // CHECK-SAME: : vector<8xf8E4M3FNUZ>, vector<8xf8E5M2FNUZ>, vector<16xf32>
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 8,

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -479,7 +479,7 @@ func.func @rock_accel_gemm_one_result(%matrixA : memref<16xf32, 5>,
                                             %matrixB : memref<16xf32, 5>,
                                             %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -502,7 +502,7 @@ func.func @rock_accel_gemm_two_results(%matrixA : memref<16xf32, 5>,
                                              %matrixB : memref<16xf32, 5>,
                                              %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -525,7 +525,7 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<12288xf32, 3>,
                                               %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
                                               %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -549,7 +549,7 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<12288xf32, 3>
                                                 %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
                                                 %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -2,7 +2,7 @@
 // RUN: rocmlir-opt %s | rocmlir-opt | FileCheck %s
 // Run: rocmlir-opt -mlir-print-op-generic %s | rocmlir-opt | FileCheck %s
 
-func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x128x1xf16, 3>, %C : memref<8x8xf16, 5>) {
+func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x128x1xf16, 3>, %C : memref<8x8xf16, 5>){
   rock.blockwise_gemm %C += %A * %B {
     params = #rock.general_gemm_params<
       blockSize = 256,
@@ -26,7 +26,7 @@ func.func @rock_xdlops_gemm_accel_one_result_f16(%matrixA : memref<4xvector<4xf1
                                                 %matrixB : memref<4xvector<4xf16>, 5>,
                                                 %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -49,7 +49,7 @@ func.func @rock_xdlops_gemm_accel_two_results_f16(%matrixA : memref<4xvector<4xf
                                                %matrixB : memref<4xvector<4xf16>, 5>,
                                                %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] {
+  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -73,7 +73,7 @@ func.func @rock_blockwise_gemm_accel_one_result_f16(%matrixA : memref<8192xf16, 
                                           %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
   %c0f = arith.constant 0.0 : f16
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<
@@ -97,7 +97,7 @@ func.func @rock_blockwise_gemm_accel_two_results_f16(%matrixA : memref<8192xf16,
                                                %bufferA : memref<4xvector<4xf16>, 5>, %bufferB : memref<4xvector<4xf16>, 5>,
                                                %matrixC : memref<2xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     params = #rock.xdlops_gemm_params<

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -290,6 +290,17 @@ static llvm::cl::opt<FeatureToggle> mfmaFeature(
                                 "remove mfma from the feature list")),
     llvm::cl::init(FeatureToggle::infer));
 
+// wmma
+static llvm::cl::opt<FeatureToggle> wmmaFeature(
+    "wmma", llvm::cl::desc("toggle feature wmma"),
+    llvm::cl::values(clEnumValN(FeatureToggle::infer, "infer",
+                                "use the default value provided by the chip"),
+                     clEnumValN(FeatureToggle::on, "on",
+                                "force wmma into the feature list"),
+                     clEnumValN(FeatureToggle::off, "off",
+                                "remove wmma from the feature list")),
+    llvm::cl::init(FeatureToggle::infer));
+
 // dot
 static llvm::cl::opt<FeatureToggle> dotFeature(
     "dot", llvm::cl::desc("toggle feature dot"),
@@ -2134,7 +2145,6 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
     verifyFuncName += "Int8";
   } else {
     llvm::errs() << "Unsupported type of validation function output: ";
-    valElemType.dump();
     llvm::errs() << " (Only f32, int32 and int64 are supported)\n";
     exit(1);
   }
@@ -2840,6 +2850,9 @@ int main(int argc, char **argv) {
         enabledFeatures =
             bitEnumSet(enabledFeatures, rock::GemmFeatures::atomic_fmax_f32,
                        atomicFMaxF32Feature == FeatureToggle::on);
+      if (wmmaFeature != FeatureToggle::infer)
+        enabledFeatures = bitEnumSet(enabledFeatures, rock::GemmFeatures::wmma,
+                                     wmmaFeature == FeatureToggle::on);
       genParams.operation = operation;
       genParams.features = enabledFeatures;
       genParams.arch = arch;


### PR DESCRIPTION
This is adding WMMA support into our core passes:
- `GridwiseGemmToBlockwise`
- `BlockwiseGemmToThreadwise`
- `ThreadwiseGemmLowering`

I also add basic support to `rocmlir-gen` so that we can run the end-to-end flow. However, testing for now is only at the IR level. Runtime test should be added after this PR.

Please note that the changes to the backend are not part of this PR but they are part of (#1035)

The high level idea has been to implement a `AccelEmitter` class to abstract away details about the calls to the specific accelerator. Wmma will implement `WmmaEmitter` and mfma will immplement `MfmaEmitter`. 

Before approving this PR we should:
- Agree if this is the correct design
- If needed, select a name to replace XDLOPS (`Accelerator`? @sjw36 was suggesting `xma`) . The idea is to create a separate PR to do the name replacement
- Approve PR https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/1035

After approving this PR we should:
- Add the correct default and tuning parameters
- Add runtime tests
- Improve `wmma` performance (e.g., select different `waveSize` during tuning time and using the `f16->f16` wmma instruction)

