### PR TITLE
Generalize finding the rocm_agent_enumerator program

### DIFF
--- a/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -269,11 +269,15 @@ if(LLVM_ENABLE_PIC)
     set(CMAKE_PREFIX_PATH "${REAL_CMAKE_PREFIX_PATH}")
 
     if (NOT DEFINED ROCM_TEST_CHIPSET)
-      execute_process(COMMAND "${ROCM_PATH}/bin/rocm_agent_enumerator"
-      OUTPUT_VARIABLE AGENTS_STRING
-      ERROR_VARIABLE AGENTS_STRING
-      RESULT_VARIABLE AGENT_ENUMERATOR_RESULT)
-
+      find_program(ROCM_AGENT_ENUMERATOR rocm_agent_enumerator "${ROCM_PATH}/bin" /usr/bin /usr/local/bin)
+      if(ROCM_AGENT_ENUMERATOR)
+	execute_process(COMMAND "${ROCM_AGENT_ENUMERATOR}"
+	  OUTPUT_VARIABLE AGENTS_STRING
+	  ERROR_VARIABLE AGENTS_STRING
+	  RESULT_VARIABLE AGENT_ENUMERATOR_RESULT)
+      else()
+        message(SEND_ERROR "Could not find rocm_agent_enumerator")
+      endif()
       if (NOT AGENT_ENUMERATOR_RESULT EQUAL 0)
         message(SEND_ERROR "Could not run rocm_agent_enumerator and ROCM_TEST_CHIPSET is not defined")
         set(AGENTS_STRING "")


### PR DESCRIPTION
On Fedora, rocminfo is a fedora package and rocm_agent_enumberator is installed to /usr/bin.  This causes this error when building.

CMake Error at external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt:232 (message):
  Could not run rocm_agent_enumerator and ROCM_TEST_CHIPSET is not defined

So use find_program() to look for rocm_agent_enumerator instead of assuming a single location.