### PR TITLE
Add Wmma tuning infrastructure

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -45,6 +45,16 @@ void createGemmTuningRangeBF(struct TunableParams *newSpace,
                                                  {1, 4, 8, 16},
                                                  {0, 1}};
 
+  // M/block N/block K/block M/wave N/wave kPack aCopyMore/forceUnroll
+  const std::vector<std::vector<uint32_t>> ValidRangeWmmaGemmParams = {
+      {4, 8, 16, 32, 64, 128, 256},
+      {16, 32, 64, 128, 256},
+      {16, 32},
+      {4, 8, 16, 32, 64, 128},
+      {4, 8, 16, 32, 64, 128},
+      {16},
+      {0, 1}};
+
   OpBuilder b(gemmOp.getContext());
   GemmFeatures currentFeatures = gemmOp.getGemmFeatures();
   if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma)) {
@@ -75,6 +85,29 @@ void createGemmTuningRangeBF(struct TunableParams *newSpace,
         }
       }
     }
+  } else if (bitEnumContainsAll(currentFeatures, GemmFeatures::wmma)) {
+    // Wmma
+    const std::vector<std::vector<uint32_t>> &wmmaParams =
+        ValidRangeWmmaGemmParams;
+    for (uint32_t gemmMPerBlock : wmmaParams[0]) {
+      for (uint32_t gemmNPerBlock : wmmaParams[1]) {
+        for (uint32_t gemmKPerBlock : wmmaParams[2]) {
+          for (uint32_t gemmMPerWave : wmmaParams[3]) {
+            for (uint32_t gemmNPerWave : wmmaParams[4]) {
+              for (uint32_t gemmKPack : wmmaParams[5]) {
+                for (uint32_t forceUnroll : wmmaParams[6]) {
+                  WmmaGemmParamsAttr gemmParams = b.getAttr<WmmaGemmParamsAttr>(
+                      gemmKPerBlock, gemmMPerBlock, gemmNPerBlock, gemmKPack,
+                      gemmMPerWave, gemmNPerWave, forceUnroll);
+                  newSpace->tuningRange.push_back(
+                      gemmParams.cast<RockTuningParamAttrInterface>());
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   } else {
     // Non-XDLOPS
     for (uint32_t blockSize : ValidRangeGeneralGemmParams[0]) {
@@ -83,7 +116,6 @@ void createGemmTuningRangeBF(struct TunableParams *newSpace,
           for (uint32_t gemmKPerBlock : ValidRangeGeneralGemmParams[3]) {
             for (uint32_t gemmMPerThread : ValidRangeGeneralGemmParams[4]) {
               for (uint32_t gemmNPerThread : ValidRangeGeneralGemmParams[5]) {
-
                 GeneralGemmParamsAttr gemmParams =
                     b.getAttr<GeneralGemmParamsAttr>(
                         blockSize, gemmKPerBlock, gemmMPerBlock, gemmNPerBlock,

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -491,7 +491,7 @@ class ConvConfiguration(PerfConfiguration):
             outs, errs = p1.communicate()
         return config.tableEntry(nanoSeconds)
 
-def getGemmConfigurations(fileName):
+def getGemmConfigurations(fileName, dataTypes=DATA_TYPES_GEMM):
     configs = []
     if fileName:
         with open(fileName, 'r') as configFile:
@@ -503,6 +503,8 @@ def getGemmConfigurations(fileName):
                 line = line.strip()
                 # Skip empty lines
                 if len(line) == 0 or line[0] == '#':
+                    continue
+                if datatype not in dataTypes:
                     continue
 
                 # We need trailing spaces here to account for the concat below
@@ -1177,6 +1179,13 @@ def main(args=None):
         help="(rocBLAS | CK) external library to run GEMM routines"
     )
 
+    parser.add_argument(
+        '--data-type',
+         nargs='+',
+         choices=["f32", "f16", "i8"],
+         default=["f32", "f16", "i8"],
+         help='Force a set of datatypes'
+    )
 
     parsed_args = parser.parse_args(args)
 
@@ -1213,7 +1222,7 @@ def main(args=None):
     if opType == Operation.CONV:
         configs = getConvConfigurations(paths.configuration_file_path)
     elif opType == Operation.GEMM:
-        configs = getGemmConfigurations(paths.configuration_file_path)
+        configs = getGemmConfigurations(paths.configuration_file_path, parsed_args.data_type)
 
     if parsed_args.external or parsed_args.batch_external or parsed_args.batch_all:
         if not foundExternalTool(paths, opType, externalLib):

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -190,7 +190,7 @@ def main(args=None):
     python3 tuningRunner.py --op gemm --config="-g 3 -m 1024 -k 769 -n 512 -t f32 -transA 0 -transB 0"
     python3 tuningRunner.py --op conv --config="conv -F 1 -f NCHW -I NCHW -O NCHW -n 256 -c 1024 -H 14 -W 14 -k 2048 -y 1 -x 1 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -t 1"
     python3 tuningRunner.py --op fusion -test_dir=../mlir/test/fusion/e2e/resnet50 --output=tuning_db.tsv
-   
+
     """
     if args is None:
         args = sys.argv[1:]
@@ -260,6 +260,14 @@ def main(args=None):
         type=str,
         help="fusion E2E tests directory")
 
+    parser.add_argument(
+        '--data-type',
+         nargs='+',
+         choices=["f32", "f16", "i8"],
+         default=["f32", "f16", "i8"],
+         help='Force a set of datatypes'
+    )
+
     parsed_args = parser.parse_args(args)
 
     rocmlir_gen_flags = ''
@@ -296,7 +304,7 @@ def main(args=None):
     elif opType == Operation.CONV:
         configs = perfRunner.getConvConfigurations(paths.configuration_file_path)
     elif opType == Operation.GEMM:
-        configs = perfRunner.getGemmConfigurations(paths.configuration_file_path)
+        configs = perfRunner.getGemmConfigurations(paths.configuration_file_path, parsed_args.data_type)
 
     winners, allData = tuneMLIRKernels(configs, confClass, paths, options)
 


### PR DESCRIPTION
This PR is adding the tuning infrastructure for WMMA:
- I added a `--data-type` argument to `perfRunner` and `tuningRunner`. This is because for wmma I want to focus on `i8` and `f16` performance, and not on `f32` (which takes a very long time to tune, since it is not using wmma)
- For now the tuning space is similar to Xdlops, but I think it can be pruned (Kpack should always be 16 and it looks that also Kouter always comes out as 16).

This PR depends on  https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/1084
