### PR TITLE
[Outliner] Refactor for divergence/re-convergence case in bert

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -64,6 +64,9 @@ def TosaPartition : Pass<"tosa-partition", "ModuleOp"> {
                "One or more operations to be used as focus of partitioned "
                "kernels",
                "llvm::cl::ZeroOrMore">,
+    ListOption<"terminalOps", "terminal-ops", "std::string",
+               "One or more operations that terminal a fusion chain",
+               "llvm::cl::ZeroOrMore">,
     Option<"partitionTagOpt", "partition-tag", "std::string",
            /*default=*/"\"kernel\"", "Attribute for outlined functions">,
     Option<"trailingOnly", "trailing-only", "bool", /*default=*/"true",

--- a/external/llvm-project/mlir/include/mlir/Transforms/OutlinerUtils.h
+++ b/external/llvm-project/mlir/include/mlir/Transforms/OutlinerUtils.h
@@ -45,22 +45,22 @@ bool isConstantZero(Operation *op);
 
 class Outliner {
 public:
-  Outliner(function_ref<bool(Operation *)> isAnchorOp,
-           function_ref<bool(Operation *)> isLeadingOp,
-           function_ref<bool(Operation *)> isTrailingOp, StringRef outlineTag)
-      : isAnchorOp(isAnchorOp), isLeadingOp(isLeadingOp),
-        isTrailingOp(isTrailingOp), outlineTag(outlineTag) {}
+  Outliner(function_ref<bool(Operation *)> _isAnchorOp,
+           function_ref<bool(Operation *)> _isLeadingOp,
+           function_ref<bool(Operation *)> _isTrailingOp,
+           function_ref<bool(Operation *)> _isTerminatingOp,
+           StringRef _outlineTag)
+      : isAnchorOp(_isAnchorOp), isLeadingOp(_isLeadingOp),
+        isTrailingOp(_isTrailingOp), isTerminatingOp(_isTerminatingOp),
+        outlineTag(_outlineTag) {}
 
   void outline(ModuleOp module);
 
-private:
   function_ref<bool(Operation *)> isAnchorOp;
   function_ref<bool(Operation *)> isLeadingOp;
   function_ref<bool(Operation *)> isTrailingOp;
+  function_ref<bool(Operation *)> isTerminatingOp;
   StringRef outlineTag;
-  void traceInputs(Operation *op, Operation *ignoreOp,
-                   SetVector<Operation *> &predecessors,
-                   SetVector<Value> &inputNodes);
 };
 
 } // namespace mlir

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaPartition.cpp
@@ -114,6 +114,10 @@ bool isAnchorOp(Operation *op, Pass::ListOption<std::string> &anchorOps) {
   return llvm::is_contained(anchorOps, op->getName().getIdentifier().str());
 }
 
+bool isTerminalOp(Operation *op, Pass::ListOption<std::string> &terminalOps) {
+  return llvm::is_contained(terminalOps, op->getName().getIdentifier().str());
+}
+
 bool isTransposeOp(Operation *op) {
   return isa<tosa::TransposeOp, tosa::ReshapeOp>(op);
 }
@@ -160,10 +164,14 @@ public:
 void TosaPartitionPass::runOnOperation() {
   ModuleOp module = getOperation();
   auto anchorPred = [&](Operation *op) { return isAnchorOp(op, anchorOps); };
+  auto terminalPred = [&](Operation *op) {
+    return isTerminalOp(op, terminalOps);
+  };
   auto leadingPred = [&](Operation *op) {
     return isLeadingOp(op, trailingOnly);
   };
-  Outliner p(anchorPred, leadingPred, isTrailingOp, partitionTagOpt);
+  Outliner p(anchorPred, leadingPred, isTrailingOp, terminalPred,
+             partitionTagOpt);
   p.outline(module);
 }
 

--- a/external/llvm-project/mlir/lib/Transforms/Utils/OutlinerUtils.cpp
+++ b/external/llvm-project/mlir/lib/Transforms/Utils/OutlinerUtils.cpp
@@ -38,6 +38,10 @@
 using llvm::SmallVector;
 using namespace mlir;
 
