### PR TITLE
Tune int8xint8->int8 gemm configurations

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -338,6 +338,42 @@ std::string getTuningProblemStr(ModuleOp &mod) {
   } else if (opType == KernelType::Gemm) { // gemm case
     rock::GemmOp rGemmOp = dyn_cast<rock::GemmOp>(gemmOp);
     // Please keep these in sync with mlir/utils/performance/perfRunner.py
+    // Data type
+    problemOS << "-t ";
+    Type elemTypeA = gemmIF.getAType(), elemTypeB = gemmIF.getBType();
+    if (elemTypeA.isF32() && elemTypeB.isF32()) {
+      problemOS << "f32";
+    } else if (elemTypeA.isF16() && elemTypeB.isF16()) {
+      problemOS << "f16";
+    } else if (elemTypeA.isBF16() && elemTypeB.isBF16()) {
+      problemOS << "bf16";
+    } else if (elemTypeA.isInteger(8) && elemTypeB.isInteger(8)) {
+      problemOS << "i8";
+    } else if (elemTypeA.isFloat8E4M3FNUZ() && elemTypeB.isFloat8E4M3FNUZ()) {
+      problemOS << "fp8_fp8";
+    } else if (elemTypeA.isFloat8E4M3FNUZ() && elemTypeB.isFloat8E5M2FNUZ()) {
+      problemOS << "fp8_bf8";
+    } else if (elemTypeA.isFloat8E5M2FNUZ() && elemTypeB.isFloat8E4M3FNUZ()) {
+      problemOS << "bf8_fp8";
+    } else if (elemTypeA.isFloat8E5M2FNUZ() && elemTypeB.isFloat8E5M2FNUZ()) {
+      problemOS << "bf8_bf8";
+    } else {
+      // Unknown data type
+      return std::string();
+    }
+
+    // OUtput datatype
+    auto outType = gemmIF.getOutArgument()->get().getType();
+    auto elemTypeC = outType.dyn_cast<mlir::MemRefType>().getElementType();
+    problemOS << " -out_datatype ";
+    if (elemTypeC.isFloat8E4M3FNUZ()) {
+      problemOS << "fp8" << sep;
+    } else if (elemTypeC.isFloat8E5M2FNUZ()) {
+      problemOS << "bf8" << sep;
+    } else {
+      problemOS << elemTypeC << sep;
+    }
+
     // TransA
     problemOS << "-transA ";
     if (rGemmOp.getATransposed())
@@ -359,30 +395,6 @@ std::string getTuningProblemStr(ModuleOp &mod) {
     problemOS << "-k " << gemmIF.getGemmSize().k << sep;
   } else {
     // Unknown op type, unreachable.
-    return std::string();
-  }
-
-  // Data type
-  problemOS << "-t ";
-  Type elemTypeA = gemmIF.getAType(), elemTypeB = gemmIF.getBType();
-  if (elemTypeA.isF32() && elemTypeB.isF32()) {
-    problemOS << "f32";
-  } else if (elemTypeA.isF16() && elemTypeB.isF16()) {
-    problemOS << "f16";
-  } else if (elemTypeA.isBF16() && elemTypeB.isBF16()) {
-    problemOS << "bf16";
-  } else if (elemTypeA.isInteger(8) && elemTypeB.isInteger(8)) {
-    problemOS << "i8";
-  } else if (elemTypeA.isFloat8E4M3FNUZ() && elemTypeB.isFloat8E4M3FNUZ()) {
-    problemOS << "fp8_fp8";
-  } else if (elemTypeA.isFloat8E4M3FNUZ() && elemTypeB.isFloat8E5M2FNUZ()) {
-    problemOS << "fp8_bf8";
-  } else if (elemTypeA.isFloat8E5M2FNUZ() && elemTypeB.isFloat8E4M3FNUZ()) {
-    problemOS << "bf8_fp8";
-  } else if (elemTypeA.isFloat8E5M2FNUZ() && elemTypeB.isFloat8E5M2FNUZ()) {
-    problemOS << "bf8_bf8";
-  } else {
-    // Unknown data type
     return std::string();
   }
 

--- a/mlir/test/rocmlir-gen/gemm-misc-options.mlir
+++ b/mlir/test/rocmlir-gen/gemm-misc-options.mlir
@@ -2,7 +2,7 @@
 // RUN: rocmlir-gen --arch gfx908 --operation gemm -p --store-method atomic_add | FileCheck %s --check-prefix=ATOMIC_ADD
 // ATOMIC_ADD: rock.gemm
 // ATOMIC_ADD-SAME: storeMethod = atomic_add
-// RUN: rocmlir-gen --emit-tuning-key -p --arch gfx900
-// CHECK: amdgcn-amd-amdhsa:gfx900        conv -F 1 -f NCHW -I NCHW -O NCHW -n 128 -c 8 -h 32 -w 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -t f32
-// RUN: rocmlir-gen --arch gfx908 --operation gemm -p --emit-tuning-key
-// CHECK: amdgcn-amd-amdhsa:gfx908        gemm -transA false -transB false -g 1 -m 1024 -n 512 -k 769 -t f32
+// RUN: rocmlir-gen --emit-tuning-key -p --arch gfx900 | FileCheck %s --check-prefix=CONV
+// CONV: amdgcn-amd-amdhsa:gfx900        conv -F 1 -f GNCHW -I NGCHW -O NGCHW -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
+// RUN: rocmlir-gen --arch gfx908 --operation gemm -p --emit-tuning-key | FileCheck %s --check-prefix=GEMM
+// GEMM: amdgcn-amd-amdhsa:gfx908        -t f32 -out_datatype f32 -transA false -transB false -g 1 -m 1024 -n 512 -k 769

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -616,11 +616,16 @@ pipeline {
                         steps {
                             buildProject('check-rocmlir-build-only ci-performance-scripts', '')
                             dir('build') {
-                                // Tune gemms, fail if the DB is not created
+                                // Tune gemms with default datatypes, fail if the DB is not created
                                 sh """python3 ./bin/tuningRunner.py --operation gemm \
                                         --configs_file=../mlir/utils/performance/gemm-configs \
                                         --output=mlir_tuning_${ARCH}.tsv
                                       [ -f mlir_tuning_${ARCH}.tsv ]"""
+                                // Tune gemms int8xint8->int8 for performance comparisons against CK.
+                                // Ideally, this'll be removed in the future.
+                                sh """python3 ./bin/tuningRunner.py --operation gemm \
+                                        --configs_file=../mlir/utils/performance/gemm-configs \
+                                        --data-type i8_i8 --output=mlir_tuning_${ARCH}.tsv"""
                             }
                         }
                     }
@@ -930,7 +935,7 @@ pipeline {
                                 dir('build') {
                                     sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
                                 --configs_file=${WORKSPACE}/mlir/utils/performance/gemm-configs \
-                                --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --external-gemm-library CK"""
+                                --tuning_db=${WORKSPACE}/mlir_tuning_${CHIP}.tsv --data-type f32 f16 i8_i8 --external-gemm-library CK"""
                                     sh 'python3 ./bin/createGemmPerformanceReports.py ${CHIP} CK'
                                 }
                             }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -629,11 +629,11 @@ pipeline {
                             dir('build') {
                                 // Tune resnet50
                                 sh """python3 ./bin/tuningRunner.py --op fusion \
---test_dir ../mlir/test/fusion/resnet50-e2e/ -o tuning_fusion_resnet50_${ARCH}.tsv"""
+--test_dir ../mlir/test/fusion/e2e/resnet50/ -o tuning_fusion_${ARCH}.tsv"""
 
                                 // Tune bert
                                 sh """python3 ./bin/tuningRunner.py --op fusion \
---test_dir ../mlir/test/xmir/bert-torch-tosa-e2e/ -o tuning_fusion_bert_${ARCH}.tsv"""
+--test_dir ../mlir/test/xmir/e2e/bert-torch-tosa/ -o tuning_fusion_${ARCH}.tsv"""
                             }
                             sh 'rm build/CMakeCache.txt'
                         }
@@ -894,10 +894,10 @@ pipeline {
                             dir('build') {
                                 // Run fusion resnet50 perf benchmarks
                                 sh """python3 ./bin/perfRunner.py --op=fusion \
-          --test_dir=${WORKSPACE}/mlir/test/fusion/resnet50-e2e/ --tuning_db=${WORKSPACE}/tuning_fusion_resnet50_${CHIP}.tsv"""
+          --test_dir=${WORKSPACE}/mlir/test/fusion/e2e/resnet50/ --tuning_db=${WORKSPACE}/tuning_fusion_${CHIP}.tsv"""
                                 // Run bert perf benchmarks
                                 sh """python3 ./bin/perfRunner.py --op fusion \
-          --test_dir=${WORKSPACE}/mlir/test/xmir/bert-torch-tosa-e2e/ --tuning_db=${WORKSPACE}/tuning_fusion_bert_${CHIP}.tsv"""
+          --test_dir=${WORKSPACE}/mlir/test/xmir/e2e/bert-torch-tosa/ --tuning_db=${WORKSPACE}/tuning_fusion_${CHIP}.tsv"""
                             }
                         }
                     }

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -23,7 +23,7 @@ CONV_TEST_PARAMETERS = ['Direction', 'DataType', 'Chip', 'FilterLayout',
                         'InputLayout', 'OutputLayout', 'N', 'C', 'H', 'W', 'K', 'Y',
                         'X', 'DilationH', 'DilationW', 'StrideH', 'StrideW',
                         'PaddingH', 'PaddingW', 'PerfConfig']
