### PR TITLE
Dropping concurrency level for parameter sweep

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -274,17 +274,9 @@ void check_randomE2ETests(String codepath) {
 }
 
 void parameterSweep(String CONFIG, String codepath) {
-    if (codepath == "navi21") {
-        timeout(time: 60, activity: true, unit: 'MINUTES') {
-            dir('build') {
-                sh """python3 ./bin/parameterSweeps.py -j 8 ${CONFIG}"""
-            }
-        }
-    } else {
-        timeout(time: 60, activity: true, unit: 'MINUTES') {
-            dir('build') {
-                sh """python3 ./bin/parameterSweeps.py ${CONFIG}"""
-            }
+    timeout(time: 300, activity: true, unit: 'MINUTES') {
+        dir('build') {
+            sh """python3 ./bin/parameterSweeps.py -j 5 ${CONFIG}"""
         }
     }
 }


### PR DESCRIPTION
Experimented at: http://ml-ci.amd.com:21096/job/MLIR/job/mlir-weekly/98/replay/diff

As it turns out the public CI starts to suffer from over-subscription starting from ROCm 5.5 bare metal. According to @okakarpa, the parameter sweep is frequently causing the dmesg to doorbell and fail:

> [145853.089070] amdgpu: Runlist is getting oversubscribed. Expect reduced ROCm performance.
[145853.641969] amdgpu: No more SDMA queue to allocate
[145853.642382] amdgpu: Pasid 0x8000 DQM create queue type 1 failed. ret -12

I'm dropping the concurrency level of parameter sweep as precautious step. The past 3 weekly has been passing, but this needs continued monitoring at weekly CI test.