### PR TITLE
Add MIGraphX erf op and its lowering

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -132,6 +132,17 @@ def MIGraphX_NegOp :
   let summary = "Negation";
   let description = [{
     get neg
+      }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
+def MIGraphX_ErfOp :
+    MIGraphX_Op<"erf">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Gauss error function";
+  let description = [{
+    compute gauss error function
   }];
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -72,9 +72,14 @@ void mlirGetKernelInfo(MlirModule module, int *size, void *data) {
 MLIR_CAPI_EXPORTED void mlirGetKernelAttrs(MlirModule module, uint32_t *attrs) {
   auto mod = unwrap(module);
   mod.walk([&](mlir::LLVM::LLVMFuncOp llvmFunc) {
-    attrs[0] =
-        llvmFunc->getAttrOfType<mlir::IntegerAttr>("block_size").getInt();
-    attrs[1] = llvmFunc->getAttrOfType<mlir::IntegerAttr>("grid_size").getInt();
+    // There can be math lib ext linkage functions that does not represent
+    // the kernel
+    if (llvmFunc->hasAttr("block_size") && llvmFunc->hasAttr("grid_size")) {
+      attrs[0] =
+          llvmFunc->getAttrOfType<mlir::IntegerAttr>("block_size").getInt();
+      attrs[1] =
+          llvmFunc->getAttrOfType<mlir::IntegerAttr>("grid_size").getInt();
+    }
   });
 }
 

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -616,6 +616,19 @@ public:
     return success();
   }
 };
+
+class ErfConverter final : public OpConversionPattern<migraphx::ErfOp> {
+public:
+  using OpConversionPattern<migraphx::ErfOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(migraphx::ErfOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Value output =
+        rewriter.create<tosa::ErfOp>(op.getLoc(), op.getType(), op.getInA());
+    rewriter.replaceOp(op, {output});
+    return success();
+  }
+};
 } // namespace
 
 void migraphx::populateMIGraphXToTosaConversionPatterns(
@@ -624,5 +637,5 @@ void migraphx::populateMIGraphXToTosaConversionPatterns(
                BroadcastConverter, MultiBroadcastConverter, ReshapeConverter,
                SoftmaxConverter, DotConverter, ReduceMeanConverter,
                QuantizeLinearConverter, DeQuantizeLinearConverter,
-               SliceConverter, DivConverter>(context);
+               SliceConverter, DivConverter, ErfConverter>(context);
 }

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -234,6 +234,19 @@ module  {
     return %0 : tensor<1x12x100x64xf32>
   }
 
+  // CHECK-LABEL: func.func @func_erf_f32
+  // CHECK: tosa.erf
+  func.func @func_erf_f32(%arg0: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.erf"(%arg0) : (tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32>
+    return %0 : tensor<1x36x384x64xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_erf_f16
+  // CHECK: tosa.erf
+  func.func @func_erf_f16(%arg0: tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16> attributes{kernel, arch = ""} {
+    %0 = "migraphx.erf"(%arg0) : (tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16>
+    return %0 : tensor<1x36x384x64xf16>
+  }
 
   // CHECK-LABEL: func.func @func_exp_f32
   // CHECK: tosa.exp

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-erf_f16.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-erf_f16.mlir
@@ -1,0 +1,14 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand 3 - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+module {
+  // CHECK:  [-1,     1,     1],
+  // CHECK-NEXT: [-1,     1,     -1],
+  // CHECK-NEXT: [-1,     1,     -1],
+  // CHECK-NEXT: [0,     -1,     -1],
+  // CHECK-NEXT: [0,     -1,     -1]
+  func.func @dot_add(%arg0: tensor<1x5x4xf16>, %arg1: tensor<1x4x3xf16>) -> tensor<1x5x3xf16> attributes{kernel, arch = ""} {
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4xf16>, tensor<1x4x3xf16>) -> tensor<1x5x3xf16>
+    %2 = "migraphx.erf"(%0) : (tensor<1x5x3xf16>)-> tensor<1x5x3xf16>
+    return %2 : tensor<1x5x3xf16>
+  }
+}

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-erf_f32.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-erf_f32.mlir
@@ -1,0 +1,14 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand 3 - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+module {
+  // CHECK:  [-1,     1,     1],
+  // CHECK-NEXT: [-1,     0.999978,     -1],
+  // CHECK-NEXT: [-1,     1,     -1],
+  // CHECK-NEXT: [0,     -1,     -0.999978],
+  // CHECK-NEXT: [0,     -1,     -1]
+  func.func @dot_add(%arg0: tensor<1x5x4xf32>, %arg1: tensor<1x4x3xf32>) -> tensor<1x5x3xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.dot"(%arg0, %arg1) : (tensor<1x5x4xf32>, tensor<1x4x3xf32>) -> tensor<1x5x3xf32>
+    %2 = "migraphx.erf"(%0) : (tensor<1x5x3xf32>)-> tensor<1x5x3xf32>
+    return %2 : tensor<1x5x3xf32>
+  }
+}


### PR DESCRIPTION
This commit adds migraphx.erf op and its
lowering to tosa.erf with tests.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/867