### PR TITLE
Fix fusion test paths

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -293,6 +293,11 @@ pipeline {
         // option only to be used with upstream merges
         booleanParam(name: 'ignoreExternalLinting', defaultValue: false,
                      description: 'Ignore linting on files in external/')
+
+        // choose the task to run in weekly
+        choice(name: 'weeklyTasks',
+               choices: ['default', 'parameterSweeps', 'Tuning'],
+               description: 'Choose the weekly tasks')
     }
     stages {
         stage("Set System Property") {
@@ -445,6 +450,10 @@ pipeline {
                 beforeAgent true;
                 equals expected: true, actual: params.weekly;
                 equals expected: true, actual: params.sharedLib;
+                anyOf {
+                    equals expected: "default", actual: params.weeklyTasks;
+                    equals expected: "parameterSweeps", actual: params.weeklyTasks;
+               }
             }
             matrix {
                 axes {
@@ -503,6 +512,10 @@ pipeline {
                 beforeAgent true;
                 equals expected: true, actual: params.weekly;
                 equals expected: true, actual: params.staticLib;
+                anyOf {
+                    equals expected: "default", actual: params.weeklyTasks;
+                    equals expected: "Tuning", actual: params.weeklyTasks;
+               }
             }
             matrix {
                 axes {
@@ -568,11 +581,11 @@ pipeline {
                             dir('build') {
                                 // Tune resnet50
                                 sh """python3 ./bin/tuningRunner.py --op fusion \
---test_dir ../mlir/test/fusion/e2e/resnet50/ -o tuning_fusion_${ARCH}.tsv"""
+--test_dir ../mlir/test/fusion/resnet50-e2e/ -o tuning_fusion_${ARCH}.tsv"""
 
                                 // Tune bert
                                 sh """python3 ./bin/tuningRunner.py --op fusion \
---test_dir ../mlir/test/xmir/e2e/bert-torch-tosa/ -o tuning_fusion_${ARCH}.tsv"""
+--test_dir ../mlir/test/xmir/bert-torch-tosa-e2e/ -o tuning_fusion_${ARCH}.tsv"""
                             }
                             sh 'rm build/CMakeCache.txt'
                         }
@@ -648,7 +661,7 @@ pipeline {
                     }
                     stage("Copy tuning database") {
                         steps {
-                            copyArtifacts filter: 'build/perfDB/**',\
+                            copyArtifacts filter: 'MIOpen/build/MIOpenUserDB/**',\
                                 optional: true,\
                                 flatten: true,\
                                 projectName: "/MLIR/mlir-weekly",\
@@ -699,10 +712,10 @@ pipeline {
                             dir('build') {
                                 // Run fusion resnet50 perf benchmarks
                                 sh """python3 ./bin/perfRunner.py --op=fusion \
-          --test_dir=${WORKSPACE}/mlir/test/fusion/e2e/resnet50/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
+          --test_dir=${WORKSPACE}/mlir/test/fusion/resnet50-e2e/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
                                 // Run bert perf benchmarks
                                 sh """python3 ./bin/perfRunner.py --op fusion \
-          --test_dir=${WORKSPACE}/mlir/test/xmir/e2e/bert-torch-tosa/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
+          --test_dir=${WORKSPACE}/mlir/test/xmir/bert-torch-tosa-e2e/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
                             }
                         }
                     }


### PR DESCRIPTION
It turned out my previous PR used old paths for tuning fusion. Fix them.
Make the nightly to copy perf db from the old directory until the new weekly succeeds. 
Add an option for choosing the tasks on weeklies, in order to skip parameterSweeps when we just want to run the tuning part.