### PR TITLE
Add synchronization primitives

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -131,6 +131,18 @@ def ROCDL_BarrierOp : ROCDL_Op<"barrier"> {
   let assemblyFormat = "attr-dict";
 }
 
+def ROCDL_SetPrioOp : ROCDL_IntrOp<"s.setprio", [], [], [], 0>,
+  Arguments<(ins I16:$priority)> {
+  let results = (outs);
+  let assemblyFormat = "$priority attr-dict `:` type($priority)";
+}
+
+def ROCDL_SchedBarrier : ROCDL_IntrOp<"sched.barrier", [], [], [], 0>,
+  Arguments<(ins I32:$mask)> {
+  let results = (outs);
+  let assemblyFormat = "$mask attr-dict `:` type($mask)";
+}
+
 
 //===---------------------------------------------------------------------===//
 // Xdlops intrinsics

--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -134,13 +134,13 @@ def ROCDL_BarrierOp : ROCDL_Op<"barrier"> {
 def ROCDL_SetPrioOp : ROCDL_IntrOp<"s.setprio", [], [], [], 0>,
   Arguments<(ins I16:$priority)> {
   let results = (outs);
-  let assemblyFormat = "$priority attr-dict `:` type($priority)";
+  let assemblyFormat = "$priority attr-dict";
 }
 
 def ROCDL_SchedBarrier : ROCDL_IntrOp<"sched.barrier", [], [], [], 0>,
   Arguments<(ins I32:$mask)> {
   let results = (outs);
-  let assemblyFormat = "$mask attr-dict `:` type($mask)";
+  let assemblyFormat = "$mask attr-dict";
 }
 
 

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -65,6 +65,26 @@ llvm.func @rocdl.barrier() {
   llvm.return
 }
 
+llvm.func @rocdl.setprio() {
+  %zero = llvm.mlir.constant(0 : i16) : i16
+  %one = llvm.mlir.constant(1 : i16) : i16
+  // CHECK: call void @llvm.amdgcn.s.setprio(i16 0)
+  rocdl.s.setprio %zero : i16
+  // CHECK-NEXT: call void @llvm.amdgcn.s.setprio(i16 1)
+  rocdl.s.setprio %one : i16
+  llvm.return
+}
+
+llvm.func @rocdl.schedbarrier() {
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %one = llvm.mlir.constant(1 : i32) : i32
+  // CHECK: call void @llvm.amdgcn.sched.barrier(i32 0)
+  rocdl.sched.barrier %zero : i32
+  // CHECK-NEXT: call void @llvm.amdgcn.sched.barrier(i32 1)
+  rocdl.sched.barrier %one : i32
+  llvm.return
+}
+
 llvm.func @rocdl.xdlops(%arg0 : f32, %arg1 : f32,
                    %arg2 : vector<32 x f32>, %arg3: i32,
                    %arg4 : vector<16 x f32>, %arg5 : vector<4xf32>,

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -69,9 +69,9 @@ llvm.func @rocdl.setprio() {
   %zero = llvm.mlir.constant(0 : i16) : i16
   %one = llvm.mlir.constant(1 : i16) : i16
   // CHECK: call void @llvm.amdgcn.s.setprio(i16 0)
-  rocdl.s.setprio %zero : i16
+  rocdl.s.setprio %zero
   // CHECK-NEXT: call void @llvm.amdgcn.s.setprio(i16 1)
-  rocdl.s.setprio %one : i16
+  rocdl.s.setprio %one
   llvm.return
 }
 
@@ -79,9 +79,9 @@ llvm.func @rocdl.schedbarrier() {
   %zero = llvm.mlir.constant(0 : i32) : i32
   %one = llvm.mlir.constant(1 : i32) : i32
   // CHECK: call void @llvm.amdgcn.sched.barrier(i32 0)
-  rocdl.sched.barrier %zero : i32
+  rocdl.sched.barrier %zero
   // CHECK-NEXT: call void @llvm.amdgcn.sched.barrier(i32 1)
-  rocdl.sched.barrier %one : i32
+  rocdl.sched.barrier %one
   llvm.return
 }
 


### PR DESCRIPTION
This PR adds two synchronization primitives to the `ROCDL` operations. Those primitives are needed by https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/856