### PR TITLE
Add test for SetDefaultDeviceOp rewrite

### DIFF
--- a/external/llvm-project/mlir/test/Conversion/GPUCommon/set-default-device.mlir
+++ b/external/llvm-project/mlir/test/Conversion/GPUCommon/set-default-device.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-opt %s --gpu-to-llvm | FileCheck %s
+
+module attributes {gpu.container_module} {
+  // CHECK-LABEL: func @set_default_device
+  func.func @set_default_device(%arg0: i32) {
+    // CHECK: mgpuSetDefaultDevice
+    gpu.set_default_device %arg0
+    return
+  }
+}


### PR DESCRIPTION
The upstream reviewer asked for a test.  I verified that the test fails without the already-merged patch.