### PR TITLE
Install miopen-hip in Dockerfile

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -104,6 +104,7 @@ RUN apt-get update && rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
   rocprofiler-dev \
   rocblas \
   rocblas-dev \
+  miopen-hip \
   libelf1 \
   pkg-config \
   sudo \


### PR DESCRIPTION
We'll use pre-built MIOpenDriver in our CI jobs.