### PR TITLE
Added rocmlir-gen support for rock.attention op

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -62,10 +62,12 @@ def KernelTypeConv2D : I32EnumAttrCase<"Conv2D", 0>;
 def KernelTypeConv2DBwdData : I32EnumAttrCase<"Conv2DBwdData", 1>;
 def KernelTypeConv2DBwdWeight : I32EnumAttrCase<"Conv2DBwdWeight", 2>;
 def KernelTypeGemm : I32EnumAttrCase<"Gemm", 3>;
+def KernelTypeAttention : I32EnumAttrCase<"Attention", 4>;
 
 def KernelType : Rock_I32Enum<"KernelType", "Any of the possible types of a rock kernel",
   [KernelTypeConv2D, KernelTypeConv2DBwdData,
-    KernelTypeConv2DBwdWeight, KernelTypeGemm]>;
+    KernelTypeConv2DBwdWeight, KernelTypeGemm,
+    KernelTypeAttention]>;
 
 /// TransformType
 def PassThrough : I32EnumAttrCase<"PassThrough", 0>;

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -1,0 +1,12 @@
+// RUN: rocmlir-gen --arch %arch --operation attention -seq_len 1024 -num_heads 32 -t f32 | FileCheck %s --enable-var-scope --check-prefixes=CHECK
+
+// CHECK:      func.func
+// CHECK-SAME: function_type
+// CHECK-SAME: memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x1024xf32>, memref<1024x32xf32>
+// CHECK-SAME: sym_name = "rock_attention"
+
+// CHECK:       "rock.attention"
+// CHECK-SAME:   memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x1024xf32>, memref<1024x32xf32>
+
+// CHECK: {kernel, mhal.arch = "[[$ARCH:.*]]"}
+// CHECK-NEXT: {mhal.arch = "[[$ARCH]]"}

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -1,12 +1,14 @@
-// RUN: rocmlir-gen --arch %arch --operation attention -seq_len 1024 -num_heads 32 -t f32 | FileCheck %s --enable-var-scope --check-prefixes=CHECK
+// RUN: rocmlir-gen --arch %arch --operation attention -seq_len 1024 -num_heads 32 -t f32 | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK
 
-// CHECK:      func.func
-// CHECK-SAME: function_type
-// CHECK-SAME: memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x1024xf32>, memref<1024x32xf32>
-// CHECK-SAME: sym_name = "rock_attention"
+// CHECK: module attributes {mhal.arch = "[[$ARCH:.*]]"}
 
-// CHECK:       "rock.attention"
-// CHECK-SAME:   memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x32xf32>, memref<1024x1024xf32>, memref<1024x32xf32>
+// CHECK-LABEL: func.func @rock_attention
+// CHECK-SAME: (%[[queries:.*0]]: memref<1024x32xf32>,
+// CHECK-SAME: %[[keys:.*1]]: memref<32x1024xf32>,
+// CHECK-SAME: %[[values:.*2]]: memref<1024x32xf32>,
+// CHECK-SAME: %[[scale:.*3]]: memref<1024x1024xf32>,
+// CHECK-SAME: %[[output:.*4]]: memref<1024x32xf32>)
+// CHECK-SAME: attributes {kernel, mhal.arch = "[[$ARCH]]"}
 
