### PR TITLE
Disable more large gemm tests to fix CI oom errors from parallelism

### DIFF
--- a/mlir/test/e2e/GemmVariants.toml
+++ b/mlir/test/e2e/GemmVariants.toml
@@ -36,8 +36,13 @@ config = "-g 1 -m 1024 -k 769 -n 1024"
 [[suite.test]]
 config = "-g 1 -m 1 -k 1 -n 1"
 
+# Large gemm, output padding
 [[suite.test]]
-config = "-g 1 -m 32768 -k 1 -n 32769"
+config = "-g 1 -m 65536 -k 1 -n 65537"
+# Only test i8 here, f32 is covered by PR tests
+[[suite.test.exclude]]
+name = "data type"
+values = ["f32", "f16", "fp8_fp8", "fp8_bf8", "bf8_fp8", "bf8_bf8"]
 
 # Large gemm, no padding.
 [[suite.test]]


### PR DESCRIPTION
Turns out I missed the padded gemm tests when disabling the large ones.