### PR TITLE
Use mcpuVerifyFloat() for all FP types;  conversion to f32 happens in caller

### DIFF
--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2400,13 +2400,16 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
 
   // obtain function name of the verifier wrapper
   std::string verifyFuncName = "mcpuVerify";
-  if (valElemType.isF32()) {
+  if (valElemType.isa<FloatType>()) {
+    // f16, bf16, fp8, bf8 will be converted to f32 by wrapper.
     verifyFuncName += "Float";
   } else if (valElemType.isInteger(8) || valElemType.isInteger(32) ||
              valElemType.isInteger(64)) {
     verifyFuncName +=
         "Int" + std::to_string(testElemType.getIntOrFloatBitWidth()) + "Int" +
         std::to_string(valElemType.getIntOrFloatBitWidth());
+  } else {
+    llvm_unreachable("There's a valElemType not accounted for");
   }
 
   auto mr1DUnkTestType =


### PR DESCRIPTION
I had changed a test from .isF32() to .isa<FloatType>(), but was persuaded to change it back because I couldn't remember the justification.  Turns out that we're in the middle of making the wrapper function that will convert floats to F32 before calling mcpuVerifyFloat(), and at this point valElemType is still the original type, which could be f16 or bf8, etc.  Thus it needs to be .isa<FloatType>().  (Or could enumerate all the other float types, but there are a lot.)