### PR TITLE
add migraphx neg,exp and div ops.

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -77,6 +77,18 @@ def MIGraphX_MulOp :
   let assemblyFormat = "`(`$inA `,` $inB`)` attr-dict `:` `(`type($inA) `,` type($inB) `)` `->` type($output)";
 }
 
+def MIGraphX_DivOp :
+    MIGraphX_Op<"div">,
+    Arguments<(ins AnyRankedTensor:$inA,
+                   AnyRankedTensor:$inB)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Elementwise binary div";
+  let description = [{
+    Divide two tensors elementwise
+  }];
+  let assemblyFormat = "`(`$inA `,` $inB`)` attr-dict `:` `(`type($inA) `,` type($inB) `)` `->` type($output)";
+}
+
 def MIGraphX_PowOp :
     MIGraphX_Op<"pow">,
     Arguments<(ins AnyRankedTensor:$inA,
@@ -98,6 +110,28 @@ def MIGraphX_TanhOp :
   let summary = "Hyperbolic Tan";
   let description = [{
     get tanh
+  }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
+def MIGraphX_ExpOp :
+    MIGraphX_Op<"exp">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Exponential";
+  let description = [{
+    get exp
+  }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
+def MIGraphX_NegOp :
+    MIGraphX_Op<"neg">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Negation";
+  let description = [{
+    get neg
   }];
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.td
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.td
@@ -14,16 +14,19 @@ include "mlir/Dialect/Func/IR/FuncOps.td"
 include "mlir/Dialect/MIGraphX/MIGraphXOps.td"
 include "mlir/Dialect/Arith/IR/ArithOps.td"
 
+def GetNullAttr : NativeCodeCall<"Attribute()">;
+
 def : Pat<(MIGraphX_AddOp $input1, $input2), (Tosa_AddOp $input1, $input2)>;
 def : Pat<(MIGraphX_SubOp $input1, $input2), (Tosa_SubOp $input1, $input2)>;
 def : Pat<(MIGraphX_MulOp $input1, $input2), (Tosa_MulOp $input1, $input2, ConstantAttr<I32Attr, "0">)>;
 def : Pat<(MIGraphX_PowOp $input1, $input2), (Tosa_PowOp $input1, $input2)>;
 def : Pat<(MIGraphX_RecipOp $input1), (Tosa_ReciprocalOp $input1)>;
+def : Pat<(MIGraphX_ExpOp $input1), (Tosa_ExpOp $input1)>;
+def : Pat<(MIGraphX_NegOp $input1), (Tosa_NegateOp $input1, (GetNullAttr))>;
 
 def : Pat<(MIGraphX_ConstantOp ElementsAttr:$valueAttr, $shapeAttr, $valueTypeAttr), (Arith_ConstantOp $valueAttr)>;
 def Convert2DTo4DSymmPad : NativeCodeCall<
     "$_builder.getArrayAttr({($0.getValue()[0]), ($0.getValue()[0]), ($0.getValue()[1]), ($0.getValue()[1])})">;
-def GetNullAttr : NativeCodeCall<"Attribute()">;
 /* convolution is converted in the cpp file to handle more options.
 def : Pat<(MIGraphX_ConvolutionOp:$result $input1, $filter, $pad, $stride, $dilation,
       $group, $_ // ignore padding mode

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -235,6 +235,50 @@ module  {
   }
 
 
+  // CHECK-LABEL: func.func @func_exp_f32
+  // CHECK: tosa.exp
+  func.func @func_exp_f32(%arg0: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.exp"(%arg0) : (tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32>
+    return %0 : tensor<1x36x384x64xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_exp_f16
+  // CHECK: tosa.exp
+  func.func @func_exp_f16(%arg0: tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16> attributes{kernel, arch = ""} {
+    %0 = "migraphx.exp"(%arg0) : (tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16>
+    return %0 : tensor<1x36x384x64xf16>
+  }
+
+  // CHECK-LABEL: func.func @func_neg_f32
+  // CHECK: tosa.negate
+  func.func @func_neg_f32(%arg0: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.neg"(%arg0) : (tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32>
+    return %0 : tensor<1x36x384x64xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_neg_f16
+  // CHECK: tosa.negate
+  func.func @func_neg_f16(%arg0: tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16> attributes{kernel, arch = ""} {
+    %0 = "migraphx.neg"(%arg0) : (tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16>
+    return %0 : tensor<1x36x384x64xf16>
+  }
+
+  // CHECK-LABEL: func.func @func_div_f32
+  // CHECK: tosa.reciprocal
+  // CHECK: tosa.mul
+  func.func @func_div_f32(%arg0: tensor<1x36x384x64xf32>, %arg1: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.div"(%arg0, %arg1) : (tensor<1x36x384x64xf32>, tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32>
+    return %0 : tensor<1x36x384x64xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_div_f16
+  // CHECK: tosa.reciprocal
+  // CHECK: tosa.mul
+  func.func @func_div_f16(%arg0: tensor<1x36x384x64xf16>, %arg1: tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16> attributes{kernel, arch = ""} {
+    %0 = "migraphx.div"(%arg0, %arg1) : (tensor<1x36x384x64xf16>, tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16>
+    return %0 : tensor<1x36x384x64xf16>
+  }
+
 }
 
 


### PR DESCRIPTION
This commit adds neg,exp and div ops for
migrapx dialect and its lowering to tosa.

closes : https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/876