### PR TITLE
Make the "exhaustive" tuning space maximally exhaustive.

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -84,9 +84,9 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
                   InitParamsAccel gemmParams(
                       gemmMPerBlock, gemmNPerBlock, gemmKPerBlock, gemmMPerWave,
                       gemmNPerWave, gemmKPack, forceUnroll, true);
-                  if (succeeded(
-                          tuningInfo.paramsProbablyValid(info, gemmParams)) &&
-                      (kind == TuningParamSetKind::Exhaustive ||
+                  if (kind == TuningParamSetKind::Exhaustive ||
+                      (succeeded(
+                           tuningInfo.paramsProbablyValid(info, gemmParams)) &&
                        succeeded(
                            tuningInfo.couldBePerformant(info, gemmParams))))
                     newSpace->tuningRange.push_back(


### PR DESCRIPTION
This commits adds known-inapplicable configs back to the exhaustive tuning space in the interests of potentially finding a performance regression.