### PR TITLE
Fixed rock.blockwise_broadcast_reduce wrong views

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -1445,8 +1445,8 @@ struct BlockwiseReduceRewritePattern
                 thenb.create<InBoundsStoreOp>(loc, reduced, workspaceLDSBuffer,
                                               firstLDSLoadCoords);
               }
-              thenb.create<LDSBarrierOp>(loc);
             }
+            rewriter.create<LDSBarrierOp>(loc);
           }
           ArrayAttr reducedldsViewArrayAttr = createLDSWorkspaceView(
               loc, rewriter, inputViewArrayAttr, axis, /*makeRDimZero-*/ true);

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -1170,7 +1170,8 @@ struct BlockwiseReduceRewritePattern
         rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
 
     // Create strides and bounds to iterate the virtual tensor
-    TransformMapAttr lowerTr = inputViewArrayAttr[0].cast<TransformMapAttr>();
+    TransformMapAttr lowerTr = inputViewArrayAttr[inputViewArrayAttr.size() - 1]
+                                   .cast<TransformMapAttr>();
     ArrayRef<int64_t> lowerTrLowerBounds =
         lowerTr.getLowerBounds().asArrayRef();
     SmallVector<int64_t, 4> regTensorShape =
@@ -1181,6 +1182,7 @@ struct BlockwiseReduceRewritePattern
         createLDSWorkspaceView(loc, rewriter, inputViewArrayAttr, axis),
         /*extraIndices=*/ValueRange{tid}, rock::GemmFeatures::none,
         StoreMethod::Set, true, true);
+    rewriter.create<LDSBarrierOp>(loc);
 
     // Following RAII scope will create reduction loops.
     {
@@ -1245,8 +1247,22 @@ struct BlockwiseReduceRewritePattern
             rewriter.setInsertionPointToStart(reductionLoop.getBody());
             Block::BlockArgListType LDSLoadCoords =
                 reductionLoop.getLowerCoords(/*domain=*/0);
+            // There are two vectorization scenarios :
+            // 1) rIterVectorLen > 1 &&  nrIterVectorLen == 1
+            //    Here we will have a load vector and accReg that is a scalar
+            //    The code in createReducingOp will vector reduce it before
+            //    doing a reducing store to accReg
+            // 2) nrIterVectorLen > 1 && rIterVectorLen == 1
+            //    Here we will have a load vector and accReg that is also a
+            //    vector The code in createReducingOp will do vector elementwise
+            //    op and store the resulting vector to accReg.
+            // NOTE: currently, LDS is viewed as [nrDim x rDim] therefore
+            // only scenario 1) is exercised. However, we'd like to keep
+            // this code compatible with both approaches for future changes.
             Value loadVal = rewriter.create<InBoundsLoadOp>(
-                loc, vectorTypeOrSelf(elemType, rIterVectorLen),
+                loc,
+                vectorTypeOrSelf(elemType,
+                                 std::max(rIterVectorLen, nrIterVectorLen)),
                 workspaceLDSBuffer, LDSLoadCoords);
             Value loadAcc = rewriter.create<InBoundsLoadOp>(
                 loc, vectorTypeOrSelf(elemType, nrIterVectorLen), accReg,
@@ -1278,6 +1294,7 @@ struct BlockwiseReduceRewritePattern
         }
         ArrayAttr reducedldsViewArrayAttr = createLDSWorkspaceView(
             loc, rewriter, inputViewArrayAttr, axis, /*makeRDimZero-*/ true);
+        rewriter.create<LDSBarrierOp>(loc);
         rewriter.create<ThreadwiseReadIntoOp>(
             loc, workspaceLDSBuffer, outputReg, reducedldsViewArrayAttr,
             /*extraIndices=*/ValueRange{tid}, true, true);
@@ -1315,9 +1332,9 @@ struct BlockwiseReduceRewritePattern
         if (threadViewShape[rIterDim] > 1) {
           // This is where thread_wise reduction result is stored.
           Type loadTypeInputReg = vectorTypeOrSelf(elemType, rIterVectorLen);
-          Value accReg = rewriter.create<GpuAllocOp>(
-              loc, MemRefType::get({1}, elemType, AffineMap{},
-                                   privateMemoryAddressSpace));
+          Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
+                                            privateMemoryAddressSpace);
+          Value accReg = rewriter.create<GpuAllocOp>(loc, accRegType);
           // This RAII scope would create a loop to iteratively partialy reduce
           // on a thread basis until items to reduce will match the available
           // number of threads.
@@ -1369,7 +1386,7 @@ struct BlockwiseReduceRewritePattern
               Block::BlockArgListType LDSStoreCoords =
                   reductionLoop.getLowerCoords(/*domain=*/0);
               Value loadVal = rewriter.create<InBoundsLoadOp>(
-                  loc, loadTypeInputReg, accReg, zeroConstantOp);
+                  loc, elemType, accReg, zeroConstantOp);
               rewriter.create<InBoundsStoreOp>(loc, loadVal, workspaceLDSBuffer,
                                                LDSStoreCoords);
             }
