### PR TITLE
Build MIOpen with no MLIR support

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -74,7 +74,7 @@ void buildMIOpenWithMLIR() {
         git branch: params.MIOpenBranch, poll: false,\
             url: 'https://github.com/ROCmSoftwarePlatform/MIOpen.git'
         // Note: setting cxxflags here works around https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1604
-        buildMIOpen("""-DMIOPEN_USE_MLIR=On
+        buildMIOpen("""-DMIOPEN_USE_MLIR=Off
                        -DMIOPEN_USE_COMPOSABLEKERNEL=Off
                        -DMIOPEN_BACKEND=HIP
                        -DCMAKE_PREFIX_PATH=${WORKSPACE}/MIOpenDeps


### PR DESCRIPTION
This should fix the latest nightly/weekly failures we are experiencing. 