### PR TITLE
[DO NOT SQUASH] Fix MIGraphX quantization / dequantization 

### DIFF
--- a/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -479,12 +479,14 @@ createLinalgBodyCalculationForElementwiseOp(Operation *op, ValueRange args,
 
     if (arith::FPToSIOp::areCastCompatible(srcTy, dstTy)) {
       auto intMin = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getF32FloatAttr(
+          loc, rewriter.getFloatAttr(
+                   getElementTypeOrSelf(srcTy),
                    APInt::getSignedMinValue(dstTy.getIntOrFloatBitWidth())
                        .getSExtValue()));
 
       auto intMax = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getF32FloatAttr(
+          loc, rewriter.getFloatAttr(
+                   getElementTypeOrSelf(srcTy),
                    APInt::getSignedMaxValue(dstTy.getIntOrFloatBitWidth())
                        .getSExtValue()));
 

--- a/external/llvm-project/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
+++ b/external/llvm-project/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
@@ -286,6 +286,14 @@ func.func @test_simple_f16(%arg0: tensor<1xf16>) -> () {
   // CHECK: arith.extf
   %0 = "tosa.cast"(%arg0) : (tensor<1xf16>) -> tensor<1xf32>
 
+  // CHECK: linalg.generic
+  // CHECK: arith.constant -1.280000e+02
+  // CHECK: arith.constant 1.270000e+02
+  // CHECK: math.roundeven
+  // CHECK: arith.minf
+  // CHECK: arith.maxf
+  // CHECK: arith.fptosi
+  %1 = "tosa.cast"(%arg0) : (tensor<1xf16>) -> tensor<1xi8>
   return
 }
 

--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -285,30 +285,29 @@ def MIGraphX_TanhOp :
 // Quantization operations.
 
 def MIGraphX_QuantizeLinearOp :
-    MIGraphX_Op<"quantizelinear">,
-    Arguments<(ins TensorOf<[F32, F16]>:$input,
-                   TensorOf<[F32]>:$scale,
+    MIGraphX_Op<"quantizelinear", [AllElementTypesMatch<["input", "scale"]>]>,
+    Arguments<(ins TensorOf<[AnyFloat]>:$input,
+                   TensorOf<[AnyFloat]>:$scale,
                    Optional<TensorOf<[AnyInteger]>>:$bias)>,
 	  Results<(outs TensorOf<[AnyInteger]>:$output)> {
   let summary = "Channelwise quantization";
   let description = [{
     Quantization tensor channelwise. It computes the following:
-    tensor[n,c,h,w] = tensor[n,c,h,w] / quantScale[c] + quantBias[c]
+    tensor[n,c,h,w] = clamping_truncate(round(tensor[n,c,h,w] / quantScale[c]) + quantBias[c])
   }];
   let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
-  let hasVerifier = 1;
 }
 
 def MIGraphX_DeQuantizeLinearOp :
-    MIGraphX_Op<"dequantizelinear">,
+    MIGraphX_Op<"dequantizelinear", [AllElementTypesMatch<["scale", "output"]>]>,
     Arguments<(ins TensorOf<[AnyInteger]>:$input,
-                   TensorOf<[F32]>:$scale,
+                   TensorOf<[AnyFloat]>:$scale,
                    Optional<TensorOf<[AnyInteger]>>:$bias)>,
-	  Results<(outs TensorOf<[F32, F16]>:$output)> {
+	  Results<(outs TensorOf<[AnyFloat]>:$output)> {
   let summary = "Channelwise dequantization";
   let description = [{
     De-Quantization tensor channelwise. It computes the following:
-    tensor[n,c,h,w] = (tensor[n,c,h,w] - quantBias[c]) * quantScale[c]
+    tensor[n,c,h,w] = to_float(tensor[n,c,h,w] - quantBias[c]) * quantScale[c]
   }];
   let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
   let hasVerifier = 1;

--- a/mlir/lib/Dialect/MIGraphX/MIGraphXOps.cpp
+++ b/mlir/lib/Dialect/MIGraphX/MIGraphXOps.cpp
@@ -7,7 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MIGraphX/MIGraphXOps.h"
 #include "mlir/Dialect/CommonFolders.h"
 #include "mlir/IR/AffineMap.h"
@@ -16,6 +15,7 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/MathExtras.h"
 
@@ -50,15 +50,6 @@ OpFoldResult RecipOp::fold(FoldAdaptor operands) {
     return parentRecip.getInA();
   }
   return {};
-}
-
-LogicalResult QuantizeLinearOp::verify() {
-  if (auto bias = getBias()) {
-    auto output = getOutput();
-    if (getShapedElementTy(bias) != getShapedElementTy(output))
-      return emitOpError() << "element type for bias and output doesn't match";
-  }
-  return success();
 }
 
 LogicalResult DeQuantizeLinearOp::verify() {

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -3,14 +3,25 @@
 module  {
   // CHECK-LABEL: func @dequantize_scale
   // CHECK-NOT: tosa.sub
+  // CHECK: tosa.cast
   // CHECK: tosa.mul
   func.func @dequantize_scale(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf32>) -> tensor<1x112x112x64xf32> attributes {kernel = "mixr"} {
     %1 = "migraphx.dequantizelinear"(%arg, %scale) : (tensor<1x112x112x64xi32>, tensor<64xf32>) -> tensor<1x112x112x64xf32>
     return %1 : tensor<1x112x112x64xf32>
   }
 
+  // CHECK-LABEL: func @dequantize_scale_f16
+  // CHECK-NOT: tosa.sub
+  // CHECK: tosa.cast{{.*}}f16
+  // CHECK: tosa.mul
+  func.func @dequantize_scale_f16(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf16>) -> tensor<1x112x112x64xf16> attributes {kernel = "mixr"} {
+    %1 = "migraphx.dequantizelinear"(%arg, %scale) : (tensor<1x112x112x64xi32>, tensor<64xf16>) -> tensor<1x112x112x64xf16>
+    return %1 : tensor<1x112x112x64xf16>
+  }
+
   // CHECK-LABEL: func @dequantize_scale_bias
   // CHECK: tosa.sub
+  // CHECK: tosa.cast{{.*}}f32
   // CHECK: tosa.mul
   func.func @dequantize_scale_bias(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf32>, %bias: tensor<64xi32>) -> tensor<1x112x112x64xf32> attributes {kernel = "mixr"} {
     %1 = "migraphx.dequantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xi32>, tensor<64xf32>, tensor<64xi32>) -> tensor<1x112x112x64xf32>
@@ -20,6 +31,7 @@ module  {
   // CHECK-LABEL: func @quantize_scale
   // CHECK: tosa.reciprocal
   // CHECK: tosa.mul
+  // CHECK: tosa.cast{{.*}}i8
   // CHECK-NOT: tosa.add
   func.func @quantize_scale(%arg: tensor<1x112x112x64xf32>, %scale: tensor<64xf32>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
     %1 = "migraphx.quantizelinear"(%arg, %scale) : (tensor<1x112x112x64xf32>, tensor<64xf32>) -> tensor<1x112x112x64xi8>
@@ -29,19 +41,55 @@ module  {
   // CHECK-LABEL: func @quantize_scale_bias
   // CHECK: tosa.reciprocal
   // CHECK: tosa.mul
+  // CHECK: tosa.cast{{.*}}i8{{.*}}i32
+  // CHECK: tosa.cast{{.*}}f32{{.*}}i32
   // CHECK: tosa.add
+  // CHECK: tosa.clamp
+  // CHECK-SAME: max_int = 127
+  // CHECK-SAME: min_int = -128
+  // CHECK: tosa.cast{{.*}}i8
   func.func @quantize_scale_bias(%arg: tensor<1x112x112x64xf32>, %scale: tensor<64xf32>, %bias: tensor<64xi8>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
     %1 = "migraphx.quantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xf32>, tensor<64xf32>, tensor<64xi8>) -> tensor<1x112x112x64xi8>
+    return %1 : tensor<1x112x112x64xi8>
+  }
+
+  // CHECK-LABEL: func @quantize_scale_bias_f16
+  // CHECK: tosa.reciprocal
+  // CHECK: tosa.mul
+  // CHECK: tosa.cast{{.*}}i8{{.*}}i32
+  // CHECK: tosa.cast{{.*}}f16{{.*}}i32
+  // CHECK: tosa.add
+  // CHECK: tosa.clamp
+  // CHECK: tosa.cast
+  func.func @quantize_scale_bias_f16(%arg: tensor<1x112x112x64xf16>, %scale: tensor<64xf16>, %bias: tensor<64xi8>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
+    %1 = "migraphx.quantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xf16>, tensor<64xf16>, tensor<64xi8>) -> tensor<1x112x112x64xi8>
+    return %1 : tensor<1x112x112x64xi8>
+  }
+
+  // CHECK-LABEL: func @quantize_scale_i32_bias_f16
+  // CHECK: tosa.reciprocal
+  // CHECK: tosa.mul
+  // CHECK: tosa.cast{{.*}}i32
+  // CHECK: tosa.add
+  // CHECK: tosa.clamp
+  // CHECK: tosa.cast
+  func.func @quantize_scale_i32_bias_f16(%arg: tensor<1x112x112x64xf16>, %scale: tensor<64xf16>, %bias: tensor<64xi32>) -> tensor<1x112x112x64xi8> attributes {kernel = "mixr"} {
+    %1 = "migraphx.quantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xf16>, tensor<64xf16>, tensor<64xi32>) -> tensor<1x112x112x64xi8>
     return %1 : tensor<1x112x112x64xi8>
   }
 
   // CHECK-LABEL: func @conv_with_quant
   // CHECK: tosa.conv2d{{.*}} quantization_info
   // CHECK: tosa.sub
+  // CHECK: tosa.cast
   // CHECK: tosa.mul
   // CHECK: tosa.reciprocal
   // CHECK: tosa.mul
+  // CHECK: tosa.cast
+  // CHECK: tosa.cast
   // CHECK: tosa.add
+  // CHECK: tosa.clamp
+  // CHECK: tosa.cast
   func.func @conv_with_quant(%arg1: tensor<1x3x224x224xi8>, %arg2: tensor<64x3x7x7xi8>, %scale: tensor<1x64x1x1xf32>, %bias: tensor<1x64x1x1xi32>, %bias2: tensor<1x64x1x1xi8>) -> tensor<1x64x112x112xi8> attributes {kernel = "mixr"} {
     %1 = migraphx.quant_convolution(%arg1, %arg2) {dilation = [1, 1], group = 1 : i64, padding = [3, 3, 3, 3], padding_mode = 0 : i64, stride = [2, 2]} : (tensor<1x3x224x224xi8>, tensor<64x3x7x7xi8>) -> tensor<1x64x112x112xi32>
     %2 = "migraphx.dequantizelinear"(%1, %scale, %bias) : (tensor<1x64x112x112xi32>, tensor<1x64x1x1xf32>, tensor<1x64x1x1xi32>) -> tensor<1x64x112x112xf32>


### PR DESCRIPTION
1. Remove the fp32 constraint on scales
2. Remove the constraint that the bias and output have the same type,
as this is not necessarily the case (for example, from what I can
tell, some frameworks allow i32 bias in a quantization to i8).
2b. When the bias type is not the output type in a quantization,
manually do a clamping truncation.
Note that manual clamps aren't needed in the usual case because
tosa.cast performs a clamping float-to-int.
3. Remove handling for input/output type != scale type, since that
can't happen in MIGraphX IR
4. Add constraints to encode the MIGraphX IR's assumptions about
quantize ops.