-// CHECK: {kernel, mhal.arch = "[[$ARCH:.*]]"}
-// CHECK-NEXT: {mhal.arch = "[[$ARCH]]"}
+// CHECK-NEXT: rock.attention(%[[queries]], %[[keys]], %[[values]], %[[scale]], %[[output]])
+// CHECK: return

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2911,7 +2911,7 @@ static ModuleOp generateKernel(MLIRContext *context, GenParams &genParams,
   const bool isConv = !(isGemm || isAttention);
   auto convConfig = populateConvConfig.getValue();
 
-  if (!convConfig.empty() && isConv) {
+  if (!convConfig.empty() && !isConv) {
     llvm::errs() << "Cannot use --conv-config with gemm/attention operations\n";
     exit(1);
   }

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -803,61 +803,70 @@ static void verifyConvLayout() {
 }
 
 static void populateDefaults() {
-  bool isGemm = operation == rock::KernelType::Gemm;
+  const bool isGemm = operation == rock::KernelType::Gemm;
+  const bool isAttention = operation == rock::KernelType::Attention;
+  const bool isConv = !(isGemm || isAttention);
   // Default f32 if we passed no `-t` arguments at all.
   if (outputDataType.empty())
     outputDataType = "f32";
   if (populateDefaultValues) {
     if (isGemm) {
+      groupSize = 1;
       gemmM = 1024;
       gemmK = 769;
       gemmN = 512;
-      groupSize = 1;
     }
-    if (mfmaFeature != FeatureToggle::on) {
+    if (isAttention) {
       groupSize = 1;
-      batchSize = 128;
-      inputChannel = 8;
-      outputChannel = 128;
-      inputHeight = 32;
-      inputWidth = 32;
-      filterHeight = 3;
-      filterWidth = 3;
-      dilationHeight = 1;
-      dilationWidth = 1;
-      strideHeight = 1;
-      strideWidth = 1;
-      paddingHeightLeft = 0;
-      paddingHeightRight = 0;
-      paddingWidthLeft = 0;
-      paddingWidthRight = 0;
-    } else {
-      groupSize = 1;
-      batchSize = 128;
-      inputChannel = 1024;
-      outputChannel = 1024;
-      inputHeight = 14;
-      inputWidth = 14;
-      filterHeight = 1;
-      filterWidth = 1;
-      dilationHeight = 1;
-      dilationWidth = 1;
-      strideHeight = 1;
-      strideWidth = 1;
-      paddingHeightLeft = 0;
-      paddingHeightRight = 0;
-      paddingWidthLeft = 0;
-      paddingWidthRight = 0;
+      sequenceLength = 1024;
+      headDims = 32;
+    }
+    if (isConv) {
+      if (mfmaFeature != FeatureToggle::on) {
+        groupSize = 1;
+        batchSize = 128;
+        inputChannel = 8;
+        outputChannel = 128;
+        inputHeight = 32;
+        inputWidth = 32;
+        filterHeight = 3;
+        filterWidth = 3;
+        dilationHeight = 1;
+        dilationWidth = 1;
+        strideHeight = 1;
+        strideWidth = 1;
+        paddingHeightLeft = 0;
+        paddingHeightRight = 0;
+        paddingWidthLeft = 0;
+        paddingWidthRight = 0;
+      } else {
+        groupSize = 1;
+        batchSize = 128;
+        inputChannel = 1024;
+        outputChannel = 1024;
+        inputHeight = 14;
+        inputWidth = 14;
+        filterHeight = 1;
+        filterWidth = 1;
+        dilationHeight = 1;
+        dilationWidth = 1;
+        strideHeight = 1;
+        strideWidth = 1;
+        paddingHeightLeft = 0;
+        paddingHeightRight = 0;
+        paddingWidthLeft = 0;
+        paddingWidthRight = 0;
+      }
     }
   }
 
-  if (!isGemm && outputHeight.getNumOccurrences() == 0) {
+  if (isConv && outputHeight.getNumOccurrences() == 0) {
     outputHeight = rock::Conv2dGenerator::outputDim(
         inputHeight.getValue(), filterHeight.getValue(),
         paddingHeightLeft.getValue(), paddingHeightRight.getValue(),
         strideHeight.getValue(), dilationHeight.getValue());
   }
-  if (!isGemm && outputWidth.getNumOccurrences() == 0) {
+  if (isConv && outputWidth.getNumOccurrences() == 0) {
     outputWidth = rock::Conv2dGenerator::outputDim(
         inputWidth.getValue(), filterWidth.getValue(),
         paddingWidthLeft.getValue(), paddingWidthRight.getValue(),

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1926,10 +1926,11 @@ static func::FuncOp createGpuGemmKernel(ModuleOp module,
 static void getAttentionTypes(SmallVectorImpl<Type> &result,
                               const Type &elemTypes) {
   SmallVector<int64_t> dims{sequenceLength, headDims};
+  SmallVector<int64_t> transposedDims{headDims, sequenceLength};
   SmallVector<int64_t> scaleDims{sequenceLength, sequenceLength};
 
   MemRefType qType = MemRefType::get(dims, elemTypes),
-             kType = MemRefType::get(dims, elemTypes),
+             kType = MemRefType::get(transposedDims, elemTypes),
              vType = MemRefType::get(dims, elemTypes),
              sType = MemRefType::get(scaleDims, elemTypes),
              outType = MemRefType::get(dims, elemTypes);


### PR DESCRIPTION
Closes ROCmSoftwarePlatform/rocMLIR-internal#956

Example:

```bash
> rocmlir-gen -seq_len 1024 -num_heads 32 -t f32 --operation attention --arch gfx908:sramecc+:xnack-  | rocmlir-opt
module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-"} {
  func.func @rock_attention(%arg0: memref<1024x32xf32>, %arg1: memref<32x1024xf32>, %arg2: memref<1024x32xf32>, %arg3: memref<1024x1024xf32>, %arg4: memref<1024x32xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-"} {
    rock.attention(%arg0, %arg1, %arg2, %arg3, %arg4) features =  mfma|dot|atomic_add : memref<1024x32xf32>, memref<32x1024xf32>, memref<1024x32xf32>, memref<1024x1024xf32>, memref<1024x32xf32>
    return
  }
}
```