### PR TITLE
Revert "Initial changes to move conversions to f32 into the verify wrapper function"

### DIFF
--- a/mlir/test/rocmlir-driver/populate_prc.mlir
+++ b/mlir/test/rocmlir-driver/populate_prc.mlir
@@ -5,18 +5,17 @@
 // F32-NEXT:    call @printMemrefF32(%[[RES]]) : (memref<*xf32>) -> ()
 
 // RUN: rocmlir-gen --arch %arch -p -prc -t f16 | FileCheck %s --check-prefixes=F16,CHECK
-// RUN: rocmlir-gen --arch %arch -p -prc -t bf16 | FileCheck %s --check-prefixes=BF16,CHECK
+// RUN: rocmlir-gen --arch %arch -p -prc -t bf16 | FileCheck %s --check-prefix=BF16
 
 // F16:    %{{.*}} = memref.alloc() : memref<1x128x8x3x3x[[type:f16]]>
-// BF16:   %{{.*}} = memref.alloc() : memref<1x128x8x3x3x[[type:bf16]]>
-// CHECK:  memref.copy %{{.*}} : memref<9216x[[type]]> to memref<9216x[[type]]>
+// BF16:   %{{.*}}= memref.alloc() : memref<1x128x8x3x3x[[type:bf16]]>
+// CHECK:  call @_memcpy_[[type]]_f32_9216(%{{.*}}, %{{.*}}) : (memref<9216x[[type]]>, memref<9216xf32>) -> ()
 // CHECK:  %{{.*}} = memref.alloc() : memref<128x1x8x32x32x[[type]]>
-// CHECK:  memref.copy %{{.*}} : memref<1048576x[[type]]> to memref<1048576x[[type]]>
-// CHECK:  %{{.*}} = memref.alloc() : memref<{{.*}}x[[type]]>
-// CHECK:  memref.copy %{{.*}} : memref<{{.*}}x[[type]]> to memref<{{.*}}x[[type]]>
-// CHECK-NEXT: call @conv2d_cpu(%{{.*}}, %{{.*}}, %[[RES1:.*]]) : (memref<1x128x8x3x3x[[type]]>, memref<{{.*}}>, memref<{{.*}}>) -> ()
+// CHECK:  call @_memcpy_[[type]]_f32_1048576(%{{.*}}, %{{.*}}) : (memref<1048576x[[type]]>, memref<1048576xf32>) -> ()
+// CHECK:  %{{.*}} = memref.alloc() : memref<{{.*}}>
 // CHECK:  call @_memcpy_[[type]]_f32_{{[0-9]+}}(%{{.*}}, %{{.*}}) : (memref<{{.*}}x[[type]]>, memref<{{.*}}xf32>) -> ()
-// CHECK:  %[[RES2:.*]] = memref.cast %{{.*}} : memref<{{.*}}> to memref<*xf32>
+// CHECK-NEXT: call @conv2d_cpu(%{{.*}}, %{{.*}}, %[[RES1:.*]]) : (memref<1x128x8x3x3xf32>, memref<{{.*}}>, memref<{{.*}}>) -> ()
+// CHECK:  %[[RES2:.*]] = memref.cast %[[RES1]] : memref<{{.*}}> to memref<*xf32>
 // CHECK:  call @printMemrefF32(%[[RES2]]) : (memref<*xf32>) -> ()
 
 // RUN: rocmlir-gen --arch %arch -p -prc -t i8 | FileCheck %s --check-prefix=INT8

--- a/mlir/test/rocmlir-driver/populate_pv_with_gpu.mlir
+++ b/mlir/test/rocmlir-driver/populate_pv_with_gpu.mlir
@@ -31,15 +31,15 @@
 // F16-CHECK: func.func @rock_conv2d_gkcyx_ngchw_ngkhw_0({{.*}}) attributes {kernel = 0 : i32, xmodel.arch = "{{.*}}"} {
 // F16-CHECK: rock.conv2d({{.*}}) features = dot {[[PARMS:.*]]} : memref<[[FILTERDIMS:[x0-9]+]]xf16>, memref<[[INPUTDIMS:[x0-9]+]]xf16>, memref<[[OUTPUTDIMS:[x0-9]+]]xf16>
 // F16-CHECK: call @rock_conv2d_gkcyx_ngchw_ngkhw_0_gpu({{.*}}) : (memref<[[FILTERDIMS]]xf16>, memref<[[INPUTDIMS]]xf16>, memref<[[OUTPUTDIMS]]xf16>) -> ()
