### PR TITLE
Reduce number of large gemm tests in nightly

### DIFF
--- a/mlir/test/e2e/GemmVariants.toml
+++ b/mlir/test/e2e/GemmVariants.toml
@@ -41,4 +41,8 @@ config = "-g 1 -m 32768 -k 1 -n 32769"
 
 # Large gemm, no padding.
 [[suite.test]]
-config = "-g 1 -m 64 -k 32768 -n 32768"
+config = "-g 1 -m 64 -k 65536 -n 65536"
+# Only test i8 here, f32 is covered by PR tests
+[[suite.test.exclude]]
+name = "data type"
+values = ["f32", "f16", "fp8_fp8", "fp8_bf8", "bf8_fp8", "bf8_bf8"]


### PR DESCRIPTION
We're getting OOM errors on nightly CI a bunch, probably caused by launching too many large-gemm tests in parallel. This commit removes most of said tests in the hope that the CI will start working reliably again.