### PR TITLE
Call rocblas in the same way migraphx does

### DIFF
--- a/mlir/utils/performance/common/benchmarkUtils.cpp
+++ b/mlir/utils/performance/common/benchmarkUtils.cpp
@@ -19,6 +19,15 @@ using namespace benchmark;
 
 namespace {
 
+/// Get the identifier of the current device
+int get_device_id() {
+  int device;
+  auto status = hipGetDevice(&device);
+  if (status != hipSuccess)
+    assert(0 && "No device found");
+  return device;
+}
+
 // Conversion helpers for F16 and BF16
 
 // BF16 conversion
@@ -302,6 +311,14 @@ void *getGpuBuffer(const void *hostMem, size_t byteSize) {
   HIP_ABORT_IF_FAIL(
       hipMemcpy(gpuBuffer, hostMem, byteSize, hipMemcpyHostToDevice));
   return gpuBuffer;
+}
+
+std::string get_device_name() {
+  hipDeviceProp_t props{};
+  auto status = hipGetDeviceProperties(&props, get_device_id());
+  if (status != hipSuccess)
+    assert(0 && "Device unknown");
+  return std::string(props.gcnArchName);
 }
 
 } // namespace benchmark

--- a/mlir/utils/performance/common/benchmarkUtils.h
+++ b/mlir/utils/performance/common/benchmarkUtils.h
@@ -60,6 +60,10 @@ size_t getBytesPerElement(DataType dataType, bool isOut);
 
 // Allocate a device buffer and copy the date from host memory
 void *getGpuBuffer(const void *hostMem, size_t byteSize);
+
+// Get the GPU device name
+std::string get_device_name();
+
 } // namespace benchmark
 
 #endif // MLIR_UTILS_PERFORMANCE_COMMON_BENCHMARKUTILS_H

--- a/mlir/utils/performance/convertRocBlasToPerfRunner.py
+++ b/mlir/utils/performance/convertRocBlasToPerfRunner.py
@@ -13,8 +13,8 @@ def convertToPerfRunner(rocblasIns):
     perfRunnerIns = {}
 
     # Default values (from rocblas-bench)
-    perfRunnerIns["-transA"] = "false"
-    perfRunnerIns["-transB"] = "false"
+    perfRunnerIns["-transA"] = "true"
+    perfRunnerIns["-transB"] = "true"
     perfRunnerIns["-g"] = "1"
     perfRunnerIns["-m"] = "128"
     perfRunnerIns["-n"] = "128"
@@ -35,13 +35,10 @@ def convertToPerfRunner(rocblasIns):
             perfRunnerIns["-t"] = t
         elif rocblasIns[ii] == "--batch_count":
             perfRunnerIns["-g"] = rocblasIns[ii + 1]
-        # When MIGraphX is sending non-transposed data to rocBLAS, this means non-transposed
-        # column-major data. Our tools work in row-major format, and this means we need to transpose
-        # when we receive a non-transposed data layout.
         elif rocblasIns[ii] == "--transposeA" and rocblasIns[ii + 1] == "N":
-            perfRunnerIns["-transA"] = "true"
+            perfRunnerIns["-transA"] = "false"
         elif rocblasIns[ii] == "--transposeB" and rocblasIns[ii + 1] == "N":
-            perfRunnerIns["-transB"] = "true"
+            perfRunnerIns["-transB"] = "false"
 
     return stringify(perfRunnerIns)
 

--- a/mlir/utils/performance/gemm-configs
+++ b/mlir/utils/performance/gemm-configs
@@ -1,21 +1,20 @@
 # The immediately following configs are generated with the following command:
 # convertRocBlasToPerfRunner.py -c bert-configs-raw --output-file bert-configs
