### PR TITLE
Give validation kernel same type signature as test kernel (except -pv_with_gpu).

### DIFF
--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -457,9 +457,8 @@ ConvOpType mlir::rock::convOpTypeFromKernelType(KernelType kernelType) {
   case KernelType::Gemm:
     llvm_unreachable(
         "Gemm ops shouldn't be in convolution-specific lowering passes");
-  default:
-    llvm_unreachable("Unsuppported KernelType");
   }
+  llvm_unreachable("Unsuppported KernelType");
 }
 
 KernelType mlir::rock::kernelTypeFromConvOpType(ConvOpType convOpType) {
@@ -470,9 +469,8 @@ KernelType mlir::rock::kernelTypeFromConvOpType(ConvOpType convOpType) {
     return KernelType::Conv2DBwdData;
   case ConvOpType::BwdWeight:
     return KernelType::Conv2DBwdWeight;
-  default:
-    llvm_unreachable("Unsupported ConvOpType");
   }
+  llvm_unreachable("Unsupported ConvOpType");
 }
 
 GemmSize GemmSize::fromConvolution(ConvOpType type,
@@ -1462,9 +1460,6 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
   else
     inputShape = extraViews[0].cast<TransformMapAttr>().getUpperBounds();
 
-  MemRefType srcType = getSource().getType().cast<MemRefType>();
-  gpu::AddressSpaceAttr srcMemSpaceAttr =
-      srcType.getMemorySpace().dyn_cast_or_null<gpu::AddressSpaceAttr>();
   size_t extraIdxCount = getExtraIndices().size();
   if (inputShape.size() != extraIdxCount + 1) {
     return emitOpError("source view must be extraIndices + 1");
@@ -1489,8 +1484,6 @@ LogicalResult ThreadwiseWriteAllOp::verify() {
   else
     outputShape = extraViews[0].cast<TransformMapAttr>().getUpperBounds();
 
-  MemRefType dstType = getDest().getType().cast<MemRefType>();
-  Attribute dstMemSpaceAttr = dstType.getMemorySpace();
   size_t extraIdxCount = getExtraIndices().size();
   if (outputShape.size() != extraIdxCount + 1) {
     return emitOpError("dest view must be extraIndices + 1");

--- a/mlir/test/rocmlir-driver/populate_prc.mlir
+++ b/mlir/test/rocmlir-driver/populate_prc.mlir
@@ -7,14 +7,17 @@
 // RUN: rocmlir-gen --arch %arch -p -prc -t f16 | FileCheck %s --check-prefixes=F16,CHECK
 // RUN: rocmlir-gen --arch %arch -p -prc -t bf16 | FileCheck %s --check-prefix=BF16
 
-// F16:    %{{.*}} = memref.alloc() : memref<1x128x8x3x3x[[type:f16]]>
+// F16:    func.func @conv2d_cpu(%{{.*}}: memref<1x128x8x3x3x[[type:f16]]>, %{{.*}}: memref<{{.*}}xf16>, %{{.*}}: memref<{{.*}}xf16>)
+// F16:    %{{.*}} = memref.alloc() : memref<1x128x8x3x3xf32>
 // BF16:   %{{.*}}= memref.alloc() : memref<1x128x8x3x3x[[type:bf16]]>
 // CHECK:  call @_memcpy_[[type]]_f32_9216(%{{.*}}, %{{.*}}) : (memref<9216x[[type]]>, memref<9216xf32>) -> ()
-// CHECK:  %{{.*}} = memref.alloc() : memref<128x1x8x32x32x[[type]]>
+// CHECK:  %{{.*}} = memref.alloc() : memref<128x1x8x32x32xf32>
 // CHECK:  call @_memcpy_[[type]]_f32_1048576(%{{.*}}, %{{.*}}) : (memref<1048576x[[type]]>, memref<1048576xf32>) -> ()
 // CHECK:  %{{.*}} = memref.alloc() : memref<{{.*}}>
 // CHECK:  call @_memcpy_[[type]]_f32_{{[0-9]+}}(%{{.*}}, %{{.*}}) : (memref<{{.*}}x[[type]]>, memref<{{.*}}xf32>) -> ()
-// CHECK-NEXT: call @conv2d_cpu(%{{.*}}, %{{.*}}, %[[RES1:.*]]) : (memref<1x128x8x3x3xf32>, memref<{{.*}}>, memref<{{.*}}>) -> ()
+// CHECK: call @conv2d_cpu(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<1x128x8x3x3x[[type]]>, memref<{{.*}}>, memref<{{.*}}>) -> ()
+// CHECK:  %[[RES1:.*]] = memref.alloc() : memref<{{.*}}xf32>
+// CHECK:  call @_memcpy_[[type]]_f32_{{[0-9]+}}(%{{.*}}, %{{.*}}) : (memref<{{.*}}x[[type]]>, memref<{{.*}}xf32>) -> ()
 // CHECK:  %[[RES2:.*]] = memref.cast %[[RES1]] : memref<{{.*}}> to memref<*xf32>
 // CHECK:  call @printMemrefF32(%[[RES2]]) : (memref<*xf32>) -> ()
 

--- a/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
+++ b/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
@@ -11,10 +11,10 @@
 // FP8-BF8-SAME: (%{{.*}}: memref<3x1024x769xf8E4M3FNUZ>, %{{.*}}: memref<3x769x512xf8E5M2FNUZ>, %{{.*}}: memref<3x1024x512xf32>)
 
 // CHECK-LABEL: func @host_naive_gemm
-// F16-SAME: (%{{.*}}: memref<3x1024x769xf32>, %{{.*}}: memref<3x769x512xf32>, %{{.*}}: memref<3x1024x512xf32>)
+// F16-SAME: (%{{.*}}: memref<3x1024x769xf16>, %{{.*}}: memref<3x769x512xf16>, %{{.*}}: memref<3x1024x512xf16>)
 // I8-SAME: (%{{.*}}: memref<3x1024x769xi8>, %{{.*}}: memref<3x769x512xi8>, %{{.*}}: memref<3x1024x512xi64>)
 // I8-I8-SAME: (%{{.*}}: memref<3x1024x769xi8>, %{{.*}}: memref<3x769x512xi8>, %{{.*}}: memref<3x1024x512xi64>)
-// FP8-BF8-SAME: (%{{.*}}: memref<3x1024x769xf32>, %{{.*}}: memref<3x769x512xf32>, %{{.*}}: memref<3x1024x512xf32>)
+// FP8-BF8-SAME: (%{{.*}}: memref<3x1024x769xf8E4M3FNUZ>, %{{.*}}: memref<3x769x512xf8E5M2FNUZ>, %{{.*}}: memref<3x1024x512xf32>)
 
 // FLOAT: arith.mulf
 // FLOAT-NEXT: arith.addf

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1767,10 +1767,8 @@ createCPUConvWithCPP(ModuleOp module, func::FuncOp &func,
   input = ensureFloatIsF32(b, loc, input, floatType);
   output = ensureFloatIsF32(b, loc, output, floatType);
 
-  auto filterType =
-      filter.getType().template dyn_cast<MemRefType>();
-  auto outputType =
-      output.getType().template dyn_cast<MemRefType>();
+  auto filterType = filter.getType().template dyn_cast<MemRefType>();
+  auto outputType = output.getType().template dyn_cast<MemRefType>();
   // Emit memref_cast.
   // %a0 = memref_cast %arg0 : memref<128x8x3x3xf32> to memref<*xf32>
   // %a1 = memref_cast %arg1 : memref<128x8x32x32xf32> to memref<*xf32>
@@ -1972,7 +1970,8 @@ createCPUConvFunc(ModuleOp module,
   OpBuilder b(module.getContext());
   auto loc = b.getUnknownLoc();
 
-  Type elemType = typeFromString(genConfig.inputDataTypeStr, module.getContext());
+  Type elemType =
+      typeFromString(genConfig.inputDataTypeStr, module.getContext());
   Type outputElemType =
       typeFromString(genConfig.outputDataTypeStr, module.getContext());
 
@@ -2289,7 +2288,7 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
 
   // obtain function name of the verifier wrapper
   std::string verifyFuncName = "mcpuVerify";
-  if (valElemType.isF32()) {            // +++pf:  isa<FloatType>
+  if (valElemType.isF32()) {
     verifyFuncName += "Float";
   } else if (valElemType.isInteger(8) || valElemType.isInteger(32) ||
              valElemType.isInteger(64)) {
@@ -2710,8 +2709,6 @@ static LogicalResult populateHostHarnessLogic(
     assert(paramMRType && "currently only supports memref types");
     Type elemType = paramMRType.getElementType();
     if (isCPUKernel) { // -prc
-//       assert(elemType.isF32() || elemType.isInteger(8) ||
-//              elemType.isInteger(32) || elemType.isInteger(64));
       if (genParams.operation.has_value()) {
         if (idx < genParams.types.size())
           elemType = genParams.types[idx];


### PR DESCRIPTION
    * Move the setting of opd1/opd2/result outside the loop-body function to allow for type conversion outside the loop nest.
    * Insert memcpy-f16-f32 ahead of CPU conv loop.
    * Insert deallocs and memcpy-f32-f16 ahead of return.
    * Similar changes for all CPU conv and gemm cases.
    * Exempt gpu validation from the same-signature principle, so it can make an f32 kernel for reference.