### PR TITLE
Update CI to 5.6, switch the MIGraphX branch to develop

### DIFF
--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/printf.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/printf.mlir
@@ -1,5 +1,3 @@
-// TODO: remove this once we upgrade to ROCM 5.6
-// XFAIL: *
 // RUN: mlir-opt %s \
 // RUN: | mlir-opt -pass-pipeline='builtin.module(gpu.module(strip-debuginfo,convert-gpu-to-rocdl{index-bitwidth=32 runtime=HIP},gpu-to-hsaco{chip=%chip}))' \
 // RUN: | mlir-opt -gpu-to-llvm \

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -276,7 +276,7 @@ pipeline {
         booleanParam(name: 'weekly', defaultValue: params.weekly ? true : false,
                      description: 'Run weekly-only jobs')
         // Temporary change to MIGraphX branch because of upstream merge.
-        string(name: 'MIGraphXBranch', defaultValue: 'upstream-merge-changes-rocmlir',
+        string(name: 'MIGraphXBranch', defaultValue: 'develop',
                description: 'The MIGraphX branch/commit to verify against.')
         string(name: 'CKBranch', defaultValue: 'develop',
             description: 'The Composable Kernel branch to be used with the job')

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -831,7 +831,7 @@ pipeline {
                     stage("Install MIGraphX Dependencies") {
                         steps {
                             // Package and install current checkout of rocMLIR as MIGraphX dependency.
-                            sh 'cget -p ${WORKSPACE}/MIGraphXDeps install ${WORKSPACE} -DBUILD_FAT_LIBROCKCOMPILER=On
+                            sh 'cget -p ${WORKSPACE}/MIGraphXDeps install ${WORKSPACE} -DBUILD_FAT_LIBROCKCOMPILER=On'
                         }
                     }
                     stage("Build MIGraphX with MLIR") {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -61,11 +61,11 @@ String dockerArgs() {
 
 String dockerImage() {
     // If this is being changed please change Dockerfile.migraphx-ci's base image as well
-    return 'rocm/mlir:rocm5.5-latest'
+    return 'rocm/mlir:rocm5.6-latest'
 }
 
 String dockerImageCIMIGraphX() {
-    return 'rocm/mlir-migraphx-ci:rocm5.5-latest'
+    return 'rocm/mlir-migraphx-ci:rocm5.6-latest'
 }
 
 void preMergeCheck(String codepath) {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -275,7 +275,6 @@ pipeline {
                      description: 'Can this CI instance use xdlops (no for public server)')
         booleanParam(name: 'weekly', defaultValue: params.weekly ? true : false,
                      description: 'Run weekly-only jobs')
-        // Temporary change to MIGraphX branch because of upstream merge.
         string(name: 'MIGraphXBranch', defaultValue: 'develop',
                description: 'The MIGraphX branch/commit to verify against.')
         string(name: 'CKBranch', defaultValue: 'develop',
@@ -832,14 +831,14 @@ pipeline {
                     stage("Install MIGraphX Dependencies") {
                         steps {
                             // Package and install current checkout of rocMLIR as MIGraphX dependency.
-                            sh 'cget -p ${WORKSPACE}/MIGraphXDeps install ${WORKSPACE} -DBUILD_FAT_LIBROCKCOMPILER=On -DLLVM_ENABLE_THREADS=Off'
+                            sh 'cget -p ${WORKSPACE}/MIGraphXDeps install ${WORKSPACE} -DBUILD_FAT_LIBROCKCOMPILER=On
                         }
                     }
                     stage("Build MIGraphX with MLIR") {
                         steps {
                             sh 'rm -rf MIGraphX'
                             dir('MIGraphX') {
-                                getAndBuildMIGraphX("-DCMAKE_PREFIX_PATH='/MIGraphXDeps;${WORKSPACE}/MIGraphXDeps' -DMIGRAPHX_ENABLE_MLIR=On -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DMIGRAPHX_USE_HIPRTC=Off")
+                                getAndBuildMIGraphX("-DCMAKE_PREFIX_PATH='${WORKSPACE}/MIGraphXDeps;/MIGraphXDeps;/opt/rocm' -DMIGRAPHX_ENABLE_MLIR=On -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DMIGRAPHX_USE_HIPRTC=Off")
                             }
                         }
                     }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -22,7 +22,7 @@ String dockerArgs() {
 }
 
 String dockerImage() {
-    return 'rocm/mlir:rocm5.5-latest'
+    return 'rocm/mlir:rocm5.6-latest'
 }
 
 

--- a/mlir/utils/jenkins/Jenkinsfile.release
+++ b/mlir/utils/jenkins/Jenkinsfile.release
@@ -23,7 +23,7 @@ String dockerArgs() {
 }
 
 String dockerImage() {
-    return 'rocm/mlir:rocm5.5-latest'
+    return 'rocm/mlir:rocm5.6-latest'
 }
 
 pipeline {


### PR DESCRIPTION
Now that the upstream merge changes landed in MIGraphX develop switch our test branch back.

Also update to 5.6 since the Dockerfile fixes needed to make this PR work also were a good excuse to bump our CI version