### PR TITLE
Fix fp8 CI with -rand N by disabling random fp8 tests

### DIFF
--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2571,7 +2571,8 @@ static LogicalResult populateHostHarnessLogic(
 
   bool isRandom = (randomSeed != "fixed" && randomSeed != "none");
   if (isRandom && isFp8) {
-    llvm::errs() << "WARNING: Random values not supported for fp8, defaulting to -rand fixed\n";
+    llvm::errs() << "WARNING: Random values not supported for fp8, defaulting "
+                    "to -rand fixed\n";
     randomSeed = "fixed";
     isRandom = false;
   }


### PR DESCRIPTION
arith.truncf isn't implemented for fp8 so don't generate code that uses it, which means don't allow -rand for those types.