### PR TITLE
Reduce LDS bank conflicts

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1046,7 +1046,9 @@ defvar LdsBufferTypes = GemmInputTypes # [VectorOfRankAndType<[1], GemmInputType
 def Rock_BlockwiseGemmOp:
     Rock_Op<"blockwise_gemm">,
     Arguments<(ins MemRefRankOf<GemmInputTypes, [3]>:$matrixA,
+                   BoolAttr : $isKContiguousDimA,
                    MemRefRankOf<GemmInputTypes, [3]>:$matrixB,
+                   BoolAttr : $isKContiguousDimB,
                    MemRefRankOf<GemmOutputTypes, [2]>:$matrixC,
                    Rock_GeneralGemmParamsAttr:$params
                    )> {
@@ -1084,7 +1086,9 @@ defvar AccelResTypes = [VectorOfLengthAndType<[4, 8, 16, 32], [F32, I32, F16, BF
 def Rock_BlockwiseGemmAccelOp:
     Rock_Op<"blockwise_gemm_accel">,
     Arguments<(ins MemRefOf<LdsBufferTypes>:$matrixA,
+                   BoolAttr:$isKContiguousDimA,
                    MemRefOf<LdsBufferTypes>:$matrixB,
+                   BoolAttr:$isKContiguousDimB,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
                    MemRefOf<AccelArgTypes>:$bufferA,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1067,6 +1067,11 @@ def Rock_BlockwiseGemmOp:
     Each {m,n}PerThread group of elements (which may themselves be kPacks)
     is read from LDS by a given thread, then the next mPerThread group is
     mRepeatStride elements later in the buffer.
+
+    `rotate{M,N}PerThread` is used to rotate the access to LDS to avoid bank-conflicts in cases
+    where subsequent threads try to write data in the same column of the output matrix. If `kpack>1`
+    the rotation is simply the row index. If `kpack==1` the rotation takes into account the number of
+    elements reads by a thread along the `M` and/or `N` dimension, namely `in{M,N}PerThread`
   }];
   let assemblyFormat = [{
     $matrixC `+` `` `=` $matrixA `*` $matrixB attr-dict

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1046,12 +1046,12 @@ defvar LdsBufferTypes = GemmInputTypes # [VectorOfRankAndType<[1], GemmInputType
 def Rock_BlockwiseGemmOp:
     Rock_Op<"blockwise_gemm">,
     Arguments<(ins MemRefRankOf<GemmInputTypes, [3]>:$matrixA,
-                   BoolAttr : $isKContiguousDimA,
                    MemRefRankOf<GemmInputTypes, [3]>:$matrixB,
-                   BoolAttr : $isKContiguousDimB,
                    MemRefRankOf<GemmOutputTypes, [2]>:$matrixC,
-                   I32Attr:$copyMPerThread,
-                   I32Attr:$copyNPerThread,
+                   I32Attr:$inMPerThread,
+                   I32Attr:$inNPerThread,
+                   UnitAttr:$rotateMWithK,
+                   UnitAttr:$rotateNWithK,
                    Rock_GeneralGemmParamsAttr:$params
                    )> {
   let summary = "Blockwise GEMM non accelerated version";
@@ -1088,11 +1088,11 @@ defvar AccelResTypes = [VectorOfLengthAndType<[4, 8, 16, 32], [F32, I32, F16, BF
 def Rock_BlockwiseGemmAccelOp:
     Rock_Op<"blockwise_gemm_accel">,
     Arguments<(ins MemRefOf<LdsBufferTypes>:$matrixA,
-                   BoolAttr:$isKContiguousDimA,
                    MemRefOf<LdsBufferTypes>:$matrixB,
-                   BoolAttr:$isKContiguousDimB,
-                   I32Attr:$copyMPerThread,
-                   I32Attr:$copyNPerThread,
+                   I32Attr:$inMPerThread,
+                   I32Attr:$inNPerThread,
+                   UnitAttr:$rotateMWithK,
+                   UnitAttr:$rotateNWithK,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
                    MemRefOf<AccelArgTypes>:$bufferA,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1050,6 +1050,8 @@ def Rock_BlockwiseGemmOp:
                    MemRefRankOf<GemmInputTypes, [3]>:$matrixB,
                    BoolAttr : $isKContiguousDimB,
                    MemRefRankOf<GemmOutputTypes, [2]>:$matrixC,
+                   I32Attr:$copyMPerThread,
+                   I32Attr:$copyNPerThread,
                    Rock_GeneralGemmParamsAttr:$params
                    )> {
   let summary = "Blockwise GEMM non accelerated version";
@@ -1089,6 +1091,8 @@ def Rock_BlockwiseGemmAccelOp:
                    BoolAttr:$isKContiguousDimA,
                    MemRefOf<LdsBufferTypes>:$matrixB,
                    BoolAttr:$isKContiguousDimB,
+                   I32Attr:$copyMPerThread,
+                   I32Attr:$copyNPerThread,
                    Index:$waveOffsetA,
                    Index:$waveOffsetB,
                    MemRefOf<AccelArgTypes>:$bufferA,

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -10,6 +10,7 @@
 #define ROCK_UTILITY_LOWERINGUTILS_H
 
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
+#include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -107,6 +108,22 @@ backwardDataKernelIds(int64_t strideHeight, int64_t strideWidth,
 /// Return a vector type of length `len` if `len` is more than 1, otherwise,
 /// return `type`.
 Type vectorTypeOrSelf(Type elementType, int64_t len);
+
+/// Compute a thread copy layout, i.e., how many elements a single thread (or
+/// workitem) reads along K and M (independently on how we vectorize the reads)
+FailureOr<std::pair<int64_t, int64_t>>
+computeCopyPerThread(Type elementType, int64_t copyPerThread, int64_t kPerBlock,
+                     int64_t dPerBlock, int64_t kpack, Location loc);
+
+// if K is not the contiguous dimension, we swapped (on each axis) the thread id
+// and the iter id dimensions, so that the threads write in a contiguous fashion
+// minimizing LDS bank conflicts.  This transformation swap those dimensions
+// back before producing the final output view
+TopDownTMBuilder swapThreadIdAndIteration(
+    TopDownTMBuilder &toMatrixC, ArrayRef<int64_t> bidGridLengths,
+    int64_t copyMPerThread, int64_t copyNPerThread, int64_t mPerBlock,
+    int64_t nPerBlock, bool isKContiguousDimA, bool isKContiguousDimB,
+    SmallVector<Attribute> &transformAttrs);
 
 } // end namespace rock
 } // end namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -60,7 +60,8 @@ FailureOr<RegsAsMatrixSubTiles> getPackedRegsAsTileViews(
     OpBuilder &b, Location loc, Value globalBuffer, StringRef dName,
     ArrayRef<StringRef> bidGridOrder, ArrayRef<int64_t> bidGridLengths,
     int64_t blockSize, int64_t kPerBlock, int64_t dPerBlock, int64_t kPerThread,
-    int64_t dPerThread, int64_t kpack, bool isKContigousDim);
+    int64_t dPerThread, int64_t kpack, bool isKContigousDim,
+    bool doSwapThreadIterSubDimsForD);
 
 bool isWrWAtomicKernel(GemmFeatures features, Type dataType,
                        bool requiredPadding);

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -113,12 +113,13 @@ Type vectorTypeOrSelf(Type elementType, int64_t len);
 // and the iter id dimensions, so that the threads write in a contiguous fashion
 // minimizing LDS bank conflicts.  This transformation swap those dimensions
 // back before producing the final output view
-TopDownTMBuilder swapThreadIdAndIteration(
-    TopDownTMBuilder &toMatrixC, ArrayRef<int64_t> bidGridLengths,
-    int64_t copyMPerThread, int64_t copyNPerThread, int64_t mPerBlock,
-    int64_t nPerBlock, bool doSwapThreadIterSubDimsForM,
-    bool doSwapThreadIterSubDimsForN, bool isBlockwise,
-    SmallVector<Attribute> &transformAttrs);
+TopDownTMBuilder
+swapThreadIdAndIteration(TopDownTMBuilder &toMatrixC, int64_t mBlocks,
+                         int64_t nBlocks, int64_t copyMPerThread,
+                         int64_t copyNPerThread, int64_t mPerBlock,
+                         int64_t nPerBlock, bool doSwapThreadIterSubDimsForM,
+                         bool doSwapThreadIterSubDimsForN, bool isBlockwise,
+                         SmallVector<Attribute> &transformAttrs);
 
 } // end namespace rock
 } // end namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -109,12 +109,6 @@ backwardDataKernelIds(int64_t strideHeight, int64_t strideWidth,
 /// return `type`.
 Type vectorTypeOrSelf(Type elementType, int64_t len);
 
-/// Compute a thread copy layout, i.e., how many elements a single thread (or
-/// workitem) reads along K and M (independently on how we vectorize the reads)
-FailureOr<std::pair<int64_t, int64_t>>
-computeCopyPerThread(Type elementType, int64_t copyPerThread, int64_t kPerBlock,
-                     int64_t dPerBlock, int64_t kpack, Location loc);
-
 // if K is not the contiguous dimension, we swapped (on each axis) the thread id
 // and the iter id dimensions, so that the threads write in a contiguous fashion
 // minimizing LDS bank conflicts.  This transformation swap those dimensions
@@ -122,7 +116,8 @@ computeCopyPerThread(Type elementType, int64_t copyPerThread, int64_t kPerBlock,
 TopDownTMBuilder swapThreadIdAndIteration(
     TopDownTMBuilder &toMatrixC, ArrayRef<int64_t> bidGridLengths,
     int64_t copyMPerThread, int64_t copyNPerThread, int64_t mPerBlock,
-    int64_t nPerBlock, bool isKContiguousDimA, bool isKContiguousDimB,
+    int64_t nPerBlock, bool doSwapThreadIterSubDimsForM,
+    bool doSwapThreadIterSubDimsForN, bool isBlockwise,
     SmallVector<Attribute> &transformAttrs);
 
 } // end namespace rock

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -9,6 +9,7 @@
 #define ROCK_UTILITY_TRANSFORMMAPUTILS_H
 
 #include "mlir/Dialect/Rock/IR/Rock.h"
+#include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 
 namespace mlir {
@@ -135,6 +136,16 @@ TransformMapAttr transformExtractSlice(OpBuilder &b, Location loc,
                                        ArrayRef<int64_t> outShape,
                                        ArrayRef<int64_t> offsets,
                                        ArrayRef<int64_t> sizes);
+
+// If the condition is satified, rotate the dimension `d` by `k` using
+// `d = (d+k*stride) % len(d)`
+rock::TopDownTMBuilder rotateIf(bool condition, TopDownTMBuilder &builder,
+                                TransformMapAttr &attr, int64_t stride,
+                                StringRef dName, int64_t d, int64_t dPos,
+                                StringRef kName, int64_t k,
+                                ArrayRef<StringRef> beforeDims,
+                                ArrayRef<StringRef> afterDims,
+                                SmallVector<Attribute, 4> &transformAttrs);
 
 // This utility function will take an ordered decreasing dimension strides and
 // total number of elements to produce an array of dimension sizes. This

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -139,13 +139,11 @@ TransformMapAttr transformExtractSlice(OpBuilder &b, Location loc,
 
 // If the condition is satified, rotate the dimension `d` by `k` using
 // `d = (d+k*stride) % len(d)`
-rock::TopDownTMBuilder rotateIf(bool condition, TopDownTMBuilder &builder,
-                                TransformMapAttr &attr, int64_t stride,
-                                StringRef dName, int64_t d, int64_t dPos,
-                                StringRef kName, int64_t k,
-                                ArrayRef<StringRef> beforeDims,
-                                ArrayRef<StringRef> afterDims,
-                                SmallVector<Attribute, 4> &transformAttrs);
+rock::TopDownTMBuilder
+rotateIf(bool condition, TopDownTMBuilder &builder, TransformMapAttr &attr,
+         int64_t stride, StringRef dName, int64_t d, int64_t dPos,
+         StringRef kName, int64_t k, ArrayRef<StringRef> beforeDims,
+         ArrayRef<StringRef> afterDims, SmallVector<Attribute> &transformAttrs);
 
 // This utility function will take an ordered decreasing dimension strides and
 // total number of elements to produce an array of dimension sizes. This

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -357,7 +357,6 @@ RegsAsMatrixSubTiles MfmaEmitter::computeOutputTransforms(
                       ArrayRef<int64_t>{dimSizesM}.slice(1));
     toMatrixC.unmerge("gemmN", 1, ArrayRef<StringRef>{dimNamesN}.slice(1),
                       ArrayRef<int64_t>{dimSizesN}.slice(1));
-    TransformMapAttr toMatrixCAttr = toMatrixC.get();
 
     // Before returning the output view, if necessary, swap back the
     // threadid/iter dimensions on both the M/N axis.

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -25,6 +25,7 @@
 #include "AccelEmitter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
+#include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 
 using namespace mlir;
@@ -193,7 +194,9 @@ makeViewsForRowsAndCols(TopDownTMBuilder &viewBuilder, int64_t mPerRepeat,
 
 RegsAsMatrixSubTiles MfmaEmitter::computeOutputTransforms(
     PatternRewriter &b, Location loc, int64_t mLen, int64_t nLen,
-    int64_t blockSize, ArrayRef<int64_t> bidGridLengths) {
+    bool isKContiguousDimA, bool isKContiguousDimB, int64_t computeMPerThread,
+    int64_t computeNPerThread, int64_t blockSize,
+    ArrayRef<int64_t> bidGridLengths) {
 
   // Extract relevant tuning parameters
   int64_t mPerBlock = tuningParams.getMPerBlock();
@@ -305,9 +308,17 @@ RegsAsMatrixSubTiles MfmaEmitter::computeOutputTransforms(
     toMatrixC.passThrough({"gemmG"}, {0}, {"g_block"});
     toMatrixC.unmerge("gemmM", 1, dimNamesM, dimSizesM);
     toMatrixC.unmerge("gemmN", 2, dimNamesN, dimSizesN);
-    TransformMapAttr toMatrixCAttr = toMatrixC.get();
-    ret.gridSubTile = b.getArrayAttr(
-        {splitMemoryCoordsAttr, toRowsAndColsAttr, toMatrixCAttr});
+
+    // Before returning the output view, if necessary, swap back the
+    // threadid/iter dimensions on both the M/N axis.
+    SmallVector<Attribute> transformAttrs{splitMemoryCoordsAttr,
+                                          toRowsAndColsAttr};
+    mlir::rock::swapThreadIdAndIteration(
+        toMatrixC, bidGridLengths, computeMPerThread, computeNPerThread,
+        mPerBlock, nPerBlock, isKContiguousDimA, isKContiguousDimB,
+        transformAttrs);
+
+    ret.gridSubTile = b.getArrayAttr(transformAttrs);
   }
 
   {
@@ -514,7 +525,9 @@ void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
 
 RegsAsMatrixSubTiles WmmaEmitter::computeOutputTransforms(
     PatternRewriter &b, Location loc, int64_t mLen, int64_t nLen,
-    int64_t blockSize, ArrayRef<int64_t> bidGridLengths) {
+    bool isKContiguousDimA, bool isKContiguousDimB, int64_t computeMPerThread,
+    int64_t computeNPerThread, int64_t blockSize,
+    ArrayRef<int64_t> bidGridLengths) {
 
   // Extract relevant tuning parameters
   int64_t mPerBlock = tuningParams.getMPerBlock();
@@ -529,6 +542,7 @@ RegsAsMatrixSubTiles WmmaEmitter::computeOutputTransforms(
 
   int64_t nWaves = nPerBlock / nPerWave;
   int64_t mWaves = mPerBlock / mPerWave;
+  SmallVector<Attribute> transformAttrs;
 
   // High level code for this loop
   // source: https://gpuopen.com/learn/wmma_on_rdna3/

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -314,9 +314,10 @@ RegsAsMatrixSubTiles MfmaEmitter::computeOutputTransforms(
     SmallVector<Attribute> transformAttrs{splitMemoryCoordsAttr,
                                           toRowsAndColsAttr};
     mlir::rock::swapThreadIdAndIteration(
-        toMatrixC, bidGridLengths, computeMPerThread, computeNPerThread,
-        mPerBlock, nPerBlock, doSwapThreadIterSubDimsForM,
-        doSwapThreadIterSubDimsForN, /*isBlockwise=*/false, transformAttrs);
+        toMatrixC, /*mBlocks=*/bidGridLengths[1], /*nBlocks=*/bidGridLengths[2],
+        computeMPerThread, computeNPerThread, mPerBlock, nPerBlock,
+        doSwapThreadIterSubDimsForM, doSwapThreadIterSubDimsForN,
+        /*isBlockwise=*/false, transformAttrs);
 
     ret.gridSubTile = b.getArrayAttr(transformAttrs);
   }
@@ -363,9 +364,10 @@ RegsAsMatrixSubTiles MfmaEmitter::computeOutputTransforms(
     SmallVector<Attribute> transformAttrs{splitMemoryCoordsAttr,
                                           toRowsAndColsAttr};
     mlir::rock::swapThreadIdAndIteration(
-        toMatrixC, bidGridLengths, computeMPerThread, computeNPerThread,
-        mPerBlock, nPerBlock, doSwapThreadIterSubDimsForM,
-        doSwapThreadIterSubDimsForN, /*isBlockwise=*/true, transformAttrs);
+        toMatrixC, /*mBlocks=*/bidGridLengths[1], /*nBlocks=*/bidGridLengths[2],
+        computeMPerThread, computeNPerThread, mPerBlock, nPerBlock,
+        doSwapThreadIterSubDimsForM, doSwapThreadIterSubDimsForN,
+        /*isBlockwise=*/true, transformAttrs);
     ret.blockSubTile = b.getArrayAttr(transformAttrs);
   }
 
@@ -625,9 +627,10 @@ RegsAsMatrixSubTiles WmmaEmitter::computeOutputTransforms(
     toMatrixC.unmerge("gemmN", 2, dimNamesN, dimSizesN);
     SmallVector<Attribute> transformAttrs{splitMemoryCoordsAttr};
     mlir::rock::swapThreadIdAndIteration(
-        toMatrixC, bidGridLengths, computeMPerThread, computeNPerThread,
-        mPerBlock, nPerBlock, doSwapThreadIterSubDimsForM,
-        doSwapThreadIterSubDimsForN, /**isBlockwise=*/false, transformAttrs);
+        toMatrixC, /*mBlocks=*/bidGridLengths[1], /*nBlocks=*/bidGridLengths[2],
+        computeMPerThread, computeNPerThread, mPerBlock, nPerBlock,
+        doSwapThreadIterSubDimsForM, doSwapThreadIterSubDimsForN,
+        /**isBlockwise=*/false, transformAttrs);
 
     ret.gridSubTile = b.getArrayAttr(transformAttrs);
   }
@@ -653,9 +656,10 @@ RegsAsMatrixSubTiles WmmaEmitter::computeOutputTransforms(
                       ArrayRef<int64_t>{dimSizesN}.slice(1));
     SmallVector<Attribute> transformAttrs{splitMemoryCoordsAttr};
     mlir::rock::swapThreadIdAndIteration(
-        toMatrixC, bidGridLengths, computeMPerThread, computeNPerThread,
-        mPerBlock, nPerBlock, doSwapThreadIterSubDimsForM,
-        doSwapThreadIterSubDimsForN, /**isBlocwise=*/true, transformAttrs);
+        toMatrixC, /*mBlocks=*/bidGridLengths[1], /*nBlocks=*/bidGridLengths[2],
+        computeMPerThread, computeNPerThread, mPerBlock, nPerBlock,
+        doSwapThreadIterSubDimsForM, doSwapThreadIterSubDimsForN,
+        /**isBlocwise=*/true, transformAttrs);
     ret.blockSubTile = b.getArrayAttr(transformAttrs);
   }
 

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -114,7 +114,9 @@ struct AccelEmitter {
   /// matrix multiplication tile.
   virtual RegsAsMatrixSubTiles
   computeOutputTransforms(PatternRewriter &b, Location loc, int64_t mLen,
-                          int64_t nLen, int64_t blockSize,
+                          int64_t nLen, bool isKContiguousDimA,
+                          bool isKContiguousDimB, int64_t computeMPerThread,
+                          int64_t computeNPerThread, int64_t blockSize,
                           ArrayRef<int64_t> bidGridLengths) = 0;
 
   /// Convert from memref<?xvector<?xT>> to memref<?xD> where the source T
@@ -156,7 +158,9 @@ struct MfmaEmitter : public AccelEmitter {
 
   RegsAsMatrixSubTiles
   computeOutputTransforms(PatternRewriter &b, Location loc, int64_t mLen,
-                          int64_t nLen, int64_t blockSize,
+                          int64_t nLen, bool isKContiguousDimA,
+                          bool isKContiguousDimB, int64_t computeMPerThread,
+                          int64_t computeNPerThread, int64_t blockSize,
                           ArrayRef<int64_t> bidGridLengths) override;
 
 private:
@@ -186,7 +190,9 @@ struct WmmaEmitter : public AccelEmitter {
 
   RegsAsMatrixSubTiles
   computeOutputTransforms(PatternRewriter &b, Location loc, int64_t mLen,
-                          int64_t nLen, int64_t blockSize,
+                          int64_t nLen, bool isKContiguousDimA,
+                          bool isKContiguousDimB, int64_t computeMPerThread,
+                          int64_t computeNPerThread, int64_t blockSize,
                           ArrayRef<int64_t> bidGridLengths) override;
 
 private:

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -112,12 +112,11 @@ struct AccelEmitter {
 
   /// Compute the output transform map to be used to store the result of the
   /// matrix multiplication tile.
-  virtual RegsAsMatrixSubTiles
-  computeOutputTransforms(PatternRewriter &b, Location loc, int64_t mLen,
-                          int64_t nLen, bool isKContiguousDimA,
-                          bool isKContiguousDimB, int64_t computeMPerThread,
-                          int64_t computeNPerThread, int64_t blockSize,
-                          ArrayRef<int64_t> bidGridLengths) = 0;
+  virtual RegsAsMatrixSubTiles computeOutputTransforms(
+      PatternRewriter &b, Location loc, int64_t mLen, int64_t nLen,
+      bool doSwapThreadIterSubDimsForM, bool doSwapThreadIterSubDimsForN,
+      int64_t computeMPerThread, int64_t computeNPerThread, int64_t blockSize,
+      ArrayRef<int64_t> bidGridLengths) = 0;
 
   /// Convert from memref<?xvector<?xT>> to memref<?xD> where the source T
   /// is the accumulator type and D is the destination type

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -156,12 +156,11 @@ struct MfmaEmitter : public AccelEmitter {
                                Location loc, Value baseOffset, Value dWaves,
                                Value laneId) override;
 
-  RegsAsMatrixSubTiles
-  computeOutputTransforms(PatternRewriter &b, Location loc, int64_t mLen,
-                          int64_t nLen, bool isKContiguousDimA,
-                          bool isKContiguousDimB, int64_t computeMPerThread,
-                          int64_t computeNPerThread, int64_t blockSize,
-                          ArrayRef<int64_t> bidGridLengths) override;
+  RegsAsMatrixSubTiles computeOutputTransforms(
+      PatternRewriter &b, Location loc, int64_t mLen, int64_t nLen,
+      bool doSwapThreadIterSubDimsForM, bool doSwapThreadIterSubDimsForN,
+      int64_t computeMPerThread, int64_t computeNPerThread, int64_t blockSize,
+      ArrayRef<int64_t> bidGridLengths) override;
 
 private:
   /// Initialize the emitter parameters for mfma
@@ -188,12 +187,11 @@ struct WmmaEmitter : public AccelEmitter {
                                Location loc, Value baseOffset, Value dWaves,
                                Value laneId) override;
 
-  RegsAsMatrixSubTiles
-  computeOutputTransforms(PatternRewriter &b, Location loc, int64_t mLen,
-                          int64_t nLen, bool isKContiguousDimA,
-                          bool isKContiguousDimB, int64_t computeMPerThread,
-                          int64_t computeNPerThread, int64_t blockSize,
-                          ArrayRef<int64_t> bidGridLengths) override;
+  RegsAsMatrixSubTiles computeOutputTransforms(
+      PatternRewriter &b, Location loc, int64_t mLen, int64_t nLen,
+      bool doSwapThreadIterSubDimsForM, bool doSwapThreadIterSubDimsForN,
+      int64_t computeMPerThread, int64_t computeNPerThread, int64_t blockSize,
+      ArrayRef<int64_t> bidGridLengths) override;
 
 private:
   /// Initialize the emitter parameters for wmma

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -753,7 +753,8 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         {N / nPerBlock, gemmNRepeat, nCuwavesPerBlock, nThreadsPerCuwave,
          nPerThread});
 
-    swapThreadIdAndIteration(toMatrixC, bidGridLengths, copyMPerThread,
+    swapThreadIdAndIteration(toMatrixC, /*mBlocks=*/bidGridLengths[1],
+                             /*nBlocks=*/bidGridLengths[2], copyMPerThread,
                              copyNPerThread, mPerBlock, nPerBlock,
                              !isKContiguousDimA, !isKContiguousDimB,
                              /*isBlockwise=*/false, transformAttrs);

--- a/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
-#include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -258,7 +258,8 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
     OpBuilder &b, Location loc, Value globalBuffer, StringRef dName,
     ArrayRef<StringRef> bidGridOrder, ArrayRef<int64_t> bidGridLengths,
     int64_t blockSize, int64_t kPerBlock, int64_t dPerBlock, int64_t kPerThread,
-    int64_t dPerThread, int64_t kpack, bool isKContigousDim) {
+    int64_t dPerThread, int64_t kpack, bool isKContigousDim,
+    bool doSwapThreadIterSubDimsForD) {
   if (dName != "m" && dName != "n") {
     return emitError(loc, "expected dName to be m or n but got " + dName);
   }
@@ -327,7 +328,7 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
                         {kThreads, kOuterPerThread, kpackPerThread});
     // if the matrix is KxD swap the iter/thread dimension. This is so that
     // each thread writes in LDS contiguously, minimizing bank conflicts
-    if (isKContigousDim)
+    if (!doSwapThreadIterSubDimsForD)
       toGlobalIdx.unmerge(dName, 1, {dThreadName, dIterName},
                           {dThreads, dPerThread});
     else

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1364,11 +1364,13 @@ TransformMapAttr mlir::rock::transformExtractSlice(OpBuilder &b, Location loc,
   return transform.get();
 }
 
-TopDownTMBuilder mlir::rock::rotateIf(
-    bool condition, TopDownTMBuilder &builder, TransformMapAttr &attr,
-    int64_t stride, StringRef dName, int64_t d, int64_t dPos, StringRef kName,
-    int64_t kOuter, ArrayRef<StringRef> beforeDims,
-    ArrayRef<StringRef> afterDims, SmallVector<Attribute, 4> &transformAttrs) {
+TopDownTMBuilder mlir::rock::rotateIf(bool condition, TopDownTMBuilder &builder,
+                                      TransformMapAttr &attr, int64_t stride,
+                                      StringRef dName, int64_t d, int64_t dPos,
+                                      StringRef kName, int64_t kOuter,
+                                      ArrayRef<StringRef> beforeDims,
+                                      ArrayRef<StringRef> afterDims,
+                                      SmallVector<Attribute> &transformAttrs) {
   if (condition) {
     // d = (d+k_outer)
     TopDownTMBuilder rotateD0 = TopDownTMBuilder::below(builder, attr);

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -12,10 +12,8 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2x
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize= 256 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
       kpack = 2,
@@ -37,10 +35,8 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<128xvector<8xi
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
       kpack = 8,
@@ -64,10 +60,8 @@ func.func @rock_blockwise_gemm_accel_fp8_bf8(%matrixA : memref<1024xvector<8xf8E
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     blockSize = 256 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 8,
       mPerBlock = 128,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -14,6 +14,8 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2x
     blockSize= 256 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
       kpack = 2,
@@ -37,6 +39,8 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<128xvector<8xi
     blockSize = 256 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
       kpack = 8,
@@ -62,6 +66,8 @@ func.func @rock_blockwise_gemm_accel_fp8_bf8(%matrixA : memref<1024xvector<8xf8E
     blockSize = 256 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 8,
       mPerBlock = 128,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -12,6 +12,8 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2x
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize= 256 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
       kpack = 2,
@@ -33,6 +35,8 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<128xvector<8xi
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
       kpack = 8,
@@ -56,6 +60,8 @@ func.func @rock_blockwise_gemm_accel_fp8_bf8(%matrixA : memref<1024xvector<8xf8E
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     blockSize = 256 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 8,
       mPerBlock = 128,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -21,6 +21,8 @@ func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<16xf16>, #
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 32 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.wmma_gemm_params<
       kpackPerBlock = 4,
       kpack = 16,
@@ -58,6 +60,8 @@ func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.wmma_gemm_params<
       mPerBlock = 32,
       nPerBlock = 32,
@@ -89,6 +93,8 @@ func.func @rock_blockwise_gemm_accel_wmma_int8(%matrixA : memref<32xvector<16xi8
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.wmma_gemm_params<
       mPerBlock = 64,
       nPerBlock = 64,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -23,6 +23,8 @@ func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<16xf16>, #
     blockSize = 32 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.wmma_gemm_params<
       kpackPerBlock = 4,
       kpack = 16,
@@ -62,6 +64,8 @@ func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector
     blockSize = 128 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.wmma_gemm_params<
       mPerBlock = 32,
       nPerBlock = 32,
@@ -95,6 +99,8 @@ func.func @rock_blockwise_gemm_accel_wmma_int8(%matrixA : memref<32xvector<16xi8
     blockSize = 128 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.wmma_gemm_params<
       mPerBlock = 64,
       nPerBlock = 64,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -21,10 +21,8 @@ func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<16xf16>, #
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 32 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.wmma_gemm_params<
       kpackPerBlock = 4,
       kpack = 16,
@@ -62,10 +60,8 @@ func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.wmma_gemm_params<
       mPerBlock = 32,
       nPerBlock = 32,
@@ -97,10 +93,8 @@ func.func @rock_blockwise_gemm_accel_wmma_int8(%matrixA : memref<32xvector<16xi8
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.wmma_gemm_params<
       mPerBlock = 64,
       nPerBlock = 64,

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -66,6 +66,8 @@ func.func @rock_indexing() {
 
 func.func @rock_blockwise_gemm(%A : memref<8x128x1xf32, 3>, %B : memref<8x128x1xf32, 3>, %C : memref<8x8xf32, 5>) {
   rock.blockwise_gemm %C += %A * %B {
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.general_gemm_params<
     blockSize = 256,
     kPerBlock = 8,
@@ -182,6 +184,8 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<12288xf32, 3>,
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -206,6 +210,8 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<12288xf32, 3>
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -68,6 +68,8 @@ func.func @rock_blockwise_gemm(%A : memref<8x128x1xf32, 3>, %B : memref<8x128x1x
   rock.blockwise_gemm %C += %A * %B {
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.general_gemm_params<
     blockSize = 256,
     kPerBlock = 8,
@@ -186,6 +188,8 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<12288xf32, 3>,
     blockSize = 256 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -212,6 +216,8 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<12288xf32, 3>
     blockSize = 256 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -66,10 +66,8 @@ func.func @rock_indexing() {
 
 func.func @rock_blockwise_gemm(%A : memref<8x128x1xf32, 3>, %B : memref<8x128x1xf32, 3>, %C : memref<8x8xf32, 5>) {
   rock.blockwise_gemm %C += %A * %B {
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.general_gemm_params<
     blockSize = 256,
     kPerBlock = 8,
@@ -186,10 +184,8 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<12288xf32, 3>,
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -214,10 +210,8 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<12288xf32, 3>
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -4,6 +4,8 @@
 
 func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x128x1xf16, 3>, %C : memref<8x8xf16, 5>){
   rock.blockwise_gemm %C += %A * %B {
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.general_gemm_params<
       blockSize = 256,
       kPerBlock = 8,
@@ -76,6 +78,8 @@ func.func @rock_blockwise_gemm_accel_one_result_f16(%matrixA : memref<8192xf16, 
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -100,6 +104,8 @@ func.func @rock_blockwise_gemm_accel_two_results_f16(%matrixA : memref<8192xf16,
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
+    isKContiguousDimA = true,
+    isKContiguousDimB = false,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -6,6 +6,8 @@ func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x12
   rock.blockwise_gemm %C += %A * %B {
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.general_gemm_params<
       blockSize = 256,
       kPerBlock = 8,
@@ -80,6 +82,8 @@ func.func @rock_blockwise_gemm_accel_one_result_f16(%matrixA : memref<8192xf16, 
     blockSize = 256 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -106,6 +110,8 @@ func.func @rock_blockwise_gemm_accel_two_results_f16(%matrixA : memref<8192xf16,
     blockSize = 256 : i32,
     isKContiguousDimA = true,
     isKContiguousDimB = false,
+    copyMPerThread = 2 : i32,
+    copyNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -4,10 +4,8 @@
 
 func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x128x1xf16, 3>, %C : memref<8x8xf16, 5>){
   rock.blockwise_gemm %C += %A * %B {
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.general_gemm_params<
       blockSize = 256,
       kPerBlock = 8,
@@ -80,10 +78,8 @@ func.func @rock_blockwise_gemm_accel_one_result_f16(%matrixA : memref<8192xf16, 
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,
@@ -108,10 +104,8 @@ func.func @rock_blockwise_gemm_accel_two_results_f16(%matrixA : memref<8192xf16,
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
-    isKContiguousDimA = true,
-    isKContiguousDimB = false,
-    copyMPerThread = 2 : i32,
-    copyNPerThread = 2 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
       nPerBlock = 256,


### PR DESCRIPTION
Given the `Kouter x D x Kpack` layout of LDS in `rocMLIR`, this PR is implementing an LDS-write bank conflicts reduction policy in  two cases: 
- When the global matrix is `DxK`, this means we would write `Kpack` vectors in the same column (because we are basically transposing the global matrix in LDS). In this case we rotate the colum dimension by the row dimension : i.e., when we want to write at position `(i,j)` in LDS, we get rerouted to position `(i, (i+j)%D)`. 
- When the global matrix is `KxD`, this means that we are writing along the `D` dimension, and that would be fine if every work-item is only writing one single vector. If a workitem is writing >2 vectors, then they are writing in a strided fashion which generates bank conflicts. The solution proposed is to do a coordinate-swap when storing in LDS, so that the contiguous dimension is the workitem id. The output will be wapped back before producing the final result (thanks @manupak for the suggestion!)

These two policies required a bit of code reshuffling:
- I have to propagate the `isKContiguousDim{A/B}` down to the `blockwiseGemm` operator
- I need `copyMPerThread` and `copyMPerThread` in `blockwiseGemm` to address cases where `kpack==1`, this means that `computeCopyPerThread` has been promoted into `loweringUtils.h` because it'll be used by two operations. 
- `wrapLDSBufferForStore` is building the transformation in a top down fashion (instead than bottom up) because I need a transformation like `(d0, d1)->(d0, d1+d0)` which cannot be build bottom up. 

There are at least three big refactors that stem from this PR:
- Moving the `BlockwiseGemmAccel` operation to use transforms (as opposed to plain `AffineLoop`s)
- Wrap the LDS as a view and pass it down, so that we don't need to propagate (or recompute) LDS layout information in `BlockwiseGemmAccel`/`BlockwiseGemm`
- Unify accel and non-accel code paths