-
--transA true -transB true -g 64 -m 1024 -n 384 -k 1024
--transA true -transB true -g 64 -m 1024 -n 384 -k 4096
--transA true -transB true -g 64 -m 2 -n 384 -k 1024
--transA true -transB true -g 64 -m 3072 -n 384 -k 1024
--transA true -transB true -g 64 -m 4096 -n 384 -k 1024
--transA true -transB true -g 1024 -m 64 -n 384 -k 384
--transA false -transB true -g 1024 -m 384 -n 384 -k 64
--transA true -transB true -g 1 -m 2304 -n 16384 -k 768
--transA true -transB true -g 1 -m 2 -n 16384 -k 768
--transA true -transB true -g 1 -m 3072 -n 16384 -k 768
--transA true -transB true -g 1 -m 768 -n 16384 -k 2
--transA true -transB true -g 1 -m 768 -n 16384 -k 3072
--transA true -transB true -g 1 -m 768 -n 16384 -k 768
--transA true -transB true -g 768 -m 64 -n 256 -k 256
--transA false -transB true -g 768 -m 256 -n 256 -k 64
+-transA false -transB false -g 64 -m 1024 -n 384 -k 1024 -t f32
+-transA false -transB false -g 64 -m 1024 -n 384 -k 4096 -t f32
+-transA false -transB false -g 64 -m 2 -n 384 -k 1024 -t f32
+-transA false -transB false -g 64 -m 3072 -n 384 -k 1024 -t f32
+-transA false -transB false -g 64 -m 4096 -n 384 -k 1024 -t f32
+-transA false -transB false -g 1024 -m 64 -n 384 -k 384 -t f32
+-transA true -transB false -g 1024 -m 384 -n 384 -k 64 -t f32
+-transA false -transB false -g 1 -m 2304 -n 16384 -k 768 -t f32
+-transA false -transB false -g 1 -m 2 -n 16384 -k 768 -t f32
+-transA false -transB false -g 1 -m 3072 -n 16384 -k 768 -t f32
+-transA false -transB false -g 1 -m 768 -n 16384 -k 2 -t f32
+-transA false -transB false -g 1 -m 768 -n 16384 -k 3072 -t f32
+-transA false -transB false -g 1 -m 768 -n 16384 -k 768 -t f32
+-transA false -transB false -g 768 -m 64 -n 256 -k 256 -t f32
+-transA true -transB false -g 768 -m 256 -n 256 -k 64 -t f32
 
 # This section of the file is selected gemm configs for unet (stable diffusion).
 -transA false -transB false -g 1 -m 128 -n 10240 -k 1280

--- a/mlir/utils/performance/gemm-configs
+++ b/mlir/utils/performance/gemm-configs
@@ -1,20 +1,20 @@
 # The immediately following configs are generated with the following command:
 # convertRocBlasToPerfRunner.py -c bert-configs-raw --output-file bert-configs
--transA false -transB false -g 64 -m 1024 -n 384 -k 1024 -t f32
--transA false -transB false -g 64 -m 1024 -n 384 -k 4096 -t f32
--transA false -transB false -g 64 -m 2 -n 384 -k 1024 -t f32
--transA false -transB false -g 64 -m 3072 -n 384 -k 1024 -t f32
--transA false -transB false -g 64 -m 4096 -n 384 -k 1024 -t f32
--transA false -transB false -g 1024 -m 64 -n 384 -k 384 -t f32
--transA true -transB false -g 1024 -m 384 -n 384 -k 64 -t f32
--transA false -transB false -g 1 -m 2304 -n 16384 -k 768 -t f32
--transA false -transB false -g 1 -m 2 -n 16384 -k 768 -t f32
--transA false -transB false -g 1 -m 3072 -n 16384 -k 768 -t f32
--transA false -transB false -g 1 -m 768 -n 16384 -k 2 -t f32
--transA false -transB false -g 1 -m 768 -n 16384 -k 3072 -t f32
--transA false -transB false -g 1 -m 768 -n 16384 -k 768 -t f32
--transA false -transB false -g 768 -m 64 -n 256 -k 256 -t f32
--transA true -transB false -g 768 -m 256 -n 256 -k 64 -t f32
+-transA false -transB false -g 64 -m 1024 -n 384 -k 1024
+-transA false -transB false -g 64 -m 1024 -n 384 -k 4096
+-transA false -transB false -g 64 -m 2 -n 384 -k 1024
+-transA false -transB false -g 64 -m 3072 -n 384 -k 1024
+-transA false -transB false -g 64 -m 4096 -n 384 -k 1024
+-transA false -transB false -g 1024 -m 64 -n 384 -k 384
+-transA true -transB false -g 1024 -m 384 -n 384 -k 64
+-transA false -transB false -g 1 -m 2304 -n 16384 -k 768
+-transA false -transB false -g 1 -m 2 -n 16384 -k 768
+-transA false -transB false -g 1 -m 3072 -n 16384 -k 768
+-transA false -transB false -g 1 -m 768 -n 16384 -k 2
+-transA false -transB false -g 1 -m 768 -n 16384 -k 3072
+-transA false -transB false -g 1 -m 768 -n 16384 -k 768
+-transA false -transB false -g 768 -m 64 -n 256 -k 256
+-transA true -transB false -g 768 -m 256 -n 256 -k 64
 
 # This section of the file is selected gemm configs for unet (stable diffusion).
 -transA false -transB false -g 1 -m 128 -n 10240 -k 1280

