### PR TITLE
[DO NOT SQUASH] Decouple VectorToLLVM, make host runner includes conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ if( BUILD_FAT_LIBROCKCOMPILER )
   set(MLIR_ENABLE_ROCM_RUNNER 0 CACHE BOOL "")
   set(MLIR_INCLUDE_INTEGRATION_TESTS OFF CACHE BOOL "")
   set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
+  set(MHAL_ENABLE_HOST_RUNNER OFF CACHE BOOL "Enable MHAL host runner")
   if(NOT WIN32)
     set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "")
     # Note, this is a hack to ignore Pytorch added conda path

--- a/cmake/mlir-hal.cmake
+++ b/cmake/mlir-hal.cmake
@@ -20,7 +20,7 @@ include_directories(${MLIR_INCLUDE_DIRS})
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
-add_subdirectory("${MHAL_PROJECT_DIR}")
+add_subdirectory("${MHAL_PROJECT_DIR}" EXCLUDE_FROM_ALL)
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath -Wl,${CMAKE_BINARY_DIR}/lib")
 

--- a/external/llvm-project/mlir/include/mlir/Conversion/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Conversion/Passes.h
@@ -58,7 +58,7 @@
 #include "mlir/Conversion/TosaToSCF/TosaToSCF.h"
 #include "mlir/Conversion/TosaToTensor/TosaToTensor.h"
 #include "mlir/Conversion/VectorToGPU/VectorToGPU.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Conversion/VectorToSPIRV/VectorToSPIRVPass.h"
 

