### PR TITLE
Fix sorting of Embed{} inputs in vectorization

### DIFF
--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -511,10 +511,48 @@ propagateVectorizationInfo(TransformMapAttr map, const VectorizationData &input,
     // isn't equal to the accumulated value times the smallest coefficient seen
     // on a dimension being vectorized.
     case TransformType::Embed: {
-      // Since embed coefficients can go in any order, we need them sorted
+      // Since embed coefficients can go in any order, we need them sorted.
+      // We first sort by the Embed coefficient
+      // We tiebreak dimensions with equal coefficients as follows:
+      //  - Dimensions that have vectorization info are processed before those
+      //    that don't.
+      //   - Two vectorization dimensions have ties broken by whether their
+      //      needed coefficient is equal to their embed coefficient.
+      //   - If both inputs have a matching coefficient, the one with the longer
+      //     vectorization length is used (sending equality to input order).
+      //   - Failing that, since neither of the inputs being compared are
+      //     going to succesfully advance the vectorizaion, we fall back to
+      //     order in the input map.
+      // - In all otther cases, ties are broken by position in the input map.
       auto &&zip = llvm::zip(params, upperDims);
       SmallVector<std::tuple<int64_t, uint32_t>> data(zip.begin(), zip.end());
-      std::sort(data.begin(), data.end());
+      std::sort(data.begin(), data.end(), [&](const auto &a, const auto &b) {
+        int64_t paramA = std::get<0>(a), paramB = std::get<0>(b);
+        uint32_t dimA = std::get<1>(a), dimB = std::get<1>(b);
+        if (paramA != paramB)
+          return paramA < paramB;
+        bool aHasVec = input[dimA].has_value(),
+             bHasVec = input[dimB].has_value();
+        if (!aHasVec && !bHasVec)
+          return dimA < dimB;
+        if (aHasVec && !bHasVec)
+          return true;
+        if (!aHasVec && bHasVec)
+          return false;
+
+        bool aIsGood = input[dimA]->needsCoefficient == paramA,
+             bIsGood = input[dimB]->needsCoefficient == paramB;
+        if (aIsGood && !bIsGood)
+          return true;
+        if (!aIsGood && bIsGood)
+          return false;
+        if (aIsGood && bIsGood) {
+          int64_t aLen = input[dimA]->maxLength, bLen = input[dimB]->maxLength;
+          if (aLen != bLen)
+            return aLen < bLen;
+        }
+        return dimA < dimB;
+      });
 
       // Note: with negative coefficients, we can't reliably vectorize, as
       // the subtraction can push us off the left edge and we don't necessarily

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -527,8 +527,8 @@ propagateVectorizationInfo(TransformMapAttr map, const VectorizationData &input,
       auto &&zip = llvm::zip(params, upperDims);
       SmallVector<std::tuple<int64_t, uint32_t>> data(zip.begin(), zip.end());
       std::sort(data.begin(), data.end(), [&](const auto &a, const auto &b) {
-        int64_t paramA = std::get<0>(a), paramB = std::get<0>(b);
-        uint32_t dimA = std::get<1>(a), dimB = std::get<1>(b);
+        auto [paramA, dimA] = a;
+        auto [paramB, dimB] = b;
         if (paramA != paramB)
           return paramA < paramB;
         bool aHasVec = input[dimA].has_value(),
@@ -540,13 +540,13 @@ propagateVectorizationInfo(TransformMapAttr map, const VectorizationData &input,
         if (!aHasVec && bHasVec)
           return false;
 
-        bool aIsGood = input[dimA]->needsCoefficient == paramA,
-             bIsGood = input[dimB]->needsCoefficient == paramB;
-        if (aIsGood && !bIsGood)
+        bool aNeedsThisCoeff = input[dimA]->needsCoefficient == paramA,
+             bNeedsThisCoeff = input[dimB]->needsCoefficient == paramB;
+        if (aNeedsThisCoeff && !bNeedsThisCoeff)
           return true;
-        if (!aIsGood && bIsGood)
+        if (!aNeedsThisCoeff && bNeedsThisCoeff)
           return false;
-        if (aIsGood && bIsGood) {
+        if (aNeedsThisCoeff && bNeedsThisCoeff) {
           int64_t aLen = input[dimA]->maxLength, bLen = input[dimB]->maxLength;
           if (aLen != bLen)
             return aLen < bLen;

--- a/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
+++ b/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
@@ -175,6 +175,15 @@
   by [<Unmerge{8, 2, 3} ["a", "b", "c"] at [0, 1, 2] -> ["x"] at [0]>]
   bounds = [8, 2, 3] -> [48]>
 
+#transform_map_embed_tiebreak1 = #rock.transform_map<affine_map<(d0, d1) -> (d0, 0, d1)>
+  by [<PassThrough ["x"] at [0] -> ["x"] at [0]>,
+    <Merge{2, 8} ["y"] at [1] -> ["a", "b"] at [1, 2]>]
+  bounds = [4, 16] -> [4, 2, 8]>
+
+#transform_map_embed_tiebreak2 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0 + d1 + d2)>
+  by [<Embed{1, 1, 1} ["x", "a", "b"] at [0, 1, 2] -> ["d"] at [0]>]
+  bounds = [4, 2, 8] -> [13]>
+
 // CHECK-LABEL: func.func @test
 func.func @test_vectorization() {
   // CHECK-NEXT: result = 4
@@ -295,7 +304,10 @@ func.func @test_vectorization() {
   // Even though we injected a 0, it _could_ have been a 1.
   // CHECK-NEXT: result = 1
   %40 = "get_length"() {transforms = [#transform_merge, #transform_inject_non_unit_const, #transform_unmerge_injected_non_unit], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<48xf32>)
- func.return
+
+  // CHECK-NEXT: result = 8
+  %41 = "get_length"() {transforms = [#transform_map_embed_tiebreak1, #transform_map_embed_tiebreak2], in_dim = 1 : index, max_len = 16 : index} : () -> (memref<13xf32>)
+  func.return
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1049

The issue found in that bug related to how the dimensions that were the arguments to Embed{} were sorted for processing. The old logic used the position in the embed arguments as the tiebreaker for arguments with equal coefficients, which caused missed vectorization opportunities as shown in the above bug.

This commit adds improved sorting logic to prevent this sort of thing.