--- a/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
+++ b/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
@@ -108,17 +108,22 @@ int main(int argc, char **argv) {
 
   for (int i = 0, e = args.kernelRepeats; i < e; ++i)
     if (args.gemmG == 1) {
-      ROCBLAS_ABORT_IF_FAIL(rocblas_gemm_ex(
-          handle, rocblas_operation_none, rocblas_operation_none, args.gemmN,
-          args.gemmM, args.gemmK, alpha, bDevice, inType, ldb, aDevice, inType,
-          lda, beta, cDevice, outType, ldc, cDevice, outType, ldc,
-          /*computeType=*/outType, rocblas_gemm_algo_standard, 0,
-          rocblas_gemm_flags_none));
+      ROCBLAS_ABORT_IF_FAIL(
+          rocblas_gemm_ex(handle, /*trans_a=*/blasTransB,
+                          /*trans_b=*/blasTransA, /*m=*/args.gemmN,
+                          /*n=*/args.gemmM, /*k=*/args.gemmK, alpha,
+                          /*a=*/bDevice, /*a_type=*/inType, /*lda=*/ldb,
+                          /*b=*/aDevice, /*b_type=*/inType, /*ldb=*/lda, beta,
+                          cDevice, outType, ldc, cDevice, outType, ldc,
+                          /*computeType=*/outType, rocblas_gemm_algo_standard,
+                          0, rocblas_gemm_flags_none));
 
     } else {
       ROCBLAS_ABORT_IF_FAIL(rocblas_gemm_strided_batched_ex(
-          handle, blasTransB, blasTransA, args.gemmN, args.gemmM, args.gemmK,
-          alpha, bDevice, inType, ldb, strideB, aDevice, inType, lda, strideA,
+          handle, /*trans_a=*/blasTransB, /*trans_b=*/blasTransA,
+          /*m=*/args.gemmN, /*n=*/args.gemmM, /*k=*/args.gemmK, alpha,
+          /*a=*/bDevice, /*a_type=*/inType, /*lda=*/ldb, /*stride_a=*/strideB,
+          /*b=*/aDevice, /*b_type=*/inType, /*ldb=*/lda, /*stride_b=*/strideA,
           beta, cDevice, outType, ldc, strideC, cDevice, outType, ldc, strideC,
           args.gemmG,
           /*computeType=*/outType, rocblas_gemm_algo_standard, 0,

--- a/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
+++ b/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
@@ -87,6 +87,11 @@ int main(int argc, char **argv) {
 
   rocblas_datatype inType = getRocblasType(false, args.dataType);
   rocblas_datatype outType = getRocblasType(true, args.dataType);
+  rocblas_datatype computeType = outType;
+
+  if (inType == rocblas_datatype_f16_r) {
+    computeType = rocblas_datatype_f32_r;
+  }
 
   rocblas_initialize();
   rocblas_handle handle;
@@ -108,15 +113,15 @@ int main(int argc, char **argv) {
 
   for (int i = 0, e = args.kernelRepeats; i < e; ++i)
     if (args.gemmG == 1) {
-      ROCBLAS_ABORT_IF_FAIL(
-          rocblas_gemm_ex(handle, /*trans_a=*/blasTransB,
-                          /*trans_b=*/blasTransA, /*m=*/args.gemmN,
-                          /*n=*/args.gemmM, /*k=*/args.gemmK, alpha,
-                          /*a=*/bDevice, /*a_type=*/inType, /*lda=*/ldb,
-                          /*b=*/aDevice, /*b_type=*/inType, /*ldb=*/lda, beta,
-                          cDevice, outType, ldc, cDevice, outType, ldc,
-                          /*computeType=*/outType, rocblas_gemm_algo_standard,
-                          0, rocblas_gemm_flags_none));
+      ROCBLAS_ABORT_IF_FAIL(rocblas_gemm_ex(
+          handle, /*trans_a=*/blasTransB,
+          /*trans_b=*/blasTransA, /*m=*/args.gemmN,
+          /*n=*/args.gemmM, /*k=*/args.gemmK, alpha,
+          /*a=*/bDevice, /*a_type=*/inType, /*lda=*/ldb,
+          /*b=*/aDevice, /*b_type=*/inType, /*ldb=*/lda, beta, cDevice, outType,
+          ldc, cDevice, outType, ldc,
+          /*computeType=*/computeType, rocblas_gemm_algo_standard, 0,
+          rocblas_gemm_flags_none));
 
     } else {
       ROCBLAS_ABORT_IF_FAIL(rocblas_gemm_strided_batched_ex(
@@ -126,7 +131,7 @@ int main(int argc, char **argv) {
           /*b=*/aDevice, /*b_type=*/inType, /*ldb=*/lda, /*stride_b=*/strideA,
           beta, cDevice, outType, ldc, strideC, cDevice, outType, ldc, strideC,
           args.gemmG,
-          /*computeType=*/outType, rocblas_gemm_algo_standard, 0,
+          /*computeType=*/computeType, rocblas_gemm_algo_standard, 0,
           rocblas_gemm_flags_none));
     }
 

--- a/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
+++ b/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
@@ -47,6 +47,25 @@ static rocblas_datatype getRocblasType(bool isOut,
   }
 }
 
+/// This code is taken from
+/// https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/84a8f450f20521242b74bd803824673739d6e858/src/targets/gpu/rocblas.cpp
+/// and is used to set the GEMM compute type (i.e., the type of the GEMM
+/// accumulation buffer)
+bool get_compute_fp32_flag() {
+  const auto device_name = benchmark::get_device_name();
+  return (device_name.find("gfx908") != std::string::npos ||
+          device_name.find("gfx90a") != std::string::npos);
+}
+
+/// This code is taken from
+/// https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/84a8f450f20521242b74bd803824673739d6e858/src/targets/gpu/rocblas.cpp
+/// and is used to query if the `rocblas_gemm_flgas_pack_int8x4` is set
+bool get_int8_x4_format(rocblas_handle &handle) {
+  rocblas_gemm_flags flag;
+  rocblas_query_int8_layout_flag(handle, &flag);
+  return flag == rocblas_gemm_flags_pack_int8x4;
+}
+
 int main(int argc, char **argv) {
   auto args =
       benchmark::parseCommandLine("rocblas-benchmark-driver", argc, argv);
@@ -89,7 +108,7 @@ int main(int argc, char **argv) {
   rocblas_datatype outType = getRocblasType(true, args.dataType);
   rocblas_datatype computeType = outType;
 
-  if (inType == rocblas_datatype_f16_r) {
+  if ((inType == rocblas_datatype_f16_r) && get_compute_fp32_flag()) {
     computeType = rocblas_datatype_f32_r;
   }
 
@@ -111,17 +130,21 @@ int main(int argc, char **argv) {
   ROCBLAS_ABORT_IF_FAIL(
       rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host));
 
+  rocblas_gemm_flags rocblas_flags = get_int8_x4_format(handle)
+                                         ? rocblas_gemm_flags_pack_int8x4
+                                         : rocblas_gemm_flags_none;
+
   for (int i = 0, e = args.kernelRepeats; i < e; ++i)
     if (args.gemmG == 1) {
-      ROCBLAS_ABORT_IF_FAIL(rocblas_gemm_ex(
-          handle, /*trans_a=*/blasTransB,
-          /*trans_b=*/blasTransA, /*m=*/args.gemmN,
-          /*n=*/args.gemmM, /*k=*/args.gemmK, alpha,
-          /*a=*/bDevice, /*a_type=*/inType, /*lda=*/ldb,
-          /*b=*/aDevice, /*b_type=*/inType, /*ldb=*/lda, beta, cDevice, outType,
-          ldc, cDevice, outType, ldc,
-          /*computeType=*/computeType, rocblas_gemm_algo_standard, 0,
-          rocblas_gemm_flags_none));
+      ROCBLAS_ABORT_IF_FAIL(
+          rocblas_gemm_ex(handle, /*trans_a=*/blasTransB,
+                          /*trans_b=*/blasTransA, /*m=*/args.gemmN,
+                          /*n=*/args.gemmM, /*k=*/args.gemmK, alpha,
+                          /*a=*/bDevice, /*a_type=*/inType, /*lda=*/ldb,
+                          /*b=*/aDevice, /*b_type=*/inType, /*ldb=*/lda, beta,
+                          cDevice, outType, ldc, cDevice, outType, ldc,
+                          /*computeType=*/computeType,
+                          rocblas_gemm_algo_standard, 0, rocblas_flags));
 
     } else {
       ROCBLAS_ABORT_IF_FAIL(rocblas_gemm_strided_batched_ex(
@@ -132,7 +155,7 @@ int main(int argc, char **argv) {
           beta, cDevice, outType, ldc, strideC, cDevice, outType, ldc, strideC,
           args.gemmG,
           /*computeType=*/computeType, rocblas_gemm_algo_standard, 0,
-          rocblas_gemm_flags_none));
+          rocblas_flags));
     }
 
   HIP_ABORT_IF_FAIL(hipMemcpy(cHost, cDevice, cBytes, hipMemcpyDeviceToHost));


### PR DESCRIPTION
This partially covers https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/932 

We were assuming MIGraphx was using a different layout and hence invoking rocBLAS in a different way. Let's fix this and run the tuner again