### PR TITLE
MLIR#842: fixed mixed layout in rock.conv2d()

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -564,7 +564,8 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
 //     %1 = expand(%0[KC]) -> [KHWC]
 // If this feeds into a conv2d as filter, we will drop the collapse/expand and
 // update the filter_layout attribute.
-struct CollapseExpandRewritePattern : public OpRewritePattern<tensor::ExpandShapeOp> {
+struct CollapseExpandRewritePattern
+    : public OpRewritePattern<tensor::ExpandShapeOp> {
   using OpRewritePattern<tensor::ExpandShapeOp>::OpRewritePattern;
 
   bool checkExpand(tensor::ExpandShapeOp expOp) const {
@@ -572,9 +573,8 @@ struct CollapseExpandRewritePattern : public OpRewritePattern<tensor::ExpandShap
     auto resSh = expOp.getResultType().cast<ShapedType>().getShape();
     // [[0, 1, 2], [3]]
     // NC -> NHWC
-    if (srcSh.size() == 2 && resSh.size() == 4 &&
-        srcSh[0] == resSh[0] && srcSh[1] == resSh[3] &&
-        resSh[1] == 1 && resSh[2] == 1) {
+    if (srcSh.size() == 2 && resSh.size() == 4 && srcSh[0] == resSh[0] &&
+        srcSh[1] == resSh[3] && resSh[1] == 1 && resSh[2] == 1) {
       return true;
     }
     return false;
@@ -585,9 +585,8 @@ struct CollapseExpandRewritePattern : public OpRewritePattern<tensor::ExpandShap
     auto resSh = colOp.getResultType().cast<ShapedType>().getShape();
     // [[0], [1, 2, 3]]
     // NCHW -> NC
-    if (srcSh.size() == 4 && resSh.size() == 2 &&
-        srcSh[0] == resSh[0] && srcSh[1] == resSh[1] &&
-        srcSh[2] == 1 && srcSh[3] == 1) {
+    if (srcSh.size() == 4 && resSh.size() == 2 && srcSh[0] == resSh[0] &&
+        srcSh[1] == resSh[1] && srcSh[2] == 1 && srcSh[3] == 1) {
       return true;
     }
     return false;
@@ -596,7 +595,7 @@ struct CollapseExpandRewritePattern : public OpRewritePattern<tensor::ExpandShap
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expOp,
                                 PatternRewriter &b) const final {
     LogicalResult lres = failure();
-    
+
     Value expInp = expOp.getOperand();
     Value expOut = expOp.getResult();
 
@@ -615,7 +614,7 @@ struct CollapseExpandRewritePattern : public OpRewritePattern<tensor::ExpandShap
             permuteLayout(convOp, "filter_layout", "kyxc", dims, true);
             // replace filter input with collapse source
             convOp->replaceUsesOfWith(expOut, colInp);
-            
+
             lres = success();
           }
         }

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -363,6 +363,23 @@ public:
   }
 };
 
+static void permuteLayout(Operation *op, const char *attrKey,
+                          const char *layoutDefault, ArrayRef<int32_t> permDims,
+                          bool isInput = false) {
+  StringRef currentLayout(layoutDefault);
+  if (auto attr = op->getAttrOfType<StringAttr>(attrKey))
+    currentLayout = attr.getValue();
+  SmallString<4> layout(currentLayout);
+  if (isInput) {
+    for (int i = 0, e = permDims.size(); i < e; ++i)
+      layout[permDims[i]] = currentLayout[i];
+  } else {
+    for (int i = 0, e = permDims.size(); i < e; ++i)
+      layout[i] = currentLayout[permDims[i]];
+  }
+  op->setAttr(attrKey, StringAttr::get(op->getContext(), layout));
+}
+
 struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
   using OpRewritePattern<tosa::TransposeOp>::OpRewritePattern;
 
@@ -382,23 +399,6 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
       }
     }
     return failure();
