### PR TITLE
Add back a few large GEMM tests

### DIFF
--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -50,6 +50,7 @@ if (ROCK_E2E_TEST_ENABLED)
   if (ROCK_E2E_TEST_SUITES STREQUAL "" OR ROCK_E2E_TEST_SUITES STREQUAL "part3")
     list(APPEND CONFIGS
     Resnext101Config
+    LargeGemm
     PaddedGemmConfig
     )
   endif()

--- a/mlir/test/e2e/LargeGemm.toml
+++ b/mlir/test/e2e/LargeGemm.toml
@@ -1,0 +1,20 @@
+directory = "LargeGemm"
+prefix = "rocmlir-gen"
+suffix = "--operation gemm --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+# Note: Just f32 for ensuring lower machine load
+[[axis]]
+name = "data type"
+values = ["f32"]
+prefix = "-t "
+
+## Gemm variants
+[[suite]]
+name = "large_gemm"
+
+# Large gemm, input padding
+[[suite.test]]
+config = "-g 1 -m 1 -k 32768 -n 32769"
+# Large gemm, no padding.
+[[suite.test]]
+config = "-g 1 -m 64 -k 32768 -n 32768"


### PR DESCRIPTION
I suspect that we're running into more oom issues because of tharnsB and transC and the like. So, move large gemm tests into their own file where there'll only be one or two tests that run, thus ensuring we don't overload the machines.

(Note: historicallly, we tried to add large GEMM tests to the usual GEMM test set and we'd get OOMs from parallel runs on memeory-constrained machines)