### PR TITLE
Use a more interleaved block layout

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -1,3 +1,27 @@
+//===- AccelEmitter.cpp - MLIR helper to emit acceleration intrinsics
+//---------------===//
+//
+// Copyright 2020 The MLIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+//
+// This class tries to abstract away the code-generation details needed to
+// generated calls to matrix multiply accelerator intrinsics (wmma, mfma).
+//
+//
+//===----------------------------------------------------------------------===//
+
 #include "AccelEmitter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
@@ -108,8 +132,8 @@ AccelEmitterParams MfmaEmitter::initAccelEmitterParams(
   params.mRepeats = mfmaGroup.getMRepeats(mPerWave);
   params.nRepeats = mfmaGroup.getNRepeats(nPerWave);
   params.nResultVectors = mfmaGroup.getImms().size();
-  params.mPerAccel = mfmaGroup.getLenPerMfmaGroup(mPerWave);
-  params.nPerAccel = mfmaGroup.getLenPerMfmaGroup(nPerWave);
+  params.mPerAccel = mfmaAttr.mfmaNonKDim * mfmaGroup.getImms().size();
+  params.nPerAccel = mfmaAttr.mfmaNonKDim * mfmaAttr.blocksMfma;
   params.kpackPerThread =
       (mfmaAttr.isKReduction ? kpackPerBlock / mfmaAttr.inputSpansPerMfmaIn
                              : kpackPerBlock);
@@ -163,6 +187,8 @@ ArrayAttr MfmaEmitter::computeOutputTransforms(PatternRewriter &b, Location loc,
   int64_t nRepeats = accelEmitterParams.nRepeats;
   int64_t nResultVectors = accelEmitterParams.nResultVectors;
   VectorType accVectorType = accelEmitterParams.accVectorType;
+  int64_t mPerAccel = accelEmitterParams.mPerAccel;
+  int64_t nPerAccel = accelEmitterParams.nPerAccel;
 
   auto mfmaAttr = mfmaGroup.getInsnAttr();
   int64_t mPerRepeat = mPerWave / mRepeats;
@@ -171,6 +197,7 @@ ArrayAttr MfmaEmitter::computeOutputTransforms(PatternRewriter &b, Location loc,
   int64_t mBlocks = matrixM / mPerBlock;
   int64_t gStride = mBlocks * nBlocks;
   int64_t nWaves = nPerBlock / nPerWave;
+  int64_t mWaves = mPerBlock / mPerWave;
   int64_t rowGroupSize = mfmaAttr.rowGroupSize;
   int64_t rowGroupsPerBlock = mfmaAttr.rowGroupsPerBlock;
   int64_t inputSpanLen = mfmaAttr.inputSpanLen;
@@ -188,8 +215,10 @@ ArrayAttr MfmaEmitter::computeOutputTransforms(PatternRewriter &b, Location loc,
   int64_t numElements = retNumElements * mRepeats * nRepeats * nResultVectors;
   TopDownTMBuilder splitMemoryCoords(b, {"bid", "tid", "item"},
                                      {gridSize, blockSize, numElements}, loc);
+
   splitMemoryCoords.merge({"g", "m", "n"}, {0, 1, 2}, {"bid"},
                           {gridSize / gStride, gStride / nBlocks, nBlocks});
+
   splitMemoryCoords.merge(
       {"wave", "m_tid", "n_tid"}, {3, 4, 5}, "tid",
       {wavesInKernelBlock, waveSize / inputSpanLen, inputSpanLen});
@@ -236,11 +265,12 @@ ArrayAttr MfmaEmitter::computeOutputTransforms(PatternRewriter &b, Location loc,
   toMatrixC.embed(
       "gemmM", 1, matrixM,
       {"m", "wave_m", "m_tid", "m_i", "blk_row", "vec_group", "vec_item"},
-      {mPerBlock, mPerWave, rowGroupSize, mPerRepeat, m,
+      {mPerBlock, mPerAccel, rowGroupSize, mPerAccel * mWaves, m,
        inputSpansPerMfmaIn * rowGroupSize, 1});
   toMatrixC.embed("gemmN", 2, matrixN,
                   {"n", "wave_n", "n_i", "blk_col", "n_tid"},
-                  {nPerBlock, nPerWave, nPerRepeat, n, 1});
+                  {nPerBlock, nPerAccel, nPerAccel * nWaves, n, 1});
+
   TransformMapAttr toMatrixCAttr = toMatrixC.get();
 
   ArrayAttr idToMatrixCMaps =
@@ -252,48 +282,52 @@ Value MfmaEmitter::computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
                                           OpBuilder &dBuilder, Value d_i,
                                           OpBuilder &builder, Value dPerBlock,
                                           Location loc, Value sourceBase,
-                                          Value laneId) {
+                                          Value dWaves, Value laneId) {
 
   // Extract relevant emitter parameters
   MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
-  int64_t nPerAccel = accelEmitterParams.nPerAccel;
   int64_t inputSpanLen = mfmaAttr.inputSpanLen;
-  int64_t inputSpansPerMfmaIn = mfmaAttr.inputSpansPerMfmaIn;
   bool isKReduction = mfmaAttr.isKReduction;
+  Value inputSpanLenConstantOp =
+      builder.create<ConstantIndexOp>(loc, inputSpanLen);
 
   Value sourceOffset = sourceBase;
   if (!isKReduction) {
-    // srcOffset = k_i * MN + laneId + mPerMfmaGroup * mn_i;
-    Value mnPerMfmaGroup = builder.create<ConstantIndexOp>(loc, nPerAccel);
+    // Compute source offset as
+    // sourceOffset = k_i * MN + laneId + waveOffset * d_i;
     sourceOffset = builder.create<AddIOp>(loc, sourceOffset, laneId);
+
+    Value waveOffset =
+        builder.create<MulIOp>(loc, dWaves, inputSpanLenConstantOp);
+
     sourceOffset = dBuilder.create<AddIOp>(
-        loc, sourceOffset, dBuilder.create<MulIOp>(loc, mnPerMfmaGroup, d_i));
+        loc, sourceOffset, dBuilder.create<MulIOp>(loc, waveOffset, d_i));
     sourceOffset = kBuilder.create<AddIOp>(
         loc, sourceOffset, kBuilder.create<MulIOp>(loc, dPerBlock, k_i));
   } else {
-    // srcOffset = (k_i * input_span_per_mfma + blk_id) * MN + blk_td + mn_i
-    // * input_span_length;
     Value inputSpanLenConstantOp =
         builder.create<ConstantIndexOp>(loc, inputSpanLen);
-    Value inputSpansPerMfmaInConstantOp =
-        builder.create<ConstantIndexOp>(loc, inputSpansPerMfmaIn);
+    Value kpackPerThreadConstantOp =
+        builder.create<ConstantIndexOp>(loc, accelEmitterParams.kpackPerThread);
+
     Value blk_id = builder.create<DivUIOp>(loc, laneId, inputSpanLenConstantOp);
     Value blk_td = builder.create<RemUIOp>(loc, laneId, inputSpanLenConstantOp);
+    Value waveOffset =
+        builder.create<MulIOp>(loc, dWaves, inputSpanLenConstantOp);
 
+    // rowOffset = (k_i + kpackPerBlock * blk_id)
+    Value rowOffset = kBuilder.create<AddIOp>(
+        loc, kBuilder.create<MulIOp>(loc, blk_id, kpackPerThreadConstantOp),
+        k_i);
+
+    // Compute source offset as
+    // sourceOffset =  rowOffset * MN + blk_td + d_i * waveOffset;
     sourceOffset = builder.create<AddIOp>(loc, sourceOffset, blk_td);
     sourceOffset = dBuilder.create<AddIOp>(
-        loc, sourceOffset,
-        dBuilder.create<MulIOp>(loc, inputSpanLenConstantOp, d_i));
+        loc, sourceOffset, dBuilder.create<MulIOp>(loc, waveOffset, d_i));
+
     sourceOffset = kBuilder.create<AddIOp>(
-        loc, sourceOffset,
-        kBuilder.create<MulIOp>(
-            loc,
-            kBuilder.create<AddIOp>(
-                loc,
-                kBuilder.create<MulIOp>(loc, k_i,
-                                        inputSpansPerMfmaInConstantOp),
-                blk_id),
-            dPerBlock));
+        loc, sourceOffset, kBuilder.create<MulIOp>(loc, rowOffset, dPerBlock));
   }
   return sourceOffset;
 }
@@ -336,14 +370,19 @@ Value WmmaEmitter::computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
                                           OpBuilder &dBuilder, Value d_i,
                                           OpBuilder &builder, Value dPerBlock,
                                           Location loc, Value sourceBase,
-                                          Value laneId) {
+                                          Value dWaves, Value laneId) {
 
-  // srcOffset = k_i * MN + (laneId % wmmaInputLen) + wmmaInputLen * mn_i;
+  Value mPerAccel =
+      builder.create<ConstantIndexOp>(loc, accelEmitterParams.mPerAccel);
+  Value waveOffset = builder.create<MulIOp>(loc, dWaves, mPerAccel);
+
+  // Compute source offset as
+  // sourceOffset = k_i * MN + (laneId % wmmaInputLen) + waveOffset * mn_i;
   Value inputLen = builder.create<ConstantIndexOp>(loc, wmmaInsn.inputLen);
   Value sourceOffset = builder.create<AddIOp>(
       loc, sourceBase, builder.create<RemUIOp>(loc, laneId, inputLen));
   sourceOffset = dBuilder.create<AddIOp>(
-      loc, sourceOffset, dBuilder.create<MulIOp>(loc, inputLen, d_i));
+      loc, sourceOffset, dBuilder.create<MulIOp>(loc, waveOffset, d_i));
   sourceOffset = kBuilder.create<AddIOp>(
       loc, sourceOffset, kBuilder.create<MulIOp>(loc, dPerBlock, k_i));
   return sourceOffset;