-GEMM_TEST_PARAMETERS = ['DataType', 'Chip', 'TransA', 'TransB', 'G', 'M', 'K', 'N', 'PerfConfig']
+GEMM_TEST_PARAMETERS = ['DataType', 'OutDataType', 'Chip', 'TransA', 'TransB', 'G', 'M', 'K', 'N', 'PerfConfig']
 ROUND_DIGITS = 2
 
 def geoMean(data):

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -181,18 +181,6 @@ def extractFusionConfigs(test_dir, paths: Paths, options: Options):
 
     return opType
 
-def getExtendedGemmConfigurations(filename):
-    # generate configurations using default datatypes
-    configs = perfRunner.getGemmConfigurations(filename, '')
-
-    # generate int8xint8->int8 configurations
-    int8_configs = []
-    for config in configs:
-        if '-t i8' in config and '-out_datatype i32' in config:
-            int8_configs.append(config.replace('i32', 'i8'))
-    configs.extend(int8_configs)
-    return configs
-
 # Main function.
 def main(args=None):
     """
@@ -275,7 +263,7 @@ def main(args=None):
     parser.add_argument(
         '--data-type',
          nargs='+',
-         choices=["f32", "f16", "i8"],
+         choices=["f32", "f16", "i8", "i8_i32", "i8_i8"],
          default=["f32", "f16", "i8"],
          help='Force a set of datatypes'
     )
@@ -316,7 +304,8 @@ def main(args=None):
     elif opType == Operation.CONV:
         configs = perfRunner.getConvConfigurations(paths.configuration_file_path)
     elif opType == Operation.GEMM:
-        configs = perfRunner.getGemmConfigurations(paths.configuration_file_path, parsed_args.data_type)
+        datatypes, outputMap = perfRunner.parseDataTypes(parsed_args.data_type)
+        configs = perfRunner.getGemmConfigurations(paths.configuration_file_path, datatypes, outputMap)
 
     winners, allData = tuneMLIRKernels(configs, confClass, paths, options)
 

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -181,6 +181,18 @@ def extractFusionConfigs(test_dir, paths: Paths, options: Options):
 
     return opType
 
+def getExtendedGemmConfigurations(filename):
+    # generate configurations using default datatypes
+    configs = perfRunner.getGemmConfigurations(filename, '')
+
+    # generate int8xint8->int8 configurations
+    int8_configs = []
+    for config in configs:
+        if '-t i8' in config and '-out_datatype i32' in config:
+            int8_configs.append(config.replace('i32', 'i8'))
+    configs.extend(int8_configs)
+    return configs
+
 # Main function.
 def main(args=None):
     """


### PR DESCRIPTION
The tuningRunner.py script generates gemm configurations with the int8 outputs for tuning.
The perfRunner.py script adds an "out_datatype" attribute to GemmConfiguration. 

ConvConfiguration does not change as we only tune convs with default output datatypes. 

Also clean up Jenkinsfile to use one fusion db for all fusion test cases. 