### PR TITLE
Add a rocmlir-gen option --out_datatype

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Generator/Conv2dGenerator.h
+++ b/mlir/include/mlir/Dialect/Rock/Generator/Conv2dGenerator.h
@@ -44,6 +44,7 @@ public:
     std::string filterLayout;
     std::string inputLayout;
     std::string outputLayout;
+    std::string outputDataTypeStr;
 
     std::string kernelBaseName;
 
@@ -70,6 +71,7 @@ public:
       const std::string &filterLayout = "kcyx",
       const std::string &inputLayout = "nchw",
       const std::string &outputLayout = "nkhw",
+      const std::string &outputDataTypeStr = "",
       const std::string &kernelBaseName = "");
 
   Conv2dGenerator(const Config &_config);
@@ -82,6 +84,8 @@ public:
   Type getDataType(OpBuilder &builder) const;
 
   void setDataType(std::string dataTypeStr);
+
+  Type getOutputDataType(OpBuilder &builder) const;
 
   void flipXdlops();
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -77,7 +77,7 @@ class Rock_Conv2DOpBase<string mnemonic, list<Type> inputTypes=[F32, F16, BF16],
 
 defvar GemmInputTypes = [F32, F16, BF16, I8, F8E5M2FNUZ, F8E4M3FNUZ];
 // This can be extended for quantization.
