### PR TITLE
Improve regression reports

### DIFF
--- a/mlir/utils/performance/perfRegressionReport.py
+++ b/mlir/utils/performance/perfRegressionReport.py
@@ -5,6 +5,7 @@ import reportUtils
 from pathlib import PurePath
 import sys
 from typing import Tuple
+import os
 
 import pandas as pd
 
@@ -120,6 +121,8 @@ if __name__ == '__main__':
         oldLabel = "copy"
 
     data, summary = computePerfStats(oldDf, newDf, oldLabel, newLabel)
+    oldNewPaths = {"old" : os.path.abspath(oldDataPath),
+                   "new": os.path.abspath(newDataPath)}
     isGemm = ("TransA" in data)
     hasTuning = ("% change (tuned)" in data)
     if isGemm and len(sys.argv) < 5:
@@ -129,4 +132,4 @@ if __name__ == '__main__':
             else ["% change"]
         reportUtils.htmlReport(data, summary,
             "MLIR Performance Changes, " + ("GEMM" if isGemm else "Conv"),
-            toHighlight, reportUtils.colorForChanges, outputStream)
+            toHighlight, reportUtils.colorForChanges, outputStream, oldNewPaths)

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -111,7 +111,8 @@ def cleanDataForHumans(data: pd.DataFrame, title: str)\
     return data, title, list(indexCols.values())
 
 def htmlReport(data: pd.DataFrame, stats: pd.DataFrame, title: str,
-                  speedupCols: list, colorizer=colorForSpeedups, stream=None):
+                  speedupCols: list, colorizer=colorForSpeedups,
+                  stream=None, oldNewCsv={}):
     data, longTitle, indexCols = cleanDataForHumans(data, title)
     print(f"""
 <!doctype html>
@@ -128,9 +129,16 @@ caption {{
 </head>
 <body>
 <h1>{longTitle}</h1>
-<h2>Summary</h2>
 """, file=stream)
 
+    if oldNewCsv:
+        print("<h2>Input files</h2>", file=stream)
+        print("<ul>", file=stream)
+        print(f"<li><b>Old data</b> {oldNewCsv['old']}</li>", file=stream)
+        print(f"<li><b>New data</b> {oldNewCsv['new']}</li>", file=stream)
+        print("</ul>", file=stream)
+
+    print("<h2>Summary</h2>", file=stream)
     statsPrinter = stats.style
     statsPrinter.set_caption(f"Summary statistics for {title}")
     setCommonStyles(statsPrinter, speedupCols, colorizer)


### PR DESCRIPTION
I added a small usability improvement to the regression reports. My use case is that I tend to generate a lot of regression reports, using different `csv` , but then I tend to don't remember which `csv` file I used. 

This changes adds the old/new files to the regression reports in its own subsection