+#define DEBUG_TYPE "outliner-utility"
+
+#define FUSION_CAPACITY_DEFAULT 32
+
 static bool isZeroAttribute(Attribute value) {
   if (auto intValue = value.dyn_cast<IntegerAttr>())
     return intValue.getValue().isZero();
@@ -56,8 +60,10 @@ static bool isZeroAttribute(Attribute value) {
 
 bool mlir::isConstantZero(Operation *op) {
   // Cheating, by assuming that constants will have "value" attribute.
-  if (op->hasTrait<OpTrait::ConstantLike>() && op->hasAttr("value"))
-    return isZeroAttribute(op->getAttr("value"));
+  if (op->hasTrait<OpTrait::ConstantLike>()) {
+    if (auto attr = op->getAttr("value"))
+      return isZeroAttribute(attr);
+  }
   return false;
 }
 
@@ -66,22 +72,14 @@ bool mlir::isConstantZero(Operation *op) {
 // Inspired by / adapted from outlineIfOp() in SCF/Transforms/Utils.cpp
 // and mergeIdenticalBlocks() in Utils/RegionUtils.cpp.
 
-struct OutliningCandidate {
-  OutliningCandidate(Operation *anchorOp, ArrayRef<Operation *> &trailingOps,
-                     ArrayRef<Operation *> &leadingOps, ArrayRef<Value> &params,
-                     ArrayRef<Value> &returnVals, StringRef partFnName);
-
-  unsigned addOp(Operation *op, unsigned orderIt);
-
-  Operation *anchorOp;
-  SmallVector<Operation *> trailingOps;
-  SmallVector<Operation *> leadingOps;
-  SmallVector<Type> params;
-  SmallVector<Value> returnVals;
-  std::string partFnName;
-  llvm::hash_code hash;
+class OutliningCandidate {
+  SmallVector<Type, FUSION_CAPACITY_DEFAULT> params;
+  SmallVector<Operation *, FUSION_CAPACITY_DEFAULT> ops;
+  llvm::hash_code hash = 0;
   func::FuncOp function;
-  Location fusedLoc;
+
+  void processOps();
+  unsigned addOp(Operation *op, unsigned orderIt);
 
   /// Return the order index for the given value that is within the block of
   /// this data.
@@ -91,7 +89,57 @@ struct OutliningCandidate {
   /// block. The order of an operation is the number of defined values that are
   /// produced within the block before this operation.
   DenseMap<Operation *, unsigned> opOrderIndex;
+
+  bool equivalent(const OutliningCandidate &that) const;
+  bool opsMatch(Operation *lhs, Operation *rhs,
+                const OutliningCandidate &two) const;
+
+public:
+  OutliningCandidate() = default;
+  OutliningCandidate(ArrayRef<Operation *> ops_, ArrayRef<Value> params_)
+      : ops(ops_) {
+    for (auto val : params_)
+      params.push_back(val.getType());
+    processOps();
+  }
+
+  void setFunction(func::FuncOp f) {
+    function = f;
+    auto type = f.getFunctionType();
+    params.assign(type.getInputs().begin(), type.getInputs().end());
+    ops.clear();
+    for (auto &op : f.getBody().getOps())
+      ops.push_back(&op);
+    ops.pop_back(); // drop the return
+    processOps();
+  }
+
+  llvm::hash_code getHash() const { return hash; }
+  func::FuncOp getFunction() const { return function; }
+
+  bool operator==(const OutliningCandidate &that) const {
+    return hash == that.hash && equivalent(that);
+  }
+  bool operator!=(const OutliningCandidate &that) const {
+    return !operator==(that);
+  }
 };
+
+/// A DenseMapInfo
+namespace llvm {
+template <>
+struct DenseMapInfo<OutliningCandidate, void> {
+  static OutliningCandidate getEmptyKey() { return OutliningCandidate(); }
+  static OutliningCandidate getTombstoneKey() { return OutliningCandidate(); }
+  static unsigned getHashValue(const OutliningCandidate &val) {
+    return val.getHash();
+  }
+  static bool isEqual(const OutliningCandidate &lhs,
+                      const OutliningCandidate &rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
 
 unsigned OutliningCandidate::addOp(Operation *op, unsigned orderIt) {
   if (unsigned numResults = op->getNumResults()) {
@@ -103,29 +151,17 @@ unsigned OutliningCandidate::addOp(Operation *op, unsigned orderIt) {
       op, OperationEquivalence::ignoreHashValue,
       OperationEquivalence::ignoreHashValue,
       OperationEquivalence::IgnoreLocations);
+
   hash = llvm::hash_combine(hash, opHash);
 
   return orderIt;
 }
 
-OutliningCandidate::OutliningCandidate(Operation *anchorOp_,
-                                       ArrayRef<Operation *> &trailingOps_,
-                                       ArrayRef<Operation *> &leadingOps_,
-                                       ArrayRef<Value> &params_,
-                                       ArrayRef<Value> &returnVals_,
-                                       StringRef partFnName_)
-    : anchorOp(anchorOp_), trailingOps(trailingOps_), leadingOps(leadingOps_),
-      returnVals(returnVals_), partFnName(partFnName_), hash(0),
-      function(nullptr), fusedLoc(UnknownLoc::get(anchorOp_->getContext())) {
-  for (auto val : params_) {
-    params.push_back(val.getType());
-  }
+void OutliningCandidate::processOps() {
+  hash = 0;
+  opOrderIndex.clear();
   unsigned orderIt = params.size();
-  for (auto *op : leadingOps) {
-    orderIt = addOp(op, orderIt);
-  }
-  orderIt = addOp(anchorOp, orderIt);
-  for (auto *op : trailingOps) {
+  for (auto *op : ops) {
     orderIt = addOp(op, orderIt);
   }
 }
@@ -148,8 +184,8 @@ unsigned OutliningCandidate::getOrderOf(Value value) const {
   return 0;
 }
 
-static bool opsMatch(Operation *lhs, Operation *rhs, OutliningCandidate &one,
-                     OutliningCandidate &two) {
+bool OutliningCandidate::opsMatch(Operation *lhs, Operation *rhs,
+                                  const OutliningCandidate &two) const {
   // Check that the operations are equivalent.
   if (!OperationEquivalence::isEquivalentTo(
           lhs, rhs, OperationEquivalence::ignoreValueEquivalence, nullptr,
@@ -173,7 +209,7 @@ static bool opsMatch(Operation *lhs, Operation *rhs, OutliningCandidate &one,
 
     // Otherwise, these operands must have the same logical order within the
     // parent block.
-    if (one.getOrderOf(lhsOperand) != two.getOrderOf(rhsOperand)) {
+    if (getOrderOf(lhsOperand) != two.getOrderOf(rhsOperand)) {
       return false;
     }
   }
@@ -181,329 +217,372 @@ static bool opsMatch(Operation *lhs, Operation *rhs, OutliningCandidate &one,
   return true;
 }
 
-static bool outliningCandidatesEquivalent(OutliningCandidate &one,
-                                          OutliningCandidate &two) {
-  if (one.hash != two.hash) {
-    return false;
+bool OutliningCandidate::equivalent(const OutliningCandidate &that) const {
+  if (hash == that.hash) {
+    if (params.size() != that.params.size() || ops.size() != that.ops.size()) {
+      return false;
+    }
+    for (auto params : llvm::zip(params, that.params)) {
+      if (std::get<0>(params) != std::get<1>(params)) {
+        return false;
+      }
+    }
+    // get Result Types
+
+    for (auto opPair : llvm::zip(ops, that.ops)) {
+      if (!opsMatch(std::get<0>(opPair), std::get<1>(opPair), that)) {
+        return false;
+      }
+    }
+    return true;
   }
 
-  if (one.params.size() != two.params.size()) {
-    return false;
-  }
-  for (auto params : llvm::zip(one.params, two.params)) {
-    if (std::get<0>(params) != std::get<1>(params)) {
-      return false;
-    }
-  }
-
-  for (auto ops : llvm::zip(one.leadingOps, two.leadingOps)) {
-    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
-      return false;
-    }
-  }
-  if (!opsMatch(one.anchorOp, two.anchorOp, one, two)) {
-    return false;
-  }
-  for (auto ops : llvm::zip(one.trailingOps, two.trailingOps)) {
-    if (!opsMatch(std::get<0>(ops), std::get<1>(ops), one, two)) {
-      return false;
-    }
-  }
-  return true;
+  return false;
 }
 
-static OutliningCandidate *
-findOutliningCandidate(OutliningCandidate &newCandidate,
-                       std::vector<OutliningCandidate> &candidates) {
-  for (auto &candidate : candidates) {
-    if (outliningCandidatesEquivalent(candidate, newCandidate)) {
-      return &candidate;
+////////////////////////////////////////////////////////////////////////////////////
+////   OutlineBuilder
+////   1) Collect all ops that can be fused
+////   2) Look for match in Candidate Set
+////   3) If no match, build outline func
+////   4) Replace ops with call to outline func
+////////////////////////////////////////////////////////////////////////////////////
+
+class OutlineBuilder {
+
+  // Debug messaging for traversal
+  inline void debug(const char *tag, Operation *op) const {
+    LLVM_DEBUG(llvm::dbgs() << tag << ": " << op << "\n");
+  }
+
+  inline void debug(const char *tag, Value v) const {
+    LLVM_DEBUG(llvm::dbgs() << tag << ": "; v.print(
+        llvm::dbgs(), OpPrintingFlags().elideLargeElementsAttrs());
+               llvm::dbgs() << "\n");
+  }
+
+  // Add Value/Operation methods
+  void addInput(Value v) {
+    debug("INPUT", v);
+    _inputs.insert(v);
+  }
+
+  void addResult(Value v) {
+    debug("RESULT", v);
+    _results.insert(v);
+  }
+
+  void addPredecessor(Operation *op) {
+    if (!_leadingOps.contains(op)) {
+      assert(!_trailingOps.contains(op));
+      debug("PRED", op);
+      _leadingOps.insert(op);
+      _locs.push_back(op->getLoc());
     }
   }
-  return nullptr;
-}
 
-// Given an op and its fuse-able trailing (second) and leading
-// (front) ops, remove them into a separate function.
-static void outlineOps(Operation *anchorOp, ArrayRef<Operation *> trailingOps,
-                       ArrayRef<Operation *> leadingOps, ArrayRef<Value> params,
-                       ArrayRef<Value> returnVals, StringRef partFnName,
-                       StringRef attrName,
-                       std::vector<OutliningCandidate> &candidates) {
-  ValueRange values(params);
-  OpBuilder b(anchorOp);
-  Location loc = anchorOp->getLoc();
-  func::FuncOp outlinedFunc;
-  Location fusedLoc(loc);
+  void addSuccessor(Operation *op) {
+    if (!_trailingOps.contains(op)) {
+      debug("SUCC", op);
+      _trailingOps.insert(op);
+      _locs.push_back(op->getLoc());
+    }
+  }
 
-  // ------------------------------------------------------------
-  // Merging part.
+  bool contains(Operation *op) const {
+    return _trailingOps.contains(op) || _leadingOps.contains(op);
+  }
 
-  OutliningCandidate newCandidate(anchorOp, trailingOps, leadingOps, params,
-                                  returnVals, partFnName);
+  // Recurse back full chain looking for anchorOp
+  // - uses encountered set to reduce time
+  bool inChainToAnchor(Operation *inOp,
+                       DenseSet<Operation *> &encountered) const {
+    if (inOp == nullptr)
+      return false;
+    else if (inOp == _anchorOp)
+      return true;
+    else if (encountered.contains(inOp))
+      return false;
+    encountered.insert(inOp);
+    for (auto opr : inOp->getOperands()) {
+      if (Operation *oprOp = opr.getDefiningOp()) {
+        debug(">>>", oprOp);
+        if (inChainToAnchor(oprOp, encountered))
+          return true;
+        debug("<<<", oprOp);
+      }
+    }
+    return false;
+  }
 
-  if (OutliningCandidate *found =
-          findOutliningCandidate(newCandidate, candidates)) {
-    // Matches one we already have.
-    outlinedFunc = found->function;
-    fusedLoc = found->fusedLoc;
-  } else {
-    // ------------------------------------------------------------
-    // Construction part.
+  // Make sure all operands are external or immediate in the chain from anchorOp
+  bool isImmediateOp(Operation *inOp) const {
+    for (auto opr : inOp->getOperands()) {
+      if (Operation *oprOp = opr.getDefiningOp()) {
+        debug("IN>", oprOp);
+        DenseSet<Operation *> encountered;
+        if (!contains(oprOp) && inChainToAnchor(oprOp, encountered))
+          return false;
+      }
+    }
+    return true;
+  }
 
-    // Insert outlined function before current function.
-    OpBuilder::InsertionGuard g(b);
-    b.setInsertionPoint(anchorOp->getParentOfType<func::FuncOp>());
+  // Recurse all inputs to op and capture predecessor ops if qualified
+  void collectInputs(Operation *op, Operation *ignoreOp) {
+    for (const auto &operand : op->getOperands()) {
+      Operation *usedOp = operand.getDefiningOp();
+      if (usedOp) {
+        // Ignore input from anchor chain or already collected
+        if (usedOp != ignoreOp && !contains(usedOp)) {
+          if (_outliner.isLeadingOp(usedOp)) {
+            // Depth first collection of Leading ops
+            collectInputs(usedOp, op);
+            addPredecessor(usedOp);
+          } else if (!contains(usedOp)) {
+            // Capture as input if not already captured as Trailing
+            addInput(operand);
+          }
+        }
+      } else {
+        // Block parameter
+        addInput(operand);
+      }
+    }
+  }
+
+public:
+  OutlineBuilder(Outliner &outliner, Operation *anchorOp)
+      : _outliner(outliner), _anchorOp(anchorOp) {
+    _anchorBlock = anchorOp->getBlock();
+    debug("ANCHOR", anchorOp);
+    collectInputs(_anchorOp, _anchorOp);
+
+    addSuccessor(_anchorOp);
+  }
+
+  ~OutlineBuilder() {
+    // Erase the ops we outlined, which should be safe now.
+    for (auto &op : llvm::make_early_inc_range(llvm::reverse(_leadingOps))) {
+      if (op->use_empty())
+        op->erase();
+    }
+  }
+
+  bool collect() {
+    // Given a Conv2DOp (or other anchor op), gather all Leading
+    // and Trailing ops in the PBV chain up to and including Terminal
+    // ops.
+    //
+    // _inputs gathers what will become the parameters of the
+    // outlined function;  initially it's the anchor's arguments,
+    // and it accumulates arguments to other ops that don't come
+    // from inside the outlined function.
+    //
+    // _results will become the results of the outlined function.
+    // These are gathered after all ops have been collected, if any
+    // op has external uses.
+
+    // BFS
+    std::deque<Operation *> worklist;
+    worklist.push_back(_anchorOp);
+    while (!worklist.empty()) {
+      Operation *op = worklist.front();
+      worklist.pop_front();
+      for (auto *userOp : op->getUsers()) {
+        if (userOp->getBlock() == _anchorBlock && !contains(userOp)) {
+          bool isTerminal = _outliner.isTerminatingOp(userOp);
+          if ((_outliner.isTrailingOp(userOp) || isTerminal) &&
+              isImmediateOp(userOp)) {
+            addSuccessor(userOp);
+            // Collect all inputs other than anchor-chain
+            collectInputs(userOp, op);
+            // Traverse if not a Terminal Op
+            if (!isTerminal)
+              worklist.push_back(userOp);
+          }
+        }
+      }
+    }
+
+    // capture all result ops after anchor op that have external uses
+    for (auto *op : _trailingOps) {
+      for (auto res : op->getResults()) {
+        if (!llvm::all_of(res.getUsers(),
+                          [&](Operation *u) { return contains(u); }))
+          addResult(res);
+      }
+    }
+
+    // concat all ops into 1 list
+    _leadingOps.insert(_trailingOps.begin(), _trailingOps.end());
+
+    return true;
+  }
+
+  // Given an op and its fuse-able trailing (second) and leading
+  // (front) ops, remove them into a separate function.
+  func::FuncOp lookupOrCreate(DenseSet<OutliningCandidate> &candidates,
+                              StringRef attrName) const {
+    auto candidatePair = candidates.insert(
+        OutliningCandidate(_leadingOps.getArrayRef(), _inputs.getArrayRef()));
+    auto candidate = std::get<0>(candidatePair);
+    if (std::get<1>(candidatePair)) {
+      // Build outlined func.
+      // And update the candidate with the cloned ops for comparison.
+      candidate->setFunction(build(candidates.size() - 1, attrName));
+    }
+    return candidate->getFunction();
+  }
+
+  // Build the outlined function.
+  func::FuncOp build(uint32_t idx, StringRef attrName) const {
+    func::FuncOp anchorFunc = _anchorOp->getParentOfType<func::FuncOp>();
+    ValueRange inputs(_inputs.getArrayRef());
+    OpBuilder b(anchorFunc);
+    Location loc = _anchorOp->getLoc();
+    MLIRContext *ctx = _anchorOp->getContext();
+
+    auto partFnName =
+        anchorFunc.getSymName().str() + "__part_" + std::to_string(idx);
 
     // Make FuncOp from anchorOp's operand types and trailingOp's result type.
-    MLIRContext *ctx = anchorOp->getContext();
-    ValueRange results(returnVals);
+    ValueRange results(_results.getArrayRef());
     FunctionType type =
-        FunctionType::get(ctx, values.getTypes(), results.getTypes());
+        FunctionType::get(ctx, inputs.getTypes(), results.getTypes());
     SmallVector<NamedAttribute, 1> kernelAttrs{
         b.getNamedAttr(attrName, b.getUnitAttr()),
     };
-    outlinedFunc = b.create<func::FuncOp>(
+    func::FuncOp outlinedFunc = b.create<func::FuncOp>(
         loc, partFnName, type, ArrayRef<NamedAttribute>(kernelAttrs));
     outlinedFunc->setAttr("sym_visibility", StringAttr::get(ctx, "private"));
-    newCandidate.function = outlinedFunc;
 
     // Add access modes for parameters: read-only, write-only, read-write
     // All MemRef params are marked as 'read-write'
     // Non-MemRef inputs are added as 'read-only'
-    auto readAccessAttr =
+    auto readAttr =
         b.getNamedAttr(func::FuncOp::getReadAccessAttrName(), b.getUnitAttr());
-    auto writeAccessAttr =
+    auto writeAttr =
         b.getNamedAttr(func::FuncOp::getWriteAccessAttrName(), b.getUnitAttr());
-    for (auto pair : llvm::enumerate(values)) {
-      auto vtype = pair.value().getType();
-      if (vtype.isa<VectorType, RankedTensorType, UnrankedTensorType>())
-        outlinedFunc.setArgAttrs(pair.index(),
-                                 b.getDictionaryAttr({readAccessAttr}));
-      else if (vtype.isa<MemRefType>())
-        outlinedFunc.setArgAttrs(
-            pair.index(),
-            b.getDictionaryAttr({readAccessAttr, writeAccessAttr}));
+    auto getAccessAttrs = [&](Type t,
+                              bool inputs) -> std::optional<DictionaryAttr> {
+      if (t.isa<VectorType, RankedTensorType, UnrankedTensorType>())
+        return b.getDictionaryAttr({inputs ? readAttr : writeAttr});
+      if (t.isa<MemRefType>())
+        return b.getDictionaryAttr({readAttr, writeAttr});
+      return {};
+    };
+
+    // Non-MemRef inputs are added as 'read-only'
+    for (auto pair : llvm::enumerate(inputs)) {
+      if (auto attrs = getAccessAttrs(pair.value().getType(), true))
+        outlinedFunc.setArgAttrs(pair.index(), *attrs);
     }
     // Non-MemRef results are added as 'write-only'
     for (auto pair : llvm::enumerate(results)) {
-      auto vtype = pair.value().getType();
-      if (vtype.isa<VectorType, RankedTensorType, UnrankedTensorType>())
-        outlinedFunc.setResultAttrs(pair.index(),
-                                    b.getDictionaryAttr({writeAccessAttr}));
-      else if (vtype.isa<MemRefType>())
-        outlinedFunc.setResultAttrs(
-            pair.index(),
-            b.getDictionaryAttr({readAccessAttr, writeAccessAttr}));
+      if (auto attrs = getAccessAttrs(pair.value().getType(), false))
+        outlinedFunc.setResultAttrs(pair.index(), *attrs);
     }
 
-    // Clone leadingOps, anchorOp, and trailingOps into the body of the new
-    // function, while also updating the comparison details for future
-    // candidates.
+    // Clone collected ops into the body of the new function.
     b.setInsertionPointToStart(outlinedFunc.addEntryBlock());
     IRMapping bvm;
-    for (auto it : llvm::zip(values, outlinedFunc.getArguments()))
+    for (auto it : llvm::zip(inputs, outlinedFunc.getArguments()))
       bvm.map(std::get<0>(it), std::get<1>(it));
 
-    SmallVector<Location> collectedLocs{anchorOp->getLoc()};
-    newCandidate.leadingOps.clear();
-    for (auto *op : llvm::reverse(leadingOps)) {
-      newCandidate.leadingOps.push_back(b.clone(*op, bvm));
-      newCandidate.opOrderIndex[newCandidate.leadingOps.back()] =
-          newCandidate.opOrderIndex[op];
-      collectedLocs.push_back(op->getLoc());
-    }
-    std::reverse(newCandidate.leadingOps.begin(),
-                 newCandidate.leadingOps.end());
-
-    newCandidate.anchorOp = b.clone(*anchorOp, bvm);
-    newCandidate.opOrderIndex[newCandidate.anchorOp] =
-        newCandidate.opOrderIndex[anchorOp];
-
-    newCandidate.trailingOps.clear();
-    for (auto *op : trailingOps) {
-      // All operands should already be in bvm.
-      assert(llvm::all_of(op->getOperands(),
-                          [&](Value v) { return bvm.lookupOrNull(v); }));
-      newCandidate.trailingOps.push_back(b.clone(*op, bvm));
-      newCandidate.opOrderIndex[newCandidate.trailingOps.back()] =
-          newCandidate.opOrderIndex[op];
-      collectedLocs.push_back(op->getLoc());
+    for (auto *op : _leadingOps) {
+      b.clone(*op, bvm);
     }
 
     // Make ReturnOp from trailingOps' results.
     SmallVector<Value> returnOperands;
-    for (auto op : returnVals) {
-      returnOperands.push_back(bvm.lookup(op));
+    for (auto res : _results) {
+      returnOperands.push_back(bvm.lookup(res));
     }
     // Can't also supply return types, because it'll see a mismatch
     // in numbers where there isn't one.
     b.create<func::ReturnOp>(loc, returnOperands);
 
-    newCandidate.fusedLoc = FusedLoc::get(ctx, collectedLocs);
-    candidates.push_back(newCandidate);
+    return outlinedFunc;
   }
 
-  // ------------------------------------------------------------
-  // Replacement part.
+  // Given an op and its fuse-able trailing (second) and leading
+  // (front) ops, remove them into a separate function.
+  void makeCall(func::FuncOp outlinedFunc) {
+    OpBuilder b(_anchorOp);
+    MLIRContext *ctx = _anchorOp->getContext();
+    Location fusedLoc = FusedLoc::get(ctx, _locs);
+    // ------------------------------------------------------------
+    // Replacement part.
 
-  // Replace anchorOp, trailingOps, and leadingOps with CallOp to new function.
-  Operation *lastOp = anchorOp;
-  if (!trailingOps.empty())
-    lastOp = trailingOps[trailingOps.size() - 1];
-  b.setInsertionPointAfter(lastOp);
-  func::CallOp callOp = b.create<func::CallOp>(fusedLoc, outlinedFunc, values);
+    // Replace anchorOp, trailingOps, and leadingOps with CallOp to new
+    // function. ? Look for earliest result ?
+    b.setInsertionPointAfter(_leadingOps.back());
+    func::CallOp callOp =
+        b.create<func::CallOp>(fusedLoc, outlinedFunc, _inputs.getArrayRef());
 
-  for (auto it : llvm::zip(returnVals, callOp->getResults())) {
-    std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
-  }
-
-  // Erase the ops we outlined, which should be safe now.
-  for (auto &op : llvm::make_early_inc_range(llvm::reverse(trailingOps))) {
-    if (op->use_empty()) {
-      op->erase();
+    for (auto it : llvm::zip(_results, callOp->getResults())) {
+      std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
     }
   }
-  assert(anchorOp->use_empty() && "expected 'op' to have no uses");
-  anchorOp->erase();
-  for (auto &op : llvm::make_early_inc_range(leadingOps)) {
-    if (op->use_empty()) {
-      op->erase();
-    }
-  }
-}
 
-void Outliner::traceInputs(Operation *op, Operation *ignoreOp,
-                           SetVector<Operation *> &predecessors,
-                           SetVector<Value> &inputNodes) {
-  for (const auto &opnd : op->getOperands()) {
-    Operation *usedOp = opnd.getDefiningOp();
-    if (usedOp == ignoreOp)
-      continue;
-    if (usedOp && isLeadingOp(usedOp)) {
-      if (predecessors.contains(
-              usedOp)) // If already present, move it for new use.
-        predecessors.remove(usedOp);
-      predecessors.insert(usedOp);
-      if (!usedOp->hasTrait<OpTrait::ConstantLike>()) {
-        // depth first
-        traceInputs(usedOp, op, predecessors, inputNodes);
-      }
-    } else if (!predecessors.contains(
-                   usedOp)) { // special-case consts aren't inputs
-      inputNodes.insert(opnd);
-    }
-  }
-}
+private:
+  Outliner &_outliner;
 
-// Inspired by / adapted from TestSCFIfUtilsPass in
-// test/lib/Transforms/TestSCFUtils.cpp.
+  Operation *_anchorOp;
+  Block *_anchorBlock;
+
+  SmallVector<Location, FUSION_CAPACITY_DEFAULT> _locs;
+
+  typedef SmallVector<Value, FUSION_CAPACITY_DEFAULT> ValVec;
+  typedef SmallVector<Operation *, FUSION_CAPACITY_DEFAULT> OpVec;
+  SetVector<Value, ValVec> _inputs;
+  SetVector<Operation *, OpVec> _leadingOps;
+  SetVector<Operation *, OpVec> _trailingOps;
+  SetVector<Value, ValVec> _results;
+};
+
+// Walk each func outlining fusion opportunities, replacing with a call
+// to a new (or matching) function containing the functionality. The call
+// will be annotated the loc's of all fused ops.
 void Outliner::outline(ModuleOp module) {
   auto funcOps = module.getOps<func::FuncOp>();
+
   for (auto func : llvm::make_early_inc_range(funcOps)) {
     // Don't outline a kernel;  it may already have been outlined.
     if (func->hasAttr(outlineTag))
       continue;
 
+    bool hasMemrefs = false;
     std::vector<Operation *> anchors;
     auto callback = [&](Operation *op) {
+      for (auto operand : op->getOperands()) {
+        if (isa<MemRefType>(operand.getType()))
+          hasMemrefs = true;
+      }
+      for (auto result : op->getResults()) {
+        if (isa<MemRefType>(result.getType()))
+          hasMemrefs = true;
+      }
       if (isAnchorOp(op))
         anchors.push_back(op);
     };
     // Gather the anchor ops so we can process them back-to-front.
     func.walk(callback);
 
-    int count = 0;
-    // (Problems with node mismatches and unexpected uses if we have the
-    // candidates list at module level.)
-    std::vector<OutliningCandidate> candidates;
-    for (auto &anchorOp : llvm::make_early_inc_range(llvm::reverse(anchors))) {
-      auto strCount = std::string("__part_") + std::to_string(count++);
+    if (!hasMemrefs) {
+      // (Problems with node mismatches and unexpected uses if we have the
+      // candidates list at module level.)
+      DenseSet<OutliningCandidate> candidates;
+      for (auto anchorOp : llvm::make_early_inc_range(llvm::reverse(anchors))) {
+        // Create an OutlineBuilder for each anchor op.
+        OutlineBuilder builder(*this, anchorOp);
+        builder.collect();
 
-      // Given a Conv2DOp (or other anchor op), gather all the
-      // element-wise ops that are reachable from its results,
-      // contiguously.
-      //
-      // The ops after the anchor are "trailing" ops.
-      //
-      // inputNodes gathers what will become the parameters of the
-      // outlined function;  initially it's the anchor's arguments,
-      // and it accumulates arguments to other ops that don't come
-      // from inside the outlined function.
-      //
-      // resultNodes will become the results of the outlined function.
-      // It starts with the anchor's result(s) and gains the results
-      // of each new trailingOp.  When all a resultNode's users can be
-      // determined to lie within the outlined function, it's removed
-      // from the set.
-      //
-      // These are SetVectors because we test with contains() a lot,
-      // but still want to preserve order.
-      SetVector<Operation *> trailingOps;
-      SetVector<Value> inputNodes;
-      SetVector<Value> resultNodes(anchorOp->getResults().begin(),
-                                   anchorOp->getResults().end());
-
-      // Grab a useful set of leading ops, like we do for trailing.
-      SetVector<Operation *> leadingOps;
-      traceInputs(anchorOp, anchorOp, leadingOps, inputNodes);
-
-      DominanceInfo domInfo(func);
-      std::deque<Operation *> worklist; // cuz I want to pull from the front.
-
-      worklist.push_back(anchorOp);
-      while (!worklist.empty()) {
-        Operation *op = worklist.front();
-        worklist.pop_front();
-        for (auto *userOp : op->getUsers()) {
-          if (isTrailingOp(userOp)) {
-            bool skip = false;
-            // First criterion is that the op is element-wise.  Second
-            // criterion is that the op dominates all the users of the
-            // accumulated results of the outlined function.  In other words,
-            // we can't take an op that comes "after" a user of the result
-            // from the eventual call, because the call needs to dominate all
-            // its users.
-            for (const Value &val : resultNodes) {
-              for (auto *user : val.getDefiningOp()->getUsers()) {
-                if (user != userOp &&
-                    !domInfo.properlyDominates(userOp, user)) {
-                  skip = true;
-                }
-              }
-            }
-
-            // userOp is acceptable.  Keep it as a trailingOp, put it on
-            // the worklist.  Add its operands to inputNodes unless
-            // they're suitable as leading ops or come from other
-            // trailingOps (indicated by being in resultNodes).  If all
-            // the users of any resultNode are in trailingOps, there's
-            // no need to return it so remove from resultNodes.
-            // Finally, add all userOp's results to resultNodes.
-            if (!skip) {
-              // Also accept inputs to userOp.
-              // Put traced ops in leadingOps so they're always ahead of op.
-              traceInputs(userOp, op, leadingOps, inputNodes);
-              // General case.
-              trailingOps.insert(userOp);
-              worklist.push_back(userOp);
-              for (const Value &val : resultNodes)
-                if (llvm::all_of(val.getUsers(), [&](Operation *u) {
-                      return trailingOps.contains(u);
-                    }))
-                  resultNodes.remove(val);
-              for (auto res : userOp->getResults())
-                resultNodes.insert(res);
-            }
-          }
-        }
+        // Make the outlined function from the ops we've gathered.
+        auto outlinedFunc = builder.lookupOrCreate(candidates, outlineTag);
+        builder.makeCall(outlinedFunc);
       }
-
-      // Make the outlined function from the ops we've gathered.
-      outlineOps(anchorOp, trailingOps.getArrayRef(), leadingOps.getArrayRef(),
-                 inputNodes.getArrayRef(), resultNodes.getArrayRef(),
-                 std::string(func.getSymName()) + strCount, outlineTag,
-                 candidates);
     }
   }
 }

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-reconverge.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-reconverge.mlir
@@ -1,0 +1,31 @@
+// RUN: mlir-opt --tosa-partition='trailing-only=false' %s | FileCheck %s
+
+// CHECK: forward__part_0
+// CHECK: func.func @forward
+// CHECK-NEXT: call @forward__part_0
+// CHECK-NEXT: return
+
+module attributes {torch.debug_module_name = "BertTinyWrapper"} {
+func.func @forward(%arg0: tensor<2x128x128xf32> {func.read_access}, %arg1: tensor<512x128xf32> {func.read_access}, %arg2: tensor<1x1x512xf32> {func.read_access}) -> (tensor<2x128x512xf32> {func.write_access}) {
+  %5 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+  %6 = "tosa.const"() <{value = dense<1.000000e+00> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+  %7 = "tosa.const"() <{value = dense<0.707106769> : tensor<1x1x1xf32>}> : () -> tensor<1x1x1xf32>
+  %8 = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}> : () -> tensor<2xi32>
+  %9 = "tosa.transpose"(%arg1, %8) : (tensor<512x128xf32>, tensor<2xi32>) -> tensor<128x512xf32>
+  %10 = "tosa.reshape"(%9) <{new_shape = array<i64: 1, 128, 512>}> : (tensor<128x512xf32>) -> tensor<1x128x512xf32>
+  %11 = "tosa.reshape"(%arg0) <{new_shape = array<i64: 1, 256, 128>}> : (tensor<2x128x128xf32>) -> tensor<1x256x128xf32>
+  %12 = "tosa.matmul"(%11, %10) : (tensor<1x256x128xf32>, tensor<1x128x512xf32>) -> tensor<1x256x512xf32>
+  %13 = "tosa.reshape"(%12) <{new_shape = array<i64: 2, 128, 512>}> : (tensor<1x256x512xf32>) -> tensor<2x128x512xf32>
+  %14 = "tosa.add"(%13, %arg2) : (tensor<2x128x512xf32>, tensor<1x1x512xf32>) -> tensor<2x128x512xf32>
+  %15 = "tosa.mul"(%14, %7) <{shift = 0 : i32}> : (tensor<2x128x512xf32>, tensor<1x1x1xf32>) -> tensor<2x128x512xf32>
+  %16 = "tosa.abs"(%15) : (tensor<2x128x512xf32>) -> tensor<2x128x512xf32>
+  %19 = "tosa.mul"(%16, %16) <{shift = 0 : i32}> : (tensor<2x128x512xf32>, tensor<2x128x512xf32>) -> tensor<2x128x512xf32>
+  %28 = "tosa.reciprocal"(%19) : (tensor<2x128x512xf32>) -> tensor<2x128x512xf32>
+  %31 = "tosa.sub"(%6, %28) : (tensor<1x1x1xf32>, tensor<2x128x512xf32>) -> tensor<2x128x512xf32>
+  %32 = "tosa.greater_equal"(%15, %5) : (tensor<2x128x512xf32>, tensor<1x1x1xf32>) -> tensor<2x128x512xi1>
+  %33 = "tosa.negate"(%31) : (tensor<2x128x512xf32>) -> tensor<2x128x512xf32>
+  %34 = "tosa.select"(%32, %31, %33) : (tensor<2x128x512xi1>, tensor<2x128x512xf32>, tensor<2x128x512xf32>) -> tensor<2x128x512xf32>
+  %37 = "tosa.mul"(%14, %34) <{shift = 0 : i32}> : (tensor<2x128x512xf32>, tensor<2x128x512xf32>) -> tensor<2x128x512xf32>
+  func.return %37 : tensor<2x128x512xf32>
+}
+}

--- a/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/tosa-partition-transpose.mlir
@@ -1,21 +1,30 @@
 // RUN: mlir-opt --tosa-partition='trailing-only=false' %s | FileCheck %s
 // CHECK-LABEL: func private @forward__part_0
 // CHECK-NEXT: tosa.const
+// CHECK-NEXT: tosa.transpose
+// CHECK-NEXT: tosa.sub
 // CHECK-NEXT: tosa.const
-// CHECK-NEXT: tosa.const
+// CHECK-NEXT: tosa.add
+// CHECK-NEXT: tosa.rsqrt
+// CHECK-NEXT: tosa.reshape
+// CHECK-NEXT: tosa.mul
+// CHECK-NEXT: tosa.mul
+// CHECK-NEXT: tosa.add
+// CHECK-NEXT: tosa.clamp
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
-// CHECK: tosa.transpose
-// CHECK: tosa.transpose
+// CHECK-NEXT: tosa.const
+// CHECK-NEXT: tosa.transpose
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.conv2d
 // CHECK-NEXT: tosa.transpose
 // CHECK: return
 // CHECK-LABEL: func private @forward__part_1
 // CHECK-NEXT: tosa.const
-// CHECK-NEXT: tosa.const
+// CHECK-NEXT: tosa.transpose
 // CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.transpose
-// CHECK-NEXT: tosa.transpose
+// CHECK-NEXT: tosa.const
 // CHECK-NEXT: tosa.conv2d
 // CHECK: return
 

--- a/external/mlir-hal/lib/Dialect/MHAL/Pipelines/Pipelines.cpp
+++ b/external/mlir-hal/lib/Dialect/MHAL/Pipelines/Pipelines.cpp
@@ -40,6 +40,7 @@
 #include "mlir/Dialect/Async/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
@@ -73,6 +74,10 @@ void mhal::buildGraphPipeline(OpPassManager &pm,
   opts.anchorOps = anchors;
   opts.trailingOnly = true;
   pm.addPass(tosa::createTosaPartition(opts));
+
+  /* mlir-opt --duplicate-function-elimination
+   */
+  pm.addPass(func::createDuplicateFunctionEliminationPass());
 
   // make mhal kernel launch's
   /* mlir-opt --mhal-infer-graph


### PR DESCRIPTION
* Add op when all operands are:
   * already collected or
   * external to the anchor op chain
      * depth first collection of these as leading ops 
* Use DenseSet for candidate lookup 
* Increased static size for leading/trailing ops vectors 
* Added debug traversal messaging 
* Also added Terminal op support  
  * don't traverse users 
* Disable for func containg MemRefTypes

https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1018