@@ -383,6 +422,7 @@ ArrayAttr WmmaEmitter::computeOutputTransforms(PatternRewriter &b, Location loc,
   int64_t mBlocks = matrixM / mPerBlock;
   int64_t gStride = mBlocks * nBlocks;
   int64_t nWaves = nPerBlock / nPerWave;
+  int64_t mWaves = mPerBlock / mPerWave;
 
   // High level code for this loop
   // source: https://gpuopen.com/learn/wmma_on_rdna3/
@@ -401,6 +441,7 @@ ArrayAttr WmmaEmitter::computeOutputTransforms(PatternRewriter &b, Location loc,
   TopDownTMBuilder splitMemoryCoords(
       b, {"bid", "tid", "item"},
       {gridSize, blockSize, mRepeats * nRepeats * retNumElements}, loc);
+
   splitMemoryCoords.merge({"g", "m", "n"}, {0, 1, 2}, {"bid"},
                           {gridSize / gStride, gStride / nBlocks, nBlocks});
 
@@ -424,12 +465,14 @@ ArrayAttr WmmaEmitter::computeOutputTransforms(PatternRewriter &b, Location loc,
   // tile. For workitems 0 to 15 m_tid is 0 and they write to 0,2,4,...,14.  For
   // workitems 16 to 31 m_tid is 1 and they write at positions 1,3,5,..,15 .
   // This is outlined in https://gpuopen.com/learn/wmma_on_rdna3/
-  toMatrixC.embed(
-      "gemmM", 1, matrixM, {"m", "wave_m", "m_tid", "rep_i", "item_i"},
-      {mPerBlock, mPerWave, 1, wmmaInsn.inputLen, wmmaInsn.outputStride});
+  toMatrixC.embed("gemmM", 1, matrixM,
+                  {"m", "wave_m", "m_tid", "rep_i", "item_i"},
+                  {mPerBlock, wmmaInsn.inputLen, 1, mWaves * wmmaInsn.inputLen,
+                   wmmaInsn.outputStride});
 
-  toMatrixC.embed("gemmN", 2, matrixN, {"n", "wave_n", "n_tid", "rep_j"},
-                  {nPerBlock, nPerWave, 1, wmmaInsn.inputLen});
+  toMatrixC.embed(
+      "gemmN", 2, matrixN, {"n", "wave_n", "n_tid", "rep_j"},
+      {nPerBlock, wmmaInsn.inputLen, 1, nWaves * wmmaInsn.inputLen});
 
   TransformMapAttr toMatrixCAttr = toMatrixC.get();
 

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -1,4 +1,3 @@
-
 //===- AccelEmitter.cpp - MLIR helper to emit acceleration intrinsics
 //---------------===//
 //
@@ -108,7 +107,7 @@ struct AccelEmitter {
                                        OpBuilder &dBuilder, Value d_i,
                                        OpBuilder &builder, Value dPerBlock,
                                        Location loc, Value baseOffset,
-                                       Value laneId) = 0;
+                                       Value dWaves, Value laneId) = 0;
 
   /// Compute the output transform map to be used to store the result of the
   /// matrix multiplication tile
@@ -151,7 +150,7 @@ struct MfmaEmitter : public AccelEmitter {
   Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
                                OpBuilder &dBuilder, Value d_i,
                                OpBuilder &builder, Value dPerBlock,
-                               Location loc, Value baseOffset,
+                               Location loc, Value baseOffset, Value dWaves,
                                Value laneId) override;
 
   ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc,
@@ -181,7 +180,7 @@ struct WmmaEmitter : public AccelEmitter {
   Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
                                OpBuilder &dBuilder, Value d_i,
                                OpBuilder &builder, Value dPerBlock,
-                               Location loc, Value baseOffset,
+                               Location loc, Value baseOffset, Value dWaves,
                                Value laneId) override;
 
   ArrayAttr computeOutputTransforms(PatternRewriter &b, Location loc,

--- a/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
@@ -48,4 +48,3 @@ add_rocmlir_dialect_library(MLIRRockTransforms
   MLIRSupport
   MLIRTosaDialect
 )
-

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -165,7 +165,6 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
         op.getStoreMethodAttr(), blockSize, gridSize,
         params.cast<RockAccelTuningParamAttrInterface>());
     rw.eraseOp(op);
-
   } else {
     rw.create<GridwiseGemmOp>(loc, a, b, c, op.getFeaturesAttr(), gridSize,
                               params.cast<GeneralGemmParamsAttr>());

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1154,11 +1154,8 @@ struct GridwiseGemmAccelRewritePattern
     // Obtain Accelerator-related attributes.
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();
-    // int64_t MWaves = mPerBlock / mPerWave;
     int64_t nWaves = nPerBlock / nPerWave;
 
-    auto mPerWaveConstantOp = b.create<ConstantIndexOp>(loc, mPerWave);
-    auto nPerWaveConstantOp = b.create<ConstantIndexOp>(loc, nPerWave);
     auto nWavesConstantOp = b.create<ConstantIndexOp>(loc, nWaves);
 
     auto accelEmitterPtr = accel::AccelEmitter::select(
@@ -1274,8 +1271,12 @@ struct GridwiseGemmAccelRewritePattern
     auto waveId_n = b.create<RemUIOp>(loc, waveId, nWavesConstantOp);
 
     Value mMyWaveOffsetA, mMyWaveOffsetB;
-    mMyWaveOffsetA = b.create<MulIOp>(loc, waveId_m, mPerWaveConstantOp);
-    mMyWaveOffsetB = b.create<MulIOp>(loc, waveId_n, nPerWaveConstantOp);
+    Value waveOffsetAConstantOp =
+        b.create<ConstantIndexOp>(loc, params.mPerAccel);
+    Value waveOffsetBConstantOp =
+        b.create<ConstantIndexOp>(loc, params.nPerAccel);
+    mMyWaveOffsetA = b.create<MulIOp>(loc, waveId_m, waveOffsetAConstantOp);
+    mMyWaveOffsetB = b.create<MulIOp>(loc, waveId_n, waveOffsetBConstantOp);
 
     // Logic to setup buffers for blockwise_gemm_accel.
 

--- a/mlir/test/Dialect/Rock/regularize.mlir
+++ b/mlir/test/Dialect/Rock/regularize.mlir
@@ -41,4 +41,3 @@ func.func private @bert_part_11__part_0(%arg0: memref<1x12x12x32xf32> {func.read
 // CHECK: linalg.generic {indexing_maps = [[[MAP0]], [[MAP0]], [[MAP0]], [[MAP0]]], iterator_types = ["parallel", "parallel", "parallel"]} ins([[ALLOC0]], [[ARG2_TR2]], [[ARG3_TR2]] : memref<12x12x12xf32>, memref<12x12x12xf32>, memref<12x12x12xf32>) outs([[ARG4_TR:.*]] : memref<12x12x12xf32>)
 
 // CHECK: memref.copy [[ALLOC1]], [[ARG4]] : memref<1x12x12x12xf32> to memref<1x12x12x12xf32>
-

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -167,10 +167,10 @@ runKernelPipeline(StringRef arch, ModuleOp kmod, bool isHighLevel,
     rock::buildKernelPipeline(pm);
   }
   if (kernelPipelineSet.contains("rocdl")) {
-    pm.addPass(
-        createLowerGpuOpsToROCDLOpsPass(/*chipset=*/devName.getChip().str(),
-                                        /*indexBitWidth=*/32,
-                                        /*useBarePtrCallConv*/ barePointers));
+    pm.addPass(createLowerGpuOpsToROCDLOpsPass(
+        /*chipset=*/devName.getChip().str(),
+        /*indexBitWidth=*/32,
+        /*useBarePtrCallConv*/ barePointers));
   }
   if (kernelPipelineSet.contains("binary")) {
     // Set up the lowering pipeline which goes down to ELF Binary

--- a/mlir/utils/performance/gemm-configs
+++ b/mlir/utils/performance/gemm-configs
@@ -30,7 +30,7 @@
 -transA false -transB false -g 1 -m 384 -n 2304 -k 768
 -transA false -transB false -g 1 -m 384 -n 2 -k 768
 -transA false -transB false -g 1 -m 384 -n 3072 -k 768
--transA false -transB false -g 1 -m 384 -n 768 -k 3072 
+-transA false -transB false -g 1 -m 384 -n 768 -k 3072
 -transA false -transB false -g 1 -m 384 -n 768 -k 768
 -transA false -transB true -g 12 -m 384 -n 384 -k 64
 -transA false -transB false -g 1 -m 1 -n 768 -k 768


### PR DESCRIPTION
Use a more interleaved layout when mPerWave/nPerWave > 1. 

Instead of `wave[0]` computing `block[0:mPerWave]`, let `wave[0]` compute blocks `block[i*numWaves:(i+1)*numWaves+mPerAccel]`  where `0 <= i < mPerWave`

Fixes: https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/925