### PR TITLE
Fix handling of linalg.generic blocks not tied to gemm inputs

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Passes.td
+++ b/mlir/include/mlir/Dialect/Rock/Passes.td
@@ -55,7 +55,7 @@ def RockGridwiseGemmToBlockwisePass : Pass<"rock-gridwise-gemm-to-blockwise", ":
 
 def RockLinalgAlignPass : Pass<"rock-linalg-align", "::mlir::func::FuncOp"> {
   let summary = "expand linalg ops aligned with threadwise copy";
-  let dependentDialects = ["rock::RockDialect", "linalg::LinalgDialect", "vector::VectorDialect", "memref::MemRefDialect"];
+  let dependentDialects = ["rock::RockDialect", "linalg::LinalgDialect", "vector::VectorDialect", "memref::MemRefDialect", "gpu::GPUDialect"];
 }
 
 def RockBlockwiseGemmToThreadwisePass : Pass<"rock-blockwise-gemm-to-threadwise", "::mlir::func::FuncOp"> {

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -39,6 +39,10 @@ std::tuple<Value, ArrayAttr, bool> untransform(OpBuilder &b, Value transformed,
                                                ArrayAttr existing = nullptr);
 std::tuple<Value, ArrayAttr, bool> untransform(OpBuilder &b, Value transformed,
                                                ArrayRef<Attribute> existing);
+/// As above, but return the values into a vector of TransformMapAttr's.
+/// Appends to the existing vector.
+std::tuple<Value, bool>
+untransform(Value transformed, SmallVectorImpl<TransformMapAttr> &transforms);
 
 /// Returns true if a given transform map has inputs or outputs that could
 /// overflow a signed 32-bit integer.

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1435,7 +1435,10 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
     inputShape = extraViews[0].cast<TransformMapAttr>().getUpperBounds();
 
   size_t extraIdxCount = getExtraIndices().size();
-  if (inputShape.size() != extraIdxCount + 1) {
+  if (inputShape.empty()) {
+    if (extraIdxCount != 0)
+      return emitOpError("read from a scalar value cannot have coordinates");
+  } else if (inputShape.size() != extraIdxCount + 1) {
     return emitOpError("source view must be extraIndices + 1");
   }
   return success();
@@ -1459,7 +1462,10 @@ LogicalResult ThreadwiseWriteAllOp::verify() {
     outputShape = extraViews[0].cast<TransformMapAttr>().getUpperBounds();
 
   size_t extraIdxCount = getExtraIndices().size();
-  if (outputShape.size() != extraIdxCount + 1) {
+  if (outputShape.empty()) {
+    if (extraIdxCount != 0)
+      return emitOpError("write to a scalar must have no coordinates");
+  } else if (outputShape.size() != extraIdxCount + 1) {
     return emitOpError("dest view must be extraIndices + 1");
   }
   return success();

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -21,6 +21,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -36,6 +37,8 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Rewrite/PatternApplicator.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -44,6 +47,7 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ScopedPrinter.h"
 
 #include <numeric>
 
@@ -65,96 +69,329 @@ struct RockLinalgAlignPass
   void runOnOperation() override;
 };
 
-struct LAGenericRewritePattern : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+/// The patterns in this file do not and cannot fulfill the contract of
+/// upstream's greedy pattern rewriter. Therefore, we implement the following
+/// custom rewriter, which:
+/// - Allows explicitly inserting operations into the worklist, to allow
+///   recursively scheduling rewrites on linalg.generic blocks that need
+///   tiling information propagated up.
+/// - Doesn't needlessly re-schedule the fusion pattern onto the linalg.generic
+///   that has already been modified.
+/// - Doesn't spend time peeking into regions
+/// - Propagates rewrite failure to the main code. However, if a pattern
+///   fails but the op indicates that it expects to be visited in a future pass,
+///   this is recorded, and the failure only counts if the re-visit doesn't
+///   happen.
+/// - Assumes all patterns match some specific operation to save time
+///   constructing the initial worklist.
+struct LinalgAlignRewriter : public PatternRewriter,
+                             public RewriterBase::Listener {
+protected:
+#ifndef NDEBUG
+  llvm::ScopedPrinter logger{llvm::dbgs()};
+#endif
+
+  // Ensure we completely process one generation of operations before moving
+  // to the next one by keeping two worklists that we copy into.
+  SmallVector<Operation *, 0> nextWorklist;
+  // Our patterns aren't stable under repetade application (ex. fuling an
+  // already fused op) but we can have cases where an operation is marked for
+  // multiple visits (ex. two arguments to a linalg.generic reading from
+  // the same source linalg.generic), so we need to prevent duplicate
+  // scheduling within a generation.
+  llvm::SmallPtrSet<Operation *, 4> scheduledOps;
+
+  SmallPtrSet<Operation *, 2> opsExpectingRevisit;
+
+  llvm::SmallDenseSet<OperationName> matchableOps;
+  bool hasMatchingPattern(Operation *op);
+
+  /// Utility for debug logging.
+  void logOpActivity(llvm::StringLiteral prefix, Operation *op);
+
+public:
+  LinalgAlignRewriter(MLIRContext *ctx);
+
+  /// Schedule the given operation for processing in a future iteration
+  /// through the patterns.
+  void scheduleVisit(Operation *op);
+
+  /// Inform the pattern rewriter that this operation will need to be revisited
+  /// in the future to make everything correct. Returns success() (we matched,
+  /// but have to wait to actually run this) as a convenience. If the operation
+  /// is never revisited, then fail.
+  LogicalResult needsRevisit(Operation *op);
+
+  /// Match all worklist itemis against the patterns in `matcher`, repetaing
+  /// this procedure until all scheduled visits are complete, including those
+  /// added during a pattern match. Fails if any pattern applicatino fails.
+  /// or if an operation that is marked as needing revisiting is not visited
+  /// after it is so marked.
+  LogicalResult drainWorklist(PatternApplicator &matcher);
+
+  /// Move `toMove` after `earliestOp` if `toMove` is before `earliestOp`
+  /// in the IR.
+  void moveAfterIfNeeded(Operation *toMove, Operation *earliestOp);
+
+  /// Move `toMove` before `latestPoint` if `toMove` is after `latestOp` in
+  /// the IR.
+  void moveBeforeIfNeeded(Operation *toMove, Operation *latestOp);
+
+  /// Debug utilities.
+  void notifyOperationModified(Operation *op) override;
+  void notifyOperationInserted(Operation *op) override;
+  void notifyOperationRemoved(Operation *op) override;
+  void notifyOperationReplaced(Operation *op, ValueRange replacement) override;
+  void notifyBlockCreated(Block *block) override;
+  using PatternRewriter::notifyMatchFailure;
+  LogicalResult
+  notifyMatchFailure(Location loc,
+                     function_ref<void(Diagnostic &)> reasonCallback) override;
+};
+
+template <typename Op>
+struct AlignRewritePattern : public OpRewritePattern<Op> {
+  using OpRewritePattern<Op>::OpRewritePattern;
+
+  using OpRewritePattern<Op>::matchAndRewrite;
+  virtual LogicalResult matchAndRewrite(Op op,
+                                        LinalgAlignRewriter &b) const = 0;
+
+  LogicalResult matchAndRewrite(Op op,
+                                PatternRewriter &rewriter) const override {
+    LinalgAlignRewriter &b = static_cast<LinalgAlignRewriter &>(rewriter);
+    return this->matchAndRewrite(op, b);
+  }
+};
+
+struct LAGenericRewritePattern : public AlignRewritePattern<linalg::GenericOp> {
+  using AlignRewritePattern<linalg::GenericOp>::AlignRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::GenericOp laGeneric,
-                                PatternRewriter &b) const override;
+                                LinalgAlignRewriter &b) const override;
 };
 
-struct MemcpyRewritePattern : public OpRewritePattern<memref::CopyOp> {
-  using OpRewritePattern<memref::CopyOp>::OpRewritePattern;
+struct MemcpyRewritePattern : public AlignRewritePattern<memref::CopyOp> {
+  using AlignRewritePattern<memref::CopyOp>::AlignRewritePattern;
 
   LogicalResult matchAndRewrite(memref::CopyOp copy,
-                                PatternRewriter &b) const override;
+                                LinalgAlignRewriter &b) const override;
 };
 
-struct ReduceRewritePattern : public OpRewritePattern<rock::ReduceOp> {
-  using OpRewritePattern<rock::ReduceOp>::OpRewritePattern;
+struct ReduceRewritePattern : public AlignRewritePattern<rock::ReduceOp> {
+  using AlignRewritePattern<rock::ReduceOp>::AlignRewritePattern;
 
   LogicalResult matchAndRewrite(rock::ReduceOp reduceOp,
-                                PatternRewriter &rewriter) const override;
+                                LinalgAlignRewriter &rewriter) const override;
 };
 } // end anonymous namespace
 