-  }
-
-  void permuteLayout(Operation *op, const char *attrKey,
-                     const char *layoutDefault, ArrayRef<int32_t> permDims,
-                     bool isInput = false) const {
-    StringRef currentLayout(layoutDefault);
-    if (auto attr = op->getAttrOfType<StringAttr>(attrKey))
-      currentLayout = attr.getValue();
-    SmallString<4> layout(currentLayout);
-    if (isInput) {
-      for (int i = 0, e = permDims.size(); i < e; ++i)
-        layout[permDims[i]] = currentLayout[i];
-    } else {
-      for (int i = 0, e = permDims.size(); i < e; ++i)
-        layout[i] = currentLayout[permDims[i]];
-    }
-    op->setAttr(attrKey, StringAttr::get(op->getContext(), layout));
   }
 
   void setTranspose(Operation *op, StringRef name, bool isNonTrivial) const {
@@ -554,6 +554,75 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
 
     b.eraseOp(top);
     return success();
+  }
+};
+
+// In Tosa canonicalize, a transpose of NCHW to NHWC where H==W==1 will convert
+// to a reshape because it does not change memory layout. Then in TosaToTensor
+// conversion, the reshape is replaced by this pattern:
+//     %0 = collapse(filters[KCHW]) -> [KC]
+//     %1 = expand(%0[KC]) -> [KHWC]
+// If this feeds into a conv2d as filter, we will drop the collapse/expand and
+// update the filter_layout attribute.
+struct CollapseExpandRewritePattern : public OpRewritePattern<tensor::ExpandShapeOp> {
+  using OpRewritePattern<tensor::ExpandShapeOp>::OpRewritePattern;
+
+  bool checkExpand(tensor::ExpandShapeOp expOp) const {
+    auto srcSh = expOp.getOperand().getType().cast<ShapedType>().getShape();
+    auto resSh = expOp.getResultType().cast<ShapedType>().getShape();
+    // [[0, 1, 2], [3]]
+    // NC -> NHWC
+    if (srcSh.size() == 2 && resSh.size() == 4 &&
+        srcSh[0] == resSh[0] && srcSh[1] == resSh[3] &&
+        resSh[1] == 1 && resSh[2] == 1) {
+      return true;
+    }
+    return false;
+  }
+
+  bool checkCollapse(tensor::CollapseShapeOp colOp) const {
+    auto srcSh = colOp.getOperand().getType().cast<ShapedType>().getShape();
+    auto resSh = colOp.getResultType().cast<ShapedType>().getShape();
+    // [[0], [1, 2, 3]]
+    // NCHW -> NC
+    if (srcSh.size() == 4 && resSh.size() == 2 &&
+        srcSh[0] == resSh[0] && srcSh[1] == resSh[1] &&
+        srcSh[2] == 1 && srcSh[3] == 1) {
+      return true;
+    }
+    return false;
+  }
+
+  LogicalResult matchAndRewrite(tensor::ExpandShapeOp expOp,
+                                PatternRewriter &b) const final {
+    LogicalResult lres = failure();
+    
+    Value expInp = expOp.getOperand();
+    Value expOut = expOp.getResult();
+
+    if (!checkExpand(expOp))
+      return failure();
+
+    auto colOp = expInp.getDefiningOp<tensor::CollapseShapeOp>();
+    if (colOp && checkCollapse(colOp)) {
+      auto colInp = colOp.getOperand();
+
+      for (Operation *usr : expOut.getUsers()) {
+        if (auto convOp = dyn_cast<tosa::Conv2DOp>(usr)) {
+          if (convOp.getOperand(1) == expOut) {
+            // update filter_layout
+            SmallVector<int32_t> dims{0, 2, 3, 1};
+            permuteLayout(convOp, "filter_layout", "kyxc", dims, true);
+            // replace filter input with collapse source
+            convOp->replaceUsesOfWith(expOut, colInp);
+            
+            lres = success();
+          }
+        }
+      }
+    }
+
+    return lres;
   }
 };
 
@@ -756,5 +825,6 @@ void tosa::populateTosaToRockConversionPatterns(MLIRContext *context,
 
 void tosa::populateTosaToRockTensorConversionPatterns(
     MLIRContext *context, RewritePatternSet &patterns) {
-  patterns.add<AttentionRewritePattern, TransposeRewritePattern>(context);
+  patterns.add<AttentionRewritePattern, TransposeRewritePattern,
+               CollapseExpandRewritePattern>(context);
 }

--- a/mlir/test/Conversion/TosaToRock/no-mixed-layout.mlir
+++ b/mlir/test/Conversion/TosaToRock/no-mixed-layout.mlir
@@ -1,0 +1,19 @@
+// RUN: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | FileCheck %s
+
+// CHECK: rock.conv2d({{.*}}) {{.*}} {{{.*}}, filter_layout = ["k", "c", "y", "x", "g"], input_layout = ["ni", "ci", "hi", "wi", "gi"], output_layout = ["no", "ko", "ho", "wo", "go"]{{.*}}}
+
+module {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x384x28x28xf32>, %arg2: tensor<512x384x1x1xf32>) -> tensor<1x512x28x28xf32> {
+    %cst = arith.constant dense<[0, 2, 3, 1]> : tensor<4xi64>
+    %0 = "tosa.transpose"(%arg1, %cst) : (tensor<1x384x28x28xf32>, tensor<4xi64>) -> tensor<1x28x28x384xf32>
+    %1 = "tosa.transpose"(%arg2, %cst) : (tensor<512x384x1x1xf32>, tensor<4xi64>) -> tensor<512x1x1x384xf32>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<512xf32>
+    %2 = "tosa.conv2d"(%0, %1, %cst_0) <{dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}> : (tensor<1x28x28x384xf32>, tensor<512x1x1x384xf32>, tensor<512xf32>) -> tensor<1x28x28x512xf32>
+    %cst_1 = arith.constant dense<[0, 3, 1, 2]> : tensor<4xi64>
+    %3 = "tosa.transpose"(%2, %cst_1) : (tensor<1x28x28x512xf32>, tensor<4xi64>) -> tensor<1x512x28x28xf32>
+    %4 = "tosa.add"(%3, %arg0) : (tensor<1x512x28x28xf32>, tensor<1x512x1x1xf32>) -> tensor<1x512x28x28xf32>
+    %5 = "tosa.clamp"(%4) <{max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64}> : (tensor<1x512x28x28xf32>) -> tensor<1x512x28x28xf32>
+    return %5 : tensor<1x512x28x28xf32>
+  }
+}
+


### PR DESCRIPTION
* when 1x1 filters get tosa.reshape then converted to collapse(NCHW) -> expand(NHWC)
* added unit test

https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/842