### PR TITLE
Upgrade Dockerfile to 5.6 and prune it

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:20.04
 MAINTAINER Zhuoran Yin <zhuoran.yin@amd.com>
 
-ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/5.5/
+ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/5.6/
 ARG ROCM_BUILD_NAME=focal
 ARG ROCM_BUILD_NUM=main
-ARG ROCM_PATH=/opt/rocm-5.5
+ARG ROCM_PATH=/opt/rocm-5.6
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -105,6 +105,7 @@ RUN apt-get update && rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
   rocblas \
   rocblas-dev \
   miopen-hip \
+  miopen-hip-dev \
   libelf1 \
   pkg-config \
   sudo \
@@ -119,13 +120,3 @@ RUN apt-get update && rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
   parallel && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
-
-# --------------------- Section 3: MIOpen dependencies ---------------
-WORKDIR /MIOpenDepsWork
-RUN wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/MIOpen/develop/requirements.txt \
-    && wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/MIOpen/develop/install_deps.cmake \
-    && sed -i -e '/rocMLIR/d' requirements.txt \
-    && sed -i -e '/composable_kernel/d' requirements.txt \
-    && cmake -P install_deps.cmake --prefix /usr/local
-RUN echo $(git ls-remote https://github.com/ROCmSoftwarePlatform/MIOpen HEAD) > miopen-deps-commit-hash
-WORKDIR /

--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -1,9 +1,8 @@
-FROM rocm/mlir:rocm5.5-latest
-ARG ROCM_PATH=/opt/rocm-5.5
+FROM rocm/mlir:rocm5.6-latest
+ARG ROCM_PATH=/opt/rocm-5.6
 
 # --------------------- Section 4: MIGraphX dependencies ---------------
 WORKDIR /MIGraphXDeps
-RUN apt-get update && apt-get install -y miopen-hip
 RUN pip3 install setuptools wheel
 RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz
 ENV MIGRAPHX_REF=develop
@@ -11,7 +10,7 @@ RUN wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/AMDMIGraphX/${MI
     && wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/AMDMIGraphX/${MIGRAPHX_REF}/dev-requirements.txt \
     && wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/AMDMIGraphX/${MIGRAPHX_REF}/rbuild.ini
 RUN echo $(git ls-remote https://github.com/ROCmSoftwarePlatform/AMDMIGraphX ${MIGRAPHX_REF}) > migraphx-deps-commit-hash
-RUN rbuild prepare -d $PWD -s develop --cxx=/opt/rocm/llvm/bin/clang++
+RUN rbuild prepare -d $PWD -s develop --cxx=/opt/rocm/llvm/bin/clang++ --cc=/opt/rocm/llvm/bin/clang
 # Download models for testing
 RUN wget https://github.com/onnx/models/raw/ba629906dd91872def671e70177c5544e0ea9e02/vision/classification/resnet/model/resnet50-v1-7.onnx
 WORKDIR /


### PR DESCRIPTION
- Update to ROCm 5.6
- Install miopen-hip-dev to get the CMake configuration files so that MIGraphX can find MIOpen on the system
- Remove redundant installation of MIOpen
- Don't install MIOpen dependencies since we're not building MIOpen anymore