### PR TITLE
[DO NOT SQUASH] Apply the compiler fix for the LDS miscomplies

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -9434,6 +9434,8 @@ SDValue SITargetLowering::performUCharToFloatCombine(SDNode *N,
 }
 
 // (shl (add x, c1), c2) -> add (shl x, c2), (shl c1, c2)
+// (shl (or x, c1), c2) -> add (shl x, c2), (shl c1, c2) iff x and c1 share no
+// bits
 
 // This is a variant of
 // (mul (add x, c1), c2) -> add (mul x, c2), (mul c1, c2),
@@ -9468,8 +9470,14 @@ SDValue SITargetLowering::performSHLPtrCombine(SDNode *N,
   if (!CAdd)
     return SDValue();
 
-  // If the resulting offset is too large, we can't fold it into the addressing
-  // mode offset.
+  SelectionDAG &DAG = DCI.DAG;
+
+  if (N0->getOpcode() == ISD::OR &&
+      !DAG.haveNoCommonBitsSet(N0.getOperand(0), N0.getOperand(1)))
+    return SDValue();
+
+  // If the resulting offset is too large, we can't fold it into the
+  // addressing mode offset.
   APInt Offset = CAdd->getAPIntValue() << CN1->getAPIntValue();
   Type *Ty = MemVT.getTypeForEVT(*DCI.DAG.getContext());
 
@@ -9479,7 +9487,6 @@ SDValue SITargetLowering::performSHLPtrCombine(SDNode *N,
   if (!isLegalAddressingMode(DCI.DAG.getDataLayout(), AM, Ty, AddrSpace))
     return SDValue();
 
-  SelectionDAG &DAG = DCI.DAG;
   SDLoc SL(N);
   EVT VT = N->getValueType(0);
 

--- a/external/llvm-project/llvm/test/CodeGen/AMDGPU/shl_add_ptr.ll
+++ b/external/llvm-project/llvm/test/CodeGen/AMDGPU/shl_add_ptr.ll
@@ -382,15 +382,12 @@ define void @shl_add_ptr_combine_2use_both_max_private_offset(i16 zeroext %idx.a
   ret void
 }
 
-; FIXME: This or should fold into an offset on the write
 ; GCN-LABEL: {{^}}shl_or_ptr_combine_2use_lds:
-; GCN: v_lshlrev_b32_e32 [[SCALE0:v[0-9]+]], 3, v0
-; GCN: v_or_b32_e32 [[SCALE1:v[0-9]+]], 32, [[SCALE0]]
-; GCN: v_lshlrev_b32_e32 [[SCALE2:v[0-9]+]], 4, v0
-; GCN: ds_write_b32 [[SCALE1]], v{{[0-9]+}}
-; GCN: ds_write_b32 [[SCALE2]], v{{[0-9]+}} offset:64
+; GCN-DAG: ds_write_b32 v{{[0-9]+}}, v{{[0-9]+}} offset:8
+; GCN-DAG: ds_write_b32 v{{[0-9]+}}, v{{[0-9]+}} offset:16
 define void @shl_or_ptr_combine_2use_lds(i32 %idx) #0 {
-  %idx.add = or i32 %idx, 4
+  %idx.shl = shl i32 %idx, 1
+  %idx.add = or i32 %idx.shl, 1
   %shl0 = shl i32 %idx.add, 3
   %shl1 = shl i32 %idx.add, 4
   %ptr0 = inttoptr i32 %shl0 to ptr addrspace(3)
@@ -399,15 +396,14 @@ define void @shl_or_ptr_combine_2use_lds(i32 %idx) #0 {
   store volatile i32 10, ptr addrspace(3) %ptr1
   ret void
 }
-
-; GCN-LABEL: {{^}}shl_or_ptr_combine_2use_max_lds_offset:
-; GCN-DAG: v_lshlrev_b32_e32 [[SCALE0:v[0-9]+]], 3, v0
-; GCN-DAG: v_lshlrev_b32_e32 [[SCALE1:v[0-9]+]], 4, v0
-; GCN-DAG: ds_write_b32 [[SCALE0]], v{{[0-9]+}} offset:65528
-; GCN-DAG: v_or_b32_e32 [[ADD1:v[0-9]+]], 0x1fff0, [[SCALE1]]
-; GCN: ds_write_b32 [[ADD1]], v{{[0-9]+$}}
-define void @shl_or_ptr_combine_2use_max_lds_offset(i32 %idx) #0 {
-  %idx.add = or i32 %idx, 8191
+; GCN-LABEL: {{^}}shl_or_ptr_not_combine_2use_lds:
+; GCN:     v_or_b32_e32 [[OR:v[0-9]+]], 1, v0
+; GCN-DAG: v_lshlrev_b32_e32 [[SCALE0:v[0-9]+]], 3, [[OR]]
+; GCN-DAG: v_lshlrev_b32_e32 [[SCALE1:v[0-9]+]], 4, [[OR]]
+; GCN-DAG: ds_write_b32 [[SCALE0]], v{{[0-9]+}}{{$}}
+; GCN-DAG: ds_write_b32 [[SCALE1]], v{{[0-9]+}}{{$}}
+define void @shl_or_ptr_not_combine_2use_lds(i32 %idx) #0 {
+  %idx.add = or i32 %idx, 1
   %shl0 = shl i32 %idx.add, 3
   %shl1 = shl i32 %idx.add, 4
   %ptr0 = inttoptr i32 %shl0 to ptr addrspace(3)

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -360,16 +360,6 @@ LogicalResult PopulateParamsXDL::isValidBlockwiseGemmXDLOPS(
     return failure();
   }
 
-  // This case triggers a miscompile, remove when it's patched. See
-  // issue #873.
-  if (dataTypeA.getIntOrFloatBitWidth() <= 16 && param.gemmMPerBlock == 64 &&
-      param.gemmNPerBlock == 64 && param.gemmMPerWave == 32 &&
-      param.gemmNPerWave == 64 && param.gemmKPerBlock >= 4 &&
-      param.gemmKPack == 8) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Rejecting due to the special compiler bug workaround case");
-    return failure();
-  }
   return success();
 }
 


### PR DESCRIPTION
Revert the earlier temporary disabling of certain perf configs as the underlying issue has been resolved by the patch included here.

The underlying upstream patch is https://reviews.llvm.org/D150246 