### PR TITLE
[CI] Bump to rocm5.5 in Jenkinsfiles

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -104,11 +104,11 @@ String dockerArgs() {
 
 String dockerImage() {
     // If this is being changed please change Dockerfile.migraphx-ci's base image as well
-    return 'rocm/mlir:rocm5.4-latest'
+    return 'rocm/mlir:rocm5.5-latest'
 }
 
 String dockerImageCIMIGraphX() {
-    return 'rocm/mlir-migraphx-ci:rocm5.4-latest'
+    return 'rocm/mlir-migraphx-ci:rocm5.5-latest'
 }
 
 void preMergeCheck(String codepath) {

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -37,7 +37,7 @@ String dockerArgs() {
 }
 
 String dockerImage() {
-    return 'rocm/mlir:rocm5.4-latest'
+    return 'rocm/mlir:rocm5.5-latest'
 }
 
 

--- a/mlir/utils/jenkins/Jenkinsfile.release
+++ b/mlir/utils/jenkins/Jenkinsfile.release
@@ -23,7 +23,7 @@ String dockerArgs() {
 }
 
 String dockerImage() {
-    return 'rocm/mlir:rocm5.1-latest'
+    return 'rocm/mlir:rocm5.5-latest'
 }
 
 pipeline {


### PR DESCRIPTION
This commit updates all the jenkinsfile to use
latest rocm5.5 images.

depends on : https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/1109
closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/889