### PR TITLE
Adding migraphx quant-dot op support

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -433,17 +433,29 @@ def MIGraphX_MultiBroadcastOp :
   let assemblyFormat = "`(`$input`)` attr-dict `:` `(`type($input)`)` `->` type($output)";
 }
 
-def MIGraphX_DotOp :
-    MIGraphX_Op<"dot">,
-    Arguments<(ins AnyRankedTensor:$in_a,
-                   AnyRankedTensor:$in_b
+class MIGraphX_DotOpBase<string mnemonic, list<Type> inputTypes=[], list<Type> outputTypes=[]> :
+    MIGraphX_Op<mnemonic>,
+    Arguments<(ins TensorOf<inputTypes>:$in_a,
+                   TensorOf<inputTypes>:$in_b
                    )>,
-	Results<(outs AnyRankedTensor:$output)> {
-  let summary = "Broadcast tensor in multiple dimensions";
+	Results<(outs TensorOf<outputTypes>:$output)> {
+  let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
+}
+
+def MIGraphX_QuantDotOp :
+    MIGraphX_DotOpBase<"quant_dot", [I8], [I32]>{
+  let summary = "Dot product of quantized tensors";
   let description = [{
-    The `migraphx.dot` op.
+    The `migraphx.quant_dot` op computes the dot product of two tensors.
   }];
-  let assemblyFormat = "`(` operands `)` attr-dict `:` type(operands) `->` type(results)";
+}
+
+def MIGraphX_DotOp :
+    MIGraphX_DotOpBase<"dot", [F32, F16, BF16], [F32, F16, BF16]>{
+  let summary = "Dot product of tensors";
+  let description = [{
+    The `migraphx.dot` op computes the dot product of two tensors.
+  }];
 }
 
 def MIGraphX_ConstantOp :

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -124,8 +124,7 @@ public:
     auto input_t = op.getInput();
     auto filter_t = op.getFilter();
     auto results = op->getResults();
-    auto elementTy =
-        input_t.getType().template cast<ShapedType>().getElementType();
+    auto elementTy = input_t.getType().getElementType();
     auto outputTy = results[0].getType().template cast<ShapedType>();
     SmallVector<int64_t> NCHW2NHWC{0, 2, 3, 1};
     SmallVector<int64_t> NHWC2NCHW{0, 3, 1, 2};
@@ -177,9 +176,9 @@ public:
                             {padTop, padBottom, padLeft, padRight}));
 
     // Convert optional attributes
-    if (auto attr = op->getAttr("xdlopsV2"))
+    if (auto attr = (*op).template getAttrOfType<BoolAttr>("xdlopsV2"))
       cop->setAttr("xdlopsV2", attr.template cast<BoolAttr>());
-    if (auto attr = op->getAttr("perf_config"))
+    if (auto attr = (*op).template getAttrOfType<BoolAttr>("perf_config"))
       cop->setAttr("perf_config", attr.template cast<StringAttr>());
 
     // Note: For TOSA convolution, a non-float type is considered as a
@@ -298,9 +297,8 @@ public:
     TypedValue<TensorType> in_A = op.getInA();
     TypedValue<TensorType> in_B = op.getInB();
     auto results = op->getResults();
-    auto elementTy =
-        in_A.getType().template cast<ShapedType>().getElementType();
-    ShapedType outputTy = results[0].getType().template cast<ShapedType>();
+    auto elementTy = in_A.getType().getElementType();
+    ShapedType outputTy = results[0].getType();
 
     // check batch dimension. Tosa matmul only allow a single dimension for it,
     // add reshape ops to flatten and restore the original dimension.
@@ -364,10 +362,10 @@ public:
     auto mop = rewriter.create<tosa::MatMulOp>(loc, newOutType, in_A, in_B);
 
     // Convert optional attributes
