### PR TITLE
Initial changes to move conversions to f32 into the verify wrapper function

### DIFF
--- a/mlir/test/rocmlir-driver/populate_prc.mlir
+++ b/mlir/test/rocmlir-driver/populate_prc.mlir
@@ -5,17 +5,18 @@
 // F32-NEXT:    call @printMemrefF32(%[[RES]]) : (memref<*xf32>) -> ()
 
 // RUN: rocmlir-gen --arch %arch -p -prc -t f16 | FileCheck %s --check-prefixes=F16,CHECK
-// RUN: rocmlir-gen --arch %arch -p -prc -t bf16 | FileCheck %s --check-prefix=BF16
+// RUN: rocmlir-gen --arch %arch -p -prc -t bf16 | FileCheck %s --check-prefixes=BF16,CHECK
 
 // F16:    %{{.*}} = memref.alloc() : memref<1x128x8x3x3x[[type:f16]]>
-// BF16:   %{{.*}}= memref.alloc() : memref<1x128x8x3x3x[[type:bf16]]>
-// CHECK:  call @_memcpy_[[type]]_f32_9216(%{{.*}}, %{{.*}}) : (memref<9216x[[type]]>, memref<9216xf32>) -> ()
+// BF16:   %{{.*}} = memref.alloc() : memref<1x128x8x3x3x[[type:bf16]]>
+// CHECK:  memref.copy %{{.*}} : memref<9216x[[type]]> to memref<9216x[[type]]>
 // CHECK:  %{{.*}} = memref.alloc() : memref<128x1x8x32x32x[[type]]>
-// CHECK:  call @_memcpy_[[type]]_f32_1048576(%{{.*}}, %{{.*}}) : (memref<1048576x[[type]]>, memref<1048576xf32>) -> ()
-// CHECK:  %{{.*}} = memref.alloc() : memref<{{.*}}>
+// CHECK:  memref.copy %{{.*}} : memref<1048576x[[type]]> to memref<1048576x[[type]]>
+// CHECK:  %{{.*}} = memref.alloc() : memref<{{.*}}x[[type]]>
+// CHECK:  memref.copy %{{.*}} : memref<{{.*}}x[[type]]> to memref<{{.*}}x[[type]]>
+// CHECK-NEXT: call @conv2d_cpu(%{{.*}}, %{{.*}}, %[[RES1:.*]]) : (memref<1x128x8x3x3x[[type]]>, memref<{{.*}}>, memref<{{.*}}>) -> ()
 // CHECK:  call @_memcpy_[[type]]_f32_{{[0-9]+}}(%{{.*}}, %{{.*}}) : (memref<{{.*}}x[[type]]>, memref<{{.*}}xf32>) -> ()
-// CHECK-NEXT: call @conv2d_cpu(%{{.*}}, %{{.*}}, %[[RES1:.*]]) : (memref<1x128x8x3x3xf32>, memref<{{.*}}>, memref<{{.*}}>) -> ()
-// CHECK:  %[[RES2:.*]] = memref.cast %[[RES1]] : memref<{{.*}}> to memref<*xf32>
+// CHECK:  %[[RES2:.*]] = memref.cast %{{.*}} : memref<{{.*}}> to memref<*xf32>
 // CHECK:  call @printMemrefF32(%[[RES2]]) : (memref<*xf32>) -> ()
 
 // RUN: rocmlir-gen --arch %arch -p -prc -t i8 | FileCheck %s --check-prefix=INT8

--- a/mlir/test/rocmlir-driver/populate_pv_with_gpu.mlir
+++ b/mlir/test/rocmlir-driver/populate_pv_with_gpu.mlir
@@ -31,15 +31,15 @@
 // F16-CHECK: func.func @rock_conv2d_gkcyx_ngchw_ngkhw_0({{.*}}) attributes {kernel = 0 : i32, xmodel.arch = "{{.*}}"} {
 // F16-CHECK: rock.conv2d({{.*}}) features = dot {[[PARMS:.*]]} : memref<[[FILTERDIMS:[x0-9]+]]xf16>, memref<[[INPUTDIMS:[x0-9]+]]xf16>, memref<[[OUTPUTDIMS:[x0-9]+]]xf16>
 // F16-CHECK: call @rock_conv2d_gkcyx_ngchw_ngkhw_0_gpu({{.*}}) : (memref<[[FILTERDIMS]]xf16>, memref<[[INPUTDIMS]]xf16>, memref<[[OUTPUTDIMS]]xf16>) -> ()
