### PR TITLE
[CI] fix build dockerfile script version extraction

### DIFF
--- a/mlir/utils/jenkins/build-dockerfile.sh
+++ b/mlir/utils/jenkins/build-dockerfile.sh
@@ -39,9 +39,11 @@ build_rocm_image() {
     image_name_wo_tag="$docker_repository-$image_name_suffix"
   fi
 
-  local rocm_full_version rocm_short_version git_commit_hash
+  local rocm_full_version rocm_short_version git_commit_hash rocm_major_version rocm_minor_version
   rocm_full_version=$(grep "ROCM_PATH" ./mlir/utils/jenkins/$docker_file | sed 's/.*-\([0-9][0-9]*[.][0-9][0-9.]*\)/\1/')
-  rocm_short_version="rocm${rocm_full_version%.*}"
+  rocm_major_version=$(echo ${rocm_full_version} | cut -d. -f1)
+  rocm_minor_version=$(echo ${rocm_full_version} | cut -d. -f2)
+  rocm_short_version="${rocm_major_version}.${rocm_minor_version}"
   git_commit_hash=$(git rev-parse --short HEAD)
 
   # Example: rocm/mlir:rocm3.7-38337614c80


### PR DESCRIPTION
Current build-dockerfile.sh assumes the rocm version to be 3 digit figure which is not the case always
(e.g. rocm-5.5).

This commit fixes this to extract major and minor
versions looking from the left rather and dropping the last digit.