### PR TITLE
Add error check for unsupported WMMA configuration (e.g., kouter*kpack < 16)

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -627,6 +627,19 @@ PopulateParamsWmma::isValidBlockwiseGemm(const InitParamsAccel &param,
   }
 
   // Reject invalid KPACK values.
+  auto maybeWmmaInsn = WmmaInsn::select(dataTypeA, dataTypeB, waveSize,
+                                        param.gemmMPerWave, param.gemmNPerWave);
+  if (failed(maybeWmmaInsn)) {
+    LLVM_DEBUG(llvm::dbgs() << "Failed to select wmma instruction.\n");
+    return failure();
+  }
+  WmmaInsn wmmaInsn = *maybeWmmaInsn;
+  if (!wmmaInsn.isCoherentWithK(param.gemmKPack, param.gemmKPerBlock)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Wmma instruction selection is not compatible with k.\n");
+    return failure();
+  }
+
   return success();
 }
 

--- a/mlir/test/Dialect/Rock/lowering_affix_params_negative.mlir
+++ b/mlir/test/Dialect/Rock/lowering_affix_params_negative.mlir
@@ -8,3 +8,6 @@
 
 // RUN: rocmlir-gen --arch %arch -p -mfma=on -t f32 --perf_config "128,128,8,64,64,8,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics
 // expected-error{{Incorrect KPACK tuning parameter: 8}}
+
+// RUN: rocmlir-gen --operation gemm --arch gfx1100 -p -wmma=on -t f16 --perf_config 256,128,8,64,128,1,1,1 | rocmlir-opt -rock-affix-params -verify-diagnostics
+// expected-error{{Wmma instruction selection is not compatible with k.}}


### PR DESCRIPTION
This is a check that is present in the `mfma` branch but I probably forgot to add it in the `wmma` branch. 