-// F16-CHECK: call @rock_conv2d_gkcyx_ngchw_ngkhw_0_ver_gpu({{.*}}) : (memref<[[FILTERDIMS]]xf32>, memref<[[INPUTDIMS]]xf32>, memref<[[OUTPUTDIMS]]xf32>) -> ()
+// F16-CHECK: call @rock_conv2d_gkcyx_ngchw_ngkhw_0_ver_gpu({{.*}}) : (memref<[[FILTERDIMS]]xf16>, memref<[[INPUTDIMS]]xf16>, memref<[[OUTPUTDIMS]]xf16>) -> ()
 // F16-CHECK: func.func @rock_conv2d_gkcyx_ngchw_ngkhw_0_ver({{.*}}) attributes {kernel = 0 : i32, xmodel.arch = "{{.*}}"} {
-// F16-CHECK: rock.conv2d({{.*}}) features = dot {{{.*}} : memref<[[FILTERDIMS]]xf32>, memref<[[INPUTDIMS]]xf32>, memref<[[OUTPUTDIMS]]xf32>
+// F16-CHECK: rock.conv2d({{.*}}) features = dot {{{.*}} : memref<[[FILTERDIMS]]xf16>, memref<[[INPUTDIMS]]xf16>, memref<[[OUTPUTDIMS]]xf16>
 
 // RUN: rocmlir-gen --operation gemm --arch gfx908 -mfma=off -atomic_add=off -dot=on -p -t f16 -pv_with_gpu | FileCheck %s --check-prefix=GEMM-F16-CHECK
 
 // GEMM-F16-CHECK: func.func @rock_gemm({{.*}}) attributes {kernel, xmodel.arch = "{{.*}}"} {
 // GEMM-F16-CHECK: rock.gemm {{.*}} = {{.*}} * {{.*}} features = dot storeMethod = {{.*}} {[[PARMS:.*]]} : memref<[[CDIMS:[x0-9]+]]xf16> = memref<[[ADIMS:[x0-9]+]]xf16> * memref<[[BDIMS:[x0-9]+]]xf16>
 // GEMM-F16-CHECK: call @rock_gemm_gpu({{.*}}) : (memref<[[ADIMS]]xf16>, memref<[[BDIMS]]xf16>, memref<[[CDIMS]]xf16>) -> ()
-// GEMM-F16-CHECK: call @rock_gemm_ver_gpu({{.*}}) : (memref<[[ADIMS]]xf32>, memref<[[BDIMS]]xf32>, memref<[[CDIMS]]xf32>) -> ()
+// GEMM-F16-CHECK: call @rock_gemm_ver_gpu({{.*}}) : (memref<[[ADIMS]]xf16>, memref<[[BDIMS]]xf16>, memref<[[CDIMS]]xf16>) -> ()
 // GEMM-F16-CHECK: func.func @rock_gemm_ver({{.*}}) attributes {kernel, xmodel.arch = "{{.*}}"} {
-// GEMM-F16-CHECK: rock.gemm {{.*}} = {{.*}} * {{.*}} features = dot storeMethod = {{.*}} {[[PARMS:.*]]} : memref<[[CDIMS:[x0-9]+]]xf32> = memref<[[ADIMS:[x0-9]+]]xf32> * memref<[[BDIMS:[x0-9]+]]xf32>
+// GEMM-F16-CHECK: rock.gemm {{.*}} = {{.*}} * {{.*}} features = dot storeMethod = {{.*}} {[[PARMS:.*]]} : memref<[[CDIMS:[x0-9]+]]xf16> = memref<[[ADIMS:[x0-9]+]]xf16> * memref<[[BDIMS:[x0-9]+]]xf16>

--- a/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
+++ b/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
@@ -7,7 +7,7 @@
 
 
 // CHECK-LABEL: func @host_naive_gemm
-// F16-SAME: (%{{.*}}: memref<3x1024x769xf32>, %{{.*}}: memref<3x769x512xf32>, %{{.*}}: memref<3x1024x512xf32>)
+// F16-SAME: (%{{.*}}: memref<3x1024x769xf16>, %{{.*}}: memref<3x769x512xf16>, %{{.*}}: memref<3x1024x512xf16>)
 // I8-SAME: (%{{.*}}: memref<3x1024x769xi8>, %{{.*}}: memref<3x769x512xi8>, %{{.*}}: memref<3x1024x512xi64>)
 
 // F16: arith.mulf


### PR DESCRIPTION
... and let tests run in their native types.  Also update three tests that were checking for f32, and allow kernel-generation cases to use clone-verification.