@@ -1388,7 +1405,6 @@ struct BlockwiseReduceRewritePattern
           int64_t ceilLog2HalfRtidDimSize =
               static_cast<int64_t>(std::ceil(log2HalfRtidDimSize));
           int64_t ceilPowerOf2 = (int64_t)1 << ceilLog2HalfRtidDimSize;
-
           for (int64_t offset = ceilPowerOf2; offset >= 1;
                offset = offset >> 1) {
             Value offsetVal =
@@ -1429,8 +1445,8 @@ struct BlockwiseReduceRewritePattern
                 thenb.create<InBoundsStoreOp>(loc, reduced, workspaceLDSBuffer,
                                               firstLDSLoadCoords);
               }
+              thenb.create<LDSBarrierOp>(loc);
             }
-            rewriter.create<LDSBarrierOp>(loc);
           }
           ArrayAttr reducedldsViewArrayAttr = createLDSWorkspaceView(
               loc, rewriter, inputViewArrayAttr, axis, /*makeRDimZero-*/ true);

--- a/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/blockwise_reduce_vector_nr_and_scalar_r.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/blockwise_reduce_vector_nr_and_scalar_r.mlir
@@ -1,0 +1,34 @@
+
+// RUN: rocmlir-gen -ph -print-results -rand none - < %s | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s
+// CHECK-COUNT-24576: 32
+
+#transform_map1 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, 0, d3 floordiv 32, d3 mod 32, 0, 0, d4 floordiv 4, d4 mod 4)> by [<PassThrough ["g_block", "m_block", "n_block"] at [0, 1, 2] -> ["g_block", "m_block", "n_block"] at [0, 1, 2]>, <Merge{1, 2, 32} ["tid"] at [3] -> ["wave", "m_tid", "n_tid"] at [3, 4, 5]>, <Merge{1, 1, 4, 4} ["item"] at [4] -> ["i", "j", "vec_group", "vec_item"] at [6, 7, 8, 9]>] bounds = [1, 2, 12, 64, 16] -> [1, 2, 12, 1, 2, 32, 1, 1, 4, 4]>
+#transform_map2 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d0, d1, d2, 0, 0, d4, d5, 0, 0, 0, 0, d8, d9)> by [<PassThrough ["g_block", "m_block", "n_block"] at [0, 1, 2] -> ["g_block", "m_block", "n_block"] at [0, 1, 2]>, <Merge{1, 1} ["wave"] at [3] -> ["wave_m", "wave_n"] at [3, 4]>, <PassThrough ["m_tid", "n_tid"] at [4, 5] -> ["m_tid", "n_tid"] at [5, 6]>, <Merge{1, 1} ["i"] at [6] -> ["m_i", "n_i"] at [7, 8]>, <Merge{1, 1} ["j"] at [7] -> ["blk_row", "blk_col"] at [9, 10]>, <PassThrough ["vec_group", "vec_item"] at [8, 9] -> ["vec_group", "vec_item"] at [11, 12]>] bounds = [1, 2, 12, 1, 2, 32, 1, 1, 4, 4] -> [1, 2, 12, 1, 1, 2, 32, 1, 1, 1, 1, 4, 4]>
+#transform_map3 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12) -> (d0, (((d1 + d7 + d3 + d9) * 4 + d11) * 2 + d5) * 4 + d12, (d2 + d8 + d4 + d10) * 32 + d6)> by [<PassThrough ["g_block"] at [0] -> ["gemmG"] at [0]>, <Unmerge{1, 1, 1, 1, 4, 2, 4} ["m_block", "m_i", "wave_m", "blk_row", "vec_group", "m_tid", "vec_item"] at [1, 7, 3, 9, 11, 5, 12] -> ["gemmM"] at [1]>, <Unmerge{1, 1, 1, 1, 32} ["n_block", "n_i", "wave_n", "blk_col", "n_tid"] at [2, 8, 4, 10, 6] -> ["gemmN"] at [2]>] bounds = [1, 2, 12, 1, 1, 2, 32, 1, 1, 1, 1, 4, 4] -> [1, 32, 32]>
+
+#map12 = affine_map<(d0, d1) -> (0, d0 floordiv 32, d0 mod 32, 0, 0, d1 floordiv 4, d1 mod 4)>
+#map13 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (0, 0, d1, d2, 0, 0, 0, 0, d5, d6)>
+#map14 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> ((((d4 + d0 + d6) * 4 + d8) * 2 + d2) * 4 + d9, (d5 + d1 + d7) * 32 + d3)>
+#transform_map21 = #rock.transform_map<#map12 by [<Merge{1, 2, 32} ["tid"] at [0] -> ["wave", "m_tid", "n_tid"] at [0, 1, 2]>, <Merge{1, 1, 4, 4} ["item"] at [1] -> ["i", "j", "vec_group", "vec_item"] at [3, 4, 5, 6]>] bounds = [64, 16] -> [1, 2, 32, 1, 1, 4, 4]>
+#transform_map22 = #rock.transform_map<#map13 by [<Merge{1, 1} ["wave"] at [0] -> ["wave_m", "wave_n"] at [0, 1]>, <PassThrough ["m_tid", "n_tid"] at [1, 2] -> ["m_tid", "n_tid"] at [2, 3]>, <Merge{1, 1} ["i"] at [3] -> ["m_i", "n_i"] at [4, 5]>, <Merge{1, 1} ["j"] at [4] -> ["blk_row", "blk_col"] at [6, 7]>, <PassThrough ["vec_group", "vec_item"] at [5, 6] -> ["vec_group", "vec_item"] at [8, 9]>] bounds = [1, 2, 32, 1, 1, 4, 4] -> [1, 1, 2, 32, 1, 1, 1, 1, 4, 4]>
+#transform_map23 = #rock.transform_map<#map14 by [<Unmerge{1, 1, 1, 4, 2, 4} ["m_i", "wave_m", "blk_row", "vec_group", "m_tid", "vec_item"] at [4, 0, 6, 8, 2, 9] -> ["gemmM"] at [0]>, <Unmerge{1, 1, 1, 32} ["n_i", "wave_n", "blk_col", "n_tid"] at [5, 1, 7, 3] -> ["gemmN"] at [1]>] bounds = [1, 1, 2, 32, 1, 1, 1, 1, 4, 4] -> [32, 32]>
+func.func @rock_blockwise_vector_nr_and_scalar_r(%input : memref<1x64x384xf32>,  %output : memref<1x64x384xf32>) attributes{arch = "", block_size = 64 : i32, grid_size = 24 : i32, kernel} {
+  %input_reg = rock.alloc() : memref<16xf32, #gpu.address_space<private>>
+  %output_reg = rock.alloc() : memref<16xf32, #gpu.address_space<private>>
+  %ws_lds = rock.alloc() : memref<1024xf32, #gpu.address_space<workgroup>>
+
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %bid = rock.workgroup_id : index
+  %m_block_id = arith.remui %bid, %c2 : index
+  %n_block_id = arith.divui %bid, %c2 : index
+
+  %tid = rock.workitem_id : index
+  rock.threadwise_read_into {forceUnroll, useIndexDiffs}
+    [#transform_map1, #transform_map2, #transform_map3](%input)[%c0, %m_block_id, %n_block_id, %tid] -> %input_reg : memref<1x64x384xf32> ->  memref<16xf32, #gpu.address_space<private>>
+
+  rock.blockwise_broadcast_reduce  sum [#transform_map21, #transform_map22, #transform_map23] %input_reg into %output_reg using %ws_lds {axis = 0 : index, blockSize = 64 : i32} : memref<16xf32, #gpu.address_space<private>> using memref<1024xf32, #gpu.address_space<workgroup>> into memref<16xf32, #gpu.address_space<private>>
+
+  rock.threadwise_write_all features = none {forceUnroll, useIndexDiffs} %output_reg -> [#transform_map1, #transform_map2, #transform_map3](%output)[%c0, %m_block_id, %n_block_id, %tid] by set : memref<16xf32, #gpu.address_space<private>> -> memref<1x64x384xf32>
+  return
+}

--- a/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
@@ -62,8 +62,8 @@ func.func @rock_blockwise_reducesum_nr_threads_gt_blocksize(%input_reg : memref<
 // CHECK: %[[ACC_NEW:.*]] = arith.addf %[[TO_REDUCE_ACC]], %[[SUM_REDUCE]]
 // CHECK: rock.in_bounds_store %[[ACC_NEW]] -> {{.*}}[%c0] {{.*}} #gpu.address_space<private>>
 // CHECK: rock.transforming_for {{.*}}[#[[TMAP3]], #[[TMAP4]], #[[TMAP5]], #[[TMAP1]], #[[TMAP2]]](%[[PRT_GROUP_IDX]], %[[PRT_THREAD_IDX]], %c0) {{.*}} bounds [1, 1, 1] strides [1, 1, 1] {
-// CHECK: rock.in_bounds_load {{.*}} : memref<1xf32, #gpu.address_space<private>>, index -> vector<4xf32>
-// CHECK: rock.in_bounds_store {{.*}} : vector<4xf32> -> memref<80xf32, #gpu.address_space<workgroup>>, index
+// CHECK: rock.in_bounds_load {{.*}} : memref<1xf32, #gpu.address_space<private>>, index -> f32
+// CHECK: rock.in_bounds_store {{.*}} : f32 -> memref<80xf32, #gpu.address_space<workgroup>>, index
 // CHECK: rock.lds_barrier
 
 // Partial threadwise reductions done now...


### PR DESCRIPTION
The lower views of the virtual distributed
tensor was incorrect. Therefore it was reducing in wrong axis.

This commit fixes that and adds a bit more barriers to be safe between LDS stores and reads.

closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1082
(though I added the code to handle it, it turned out due to not taking lower views correctly)