--- a/external/llvm-project/mlir/include/mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h
+++ b/external/llvm-project/mlir/include/mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h
@@ -12,10 +12,6 @@
 
 namespace mlir {
 class LLVMTypeConverter;
-class Pass;
-
-#define GEN_PASS_DECL_CONVERTVECTORTOLLVMPASS
-#include "mlir/Conversion/Passes.h.inc"
 
 /// Collect a set of patterns to convert from Vector contractions to LLVM Matrix
 /// Intrinsics. To lower to assembly, the LLVM flag -lower-matrix-intrinsics

--- a/external/llvm-project/mlir/include/mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h
+++ b/external/llvm-project/mlir/include/mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h
@@ -1,0 +1,19 @@
+//===- ConvertVectorToLLVMPass.h - Pass to check Vector->LLVM --- --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef MLIR_CONVERSION_VECTORTOLLVM_CONVERTVECTORTOLLVMPASS_H_
+#define MLIR_CONVERSION_VECTORTOLLVM_CONVERTVECTORTOLLVMPASS_H_
+
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
+
+namespace mlir {
+class Pass;
+
+#define GEN_PASS_DECL_CONVERTVECTORTOLLVMPASS
+#include "mlir/Conversion/Passes.h.inc"
+} // namespace mlir
+#endif // MLIR_CONVERSION_VECTORTOLLVM_CONVERTVECTORTOLLVMPASS_H_

--- a/external/llvm-project/mlir/include/mlir/Dialect/SparseTensor/Pipelines/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/SparseTensor/Pipelines/Passes.h
@@ -13,7 +13,7 @@
 #ifndef MLIR_DIALECT_SPARSETENSOR_PIPELINES_PASSES_H_
 #define MLIR_DIALECT_SPARSETENSOR_PIPELINES_PASSES_H_
 
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Dialect/SparseTensor/Transforms/Passes.h"
 #include "mlir/Pass/PassOptions.h"
 

--- a/external/llvm-project/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Conversion/VectorToLLVM/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_mlir_conversion_library(MLIRVectorToLLVM
+  PARTIAL_SOURCES_INTENDED
   ConvertVectorToLLVM.cpp
-  ConvertVectorToLLVMPass.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToLLVM
@@ -14,13 +14,6 @@ add_mlir_conversion_library(MLIRVectorToLLVM
 
   LINK_LIBS PUBLIC
   MLIRArithDialect
-  MLIRArmNeonDialect
-  MLIRArmSMEDialect
-  MLIRArmSMETransforms
-  MLIRArmSVEDialect
-  MLIRArmSVETransforms
-  MLIRAMXDialect
-  MLIRAMXTransforms
   MLIRLLVMCommonConversion
   MLIRLLVMDialect
   MLIRMemRefDialect
@@ -28,6 +21,25 @@ add_mlir_conversion_library(MLIRVectorToLLVM
   MLIRTransforms
   MLIRVectorDialect
   MLIRVectorTransforms
+  )
+
+add_mlir_conversion_library(MLIRVectorToLLVMPass
+  PARTIAL_SOURCES_INTENDED
+
+  ConvertVectorToLLVMPass.cpp
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/VectorToLLVM
+
+  LINK_LIBS PUBLIC
+  MLIRVectorToLLVM
+
+  MLIRArmNeonDialect
+  MLIRArmSMEDialect
+  MLIRArmSMETransforms
+  MLIRArmSVEDialect
+  MLIRArmSVETransforms
+  MLIRAMXDialect
+  MLIRAMXTransforms
   MLIRX86VectorDialect
   MLIRX86VectorTransforms
-  )
+)

--- a/external/llvm-project/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"

--- a/external/llvm-project/mlir/lib/Dialect/SparseTensor/Pipelines/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/SparseTensor/Pipelines/CMakeLists.txt
@@ -24,7 +24,7 @@ add_mlir_dialect_library(MLIRSparseTensorPipelines
   MLIRSparseTensorDialect
   MLIRSparseTensorTransforms
   MLIRTensorTransforms
-  MLIRVectorToLLVM
+  MLIRVectorToLLVMPass
   MLIRVectorTransforms
 )
 

--- a/external/llvm-project/mlir/test/lib/Dialect/LLVM/CMakeLists.txt
+++ b/external/llvm-project/mlir/test/lib/Dialect/LLVM/CMakeLists.txt
@@ -20,6 +20,6 @@ add_mlir_library(MLIRLLVMTestPasses
   MLIRReconcileUnrealizedCasts
   MLIRSCFToControlFlow
   MLIRTransforms
-  MLIRVectorToLLVM
+  MLIRVectorToLLVMPass
   MLIRVectorToSCF
   )

--- a/external/llvm-project/mlir/test/lib/Dialect/LLVM/TestLowerToLLVM.cpp
+++ b/external/llvm-project/mlir/test/lib/Dialect/LLVM/TestLowerToLLVM.cpp
@@ -19,7 +19,7 @@
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/external/llvm-project/mlir/tools/mlir-vulkan-runner/CMakeLists.txt
+++ b/external/llvm-project/mlir/tools/mlir-vulkan-runner/CMakeLists.txt
@@ -72,7 +72,7 @@ if (MLIR_ENABLE_VULKAN_RUNNER)
     MLIRTransforms
     MLIRTranslateLib
     MLIRVectorDialect
-    MLIRVectorToLLVM
+    MLIRVectorToLLVMPass
     ${Vulkan_LIBRARY}
   )
 

--- a/external/llvm-project/mlir/tools/mlir-vulkan-runner/mlir-vulkan-runner.cpp
+++ b/external/llvm-project/mlir/tools/mlir-vulkan-runner/mlir-vulkan-runner.cpp
@@ -18,7 +18,7 @@
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"

--- a/external/mlir-hal/CMakeLists.txt
+++ b/external/mlir-hal/CMakeLists.txt
@@ -8,6 +8,8 @@ message(STATUS "MHAL BINARY: ${MHAL_BINARY_DIR}")
 set(MHAL_MAIN_INCLUDE_DIR "${MHAL_PROJECT_DIR}/include")
 option(MHAL_ENABLE_TRANSFORMS "Enable MHAL transforms" ON)
 
+option(MHAL_ENABLE_HOST_RUNNER "Enable MHAL host runner pipeline" ON)
+
 set(LLVM_ENABLE_RTTI OFF CACHE BOOL "")
 
 include_directories("${MHAL_MAIN_INCLUDE_DIR}")

--- a/external/mlir-hal/lib/Dialect/MHAL/Pipelines/CMakeLists.txt
+++ b/external/mlir-hal/lib/Dialect/MHAL/Pipelines/CMakeLists.txt
@@ -1,29 +1,47 @@
-add_mlir_dialect_library(MLIRMHALPipeline
-  Pipelines.cpp
-
-  LINK_LIBS PUBLIC
-  MLIRDialect
-  MLIRFuncDialect
-  MLIRTensorToLinalg
+if (MHAL_ENABLE_HOST_RUNNER)
+  set(host_runner_libs
   MLIRAsyncTransforms
   MLIRGPUTransforms
-  MLIRTosaToLinalg
-  MLIRTosaToSCF
-  MLIRTosaToArith
   MLIRLinalgToLLVM
   MLIRMathToLLVM
   MLIRMathToLibm
   MLIRGPUToROCDLTransforms
   MLIRReconcileUnrealizedCasts
-  MLIRMHALTransforms
+  MLIRVectorToLLVMPass
+
   MLIRMHALToGPU
   MLIRMHALToCPU
+  MLIRAffineToStandard
+  MLIRSCFToControlFlow
+  )
+else()
+  set(host_runner_libs)
+endif()
+
+add_mlir_dialect_library(MLIRMHALPipeline
+  Pipelines.cpp
+
+  DEPENDS
+  MHALConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRDialect
+  MLIRFuncDialect
+  MLIRTensorToLinalg
+  MLIRTosaToLinalg
+  MLIRMHALTransforms
   MLIRIR
   MLIRPass
   MLIRLLVMDialect
-  MLIRAffineToStandard
-  MLIRSCFToControlFlow
   MLIRSupport
   MLIRTransforms
   MLIRTransformUtils
+
+  ${host_runner_libs}
 )
+
+if (MHAL_ENABLE_HOST_RUNNER)
+  target_compile_definitions(obj.MLIRMHALPipeline
+    PRIVATE
+    MHAL_ENABLE_HOST_RUNNER=1)
+endif()

--- a/external/mlir-hal/lib/Dialect/MHAL/Pipelines/Pipelines.cpp
+++ b/external/mlir-hal/lib/Dialect/MHAL/Pipelines/Pipelines.cpp
@@ -22,6 +22,22 @@
 
 #include "mlir/Dialect/MHAL/Pipelines/Pipelines.h"
 
+#include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/Passes.h"
+#include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/MHAL/Transforms/Passes.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/SCF/Transforms/Passes.h"
+#include "mlir/Dialect/Tosa/Transforms/Passes.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/Passes.h"
+
+#ifdef MHAL_ENABLE_HOST_RUNNER
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/AsyncToLLVM/AsyncToLLVM.h"
@@ -34,25 +50,12 @@
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
-#include "mlir/Dialect/Affine/Passes.h"
-#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Dialect/Async/Passes.h"
-#include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
-#include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
-#include "mlir/Dialect/Linalg/Passes.h"
-#include "mlir/Dialect/MHAL/Transforms/Passes.h"
-#include "mlir/Dialect/MemRef/Transforms/Passes.h"
-#include "mlir/Dialect/SCF/Transforms/Passes.h"
-#include "mlir/Dialect/Tosa/Transforms/Passes.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Pass/PassRegistry.h"
-#include "mlir/Transforms/Passes.h"
 
 #include "llvm/Support/TargetSelect.h"
+#endif
 
 using namespace mlir;
 
@@ -104,6 +107,7 @@ void mhal::buildPackagePipeline(OpPassManager &pm,
 // to generate X86 binary and runs it.
 void mhal::buildRunnerPipeline(OpPassManager &pm,
                                const mhal::RunnerOptions &options) {
+#ifdef MHAL_ENABLE_HOST_RUNNER
   // Select targets
   MHALSelectTargetsPassOptions targetOpts;
   targetOpts.targetTypes = options.targetTypes;
@@ -147,6 +151,10 @@ void mhal::buildRunnerPipeline(OpPassManager &pm,
 
   pm.addPass(createConvertFuncToLLVMPass());
   pm.addPass(createReconcileUnrealizedCastsPass());
+#else
+  (void)pm;
+  (void)options;
+#endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/external/mlir-hal/lib/Dialect/MHAL/Transforms/CMakeLists.txt
+++ b/external/mlir-hal/lib/Dialect/MHAL/Transforms/CMakeLists.txt
@@ -18,13 +18,10 @@ add_mlir_dialect_library(MLIRMHALTransforms
   MLIRMHAL
   MLIRMHALSupport
   MLIRFuncDialect
-  MLIRExecutionEngineUtils
   MLIRGPUTransforms
   MLIRIR
   MLIRPass
   MLIRLLVMDialect
-  MLIRAffineToStandard
-  MLIRSCFToControlFlow
   MLIRSupport
   MLIRTransformUtils
 )

--- a/mlir/lib/Conversion/GPUToMIGraphX/GPUToMIGraphXPass.cpp
+++ b/mlir/lib/Conversion/GPUToMIGraphX/GPUToMIGraphXPass.cpp
@@ -22,7 +22,6 @@
 #include "mlir/Conversion/AsyncToLLVM/AsyncToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Dialect/Async/IR/Async.h"
 
 #include "mlir/IR/PatternMatch.h"

--- a/mlir/test/rocmlir-driver/fp8_ops.mlir
+++ b/mlir/test/rocmlir-driver/fp8_ops.mlir
@@ -1,11 +1,14 @@
 // RUN: rocmlir-gen --arch gfx940 --operation gemm -t fp8 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=MFMA
 // RUN: rocmlir-gen --arch gfx940 --operation gemm -mfma=off -t fp8 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=MFMA_OFF
 // RUN: rocmlir-gen --arch gfx1100 --operation gemm -t fp8 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=GFX11
-// RUN: rocmlir-gen --arch gfx940 --operation gemm -t fp8 -p -pv | rocmlir-driver -c | FileCheck %s --check-prefix=HOST
+// COM: This runs the kernel pipeline so that we still get a good test with the
+// COM: host pipeline off as in the static library build, using the fact that
+// COM: the fp8 expander isn't limited to GPU code.
+// RUN: rocmlir-gen --arch gfx940 --operation gemm -t fp8 -p -pv | rocmlir-driver -kernel-pipeline=full | FileCheck %s --check-prefix=HOST
 
 // MFMA: rocdl.mfma.f32.32x32x16.fp8.fp8
 // MFMA-NOT: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ
 // MFMA_OFF: rocdl.cvt.f32.fp8
 // MFMA_OFF-NOT: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ
 // GFX11: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ
-// HOST: llvm.mlir.global private constant @__rocmlir_extf_tbl_f8E4M3FNUZ
+// HOST: memref.global "private" constant @__rocmlir_extf_tbl_f8E4M3FNUZ

--- a/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
+++ b/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
@@ -57,8 +57,6 @@ MLIRAMDGPUDialect
 MLIRAMDGPUToROCDL
 MLIRAMDGPUTransforms
 MLIRAMDGPUUtils
-MLIRAMXDialect
-MLIRAMXTransforms
 MLIRAffineAnalysis
 MLIRAffineDialect
 MLIRAffineToStandard
@@ -71,15 +69,9 @@ MLIRArithToAMDGPU
 MLIRArithToLLVM
 MLIRArithTransforms
 MLIRArithUtils
-MLIRArmNeonDialect
-MLIRArmSMEDialect
-MLIRArmSMETransforms
-MLIRArmSVEDialect
-MLIRArmSVETransforms
 MLIRAsmParser
 MLIRAsyncDialect
 MLIRAsyncToLLVM
-MLIRAsyncTransforms
 MLIRBufferizationDialect
 MLIRBufferizationTransformOps
 MLIRBufferizationTransforms
@@ -127,7 +119,6 @@ MLIRMaskableOpInterface
 MLIRMaskingOpInterface
 MLIRMathDialect
 MLIRMathToLLVM
-MLIRMathToLibm
 MLIRMemRefDialect
 MLIRMemRefToLLVM
 MLIRMemRefTransforms
@@ -197,8 +188,6 @@ MLIRGPUToMIGraphX
 MLIRMHAL
 MLIRMHALPipeline
 MLIRMHALSupport
-MLIRMHALToCPU
-MLIRMHALToGPU
 MLIRMHALTransforms
 MLIRMIGraphX
 MLIRMIGraphXPipeline


### PR DESCRIPTION
This depends on #1160 .

1. Split VectorToLLVM into separate libraries for the pass and the conversion patterns so that you can include VectorToLLVM and not bring in, for example, the amx dialect (which has its own conversion patterns)
2. MHAL's host runner used vector-to-llvm as a pass, and is pulled in to the static library builds. We should, ideally, not be doing that. So this commit makes the host runner part (and its dependencies) optional - and turns them off for fat library builds.
3. Misc. changes made in the mlir directory, mostly around the new MHAL CMake options and removing a stray include.
