### PR TITLE
Temporarily override MIOpen branch to fix nightly CI

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -340,7 +340,7 @@ pipeline {
                      description: 'Can this CI instance use xdlops (no for public server)')
         booleanParam(name: 'weekly', defaultValue: params.weekly ? true : false,
                      description: 'Run weekly-only jobs')
-        string(name: 'MIOpenBranch', defaultValue: 'develop',
+        string(name: 'MIOpenBranch', defaultValue: 'bump-mlir-release/rocm-5.6',
                description: 'The MIOpen branch to be used with the job')
         string(name: 'MIGraphXBranch', defaultValue: 'develop',
                description: 'The MIGraphX branch/commit to verify against.')


### PR DESCRIPTION
Our nightly starts to run into a nightly failure due to MIOpen end exception. This has not yet been merged by MIOpen: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2099. In the mean time I want the CI to be unblocked from this trivial failure, therefore, overriding the develop branch with my PR branch.