### PR TITLE
Refactoring rocmlir-gen.

### DIFF
--- a/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness.mlir
+++ b/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness.mlir
@@ -1,6 +1,6 @@
-// RUN: rocmlir-gen --arch %arch -p --host %s | FileCheck %s --check-prefix=HARNESS
-// RUN: rocmlir-gen --arch %arch -p --host %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
-// RUN: rocmlir-gen --arch %arch -p --host %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
+// RUN: rocmlir-gen --arch %arch -p %s | FileCheck %s --check-prefix=HARNESS
+// RUN: rocmlir-gen --arch %arch -p %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
+// RUN: rocmlir-gen --arch %arch -p %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
 
 func.func private @rock_conv2d_gkcyx_ngchw_ngkhw_0(%arg0: memref<1x128x8x3x3xf32>, %arg1: memref<128x1x8x32x32xf32>, %arg2: memref<128x1x128x30x30xf32>) -> ()
 

--- a/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_ckyx_cnhw_knhw.mlir
+++ b/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_ckyx_cnhw_knhw.mlir
@@ -1,6 +1,6 @@
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gckyx -in_layout=gcnhw -out_layout=gknhw --host %s | FileCheck %s --check-prefix=HARNESS
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gckyx -in_layout=gcnhw -out_layout=gknhw --host %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gckyx -in_layout=gcnhw -out_layout=gknhw --host %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gckyx -in_layout=gcnhw -out_layout=gknhw %s | FileCheck %s --check-prefix=HARNESS
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gckyx -in_layout=gcnhw -out_layout=gknhw %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gckyx -in_layout=gcnhw -out_layout=gknhw %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
 
 func.func private @rock_conv2d_gckyx_gcnhw_gknhw_0(%filter : memref<1x8x128x3x3xf32>, %input : memref<1x8x128x32x32xf32>, %output : memref<1x128x128x30x30xf32>) -> ()
 

--- a/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_cyxk_chwn_khwn.mlir
+++ b/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_cyxk_chwn_khwn.mlir
@@ -1,6 +1,6 @@
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gcyxk -in_layout=gchwn -out_layout=gkhwn --host %s | FileCheck %s --check-prefix=HARNESS
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gcyxk -in_layout=gchwn -out_layout=gkhwn --host %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gcyxk -in_layout=gchwn -out_layout=gkhwn --host %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gcyxk -in_layout=gchwn -out_layout=gkhwn %s | FileCheck %s --check-prefix=HARNESS
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gcyxk -in_layout=gchwn -out_layout=gkhwn %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gcyxk -in_layout=gchwn -out_layout=gkhwn %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
 
 func.func private @rock_conv2d_gcyxk_gchwn_gkhwn_0(%filter : memref<1x8x3x3x128xf32>, %input : memref<1x8x32x32x128xf32>, %output : memref<1x128x30x30x128xf32>) -> ()
 

--- a/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_kyxc_nhwc_nhwk.mlir
+++ b/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_kyxc_nhwc_nhwk.mlir
@@ -1,6 +1,6 @@
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk --host %s | FileCheck %s --check-prefix=HARNESS
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk --host %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk --host %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk %s | FileCheck %s --check-prefix=HARNESS
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
 
 func.func private @rock_conv2d_gkyxc_nhwgc_nhwgk_0(%filter : memref<1x128x3x3x8xf32>, %input : memref<128x32x32x1x8xf32>, %output : memref<128x30x30x1x128xf32>) -> ()
 

--- a/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_yxck_hwcn_hwkn.mlir
+++ b/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_yxck_hwcn_hwkn.mlir
@@ -1,6 +1,6 @@
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxck -in_layout=hwgcn -out_layout=hwgkn --host %s | FileCheck %s --check-prefix=HARNESS
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxck -in_layout=hwgcn -out_layout=hwgkn --host %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxck -in_layout=hwgcn -out_layout=hwgkn --host %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxck -in_layout=hwgcn -out_layout=hwgkn %s | FileCheck %s --check-prefix=HARNESS
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxck -in_layout=hwgcn -out_layout=hwgkn %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxck -in_layout=hwgcn -out_layout=hwgkn %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
 
 func.func private @rock_conv2d_gyxck_hwgcn_hwgkn_0(%filter : memref<1x3x3x8x128xf32>, %input : memref<32x32x1x8x128xf32>, %output : memref<30x30x1x128x128xf32>) -> ()
 

--- a/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_yxkc_hwnc_hwnk.mlir
+++ b/mlir/test/rocmlir-driver/conv2d_harness/conv2d_harness_yxkc_hwnc_hwnk.mlir
@@ -1,6 +1,6 @@
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxkc -in_layout=hwngc -out_layout=hwngk --host %s | FileCheck %s --check-prefix=HARNESS
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxkc -in_layout=hwngc -out_layout=hwngk --host %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
-// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxkc -in_layout=hwngc -out_layout=hwngk --host %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxkc -in_layout=hwngc -out_layout=hwngk %s | FileCheck %s --check-prefix=HARNESS
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxkc -in_layout=hwngc -out_layout=hwngk %s | rocmlir-driver -c | FileCheck %s --check-prefix=LOWERING
+// RUN: rocmlir-gen --arch %arch -p -fil_layout=gyxkc -in_layout=hwngc -out_layout=hwngk %s | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=E2E
 
 func.func private @rock_conv2d_gyxkc_hwngc_hwngk_0(%filter : memref<1x3x3x128x8xf32>, %input : memref<32x32x128x1x8xf32>, %output : memref<30x30x128x1x128xf32>) -> ()
 

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2491,18 +2491,9 @@ static LogicalResult populateHostHarnessLogic(
   bool isRandom = (randomSeed != "fixed" && randomSeed != "none");
 
   if (isRandom) {
-    llvm::SmallDenseMap<int32_t, Value> i32vals;
-    auto getI32Val = [&](int32_t v) {
-      if (i32vals.find(v) == i32vals.end()) {
-        auto i32Type = b.getIntegerType(32);
-        i32vals.try_emplace(v, b.create<arith::ConstantIntOp>(loc, v, i32Type));
-      }
-      return i32vals[v];
-    };
-
     auto seedFunc = makeFuncDecl(module, "seedRandomValues", {b.getI32Type()});
     int seed = getRandomSeed();
-    Value seedConst = getI32Val(seed);
+    Value seedConst = b.create<arith::ConstantIntOp>(loc, seed, b.getI32Type());
     b.create<func::CallOp>(loc, seedFunc, seedConst);
   }
 


### PR DESCRIPTION
Originally for #750, but #750 changes can be independent of refactoring.

I started abstracting functions and cleaning up some old things, to help me figure out what was going on.  Then the changes for #750 turned out to be simpler than I expected, and can work without the refactoring.  If this is still useful, we can keep it.