### PR TITLE
Add rock.blockwise_fill op

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -406,6 +406,21 @@ def Rock_FillOp:
   }];
 }
 
+def Rock_BlockwiseFillOp:
+    Rock_Op<"blockwise_fill", [AllElementTypesMatch<["memref", "value"]>]>,
+    Arguments<(ins AnyMemRef:$memref,
+                   AnyTypeOf<[AnyInteger, AnyFloat, AnyVector]>:$value,
+                   I32Attr:$blockSize)> {
+  let summary = "Fill memory with constant value on GPU";
+  let description = [{
+    The `rock.blockwise_fill` op fills a LDS memref on GPU with a constant value.
+  }];
+  let assemblyFormat = [{
+    `(` operands `)` attr-dict `:` type(operands)
+  }];
+  let hasVerifier = 1;
+}
+
 def Rock_WorkgroupBarrierOp:
     Rock_Op<"workgroup_barrier"> {
   let summary = "Setup an workgroup barrier";

--- a/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_scalar_case1.mlir
+++ b/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_scalar_case1.mlir
@@ -1,0 +1,18 @@
+// RUN: cat %s | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// CHECK-COUNT-256: 1
+
+#map = affine_map<(d0, d1) -> (d0 + d1)>
+#map1 = affine_map<(d0) -> (d0)>
+#transform_map = #rock.transform_map<#map by [<Unmerge{256, 1} ["tid", "iter"] at [0, 1] -> ["dim0"] at [0]>] bounds = [256, 1] -> [256]>
+#transform_map1 = #rock.transform_map<#map1 by [<Pad{0, 0} ["dim0"] at [0] -> ["dim0"] at [0]>] bounds = [256] -> [256]>
+
+func.func @rock_blockwise_fill_scalar_case1(%output : memref<1x256x1xf32>) attributes{arch = "", block_size = 256 : i32, grid_size = 1 : i32, kernel} {
+    %output_reg = rock.alloc() : memref<1xf32, #gpu.address_space<private>>
+    %ldsbuf = rock.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
+    %c1 = arith.constant 1.0 : f32
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<256xf32, #gpu.address_space<workgroup>>, f32
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs}
+    [#transform_map, #transform_map1](%ldsbuf) -> %output_reg : memref<256xf32, #gpu.address_space<workgroup>> ->  memref<1xf32, #gpu.address_space<private>>
+    rock.threadwise_write_all features = none {forceUnroll, useIndexDiffs} %output_reg -> [](%output) by set : memref<1xf32, #gpu.address_space<private>> -> memref<1x256x1xf32>
+    return
+}

--- a/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_scalar_case2.mlir
+++ b/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_scalar_case2.mlir
@@ -1,0 +1,23 @@
+// RUN: cat %s | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// CHECK-COUNT-300: 3
+
+#map = affine_map<(d0, d1) -> (d0 * 2 + d1)>
+#map1 = affine_map<(d0) -> (d0)>
+#transform_map = #rock.transform_map<#map by [<Unmerge{256, 2} ["tid", "iter"] at [0, 1] -> ["dim0"] at [0]>] bounds = [256, 2] -> [512]>
+#transform_map1 = #rock.transform_map<#map1 by [<Pad{0, 212} ["dim0"] at [0] -> ["dim0"] at [0]>] bounds = [512] -> [300]>
+
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1 * 2 + d2)>
+#map5 = affine_map<(d0, d1) -> (d0, d1)>
+#transform_map4 = #rock.transform_map<#map4 by [<Unmerge{256, 2} ["tid", "iter"] at [1, 2] -> ["dim0"] at [1]>, <PassThrough ["bid"] at [0] -> ["bid"] at [0]>] bounds = [1, 256, 2] -> [1, 512]>
+#transform_map5 = #rock.transform_map<#map5 by [<Pad{0, 212} ["tid"] at [1] -> ["tid"] at [1]>, <PassThrough ["bid"] at [0] -> ["bid"] at [0]>] bounds = [1, 512] -> [1, 300]>
+
+func.func @rock_blockwise_fill_scalar_case1(%output : memref<1x300xf32>) attributes{arch = "", block_size = 256 : i32, grid_size = 1 : i32, kernel} {
+    %output_reg = rock.alloc() : memref<1xf32, #gpu.address_space<private>>
+    %ldsbuf = rock.alloc() : memref<300xf32, #gpu.address_space<workgroup>>
+    %c1 = arith.constant 3.0 : f32
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<300xf32, #gpu.address_space<workgroup>>, f32
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs}
+    [#transform_map, #transform_map1](%ldsbuf) -> %output_reg : memref<300xf32, #gpu.address_space<workgroup>> ->  memref<1xf32, #gpu.address_space<private>>
+    rock.threadwise_write_all features = none {forceUnroll, useIndexDiffs} %output_reg -> [#transform_map4, #transform_map5](%output) by set : memref<1xf32, #gpu.address_space<private>> -> memref<1x300xf32>
+    return
+}

--- a/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_vec_case1.mlir
+++ b/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_vec_case1.mlir
@@ -1,0 +1,23 @@
+// RUN: cat %s | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// CHECK-COUNT-16: 1, 2, 3, 4
+
+#map = affine_map<(d0, d1) -> (d0 * 4 + d1)>
+#map1 = affine_map<(d0) -> (d0)>
+#transform_map = #rock.transform_map<#map by [<Unmerge{256, 4} ["tid", "iter"] at [0, 1] -> ["dim0"] at [0]>] bounds = [256, 4] -> [1024]>
+#transform_map1 = #rock.transform_map<#map1 by [<Pad{0, 960} ["dim0"] at [0] -> ["dim0"] at [0]>] bounds = [1024] -> [64]>
+
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1 * 4 + d2)>
+#map5 = affine_map<(d0, d1) -> (d0, d1)>
+#transform_map4 = #rock.transform_map<#map4 by [<Unmerge{256, 4} ["iter", "tid"] at [1, 2] -> ["dim0"] at [1]>, <PassThrough ["bid"] at [0] -> ["bid"] at [0]>] bounds = [1, 256, 4] -> [1, 1024]>
+#transform_map5 = #rock.transform_map<#map5 by [<Pad{0, 960} ["tid"] at [1] -> ["tid"] at [1]>, <PassThrough ["bid"] at [0] -> ["bid"] at [0]>] bounds = [1, 1024] -> [1, 64]>
+
+func.func @rock_blockwise_fill_vec_case1(%output : memref<1x64xf32>) attributes{arch = "", block_size = 256 : i32, grid_size = 1 : i32, kernel} {
+    %output_reg = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
+    %ldsbuf = rock.alloc() : memref<64xf32, #gpu.address_space<workgroup>>
+    %c1 = arith.constant dense<[1.0, 2.0, 3.0, 4.0]> : vector<4xf32>
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<64xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs}
+    [#transform_map, #transform_map1](%ldsbuf) -> %output_reg : memref<64xf32, #gpu.address_space<workgroup>> ->  memref<4xf32, #gpu.address_space<private>>
+    rock.threadwise_write_all features = none {forceUnroll, useIndexDiffs} %output_reg -> [#transform_map4, #transform_map5](%output) by set : memref<4xf32, #gpu.address_space<private>> -> memref<1x64xf32>
+    return
+}

--- a/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_vec_case2.mlir
+++ b/mlir/test/Dialect/Rock/integration/blockwise_fill/bfill_vec_case2.mlir
@@ -1,0 +1,23 @@
+// RUN: cat %s | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// CHECK-COUNT-64: 1, 2, 3, 4
+
+#map = affine_map<(d0, d1) -> (d0 * 4 + d1)>
+#map1 = affine_map<(d0) -> (d0)>
+#transform_map = #rock.transform_map<#map by [<Unmerge{256, 4} ["tid", "iter"] at [0, 1] -> ["dim0"] at [0]>] bounds = [256, 4] -> [1024]>
+#transform_map1 = #rock.transform_map<#map1 by [<Pad{0, 768} ["dim0"] at [0] -> ["dim0"] at [0]>] bounds = [1024] -> [256]>
+
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1 * 4 + d2)>
+#map5 = affine_map<(d0, d1) -> (d0, d1)>
+#transform_map4 = #rock.transform_map<#map4 by [<Unmerge{256, 4} ["iter", "tid"] at [1, 2] -> ["dim0"] at [1]>, <PassThrough ["bid"] at [0] -> ["bid"] at [0]>] bounds = [1, 256, 4] -> [1, 1024]>
+#transform_map5 = #rock.transform_map<#map5 by [<Pad{0, 768} ["tid"] at [1] -> ["tid"] at [1]>, <PassThrough ["bid"] at [0] -> ["bid"] at [0]>] bounds = [1, 1024] -> [1, 256]>
+
+func.func @rock_blockwise_fill_vec_case1(%output : memref<1x256xf32>) attributes{arch = "", block_size = 256 : i32, grid_size = 1 : i32, kernel} {
+    %output_reg = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
+    %ldsbuf = rock.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
+    %c1 = arith.constant dense<[1.0, 2.0, 3.0, 4.0]> : vector<4xf32>
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<256xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs}
+    [#transform_map, #transform_map1](%ldsbuf) -> %output_reg : memref<256xf32, #gpu.address_space<workgroup>> ->  memref<4xf32, #gpu.address_space<private>>
+    rock.threadwise_write_all features = none {forceUnroll, useIndexDiffs} %output_reg -> [#transform_map4, #transform_map5](%output) by set : memref<4xf32, #gpu.address_space<private>> -> memref<1x256xf32>
+    return
+}

--- a/mlir/test/Dialect/Rock/integration/blockwise_fill/lit.local.cfg
+++ b/mlir/test/Dialect/Rock/integration/blockwise_fill/lit.local.cfg
@@ -1,0 +1,3 @@
+# These tests are disabled in the interest of CI load
+# However, they should be passing.
+config.unsupported = True

--- a/mlir/test/Dialect/Rock/lowering_blockwise_fill.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_fill.mlir
@@ -1,0 +1,69 @@
+// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise -split-input-file %s | FileCheck %s
+
+// CHECK-DAG: [[MAP:.*]] = affine_map<(d0, d1) -> (d0 + d1)>
+// CHECK-DAG: [[TMAP:.*]] = #rock.transform_map<[[MAP]]{{.*}}
+// CHECK-DAG: [[MAP1:.*]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG: [[TMAP1:.*]] = #rock.transform_map<[[MAP1]]{{.*}}[<Pad{0, 0} ["dim0"] at [0] -> ["dim0"] at [0]>]
+// CHECK: func @rock_blockwise_fill_scalar_case1
+func.func @rock_blockwise_fill_scalar_case1(%ldsbuf : memref<256xf32, #gpu.address_space<workgroup>>){
+    %c1 = arith.constant 1.0 : f32
+    // CHECK: rock.transforming_for {{.*}} [[[TMAP]], [[TMAP1]]]
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<256xf32, #gpu.address_space<workgroup>>, f32
+    return
+}
+
+// -----
+
+// CHECK-DAG: [[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 2 + d1)>
+// CHECK-DAG: [[TMAP:.*]] = #rock.transform_map<[[MAP]]{{.*}}
+// CHECK-DAG: [[MAP1:.*]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG: [[TMAP1:.*]] = #rock.transform_map<[[MAP1]]{{.*}}[<Pad{0, 212} ["dim0"] at [0] -> ["dim0"] at [0]>]
+// CHECK: func @rock_blockwise_fill_scalar_case2
+func.func @rock_blockwise_fill_scalar_case2(%ldsbuf : memref<300xf32, #gpu.address_space<workgroup>>){
+    %c1 = arith.constant 1.0 : f32
+    // CHECK: rock.transforming_for {{.*}} [[[TMAP]], [[TMAP1]]]
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<300xf32, #gpu.address_space<workgroup>>, f32
+    return
+}
+
+// -----
+
+// CHECK-DAG: [[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 4 + d1)>
+// CHECK-DAG: [[TMAP:.*]] = #rock.transform_map<[[MAP]]{{.*}}
+// CHECK-DAG: [[MAP1:.*]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG: [[TMAP1:.*]] = #rock.transform_map<[[MAP1]]{{.*}}[<Pad{0, 960} ["dim0"] at [0] -> ["dim0"] at [0]>]
+// CHECK: func @rock_blockwise_fill_vec_case1
+func.func @rock_blockwise_fill_vec_case1(%ldsbuf : memref<64xf32, #gpu.address_space<workgroup>>){
+    %c1 = arith.constant dense<1.0> : vector<4xf32>
+    // CHECK: rock.transforming_for {{.*}} [[[TMAP]], [[TMAP1]]]
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<64xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+    return
+}
+
+// -----
+
+// CHECK-DAG: [[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 4 + d1)>
+// CHECK-DAG: [[TMAP:.*]] = #rock.transform_map<[[MAP]]{{.*}}
+// CHECK-DAG: [[MAP1:.*]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG: [[TMAP1:.*]] = #rock.transform_map<[[MAP1]]{{.*}}[<Pad{0, 768} ["dim0"] at [0] -> ["dim0"] at [0]>]
+// CHECK: func @rock_blockwise_fill_vec_case2
+func.func @rock_blockwise_fill_vec_case2(%ldsbuf : memref<256xf32, #gpu.address_space<workgroup>>){
+    %c1 = arith.constant dense<1.0> : vector<4xf32>
+    // CHECK: rock.transforming_for {{.*}} [[[TMAP]], [[TMAP1]]]
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<256xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+    return
+}
+
+// -----
+
+// CHECK-DAG: [[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 4 + d1)>
+// CHECK-DAG: [[TMAP:.*]] = #rock.transform_map<[[MAP]]{{.*}}
+// CHECK-DAG: [[MAP1:.*]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG: [[TMAP1:.*]] = #rock.transform_map<[[MAP1]]{{.*}}[<Pad{0, 0} ["dim0"] at [0] -> ["dim0"] at [0]>]
+// CHECK: func @rock_blockwise_fill_vec_case3
+func.func @rock_blockwise_fill_vec_case3(%ldsbuf : memref<1024xf32, #gpu.address_space<workgroup>>){
+    %c1 = arith.constant dense<1.0> : vector<4xf32>
+    // CHECK: rock.transforming_for {{.*}} [[[TMAP]], [[TMAP1]]]
+    rock.blockwise_fill(%ldsbuf, %c1) {blockSize = 256 : i32} : memref<1024xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+    return
+}


### PR DESCRIPTION
This commit add rock.blockwise_fill op
that could be used to fill up a LDS
memref with data.

closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/881