### PR TITLE
[DO NOT SQUASH] Brute-force compiler patch to fix all the miscompiles we've tripped over

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -9468,6 +9468,12 @@ SDValue SITargetLowering::performSHLPtrCombine(SDNode *N,
   if (!CAdd)
     return SDValue();
 
+  // EMERGENCY WORKAROUND! When this rewrite triggers, it causes some other
+  // currently unknown pattern causes a miscompile for certain cases.
+  // Therefore, disable this unconditionally. We'll want to remove this as
+  // soon as these's an actual fix to whatever the underlying problem is.
+  return SDValue();
+
   // If the resulting offset is too large, we can't fold it into the addressing
   // mode offset.
   APInt Offset = CAdd->getAPIntValue() << CN1->getAPIntValue();

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -86,22 +86,18 @@ static Type obtainAccumulatorType(OpBuilder &b, Type elementTypeA,
 
 /// Construct a `memref.view` operation that interprets the buffer `buffer`,
 /// whose elements are bytes, as a buffer of `type`.
-/// UGLY WORKAROUND NOTE: `numBytes` and `byteOffset` should be
-/// taken from the buffer's type and automatically introduced by the
-/// compiler, respectively, but due to a miscompile we have to use one
-/// big LDS buffer.
 static TypedValue<MemRefType> viewBufferAs(OpBuilder &b, Value buffer,
-                                           Type type, int64_t numBytes,
-                                           int64_t byteOffset) {
+                                           Type type) {
   Location loc = buffer.getLoc();
-  Value byteOffsetVal = b.createOrFold<arith::ConstantIndexOp>(loc, byteOffset);
+  Value zeroByteOffset = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
   auto bufferType = buffer.getType().cast<MemRefType>();
   int64_t byteWidth = getByteWidth(type);
+  int64_t numBytes = bufferType.getShape()[0];
   assert(numBytes % byteWidth == 0 && "Can't evenly fit type into buffer");
   int64_t length = numBytes / byteWidth;
   auto newBufferType = bufferType.cloneWith({length}, type);
   auto view =
-      b.create<memref::ViewOp>(loc, newBufferType, buffer, byteOffsetVal,
+      b.create<memref::ViewOp>(loc, newBufferType, buffer, zeroByteOffset,
                                /*dynamic dim sizes=*/ValueRange{});
   return TypedValue<MemRefType>(view.getResult());
 }
@@ -255,14 +251,12 @@ static FailureOr<Value> wrapMatrixForGlobalLoad(
 /// element type vector<kpackPerThread x T> (with kpackPerThread == 1 meaning
 /// just T). The resulting view must be iterated over with a stride of no less
 /// than min(kPerThread, kpack).
-/// UGLY WORKAROUND NOTE: `ldsNumBytes` and `ldsByteOffset` should be
-/// taken from the buffer's type and automatically introduced by the
-/// compiler, respectively, but due to a miscompile we have to use one
-/// big LDS buffer.
-static FailureOr<Value> wrapLDSBufferForStore(
-    OpBuilder &b, Location loc, Value buffer, Type ldsReadType, int64_t kOuter,
-    StringRef dName, int64_t d, int64_t kPerThread, int64_t dPerThread,
-    GemmDimension vectorDim, int64_t ldsNumBytes, int64_t ldsByteOffset) {
+static FailureOr<Value> wrapLDSBufferForStore(OpBuilder &b, Location loc,
+                                              Value buffer, Type ldsReadType,
+                                              int64_t kOuter, StringRef dName,
+                                              int64_t d, int64_t kPerThread,
+                                              int64_t dPerThread,
+                                              GemmDimension vectorDim) {
   MemRefType bufferType = buffer.getType().cast<MemRefType>();
   ArrayRef<int64_t> bufferShape = bufferType.getShape();
   Type dataType = ldsReadType;
@@ -274,18 +268,17 @@ static FailureOr<Value> wrapLDSBufferForStore(
     dataType = vectorDataType.getElementType();
   }
 
-  if (ldsNumBytes != kOuter * d * kpack * getByteWidth(dataType))
+  if (bufferShape[0] != kOuter * d * kpack * getByteWidth(dataType))
     return emitError(loc, "LDS buffer should have ")
            << kOuter * d * kpack * getByteWidth(dataType)
-           << " elements but has " << ldsNumBytes;
+           << " elements but has " << bufferShape[0];
 
   int64_t kpackPerThread = std::min(kPerThread, kpack);
   int64_t kOuterPerThread = kPerThread / kpackPerThread;
   int64_t threadsPerKpack = kpack / kpackPerThread;
 
   Type ldsWriteType = vectorTypeOrSelf(dataType, kpackPerThread);
-  auto typedBuffer =
-      viewBufferAs(b, buffer, ldsWriteType, ldsNumBytes, ldsByteOffset);
+  auto typedBuffer = viewBufferAs(b, buffer, ldsWriteType);
   BottomUpTMBuilder reshapeBuf(b, {"raw"}, typedBuffer.getType().getShape(),
                                loc);
   reshapeBuf.unmerge({"k_outer", dName, "kpack_idx"}, {0, 1, 2}, "raw",
@@ -686,19 +679,18 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
                             << " " << ldsBlockBSize << "\n");
     if (failed(checkLDSSize(op, ldsBlockASize, ldsBlockBSize)))
       return op.emitOpError("requires too much LDS");
-    // Workaround that we can only have one buffer at complire level at the
-    // moment. No alignment concerns: we're alligned to waveSize >= 32 bytes
-    // anyway, which is more than we need.
-    int64_t totalLdsSize = ldsBlockASize + ldsBlockBSize;
+
     // Allocate LDS.
     auto workgroupMemoryAddressSpace = b.getAttr<gpu::AddressSpaceAttr>(
         gpu::GPUDialect::getWorkgroupAddressSpace());
-    // This should be two variable, but isn't because workarounds.
-    // Try reverting the commit introducing this every once ina while.
-    auto wholeLdsMemRefType =
-        MemRefType::get({totalLdsSize}, b.getI8Type(), AffineMap{},
+    auto ldsMemRefAType =
+        MemRefType::get({ldsBlockASize}, b.getI8Type(), AffineMap{},
                         workgroupMemoryAddressSpace);
-    auto wholeLdsBuffer = b.create<GpuAllocOp>(loc, wholeLdsMemRefType);
+    auto ldsBufferA = b.create<GpuAllocOp>(loc, ldsMemRefAType);
+    auto ldsMemRefBType =
+        MemRefType::get({ldsBlockBSize}, b.getI8Type(), AffineMap{},
+                        workgroupMemoryAddressSpace);
+    auto ldsBufferB = b.create<GpuAllocOp>(loc, ldsMemRefBType);
 
     // Alloc for Matrix C on registers.
     // Compute register size from attributes.
@@ -817,14 +809,13 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     Type ldsReadTypeA = vectorTypeOrSelf(elementTypeA, kpack);
     Type ldsReadTypeB = vectorTypeOrSelf(elementTypeB, kpack);
     FailureOr<Value> maybeWrappedLdsA = wrapLDSBufferForStore(
-        b, loc, wholeLdsBuffer, ldsReadTypeA, kpacksPerBlock, "m", mPerBlock,
-        aCopyKPerThread, copyMPerThread, aVectorDim, ldsBlockASize, 0);
+        b, loc, ldsBufferA, ldsReadTypeA, kpacksPerBlock, "m", mPerBlock,
+        aCopyKPerThread, copyMPerThread, aVectorDim);
     if (failed(maybeWrappedLdsA))
       return maybeWrappedLdsA;
     FailureOr<Value> maybeWrappedLdsB = wrapLDSBufferForStore(
-        b, loc, wholeLdsBuffer, ldsReadTypeB, kpacksPerBlock, "n", nPerBlock,
-        bCopyKPerThread, copyNPerThread, bVectorDim, ldsBlockBSize,
-        ldsBlockASize);
+        b, loc, ldsBufferB, ldsReadTypeB, kpacksPerBlock, "n", nPerBlock,
+        bCopyKPerThread, copyNPerThread, bVectorDim);
     if (failed(maybeWrappedLdsB))
       return maybeWrappedLdsB;
     Value wrappedLdsA = std::move(*maybeWrappedLdsA),
@@ -850,12 +841,10 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
 
     // The blockwise gemm isn't set up for vector-of-kpack loads and so expects
     // a scalar kpacksPerBlock x dPerBlock x kpack x T buffer unconditionally.
-    Value ldsMatrixA =
-        viewBufferAs(b, wholeLdsBuffer, elementTypeA, ldsBlockASize, 0);
+    Value ldsMatrixA = viewBufferAs(b, ldsBufferA, elementTypeA);
     ldsMatrixA = reshapeBuffer(b, loc, ldsMatrixA, {"k", "m", "kpack"},
                                {kpacksPerBlock, mPerBlock, kpack});
-    Value ldsMatrixB = viewBufferAs(b, wholeLdsBuffer, elementTypeB,
-                                    ldsBlockBSize, ldsBlockASize);
+    Value ldsMatrixB = viewBufferAs(b, ldsBufferB, elementTypeB);
     ldsMatrixB = reshapeBuffer(b, loc, ldsMatrixB, {"k", "n", "kpack"},
                                {kpacksPerBlock, nPerBlock, kpack});
 
@@ -1222,20 +1211,18 @@ struct GridwiseGemmAccelRewritePattern
                             << " " << ldsBlockBSize << "\n");
     if (failed(checkLDSSize(op, ldsBlockASize, ldsBlockBSize)))
       return op.emitOpError("requires too much LDS");
-    // Workaround that we can only have one buffer at complire level at the
-    // moment. No alignment concerns: we're alligned to waveSize >= 32 bytes
-    // anyway, which is more than we need.
-    int64_t totalLdsSize = ldsBlockASize + ldsBlockBSize;
 
     // Allocate LDS.
     auto workgroupMemoryAddressSpace = b.getAttr<gpu::AddressSpaceAttr>(
         gpu::GPUDialect::getWorkgroupAddressSpace());
-    // This should be two variable, but isn't because workarounds.
-    // Try reverting the commit introducing this every once ina while.
-    auto wholeLdsMemRefType =
-        MemRefType::get({totalLdsSize}, b.getI8Type(), AffineMap{},
+    auto ldsMemRefAType =
+        MemRefType::get({ldsBlockASize}, b.getI8Type(), AffineMap{},
                         workgroupMemoryAddressSpace);
-    auto wholeLdsBuffer = b.create<GpuAllocOp>(loc, wholeLdsMemRefType);
+    auto ldsBufferA = b.create<GpuAllocOp>(loc, ldsMemRefAType);
+    auto ldsMemRefBType =
+        MemRefType::get({ldsBlockBSize}, b.getI8Type(), AffineMap{},
+                        workgroupMemoryAddressSpace);
+    auto ldsBufferB = b.create<GpuAllocOp>(loc, ldsMemRefBType);
 
     ArrayAttr aVectorLdsMap = ldsVectorLayout(b, loc, aCopyPerThread);
     ArrayAttr bVectorLdsMap = ldsVectorLayout(b, loc, bCopyPerThread);
@@ -1243,14 +1230,13 @@ struct GridwiseGemmAccelRewritePattern
     Type ldsReadTypeA = vectorTypeOrSelf(elementTypeA, kpack);
     Type ldsReadTypeB = vectorTypeOrSelf(elementTypeB, kpack);
     FailureOr<Value> maybeWrappedLdsA = wrapLDSBufferForStore(
-        b, loc, wholeLdsBuffer, ldsReadTypeA, kpacksPerBlock, "m", mPerBlock,
-        aCopyKPerThread, copyMPerThread, aVectorDim, ldsBlockASize, 0);
+        b, loc, ldsBufferA, ldsReadTypeA, kpacksPerBlock, "m", mPerBlock,
+        aCopyKPerThread, copyMPerThread, aVectorDim);
     if (failed(maybeWrappedLdsA))
       return maybeWrappedLdsA;
     FailureOr<Value> maybeWrappedLdsB = wrapLDSBufferForStore(
-        b, loc, wholeLdsBuffer, ldsReadTypeB, kpacksPerBlock, "n", nPerBlock,
-        bCopyKPerThread, copyNPerThread, bVectorDim, ldsBlockBSize,
-        ldsBlockASize);
+        b, loc, ldsBufferB, ldsReadTypeB, kpacksPerBlock, "n", nPerBlock,
+        bCopyKPerThread, copyNPerThread, bVectorDim);
     if (failed(maybeWrappedLdsB))
       return maybeWrappedLdsB;
     Value wrappedLdsA = std::move(*maybeWrappedLdsA),
@@ -1263,10 +1249,8 @@ struct GridwiseGemmAccelRewritePattern
         createLdsStoreLoop(b, loc, storeBufferB, bVectorLdsMap, wrappedLdsB,
                            bCopyPerThread, tid, forceUnroll);
 
-    Value ldsViewForGemmA =
-        viewBufferAs(b, wholeLdsBuffer, ldsReadTypeA, ldsBlockASize, 0);
-    Value ldsViewForGemmB = viewBufferAs(b, wholeLdsBuffer, ldsReadTypeB,
-                                         ldsBlockBSize, ldsBlockASize);
+    Value ldsViewForGemmA = viewBufferAs(b, ldsBufferA, ldsReadTypeA);
+    Value ldsViewForGemmB = viewBufferAs(b, ldsBufferB, ldsReadTypeB);
     // -----
 
     Type destType = op.getC().getType().getElementType();

--- a/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
@@ -4,13 +4,14 @@
 // CHECK-LABEL: @fp8_bf8_xdlops
 func.func @fp8_bf8_xdlops(%arg0: memref<1x128x128xf8E4M3FNUZ>, %arg1: memref<1x128x115200xf8E5M2FNUZ>, %arg2: memref<1x128x115200xf32>) attributes {block_size = 256 : i32, grid_size = 900 : i32} {
   // The tuning testcase leads to padded buffers, we simplify here.
-  // CHECK: %[[lds:.+]] = rock.alloc() : memref<16384xi8, #gpu.address_space<workgroup>>
-  // CHECK: %[[viewAStore:.+]] = memref.view %[[lds]][{{.*}}][] : memref<16384xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
-  // CHECK: %[[viewBStore:.+]] = memref.view %[[lds]][{{.*}}][] : memref<16384xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsA:.+]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsB:.+]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewAStore:.+]] = memref.view %[[ldsA]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewBStore:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
   // CHECK: memref.store %{{.*}}, %[[viewAStore]]
   // CHECK: memref.store %{{.*}}, %[[viewBStore]]
-  // CHECK: %[[viewAGemm:.+]] = memref.view %[[lds]][{{.*}}][] : memref<16384xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
-  // CHECK: %[[viewBGemm:.+]] = memref.view %[[lds]][{{.*}}][] : memref<16384xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewAGemm:.+]] = memref.view %[[ldsA]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewBGemm:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
   // CHECK: rock.blockwise_gemm_accel
   // CHECK-SAME %[[viewAGemm]]
   // CHECK-SAME: %[[viewBGemm]]


### PR DESCRIPTION
1. Revert the old workaround, since it only shifted around what caused the breakage and is something we'd rather not have running around if we don't need it.
2. Disable (by making it do nothing) a rewrite in the compiler that seems to be in the chain of code leading to the bug - that is, I don't think the function I patched is the buggy one, but that if it runs, it triggers the bug somewhere down the line. This is definitely an ugly workaround, but shouldn't have much of an impact perf-wise.

I've tested all the configs that've failed so far and all of them pass on this branch.

