### PR TITLE
[DO NOT SQUASH] arith.extf on 8-bit floats by tables

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Conversion/LLVMCommon/TypeConverter.h
+++ b/external/llvm-project/mlir/include/mlir/Conversion/LLVMCommon/TypeConverter.h
@@ -155,7 +155,8 @@ private:
 
   /// Convert a floating point type: `f16` to `f16`, `f32` to
   /// `f32` and `f64` to `f64`.  `bf16` is not supported
-  /// by LLVM.
+  /// by LLVM. 8-bit float types are converted to 8-bit integers as this is how
+  /// all LLVM backends that support them currently represent them.
   Type convertFloatType(FloatType type);
 
   /// Convert complex number type: `complex<f16>` to `!llvm<"{ half, half }">`,

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -824,14 +824,6 @@ struct ConvertAMDGPUToROCDLPass
 void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                                    RewritePatternSet &patterns,
                                                    Chipset chipset) {
-  // ROCDL supports fp8 types in some contexts, but there is no LLVM-level f8
-  // type. Therefore, for this target, declare f8 to be equal to i8.
-  converter.addConversion([](FloatType type) -> std::optional<Type> {
-    if (type.isFloat8E5M2FNUZ() || type.isFloat8E4M3FNUZ())
-      return IntegerType::get(type.getContext(), 8);
-    return std::nullopt;
-  });
-
   patterns.add<LDSBarrierOpLowering>(converter);
   patterns.add<
       RawBufferOpLowering<RawBufferLoadOp, ROCDL::RawBufferLoadOp>,

--- a/external/llvm-project/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
@@ -181,7 +181,12 @@ Type LLVMTypeConverter::convertIntegerType(IntegerType type) {
   return IntegerType::get(&getContext(), type.getWidth());
 }
 
-Type LLVMTypeConverter::convertFloatType(FloatType type) { return type; }
+Type LLVMTypeConverter::convertFloatType(FloatType type) {
+  if (type.isFloat8E5M2() || type.isFloat8E4M3FN() || type.isFloat8E5M2FNUZ() ||
+      type.isFloat8E4M3FNUZ())
+    return IntegerType::get(&getContext(), type.getWidth());
+  return type;
+}
 
 // Convert a `ComplexType` to an LLVM type. The result is a complex number
 // struct with entries for the

--- a/external/llvm-project/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -39,6 +39,18 @@ llvm.mlir.global internal constant @string_const("foobar") : !llvm.array<6 x i8>
 // CHECK: @int_global_undef = internal global i64 undef
 llvm.mlir.global internal @int_global_undef() : i64
 
+// CHECK: @f8E4M3FN_global_as_i8 = internal global i8 60
+llvm.mlir.global internal @f8E4M3FN_global_as_i8(1.5 : f8E4M3FN) : i8
+
+// CHECK: @f8E5M2_global_as_i8 = internal global i8 62
+llvm.mlir.global internal @f8E5M2_global_as_i8(1.5 : f8E5M2) : i8
+
+// CHECK: @f8E4M3FNUZ_global_as_i8 = internal global i8 68
+llvm.mlir.global internal @f8E4M3FNUZ_global_as_i8(1.5 : f8E4M3FNUZ) : i8
+
+// CHECK: @f8E5M2FNUZ_global_as_i8 = internal global i8 66
+llvm.mlir.global internal @f8E5M2FNUZ_global_as_i8(1.5 : f8E5M2FNUZ) : i8
+
 // CHECK: @explicit_undef = global i32 undef
 llvm.mlir.global external @explicit_undef() : i32 {
   %0 = llvm.mlir.undef : i32

--- a/mlir/include/mlir/Conversion/Fp8ExtToTables/Fp8ExtToTables.h
+++ b/mlir/include/mlir/Conversion/Fp8ExtToTables/Fp8ExtToTables.h
@@ -1,0 +1,29 @@
+//===-- Fp8ExtToTables pass declarations ----------------*- C++ -*-===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Advanced Micro Devices Inc.
+//===----------------------------------------------------------------------===//
+//
+// Declares the passes for remapping `arith.extf` on fp8 types to a table lookup
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_CONVERSION_FP8EXTTOTABLES_FP8EXTTOTABLES_H
+#define MLIR_CONVERSION_FP8EXTTOTABLES_FP8EXTTOTABLES_H
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+#define GEN_PASS_DECL_FP8EXTTOTABLESPASS
+#include "mlir/Conversion/RocMLIRPasses.h.inc"
+
+void addFp8ExtToTablesPatterns(RewritePatternSet &patterns);
+
+} // namespace mlir
+
+#endif // MLIR_CONVERSION_GPUTOMIGRAPHX_GPUTOMIGRAPHX_H

--- a/mlir/include/mlir/Conversion/RocMLIRPasses.h
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_CONVERSION_ROCMLIRPASSES_H
 #define MLIR_CONVERSION_ROCMLIRPASSES_H
 
+#include "mlir/Conversion/Fp8ExtToTables/Fp8ExtToTables.h"
 #include "mlir/Conversion/GPUToMIGraphX/GPUToMIGraphX.h"
 #include "mlir/Conversion/MIGraphXToTosa/MIGraphXToTosa.h"
 #include "mlir/Conversion/Passes.h"

--- a/mlir/include/mlir/Conversion/RocMLIRPasses.td
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.td
@@ -87,4 +87,28 @@ def GPUToMIGraphXPass : Pass<"gpu-to-migraphx", "::mlir::func::FuncOp"> {
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// Fp8ExtToTables
+//===----------------------------------------------------------------------===//
+
+def Fp8ExtToTablesPass : Pass<"fp8-ext-to-tables"> {
+  let summary = "Lower arith.extf on fp8 types to table lookup";
+  let description = [{
+    Pass that converts arith.extf on 8-bit float types to a lookup in a
+    constant table.
+
+    This is a quick implementation that provides the mimimal functionality to
+    test 8-bit float kernels.
+
+    This pass must be run at the `builtin.module`/`gpu.module` level
+    (the root operation needs to have a symbol table)
+  }];
+
+  let dependentDialects = [
+    "arith::ArithDialect",
+    "memref::MemRefDialect",
+    "vector::VectorDialect",
+  ];
+}
+
 #endif // ROCMLIR_CONVERSION_PASSES

--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -4,6 +4,7 @@
 #add_subdirectory(AVX512ToLLVM)
 #add_subdirectory(ComplexToLLVM)
 #add_subdirectory(GPUCommon)
+add_subdirectory(Fp8ExtToTables)
 add_subdirectory(GPUToMIGraphX)
 #add_subdirectory(GPUToNVVM)
 #add_subdirectory(GPUToROCDL)

--- a/mlir/lib/Conversion/Fp8ExtToTables/CMakeLists.txt
+++ b/mlir/lib/Conversion/Fp8ExtToTables/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_rocmlir_conversion_library(RocmlirFp8ExtToTables
+  Fp8ExtToTables.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Arith
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/MemRef
+
+  DEPENDS
+  RocMLIRConversionPassIncGen
+)
+
+target_link_libraries(RocmlirFp8ExtToTables
+  PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+  MLIRSupport
+  MLIRArithDialect
+  MLIRMemRefDialect
+  MLIRVectorDialect
+)

--- a/mlir/lib/Conversion/Fp8ExtToTables/Fp8ExtToTables.cpp
+++ b/mlir/lib/Conversion/Fp8ExtToTables/Fp8ExtToTables.cpp
@@ -1,0 +1,197 @@
+//===- Fp8ExtToTables.cpp - arith.extf on fp8 by table lookup -----------===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Advanced Micro Devices Inc.
+//===----------------------------------------------------------------------===//
+//
+// Declares the passes for remapping `arith.extf` on fp8 types to a table lookup
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/Fp8ExtToTables/Fp8ExtToTables.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_FP8EXTTOTABLESPASS
+#include "mlir/Conversion/RocMLIRPasses.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::arith;
+
+namespace {
+struct Fp8ExtToTablesPass final
+    : public impl::Fp8ExtToTablesPassBase<Fp8ExtToTablesPass> {
+  using impl::Fp8ExtToTablesPassBase<
+      Fp8ExtToTablesPass>::Fp8ExtToTablesPassBase;
+
+  void runOnOperation() override;
+};
+
+struct Fp8ExtToTableLookupPattern final : public OpConversionPattern<ExtFOp> {
+  using OpConversionPattern<ExtFOp>::OpConversionPattern;
+
+  LogicalResult match(ExtFOp op) const override;
+  void rewrite(ExtFOp op, OpAdaptor adaptor,
+               ConversionPatternRewriter &rewriter) const override;
+};
+} // namespace
+
+static bool isFp8(Type t) {
+  return t.isFloat8E5M2() || t.isFloat8E4M3FN() || t.isFloat8E5M2FNUZ() ||
+         t.isFloat8E4M3FNUZ();
+}
+
+static LogicalResult canRewriteToTable(ExtFOp op) {
+  Type inType = op.getIn().getType();
+  Type inElemType = getElementTypeOrSelf(inType);
+  if (!isFp8(inElemType))
+    return failure();
+  if (isa<FloatType>(inType))
+    return success();
+  if (auto vecType = dyn_cast<VectorType>(inType))
+    return success(vecType.hasStaticShape());
+  return failure();
+}
+
+LogicalResult Fp8ExtToTableLookupPattern::match(ExtFOp op) const {
+  return canRewriteToTable(op);
+}
+
+static Value getFloatValueTableFor(Type elementType, Operation *op,
+                                   ConversionPatternRewriter &rewriter) {
+  assert(isFp8(elementType) &&
+         "tables can only be generated for scalar float types");
+  auto type = cast<FloatType>(elementType);
+  Operation *module = SymbolTable::getNearestSymbolTable(op);
+  auto globalType = MemRefType::get(256, rewriter.getF32Type());
+  SmallString<32> extTableName;
+  // Name collisions are unlikely to be an issue as
+  // - in an XMIR context, this'll be placed within individual copies of the
+  // code,
+  //   , which tend to add suffixes to function names etc.
+  // - In the MIGraphX context, fp8 isn't supported (so even if they feed us
+  //   arbitrarily evil function names, we won't hit this case).
+  // - In our testing context, we control the top-level module names and won't
+  //    pick one like this.
+  llvm::raw_svector_ostream extTableNameGen(extTableName);
+  extTableNameGen << "__rocmlir_extf_tbl_" << type;
+  auto table = dyn_cast_if_present<memref::GlobalOp>(
+      SymbolTable::lookupSymbolIn(module, extTableName));
+  if (table) {
+    return rewriter.createOrFold<memref::GetGlobalOp>(op->getLoc(), globalType,
+                                                      extTableName);
+  }
+  SmallVector<float, 0> tableElems;
+  tableElems.reserve(256);
+  const auto &sem = type.getFloatSemantics();
+  for (uint32_t i = 0; i < 256; ++i) {
+    APFloat entry(sem, APInt(8, i));
+    tableElems.push_back(entry.convertToFloat());
+  }
+  ElementsAttr tableElemsAttr = DenseElementsAttr::get<float>(
+      RankedTensorType::get(256, rewriter.getF32Type()), tableElems);
+  OpBuilder nowhereBuilder(module->getContext(), rewriter.getListener());
+  table = nowhereBuilder.create<memref::GlobalOp>(
+      op->getLoc(), extTableName,
+      /*sym_visibility=*/rewriter.getStringAttr("private"),
+      /*type=*/globalType,
+      /*initial_value=*/tableElemsAttr,
+      /*constant=*/true,
+      /*alignment=*/nullptr);
+  SymbolTable(module).insert(table);
+  return rewriter.createOrFold<memref::GetGlobalOp>(op->getLoc(), globalType,
+                                                    extTableName);
+}
+
+void Fp8ExtToTableLookupPattern::rewrite(
+    ExtFOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+  Type inType = op.getIn().getType();
+  Type outType = op.getResult().getType();
+  Type outElemType = getElementTypeOrSelf(outType);
+  Type elemType = getElementTypeOrSelf(inType);
+  Type f32 = rewriter.getF32Type();
+
+  Value table = getFloatValueTableFor(elemType, op, rewriter);
+  auto oneToFloat = [&](Value fp8) -> Value {
+    Value bitcast =
+        rewriter.create<arith::BitcastOp>(loc, rewriter.getI8Type(), fp8);
+    // Don't sign-extend the byte when index casting.
+    Value i32 =
+        rewriter.create<arith::ExtUIOp>(loc, rewriter.getI32Type(), bitcast);
+    Value index =
+        rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(), i32);
+    Value extended = rewriter.create<memref::LoadOp>(loc, table, index);
+    return extended;
+  };
+
+  auto floatsToResult = [&](Value floats) -> Value {
+    if (outElemType.isF32())
+      return floats;
+    if (outElemType.getIntOrFloatBitWidth() < 32)
+      return rewriter.create<arith::TruncFOp>(loc, outType, floats);
+    if (outElemType.getIntOrFloatBitWidth() > 32)
+      return rewriter.create<arith::ExtFOp>(loc, outType, floats);
+    llvm_unreachable("f32 is the only 32-bit float type");
+  };
+  auto inVecType = dyn_cast<VectorType>(inType);
+  if (!inVecType) {
+    Value ret = floatsToResult(oneToFloat(adaptor.getIn()));
+    return rewriter.replaceOp(op, ret);
+  }
+  VectorType floatVecType = inVecType.clone(f32);
+  Value floats = rewriter.createOrFold<vector::SplatOp>(
+      loc,
+      rewriter.createOrFold<arith::ConstantOp>(loc, f32,
+                                               rewriter.getF32FloatAttr(0.0f)),
+      floatVecType);
+  SmallVector<int64_t> strides = computeStrides(inVecType.getShape());
+  for (int64_t i = 0, e = inVecType.getNumElements(); i < e; ++i) {
+    SmallVector<int64_t> idx = delinearize(strides, i);
+    Value scalar =
+        rewriter.create<vector::ExtractOp>(loc, adaptor.getIn(), idx);
+    Value extended = oneToFloat(scalar);
+    floats = rewriter.create<vector::InsertOp>(loc, extended, floats, idx);
+  }
+  Value ret = floatsToResult(floats);
+  return rewriter.replaceOp(op, ret);
+}
+
+void mlir::addFp8ExtToTablesPatterns(RewritePatternSet &patterns) {
+  patterns.add<Fp8ExtToTableLookupPattern>(patterns.getContext());
+}
+
+void Fp8ExtToTablesPass::runOnOperation() {
+  Operation *op = getOperation();
+  if (!op->hasTrait<OpTrait::SymbolTable>()) {
+    emitError(op->getLoc(), "fp8-ext-to-tables requires a module-like (symbol "
+                            "table having) root operation");
+    return signalPassFailure();
+  }
+
+  MLIRContext *ctx = &getContext();
+  ConversionTarget target(getContext());
+  target.addLegalDialect<arith::ArithDialect, memref::MemRefDialect,
+                         vector::VectorDialect>();
+  target.addDynamicallyLegalOp<arith::ExtFOp>(
+      [](ExtFOp op) { return failed(canRewriteToTable(op)); });
+  RewritePatternSet rewrites(ctx);
+  addFp8ExtToTablesPatterns(rewrites);
+  if (failed(applyPartialConversion(op, target, std::move(rewrites))))
+    return signalPassFailure();
+}

--- a/mlir/test/Conversion/Fp8ExtToTables/fp8-ext-to-tables.mlir
+++ b/mlir/test/Conversion/Fp8ExtToTables/fp8-ext-to-tables.mlir
@@ -1,0 +1,57 @@
+// RUN: rocmlir-opt -fp8-ext-to-tables -split-input-file %s | FileCheck %s
+
+module {
+  func.func @ext_scalar(%arg0: f8E5M2FNUZ) -> f16 {
+    // CHECK-LABEL: @ext_scalar
+    // CHECK-SAME: ([[ARG0:%.+]]: f8E5M2FNUZ)
+    // CHECK: [[TABLE:%.+]] = memref.get_global @__rocmlir_extf_tbl_f8E5M2FNUZ : memref<256xf32>
+    // CHECK: [[BYTE:%.+]] = arith.bitcast [[ARG0]] : f8E5M2FNUZ to i8
+    // CHECK: [[LONGBYTE:%.+]] = arith.extui [[BYTE]] : i8 to i32
+    // CHECK: [[IDX:%.+]] = arith.index_cast [[LONGBYTE]] : i32 to index
+    // CHECK: [[EXT:%.+]] = memref.load [[TABLE]]{{\[}}[[IDX]]]
+    // CHECK: [[TRUNC:%.+]] = arith.truncf [[EXT]] : f32 to f16
+    // CHECK: return [[TRUNC]]
+    %ret = arith.extf %arg0 : f8E5M2FNUZ to f16
+    return %ret : f16
+  }
+  // CHECK-LABEL: memref.global "private" constant @__rocmlir_extf_tbl_f8E5M2FNUZ
+}
+
+// -----
+
+module {
+  func.func @ext_vector(%arg0: vector<2x2xf8E4M3FNUZ>) -> vector<2x2xf32> {
+  // CHECK-LABEL: @ext_vector
+  // CHECK-SAME: ([[ARG0:%.+]]: vector<2x2xf8E4M3FNUZ>)
+  // CHECK: [[TABLE:%.+]] = memref.get_global @__rocmlir_extf_tbl_f8E4M3FNUZ : memref<256xf32>
+  // CHECK: [[RET0:%.+]] = arith.constant dense<0.000000e+00> : vector<2x2xf32>
+  // CHECK: [[IN0:%.+]] = vector.extract [[ARG0]][0, 0]
+  // CHECK: [[BYTE0:%.+]] = arith.bitcast [[IN0]] : f8E4M3FNUZ to i8
+  // CHECK: [[LONGBYTE0:%.+]] = arith.extui [[BYTE0]] : i8 to i32
+  // CHECK: [[IDX0:%.+]] = arith.index_cast [[LONGBYTE0]] : i32 to index
+  // CHECK: [[EXT0:%.+]] = memref.load [[TABLE]]{{\[}}[[IDX0]]]
+  // CHECK: [[RET1:%.+]] = vector.insert [[EXT0]], [[RET0]] [0, 0] : f32 into vector<2x2xf32>
+  // ...
+    %ret = arith.extf %arg0 : vector<2x2xf8E4M3FNUZ> to vector<2x2xf32>
+    func.return %ret : vector<2x2xf32>
+  }
+}
+
+// -----
+
+// Test that the buffer gets inserted inside GPU modules if relevant.
+module attributes {gpu.container_module} {
+  gpu.module @kernel_mod {
+    gpu.func @kernel(%arg0: f8E4M3FNUZ, %arg1: memref<1xf64>) kernel {
+      %c0 = arith.constant 0 : index
+      %ret = arith.extf %arg0 : f8E4M3FNUZ to f64
+      memref.store %ret, %arg1[%c0] : memref<1xf64>
+      gpu.return
+    }
+    // CHECK: gpu.return
+    // CHECK-NEXT: }
+    // CHECK-NEXT: memref.global "private" constant @__rocmlir_extf_tbl_f8E4M3FNUZ
+    // CHECK-NEXT: }
+    // CHECK-NEXT: }
+  }
+}

--- a/mlir/tools/rocmlir-translate/CMakeLists.txt
+++ b/mlir/tools/rocmlir-translate/CMakeLists.txt
@@ -2,7 +2,6 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-get_property(rocm_dialect_libs GLOBAL PROPERTY ROCMLIR_DIALECT_LIBS)
 get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
 
 add_llvm_tool(rocmlir-translate
@@ -11,7 +10,6 @@ add_llvm_tool(rocmlir-translate
 llvm_update_compile_flags(rocmlir-translate)
 target_link_libraries(rocmlir-translate
   PRIVATE
-  ${rocm_dialect_libs}
   ${translation_libs}
   ${test_libs}
   MLIRROCDLToLLVMIRTranslation

--- a/mlir/tools/rocmlir-translate/rocmlir-translate.cpp
+++ b/mlir/tools/rocmlir-translate/rocmlir-translate.cpp
@@ -11,11 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Conversion/RocMLIRPasses.h"
-#include "mlir/Conversion/RockToGPU/RockToGPU.h"
-#include "mlir/Dialect/Rock/Passes.h"
 #include "mlir/InitAllTranslations.h"
-#include "mlir/InitRocMLIRPasses.h"
 #include "mlir/InitRocMLIRTranslations.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.h"
@@ -26,8 +22,5 @@ using namespace mlir;
 int main(int argc, char **argv) {
   registerAllTranslations();
   rock::registerRocMLIRTranslations();
-  registerRocMLIRPasses();
-  mlir::registerRocMLIRConversionPasses();
-  rock::registerPasses();
   return failed(mlirTranslateMain(argc, argv, "MLIR Translation Testing Tool"));
 }


### PR DESCRIPTION
1. Set up the lowering of fp8 constants to i8 everywhere so translation to LLVM IR doesn't explode
2. Add a pass that implements a translation from `arith.extf` on 8-bit floats to table lookup and inserts the relevant tables.

(End-to-end hookups are a followup PR)