### PR TITLE
Add E2E test support for fp8

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/AmdArchDb.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/AmdArchDb.h
@@ -18,9 +18,12 @@ namespace rock {
 struct AmdArchInfo {
   GemmFeatures defaultFeatures;
   int64_t waveSize;
+  bool hasFp8ConversionInstrs;
 
-  constexpr AmdArchInfo(GemmFeatures defaultFeatures, int64_t waveSize)
-      : defaultFeatures(defaultFeatures), waveSize(waveSize) {}
+  constexpr AmdArchInfo(GemmFeatures defaultFeatures, int64_t waveSize,
+                        bool hasFp8ConversionInstrs)
+      : defaultFeatures(defaultFeatures), waveSize(waveSize),
+        hasFp8ConversionInstrs(hasFp8ConversionInstrs) {}
 
   /// Get the default features for the pari <arch, datatype>
   GemmFeatures getDefaultFeatures(Type dataType);

--- a/mlir/include/mlir/InitRocMLIRPasses.h
+++ b/mlir/include/mlir/InitRocMLIRPasses.h
@@ -44,6 +44,7 @@ inline void registerUpstreamPasses() {
 
   // Conversion passes
   registerConvertAffineToStandard();
+  registerArithToAMDGPUConversionPass();
   registerConvertAMDGPUToROCDL();
   registerArithToLLVMConversionPass();
   registerConvertFuncToLLVM();

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -309,14 +309,13 @@ LogicalResult Conv2dGenerator::getBwdWeightKernelCount(OpBuilder &builder,
 
   kernelCount = 1;
   if (isAccel(config.features)) {
-    Type dataType = getInputDataType(builder);
     bool needExtraPad = false;
     if (failed(needExtraPadBwdWeight(builder, needExtraPad))) {
       return failure();
     }
     if (!needExtraPad) {
       Type dataType = getInputDataType(builder);
-      if (dataType == builder.getF32Type()) {
+      if (dataType.isF32()) {
         // For the following case, use 2 kernels:
         // - backward weight
         // - XDLOPS
@@ -326,7 +325,7 @@ LogicalResult Conv2dGenerator::getBwdWeightKernelCount(OpBuilder &builder,
         // The second kernel will conduct the actual backward weight
         // convolution, using atomic add instructions.
         kernelCount = 2;
-      } else if (dataType == builder.getF16Type()) {
+      } else if (dataType.isF16()) {
         // For the following case, use 3 kernels:
         // - backward weight
         // - XDLOPS

--- a/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
@@ -4,6 +4,7 @@ add_rocmlir_dialect_library(MLIRRockPipeline
   LINK_LIBS PUBLIC
   MLIRAMDGPUTransforms
   MLIRGPUToROCDLTransforms
+  MLIRArithToAMDGPU
   MLIRTensorToLinalg
   MLIRTosaToArith
   MLIRTosaToRock
@@ -14,4 +15,6 @@ add_rocmlir_dialect_library(MLIRRockPipeline
   MLIRRockToGPU
   MLIRRockOps
   MLIRRockTransforms
+  MLIRRockUtility
+  RocmlirFp8ExtToTables
 )

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -21,11 +21,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Rock/Pipelines/Pipelines.h"
+#include "mlir/Conversion/ArithToAMDGPU/ArithToAMDGPU.h"
+#include "mlir/Conversion/Fp8ExtToTables/Fp8ExtToTables.h"
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Conversion/RockToGPU/RockToGPU.h"
 #include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Passes.h"
@@ -35,6 +38,7 @@
 #include "mlir/Conversion/RocMLIRPasses.h"
 #include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
 #include "mlir/Dialect/Rock/Passes.h"
+#include "mlir/Dialect/Rock/utility/AmdArchDb.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
@@ -173,14 +177,21 @@ void rock::buildKernelPipeline(OpPassManager &pm,
 
 void rock::buildBackendPipeline(OpPassManager &pm,
                                 const rock::BackendOptions &options) {
-  // lowering ROCDL (LLVM) to binary
+  // lowering ROCDL (LLVM) to binary.
+  // Leave off --convert-arith-to-amdgpu if not targetting gfx94x+.
   /* rocmlir-opt --strip-debuginfo
+   *   --convert-arith-to-amdgpu
+   *   --fp8-ext-to-tables
    *   "--amdgpu-emulate-atomics=chipset=$chip"
    *   "--convert-gpu-to-rocdl=chipset=$chip index-bitwidth=32"
    *   "--gpu-to-hsaco=triple=$triple chip=$chip features=$features opt-level=3"
    */
   pm.addPass(createStripDebugInfoPass());
-  pm.addNestedPass<gpu::GPUFuncOp>(
+  AmdArchInfo archInfo = lookupArchInfo(options.chip);
+  if (archInfo.hasFp8ConversionInstrs)
+    pm.addNestedPass<gpu::GPUModuleOp>(createArithToAMDGPUConversionPass());
+  pm.addPass(createFp8ExtToTablesPass());
+  pm.addNestedPass<gpu::GPUModuleOp>(
       amdgpu::createAmdgpuEmulateAtomicsPass({options.chip}));
   pm.addPass(createLowerGpuOpsToROCDLOpsPass(
       options.chip, options.indexBitwidth, /*useBarePtrCallConv=*/true));

--- a/mlir/test/e2e/GemmVariants.toml
+++ b/mlir/test/e2e/GemmVariants.toml
@@ -19,7 +19,7 @@ prefix = "--transC="
 
 [[axis]]
 name = "data type"
-values = ["f32", "f16", "i8"]
+values = ["f32", "f16", "i8", "fp8_fp8", "fp8_bf8", "bf8_fp8", "bf8_bf8"]
 prefix = "-t "
 
 ## Gemm variants

--- a/mlir/test/e2e/PrGemm.toml
+++ b/mlir/test/e2e/PrGemm.toml
@@ -18,9 +18,10 @@ prefix = "--transA="
 #values = ["true", "false"]
 #prefix = "--transC="
 
+# Note: only one fp8 variant is tested as that's enough for a sanity check
 [[axis]]
 name = "data type"
-values = ["f32", "f16", "i8"]
+values = ["f32", "f16", "i8", "fp8_bf8"]
 prefix = "-t "
 
 ## Gemm variants
@@ -32,7 +33,7 @@ config = "-g 3 -m 1024 -k 769 -n 1024"
 # Don't re-test f16 and i8 with transposes: it won't give us much new
 [[suite.test.exclude]]
 name = "data type"
-values = ["f16", "i8"]
+values = ["f16", "i8", "fp8"]
 [[suite.test.exclude]]
 name = "transA"
 values = ["true"]

--- a/mlir/test/rocmlir-driver/fp8_ops.mlir
+++ b/mlir/test/rocmlir-driver/fp8_ops.mlir
@@ -1,0 +1,11 @@
+// RUN: rocmlir-gen --arch gfx940 --operation gemm -t fp8 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=MFMA
+// RUN: rocmlir-gen --arch gfx940 --operation gemm -mfma=off -t fp8 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=MFMA_OFF
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -t fp8 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=GFX11
+// RUN: rocmlir-gen --arch gfx940 --operation gemm -t fp8 -p -pv | rocmlir-driver -c | FileCheck %s --check-prefix=HOST
+
+// MFMA: rocdl.mfma.f32.32x32x16.fp8.fp8
+// MFMA-NOT: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ
+// MFMA_OFF: rocdl.cvt.f32.fp8
+// MFMA_OFF-NOT: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ
+// GFX11: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ
+// HOST: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ


### PR DESCRIPTION
1. Fix up the "rocdl" pipeline option to rocmilr-driver which has gotten out of sync with the backend pipeline
2. Fix nesting of atomics emulation so that it actually runs and only runs on the GPU modules.
3. Add a boolean flag for whether a target has fp8 conversion instructions to the arch DB (since we can't toggle their use on a per-kernel basis, this isn't a gemm feature)
4. Add --convert-arith-to-amdgpu (if supported based on the flag above) and --fp8-ext-to-tables to the backend pipelines. (**NOTE**: These fp8 passes are not running in the xmodel pipeline. This is a consequence of the hacky fp8 tables pass being downstream and not a patch onto upstream, so it can't be added to Xmodel pipelines. Since xmodel is being moved anyway this is fine for now?)
5. Add tests to make sure fp8 ops are lowered as expected.
6. Add fp8 to select end-to-end tests to ensure minimal coverage of the datatype (which is all we really need because it acts like int8 for most purposes).