-// F16-CHECK: call @rock_conv2d_gkcyx_ngchw_ngkhw_0_ver_gpu({{.*}}) : (memref<[[FILTERDIMS]]xf16>, memref<[[INPUTDIMS]]xf16>, memref<[[OUTPUTDIMS]]xf16>) -> ()
+// F16-CHECK: call @rock_conv2d_gkcyx_ngchw_ngkhw_0_ver_gpu({{.*}}) : (memref<[[FILTERDIMS]]xf32>, memref<[[INPUTDIMS]]xf32>, memref<[[OUTPUTDIMS]]xf32>) -> ()
 // F16-CHECK: func.func @rock_conv2d_gkcyx_ngchw_ngkhw_0_ver({{.*}}) attributes {kernel = 0 : i32, xmodel.arch = "{{.*}}"} {
-// F16-CHECK: rock.conv2d({{.*}}) features = dot {{{.*}} : memref<[[FILTERDIMS]]xf16>, memref<[[INPUTDIMS]]xf16>, memref<[[OUTPUTDIMS]]xf16>
+// F16-CHECK: rock.conv2d({{.*}}) features = dot {{{.*}} : memref<[[FILTERDIMS]]xf32>, memref<[[INPUTDIMS]]xf32>, memref<[[OUTPUTDIMS]]xf32>
 
 // RUN: rocmlir-gen --operation gemm --arch gfx908 -mfma=off -atomic_add=off -dot=on -p -t f16 -pv_with_gpu | FileCheck %s --check-prefix=GEMM-F16-CHECK
 
 // GEMM-F16-CHECK: func.func @rock_gemm({{.*}}) attributes {kernel, xmodel.arch = "{{.*}}"} {
 // GEMM-F16-CHECK: rock.gemm {{.*}} = {{.*}} * {{.*}} features = dot storeMethod = {{.*}} {[[PARMS:.*]]} : memref<[[CDIMS:[x0-9]+]]xf16> = memref<[[ADIMS:[x0-9]+]]xf16> * memref<[[BDIMS:[x0-9]+]]xf16>
 // GEMM-F16-CHECK: call @rock_gemm_gpu({{.*}}) : (memref<[[ADIMS]]xf16>, memref<[[BDIMS]]xf16>, memref<[[CDIMS]]xf16>) -> ()
-// GEMM-F16-CHECK: call @rock_gemm_ver_gpu({{.*}}) : (memref<[[ADIMS]]xf16>, memref<[[BDIMS]]xf16>, memref<[[CDIMS]]xf16>) -> ()
+// GEMM-F16-CHECK: call @rock_gemm_ver_gpu({{.*}}) : (memref<[[ADIMS]]xf32>, memref<[[BDIMS]]xf32>, memref<[[CDIMS]]xf32>) -> ()
 // GEMM-F16-CHECK: func.func @rock_gemm_ver({{.*}}) attributes {kernel, xmodel.arch = "{{.*}}"} {
-// GEMM-F16-CHECK: rock.gemm {{.*}} = {{.*}} * {{.*}} features = dot storeMethod = {{.*}} {[[PARMS:.*]]} : memref<[[CDIMS:[x0-9]+]]xf16> = memref<[[ADIMS:[x0-9]+]]xf16> * memref<[[BDIMS:[x0-9]+]]xf16>
+// GEMM-F16-CHECK: rock.gemm {{.*}} = {{.*}} * {{.*}} features = dot storeMethod = {{.*}} {[[PARMS:.*]]} : memref<[[CDIMS:[x0-9]+]]xf32> = memref<[[ADIMS:[x0-9]+]]xf32> * memref<[[BDIMS:[x0-9]+]]xf32>

--- a/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
+++ b/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
@@ -7,7 +7,7 @@
 
 
 // CHECK-LABEL: func @host_naive_gemm
-// F16-SAME: (%{{.*}}: memref<3x1024x769xf16>, %{{.*}}: memref<3x769x512xf16>, %{{.*}}: memref<3x1024x512xf16>)
+// F16-SAME: (%{{.*}}: memref<3x1024x769xf32>, %{{.*}}: memref<3x769x512xf32>, %{{.*}}: memref<3x1024x512xf32>)
 // I8-SAME: (%{{.*}}: memref<3x1024x769xi8>, %{{.*}}: memref<3x769x512xi8>, %{{.*}}: memref<3x1024x512xi64>)
 
 // F16: arith.mulf

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -685,7 +685,7 @@ static void correctConvParameters() {
                         conv_dilation_h);
   int hi_minimum = 1 + (y - 1) * conv_dilation_h + (ho - 1) * conv_stride_h;
   int hi_specified = hi + in_left_pad_h + in_right_pad_h;