-    if (auto attr = op->getAttr("xdlopsV2"))
-      mop->setAttr("xdlopsV2", attr.template cast<BoolAttr>());
-    if (auto attr = op->getAttr("perf_config"))
-      mop->setAttr("perf_config", attr.template cast<StringAttr>());
+    if (auto attr = (*op).template getAttrOfType<BoolAttr>("xdlopsV2"))
+      mop->setAttr("xdlopsV2", attr);
+    if (auto attr = (*op).template getAttrOfType<BoolAttr>("perf_config"))
+      mop->setAttr("perf_config", attr);
 
     // Note: For TOSA matmul, a non-float type is considered as a
     // quantized convolution. For quantized convolution, it is required

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -177,9 +177,9 @@ public:
 
     // Convert optional attributes
     if (auto attr = (*op).template getAttrOfType<BoolAttr>("xdlopsV2"))
-      cop->setAttr("xdlopsV2", attr.template cast<BoolAttr>());
-    if (auto attr = (*op).template getAttrOfType<BoolAttr>("perf_config"))
-      cop->setAttr("perf_config", attr.template cast<StringAttr>());
+      cop->setAttr("xdlopsV2", attr);
+    if (auto attr = (*op).template getAttrOfType<StringAttr>("perf_config"))
+      cop->setAttr("perf_config", attr);
 
     // Note: For TOSA convolution, a non-float type is considered as a
     // quantized convolution. For quantized convolution, it is required
@@ -364,7 +364,7 @@ public:
     // Convert optional attributes
     if (auto attr = (*op).template getAttrOfType<BoolAttr>("xdlopsV2"))
       mop->setAttr("xdlopsV2", attr);
-    if (auto attr = (*op).template getAttrOfType<BoolAttr>("perf_config"))
+    if (auto attr = (*op).template getAttrOfType<StringAttr>("perf_config"))
       mop->setAttr("perf_config", attr);
 
     // Note: For TOSA matmul, a non-float type is considered as a

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -285,25 +285,28 @@ public:
   }
 };
 
