### PR TITLE
[CI] bump to rocm 5.5

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:20.04
 MAINTAINER Zhuoran Yin <zhuoran.yin@amd.com>
 
-ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/5.4.2/
+ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/5.5/
 ARG ROCM_BUILD_NAME=focal
 ARG ROCM_BUILD_NUM=main
-ARG ROCM_PATH=/opt/rocm-5.4.2
+ARG ROCM_PATH=/opt/rocm-5.5
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
This commit bumps rocm version to 5.5.
The migraphx-ci docker file updarte will
follow once this image is built.

Plan : 
* This PR to update Dockerfile
* Next PR to update Dockerfile.migraphx-ci
* Future PR to update Jenkins once images are built