### PR TITLE
[DO NOT MERGE] Rename and enhance threadwise_read_into to threadwise_memcpy

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -904,57 +904,102 @@ def Rock_GlobalStoreOp :
   }];
 }
 
-// threadwise_read_into
-def Rock_ThreadwiseReadIntoOp :
-    Rock_Op<"threadwise_read_into">,
+def Rock_ThreadwiseMemCpyOp :
+    Rock_Op<"threadwise_memcpy">,
     AllElementTypesMatch<["source", "dest"]>,
     Arguments<(ins Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemRead]>:$source,
       Arg<MemRefRankOf<SupportedMemoryElems, [1]>,
         "destination registers", [MemWrite]>:$dest,
-      TransformMapArrayAttr:$extraViews,
+      OptionalAttr<TransformMapArrayAttr>:$extraSrcViews,
+      OptionalAttr<TransformMapArrayAttr>:$extraDstViews,
       UnitAttr:$forceUnroll,
       UnitAttr:$useIndexDiffs
     )> {
   let summary = "Read values from transformed source into destination";
 
   let description = [{
-    A high-level representation of a global -> register read loop that
-    accounts for coordinate transformations.
+    A high-level representation of a 
+    1) global -> register or 
+    2) register -> LDS 
+    read loop that accounts for coordinate transformations.
 
-    If `%source = rock.transform #transform_mapN %buffer`
+    Case (1) :
+
+    Let `%source = rock.transform #transform_mapS1 %buffer`
     (with the one transformation representing an entire sequence),
-    and `%buffer` is in global memory, the operation
+    and `%buffer` is in global memory.
+    
+    Let `%dest = rock.transform #transform_mapD1 %regs`
+    (with the one transformation representing an entire sequence),
+    and `%regs` is in registers.
 
     ```mlir
-    rock.threadwise_read_into [#transform_mapM](%source) -> %dest
+    rock.threadwise_memcpy [#transform_mapS2](%source) -> [#transform_mapD2](%dest)
     ```
+
+    `#transform_mapS2` must have the form (workgroup_id, workitem_id, iteration_number)
+    `#transform_mapD2` must have the form (workgroup_id, workitem_id, iteration_number)
+
+    Let SRC_MAPS = [#transform_mapS2, #transform_mapS1]
+    Let DST_MAPS = [#transform_mapD2, #transform_mapD1]
 
     will lower to
     ```mlir
     %bid = rock.workgroup_id
     %tid = rock.workitem_id
     rock.transforming_for
-      (%args, ...) = MAPS(%bid, %tid, %c0)
-      (%_, %_, %i) = [](%c0, %c0, %c0)
+      (%sargs, ...) = SRC_MAPS(%bid, %tid, %c0)
+      (%dargs, ...) = DST_MAPS(%bid, %tid, %c0)
       (%isValid, %isValid) = isValid
       bounds = [1, 1, L], strides = [1, 1, V] {
-        %v = rock.global_load {length = V} %buffer[%args] if %isValid
-        rock.in_bounds_store %v -> %dest[%i]
+        %v = rock.global_load {length = V} %buffer[%sargs] if %isValid
+        rock.in_bounds_store %v -> %dest[%dargs]
     }
     ```
-    where MAPS is `[#transform_mapM, #transform_mapN]`,
-    L is the length of `%dest`, V is the maximum vectorization computed
-    for MAPS.
 
-    The input to extraViews ; (the transforms on %source) must have the form
-    (workgroup_id, workitem_id, iteration_number)
+    extraDestViews(#transform_mapD2) will default to (%bid, %tid, %c0) -> (%c0)
+    to facilitate to common usage of register dests w/o any views on it.
 
-    This is used during fusion to represent loads from addition arguments like
-    bias tensors.
+    Case (2) :
+
+    Let `%source = rock.transform #transform_mapS1 %regs`
+    (with the one transformation representing an entire sequence),
+    and `%regs` are registers.
+
+    Let `%dest = rock.transform #transform_mapD1 %lds`
+    (with the one transformation representing an entire sequence),
+    and `%lds` is in LDS.
+
+    ```mlir
+    rock.threadwise_memcpy [#transform_mapS2](%source) -> [#transform_mapD2](%dest)
+    ```
+
+    `#transform_mapS2` must have the form (workgroup_id, workitem_id, iteration_number)
+    `#transform_mapD2` must have the form (workgroup_id, workitem_id, iteration_number)
+
+    Let SRC_MAPS = [#transform_mapS2, #transform_mapS1]
+    Let DST_MAPS = [#transform_mapD2, #transform_mapD1]
+
+    will lower to
+    ```mlir
+    %bid = rock.workgroup_id
+    %tid = rock.workitem_id
+    rock.transforming_for
+      (%sargs, ...) = SRC_MAPS(%bid, %tid, %c0)
+      (%dargs, ...) = DST_MAPS(%bid, %tid, %c0)
+      bounds = [1, 1, L], strides = [1, 1, V] {
+        %v = rock.in_bounds_load {length = V} %regs[%sargs]
+        rock.in_bounds_store %v -> %lds[%dargs]
+    }
+    ```
+
+    extraSrcViews(#transform_mapS2) will default to (%bid, %tid, %c0) -> (%c0)
+    to facilitate to common usage of register dests w/o any views on it.
+
   }];
 
   let assemblyFormat = [{
-    attr-dict $extraViews `(` $source `)` `->` $dest
+    attr-dict ($extraSrcViews^)? `(` $source `)` `->` ($extraDstViews^)? $dest
     `:` type($source) `->` type($dest)
   }];
   let hasVerifier = 1;

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -908,7 +908,7 @@ def Rock_ThreadwiseMemCpyOp :
     Rock_Op<"threadwise_memcpy">,
     AllElementTypesMatch<["source", "dest"]>,
     Arguments<(ins Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemRead]>:$source,
-      Arg<MemRefRankOf<SupportedMemoryElems, [1]>,
+      Arg<MemRefOf<SupportedMemoryElems>,
         "destination registers", [MemWrite]>:$dest,
       OptionalAttr<TransformMapArrayAttr>:$extraSrcViews,
       OptionalAttr<TransformMapArrayAttr>:$extraDstViews,
@@ -920,7 +920,8 @@ def Rock_ThreadwiseMemCpyOp :
   let description = [{
     A high-level representation of a 
     1) global -> register or 
-    2) register -> LDS 
+    2) register -> LDS
+    3) LDS -> register
     read loop that accounts for coordinate transformations.
 
     Case (1) :
@@ -938,7 +939,7 @@ def Rock_ThreadwiseMemCpyOp :
     ```
 
     `#transform_mapS2` must have the form (workgroup_id, workitem_id, iteration_number)
-    `#transform_mapD2` must have the form (workgroup_id, workitem_id, iteration_number)
+    `#transform_mapD2` must have the form (iteration_number)
 
     Let SRC_MAPS = [#transform_mapS2, #transform_mapS1]
     Let DST_MAPS = [#transform_mapD2, #transform_mapD1]
@@ -960,7 +961,7 @@ def Rock_ThreadwiseMemCpyOp :
     extraDestViews(#transform_mapD2) will default to (%bid, %tid, %c0) -> (%c0)
     to facilitate to common usage of register dests w/o any views on it.
 
-    Case (2) :
+    Case (2) / (3) :
 
     Let `%source = rock.transform #transform_mapS1 %regs`
     (with the one transformation representing an entire sequence),
@@ -974,8 +975,8 @@ def Rock_ThreadwiseMemCpyOp :
     rock.threadwise_memcpy [#transform_mapS2](%source) -> [#transform_mapD2](%dest)
     ```
 
-    `#transform_mapS2` must have the form (workgroup_id, workitem_id, iteration_number)
-    `#transform_mapD2` must have the form (workgroup_id, workitem_id, iteration_number)
+    `#transform_mapS2` must have the form (workitem_id, iteration_number) if LDS or (iteration_number) if regs
+    `#transform_mapD2` must have the form (workitem_id, iteration_number) if LDS or (iteration_number) if regs
 
     Let SRC_MAPS = [#transform_mapS2, #transform_mapS1]
     Let DST_MAPS = [#transform_mapD2, #transform_mapD1]

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -138,9 +138,9 @@ static Value applyTransforms(PatternRewriter &b, ThreadwiseWriteAllOp storeOp,
   src = applyViewsOnDest(b, loc, src, relativeViewsOnStore);
 
   // 2.2. load into registers
-  b.create<ThreadwiseReadIntoOp>(loc, src, alloc, storeOp.getExtraViews(),
-                                 storeOp.getForceUnroll(),
-                                 storeOp.getUseIndexDiffs());
+  b.create<ThreadwiseMemCpyOp>(
+      loc, src, alloc, storeOp.getExtraViews(), /*extraDstViews=*/nullptr,
+      storeOp.getForceUnroll(), storeOp.getUseIndexDiffs());
   return alloc;
 }
 

--- a/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
@@ -6,6 +6,7 @@
 // CHECK-DAG-SAME: [0, 1, 2]
 // CHECK-DAG-SAME: [0, 1, 2]
 // CHECK-DAG: #[[$IN_FUNC:transform_map.+]] = #rock.transform_map
+// CHECK-DAG: #[[$OUT_FUNC:transform_map.+]] = #rock.transform_map
 // CHECK-DAG-SAME: PassThrough
 // CHECK-DAG-SAME: [0, 1]
 // CHECK-DAG-SAME: [0, 1]
@@ -26,7 +27,7 @@ func.func @threadwise_memcpy( %source: memref<2x64x30xf32>, %dest: memref<32xf32
   // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
   // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
   // CHECK-SAME: ([[args:%.+, %.+, %.+]]) = [#[[$ON_OP]], #[[$IN_FUNC]]]([[bid]], [[tid]], [[zero]])
-  // CHECK-SAME: ({{%.*}}, {{%.*}}, [[i:%.+]]) = []([[bid]], [[tid]], [[zero]])
+  // CHECK-SAME: ({{%.*}}, {{%.*}}, [[i:%.+]]) = [#[[$OUT_FUNC]]]([[bid]], [[tid]], [[zero]])
   // CHECK-SAME: ([[valid:%.+]], {{%.*}}) = validity
   // CHECK-SAME: bounds [1, 1, 32]
   // CHECK-SAME: strides [1, 1, 2]

--- a/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
@@ -18,9 +18,9 @@
     <Pad{2, 0} ["z"] at [2] -> ["z"] at [2]>]
   bounds = [2, 64, 32] -> [2, 64, 30]>
 
-// CHECK-LABEL: func @threadwise_read_into
+// CHECK-LABEL: func @threadwise_memcpy
 // CHECK-SAME: [[source:%.+]]: memref<2x64x30xf32>, [[dest:%.+]]: memref<32xf32, #gpu.address_space<private>>
-func.func @threadwise_read_into( %source: memref<2x64x30xf32>, %dest: memref<32xf32, #gpu.address_space<private>>) {
+func.func @threadwise_memcpy( %source: memref<2x64x30xf32>, %dest: memref<32xf32, #gpu.address_space<private>>) {
   // CHECK-DAG: [[zero:%.+]] = arith.constant 0
   // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
   // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
@@ -34,7 +34,7 @@ func.func @threadwise_read_into( %source: memref<2x64x30xf32>, %dest: memref<32x
   // CHECK-NEXT: rock.in_bounds_store [[tmp]] -> [[dest]][[[i]]]
 
   %view = rock.transform %source by #transform_map1 : memref<2x64x30xf32> to memref<2x64x32xf32>
-  rock.threadwise_read_into {forceUnroll, useIndexDiffs}
+  rock.threadwise_memcpy {forceUnroll, useIndexDiffs}
     [#transform_map0](%view) -> %dest
     : memref<2x64x32xf32> -> memref<32xf32, #gpu.address_space<private>>
   func.return

--- a/mlir/test/fusion/e2e/mixr-bcast-add-align-tiling.mlir
+++ b/mlir/test/fusion/e2e/mixr-bcast-add-align-tiling.mlir
@@ -2,7 +2,7 @@
 // ALLOW_RETRIES: 2
 
 module {
-    // CHECK: rock.threadwise_read_into 
+    // CHECK: rock.threadwise_memcpy 
     // CHECK: linalg.generic
     // CHECK: rock.threadwise_write_all
     // CHECK-NOT: memref.copy

--- a/mlir/test/fusion/e2e/mixr-mbcast-add-align-tiling.mlir
+++ b/mlir/test/fusion/e2e/mixr-mbcast-add-align-tiling.mlir
@@ -2,7 +2,7 @@
 // ALLOW_RETRIES: 2
 
 module {
-    // CHECK: rock.threadwise_read_into 
+    // CHECK: rock.threadwise_memcpy 
     // CHECK: linalg.generic
     // CHECK: rock.threadwise_write_all
     // CHECK-NOT: memref.copy

--- a/mlir/test/fusion/e2e/mixr-mbcast-add-relu-align-tiling-collapse-expand-chains.mlir
+++ b/mlir/test/fusion/e2e/mixr-mbcast-add-relu-align-tiling-collapse-expand-chains.mlir
@@ -2,7 +2,7 @@
 // ALLOW_RETRIES: 2
 
 module {
-    // CHECK: rock.threadwise_read_into 
+    // CHECK: rock.threadwise_memcpy 
     // CHECK: linalg.generic
     // CHECK: rock.threadwise_write_all
     // CHECK-NOT: memref.copy

--- a/mlir/test/fusion/e2e/mixr-mbcast-scalar-conv-align-tiling.mlir
+++ b/mlir/test/fusion/e2e/mixr-mbcast-scalar-conv-align-tiling.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-opt -migraphx-to-tosa %s | rocmlir-driver -host-pipeline highlevel | rocmlir-opt -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise -rock-regularize -rock-gridwise-gemm-to-blockwise -rock-linalg-align | FileCheck %s
 // ALLOW_RETRIES: 2
 module {
-  // CHECK: rock.threadwise_read_into 
+  // CHECK: rock.threadwise_memcpy 
   // CHECK: linalg.generic
   // CHECK: rock.threadwise_write_all
   // CHECK-NOT: memref.copy

--- a/mlir/test/fusion/multi-collapse-expand-chains.mlir
+++ b/mlir/test/fusion/multi-collapse-expand-chains.mlir
@@ -7,7 +7,7 @@
 #transform_map1 = #rock.transform_map<#map3 by [<PassThrough ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>, <AddDim{1} ["g"] at [4] -> [] at []>] bounds = [4, 4, 1, 1, 1] -> [4, 4, 1, 1]>
 module {
     // CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<#map{{.*}} by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>] bounds = [4, 4] -> [1, 4]>
-    // CHECK: rock.threadwise_read_into {{.*}}
+    // CHECK: rock.threadwise_memcpy {{.*}}
   func.func @test(%arg0: memref<1x4x1x1xf32>, %arg1: memref<4x3x3x3xf32>, %arg2: memref<4x3x3x3xf32>, %arg3: memref<4x4x1x1xf32>) attributes {arch = "gfx908:sramecc+:xnack-", kernel = "mixr"} {
     %cst = arith.constant 0.000000e+00 : f32
     %cst_0 = arith.constant 3.40282347E+38 : f32

--- a/mlir/test/fusion/tosa-to-rock-gemm-reshape-add.mlir
+++ b/mlir/test/fusion/tosa-to-rock-gemm-reshape-add.mlir
@@ -5,7 +5,7 @@
 // CHECK_LINALG_ALIGN-DAG: #[[MAP1:.*]] = #rock.transform_map<#[[AMAP]] by [<Unmerge{1, 1} ["col0", "col1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 1, 1000] -> [1, 1000]>
 // CHECK_LINALG_ALIGN-DAG: #[[MAP2:.*]] = #rock.transform_map<#[[AMAP1]] by [<Unmerge{1, 1000} ["col0", "col1"] at [0, 1] -> ["dim0"] at [0]>] bounds = [1, 1000] -> [1000]>
 
-// CHECK_LINALG_ALIGN: rock.threadwise_read_into {{.*}} -> [[lain:%.*]] :
+// CHECK_LINALG_ALIGN: rock.threadwise_memcpy {{.*}} -> [[lain:%.*]] :
 // CHECK_LINALG_ALIGN: linalg.generic{{.*}} ins({{.*}}, [[lain]] :{{.*}}) outs(%[[outBuf:.*]] : memref<32xf32, #gpu.address_space<private>>)
 // CHECK_LINALG_ALIGN: rock.threadwise_write_all {{.*}} %[[outBuf]] ->
 // to test reshape is converted as transform and fused.

--- a/mlir/test/fusion/tosa-to-rock-tp-add-tp.mlir
+++ b/mlir/test/fusion/tosa-to-rock-tp-add-tp.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-driver --host-pipeline highlevel %s | rocmlir-opt --rock-affix-params --rock-conv-to-gemm --rock-gemm-to-gridwise -rock-regularize --rock-gridwise-gemm-to-blockwise --rock-linalg-align | FileCheck %s
 
 // CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<{{.*}} by [<PassThrough ["dim0", "dim2", "dim3", "dim1"] at [0, 1, 2, 3] -> ["dim0", "dim2", "dim3", "dim1"] at [0, 2, 3, 1]>] bounds = [256, 28, 28, 64] -> [256, 64, 28, 28]>
-// CHECK: rock.threadwise_read_into {{.*}} -> [[lain:%.*]] :
+// CHECK: rock.threadwise_memcpy {{.*}} -> [[lain:%.*]] :
 // CHECK: linalg.generic{{.*}} ins({{.*}}, [[lain]] :{{.*}}) outs(%[[outBuf:.*]] : memref<64xf32, #gpu.address_space<private>>)
 // CHECK: rock.threadwise_write_all {{.*}} %[[outBuf]] ->
 // to test transpose is converted as transform and fused.

--- a/mlir/test/fusion/tosa-to-rock-tp-add.mlir
+++ b/mlir/test/fusion/tosa-to-rock-tp-add.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-driver --host-pipeline highlevel %s | rocmlir-opt --rock-affix-params --rock-conv-to-gemm --rock-gemm-to-gridwise -rock-regularize --rock-gridwise-gemm-to-blockwise --rock-linalg-align | FileCheck %s
 
 // CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<#map{{.*}} by [<PassThrough ["{{.*}}", "{{.*}}", "{{.*}}", "{{.*}}"] at [0, 1, 2, 3] -> ["{{.*}}", "{{.*}}", "{{.*}}", "{{.*}}"] at [0, 2, 3, 1]>] bounds = [256, 28, 28, 64] -> [256, 64, 28, 28]>
-// CHECK: rock.threadwise_read_into {{.*}} -> [[lain:%.*]] :
+// CHECK: rock.threadwise_memcpy {{.*}} -> [[lain:%.*]] :
 // CHECK: linalg.generic{{.*}} ins({{.*}}, [[lain]] :{{.*}}) outs(%[[outBuf:.*]] : memref<64xf32, #gpu.address_space<private>>)
 // CHECK: rock.threadwise_write_all {{.*}} %[[outBuf]] ->
 // to test transpose is converted as transform and fused.


### PR DESCRIPTION
This is a draft commit (more like to stand as a proposal).

Problem Description :

On my way to implement blockwise_reduction, I encountered that I m needing to write to LDS from regs. I end up creating transforming_for loops for that. However, I think we can benefit from having a dedicated op for that.

We do have threadwise_read_into but it is specific to reading from global memory into registers.

Proposal :

* Rename threadwise_read_into to threadwise_memcpy
* Add support for reading from regs to LDS
* Also add support for views on both source and dest while not requiring them if they are regs.

Alternative :

* We could add threadwise_(somename that I cant think of) that is specifically for regs to LDS, but I felt it shares more things with read_into (subjective).