### PR TITLE
Fix spurious perormance degradation introduced in #985

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -147,14 +147,15 @@ static FailureOr<double> benchmarkKernels(
         func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
         argPointers.data(), nullptr, startEvent, stopEvent))
     HIPCHECK(hipStreamSynchronize(stream))
-    HIPCHECK(hipEventElapsedTime(&milliseconds, startEvent, stopEvent))
+    float currentMilliseconds = 0.0;
+    HIPCHECK(hipEventElapsedTime(&currentMilliseconds, startEvent, stopEvent))
 
     HIPCHECK(hipEventDestroy(stopEvent))
     HIPCHECK(hipEventDestroy(startEvent))
 
     HIPCHECK(hipModuleUnload(mod))
 
-    milliseconds += milliseconds;
+    milliseconds += currentMilliseconds;
   }
 
   double ret = msToNs * static_cast<double>(milliseconds);


### PR DESCRIPTION
This fix a bug in the tuning driver where we were using the same variable to accumulate the total time to run all the kernels and to compute the actual time for the current kernel. 

Before this fix:
```
python3 ./bin/tuningRunner.py --op gemm --config="-g 64 -m 1024 -k 1024 -n 384 -t f32 -out_datatype f32 -transA 0 -transB 0" 
Tuning: -g 64 -m 1024 -k 1024 -n 384 -t f32 -out_datatype f32 -transA 0 -transB 0
Tested 100 configs, best perf 5.3430579891039764 TFlops on perf_config 8,128,4,8,64,4,1,1
Tested 200 configs, best perf 12.901409241124018 TFlops on perf_config 32,64,2,32,32,8,1,1
Tested 300 configs, best perf 16.227825911948415 TFlops on perf_config 64,64,2,32,32,8,1,1
Tested 400 configs, best perf 16.32321592985714 TFlops on perf_config 64,128,4,32,64,4,1,1
Tested 500 configs, best perf 16.32321592985714 TFlops on perf_config 64,128,4,32,64,4,1,1
Verifying with perfConfig = 64,128,4,32,64,4,1,1
Tuned and verified : -g 64 -m 1024 -k 1024 -n 384 -t f32 -out_datatype f32 -transA 0 -transB 0 : 64,128,4,32,64,4,1,1 with 16.32321592985714 TFlops and 10.00783264539478 on verification
```

After this fix:
```
python3 ./bin/tuningRunner.py --op gemm --config="-g 64 -m 1024 -k 1024 -n 384 -t f32 -out_datatype f32 -transA 0 -transB 0" 
Tuning: -g 64 -m 1024 -k 1024 -n 384 -t f32 -out_datatype f32 -transA 0 -transB 0
Tested 100 configs, best perf 10.697825143401557 TFlops on perf_config 8,128,4,8,64,4,1,1
Tested 200 configs, best perf 22.878001507456048 TFlops on perf_config 32,64,2,32,32,8,1,1
Tested 300 configs, best perf 32.43930961272053 TFlops on perf_config 64,64,2,32,32,8,1,1
Tested 400 configs, best perf 32.692818722204706 TFlops on perf_config 64,128,4,64,32,4,1,1
Tested 500 configs, best perf 32.692818722204706 TFlops on perf_config 64,128,4,64,32,4,1,1
Verifying with perfConfig = 64,128,4,64,32,4,1,1
Tuned and verified : -g 64 -m 1024 -k 1024 -n 384 -t f32 -out_datatype f32 -transA 0 -transB 0 : 64,128,4,64,32,4,1,1 with 32.692818722204706 TFlops and 10.015923292290536 on verification
Note: Verify tflops counts verification kernel
Arch = gfx90a:sramecc+:xnack-(110 CUs), vector = '-g 64 -m 1024 -k 1024 -n 384 -t f32 -out_datatype f32 -transA 0 -transB 0', perfConfig = 64,128,4,64,32,4,1,1

```