### PR TITLE
[migraphx] Fixing dot operator syntax in migraphx

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -56,7 +56,7 @@ void getAndBuildMIGraphX(String cmakeOpts) {
     // TODO: https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/889
     // git branch: params.MIGraphXBranch, poll: false,\
     //     url: 'https://github.com/ROCmSoftwarePlatform/AMDMIGraphX.git'
-    checkout([$class: 'GitSCM', branches: [[name: '0e6ee3f7ff7880e9e65b84fbceed8686e426bc8a' ]],
+    checkout([$class: 'GitSCM', branches: [[name: 'mlir-fix-dot-format' ]],
               userRemoteConfigs: [[url: 'https://github.com/ROCmSoftwarePlatform/AMDMIGraphX.git']]])
     buildMIGraphX(cmakeOpts)
 }


### PR DESCRIPTION
I fixed the parenthesis syntax in the dot operator. This caused the migraphx unit test to be failing. Fixing it in a independent branch until corrected in develop.