### PR TITLE
Add infrastructure for tracking fusion performance

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -600,7 +600,7 @@ pipeline {
                             showEnv()
                         }
                     }
-                    stage("Tune Gemm") {
+                    stage("Tune Gemm and Fusion") {
                         steps {
                             buildProject('check-rocmlir-build-only ci-performance-scripts', '')
                             dir('build') {
@@ -609,10 +609,19 @@ pipeline {
 --configs_file=../mlir/utils/performance/bert-configs \
 --output=mlir_tuning_${ARCH}.tsv
 [ -f mlir_tuning_${ARCH}.tsv ]"""
+
+                                // Tune resnet50
+                                sh """python3 ./bin/tuningRunner.py --op fusion \
+--test_dir ../mlir/test/fusion/e2e/resnet50/ -o tuning_fusion_resnet50_${ARCH}.tsv"""
+
+                                // Tune bert
+                                sh """python3 ./bin/tuningRunner.py --op fusion \
+--test_dir ../mlir/test/xmir/e2e/bert-torch-tosa/ -o tuning_fusion_bert_${ARCH}.tsv"""
                             }
                             sh 'rm build/CMakeCache.txt'
                         }
                     }
+
                     stage("Build MIOpen with librockCompiler") {
                         steps {
                             buildMIOpenWithMLIR()
@@ -626,9 +635,9 @@ pipeline {
                         steps {
                             tuneMLIRKernels()
                             // Save user database for nightly jobs
-                            // Hack: move the GEMM tuning DB to MIOpenUserDB
+                            // Hack: move the GEMM/Fusion tuning DB to MIOpenUserDB
                             // to make all the stashes work
-                            sh "cp ${WORKSPACE}/build/mlir_tuning_${ARCH}.tsv ${WORKSPACE}/MIOpen/build/MIOpenUserDB/"
+                            sh "cp ${WORKSPACE}/build/*_${ARCH}.tsv ${WORKSPACE}/MIOpen/build/MIOpenUserDB/"
                             dir ('MIOpen/build/MIOpenUserDB') {
                                 stash name: "MLIR-PerfDB-${ARCH}", includes: "**"
                             }
@@ -790,7 +799,7 @@ pipeline {
                                 selector: lastSuccessful(),\
                                 target: 'MIOpen/build/MIOpenUserDB'
                                 sh 'ls MIOpen/build/MIOpenUserDB'
-                                // Move GEMM tuning DB out of the way if it exists
+                                // Move GEMM and fusion tuning DB out of the way if it exists
                                 // This is needed because the tuned vs. untuned MIOpen
                                 // code will delete the MIOpenUserBD directory
                                 catchError (buildResult: null) {
@@ -856,6 +865,18 @@ pipeline {
                             }
                         }
                     }
+                    //stage("Test Fusion") {
+                    //    steps {
+                    //        dir('build') {
+                                // Run fusion resnet50 perf benchmarks
+                                //sh """python3 ./bin/perfRunner.py --op=fusion \
+          //--test_dir=${WORKSPACE}/mlir/test/fusion/e2e/resnet50/ --tuning_db=${WORKSPACE}/tuning_fusion_resnet50_${CHIP}.tsv"""
+                                // Run bert perf benchmarks
+                                //sh """python3 ./bin/perfRunner.py --op fusion \
+          //--test_dir=${WORKSPACE}/mlir/test/xmir/e2e/bert-torch-tosa/ --tuning_db=${WORKSPACE}/tuning_fusion_bert_${CHIP}.tsv"""
+                            //}
+                        //}
+                    //}
                     stage("Test MLIR vs CK") {
                         when {
                             beforeAgent true;
@@ -896,6 +917,7 @@ pipeline {
                                 sh 'ls -l'
                                 sh 'python3 ./bin/createPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP}'
+                                //sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
                                 sh 'mkdir -p reports && cp ./*.html reports'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -600,7 +600,7 @@ pipeline {
                             showEnv()
                         }
                     }
-                    stage("Tune Gemm and Fusion") {
+                    stage("Tune Gemm") {
                         steps {
                             buildProject('check-rocmlir-build-only ci-performance-scripts', '')
                             dir('build') {
@@ -609,7 +609,12 @@ pipeline {
 --configs_file=../mlir/utils/performance/bert-configs \
 --output=mlir_tuning_${ARCH}.tsv
 [ -f mlir_tuning_${ARCH}.tsv ]"""
-
+                            }
+                        }
+                    }
+                    stage("Tune Fusion") {
+                        steps {
+                            dir('build') {
                                 // Tune resnet50
                                 sh """python3 ./bin/tuningRunner.py --op fusion \
 --test_dir ../mlir/test/fusion/e2e/resnet50/ -o tuning_fusion_resnet50_${ARCH}.tsv"""
@@ -621,7 +626,6 @@ pipeline {
                             sh 'rm build/CMakeCache.txt'
                         }
                     }
-
                     stage("Build MIOpen with librockCompiler") {
                         steps {
                             buildMIOpenWithMLIR()

--- a/mlir/utils/performance/CMakeLists.txt
+++ b/mlir/utils/performance/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(ck-benchmark-driver)
 set(PERFORMANCE_SCRIPTS
   convertRocBlasToPerfRunner.py
   createGemmPerformanceReports.py
+  createFusionPerformanceReports.py
   createPerformanceReports.py
   perfCommonUtils.py
   perfRunner.py

--- a/mlir/utils/performance/createFusionPerformanceReports.py
+++ b/mlir/utils/performance/createFusionPerformanceReports.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import reportUtils
+
+import csv
+import numpy as np
+import pandas as pd
+import sys
+
+#Create html reports from .csv files
+def printAllPerformance(chip, op):
+    perfReportFound = False
+
+    COLUMNS_TO_AVERAGE = ['TFlops']
+    try:
+        df = pd.read_csv(chip + '_' + op + '_' + reportUtils.PERF_REPORT_FUSION_FILE)
+        perfReportFound = True
+    except FileNotFoundError:
+        print('Perf report not found.')
+        return
+
+    plotMean = df[COLUMNS_TO_AVERAGE].agg(reportUtils.geoMean)
+    plotMean.name = "Geo. mean"
+    plotMean = pd.DataFrame(plotMean).T
+
+    plotMean[['TFlops']]\
+        .to_csv(chip + '_' + op + '_' + reportUtils.PERF_PLOT_REPORT_FUSION_FILE, index=False)
+
+    if (op == 'conv'):
+        means = df.groupby(["Direction", "DataType", "InputLayout"])[COLUMNS_TO_AVERAGE]\
+            .agg(reportUtils.geoMean)
+        means.loc[("All", "All", "All"),:] = df[COLUMNS_TO_AVERAGE].agg(reportUtils.geoMean)
+        means.to_csv(chip + '_' + op + '_' + reportUtils.PERF_STATS_REPORT_FUSION_FILE)
+    else:
+        means = df.groupby(["DataType"])[COLUMNS_TO_AVERAGE]\
+            .agg(reportUtils.geoMean)
+        means.loc["All"] = df[COLUMNS_TO_AVERAGE].agg(reportUtils.geoMean)
+        means.to_csv(chip + '_' + op + '_' + reportUtils.PERF_STATS_REPORT_FUSION_FILE)
+
+    toHighlight = []
+
+    with open(chip + "_" + op + '_' + f"fusion.html", 'w') as htmlOutput:
+        reportUtils.htmlReport(df, means, f"Fusion performance",
+        toHighlight, reportUtils.colorForSpeedups, htmlOutput)
+
+# Main function.
+if __name__ == '__main__':
+    printAllPerformance(sys.argv[1], 'conv')
+    printAllPerformance(sys.argv[1], 'gemm')

--- a/mlir/utils/performance/perfCommonUtils.py
+++ b/mlir/utils/performance/perfCommonUtils.py
@@ -4,6 +4,7 @@ import re
 class Operation(enum.IntEnum):
   CONV = 1
   GEMM = 2
+  FUSION = 3
 
   @staticmethod
   def fromName(name: str) -> 'self':
@@ -12,6 +13,8 @@ class Operation(enum.IntEnum):
       return Operation.CONV
     elif name == 'gemm':
       return Operation.GEMM
+    elif name == 'fusion':
+      return Operation.FUSION
     else:
       raise ValueError(f"Unknown operation type {name}")
 

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -791,8 +791,8 @@ def benchmarkMIOpenWithMLIRKernels(configs, arch, filename, paths: Paths):
     chip = GFX_CHIP_RE.search(arch).group(0)
     df.to_csv(chip + '_' + filename, index=False)
 
-RUNNABLE_TEST_RE = re.compile(r"//\s*RUN\s*:")
-ROCMLIRGEN_RE = re.compile(r"rocmlir-gen.*-fut")
+RUNNABLE_TEST_RE = re.compile(r"//\s*RUN\s*:(.*)")
+ROCMLIRGEN_RE = re.compile(r"rocmlir-gen.*-fut\s*(\w+)")
 def findRunCommand(filename):
     firstCommand = None
     futName = None
@@ -801,14 +801,13 @@ def findRunCommand(filename):
             hasRun = RUNNABLE_TEST_RE.search(line)
             hasRocmlirGen = ROCMLIRGEN_RE.search(line)
             if hasRun:
-                command = line.split("RUN")[1].strip()[1:] # Remove the "//" and "RUN" prefixes, leading/trailing whitespace and ':'
+                command = hasRun.group(1)
                 if not firstCommand:
                     parts = command.split('|')  # Split the command using the "|" separator
                     firstCommand = parts[0].strip() # Find the first command
 
                 if hasRocmlirGen:
-                    words = line.split()
-                    futName = words[words.index("-fut") + 1] # Find the word after '-fut'
+                    futName = hasRocmlirGen.group(1)
 
                 if 'runner' in line: # Stop processing lines after finding a runner
                     return firstCommand, futName

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -24,7 +24,6 @@ CONV_TEST_PARAMETERS = ['Direction', 'DataType', 'Chip', 'FilterLayout',
                         'X', 'DilationH', 'DilationW', 'StrideH', 'StrideW',
                         'PaddingH', 'PaddingW', 'PerfConfig']
 GEMM_TEST_PARAMETERS = ['DataType', 'Chip', 'TransA', 'TransB', 'G', 'M', 'K', 'N', 'PerfConfig']
-FUSION_TEST_COL = ['TestFile', 'PerfConfig', 'Time']
 ROUND_DIGITS = 2
 
 def geoMean(data):

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -6,10 +6,13 @@ from typing import Tuple, List
 
 PERF_REPORT_FILE = 'mlir_vs_miopen_perf.csv'
 PERF_REPORT_GEMM_FILE = {'rocBLAS': 'mlir_vs_rocblas_perf.csv', 'CK': 'mlir_vs_ck_perf.csv'}
+PERF_REPORT_FUSION_FILE = 'mlir_fusion_perf.csv'
 PERF_PLOT_REPORT_FILE = 'mlir_vs_miopen_perf_for_plot.csv'
 PERF_PLOT_REPORT_GEMM_FILE = {'rocBLAS': 'mlir_vs_rocblas_perf_for_plot.csv', 'CK' : 'mlir_vs_ck_perf_for_plot.csv'}
+PERF_PLOT_REPORT_FUSION_FILE = 'mlir_fusion_perf_for_plot.csv'
 PERF_STATS_REPORT_FILE = 'mlir_vs_miopen_perf_means.csv'
 PERF_STATS_REPORT_GEMM_FILE = {'rocBLAS': 'mlir_vs_rocblas_perf_means.csv', 'CK' : 'mlir_vs_ck_perf_means.csv'}
+PERF_STATS_REPORT_FUSION_FILE = 'mlir_fusion_perf_means.csv'
 MIOPEN_REPORT_FILE = 'miopen_perf.csv'
 MIOPEN_TUNED_REPORT_FILE = 'miopen_tuned_perf.csv'
 MIOPEN_UNTUNED_REPORT_FILE = 'miopen_untuned_perf.csv'
@@ -21,6 +24,7 @@ CONV_TEST_PARAMETERS = ['Direction', 'DataType', 'Chip', 'FilterLayout',
                         'X', 'DilationH', 'DilationW', 'StrideH', 'StrideW',
                         'PaddingH', 'PaddingW', 'PerfConfig']
 GEMM_TEST_PARAMETERS = ['DataType', 'Chip', 'TransA', 'TransB', 'G', 'M', 'K', 'N', 'PerfConfig']
+FUSION_TEST_COL = ['TestFile', 'PerfConfig', 'Time']
 ROUND_DIGITS = 2
 
 def geoMean(data):

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -146,12 +146,14 @@ def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
 
 #Extract gemm or conv configurations from fusion tests
 def extractFusionConfigs(test_dir, paths: Paths, options: Options):
-    TABLE_COLUMNS = reportUtils.FUSION_TEST_COL
     allConfigs = []
     opType=Operation.FUSION
     for filename in glob.glob(test_dir + '/*mlir'):
-        testVector = perfRunner.getTestVector(filename, paths)
-        print("Extract from:", filename, ':', testVector)
+        print("Extract from:", filename)
+        testEntry = perfRunner.getFusionTestInfo(filename, paths)
+        if not testEntry:
+            continue
+        testVector = testEntry['testVector']
         if not testVector:
             continue
         # skip if the best config already exists

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -9,14 +9,18 @@ import subprocess
 import sys
 from pathlib import Path
 import argparse
+import glob
 
+from collections import OrderedDict
 from typing import Optional
 import perfRunner
 from perfRunner import PerfConfiguration
 from perfRunner import ConvConfiguration
 from perfRunner import GemmConfiguration
 from perfRunner import Paths
+from perfRunner import getChip
 from perfCommonUtils import CORRECT_RESULT_RE
+import reportUtils
 
 import numpy as np
 import pandas as pd
@@ -79,6 +83,32 @@ Errors = {errs.decode('utf-8')}""")
     nanoSeconds = perfRunner.getNanoSeconds(perfRunner.BENCHMARKING_RESULT_FILE_NAME)
     return nanoSeconds
 
+def getWinningConfig(tuningOutput, config, allData, options: Options):
+    maxTFlops = -np.inf
+    winningConfig = "None"
+    for i, result in enumerate(tuningOutput):
+        result = result.decode('utf-8').strip()
+        if i > 0 and i % 1000 == 0:
+            print(f"Tested {i} configs, best perf {maxTFlops} TFlops on perf_config {winningConfig}")
+        if options.debug:
+            print(result)
+        # Time is in ns
+        perfConfig, time = result.split('\t')
+        if time == "N/A":
+            nanoSeconds = np.nan
+        else:
+            nanoSeconds = float(time)
+
+        config.setPerfConfig(perfConfig)
+        entry = config.tableEntry(nanoSeconds)
+        allData.append(entry)
+        theseTFlops = entry['TFlops']
+        if not np.isnan(theseTFlops) and theseTFlops > maxTFlops:
+            maxTFlops = theseTFlops
+            winningConfig = perfConfig
+
+    return winningConfig, maxTFlops
+
 #Tune MLIR Gemm or Convolution kernels
 def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
     allData = []
@@ -97,28 +127,8 @@ def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
         kernelGen.stdout.close()
 
         # Tune, printing progress as we go to avoid CI timeouts
-        maxTFlops = -np.inf
-        winningConfig = "None"
-        for i, result in enumerate(tuningLoop.stdout):
-            result = result.decode('utf-8').strip()
-            if i > 0 and i % 50 == 0:
-                print(f"Tested {i} configs, best perf {maxTFlops} TFlops on perf_config {winningConfig}")
-            if options.debug:
-                print(result)
-            # Time is in ns
-            perfConfig, time = result.split('\t')
-            if time == "N/A":
-                nanoSeconds = np.nan
-            else:
-                nanoSeconds = float(time)
+        winningConfig, maxTFlops = getWinningConfig(tuningLoop.stdout, config, allData, options)
 
-            config.setPerfConfig(perfConfig)
-            entry = config.tableEntry(nanoSeconds)
-            allData.append(entry)
-            theseTFlops = entry['TFlops']
-            if not np.isnan(theseTFlops) and theseTFlops > maxTFlops:
-                maxTFlops = theseTFlops
-                winningConfig = perfConfig
         if options.verifyMode != "none":
             verifyNs = verifyKernelWithPerfConfig(winningConfig, config, paths, options)
             if np.isnan(verifyNs):
@@ -134,6 +144,41 @@ def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
     allData = pd.DataFrame(allData)
     return winners, allData
 
+#Extract gemm or conv configurations from fusion tests
+def extractFusionConfigs(test_dir, paths: Paths, options: Options):
+    TABLE_COLUMNS = reportUtils.FUSION_TEST_COL
+    allConfigs = []
+    opType=Operation.FUSION
+    for filename in glob.glob(test_dir + '/*mlir'):
+        testVector = perfRunner.getTestVector(filename, paths)
+        print("Extract from:", filename, ':', testVector)
+        if not testVector:
+            continue
+        # skip if the best config already exists
+        if testVector in allConfigs:
+            print("An entry already exists in the tuning DB")
+            continue
+        commandLine = testVector.split(sep=' ')
+        if commandLine[0].startswith('conv'):
+            if opType == Operation.FUSION:
+                opType = Operation.CONV
+            elif opType != Operation.CONV:
+                print("Invalid config op: ", testVector)
+                continue
+        else:
+            if opType == Operation.FUSION:
+                opType = Operation.GEMM
+            elif opType != Operation.GEMM:
+                print("Invalid config op: ", testVector)
+                continue
+        allConfigs.append(testVector)
+
+    with open(paths.configuration_file_path, 'w') as outFile:
+        for item in allConfigs:
+            outFile.write("%s\n" % item)
+
+    return opType
+
 # Main function.
 def main(args=None):
     """
@@ -142,7 +187,8 @@ def main(args=None):
     python3 tuningRunner.py --op gemm -configs_file=../mlir/utils/performance/toy-gemm-configs --output=tuning_db.tsv
     python3 tuningRunner.py --op gemm --config="-g 3 -m 1024 -k 769 -n 512 -t f32 -transA 0 -transB 0"
     python3 tuningRunner.py --op conv --config="conv -F 1 -f NCHW -I NCHW -O NCHW -n 256 -c 1024 -H 14 -W 14 -k 2048 -y 1 -x 1 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -t 1"
-
+    python3 tuningRunner.py --op fusion -test_dir=../mlir/test/fusion/e2e/resnet50 --output=tuning_db.tsv
+   
     """
     if args is None:
         args = sys.argv[1:]
@@ -159,7 +205,7 @@ def main(args=None):
         allow_abbrev=False,
     )
 
-    parser.add_argument("--op", "--operation", choices=['conv', 'gemm'],
+    parser.add_argument("--op", "--operation", choices=['conv', 'gemm', 'fusion'],
         default='conv',
         help="Operation for tuning")
 
@@ -207,21 +253,41 @@ def main(args=None):
         choices=["none", "cpu", "gpu"],
         help="How to verify the winning tuned kernel")
 
+    parser.add_argument("--test_dir",
+        default="../mlir/test/fusion/e2e/resnet50",
+        type=str,
+        help="fusion E2E tests directory")
+
     parsed_args = parser.parse_args(args)
 
     rocmlir_gen_flags = ''
     if 'rocmlir_gen_flags' in parsed_args:
         rocmlir_gen_flags = parsed_args.rocmlir_gen_flags
 
-    confClass = PerfConfiguration
     opType = Operation.fromName(parsed_args.op)
+    if opType == Operation.FUSION:
+        configs_path = "./fusion_config_file"
+    else:
+        configs_path = None if parsed_args.config else parsed_args.configs_file
+    paths = perfRunner.create_paths(configs_path, parsed_args.mlir_build_dir, None)
+
+    if not paths.mlir_paths:
+        raise RuntimeError("MLIR build dir was not provided/found")
+
+    options = Options(arch=arch, debug=parsed_args.debug,
+        rocmlir_gen_flags=rocmlir_gen_flags,
+        verifyMode=parsed_args.verify_mode)
+
+    if opType == Operation.FUSION:
+        opType = extractFusionConfigs(parsed_args.test_dir, paths, options)
+
+    confClass = PerfConfiguration
     if opType == Operation.CONV:
         confClass = ConvConfiguration
     elif opType == Operation.GEMM:
         confClass = GemmConfiguration
-
-    configs_path = None if parsed_args.config else parsed_args.configs_file
-    paths = perfRunner.create_paths(configs_path, parsed_args.mlir_build_dir, None)
+    else:
+        raise RuntimeError("Tuning operation was not provided/found")
 
     if parsed_args.config:
         configs = parsed_args.config
@@ -229,15 +295,6 @@ def main(args=None):
         configs = perfRunner.getConvConfigurations(paths.configuration_file_path)
     elif opType == Operation.GEMM:
         configs = perfRunner.getGemmConfigurations(paths.configuration_file_path)
-    else:
-        raise RuntimeError("Tuning operation was not provided/found")
-
-    options = Options(arch=arch, debug=parsed_args.debug,
-        rocmlir_gen_flags=rocmlir_gen_flags,
-        verifyMode=parsed_args.verify_mode)
-
-    if not paths.mlir_paths:
-        raise RuntimeError("MLIR build dir was not provided/found")
 
     winners, allData = tuneMLIRKernels(configs, confClass, paths, options)
 
@@ -248,6 +305,7 @@ def main(args=None):
     if parsed_args.debug:
         print(allData)
         allData.to_csv(f"{parsed_args.output}.debug", sep='\t')
+
     # Note, appending results here to allow multiple config sets
     with open(parsed_args.output, 'a') as outFile:
         print("# arch\ttestVector\tperfConfig", file=outFile)


### PR DESCRIPTION
Add tuning fusion test cases in weekly CI.
Testing and reporting of fusion performance are currently disabled until a tuning DB is availabe. Currently the performance report only shows 'TFLops'. May include other performance metrics later.