-class DotConverter final : public OpConversionPattern<migraphx::DotOp> {
+template <typename DotType>
+class DotConverter final : public OpConversionPattern<DotType> {
 public:
-  using OpConversionPattern<migraphx::DotOp>::OpConversionPattern;
+  using OpConversionPattern<DotType>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(migraphx::DotOp op, OpAdaptor adaptor,
+  matchAndRewrite(DotType op,
+                  typename OpConversionPattern<DotType>::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
     TypedValue<TensorType> in_A = op.getInA();
     TypedValue<TensorType> in_B = op.getInB();
     auto results = op->getResults();
     auto elementTy =
-        op->getOperand(0).getType().cast<ShapedType>().getElementType();
-    ShapedType outputTy = results[0].getType().cast<ShapedType>();
+        in_A.getType().template cast<ShapedType>().getElementType();
+    ShapedType outputTy = results[0].getType().template cast<ShapedType>();
 
     // check batch dimension. Tosa matmul only allow a single dimension for it,
     // add reshape ops to flatten and restore the original dimension.
     ArrayRef<int64_t> orgOutDims = outputTy.getShape();
-    RankedTensorType newOutType = RankedTensorType::get(orgOutDims, elementTy);
+    RankedTensorType newOutType =
+        RankedTensorType::get(orgOutDims, outputTy.getElementType());
     size_t outRank = orgOutDims.size();
     ArrayRef<int64_t> orgDimsA = in_A.getType().getShape();
     ArrayRef<int64_t> orgDimsB = in_B.getType().getShape();
@@ -313,7 +316,7 @@ public:
     // A, B, Out have the same rank. rank=2 assumes batch=1.
     // Here handling special cases.
     if (outRank != 3 || rankA != rankB ||
-        (outRank == 3 && orgDimsA != orgDimsB)) {
+        (outRank == 3 && orgDimsA[0] != orgDimsB[0])) {
       int64_t batchSizeA = 1, batchSizeB = 1, batchSizeC = 1;
       for (size_t i = 0; i < outRank - 2; i++) {
         batchSizeC *= orgOutDims[i];
@@ -347,7 +350,7 @@ public:
       }
       RankedTensorType newAType = RankedTensorType::get(newDimsA, elementTy);
       RankedTensorType newBType = RankedTensorType::get(newDimsB, elementTy);
-      newOutType = RankedTensorType::get(newDimsOut, elementTy);
+      newOutType = RankedTensorType::get(newDimsOut, outputTy.getElementType());
       auto reshapeAOp = rewriter.create<tosa::ReshapeOp>(
           loc, newAType, in_A, rewriter.getDenseI64ArrayAttr(newDimsA));
       auto reshapeBOp = rewriter.create<tosa::ReshapeOp>(
@@ -361,13 +364,27 @@ public:
     auto mop = rewriter.create<tosa::MatMulOp>(loc, newOutType, in_A, in_B);
 
     // Convert optional attributes
-    if (auto attr = op->getAttrOfType<BoolAttr>("xdlopsV2"))
-      mop->setAttr("xdlopsV2", attr);
-    if (auto attr = op->getAttrOfType<StringAttr>("perf_config"))
-      mop->setAttr("perf_config", attr);
+    if (auto attr = op->getAttr("xdlopsV2"))
+      mop->setAttr("xdlopsV2", attr.template cast<BoolAttr>());
+    if (auto attr = op->getAttr("perf_config"))
+      mop->setAttr("perf_config", attr.template cast<StringAttr>());
+
+    // Note: For TOSA matmul, a non-float type is considered as a
+    // quantized convolution. For quantized convolution, it is required
+    // to carry the "quantization_info" as attribute. Adding this
+    // attribute help us populate the correct TOSA IR.
+    //
+    // When we add support to quantized types and TOSA.rescale Op, we
+    // should make the quantized attribute to accept actual zero point
+    // values from intput and filter.
+    if (elementTy.isInteger(8)) {
+      auto quantAttr = rewriter.getAttr<tosa::MatMulOpQuantizationAttr>(
+          /*a_zp =*/0, /*b_zp =*/0);
+      mop->setAttr("quantization_info", quantAttr);
+    }
 
     if (outRank != 3 || rankA != rankB ||
-        (outRank == 3 && orgDimsA != orgDimsB)) {
+        (outRank == 3 && orgDimsA[0] != orgDimsB[0])) {
       auto rop = rewriter.create<tosa::ReshapeOp>(
           loc, outputTy, mop, rewriter.getDenseI64ArrayAttr(orgOutDims));
       rewriter.replaceOp(op, {rop});
@@ -635,7 +652,8 @@ void migraphx::populateMIGraphXToTosaConversionPatterns(
     MLIRContext *context, RewritePatternSet &patterns) {
   patterns.add<ConvConverter<ConvolutionOp>, ConvConverter<QuantConvolutionOp>,
                BroadcastConverter, MultiBroadcastConverter, ReshapeConverter,
-               SoftmaxConverter, DotConverter, ReduceMeanConverter,
-               QuantizeLinearConverter, DeQuantizeLinearConverter,
-               SliceConverter, DivConverter, ErfConverter>(context);
+               SoftmaxConverter, DotConverter<DotOp>, DotConverter<QuantDotOp>,
+               ReduceMeanConverter, QuantizeLinearConverter,
+               DeQuantizeLinearConverter, SliceConverter, DivConverter,
+               ErfConverter>(context);
 }

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -50,7 +50,9 @@ module  {
 }
 
   // CHECK-LABEL: func.func @matmul
+  // CHECK-NOT: tosa.reshape
   // CHECK: tosa.matmul
+  // CHECK-NOT: tosa.reshape
   func.func @matmul(%arg0: tensor<2x256x384xf32>, %arg1: tensor<2x384x768xf32>) -> tensor<2x256x768xf32> {
     %0 = migraphx.dot(%arg0, %arg1) : (tensor<2x256x384xf32>, tensor<2x384x768xf32>) -> tensor<2x256x768xf32>
      return %0 : tensor<2x256x768xf32>
@@ -225,16 +227,6 @@ module  {
     %0 = migraphx.dot(%arg0, %arg1) : (tensor<1x5x4xf32>, tensor<1x4x3xf32>) -> tensor<1x5x3xf32>
     %2 = "migraphx.mul"(%0, %arg2) {} : (tensor<1x5x3xf32>, tensor<1x5x3xf32>)-> tensor<1x5x3xf32>
     return %2 : tensor<1x5x3xf32>
-  }
-
-  // CHECK-LABEL: func.func @func_mul_bcast
-  // CHECK: tosa.reshape{{.*}}1x10x4
-  // CHECK: tosa.reshape{{.*}}1x4x3
-  // CHECK: tosa.matmul
-  // CHECK: tosa.reshape{{.*}}2x5x3
-  func.func @func_mul_bcast(%arg0: tensor<2x5x4xf32>, %arg1: tensor<1x4x3xf32>, %arg2: tensor<2x5x3xf32>) -> tensor<2x5x3xf32> attributes{kernel, arch = ""} {
-    %0 = migraphx.dot(%arg0, %arg1) : (tensor<2x5x4xf32>, tensor<1x4x3xf32>) -> tensor<2x5x3xf32>
-    return %0 : tensor<2x5x3xf32>
   }
 
   // CHECK-LABEL: func.func @func_slice1

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -227,6 +227,16 @@ module  {
     return %2 : tensor<1x5x3xf32>
   }
 
+  // CHECK-LABEL: func.func @func_mul_bcast
+  // CHECK: tosa.reshape{{.*}}1x10x4
+  // CHECK: tosa.reshape{{.*}}1x4x3
+  // CHECK: tosa.matmul
+  // CHECK: tosa.reshape{{.*}}2x5x3
+  func.func @func_mul_bcast(%arg0: tensor<2x5x4xf32>, %arg1: tensor<1x4x3xf32>, %arg2: tensor<2x5x3xf32>) -> tensor<2x5x3xf32> attributes{kernel, arch = ""} {
+    %0 = migraphx.dot(%arg0, %arg1) : (tensor<2x5x4xf32>, tensor<1x4x3xf32>) -> tensor<2x5x3xf32>
+    return %0 : tensor<2x5x3xf32>
+  }
+
   // CHECK-LABEL: func.func @func_slice1
   // CHECK: tosa.slice
   func.func @func_slice1(%arg0: tensor<1x36x384x64xf32>) -> tensor<1x12x384x64xf32> attributes{kernel, arch = ""} {

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-matmul.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-matmul.mlir
@@ -12,6 +12,16 @@ func.func @test_basic(%a: tensor<2x128x64xf32>, %b: tensor<2x64x256xf32>) -> ten
   return %c : tensor<2x128x256xf32>
 }
 
+// CHECK: @test_quant
+// CHECK-SAME: (%[[a:.*]]: tensor<2x128x64xi8>, %[[b:.*]]: tensor<2x64x256xi8>)
+func.func @test_quant(%a: tensor<2x128x64xi8>, %b: tensor<2x64x256xi8>) -> tensor<2x128x256xi32> attributes {kernel} {
+  // CHECK: %[[out:.*]] = bufferization.alloc_tensor{{.*}} tensor<2x128x256xi32>
+  // CHECK: %[[res:.*]] = rock.gemm %[[out]] = %[[a]] * %[[b]]
+  // CHECK: return %[[res]] : tensor<2x128x256xi32>
+  %c = "tosa.matmul"(%a, %b) {quantizeation_info =#tosa.matmul_quant<a_zp = 0, b_zp = 0>} : (tensor<2x128x64xi8>, tensor<2x64x256xi8>) -> tensor<2x128x256xi32>
+  return %c : tensor<2x128x256xi32>
+}
+
 // CHECK: @test_transpose
 // CHECK-SAME: (%[[a:.*]]: tensor<2x64x128xf32>, %[[b:.*]]: tensor<2x64x256xf32>)
 func.func @test_transpose(%a: tensor<2x64x128xf32>, %b: tensor<2x64x256xf32>) -> tensor<2x256x128xf32> attributes {kernel} {

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-inlined-const.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-inlined-const.mlir
@@ -7,7 +7,7 @@ module {
     %0 = "tosa.const"() {value = dense<1.250000e-01> : tensor<1xf32>} : () -> tensor<1xf32>
     %1 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1x1x1x1xf32>) -> tensor<1x12x384x384xf32>
     %2 = migraphx.transpose(%arg2) {permutation = [0, 1, 3, 2]} : (tensor<1x12x384x64xf32>) -> tensor<1x12x64x384xf32>
-    %3 = migraphx.dot(%arg1, %2) : tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32> -> tensor<1x12x384x384xf32>
+    %3 = migraphx.dot(%arg1, %2) : (tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32>) -> tensor<1x12x384x384xf32>
     %4 = migraphx.multibroadcast(%0) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1xf32>) -> tensor<1x12x384x384xf32>
     %5 = migraphx.mul(%3, %4) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
     %6 = migraphx.add(%5, %1) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast-tp.e2e.mlir
@@ -6,7 +6,7 @@ module {
   func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x4x3xf32>) -> tensor<1x2x4xf32> attributes{kernel, arch = ""} {
     %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 2, 3]} : (tensor<1x1x1xf32>) -> tensor<1x2x3xf32>
     %arg2tp = migraphx.transpose(%arg2) {permutation = [0:i64, 2:i64, 1:i64]} : (tensor<1x4x3xf32>)-> tensor<1x3x4xf32>
-    %1 = migraphx.dot(%0, %arg2tp) : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
+    %1 = migraphx.dot(%0, %arg2tp) : (tensor<1x2x3xf32>, tensor<1x3x4xf32>) -> tensor<1x2x4xf32>
     %2 = migraphx.add(%1, %arg0) : (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
     return %2 : tensor<1x2x4xf32>
   }

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-input-bcast.e2e.mlir
@@ -5,7 +5,7 @@ module {
   // CHECK-NEXT:   [4, 4, 4, 4]{{.*}}
   func.func @mlir_dot(%arg0: tensor<1x2x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1x3x4xf32>) -> tensor<1x2x4xf32> attributes{kernel, arch = ""} {
     %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 2, 3]} : (tensor<1x1x1xf32>) -> tensor<1x2x3xf32>
-    %1 = migraphx.dot(%0, %arg2) : tensor<1x2x3xf32>, tensor<1x3x4xf32> -> tensor<1x2x4xf32>
+    %1 = migraphx.dot(%0, %arg2) : (tensor<1x2x3xf32>, tensor<1x3x4xf32>) -> tensor<1x2x4xf32>
     %2 = migraphx.add(%1, %arg0) : (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
     return %2 : tensor<1x2x4xf32>
   }

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-mbcast-mul-add.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-mbcast-mul-add.mlir
@@ -8,7 +8,7 @@ func.func @mlir_dot(%arg0: tensor<1x1x1x1xf32>, %arg1: tensor<1x1x1x1xf32>, %arg
     %0 = migraphx.multibroadcast(%arg1) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1x1x1x1xf32>) -> tensor<1x12x384x384xf32>
     %1 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1x1x1x1xf32>) -> tensor<1x12x384x384xf32>
     %2 = migraphx.transpose(%arg3) {permutation = [0, 1, 3, 2]} : (tensor<1x12x384x64xf32>) -> tensor<1x12x64x384xf32>
-    %3 = migraphx.dot(%arg2, %2) : tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32> -> tensor<1x12x384x384xf32>
+    %3 = migraphx.dot(%arg2, %2) : (tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32>) -> tensor<1x12x384x384xf32>
     %4 = migraphx.mul(%3, %1) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
     %5 = migraphx.add(%4, %0) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
     return %5 : tensor<1x12x384x384xf32>

--- a/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case1-quant.e2e.mlir
+++ b/mlir/test/fusion/e2e/mixr-gemm/mixr-gemm-reshape-case1-quant.e2e.mlir
@@ -1,0 +1,14 @@
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut quant_dot --verifier clone - | rocmlir-driver -host-pipeline xmodel,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+
+module {
+  // CHECK:  [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+  func.func @quant_dot(%arg0: tensor<1x5x4xi8>, %arg1: tensor<1x4x3xi8>) -> tensor<1x15xi32> attributes{kernel, arch = ""} {
+    %0 = migraphx.quant_dot(%arg0, %arg1) : (tensor<1x5x4xi8>, tensor<1x4x3xi8>) -> tensor<1x5x3xi32>
+    %1 = migraphx.reshape(%0) {dims = [1:i64, 15:i64]} : (tensor<1x5x3xi32>)-> tensor<1x15xi32>
+    return %1 : tensor<1x15xi32>
+  }
+}

--- a/mlir/test/fusion/e2e/mixr-slice-dot.mlir
+++ b/mlir/test/fusion/e2e/mixr-slice-dot.mlir
@@ -13,7 +13,7 @@ module {
     %6 = migraphx.transpose(%5) {permutation = [0, 2, 1, 3]} : (tensor<1x384x36x64xf32>) -> tensor<1x36x384x64xf32>
     %7 = migraphx.slice(%6) {axes = [1], ends = [24], starts = [12]} : (tensor<1x36x384x64xf32>) -> tensor<1x12x384x64xf32>
     %8 = migraphx.transpose(%7) {permutation = [0, 1, 3, 2]} : (tensor<1x12x384x64xf32>) -> tensor<1x12x64x384xf32>
-    %9 = migraphx.dot(%4, %8) : tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32> -> tensor<1x12x384x384xf32>
+    %9 = migraphx.dot(%4, %8) : (tensor<1x12x384x64xf32>, tensor<1x12x64x384xf32>) -> tensor<1x12x384x384xf32>
     %10 = migraphx.multibroadcast(%0) {out_dyn_dims = [], out_lens = [1, 12, 384, 384]} : (tensor<1xf32>) -> tensor<1x12x384x384xf32>
     %11 = migraphx.mul(%9, %10) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>
     %12 = migraphx.add(%11, %1) : (tensor<1x12x384x384xf32>, tensor<1x12x384x384xf32>) -> tensor<1x12x384x384xf32>

--- a/mlir/test/fusion/e2e/mixr-tp-reshape-dot-add.mlir
+++ b/mlir/test/fusion/e2e/mixr-tp-reshape-dot-add.mlir
@@ -7,7 +7,7 @@ module {
     %0 = migraphx.multibroadcast(%arg2) {out_dyn_dims = [], out_lens = [1, 768, 768]} : (tensor<1x768x768xf32>) -> tensor<1x768x768xf32>
     %1 = migraphx.transpose(%arg1) {permutation = [0, 2, 1, 3]} : (tensor<1x12x384x64xf32>) -> tensor<1x384x12x64xf32>
     %2 = migraphx.reshape(%1) {dims = [1, 384, 768]} : (tensor<1x384x12x64xf32>) -> tensor<1x384x768xf32>
-    %3 = migraphx.dot(%2, %0) : tensor<1x384x768xf32>, tensor<1x768x768xf32> -> tensor<1x384x768xf32>
+    %3 = migraphx.dot(%2, %0) : (tensor<1x384x768xf32>, tensor<1x768x768xf32>) -> tensor<1x384x768xf32>
     %4 = migraphx.add(%3, %arg0) : (tensor<1x384x768xf32>, tensor<1x384x768xf32>) -> tensor<1x384x768xf32>
     return %4 : tensor<1x384x768xf32>
   }


### PR DESCRIPTION
This PR adds support for `migraphx.quant_dot` and its lowering. With it, migraphx kernel is able to do `rock.gemm()` computation on int8 type.

This PR does the following:
 - Abstracted the dot op into a common base: MIGraphX_DotOpBase
 - A number of bug fixes in the dot op lowering to enabling i8 support
 - Conversion tests and end to end tests