### PR TITLE
[HOT FIX]Disable tuning of backward-data convolution

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -675,7 +675,7 @@ pipeline {
                     }
                     stage("Copy tuning database") {
                         steps {
-                            copyArtifacts filter: 'MIOpen/build/MIOpenUserDB/**',\
+                            copyArtifacts filter: 'build/perfDB/**',\
                                 optional: true,\
                                 flatten: true,\
                                 projectName: "/MLIR/mlir-weekly",\

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -27,7 +27,9 @@ from typing import Optional, Dict, Tuple
 ROCPROF = '/opt/rocm/bin/rocprof'
 MIOPENDRIVER = '/opt/rocm/bin/MIOpenDriver'
 BENCHMARKING_RESULT_FILE_NAME = 'results.stats.csv'
-DIRECTIONS = ['-F 1', '-F 2', '-F 4']
+#DIRECTIONS = ['-F 1', '-F 2', '-F 4']
+# temporarily disable backward-data until rocmlir-tuning-driver can handle multi-kernel code
+DIRECTIONS = ['-F 1', '-F 4']
 DATA_TYPES = ['conv', 'convfp16', 'convint8']
 LAYOUTS = ['NHWC', 'NCHW']
 


### PR DESCRIPTION
Also update Jenkinsfile to copy tuning databases from the new directory.