-static void moveTransformsBefore(PatternRewriter &b, Value val) {
-  if (auto defOp = val.getDefiningOp()) {
-    if (auto rtop = dyn_cast<TransformOp>(defOp)) {
-      moveTransformsBefore(b, rtop.getOperand());
+/// Pattern rewriter
+LinalgAlignRewriter::LinalgAlignRewriter(MLIRContext *ctx)
+    : PatternRewriter(ctx) {
+  setListener(this);
+}
 
-      defOp->remove();
-      b.insert(defOp);
-    } else {
-      llvm_unreachable("must trace to func.arg");
-    }
+bool LinalgAlignRewriter::hasMatchingPattern(Operation *op) {
+  return matchableOps.contains(op->getName());
+}
+
+void LinalgAlignRewriter::moveAfterIfNeeded(Operation *toMove,
+                                            Operation *earliestOp) {
+  constexpr llvm::StringLiteral movePrefix("** Move    : ");
+  constexpr llvm::StringLiteral afterPrefix("   after   : ");
+  logOpActivity(movePrefix, toMove);
+  logOpActivity(afterPrefix, earliestOp);
+  if (toMove->isBeforeInBlock(earliestOp))
+    toMove->moveAfter(earliestOp);
+  else
+    LLVM_DEBUG(logger.startLine() << "   No move needed.\n");
+}
+
+void LinalgAlignRewriter::moveBeforeIfNeeded(Operation *toMove,
+                                             Operation *latestOp) {
+  constexpr llvm::StringLiteral movePrefix("** Move    : ");
+  constexpr llvm::StringLiteral beforePrefix("   before  : ");
+  logOpActivity(movePrefix, toMove);
+  logOpActivity(beforePrefix, latestOp);
+  if (latestOp->isBeforeInBlock(toMove))
+    toMove->moveBefore(latestOp);
+  else
+    LLVM_DEBUG(logger.startLine() << "   No move needed.\n");
+}
+
+void LinalgAlignRewriter::scheduleVisit(Operation *op) {
+  constexpr llvm::StringLiteral prefix("** To visit: ");
+  constexpr llvm::StringLiteral dupePrefix("** Duplicate:  ");
+  if (scheduledOps.insert(op).second) {
+    logOpActivity(prefix, op);
+    nextWorklist.push_back(op);
+  } else {
+    logOpActivity(dupePrefix, op);
   }
 }
 
-static Value applyViewsOnDest(PatternRewriter &rewriter, Location loc,
+LogicalResult LinalgAlignRewriter::needsRevisit(Operation *op) {
+  constexpr llvm::StringLiteral prefix("** Needs revisiting : ");
+  logOpActivity(prefix, op);
+  opsExpectingRevisit.insert(op);
+  return success();
+}
+
+LogicalResult LinalgAlignRewriter::drainWorklist(PatternApplicator &matcher) {
+  SmallVector<Operation *, 0> currentWorklist;
+  while (!nextWorklist.empty()) {
+    // Copy the operations to be visited out of the way so we don't have
+    // iterator invalidation.
+    currentWorklist.append(nextWorklist);
+    nextWorklist.clear();
+    scheduledOps.clear();
+    for (Operation *op : currentWorklist) {
+#ifndef NDEBUG
+      auto canApply = [&](const Pattern &pattern) -> bool {
+        LLVM_DEBUG({
+          logger.startLine() << "Applying pattern " << pattern.getDebugName()
+                             << " (matches" << *pattern.getRootKind() << ")"
+                             << " on " << op->getName() << "\n";
+          logger.indent();
+        });
+        return true;
+      };
+      auto onFailure = [&](const Pattern &pattern) {
+        LLVM_DEBUG({
+          logger.unindent();
+          logger.startLine() << "Failed to match the " << pattern.getDebugName()
+                             << " pattern (matches " << *pattern.getRootKind()
+                             << ") on " << op->getName() << "\n";
+        });
+      };
+      auto onSuccess = [&](const Pattern &pattern) -> LogicalResult {
+        LLVM_DEBUG({
+          logger.unindent();
+          logger.startLine() << "Matched " << pattern.getDebugName()
+                             << " pattern on " << op->getName() << "\n";
+        });
+        return success();
+      };
+#else
+      function_ref<bool(const Pattern &)> canApply = {};
+      function_ref<void(const Pattern &)> onFailure = {};
+      function_ref<LogicalResult(const Pattern &)> onSuccess = {};
+#endif
+      opsExpectingRevisit.erase(op);
+      LogicalResult matchResult =
+          matcher.matchAndRewrite(op, *this, canApply, onFailure, onSuccess);
+      if (failed(matchResult)) {
+        LLVM_DEBUG(llvm::dbgs() << "Pattern match failed\n");
+        return failure();
+      }
+    }
+    currentWorklist.clear();
+  }
+  if (!opsExpectingRevisit.empty()) {
+#ifndef NDEBUG
+    for (Operation *op : opsExpectingRevisit) {
+      LLVM_DEBUG(logger.startLine() << "Failed to revisit " << *op << "\n");
+    }
+#endif
+    return failure();
+  }
+  return success();
+}
+
+LogicalResult applyAlignPatterns(Operation *op,
+                                 const FrozenRewritePatternSet &patterns) {
+  LinalgAlignRewriter rewriter(op->getContext());
+  PatternApplicator matcher(patterns);
+
+  llvm::SmallDenseSet<OperationName, 4> matchableOps;
+  for (const auto &entry : patterns.getOpSpecificNativePatterns())
+    matchableOps.insert(entry.first);
+  assert(patterns.getMatchAnyOpNativePatterns().empty() &&
+         "We're assuming no catch-all logic");
+  matcher.applyDefaultCostModel();
+
+  // Initialize worklist with patterns that might need to be processed
+  // top-down.
+  for (Region &region : op->getRegions()) {
+    for (Block &block : region.getBlocks()) {
+      for (Operation &op : block.getOperations()) {
+        if (matchableOps.contains(op.getName())) {
+          rewriter.scheduleVisit(&op);
+        }
+      }
+    }
+  }
+
+  return rewriter.drainWorklist(matcher);
+}
+
+void LinalgAlignRewriter::logOpActivity(llvm::StringLiteral prefix,
+                                        Operation *op) {
+#ifndef NDEBUG
+  LLVM_DEBUG({
+    logger.startLine() << prefix;
+    op->print(logger.getOStream(), OpPrintingFlags()
+                                       .skipRegions()
+                                       .printGenericOpForm()
+                                       .useLocalScope()
+                                       .elideLargeElementsAttrs());
+    logger.getOStream() << "\n";
+  });
+#else
+  std::ignore = prefix;
+  std::ignore = op;
+#endif
+}
+
+void LinalgAlignRewriter::notifyOperationModified(Operation *op) {
+  constexpr llvm::StringLiteral prefix("** Modified: ");
+  logOpActivity(prefix, op);
+}
+
+void LinalgAlignRewriter::notifyOperationInserted(Operation *op) {
+  constexpr llvm::StringLiteral prefix("** Insert  : '");
+  logOpActivity(prefix, op);
+}
+
+void LinalgAlignRewriter::notifyOperationRemoved(Operation *op) {
+  constexpr llvm::StringLiteral prefix("** Erase   : ");
+  logOpActivity(prefix, op);
+}
+
+void LinalgAlignRewriter::notifyOperationReplaced(Operation *op,
+                                                  ValueRange replacement) {
+  constexpr llvm::StringLiteral prefix("** Replace : ");
+  logOpActivity(prefix, op);
+  std::ignore = replacement;
+}
+
+void LinalgAlignRewriter::notifyBlockCreated(Block *block) {
+  std::ignore = block;
+}
+
+LogicalResult LinalgAlignRewriter::notifyMatchFailure(
+    Location loc, function_ref<void(Diagnostic &)> reasonCallback) {
+  LLVM_DEBUG({
+    Diagnostic diag(loc, DiagnosticSeverity::Remark);
+    reasonCallback(diag);
+    logger.startLine() << "** Failure : " << diag.str() << "\n";
+  });
+#ifdef NDEBUG
+  std::ignore = loc;
+  std::ignore reasonCallback;
+#endif
+  return failure();
+}
+
+/// Fusion
+
+static Value applyViewsOnDest(LinalgAlignRewriter &rewriter, Location loc,
                               Value dest, ArrayRef<TransformMapAttr> views) {
-  for (TransformMapAttr trMap : views) {
+  for (TransformMapAttr trMap : llvm::reverse(views)) {
     dest = rewriter.create<TransformOp>(loc, dest, trMap);
   }
   return dest;
-}
-
-Value makeRegs(PatternRewriter &b, MemRefType::Builder &mrb, Location loc,
-               Type srcType) {
-  auto srcMemType = srcType.cast<MemRefType>();
-  // 1. create a second allocation of the same type to hold loaded elements
-  return b.create<GpuAllocOp>(loc, static_cast<MemRefType>(mrb.setElementType(
-                                       srcMemType.getElementType())));
-}
-
-static Value applyTransforms(PatternRewriter &b, ThreadwiseWriteAllOp storeOp,
-                             Value src,
-                             ArrayRef<TransformMapAttr> relativeViewsOnStore) {
-  // 0. capture the memref containing the outputs being written
-  Location loc = storeOp.getLoc();
-  Value gemmOut = storeOp.getSource();
-
-  // 1. create a second allocation of the same type to hold loaded elements
-  MemRefType::Builder mrb(gemmOut.getType().cast<MemRefType>());
-  Value alloc = makeRegs(b, mrb, loc, src.getType());
-
-  // 2. clone twcopy for <addend> into regs
-  LLVM_DEBUG(llvm::dbgs() << "Src type: " << src.getType() << " dest type: "
-                          << storeOp.getDest().getType() << "\n");
-
-  // 2.0. first move all transforms before the relocated linalg.generic
-  moveTransformsBefore(b, src);
-
-  // 2.1. apply transform chain from output
-  src = applyViewsOnDest(b, loc, src, relativeViewsOnStore);
-
-  // 2.2. load into registers
-  b.create<ThreadwiseReadIntoOp>(loc, src, alloc, storeOp.getExtraViews(),
-                                 /*extraIndices=*/storeOp.getExtraIndices(),
-                                 storeOp.getForceUnroll(),
-                                 storeOp.getUseIndexDiffs());
-  return alloc;
-}
-
-static void traceToNonViewUsers(Operation *op,
-                                SmallVectorImpl<Operation *> &nonViewOps) {
-  if (auto transform = dyn_cast<TransformOp>(op)) {
-    Value result = transform.getResult();
-    for (auto &use : result.getUses()) {
-      traceToNonViewUsers(use.getOwner(), nonViewOps);
-    }
-  } else {
-    nonViewOps.push_back(op);
-  }
 }
 
 // This function traces to non view readers.
@@ -166,54 +403,37 @@ traceToNonViewReaders(Operation *op, Value parentVal,
                       SmallVectorImpl<Operation *> &nonViewReaders) {
   if (auto transform = dyn_cast<TransformOp>(op)) {
     Value result = transform.getResult();
+    bool recurStatus = true;
     for (auto &use : result.getUses()) {
-      return traceToNonViewReaders(use.getOwner(), result, nonViewReaders);
+      recurStatus &= succeeded(
+          traceToNonViewReaders(use.getOwner(), result, nonViewReaders));
+    }
+    return success(recurStatus);
+  }
+  if (auto twWriteAllOp = dyn_cast<ThreadwiseWriteAllOp>(op)) {
+    if (twWriteAllOp.getSource() == parentVal) {
+      nonViewReaders.push_back(op);
+    }
+    // linalg.generic is conservative when it comes to memory effects, so it
+    // needs to be handled separately.
+  } else if (auto linalgGeneric = dyn_cast<linalg::GenericOp>(op)) {
+    if (llvm::is_contained(linalgGeneric.getInputs(), parentVal)) {
+      nonViewReaders.push_back(op);
+    }
+  } else if (auto memEffectOp = dyn_cast<MemoryEffectOpInterface>(op)) {
+    if (hasEffect<MemoryEffects::Read>(memEffectOp, parentVal)) {
+      nonViewReaders.push_back(op);
+    }
+  } else if (auto copyOp = dyn_cast<CopyOpInterface>(op)) {
+    if (copyOp.getSource() == parentVal) {
+      nonViewReaders.push_back(op);
     }
   } else {
-    if (ThreadwiseWriteAllOp twWriteAllOp =
-            dyn_cast<ThreadwiseWriteAllOp>(op)) {
-      if (twWriteAllOp.getSource() == parentVal) {
-        nonViewReaders.push_back(op);
-      }
-    } else if (MemoryEffectOpInterface memEffectOp =
-                   dyn_cast<MemoryEffectOpInterface>(op)) {
-      if (hasEffect<MemoryEffects::Read>(memEffectOp, parentVal)) {
-        nonViewReaders.push_back(op);
-      }
-    } else if (CopyOpInterface copyOp = dyn_cast<CopyOpInterface>(op)) {
-      if (copyOp.getSource() == parentVal) {
-        nonViewReaders.push_back(op);
-      }
-    } else {
-      return op->emitError() << "Found an unsupported operator that needs to "
-                                "be added reader checks \n"
-                             << op;
-    }
+    return op->emitError() << "Found an unsupported operator that needs to "
+                              "be added reader checks \n"
+                           << op;
   }
   return success();
-}
-
-static Operation *traceToNonViewDef(Operation *op,
-                                    SmallVectorImpl<TransformMapAttr> &views,
-                                    Operation *terminator) {
-  if (op == terminator) {
-    return op;
-  }
-  if (auto transform = dyn_cast<TransformOp>(op)) {
-    Operation *nonViewDef = traceToNonViewDef(
-        transform.getViewSource().getDefiningOp(), views, terminator);
-    views.push_back(transform.getTransformAttr());
-    return nonViewDef;
-  }
-  return op;
-}
-
-static Operation *traceToNonViewDef(Operation *op) {
-  if (auto transform = dyn_cast<TransformOp>(op)) {
-    return traceToNonViewDef(transform.getViewSource().getDefiningOp());
-  } else {
-    return op;
-  }
 }
 
 // This function checks given a parent operation and a reader candidate
@@ -222,10 +442,10 @@ static Operation *traceToNonViewDef(Operation *op) {
 // and fused.
 static LogicalResult checkUniqueReader(Operation *op, Operation *reader,
                                        bool &isUnique) {
-  op = traceToNonViewDef(op);
-  SmallVector<Operation *, 4> nonViewReaders;
-  Operation *nonViewDef = traceToNonViewDef(op);
-  for (Value result : nonViewDef->getResults()) {
+  while (auto trOp = dyn_cast_if_present<TransformOp>(op))
+    op = trOp.getViewSource().getDefiningOp();
+  SmallVector<Operation *> nonViewReaders;
+  for (Value result : op->getResults()) {
     // if its block arg, it can have uses beyond the unit of compilation
     // in scope here.
     if (result.isa<BlockArgument>()) {
@@ -239,94 +459,255 @@ static LogicalResult checkUniqueReader(Operation *op, Operation *reader,
       }
     }
   }
-  if (nonViewReaders.size() != 1) {
+#ifndef NDEBUG
+  LLVM_DEBUG(llvm::dbgs() << "Non-view readers:\n");
+  for (Operation *reader : nonViewReaders)
+    LLVM_DEBUG(llvm::dbgs() << *reader << "\n");
+#endif
+  if (nonViewReaders.size() != 1)
     isUnique = false;
-  }
-  isUnique = (nonViewReaders[0] == reader);
+  else
+    isUnique = nonViewReaders[0] == reader;
   return success();
 }
 
-static ThreadwiseWriteAllOp traceToThreadwiseWrite(
-    Value inp, SmallVectorImpl<TransformMapAttr> &inpToTWWriteAllViews) {
+static Operation *
+traceToWriter(Value startVal,
+              SmallVectorImpl<TransformMapAttr> &writerToStartValViews) {
   // 1. Validate that the only uses of the linalg.generic input are the one
   // generic and a copy operation or transform.
-  ThreadwiseWriteAllOp result;
-  for (Operation *use : inp.getUsers()) {
-    SmallVector<Operation *, 4> nonViewUsers;
-    traceToNonViewUsers(use, nonViewUsers);
-    for (Operation *nonViewUse : nonViewUsers) {
-      if (isa<memref::DeallocOp>(nonViewUse)) {
-        // ignore
-        continue;
+  Operation *result = nullptr;
+  Operation *startValDef = startVal.getDefiningOp();
+  if (!startValDef)
+    return nullptr;
+  bool unique = true;
+  auto setResult = [&](Value val, Operation *theResult) {
+    if (result != nullptr) {
+      LLVM_DEBUG(llvm::dbgs() << "Found writer " << *theResult
+                              << " after finding " << *result << "\n");
+      unique = false;
+    } else {
+      result = theResult;
+      TransformOp trOp = dyn_cast_if_present<TransformOp>(val.getDefiningOp());
+      while (trOp && trOp != startValDef) {
+        writerToStartValViews.push_back(trOp.getTransformAttr());
+        trOp = dyn_cast_if_present<TransformOp>(
+            trOp.getViewSource().getDefiningOp());
       }
-      if (auto lgop = dyn_cast<linalg::GenericOp>(nonViewUse)) {
-        // We dont check for linalg.generic readers
-        // here because they could both be reading and writing
-        // to intermediary buffer that could be copied as an
-        // additional kernel output.
-      } else if (auto reduceOp = dyn_cast<ReduceOp>(nonViewUse)) {
-        // reader
-        if (inp != reduceOp.getIn()) {
-          return ThreadwiseWriteAllOp();
-        }
-      } else if (auto memcpy = dyn_cast<memref::CopyOp>(nonViewUse)) {
-        // reader
-        if (memcpy.getSource() != inp) {
-          return ThreadwiseWriteAllOp();
-        }
-      } else if (auto store = dyn_cast<ThreadwiseWriteAllOp>(nonViewUse)) {
-        // Threadwise copy that is already unttransformed (new style)
-        if (result) {
-          LLVM_DEBUG(llvm::dbgs() << "Multiple global stores somehow\n");
-          return ThreadwiseWriteAllOp();
-        } else {
-          SmallVector<TransformMapAttr> views;
-          traceToNonViewDef(store.getDest().getDefiningOp(), views,
-                            inp.getDefiningOp());
-          result = store;
-          inpToTWWriteAllViews.insert(inpToTWWriteAllViews.begin(),
-                                      views.begin(), views.end());
-        }
-      } else {
-        return ThreadwiseWriteAllOp();
+      // This recursion got us our transform stack in the opposite order.
+      llvm::reverse(writerToStartValViews);
+    }
+  };
+  SmallVector<std::pair<Value, Operation *>> worklist =
+      llvm::map_to_vector(startVal.getUsers(), [&](Operation *op) {
+        return std::make_pair(startVal, op);
+      });
+  while (!worklist.empty()) {
+    auto [val, use] = worklist.pop_back_val();
+    if (auto transformOp = dyn_cast<TransformOp>(use)) {
+      for (Operation *transformUse : transformOp->getUsers()) {
+        worklist.push_back({transformOp, transformUse});
       }
+    } else if (auto lgop = dyn_cast<linalg::GenericOp>(use)) {
+      if (llvm::is_contained(lgop.getOutputs(), val))
+        setResult(val, use);
+    } else if (auto reduceOp = dyn_cast<ReduceOp>(use)) {
+      if (val == reduceOp.getOut())
+        setResult(val, use);
+    } else if (auto memcpy = dyn_cast<memref::CopyOp>(use)) {
+      if (memcpy.getTarget() == val)
+        setResult(val, use);
+    } else if (auto store = dyn_cast<ThreadwiseWriteAllOp>(use)) {
+      if (store.getDest() == val)
+        setResult(val, use);
     }
   }
 
-  if (!result)
-    LLVM_DEBUG(llvm::dbgs() << "Align tiling: generic not tracing to copy\n");
+  if (!unique) {
+    LLVM_DEBUG(llvm::dbgs() << "Found multiple writers somehow\n");
+    result = nullptr;
+  }
   return result;
 }
 
-// Returns the value of the buffer that's meant to be the new writeback.
-static void
-reconfigureLAGeneric(PatternRewriter &b, linalg::GenericOp laGeneric,
-                     Value inRegs, Value outRegs,
-                     ThreadwiseWriteAllOp twWriteOp,
-                     ArrayRef<TransformMapAttr> relativeViewsOnStore) {
-  SmallVector<Value, 5> newInputs;
-  SmallVector<AffineMap, 5> lgAMaps;
+static Value makeRegs(LinalgAlignRewriter &b, MemRefType::Builder &mrb,
+                      Location loc, Type srcType) {
+  auto srcMemType = srcType.cast<MemRefType>();
+  // 1. create a second allocation of the same type to hold loaded elements
+  return b.create<GpuAllocOp>(loc, static_cast<MemRefType>(mrb.setElementType(
+                                       srcMemType.getElementType())));
+}
 
+static void markGenericWritersToRevisit(LinalgAlignRewriter &b,
+                                        Value transformedSource) {
+  Value source;
+  std::tie(source, std::ignore, std::ignore) =
+      untransform(b, transformedSource);
+  SmallVector<TransformMapAttr> views;
+  auto genericWriter =
+      dyn_cast_if_present<linalg::GenericOp>(traceToWriter(source, views));
+  if (genericWriter)
+    b.scheduleVisit(genericWriter);
+}
+
+template <typename TiledOp> Value getRegisterValue(TiledOp op);
+template <>
+Value getRegisterValue<ThreadwiseReadIntoOp>(ThreadwiseReadIntoOp op) {
+  return op.getDest();
+}
+template <>
+Value getRegisterValue<ThreadwiseWriteAllOp>(ThreadwiseWriteAllOp op) {
+  return op.getSource();
+}
+
+/// Given a `tiledOp` that has as its arguments the thread tile (a set of
+/// registers) and a global buffer (with some series of views applied, which
+/// have been collected into `globalCoordsToGenericViews`) indexed by a set of
+/// global coordinates, read the equivalent tile of `src` into a newly-created
+/// set of registers. The views in `globalCoordsToGenericViews` should produce
+/// coordinates that can index `src` (which will have the same size as the other
+/// generic inputs at this point thanks to regularization processes and view
+/// application).
+///
+/// While doing this, also mark any linalg.generic that write to this input as
+/// needing revisiting because we now know their tile size.
+///
+/// Returns the new register tile.
+template <typename TiledOp>
+static Value
+makeExtraInputTile(LinalgAlignRewriter &b, TiledOp tiledOp, Value src,
+                   ArrayRef<TransformMapAttr> globalCoordsToGenericViews) {
+  // 0. capture the memref containing the outputs being written or
+  // (in the case of propagating tiling informatinon up to gemm-independent
+  // code) where the values will be written.
+  Location loc = tiledOp.getLoc();
+  Value tile = getRegisterValue(tiledOp);
+
+  // 1. create a second allocation of the same type to hold loaded elements
+  MemRefType::Builder mrb(tile.getType().cast<MemRefType>());
+  Value alloc = makeRegs(b, mrb, loc, src.getType());
+
+  // 2. clone twcopy for <addend> into regs
+  LLVM_DEBUG(llvm::dbgs() << "Src type: " << src.getType()
+                          << " tile type: " << tile.getType() << "\n");
+
+  // 2.0. apply transform chain from output
+  src = applyViewsOnDest(b, loc, src, globalCoordsToGenericViews);
+
+  // 2.1. load into registers
+  b.create<ThreadwiseReadIntoOp>(loc, src, alloc, tiledOp.getExtraViews(),
+                                 /*extraIndices=*/tiledOp.getExtraIndices(),
+                                 tiledOp.getForceUnroll(),
+                                 tiledOp.getUseIndexDiffs());
+
+  // 3. Mark linalg.generic operations that populate this source buffer as
+  // operations that need to be re-checekd for fusion now that we know their
+  // tiling.
+  markGenericWritersToRevisit(b, src);
+
+  return alloc;
+}
+
+static Value findThreadwiseWrite(
+    linalg::GenericOp laGeneric, ThreadwiseWriteAllOp &twWriteOp,
+    SmallVectorImpl<TransformMapAttr> &globalCoordsToGenericViews) {
+  for (auto input : laGeneric.getInputs()) {
+    if (auto twop = dyn_cast_if_present<ThreadwiseWriteAllOp>(
+            traceToWriter(input, globalCoordsToGenericViews))) {
+      twWriteOp = twop;
+      return input;
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "No input is leading to a global store.\n");
+  return Value();
+}
+
+/// Find, if there is one, the threadwise_read_into that reads the output of
+/// this `linalg.generic` so that we have a tile size to use. If this fails,
+/// we'll neeed to revisit the operation later once we have a tile size.
+///
+/// Returns failure on an error during the search, and fails to set twReadOp
+/// if no reader is found.
+static LogicalResult findThreadwiseRead(
+    linalg::GenericOp laGeneric, ThreadwiseReadIntoOp &twReadOp,
+    SmallVectorImpl<TransformMapAttr> &globalCoordsToGenericViews) {
+  Value out = laGeneric.getOutputs().front();
+  SmallVector<Operation *> readers;
+  for (Operation *user : out.getUsers()) {
+    if (user == laGeneric)
+      continue;
+    if (failed(traceToNonViewReaders(user, out, readers)))
+      return failure();
+  }
+  for (Operation *reader : readers) {
+    twReadOp = dyn_cast<ThreadwiseReadIntoOp>(reader);
+    if (twReadOp) {
+      auto [underlying, isBig] =
+          untransform(twReadOp.getSource(), globalCoordsToGenericViews);
+      std::ignore = isBig;
+      if (underlying != out) {
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "A non-view threadwise_read_into of this linalg.generic's "
+               "output doesn't trace back to said output\n");
+        return failure();
+      }
+      return success();
+    }
+  }
+  LLVM_DEBUG(llvm::dbgs() << "Output doesn't lead to a tiled read either\n");
+  return success();
+}
+
+// Rewrite the inputs of a given linalg.generic to match the tiling from
+// the given `twWriteOp`, repalacing each input other than the one that the
+// `twWriteOp` was writing to with a `threadwise_read_into` with the
+// appropriate registers.
+static void addRegisterReadsForTiledInput(
+    LinalgAlignRewriter &b, linalg::GenericOp laGeneric,
+    Value laGenericInputLeadingToWrite, ThreadwiseWriteAllOp twWriteOp,
+    ArrayRef<TransformMapAttr> relativeViewsOnWrite,
+    SmallVectorImpl<Value> &newInputs) {
   for (auto inp : laGeneric.getInputs()) {
     Value newInput;
-    SmallVector<TransformMapAttr> views;
-    if (traceToThreadwiseWrite(inp, views)) {
-      newInput = inRegs;
+    if (inp == laGenericInputLeadingToWrite) {
+      newInput = twWriteOp.getSource();
     } else {
-      // 2.1.1. Align tiling of other inputs
-      newInput = applyTransforms(b, twWriteOp, inp, relativeViewsOnStore);
+      newInput = makeExtraInputTile(b, twWriteOp, inp, relativeViewsOnWrite);
     }
     newInputs.push_back(newInput);
+  }
+}
 
+/// As above, but applying
+static void
+addRegisterReadsForTiledOutput(LinalgAlignRewriter &b,
+                               linalg::GenericOp laGeneric,
+                               ThreadwiseReadIntoOp twReadOp,
+                               ArrayRef<TransformMapAttr> relativeViewsOnResult,
+                               SmallVectorImpl<Value> &newInputs) {
+  for (auto inp : laGeneric.getInputs()) {
+    Value newInput =
+        makeExtraInputTile(b, twReadOp, inp, relativeViewsOnResult);
+    newInputs.push_back(newInput);
+  }
+}
+
+static void reconfigureLAGeneric(LinalgAlignRewriter &b,
+                                 linalg::GenericOp laGeneric,
+                                 ValueRange newInputs, Value newOutput) {
+  SmallVector<AffineMap, 5> lgAMaps;
+
+  for (Value newInput : newInputs) {
     auto inpRank = newInput.getType().cast<ShapedType>().getRank();
     lgAMaps.push_back(b.getMultiDimIdentityMap(inpRank));
   }
 
   laGeneric.getInputsMutable().assign(newInputs);
-  laGeneric.getOutputsMutable().assign(outRegs);
+  laGeneric.getOutputsMutable().assign(newOutput);
 
-  // 2.2. Reset affine maps
-  auto regRank = inRegs.getType().cast<ShapedType>().getRank();
+  auto regRank = newOutput.getType().cast<ShapedType>().getRank();
 
   lgAMaps.push_back(b.getMultiDimIdentityMap(regRank));
   laGeneric.setIndexingMapsAttr(b.getAffineMapArrayAttr(lgAMaps));
@@ -339,135 +720,132 @@ reconfigureLAGeneric(PatternRewriter &b, linalg::GenericOp laGeneric,
   laGeneric.setIteratorTypesAttr(ArrayAttr::get(ctx, iteratorTypes));
 }
 
-static Value
-findThreadwiseWrite(linalg::GenericOp laGeneric,
-                    ThreadwiseWriteAllOp &twWriteOp,
-                    SmallVector<TransformMapAttr> &laInToOutViews) {
-  for (auto input : laGeneric.getInputs()) {
-    if (auto twop = traceToThreadwiseWrite(input, laInToOutViews)) {
-      twWriteOp = twop;
-      return input;
-    }
-  }
-
-  LLVM_DEBUG(llvm::dbgs() << "No input is leading to a global store.\n");
-  return Value();
-}
-
 LogicalResult
 LAGenericRewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
-                                         PatternRewriter &b) const {
+                                         LinalgAlignRewriter &b) const {
   Location loc = laGeneric.getLoc();
 
   // 0. Test compatibility
   // 0.0. Only fully parallel for now
   for (utils::IteratorType iterType : laGeneric.getIteratorTypesArray())
     if (!linalg::isParallelIterator(iterType))
-      return laGeneric.emitError("must be fully parallel");
+      return laGeneric.emitOpError("must be fully parallel");
 
   // 0.1. Test compatibility,  Only 1 output supported
   if (laGeneric.getOutputs().size() != 1)
-    return laGeneric.emitError("only 1 output supported");
+    return laGeneric.emitOpError("only 1 output supported");
   Value out = *laGeneric.getOutputs().begin();
 
-  // 0.2. Sanity check, skip already fused.
-  for (auto inp : laGeneric.getInputs()) {
-    if (auto fusedAlloc = inp.getDefiningOp<GpuAllocOp>()) {
-      LLVM_DEBUG(llvm::dbgs() << "Found existing fusion, bailing\n");
-      return failure();
-    }
+  // 0.2. Prevent re-applying pattern to existing fusions.
+  if (out.getDefiningOp<rock::GpuAllocOp>())
+    return b.notifyMatchFailure(loc,
+                                "encountered already-processed fusion op\n");
+
+  for (auto idxMap : laGeneric.getIndexingMapsArray())
+    if (!idxMap.isIdentity())
+      return b.notifyMatchFailure(loc, "indexing_maps must all be identity");
+
+  // 1. Find the tiling needed for this linalg generic.
+  // 1.1. Find the (implicit) gemm output, if it exists.
+  ThreadwiseWriteAllOp gemmStoreOp;
+  SmallVector<TransformMapAttr> globalCoordsToGenericViews;
+  Value laGenericArgLeadingToTile =
+      findThreadwiseWrite(laGeneric, gemmStoreOp, globalCoordsToGenericViews);
+
+  // 1.2. If there is no input being written, try to find a threadwise_read_into
+  // operation that reads from the output of this generic. If there is such an
+  ThreadwiseReadIntoOp tileReadOp;
+  if (!gemmStoreOp) {
+    if (failed(findThreadwiseRead(laGeneric, tileReadOp,
+                                  globalCoordsToGenericViews)))
+      return b.notifyMatchFailure(
+          loc, "search for readers hit something unexpected\n");
+    if (!tileReadOp)
+      // 1.2.1 If there's no threadwise reader, we don't know the tile size for
+      // this generic yet, and so have to wait for it to by put on the schedule
+      // by someone else using the input.
+      return b.needsRevisit(laGeneric);
+    laGenericArgLeadingToTile = out;
   }
 
-  // 1. Trace input to global_store.
-  // 1.1. Find the (implicit) gemm output
-  ThreadwiseWriteAllOp gemmStoreOp;
-  SmallVector<TransformMapAttr> laInToOutViews;
-  Value laGenericInputLeadingToGemmStore =
-      findThreadwiseWrite(laGeneric, gemmStoreOp, laInToOutViews);
-  if (!laGenericInputLeadingToGemmStore)
-    return failure();
-
+  // 2. The less common case, where the tile size and global coordinates come
+  // from a threadwise_read_into of the output of this generic.
+  if (!gemmStoreOp && tileReadOp) {
+    bool isUniqueReader = false;
+    if (failed(checkUniqueReader(laGenericArgLeadingToTile.getDefiningOp(),
+                                 tileReadOp, isUniqueReader)))
+      return b.notifyMatchFailure(
+          loc, "failed to check reader uniqueness of generic reader output");
+    if (!isUniqueReader) {
+      // Clone ourselves so that we can rewrite this writer without disturbing
+      // the rest of the fusion process.
+      b.scheduleVisit(laGeneric);
+      laGeneric = cast<linalg::GenericOp>(b.clone(*laGeneric));
+      // We have to move the insertion point to avoid SSA issues.
+      b.setInsertionPoint(laGeneric);
+    }
+    Value newOutput = tileReadOp.getDest();
+    SmallVector<Value> newInputs;
+    addRegisterReadsForTiledOutput(b, laGeneric, tileReadOp,
+                                   globalCoordsToGenericViews, newInputs);
+    // Prevent SSA weirdness from register allocations introduced too late.
+    b.moveBeforeIfNeeded(newOutput.getDefiningOp(), laGeneric);
+    reconfigureLAGeneric(b, laGeneric, newInputs, newOutput);
+    b.eraseOp(tileReadOp);
+    return success();
+  }
   auto outType = out.getType().cast<ShapedType>();
-  auto inpType = laGenericInputLeadingToGemmStore.getType().cast<ShapedType>();
+  auto inpType = laGenericArgLeadingToTile.getType().cast<ShapedType>();
   if (outType.getShape() != inpType.getShape()) {
     return laGeneric.emitError("input and output types must match");
   }
 
-  for (auto idxMap : laGeneric.getIndexingMapsArray()) {
-    if (!idxMap.isIdentity()) {
-      return laGeneric.emitError("indexing_maps must all be identity");
-    }
+  // 3. The typical case, where there's in inputh that traced back to a
+  // threadwise_write_all, which is the store of our gemm.
+  bool isUniqueReader = false;
+  if (failed(checkUniqueReader(laGenericArgLeadingToTile.getDefiningOp(),
+                               laGeneric, isUniqueReader))) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "This generic isn't the only reader from the gemm output\n");
   }
-
-  if (!gemmStoreOp) {
-    LLVM_DEBUG(llvm::dbgs() << "Align tiling: couldn't find writeback\n");
-    return failure();
-  }
-
-  // We check the input leading to GEMM store has the current LA generic,
-  // that is being rewritten, as the unique reader. This is because if it is the
-  // unique reader, the previous memref does not need to be maintained anymore
-  // and we can directly write into the outputs of the current linalg blocks.
-  // Moreover, this is checked before any rewrite happens to avoid interference
-  // and used later below.
-  bool isUniqueReader;
-  LogicalResult checkResult =
-      checkUniqueReader(laGenericInputLeadingToGemmStore.getDefiningOp(),
-                        laGeneric, isUniqueReader);
-  if (checkResult.failed()) {
-    return checkResult;
-  }
-
-  // 2. Apply if input found
-  Value gemmOut = gemmStoreOp.getSource();
-  auto gemmOutType = gemmOut.getType().cast<MemRefType>();
-
-  Value fusionRegs;
-  {
-    PatternRewriter::InsertionGuard guard(b);
-    // 2.0. Reset insertion point to before the copy.
-    b.setInsertionPoint(gemmOut.getDefiningOp());
-    // 2.1. Take out a slice of the result vector to create a vector-sized
-    // slice to enable creating the fusion section.
-    fusionRegs = b.create<GpuAllocOp>(loc, gemmOutType);
-  }
-
-  PatternRewriter::InsertionGuard guard(b);
-  // 2.0. Reset insertion point to before the copy.
-  b.setInsertionPoint(gemmStoreOp);
-
-  MemRefType::Builder mrb(gemmOutType);
-  auto laOutRegs = makeRegs(b, mrb, loc, out.getType());
-  // 2.2. Tile linalg.generic with vgpr as input, return output vgprs
-  reconfigureLAGeneric(b, laGeneric, fusionRegs, laOutRegs, gemmStoreOp,
-                       laInToOutViews);
-  // 2.2.0. Move the generic before the write-back. This'll put all
-  // the copy loops for other inputs before the generic due to insertion
-  // order.
-
-  // We need to clone ThreadwiseWriteAllOp if the current op is not the unique
-  // reader of it because the fusion process will eliminate the input memref.
   if (!isUniqueReader) {
-    gemmStoreOp =
-        static_cast<ThreadwiseWriteAllOp>(b.clone(*gemmStoreOp.getOperation()));
+    gemmStoreOp = cast<ThreadwiseWriteAllOp>(b.clone(*gemmStoreOp));
   }
-  gemmStoreOp->moveAfter(laGeneric);
-  gemmOut.replaceAllUsesWith(fusionRegs);
 
-  // 2.3. Replace rock.threadwise_write_all inputs with la.generic result vgprs
+  Value gemmOutRegs = gemmStoreOp.getSource();
+  auto gemmOutType = gemmOutRegs.getType().cast<MemRefType>();
+
+  // 3.1. Make an allocation that matches the tile but has the type of the
+  // linalg.generic output.
+  MemRefType::Builder mrb(gemmOutType);
+  Value laOutRegs = makeRegs(b, mrb, loc, out.getType());
+
+  // 3.2. Tile linalg.generic with vgpr as input, return output vgprs
+  SmallVector<Value> newInputs;
+  addRegisterReadsForTiledInput(b, laGeneric, laGenericArgLeadingToTile,
+                                gemmStoreOp, globalCoordsToGenericViews,
+                                newInputs);
+  reconfigureLAGeneric(b, laGeneric, newInputs, laOutRegs);
+
+  // 4. Amend the tiled write to write the fusion result to the output of this
+  // generic.
+
+  // 4.1.  Prevent SSA issues from adjusting the write.
+  b.moveAfterIfNeeded(gemmStoreOp, laGeneric);
+
+  // 4.2. Replace rock.threadwise_write_all inputs with la.generic result vgprs
   gemmStoreOp.getSourceMutable().assign(laOutRegs);
-  out = applyViewsOnDest(b, loc, out, laInToOutViews);
+
+  // 4.3 . Eliminate the intermediate allocation, applynig the chain of views
+  // on top of the eliminated temporary to the generic's output.
+  out = applyViewsOnDest(b, loc, out, globalCoordsToGenericViews);
   gemmStoreOp.getDestMutable().assign(out);
-
-  if (auto outAlloc = out.getDefiningOp<memref::AllocOp>()) {
-    outAlloc->moveBefore(gemmStoreOp);
-  }
-
   return success();
 }
 
-LogicalResult MemcpyRewritePattern::matchAndRewrite(memref::CopyOp copy,
-                                                    PatternRewriter &b) const {
+LogicalResult
+MemcpyRewritePattern::matchAndRewrite(memref::CopyOp copy,
+                                      LinalgAlignRewriter &b) const {
   auto src = copy.getSource();
   auto target = copy.getTarget();
   Location loc = copy.getLoc();
@@ -475,7 +853,8 @@ LogicalResult MemcpyRewritePattern::matchAndRewrite(memref::CopyOp copy,
   Operation *gemmStoreOp = nullptr;
   SmallVector<TransformMapAttr> views;
   if (auto allocOp = src.getDefiningOp<memref::AllocOp>()) {
-    if (auto twop = traceToThreadwiseWrite(src, views)) {
+    if (auto twop = dyn_cast_if_present<ThreadwiseWriteAllOp>(
+            traceToWriter(src, views))) {
       // We check the input leading to GEMM store has the current memref
       // copy, that is being rewritten, as the unique reader. This is because if
       // it is the unique reader, the previous memref does not need to be
@@ -499,18 +878,12 @@ LogicalResult MemcpyRewritePattern::matchAndRewrite(memref::CopyOp copy,
   if (gemmStoreOp) {
     if (ThreadwiseWriteAllOp twWriteAllOp =
             dyn_cast<ThreadwiseWriteAllOp>(gemmStoreOp)) {
-      PatternRewriter::InsertionGuard guard(b);
-      b.setInsertionPoint(twWriteAllOp);
+      b.moveAfterIfNeeded(twWriteAllOp, copy);
 
       // 1. replace memref.copy with rock.threadwise_write_all
       target = cast<TypedValue<BaseMemRefType>>(
           applyViewsOnDest(b, loc, target, views));
       twWriteAllOp.getDestMutable().assign(target);
-      // twWriteAllOp->moveAfter(target.getDefiningOp());
-
-      if (auto outAlloc = target.getDefiningOp<memref::AllocOp>()) {
-        outAlloc->moveBefore(gemmStoreOp);
-      }
 
       b.eraseOp(copy);
       return success();
@@ -520,27 +893,17 @@ LogicalResult MemcpyRewritePattern::matchAndRewrite(memref::CopyOp copy,
   return failure();
 }
 
-static bool isUnfusedKernelStore(ThreadwiseWriteAllOp store) {
-  bool ret = isa_and_nonnull<memref::AllocOp>(store.getDest().getDefiningOp());
-  if (ret) {
-    store.getDest().getDefiningOp()->emitOpError(
-        "could not use fusion to eliminate this intermediate buffer. Kernel "
-        "compilation cannot proceed");
-  }
-  return ret;
-}
-
 LogicalResult
 ReduceRewritePattern::matchAndRewrite(rock::ReduceOp reduceOp,
-                                      PatternRewriter &rewriter) const {
+                                      LinalgAlignRewriter &rewriter) const {
   Location loc = reduceOp.getLoc();
   SmallVector<TransformMapAttr, 4> views;
-  ThreadwiseWriteAllOp threadwiseWriteOp =
-      traceToThreadwiseWrite(reduceOp.getIn(), views);
+  auto threadwiseWriteOp = dyn_cast_if_present<ThreadwiseWriteAllOp>(
+      traceToWriter(reduceOp.getIn(), views));
   if (!threadwiseWriteOp) {
-    return rewriter.notifyMatchFailure(
-        reduceOp, "rock.reduce input is not leading to ThreadwiseWriteAllOp of "
-                  "the previous op.");
+    LLVM_DEBUG(llvm::dbgs() << "Not fusing reduction " << reduceOp
+                            << " as it's not tied directly to a gemm\n");
+    return success();
   }
 
   StoreMethodAttr stMethod;
@@ -576,6 +939,8 @@ ReduceRewritePattern::matchAndRewrite(rock::ReduceOp reduceOp,
     threadwiseWriteOp = static_cast<ThreadwiseWriteAllOp>(
         rewriter.clone(*threadwiseWriteOp.getOperation()));
   }
+  rewriter.moveAfterIfNeeded(threadwiseWriteOp, reduceOp);
+
   int64_t reductionAxis = reduceOp.getAxisAttr().getInt();
   TypedValue<ShapedType> redOut = reduceOp.getOut();
   ArrayRef<int64_t> reduceOutShape = redOut.getType().getShape();
@@ -591,15 +956,12 @@ ReduceRewritePattern::matchAndRewrite(rock::ReduceOp reduceOp,
   }
   TransformMapAttr trAttr = dropReductionDim.get();
   views.push_back(trAttr);
-  {
-    OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(threadwiseWriteOp);
-    TypedValue<ShapedType> reduceOut = reduceOp.getOut();
-    reduceOut = cast<TypedValue<ShapedType>>(
-        applyViewsOnDest(rewriter, loc, reduceOut, views));
-    threadwiseWriteOp.getDestMutable().assign(reduceOut);
-    threadwiseWriteOp.setStoreMethodAttr(stMethod);
-  }
+  TypedValue<ShapedType> reduceOut = reduceOp.getOut();
+  reduceOut = cast<TypedValue<ShapedType>>(
+      applyViewsOnDest(rewriter, loc, reduceOut, views));
+  threadwiseWriteOp.getDestMutable().assign(reduceOut);
+  threadwiseWriteOp.setStoreMethodAttr(stMethod);
+
   rewriter.eraseOp(reduceOp);
   return success();
 }
@@ -612,22 +974,9 @@ void RockLinalgAlignPass::runOnOperation() {
     return;
   {
     RewritePatternSet patterns(ctx);
-    patterns.add<LAGenericRewritePattern>(ctx);
-    patterns.add<ReduceRewritePattern>(ctx);
-    patterns.add<MemcpyRewritePattern>(ctx);
-    GreedyRewriteConfig config;
-    config.useTopDownTraversal = true;
-    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns), config)))
-      signalPassFailure();
-  }
-
-  {
-    WalkResult verifyAllStores =
-        func.walk([](ThreadwiseWriteAllOp store) {
-          return isUnfusedKernelStore(store) ? WalkResult::interrupt()
-                                             : WalkResult::advance();
-        });
-    if (verifyAllStores.wasInterrupted())
-      signalPassFailure();
+    patterns.add<LAGenericRewritePattern, ReduceRewritePattern,
+                 MemcpyRewritePattern>(ctx);
+    if (failed(applyAlignPatterns(func, std::move(patterns))))
+      return signalPassFailure();
   }
 }

--- a/mlir/test/fusion/linalg-generic-const-initializer.mlir
+++ b/mlir/test/fusion/linalg-generic-const-initializer.mlir
@@ -1,0 +1,66 @@
+// RUN: rocmlir-opt -rock-linalg-align < %s | FileCheck %s
+#map18 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 floordiv 64, (d3 mod 64) floordiv 32, (d3 mod 32) floordiv 16, d3 mod 16, d4 floordiv 32, (d4 mod 32) floordiv 8, d4 mod 8)>
+#map19 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d0, (((d1 * 4 + d7) * 2 + d3) * 8 + d9) * 2 + d5, ((d2 * 4 + d8) * 2 + d4) * 16 + d6)>
+#map20 = affine_map<() -> ()>
+#map21 = affine_map<(d0) -> (0, 0, d0)>
+#map22 = affine_map<(d0, d1, d2) -> (d2)>
+#map23 = affine_map<(d0, d1, d2) -> (0, 0, d2)>
+#map24 = affine_map<(d0, d1, d2) -> ()>
+#map25 = affine_map<(d0, d1, d2) -> (0, 0, 0)>
+#map26 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#transform_map22 = #rock.transform_map<#map18 by [<PassThrough ["g_block", "m_block", "n_block"] at [0, 1, 2] -> ["g_block", "m_block", "n_block"] at [0, 1, 2]>, <Merge{2, 2, 2, 16} ["tid"] at [3] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [3, 4, 5, 6]>, <Merge{4, 4, 8} ["item"] at [4] -> ["rep_i", "rep_j", "item_i"] at [7, 8, 9]>] bounds = [32, 3, 24, 128, 128] -> [32, 3, 24, 2, 2, 2, 16, 4, 4, 8]>
+#transform_map23 = #rock.transform_map<#map19 by [<PassThrough ["g_block"] at [0] -> ["gemmG"] at [0]>, <Unmerge{3, 4, 2, 8, 2} ["m_block", "rep_i", "wave_m", "item_i", "m_tid"] at [1, 7, 3, 9, 5] -> ["gemmM"] at [1]>, <Unmerge{24, 4, 2, 16} ["n_block", "rep_j", "wave_n", "n_tid"] at [2, 8, 4, 6] -> ["gemmN"] at [2]>] bounds = [32, 3, 24, 2, 2, 2, 16, 4, 4, 8] -> [32, 384, 3072]>
+#transform_map24 = #rock.transform_map<#map21 by [<Merge{1, 1, 3072} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [3072] -> [1, 1, 3072]>
+#transform_map25 = #rock.transform_map<#map22 by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>, <PassThrough ["dim0"] at [2] -> ["dim0"] at [0]>] bounds = [1, 1, 3072] -> [3072]>
+#transform_map26 = #rock.transform_map<#map23 by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <Broadcast{1} ["dim1"] at [1] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [2]>] bounds = [32, 384, 3072] -> [1, 1, 3072]>
+#transform_map27 = #rock.transform_map<#map24 by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>, <AddDim{1} ["exp2"] at [2] -> [] at []>] bounds = [1, 1, 1] -> []>
+#transform_map28 = #rock.transform_map<#map25 by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <Broadcast{1} ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>] bounds = [32, 384, 3072] -> [1, 1, 1]>
+// A cut down version of the input from
+// https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1098
+// right before it headed down to linalg.generic. The actuall gemm part has been
+// removed for test simplicity.
+module {
+  func.func @mlir_simplified_issue_(%arg0: memref<1x1x3072xf32>, %arg1: memref<32x384x768xi8>, %arg2: memref<32x768x3072xi8>, %arg3: memref<32x384x3072xi8>) attributes {arch = "gfx1100", block_size = 128 : i32, grid_size = 2304 : i32, kernel = "mixr", num_cu = 48 : i64, wave_size = 32 : i32} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 34.907238 : f32
+    %cst_4 = arith.constant 1.270000e+02 : f32
+    %cst_5 = arith.constant -1.280000e+02 : f32
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x384x3072xi32>
+    // CHECK: [[gemmTile:%.+]] = rock.alloc() : memref<128xi32
+    %47 = rock.alloc() : memref<128xi32, #gpu.address_space<private>>
+    rock.threadwise_write_all features =  dot|atomic_add|atomic_fmax_f32|wmma {forceUnroll, useIndexDiffs} %47 -> [#transform_map22, #transform_map23](%alloc) [%c0, %c0, %c0, %c0] by  set : memref<128xi32, #gpu.address_space<private>> -> memref<32x384x3072xi32>
+    // CHECK: [[cstTile:%.+]] = rock.alloc() : memref<128xf32, #gpu.address_space<private>>
+    // CHECK-NEXT: linalg.generic
+    // CHECK-SAME: outs([[cstTile]]
+    %alloc_18 = memref.alloc() {alignment = 64 : i64} : memref<f32>
+    linalg.generic {indexing_maps = [#map20], iterator_types = []} outs(%alloc_18 : memref<f32>) {
+    ^bb0(%out: f32):
+      linalg.yield %cst : f32
+    }
+    %48 = rock.transform %arg0 by #transform_map24 : memref<1x1x3072xf32> to memref<3072xf32>
+    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<32x384x3072xi8>
+    %49 = rock.transform %48 by #transform_map25 : memref<3072xf32> to memref<1x1x3072xf32>
+    %50 = rock.transform %49 by #transform_map26 : memref<1x1x3072xf32> to memref<32x384x3072xf32>
+    %51 = rock.transform %alloc_18 by #transform_map27 : memref<f32> to memref<1x1x1xf32>
+    %52 = rock.transform %51 by #transform_map28 : memref<1x1x1xf32> to memref<32x384x3072xf32>
+    // CHECK: [[globalTile:%.+]] = rock.alloc() : memref<128xf32
+    // CHECK-NEXT: threadwise_read_into
+    // CHECK-SAME -> [[globalTile]]
+    // CHECK: linalg.generic
+    // CHECK-SAME: ins([[gemmTile]], [[globalTile]], [[cstTile]]
+    linalg.generic {indexing_maps = [#map26, #map26, #map26, #map26], iterator_types = ["parallel", "parallel", "parallel"]} ins(%alloc, %50, %52 : memref<32x384x3072xi32>, memref<32x384x3072xf32>, memref<32x384x3072xf32>) outs(%alloc_19 : memref<32x384x3072xi8>) {
+    ^bb0(%in: i32, %in_20: f32, %in_21: f32, %out: i8):
+      %53 = arith.sitofp %in : i32 to f32
+      %55 = arith.addf %53, %in_20 : f32
+      %61 = arith.mulf %55, %in_21 : f32
+      %62 = math.roundeven %61 : f32
+      %63 = arith.minf %62, %cst_4 : f32
+      %64 = arith.maxf %63, %cst_5 : f32
+      %65 = arith.fptosi %64 : f32 to i8
+      linalg.yield %65 : i8
+    }
+    memref.copy %alloc_19, %arg3 : memref<32x384x3072xi8> to memref<32x384x3072xi8>
+    return
+  }
+}
+

--- a/mlir/test/fusion/linalg-generic-sigmoid-elementwise-block.mlir
+++ b/mlir/test/fusion/linalg-generic-sigmoid-elementwise-block.mlir
@@ -1,0 +1,96 @@
+// RUN: rocmlir-opt -rock-linalg-align < %s | FileCheck %s
+
+#map2 = affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)>
+#map5 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map10 = affine_map<(d0, d1) -> (0, d1)>
+#map18 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 floordiv 32, (d3 mod 32) floordiv 16, (d3 mod 16) floordiv 4, d3 mod 4, d4 floordiv 8, (d4 mod 8) floordiv 4, (d4 mod 4) floordiv 2, d4 mod 2)>
+#map19 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10) -> (d0, (((d1 * 2 + d7) * 2 + d3) * 4 + d5) * 2 + d8, (((d2 * 2 + d9) * 2 + d4) * 4 + d6) * 2 + d10)>
+#map20 = affine_map<(d0, d1) -> (d0, d1)>
+#map21 = affine_map<(d0) -> (0, d0)>
+#map22 = affine_map<(d0, d1) -> (d1)>
+#transform_map4 = #rock.transform_map<#map2 by [<Unmerge{1, 2} ["col0", "col1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 5] -> [2, 5]>
+#transform_map8 = #rock.transform_map<#map5 by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 30} ["gemmMPad"] at [1] -> ["gemmM"] at [1]>, <Pad{0, 27} ["gemmNPad"] at [2] -> ["gemmN"] at [2]>] bounds = [1, 32, 32] -> [1, 2, 5]>
+#transform_map32 = #rock.transform_map<#map18 by [<PassThrough ["g_block", "m_block", "n_block"] at [0, 1, 2] -> ["g_block", "m_block", "n_block"] at [0, 1, 2]>, <Merge{2, 2, 4, 4} ["tid"] at [3] -> ["m_cuwaves", "n_cuwaves", "m_cuwave", "n_cuwave"] at [3, 4, 5, 6]>, <Merge{2, 2, 2, 2} ["iter"] at [4] -> ["m_repeat", "m_thread", "n_repeat", "n_thread"] at [7, 8, 9, 10]>] bounds = [1, 1, 1, 64, 16] -> [1, 1, 1, 2, 2, 4, 4, 2, 2, 2, 2]>
+#transform_map33 = #rock.transform_map<#map19 by [<PassThrough ["g_block"] at [0] -> ["gemmG"] at [0]>, <Unmerge{1, 2, 2, 4, 2} ["m_block", "m_repeat", "m_cuwaves", "m_cuwave", "m_thread"] at [1, 7, 3, 5, 8] -> ["gemmM"] at [1]>, <Unmerge{1, 2, 2, 4, 2} ["n_block", "n_repeat", "n_cuwaves", "n_cuwave", "n_thread"] at [2, 9, 4, 6, 10] -> ["gemmN"] at [2]>] bounds = [1, 1, 1, 2, 2, 4, 4, 2, 2, 2, 2] -> [1, 32, 32]>
+#transform_map34 = #rock.transform_map<#map21 by [<Merge{1, 5} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>] bounds = [5] -> [1, 5]>
+#transform_map35 = #rock.transform_map<#map22 by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <PassThrough ["dim0"] at [1] -> ["dim0"] at [0]>] bounds = [1, 5] -> [5]>
+#transform_map36 = #rock.transform_map<#map10 by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>] bounds = [2, 5] -> [1, 5]>
+// Cut down version of a MIGraphX test that triggered a crash, see
+// https://github.com/ROCmSoftwarePlatform/rocMLIR/issues/1188
+// Arguments have been rearranged to make pattern matching easier.
+
+module {
+  // CHECK-LABEL: @mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add
+  // CHECK-SAME: ([[arg0:%[^:]+]]: memref<2x5xf32>, [[arg1:%[^:]+]]: memref<2x5xf32>
+  func.func @mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>, %arg2: memref<1x5xf32>, %arg3: memref<2x5xf32>,  %arg4: memref<2x5xf32>, %arg5: memref<2x5xf32>, %arg6: memref<2x5xf32>, %arg7: memref<15x5xf32>, %arg8: memref<2x5xf32>) attributes {arch = "gfx1100", block_size = 64 : i32, grid_size = 1 : i32, kernel = "mixr", num_cu = 48 : i64, wave_size = 32 : i32} {
+    %cst = arith.constant 1.000000e+00 : f32
+    %alloc = memref.alloc() : memref<2x5xf32>
+    %4 = rock.transform %alloc by #transform_map4 : memref<2x5xf32> to memref<1x2x5xf32>
+    %8 = rock.transform %4 by #transform_map8 : memref<1x2x5xf32> to memref<1x32x32xf32>
+    %c0 = arith.constant 0 : index
+    // CHECK: [[gemmAlloc:%.+]] = rock.alloc() : memref<16xf32
+    %11 = rock.alloc() : memref<16xf32, #gpu.address_space<private>>
+    rock.threadwise_write_all features =  dot|atomic_add|atomic_fmax_f32 {forceUnroll, useIndexDiffs} %11 -> [#transform_map32, #transform_map33](%8) [%c0, %c0, %c0, %c0] by  set : memref<16xf32, #gpu.address_space<private>> -> memref<1x32x32xf32>
+    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<2x5xf32>
+    %alloc_13 = memref.alloc() {alignment = 64 : i64} : memref<2x5xf32>
+
+    // CHECK: [[arg0_alloc:%.+]] = rock.alloc() : memref<16xf32
+    // CHECK-NEXT: [[arg0_group:%.+]] = rock.transform [[arg0]]
+    // CHECK-SAME: memref<2x5xf32> to memref<1x2x5xf32>
+    // CHECK-NEXT: [[arg0_padded:%.+]] = rock.transform [[arg0_group]]
+    // CHECK-SAME: memref<1x2x5xf32> to memref<1x32x32xf32>
+    // CHECK-NEXT: rock.threadwise_read_into
+    // CHECK-SAME: [[arg0_padded]]
+    // CHECK-SAME: [[arg0_alloc]]
+    // CHECK-NEXT: [[arg1_alloc:%.+]] = rock.alloc() : memref<16xf32
+    // CHECK-NEXT: [[arg1_group:%.+]] = rock.transform [[arg1]]
+    // CHECK-SAME: memref<2x5xf32> to memref<1x2x5xf32>
+    // CHECK-NEXT: [[arg1_padded:%.+]] = rock.transform [[arg1_group]]
+    // CHECK-SAME: memref<1x2x5xf32> to memref<1x32x32xf32>
+    // CHECK-NEXT: rock.threadwise_read_into
+    // CHECK-SAME: [[arg1_padded]]
+    // CHECK-SAME: [[arg1_alloc]]
+    // CHECK-NEXT: [[cst_alloc0:%.+]] = rock.alloc() : memref<16xf32
+    // CHECK-NEXT: linalg.generic
+    // CHECK-SAME: ins([[arg0_alloc]], [[arg1_alloc]]
+    // CHECK-SAME: outs([[cst_alloc0]]
+
+    // Since the original allocation is read twice by the second generic, we
+    // have two copies of said generic floating around, as is needed for general
+    // correctness.
+    // CHECK: rock.threadwise_read_into
+    // CHECK: rock.threadwise_read_into
+    // CHECK-NEXT: [[cst_alloc1:%.+]] = rock.alloc
+    // CHECK-NEXT: linalg.generic
+    // CHECK-SAME: outs([[cst_alloc1]]
+    linalg.generic {indexing_maps = [#map20, #map20, #map20], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : memref<2x5xf32>, memref<2x5xf32>) outs(%alloc_13 : memref<2x5xf32>) {
+    ^bb0(%in: f32, %in_14: f32, %out: f32):
+      %54 = arith.addf %in, %in_14 : f32
+      %55 = arith.negf %54 : f32
+      %56 = math.exp %55 : f32
+      %57 = arith.addf %56, %cst : f32
+      %58 = arith.divf %cst, %57 : f32
+      linalg.yield %58 : f32
+    }
+    %51 = rock.transform %arg2 by #transform_map34 : memref<1x5xf32> to memref<5xf32>
+    %52 = rock.transform %51 by #transform_map35 : memref<5xf32> to memref<1x5xf32>
+    %53 = rock.transform %52 by #transform_map36 : memref<1x5xf32> to memref<2x5xf32>
+    // CHECK: linalg.generic
+    // CHECK-SAME: [[cst_alloc1]]
+    // CHECK-SAME: [[cst_alloc0]]
+    linalg.generic {indexing_maps = [#map20, #map20, #map20, #map20, #map20, #map20, #map20, #map20], iterator_types = ["parallel", "parallel"]} ins(%arg4, %alloc_13, %arg3, %alloc, %53, %alloc_13, %arg5 : memref<2x5xf32>, memref<2x5xf32>, memref<2x5xf32>, memref<2x5xf32>, memref<2x5xf32>, memref<2x5xf32>, memref<2x5xf32>) outs(%alloc_12 : memref<2x5xf32>) {
+    ^bb0(%in: f32, %in_14: f32, %in_15: f32, %in_16: f32, %in_17: f32, %in_18: f32, %in_19: f32, %out: f32):
+      %54 = arith.addf %in_16, %in_17 : f32
+      %55 = arith.addf %in_15, %54 : f32
+      %56 = math.tanh %55 : f32
+      %57 = arith.subf %in, %in_14 : f32
+      %58 = arith.mulf %57, %56 : f32
+      %59 = arith.mulf %in_18, %in_19 : f32
+      %60 = arith.addf %58, %59 : f32
+      linalg.yield %60 : f32
+    }
+    memref.copy %alloc_12, %arg8 : memref<2x5xf32> to memref<2x5xf32>
+    return
+  }
+}
+

--- a/mlir/test/fusion/pr-e2e/mixr-complex-elementwise-functions-issue-1188.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-complex-elementwise-functions-issue-1188.mlir
@@ -1,18 +1,29 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx %s | rocmlir-driver -host-pipeline=partition,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add --verifier clone - | rocmlir-driver -c -arch %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
+// Note the fake wrapper function to make it look like this has already been partitioned,
+// since we want "partition" for the xmodel packaging but don't actually want to use
+// the partition logic.
+// This is an awkward hack that should be fixed Later (tm)
 module {
-  func.func @mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add(%arg0: tensor<1x5xf32>, %arg1: tensor<2x5xf32>, %arg2: tensor<2x5xf32>, %arg3: tensor<2x5xf32>, %arg4: tensor<2x5xf32>, %arg5: tensor<2x5xf32>, %arg6: tensor<2x5xf32>, %arg7: tensor<15x5xf32>) -> tensor<2x5xf32> attributes {kernel = "mixr", num_cu = 48 : i64} {
+  func.func @mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add_real(%arg0: tensor<1x5xf32>, %arg1: tensor<2x5xf32>, %arg2: tensor<2x5xf32>, %arg3: tensor<2x5xf32>, %arg4: tensor<2x5xf32>, %arg5: tensor<2x5xf32>, %arg6: tensor<2x5xf32>, %arg7: tensor<15x5xf32>) -> tensor<2x5xf32> attributes {kernel = "mixr", num_cu = 48 : i64} {
     %0 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [2, 5]} : (tensor<1x5xf32>) -> tensor<2x5xf32>
     %1 = migraphx.transpose(%arg7) {permutation = [1, 0]} : (tensor<15x5xf32>) -> tensor<5x15xf32>
     %2 = migraphx.slice(%1) {axes = [1], ends = [15], starts = [10]} : (tensor<5x15xf32>) -> tensor<5x5xf32>
-    %3 = migraphx.dot(%arg6, %2) : (tensor<2x5xf32>, tensor<5x5xf32>) -> tensor<2x5xf32>    %4 = migraphx.add(%3, %0) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
-    %5 = migraphx.add(%arg1, %4) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>    %6 = migraphx.tanh(%5) : (tensor<2x5xf32>) -> tensor<2x5xf32>
+    %3 = migraphx.dot(%arg6, %2) : (tensor<2x5xf32>, tensor<5x5xf32>) -> tensor<2x5xf32>
+    %4 = migraphx.add(%3, %0) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    %5 = migraphx.add(%arg1, %4) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    %6 = migraphx.tanh(%5) : (tensor<2x5xf32>) -> tensor<2x5xf32>
     %7 = migraphx.add(%arg2, %arg3) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
     %8 = migraphx.sigmoid(%7) : (tensor<2x5xf32>) -> tensor<2x5xf32>
     %9 = migraphx.sub(%arg4, %8) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
     %10 = migraphx.mul(%9, %6) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
     %11 = migraphx.mul(%8, %arg5) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
-    %12 = migraphx.add(%10, %11) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>    return %12 : tensor<2x5xf32>
+    %12 = migraphx.add(%10, %11) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    return %12 : tensor<2x5xf32>
+  }
+  func.func @mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add(%arg0: tensor<1x5xf32>, %arg1: tensor<2x5xf32>, %arg2: tensor<2x5xf32>, %arg3: tensor<2x5xf32>, %arg4: tensor<2x5xf32>, %arg5: tensor<2x5xf32>, %arg6: tensor<2x5xf32>, %arg7: tensor<15x5xf32>) -> tensor<2x5xf32> {
+    %ret = call @mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add_real(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) : (tensor<1x5xf32>, tensor<2x5xf32>, tensor<2x5xf32>, tensor<2x5xf32>, tensor<2x5xf32>, tensor<2x5xf32>, tensor<2x5xf32>, tensor<15x5xf32>) -> (tensor<2x5xf32>)
+    return %ret : tensor<2x5xf32>
   }
 }

--- a/mlir/test/fusion/pr-e2e/mixr-complex-elementwise-functions-issue-1188.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-complex-elementwise-functions-issue-1188.mlir
@@ -1,0 +1,18 @@
+// RUN: rocmlir-driver -kernel-pipeline=migraphx %s | rocmlir-driver -host-pipeline=partition,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add --verifier clone - | rocmlir-driver -c -arch %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func @mlir_transpose_slice_dot_add_add_tanh_add_sigmoid_sub_mul_mul_add(%arg0: tensor<1x5xf32>, %arg1: tensor<2x5xf32>, %arg2: tensor<2x5xf32>, %arg3: tensor<2x5xf32>, %arg4: tensor<2x5xf32>, %arg5: tensor<2x5xf32>, %arg6: tensor<2x5xf32>, %arg7: tensor<15x5xf32>) -> tensor<2x5xf32> attributes {kernel = "mixr", num_cu = 48 : i64} {
+    %0 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [2, 5]} : (tensor<1x5xf32>) -> tensor<2x5xf32>
+    %1 = migraphx.transpose(%arg7) {permutation = [1, 0]} : (tensor<15x5xf32>) -> tensor<5x15xf32>
+    %2 = migraphx.slice(%1) {axes = [1], ends = [15], starts = [10]} : (tensor<5x15xf32>) -> tensor<5x5xf32>
+    %3 = migraphx.dot(%arg6, %2) : (tensor<2x5xf32>, tensor<5x5xf32>) -> tensor<2x5xf32>    %4 = migraphx.add(%3, %0) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    %5 = migraphx.add(%arg1, %4) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>    %6 = migraphx.tanh(%5) : (tensor<2x5xf32>) -> tensor<2x5xf32>
+    %7 = migraphx.add(%arg2, %arg3) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    %8 = migraphx.sigmoid(%7) : (tensor<2x5xf32>) -> tensor<2x5xf32>
+    %9 = migraphx.sub(%arg4, %8) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    %10 = migraphx.mul(%9, %6) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    %11 = migraphx.mul(%8, %arg5) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>
+    %12 = migraphx.add(%10, %11) : (tensor<2x5xf32>, tensor<2x5xf32>) -> tensor<2x5xf32>    return %12 : tensor<2x5xf32>
+  }
+}


### PR DESCRIPTION
This commit fixes the handling of linalg.generic blocks where none of
the inputs participate in a chain of writers that lead to a gemm, but
that feed into such chains. For example, the linalg.generic blocks
that ultimately result from the `migraphx.add(%arg2, %arg3)` in the
example test.

The general solution requires us to add a second case to the
linalg.generic fusion matching. The fusion logic would previously scan
the inputs of a linalg.generic for a threadwise_write_all, which it
would use to get a tile size, set of global coordinates, and a set of
transformations that had to be applied to those arguments in order to
make them all indexable with said global coordinates.

Now, we support a second case: tracing from the output of a
linalg.generic to a threadwise_read_into that was generated by another
round of fusion. That threadwise_read_into then gives us the tiling
information we need to efficiently load a relevant tile of any
additional constant arguments.

Implementing this "visit a generic that we can't do
anything with but might handle later" pattern required control over
the pattern matching worklist that none of the upstream pattern
rewrites could provide. Therefore, this commit defines its own
subclass PatternRewriter - the LinalgAlignRewriter, that lets us
schedule revisits after an initial top-down pass. This rewriter also
provides failure behavior that is more in keeping with how we're using
the rewrite patterns - failure of any rewrite indicates malformed IR
that should fail the fusion pass, as opposed to the current approach
where it leads to stray memref.alloc() ops that throw errors near the
backend.

The fusion flow is relatively unchanged, aside from some variables
being remaned for clarity. The main changes are that the code which
creates threadwise_read_into operations now goes in and schedules the
linalg.generic that wrote the buffer (if any) for re-processing.

Other changes including traceToThreadwiseWriteAll() to
traceToWriter(), removing a function that was equivalant to
untransform().

The fusion flow is also changed to move the writes after the relevant
linalg.generic instead of trying to clone things before the write so
as to prevent use-before-def problems that may have arisen with the
old approach.

We also fix handling of 0-D inputs to threadwise_read_into and
threadwise_write_all in blockwise-gemm-to-threadwise since I needed
that in a previous iteration of the PR and there's no reason to let
that code go to waste.

There is also now a new version of untransform() that doesn't package
the attributes into an ArrayAttr.

Fixes #1188

Fixes
https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1098