-  // hi_minimum is the mininum number of input elements needed to correctly
+  // hi_minimum is the miminum number of input elements needed to correctly
   // apply the filter in the h direction, which is a function of the stride and
   // dilation parameters. If the specified input height is less than this value,
   // add extra padding on the right to allow the convolution to execute
@@ -1395,8 +1395,7 @@ createCPUConvWithMLIR(ModuleOp module, func::FuncOp &func,
           if (c == 'h') {
             result.push_back(heightIdx);
             continue;
-          }
-          if (c == 'w') {
+          } else if (c == 'w') {
             result.push_back(widthIdx);
             continue;
           }
@@ -1404,8 +1403,7 @@ createCPUConvWithMLIR(ModuleOp module, func::FuncOp &func,
           if (c == 'h') {
             result.push_back(heightIdx);
             continue;
-          }
-          if (c == 'w') {
+          } else if (c == 'w') {
             result.push_back(widthIdx);
             continue;
           }
@@ -1488,6 +1486,7 @@ createCPUConvWithMLIR(ModuleOp module, func::FuncOp &func,
                       createConv2dLoopNest);
 
   b.create<func::ReturnOp>(loc, ValueRange{});
+  return;
 }
 
 static void
@@ -1683,6 +1682,7 @@ createCPUConvWithCPP(ModuleOp module, func::FuncOp &func,
 
   // Emit return op
   b.create<func::ReturnOp>(loc, ValueRange{});
+  return;
 }
 
 static func::FuncOp
@@ -1700,10 +1700,8 @@ createCPUConvFunc(ModuleOp module,
   OpBuilder b(module.getContext());
   auto loc = b.getUnknownLoc();
 
-  Type elemType = typeFromString(genConfig.dataTypeStr, module.getContext());
-  Type outputElemType =
-      typeFromString(genConfig.dataTypeStr, module.getContext());
-
+  Type elemType = b.getF32Type();
+  Type outputElemType = b.getF32Type();
   if (genConfig.dataTypeStr == "i8") {
     elemType = b.getI8Type();
     // Compute the output in int64_t to detect overflow
@@ -1826,7 +1824,11 @@ static func::FuncOp createCpuGemmKernelWithMlir(ModuleOp module,
   MLIRContext *ctx = module.getContext();
   OpBuilder b(ctx);
   Location loc = module->getLoc();
+
   Type cpuInType = params.dtype;
+  // Raise floats to f32
+  if (cpuInType.isa<FloatType>())
+    cpuInType = b.getF32Type();
 
   SmallVector<Type, 3> argTypes;
   getGemmTypes(cpuInType, argTypes, /*isCpuVerifier=*/true);
@@ -1880,7 +1882,6 @@ static func::FuncOp createCpuGemmKernelWithMlir(ModuleOp module,
   return func;
 }
 
-// Make an element-by-element copy that converts from srcType to destType.
 static func::FuncOp getMemcpyFuncDecl(ModuleOp module, const MemRefType srcType,
                                       const MemRefType destType) {
   OpBuilder b(module.getContext());
@@ -2005,13 +2006,9 @@ static void emitMemcpy(OpBuilder &b, Value src, Value dst) {
   Value dstFlat = makeNDMemRef(b, dst, 1);
   auto srcFlatType = srcFlat.getType().cast<MemRefType>();
   auto dstFlatType = dstFlat.getType().cast<MemRefType>();
+  auto memcpyFunc = getMemcpyFuncDecl(module, srcFlatType, dstFlatType);
 
-  if (srcFlatType == dstFlatType) {
-    b.create<memref::CopyOp>(loc, srcFlat, dstFlat);
-  } else {
-    auto memcpyFunc = getMemcpyFuncDecl(module, srcFlatType, dstFlatType);
-    b.create<func::CallOp>(loc, memcpyFunc, ValueRange{srcFlat, dstFlat});
-  }
+  b.create<func::CallOp>(loc, memcpyFunc, ValueRange{srcFlat, dstFlat});
 }
 
 static void emitPrintTensor(OpBuilder &b, Value var) {
@@ -2070,10 +2067,6 @@ static void checkRandomInputsE2E() {
   }
 }
 
-// Overall structure:  both kernel and validation (reference) function produce
-// the same output type.  Those native types are used in the parameters of the
-// verifierFunc that we create here, and this function converts the parameters
-// to types usable by the mcpuVerify function that does the comparison.
 static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
                                        MemRefType testType, MemRefType valType,
                                        std::string funcName) {
@@ -2112,8 +2105,6 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
   Value testFlat = makeNDMemRef(b, test, 1);
   Value valFlat = makeNDMemRef(b, val, 1);
   auto valFlatType = valFlat.getType().cast<MemRefType>();
-  auto f32FlatType = MemRefType::get(valFlatType.getShape(), floatType);
-
   // Emit constants for thresholds
 
   // clang-format off
@@ -2142,48 +2133,6 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
   auto printDebugVal =
       b.create<arith::ConstantIntOp>(loc, printDebug, charType);
 
-  Value testResult, valResult;       // Values passed to the verify function
-  Value testResultNew, valResultNew; // Values used for type conversion
-
-  auto mr1DUnkTestType =
-      MemRefType::get({mlir::ShapedType::kDynamic}, testOutType);
-  auto mr1DUnkValType =
-      MemRefType::get({mlir::ShapedType::kDynamic}, valElemType);
-  auto mr1DUnkF32Type =
-      MemRefType::get({mlir::ShapedType::kDynamic}, floatType);
-
-  if (testOutType.isa<FloatType>() && !testOutType.isF32()) {
-    // When gpu kernel output data type = f16 | bf16, type conversions
-    // are required before calling the verify function, because it runs
-    // on the host and doesn't have f16|bf16.
-
-    // clang-format off
-    // %0 = memref.alloc() : memref<802816xf32>
-    // call @_memcpy_f16_f32_802816(%test_flat, %0) : (memref<802816xf16>, memref<802816xf32>) -> ()
-    // %5 = memref.cast %0 : memref<802816xf32> to memref<?x?x?x?x?xf32>
-    // clang-format on
-
-    testResultNew = b.create<memref::AllocOp>(loc, f32FlatType);
-    emitMemcpy(b, testFlat, testResultNew);
-    testResult = b.create<memref::CastOp>(loc, mr1DUnkF32Type, testResultNew);
-    mr1DUnkTestType = mr1DUnkF32Type;
-    testOutType = mr1DUnkTestType.getElementType();
-  } else {
-    // Cast necessary for the rank of the access.
-    testResult = b.create<memref::CastOp>(loc, mr1DUnkTestType, testFlat);
-  }
-
-  // And also the validation data.
-  if (valElemType.isa<FloatType>() && !valElemType.isF32()) {
-    valResultNew = b.create<memref::AllocOp>(loc, f32FlatType);
-    emitMemcpy(b, valFlat, valResultNew);
-    valResult = b.create<memref::CastOp>(loc, mr1DUnkF32Type, valResultNew);
-    mr1DUnkValType = mr1DUnkF32Type;
-    valElemType = mr1DUnkValType.getElementType();
-  } else {
-    valResult = b.create<memref::CastOp>(loc, mr1DUnkValType, valFlat);
-  }
-
   // obtain function name of the verifier wrapper
   std::string verifyFuncName = "mcpuVerify";
   if (valElemType.isF32()) {
@@ -2196,11 +2145,75 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
     verifyFuncName += "Int8";
   } else {
     llvm::errs() << "Unsupported type of validation function output: ";
-    valElemType.dump();
     llvm::errs() << " (Only f32, int32 and int64 are supported)\n";
     exit(1);
   }
 
+  auto mr1DUnkTestType =
+      MemRefType::get({mlir::ShapedType::kDynamic}, testOutType);
+  auto mr1DUnkValType =
+      MemRefType::get({mlir::ShapedType::kDynamic}, valElemType);
+
+  bool isTestAndValSameType =
+      (testOutType.isInteger(32) || testOutType.isF32());
+
+  Value testResult, valResult; // Values passed to the verify function
+  Value testResultNew;         // Values used for type conversion
+  if (!isTestAndValSameType) {
+    // When gpu kernel output data type = f16 | bf16, type conversions
+    // are required before calling the verify function
+
+    // Cast test result to the same type as valid result
+
+    // clang-format off
+    // %0 = memref.alloc() : memref<802816xf32>
+    // call @_memcpy_f16_f32_802816(%test_flat, %0) : (memref<802816xf16>, memref<802816xf32>) -> ()
+    // %5 = memref.cast %0 : memref<802816xf32> to memref<?x?x?x?x?xf32>
+    // clang-format on
+
+    testResultNew = b.create<memref::AllocOp>(loc, valFlatType);
+    emitMemcpy(b, testFlat, testResultNew);
+    testResult = b.create<memref::CastOp>(loc, mr1DUnkValType, testResultNew);
+    mr1DUnkTestType = mr1DUnkValType;
+
+    // Cast valid result down to the same type as test result and cast back
+    //   For f16 and bf16 datatypes, gpu hardware outputs f32 results, which are
+    //   truncated to f16/bf16 before returning from the gpu kernel
+    //   To make the comparison fair, the truncation step is added manually to
+    //   the validation results.
+
+    // clang-format off
+    // affine.for %arg2 = 0 to 802816 {
+    //   %7 = memref.load %arg1[%arg2] : memref<802816xf32>
+    //   %8 = arith.truncf %7 : f32 to f16
+    //   %9 = arith.extf %8 : f16 to f32
+    //   memref.store %9, %arg1[%arg2] : memref<802816xf32>
+    // }
+    // clang-format on
+
+    SmallVector<int64_t, 1> lowerBounds(1, 0);
+    SmallVector<int64_t, 1> upperBounds = {valFlatType.getNumElements()};
+    SmallVector<int64_t, 1> steps(1, 1);
+
+    if (testOutType != valElemType) {
+      buildAffineLoopNest(
+          b, loc, lowerBounds, upperBounds, steps,
+          [valFlat, testOutType, valElemType](OpBuilder &b, Location loc,
+                                              ValueRange ivs) {
+            auto valOrig = b.create<memref::LoadOp>(loc, valFlat, ivs);
+            auto valTruncated =
+                b.create<arith::TruncFOp>(loc, testOutType, valOrig);
+            auto valExt =
+                b.create<arith::ExtFOp>(loc, valElemType, valTruncated);
+            b.create<memref::StoreOp>(loc, valExt, valFlat, ivs);
+          });
+    }
+  } else {
+    testResult = b.create<memref::CastOp>(loc, mr1DUnkTestType, testFlat);
+  }
+
+  // Prepare the validation result for the verify function
+  valResult = b.create<memref::CastOp>(loc, mr1DUnkValType, valFlat);
   // Declare and call the wrapper verify function
   func::FuncOp verifyFuncDecl;
 
@@ -2218,13 +2231,9 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
                            ValueRange{testResult, valResult, printDebugVal});
   }
 
-  if (testResultNew && !testResultNew.use_empty()) {
+  if (!isTestAndValSameType) {
     // Deallocate the buffer for f32 version of the test results
     b.create<memref::DeallocOp>(loc, testResultNew);
-  }
-  if (valResultNew && !valResultNew.use_empty()) {
-    // Deallocate the buffer for f32 version of the validation results
-    b.create<memref::DeallocOp>(loc, valResultNew);
   }
 
   b.create<func::ReturnOp>(loc, ValueRange{});
@@ -2326,6 +2335,11 @@ static void insertValidationCalls(const GenParams &genParams, OpBuilder &b,
       // verifying a tuning case
       if (hasXdlops)
         conv2dGenerator.flipXdlops();
+      if (!((hasXdlops || heuristicValidation) &&
+            genConfig.dataTypeStr == "i8"))
+        // use f32 data type to verify non-f32 or xdlops f32 kernels
+        // except that i8 xdlops or tuned is verified with i8 non-xdlops.
+        conv2dGenerator.setDataType("f32");
 
       int kernelStart = genConfig.kernelId;
       int kernelCount = 0;
@@ -2349,6 +2363,7 @@ static void insertValidationCalls(const GenParams &genParams, OpBuilder &b,
           exit(1);
         }
         KernelIF kernel(conv2dGenerator.getKernelFunc());
+        rock::Conv2dGenerator::Config newConfig = conv2dGenerator.getConfig();
         auto kernelWrapperFunc = createGPUWrapper(module, kernel);
 
         // Decide whether to trim the last workspace argument to the verifier
@@ -2380,8 +2395,14 @@ static void insertValidationCalls(const GenParams &genParams, OpBuilder &b,
         newParams.features =
             genParams.features ^ mlir::rock::GemmFeatures::mfma;
 
+      if (!((heuristicValidation || hasXdlops) && genParams.dtype.isInteger(8)))
+        // use f32 data type to verify non-f32 or xdlops f32 kernels
+        // except that i8 xdops is verified with i8 non-xdolps and tuned i8 is
+        // verified with itself in heuristic mode.
+        newParams.dtype = b.getF32Type();
+
       KernelIF kernel(
-          createGpuGemmKernel(module, newParams, /*isVerifier=*/true));
+          createGpuGemmKernel(module, newParams, /*is_verifier=*/true));
       auto kernelWrapperFunc = createGPUWrapper(module, kernel);
       b.create<func::CallOp>(loc, kernelWrapperFunc, valVars);
     }
@@ -2461,6 +2482,8 @@ static LogicalResult populateHostHarnessLogic(
     }
     return i32vals[v];
   };
+  auto floatType = b.getF32Type();
+
   auto validationType = genValidation.getValue();
 
   // Create all local variables for each kernel param
@@ -2475,7 +2498,7 @@ static LogicalResult populateHostHarnessLogic(
   bool hasXdlops =
       rock::bitEnumContainsAll(genParams.features, rock::GemmFeatures::mfma);
   bool heuristicValidation =
-      !genVerifierKeepPerfConfig && !genParams.perfConfig.empty();
+      genVerifierKeepPerfConfig == false && !genParams.perfConfig.empty();
   bool gpuValidation =
       validationType == "gpu" &&
       ((hasXdlops || genParams.dtype.isF16() || genParams.dtype.isBF16()) ||
@@ -2516,6 +2539,8 @@ static LogicalResult populateHostHarnessLogic(
     assert(paramMRType && "currently only supports memref types");
     auto elemType = paramMRType.getElementType();
     if (isCPUKernel) { // -prc
+      assert(elemType.isF32() || elemType.isInteger(8) ||
+             elemType.isInteger(32) || elemType.isInteger(64));
       if (genParams.operation.has_value()) {
         elemType = genParams.dtype;
         if (elemType.isInteger(8) && idx == 2)
@@ -2538,7 +2563,7 @@ static LogicalResult populateHostHarnessLogic(
     if (hasValidation ||
         (isCPUKernel && (elemType.isF16() || elemType.isBF16()))) {
       // Emit validation var
-      Type valElemType = elemType;
+      Type valElemType = floatType;
       if (genParams.operation.has_value() && genParams.dtype.isInteger(8)) {
         valElemType = elemType;
         if (!gpuValidation && idx == 2)
@@ -2694,7 +2719,7 @@ int main(int argc, char **argv) {
 
   std::string errorMessage;
   auto inputFilenameStr = inputFilename.getValue();
-  if (!inputFilenameStr.empty()) {
+  if (inputFilenameStr.size()) {
     // Set up the input file.
     auto file = openInputFile(inputFilename, &errorMessage);
     if (!file) {
@@ -2727,7 +2752,7 @@ int main(int argc, char **argv) {
     }
 
     if (emitTuningSpace) {
-      auto *tunableParams = rock::createTunableParamSpace(module);
+      auto tunableParams = rock::createTunableParamSpace(module);
       std::string perfConfig;
       for (auto param : tunableParams->tuningRange) {
         param.getPerfConfigStr(perfConfig);
@@ -2750,6 +2775,12 @@ int main(int argc, char **argv) {
     });
 
   } else {
+    if (genValidation == "clone") {
+      llvm::errs()
+          << "Clone validation is not compatible with kernel generation.\n";
+      exit(1);
+    }
+
     // Construct a new ModuleOp.
     module = ModuleOp::create(builder.getUnknownLoc());
   }
@@ -2897,7 +2928,7 @@ int main(int argc, char **argv) {
   }
 
   if (emitTuningSpace) {
-    auto *tunableParams = rock::createTunableParamSpace(module);
+    auto tunableParams = rock::createTunableParamSpace(module);
     std::string perfConfig;
     for (auto param : tunableParams->tuningRange) {
       param.getPerfConfigStr(perfConfig);


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/rocMLIR#1071

This is causing nightly CI to run into failure: http://rocmhead.amd.com:8080/blue/organizations/jenkins/MLIR%2Fmlir-nightly-all/detail/mlir-nightly-all/780/pipeline

If no workaround found by the end of the day, I tend to revert the feature and find out:
 - Why this isn't captured by PR CI
 - Fix the issue that caused the nightly to run into failure