-defvar GemmOutputTypes = [F32, F16, BF16, I32];
+defvar GemmOutputTypes = [F32, F16, BF16, I32, I8];
 
 def Rock_Conv2DOp : Rock_Conv2DOpBase<"conv2d", GemmInputTypes, GemmOutputTypes> {
   dag additionalArgs = (ins OptionalAttr<I32Attr>:$numCu);

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -347,6 +347,7 @@ static Type strToType(StringRef dataTypeStr, OpBuilder &builder) {
           .Case("f16", builder.getF16Type())
           .Case("fp16", builder.getF16Type())
           .Case("bf16", builder.getBF16Type())
+          .Case("i32", builder.getI32Type())
           .Case("i8", builder.getI8Type())
           .Default(std::nullopt);
   if (!type) {

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -560,6 +560,7 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
   config.operation = op.value();
   strToInt("kernel_id", config.kernelId);
   config.dataTypeStr = canonicalizeDataType(argMap["in_type"]);
+  config.outputDataTypeStr = canonicalizeDataType(argMap["out_type"]);
   strToInt("dilation_h", config.dilationHeight);
   strToInt("dilation_w", config.dilationWidth);
   strToInt("conv_stride_h", config.strideHeight);
@@ -568,7 +569,6 @@ LogicalResult Conv2dGenerator::parseConvConfig(const char *arguments) {
   strToInt("padding_h", config.paddingHeightRight);
   strToInt("padding_w", config.paddingWidthLeft);
   strToInt("padding_w", config.paddingWidthRight);
-  config.outputDataTypeStr = canonicalizeDataType(argMap["out_type"]);
 
   strToStr("kernel_name", config.kernelBaseName);
 

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -697,7 +697,8 @@ LogicalResult GemmOp::verify() {
   ShapedType typeA = getA().getType(), typeB = getB().getType(),
              typeC = getC().getType();
   Type inElems = typeA.getElementType(), outElems = typeC.getElementType();
-  if (inElems.isa<IntegerType>() && !outElems.isInteger(32))
+  if (inElems.isa<IntegerType>() &&
+      !(outElems.isInteger(32) || outElems.isInteger(8)))
     return emitOpError("integer-valued multiply must have i32 as its result");
   if (inElems.isa<FloatType>() && !outElems.isa<FloatType>())
     return emitOpError(
@@ -797,8 +798,8 @@ template <typename GridOp> static LogicalResult verifyGridwiseGemm(GridOp op) {
        cElem = cType.getElementType();
   if (failed(verifyGemmTypes(op, aElem, bElem, cElem)))
     return failure();
-  if (aElem.isInteger(8) && !cElem.isInteger(32))
-    return op.emitOpError("i8 input requires i32 output");
+  if (aElem.isInteger(8) && !(cElem.isInteger(32) || cElem.isInteger(8)))
+    return op.emitOpError("i8 input requires i32 or i8 output");
   if ((aElem.isFloat8E4M3FNUZ() || aElem.isFloat8E5M2FNUZ()) && !cElem.isF32())
     return op.emitOpError("8-bit float input requires f32 output");
 

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -697,9 +697,8 @@ LogicalResult GemmOp::verify() {
   ShapedType typeA = getA().getType(), typeB = getB().getType(),
              typeC = getC().getType();
   Type inElems = typeA.getElementType(), outElems = typeC.getElementType();
-  if (inElems.isa<IntegerType>() &&
-      !(outElems.isInteger(32) || outElems.isInteger(8)))
-    return emitOpError("integer-valued multiply must have i32 as its result");
+  // The integer gemm will produce i32 and then truncate/extend to the requested
+  // iN e.g. i8.
   if (inElems.isa<FloatType>() && !outElems.isa<FloatType>())
     return emitOpError(
         "float-valued inputs must have a floating-point output type");

--- a/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
@@ -557,16 +557,17 @@ extern "C" void mcpuVerifyFloat(float *gpuAllocated, float *gpuAligned,
 // Compare the results in int32
 template <typename GPUTYPE, typename VALTYPE>
 void mcpuVerifyInt(GPUTYPE *gpuAligned, VALTYPE *valAligned, int64_t dataSize,
-                   int64_t MIN, int64_t MAX, char printDebug) {
+                   char printDebug) {
   int64_t failure_count = 0;  // the number of incorrect elements
   int64_t overflow_count = 0; // the number of overflow elements
   int64_t maxAbsDiff = 0;
-
+  int64_t max = std::numeric_limits<GPUTYPE>::max();
+  int64_t min = std::numeric_limits<GPUTYPE>::min();
   PrintOption print_option = static_cast<PrintOption>(printDebug);
   for (int64_t i = 0; i < dataSize; ++i) {
     int64_t valNum = static_cast<int64_t>(valAligned[i]);
     int32_t gpuNum = gpuAligned[i];
-    if (valNum > MAX || valNum < MIN) {
+    if (valNum > max || valNum < min) {
       overflow_count++;
       if (print_option == PrintOption::Always)
         printf("overflow at element : %ld, gpu=%d, val=%ld\n", i, gpuNum,
@@ -609,16 +610,15 @@ void mcpuVerifyInt(GPUTYPE *gpuAligned, VALTYPE *valAligned, int64_t dataSize,
   return;
 }
 
-extern "C" void mcpuVerifyInt32(int32_t *gpuAllocated, int32_t *gpuAligned,
-                                int64_t gpuOffset, int64_t gpuSize,
-                                int64_t gpuStride, int32_t *valAllocated,
-                                int32_t *valAligned, int32_t valOffset,
-                                int64_t valSize, int64_t valStride,
-                                char printDebug) {
+extern "C" void mcpuVerifyInt32Int32(int32_t *gpuAllocated, int32_t *gpuAligned,
+                                     int64_t gpuOffset, int64_t gpuSize,
+                                     int64_t gpuStride, int32_t *valAllocated,
+                                     int32_t *valAligned, int32_t valOffset,
+                                     int64_t valSize, int64_t valStride,
+                                     char printDebug) {
 
   assert(gpuSize == valSize);
-  mcpuVerifyInt<int32_t, int32_t>(gpuAligned, valAligned, valSize, INT32_MAX,
-                                  INT32_MIN, printDebug);
+  mcpuVerifyInt<int32_t, int32_t>(gpuAligned, valAligned, valSize, printDebug);
 }
 
 extern "C" void mcpuVerifyInt32Int64(int32_t *gpuAllocated, int32_t *gpuAligned,
@@ -629,8 +629,7 @@ extern "C" void mcpuVerifyInt32Int64(int32_t *gpuAllocated, int32_t *gpuAligned,
                                      char printDebug) {
 
   assert(gpuSize == valSize);
-  mcpuVerifyInt<int32_t, int64_t>(gpuAligned, valAligned, valSize, INT32_MAX,
-                                  INT32_MIN, printDebug);
+  mcpuVerifyInt<int32_t, int64_t>(gpuAligned, valAligned, valSize, printDebug);
 }
 
 extern "C" void mcpuVerifyInt8Int64(int8_t *gpuAllocated, int8_t *gpuAligned,
@@ -641,8 +640,7 @@ extern "C" void mcpuVerifyInt8Int64(int8_t *gpuAllocated, int8_t *gpuAligned,
                                     char printDebug) {
 
   assert(gpuSize == valSize);
-  mcpuVerifyInt<int8_t, int64_t>(gpuAligned, valAligned, valSize, INT8_MAX,
-                                 INT8_MIN, printDebug);
+  mcpuVerifyInt<int8_t, int64_t>(gpuAligned, valAligned, valSize, printDebug);
 }
 
 template <typename T>
@@ -686,12 +684,12 @@ void mcpuVerifyNaive(T *gpuAligned, T *valAligned, int64_t dataSize,
   return;
 }
 
-extern "C" void mcpuVerifyInt8(int8_t *gpuAllocated, int8_t *gpuAligned,
-                               int64_t gpuOffset, int64_t gpuSize,
-                               int64_t gpuStride, int8_t *valAllocated,
-                               int8_t *valAligned, int32_t valOffset,
-                               int64_t valSize, int64_t valStride,
-                               char printDebug) {
+extern "C" void mcpuVerifyInt8Int8(int8_t *gpuAllocated, int8_t *gpuAligned,
+                                   int64_t gpuOffset, int64_t gpuSize,
+                                   int64_t gpuStride, int8_t *valAllocated,
+                                   int8_t *valAligned, int32_t valOffset,
+                                   int64_t valSize, int64_t valStride,
+                                   char printDebug) {
 
   assert(gpuSize == valSize);
   mcpuVerifyNaive(gpuAligned, valAligned, valSize, printDebug);

--- a/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
@@ -555,9 +555,9 @@ extern "C" void mcpuVerifyFloat(float *gpuAllocated, float *gpuAligned,
 }
 
 // Compare the results in int32
-template <typename VALTYPE>
-void mcpuVerifyInt(int32_t *gpuAligned, VALTYPE *valAligned, int64_t dataSize,
-                   char printDebug) {
+template <typename GPUTYPE, typename VALTYPE>
+void mcpuVerifyInt(GPUTYPE *gpuAligned, VALTYPE *valAligned, int64_t dataSize,
+                   int64_t MIN, int64_t MAX, char printDebug) {
   int64_t failure_count = 0;  // the number of incorrect elements
   int64_t overflow_count = 0; // the number of overflow elements
   int64_t maxAbsDiff = 0;
@@ -566,7 +566,7 @@ void mcpuVerifyInt(int32_t *gpuAligned, VALTYPE *valAligned, int64_t dataSize,
   for (int64_t i = 0; i < dataSize; ++i) {
     int64_t valNum = static_cast<int64_t>(valAligned[i]);
     int32_t gpuNum = gpuAligned[i];
-    if (valNum > INT32_MAX || valNum < INT32_MIN) {
+    if (valNum > MAX || valNum < MIN) {
       overflow_count++;
       if (print_option == PrintOption::Always)
         printf("overflow at element : %ld, gpu=%d, val=%ld\n", i, gpuNum,
@@ -617,7 +617,8 @@ extern "C" void mcpuVerifyInt32(int32_t *gpuAllocated, int32_t *gpuAligned,
                                 char printDebug) {
 
   assert(gpuSize == valSize);
-  mcpuVerifyInt<int32_t>(gpuAligned, valAligned, valSize, printDebug);
+  mcpuVerifyInt<int32_t, int32_t>(gpuAligned, valAligned, valSize, INT32_MAX,
+                                  INT32_MIN, printDebug);
 }
 
 extern "C" void mcpuVerifyInt32Int64(int32_t *gpuAllocated, int32_t *gpuAligned,
@@ -628,7 +629,20 @@ extern "C" void mcpuVerifyInt32Int64(int32_t *gpuAllocated, int32_t *gpuAligned,
                                      char printDebug) {
 
   assert(gpuSize == valSize);
-  mcpuVerifyInt<int64_t>(gpuAligned, valAligned, valSize, printDebug);
+  mcpuVerifyInt<int32_t, int64_t>(gpuAligned, valAligned, valSize, INT32_MAX,
+                                  INT32_MIN, printDebug);
+}
+
+extern "C" void mcpuVerifyInt8Int64(int8_t *gpuAllocated, int8_t *gpuAligned,
+                                    int64_t gpuOffset, int64_t gpuSize,
+                                    int64_t gpuStride, int64_t *valAllocated,
+                                    int64_t *valAligned, int64_t valOffset,
+                                    int64_t valSize, int64_t valStride,
+                                    char printDebug) {
+
+  assert(gpuSize == valSize);
+  mcpuVerifyInt<int8_t, int64_t>(gpuAligned, valAligned, valSize, INT8_MAX,
+                                 INT8_MIN, printDebug);
 }
 
 template <typename T>

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2129,11 +2129,6 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
   // relDiff 100.0f for f16, i.e. maxRelDiff metric is disabled for f16
   // datatypes
   //         0.000001f for other data types
-  //  auto thr_RMS = getF32Val(RMSThreshold.getValue());
-  //  auto thr_absDiff = getF32Val(absDiffThreshold.getValue());
-  //  Value thr_relDiff = getF32Val(relDiffThreshold.getValue());
-  //  if (testOutType.isF16())
-  //    thr_relDiff = getF32Val(100.0f);
   char printDebug = static_cast<char>(printVerifyResults.getValue());
 
   auto printDebugVal =
@@ -2759,7 +2754,7 @@ static ModuleOp generateKernel(MLIRContext *context, GenParams &genParams,
       exit(1);
     }
     genParams.dtype = conv2dGenerator.getDataType(builder);
-    genParams.dtype = conv2dGenerator.getOutputDataType(builder);
+    genParams.outDType = conv2dGenerator.getOutputDataType(builder);
     const auto *convConfig = &conv2dGenerator.getConfig();
     genParams.convConfig = convConfig;
     genParams.features = convConfig->features;

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -574,7 +574,6 @@ class GemmConfiguration(PerfConfiguration):
         n = None
         transA = None
         transB = None
-
         for i in range(0, len(argv), 2):
             opt = argv[i]
             val = argv[i + 1]

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -326,7 +326,8 @@ class ConvConfiguration(PerfConfiguration):
                            '--padding_h', str(self.paddingH),
                            '--padding_w', str(self.paddingW),
                            '--kernel-repeats', str(self.MLIR_N_REPEATS),
-                           f"--perf_config={self.perfConfig} "])
+                           f"--perf_config={self.perfConfig}"])
+        result += ' '
         if rocmlir_gen_flags != '':
             result += ' '.join(rocmlir_gen_flags.split())
         return result
@@ -558,8 +559,9 @@ class GemmConfiguration(PerfConfiguration):
                            f"-transA={self.transA}",
                            f"-transB={self.transB}",
                            '--kernel-repeats', str(self.MLIR_N_REPEATS),
-                           f"--perf_config={self.perfConfig} "])
+                           f"--perf_config={self.perfConfig}"])
 
+        result += ' '
         if rocmlir_gen_flags != '':
             result += ' '.join(rocmlir_gen_flags.split())
         return result


### PR DESCRIPTION
The rocmlir-gen option --out_datatype specifies the datatype of output tensors. Currently only int8 is allowed for int8 conv and gemm. 

This feature is added to get compatible performances with CK as stated in [issue#855](https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/855).