### PR TITLE
Enable fusion performance tests in nightly CI

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -875,18 +875,18 @@ pipeline {
                             }
                         }
                     }
-                    //stage("Test Fusion") {
-                    //    steps {
-                    //        dir('build') {
+                    stage("Test Fusion") {
+                        steps {
+                            dir('build') {
                                 // Run fusion resnet50 perf benchmarks
-                                //sh """python3 ./bin/perfRunner.py --op=fusion \
-          //--test_dir=${WORKSPACE}/mlir/test/fusion/e2e/resnet50/ --tuning_db=${WORKSPACE}/tuning_fusion_resnet50_${CHIP}.tsv"""
+                                sh """python3 ./bin/perfRunner.py --op=fusion \
+          --test_dir=${WORKSPACE}/mlir/test/fusion/e2e/resnet50/ --tuning_db=${WORKSPACE}/tuning_fusion_resnet50_${CHIP}.tsv"""
                                 // Run bert perf benchmarks
-                                //sh """python3 ./bin/perfRunner.py --op fusion \
-          //--test_dir=${WORKSPACE}/mlir/test/xmir/e2e/bert-torch-tosa/ --tuning_db=${WORKSPACE}/tuning_fusion_bert_${CHIP}.tsv"""
-                            //}
-                        //}
-                    //}
+                                sh """python3 ./bin/perfRunner.py --op fusion \
+          --test_dir=${WORKSPACE}/mlir/test/xmir/e2e/bert-torch-tosa/ --tuning_db=${WORKSPACE}/tuning_fusion_bert_${CHIP}.tsv"""
+                            }
+                        }
+                    }
                     stage("Test MLIR vs CK") {
                         when {
                             beforeAgent true;
@@ -927,7 +927,7 @@ pipeline {
                                 sh 'ls -l'
                                 sh 'python3 ./bin/createPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP}'
-                                //sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
+                                sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
                                 sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
                                 sh 'mkdir -p reports && cp ./*.html reports'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -156,7 +156,7 @@ void postProcessPerfRes(String chip) {
         alwaysLinkToLastBuild: false,
         keepAll: true,
         reportDir: 'build/reports',
-        reportFiles: "${chip}_MLIR_Performance_Changes.html,${chip}_MLIR_vs_MIOpen.html,${chip}_MLIR_Performance_Changes_Gemm.html,${chip}_MLIR_vs_rocBLAS.html,${chip}_MLIR_vs_CK.html",
+        reportFiles: "${chip}_MLIR_Performance_Changes.html,${chip}_MLIR_vs_MIOpen.html,${chip}_MLIR_Performance_Changes_Gemm.html,${chip}_MLIR_vs_rocBLAS.html,${chip}_MLIR_vs_CK.html,${chip}_conv_fusion.html,${chip}_gemm_fusion.html",
         reportName: "Performance report for ${chip}"
     ])
 

--- a/mlir/utils/performance/createFusionPerformanceReports.py
+++ b/mlir/utils/performance/createFusionPerformanceReports.py
@@ -37,7 +37,7 @@ def printAllPerformance(chip, op):
         means.loc["All"] = df[COLUMNS_TO_AVERAGE].agg(reportUtils.geoMean)
         means.to_csv(chip + '_' + op + '_' + reportUtils.PERF_STATS_REPORT_FUSION_FILE)
 
-    toHighlight = []
+    toHighlight = ['Fusion/MLIR']
 
     with open(chip + "_" + op + '_' + f"fusion.html", 'w') as htmlOutput:
         reportUtils.htmlReport(df, means, f"Fusion performance",

--- a/mlir/utils/performance/createFusionPerformanceReports.py
+++ b/mlir/utils/performance/createFusionPerformanceReports.py
@@ -11,7 +11,7 @@ import sys
 def printAllPerformance(chip, op):
     perfReportFound = False
 
-    COLUMNS_TO_AVERAGE = ['TFlops']
+    COLUMNS_TO_AVERAGE = ['Fusion TFlops', 'MLIR TFlops', 'Fusion/MLIR']
     try:
         df = pd.read_csv(chip + '_' + op + '_' + reportUtils.PERF_REPORT_FUSION_FILE)
         perfReportFound = True
@@ -23,7 +23,7 @@ def printAllPerformance(chip, op):
     plotMean.name = "Geo. mean"
     plotMean = pd.DataFrame(plotMean).T
 
-    plotMean[['TFlops']]\
+    plotMean[['Fusion TFlops']]\
         .to_csv(chip + '_' + op + '_' + reportUtils.PERF_PLOT_REPORT_FUSION_FILE, index=False)
 
     if (op == 'conv'):

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -896,7 +896,7 @@ def benchmarkFusionKernels(test_dir, paths: Paths, arch, tuningDb: MaybeTuningDb
     # Prepare test cases
     for filename in glob.glob(test_dir+'/*.mlir'):
         testEntry = getFusionTestInfo(filename, paths)
-        if testEntry:
+        if testEntry and not testEntry['testVector'] in [tv['testVector'] for tv in allTests]:
             allTests.append(testEntry)
 
     # Profile each test case


### PR DESCRIPTION
Compare fusion vs. gemm/conv with the same configuration.

These changes passed validation [here](http://rocmhead.amd.com:8080/job/MLIR/job/mlir/view/change-requests/job/PR-1070/19/). One of the fusion performance reports is [here](http://rocmhead.amd.com:8080/job/MLIR/job/mlir/view/change-requests/job/PR-1070/19/Performance_20report_20for_20gfx90a/gfx90a_conv_fusion.html)