### PR TITLE
Reorganize and add MIGraphX elementwise ops

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -103,13 +103,35 @@ def MIGraphX_PowOp :
 
 // Elementwise unary operations
 
-def MIGraphX_TanhOp :
-    MIGraphX_Op<"tanh">,
+def MIGraphX_AbsOp :
+    MIGraphX_Op<"abs">,
     Arguments<(ins AnyRankedTensor:$inA)>,
 	  Results<(outs AnyRankedTensor:$output)> {
-  let summary = "Hyperbolic Tan";
+  let summary = "Elementwise absolute value";
   let description = [{
-    get tanh
+    Take absolute value elementwise
+  }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
+def MIGraphX_CeilOp :
+    MIGraphX_Op<"ceil">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Elementwise ceil";
+  let description = [{
+    Ceil tensor elementwise
+  }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
+def MIGraphX_ErfOp :
+    MIGraphX_Op<"erf">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Gauss error function";
+  let description = [{
+    compute gauss error function
   }];
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
@@ -125,6 +147,28 @@ def MIGraphX_ExpOp :
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
 
+def MIGraphX_FloorOp :
+    MIGraphX_Op<"floor">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Elementwise floor";
+  let description = [{
+    Floor tensor elementwise
+  }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
+def MIGraphX_LogOp :
+    MIGraphX_Op<"log">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Logarithm";
+  let description = [{
+    get log
+  }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
 def MIGraphX_NegOp :
     MIGraphX_Op<"neg">,
     Arguments<(ins AnyRankedTensor:$inA)>,
@@ -132,17 +176,6 @@ def MIGraphX_NegOp :
   let summary = "Negation";
   let description = [{
     get neg
-      }];
-  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
-}
-
-def MIGraphX_ErfOp :
-    MIGraphX_Op<"erf">,
-    Arguments<(ins AnyRankedTensor:$inA)>,
-	  Results<(outs AnyRankedTensor:$output)> {
-  let summary = "Gauss error function";
-  let description = [{
-    compute gauss error function
   }];
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
@@ -159,17 +192,6 @@ def MIGraphX_RecipOp :
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
 
-def MIGraphX_SqrtOp :
-    MIGraphX_Op<"sqrt">,
-    Arguments<(ins AnyRankedTensor:$inA)>,
-	  Results<(outs AnyRankedTensor:$output)> {
-  let summary = "Elementwise sqrt";
-  let description = [{
-    square root elementwise
-  }];
-  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
-}
-
 def MIGraphX_RsqrtOp :
     MIGraphX_Op<"rsqrt">,
     Arguments<(ins AnyRankedTensor:$inA)>,
@@ -181,27 +203,40 @@ def MIGraphX_RsqrtOp :
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
 
-def MIGraphX_CeilOp :
-    MIGraphX_Op<"ceil">,
+def MIGraphX_SigmoidOp :
+    MIGraphX_Op<"sigmoid">,
     Arguments<(ins AnyRankedTensor:$inA)>,
 	  Results<(outs AnyRankedTensor:$output)> {
-  let summary = "Elementwise ceil";
+  let summary = "Sigmoid activation function";
   let description = [{
-    Ceil tensor elementwise
+    Sigmoid function, aka 1 / (1 + exp(-x)).
   }];
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
 
-def MIGraphX_FloorOp :
-    MIGraphX_Op<"floor">,
+def MIGraphX_SqrtOp :
+    MIGraphX_Op<"sqrt">,
     Arguments<(ins AnyRankedTensor:$inA)>,
 	  Results<(outs AnyRankedTensor:$output)> {
-  let summary = "Elementwise floor";
+  let summary = "Elementwise sqrt";
   let description = [{
-    Floor tensor elementwise
+    square root elementwise
   }];
   let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
 }
+
+def MIGraphX_TanhOp :
+    MIGraphX_Op<"tanh">,
+    Arguments<(ins AnyRankedTensor:$inA)>,
+	  Results<(outs AnyRankedTensor:$output)> {
+  let summary = "Hyperbolic Tan";
+  let description = [{
+    get tanh
+  }];
+  let assemblyFormat = "`(`$inA`)` attr-dict `:` `(`type($inA)`)` `->` type($output)";
+}
+
+// Quantization operations.
 
 def MIGraphX_QuantizeLinearOp :
     MIGraphX_Op<"quantizelinear">,

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.td
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.td
@@ -20,9 +20,19 @@ def : Pat<(MIGraphX_AddOp $input1, $input2), (Tosa_AddOp $input1, $input2)>;
 def : Pat<(MIGraphX_SubOp $input1, $input2), (Tosa_SubOp $input1, $input2)>;
 def : Pat<(MIGraphX_MulOp $input1, $input2), (Tosa_MulOp $input1, $input2, ConstantAttr<I32Attr, "0">)>;
 def : Pat<(MIGraphX_PowOp $input1, $input2), (Tosa_PowOp $input1, $input2)>;
-def : Pat<(MIGraphX_RecipOp $input1), (Tosa_ReciprocalOp $input1)>;
+
+// Unary operators.
+def : Pat<(MIGraphX_AbsOp $input1), (Tosa_AbsOp $input1)>;
+def : Pat<(MIGraphX_CeilOp $input1), (Tosa_CeilOp $input1)>;
 def : Pat<(MIGraphX_ExpOp $input1), (Tosa_ExpOp $input1)>;
+def : Pat<(MIGraphX_ErfOp $input1), (Tosa_ErfOp $input1)>;
+def : Pat<(MIGraphX_FloorOp $input1), (Tosa_FloorOp $input1)>;
+def : Pat<(MIGraphX_LogOp $input1), (Tosa_LogOp $input1)>;
 def : Pat<(MIGraphX_NegOp $input1), (Tosa_NegateOp $input1, (GetNullAttr))>;
+def : Pat<(MIGraphX_RecipOp $input1), (Tosa_ReciprocalOp $input1)>;
+def : Pat<(MIGraphX_RsqrtOp $input1), (Tosa_RsqrtOp $input1)>;
+def : Pat<(MIGraphX_SigmoidOp $input1), (Tosa_SigmoidOp $input1)>;
+def : Pat<(MIGraphX_TanhOp $input1), (Tosa_TanhOp $input1)>;
 
 def : Pat<(MIGraphX_ConstantOp ElementsAttr:$valueAttr, $shapeAttr, $valueTypeAttr), (Arith_ConstantOp $valueAttr)>;
 def Convert2DTo4DSymmPad : NativeCodeCall<
@@ -33,8 +43,6 @@ def : Pat<(MIGraphX_ConvolutionOp:$result $input1, $filter, $pad, $stride, $dila
       ),
     (Tosa_Conv2DOp $input1, $filter, (ConstantOp ConstantAttr<RankedF32ElementsAttr<[1]>, "{0.0f}">:$f32attr), (Convert2DTo4DSymmPad $pad), $stride, $dilation, (GetNullAttr))>;
 */
-def : Pat<(MIGraphX_RsqrtOp $input1), (Tosa_RsqrtOp $input1)>;
-def : Pat<(MIGraphX_TanhOp $input1), (Tosa_TanhOp $input1)>;
 
 // Clamp to Relu if it clamps to max/min number, otherwise convert to ceil + floor
 // {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64}
@@ -44,7 +52,7 @@ def : Pat<(MIGraphX_ReluOp $input1),
 
 def ConvertI64ArrayAttrtoDenseElementsAttr : NativeCodeCall<
     "DenseIntElementsAttr::get(RankedTensorType::get({static_cast<int64_t>($0.size())}, rewriter.getI64Type()), $0.getValue())">;
-def : Pat<(MIGraphX_TransposeOp $input1, $permAttr), 
+def : Pat<(MIGraphX_TransposeOp $input1, $permAttr),
   (Tosa_TransposeOp $input1, (Arith_ConstantOp (ConvertI64ArrayAttrtoDenseElementsAttr $permAttr)))>;
 
 #endif // MLIR_CONVERSION_MIGRAPHX_TO_TOSA

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-opt --migraphx-transform --canonicalize --migraphx-to-tosa %s -verify-diagnostics -o -| FileCheck %s
+// RUN: rocmlir-opt -split-input-file --migraphx-transform --canonicalize --migraphx-to-tosa %s -verify-diagnostics -o -| FileCheck %s
 
 module  {
   // CHECK-LABEL: func @dequantize_scale
@@ -7,7 +7,7 @@ module  {
   func.func @dequantize_scale(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf32>) -> tensor<1x112x112x64xf32> attributes {kernel = "mixr"} {
     %1 = "migraphx.dequantizelinear"(%arg, %scale) : (tensor<1x112x112x64xi32>, tensor<64xf32>) -> tensor<1x112x112x64xf32>
     return %1 : tensor<1x112x112x64xf32>
-}
+  }
 
   // CHECK-LABEL: func @dequantize_scale_bias
   // CHECK: tosa.sub
@@ -15,7 +15,7 @@ module  {
   func.func @dequantize_scale_bias(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf32>, %bias: tensor<64xi32>) -> tensor<1x112x112x64xf32> attributes {kernel = "mixr"} {
     %1 = "migraphx.dequantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xi32>, tensor<64xf32>, tensor<64xi32>) -> tensor<1x112x112x64xf32>
     return %1 : tensor<1x112x112x64xf32>
-}
+  }
 
   // CHECK-LABEL: func @quantize_scale
   // CHECK: tosa.reciprocal
@@ -33,7 +33,7 @@ module  {
   func.func @quantize_scale_bias(%arg: tensor<1x112x112x64xf32>, %scale: tensor<64xf32>, %bias: tensor<64xi8>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
     %1 = "migraphx.quantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xf32>, tensor<64xf32>, tensor<64xi8>) -> tensor<1x112x112x64xi8>
     return %1 : tensor<1x112x112x64xi8>
-}
+  }
 
   // CHECK-LABEL: func @conv_with_quant
   // CHECK: tosa.conv2d{{.*}} quantization_info
@@ -47,7 +47,7 @@ module  {
     %2 = "migraphx.dequantizelinear"(%1, %scale, %bias) : (tensor<1x64x112x112xi32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xf32>
     %3 = "migraphx.quantizelinear"(%2, %scale, %bias2) : (tensor<1x64x112x112xf32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi8>) -> tensor<1x64x112x112xi8>
     return %3 : tensor<1x64x112x112xi8>
-}
+  }
 
   // CHECK-LABEL: func.func @matmul
   // CHECK-NOT: tosa.reshape
@@ -103,52 +103,6 @@ module  {
     return %2 : tensor<2x4x8x64x2304xf16>
   }
 
-  // CHECK-LABEL: func.func @func_power
-  // CHECK: tosa.pow
-  func.func @func_power(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf32> {
-    %0 = "migraphx.pow"(%arg0, %arg1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
-     return %0 : tensor<16xf32>
-  }
-
-  // CHECK-LABEL: func.func @func_recip
-  // CHECK: tosa.recip
-  func.func @func_recip(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-    %0 = "migraphx.recip"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
-     return %0 : tensor<16xf32>
-  }
-
-  // CHECK-LABEL: func.func @func_sqrt
-  // CHECK: tosa.rsqrt
-  // CHECK-NOT: tosa.reciprocal
-  func.func @func_sqrt(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-    %0 = "migraphx.sqrt"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
-    %1 = "migraphx.recip"(%0) : (tensor<16xf32>) -> tensor<16xf32>
-     return %1 : tensor<16xf32>
-  }
-
-  // CHECK-LABEL: func.func @func_softmax_1d
-  // CHECK-DAG: [[REDUCE_MAX:%[a-z0-9]+]] = "tosa.reduce_max"([[INPUT:%[a-z0-9]+]])
-  // CHECK-DAG: [[SUB:%[a-z0-9]+]] = "tosa.sub"([[INPUT]], [[REDUCE_MAX]])
-  // CHECK-DAG: [[EXP:%[a-z0-9]+]] = "tosa.exp"([[SUB]])
-  // CHECK-DAG: [[REDUCE_SUM:%[a-z0-9]+]] = "tosa.reduce_sum"([[EXP]])
-  // CHECK-DAG: [[RECIPROCAL:%[a-z0-9]+]] = "tosa.reciprocal"([[REDUCE_SUM]])
-  // CHECK-DAG: "tosa.mul"([[EXP]], [[RECIPROCAL]])
-  func.func @func_softmax_1d(%arg0: tensor<16xf32>) -> tensor<16xf32> {
-    %0 = "migraphx.softmax"(%arg0) {axis = 0 : i64} : (tensor<16xf32>) -> tensor<16xf32>
-     return %0 : tensor<16xf32>
-  }
-
-  // CHECK-LABEL: func.func @func_softmax_4d
-  // CHECK-DAG: [[REDUCE_MAX:%[a-z0-9]+]] = "tosa.reduce_max"([[INPUT:%[a-z0-9]+]])
-  // CHECK-DAG: [[SUB:%[a-z0-9]+]] = "tosa.sub"([[INPUT]], [[REDUCE_MAX]])
-  // CHECK-DAG: [[EXP:%[a-z0-9]+]] = "tosa.exp"([[SUB]])
-  // CHECK-DAG: [[REDUCE_SUM:%[a-z0-9]+]] = "tosa.reduce_sum"([[EXP]])
-  // CHECK-DAG: [[RECIPROCAL:%[a-z0-9]+]] = "tosa.reciprocal"([[REDUCE_SUM]])
-  // CHECK-DAG: "tosa.mul"([[EXP]], [[RECIPROCAL]])
-  func.func @func_softmax_4d(%arg0: tensor<16x16x16x16xf32>) -> tensor<16x16x16x16xf32> {
-    %0 = "migraphx.softmax"(%arg0) {axis = 1 : i64} : (tensor<16x16x16x16xf32>) -> tensor<16x16x16x16xf32>
-     return %0 : tensor<16x16x16x16xf32>
-  }
 
   // broadcast ops will be lowered as implicit broadcast in tosa, passes if they're converted and legalize tosa.
   // CHECK-LABEL: func @func_mbcast
@@ -242,6 +196,49 @@ module  {
     %0 = "migraphx.slice"(%arg0) {axes = [1, 2], ends = [12, 284], starts = [0, 184]} : (tensor<1x36x384x64xf32>) -> tensor<1x12x100x64xf32>
     return %0 : tensor<1x12x100x64xf32>
   }
+}
+
+// -----
+
+// Unary operations
+
+module {
+  // CHECK-LABEL: func.func @func_abs
+  // CHECK: tosa.abs
+  func.func @func_abs(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.abs"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
+     return %0 : tensor<16xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_ceil
+  // CHECK: tosa.ceil
+  func.func @func_ceil(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.ceil"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
+     return %0 : tensor<16xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_div_f32
+  // CHECK: tosa.reciprocal
+  // CHECK: tosa.mul
+  func.func @func_div_f32(%arg0: tensor<1x36x384x64xf32>, %arg1: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.div"(%arg0, %arg1) : (tensor<1x36x384x64xf32>, tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32>
+    return %0 : tensor<1x36x384x64xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_div_f16
+  // CHECK: tosa.reciprocal
+  // CHECK: tosa.mul
+  func.func @func_div_f16(%arg0: tensor<1x36x384x64xf16>, %arg1: tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16> attributes{kernel, arch = ""} {
+    %0 = "migraphx.div"(%arg0, %arg1) : (tensor<1x36x384x64xf16>, tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16>
+    return %0 : tensor<1x36x384x64xf16>
+  }
+
+  // CHECK-LABEL: func.func @func_div_i32
+  // CHECK: tosa.div
+  func.func @func_div_i32(%arg0: tensor<1x36x384x64xi32>, %arg1: tensor<1x36x384x64xi32>) -> tensor<1x36x384x64xi32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.div"(%arg0, %arg1) : (tensor<1x36x384x64xi32>, tensor<1x36x384x64xi32>) -> tensor<1x36x384x64xi32>
+    return %0 : tensor<1x36x384x64xi32>
+  }
 
   // CHECK-LABEL: func.func @func_erf_f32
   // CHECK: tosa.erf
@@ -271,6 +268,27 @@ module  {
     return %0 : tensor<1x36x384x64xf16>
   }
 
+  // CHECK-LABEL: func.func @func_floor
+  // CHECK: tosa.floor
+  func.func @func_floor(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.floor"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
+     return %0 : tensor<16xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_log_f32
+  // CHECK: tosa.log
+  func.func @func_log_f32(%arg0: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
+    %0 = "migraphx.log"(%arg0) : (tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32>
+    return %0 : tensor<1x36x384x64xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_log_f16
+  // CHECK: tosa.log
+  func.func @func_log_f16(%arg0: tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16> attributes{kernel, arch = ""} {
+    %0 = "migraphx.log"(%arg0) : (tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16>
+    return %0 : tensor<1x36x384x64xf16>
+  }
+
   // CHECK-LABEL: func.func @func_neg_f32
   // CHECK: tosa.negate
   func.func @func_neg_f32(%arg0: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
@@ -285,25 +303,70 @@ module  {
     return %0 : tensor<1x36x384x64xf16>
   }
 
-  // CHECK-LABEL: func.func @func_div_f32
-  // CHECK: tosa.reciprocal
-  // CHECK: tosa.mul
-  func.func @func_div_f32(%arg0: tensor<1x36x384x64xf32>, %arg1: tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32> attributes{kernel, arch = ""} {
-    %0 = "migraphx.div"(%arg0, %arg1) : (tensor<1x36x384x64xf32>, tensor<1x36x384x64xf32>) -> tensor<1x36x384x64xf32>
-    return %0 : tensor<1x36x384x64xf32>
+  // CHECK-LABEL: func.func @func_power
+  // CHECK: tosa.pow
+  func.func @func_power(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.pow"(%arg0, %arg1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
+    return %0 : tensor<16xf32>
   }
 
-  // CHECK-LABEL: func.func @func_div_f16
-  // CHECK: tosa.reciprocal
-  // CHECK: tosa.mul
-  func.func @func_div_f16(%arg0: tensor<1x36x384x64xf16>, %arg1: tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16> attributes{kernel, arch = ""} {
-    %0 = "migraphx.div"(%arg0, %arg1) : (tensor<1x36x384x64xf16>, tensor<1x36x384x64xf16>) -> tensor<1x36x384x64xf16>
-    return %0 : tensor<1x36x384x64xf16>
+  // CHECK-LABEL: func.func @func_recip
+  // CHECK: tosa.recip
+  func.func @func_recip(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.recip"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
+     return %0 : tensor<16xf32>
   }
 
+  // CHECK-LABEL: func.func @func_rsqrt
+  // CHECK: tosa.rsqrt
+  func.func @func_rsqrt(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.rsqrt"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
+     return %0 : tensor<16xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_sigmoid
+  // CHECK: tosa.sigmoid
+  func.func @func_sigmoid(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.sigmoid"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
+     return %0 : tensor<16xf32>
+  }
+
+
+  // CHECK-LABEL: func.func @func_rsqrt_opt
+  // CHECK: tosa.rsqrt
+  // CHECK-NOT: tosa.reciprocal
+  func.func @func_rsqrt_opt(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.sqrt"(%arg0) : (tensor<16xf32>) -> tensor<16xf32>
+    %1 = "migraphx.recip"(%0) : (tensor<16xf32>) -> tensor<16xf32>
+     return %1 : tensor<16xf32>
+  }
 }
-
-
 
 // -----
 
+// Less trivial pointwise ops
+module {
+  // CHECK-LABEL: func.func @func_softmax_1d
+  // CHECK-DAG: [[REDUCE_MAX:%[a-z0-9]+]] = "tosa.reduce_max"([[INPUT:%[a-z0-9]+]])
+  // CHECK-DAG: [[SUB:%[a-z0-9]+]] = "tosa.sub"([[INPUT]], [[REDUCE_MAX]])
+  // CHECK-DAG: [[EXP:%[a-z0-9]+]] = "tosa.exp"([[SUB]])
+  // CHECK-DAG: [[REDUCE_SUM:%[a-z0-9]+]] = "tosa.reduce_sum"([[EXP]])
+  // CHECK-DAG: [[RECIPROCAL:%[a-z0-9]+]] = "tosa.reciprocal"([[REDUCE_SUM]])
+  // CHECK-DAG: "tosa.mul"([[EXP]], [[RECIPROCAL]])
+  func.func @func_softmax_1d(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = "migraphx.softmax"(%arg0) {axis = 0 : i64} : (tensor<16xf32>) -> tensor<16xf32>
+     return %0 : tensor<16xf32>
+  }
+
+  // CHECK-LABEL: func.func @func_softmax_4d
+  // CHECK-DAG: [[REDUCE_MAX:%[a-z0-9]+]] = "tosa.reduce_max"([[INPUT:%[a-z0-9]+]])
+  // CHECK-DAG: [[SUB:%[a-z0-9]+]] = "tosa.sub"([[INPUT]], [[REDUCE_MAX]])
+  // CHECK-DAG: [[EXP:%[a-z0-9]+]] = "tosa.exp"([[SUB]])
+  // CHECK-DAG: [[REDUCE_SUM:%[a-z0-9]+]] = "tosa.reduce_sum"([[EXP]])
+  // CHECK-DAG: [[RECIPROCAL:%[a-z0-9]+]] = "tosa.reciprocal"([[REDUCE_SUM]])
+  // CHECK-DAG: "tosa.mul"([[EXP]], [[RECIPROCAL]])
+  func.func @func_softmax_4d(%arg0: tensor<16x16x16x16xf32>) -> tensor<16x16x16x16xf32> {
+    %0 = "migraphx.softmax"(%arg0) {axis = 1 : i64} : (tensor<16x16x16x16xf32>) -> tensor<16x16x16x16xf32>
+     return %0 : tensor<16x16x16x16xf32>
+  }
+}


### PR DESCRIPTION
1. Move the `erf` conversion to the tablegen-based pattern rewrite system
2. Add other elementwise ops that both MIGraphX and Tosa support (abs, ceil, floor, sigmoid, log) to those patterns
3. Add tests
4. Organize everything into neat alphabetical order while I'm here.
5. Define i32 `div` just in case.

See https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/928 for where I got this list.