### PR TITLE
Introduce the rock.threadwise_transpose to ease the grouping of operations during a pipeline pass

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1260,7 +1260,7 @@ def Rock_ThreadwiseTransposeOp :
     Rock_Op<"threadwise_transpose">,
     AllElementTypesMatch<["source", "dest"]>,
     Arguments<(ins
-      Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemWrite]>:$source,
+      Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemRead]>:$source,
       Arg<MemRefOf<SupportedMemoryElems>, "detination view", [MemWrite]>:$dest,
       I64Attr : $kpack,
       UnitAttr:$forceUnroll,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1256,4 +1256,27 @@ def Rock_InWarpTransposeOp :
     # !cast<string>(swizzleGroupSize) # ";\n";
 }
 
+def Rock_ThreadwiseTransposeOp :
+    Rock_Op<"threadwise_transpose">,
+    AllElementTypesMatch<["source", "dest"]>,
+    Arguments<(ins
+      Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemWrite]>:$source,
+      Arg<MemRefOf<SupportedMemoryElems>, "detination view", [MemWrite]>:$dest,
+      I64Attr : $kpack,
+      UnitAttr:$forceUnroll,
+      UnitAttr:$useIndexDiffs
+    )> {
+  let summary = "Threadwise register-to-register transpose";
+
+  let description = [{
+    `rock.threadwise_transpose` accepts a source view and a destination view and copy
+    data from source to destination.
+  }];
+
+  let assemblyFormat = [{
+    attr-dict $source  `->` $dest `:` type($source) `->` type($dest)
+  }];
+  let hasVerifier = 0;
+}
+
 #endif // ROCK_OPS

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
 #include "mlir/Dialect/Rock/utility/builderUtils.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
+#include "mlir/Dialect/Rock/utility/math.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -575,7 +576,97 @@ struct ThreadwiseWriteAllRewritePattern
   LogicalResult matchAndRewrite(ThreadwiseWriteAllOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const final;
 };
+
+struct ThreadwiseTransposeRewritePattern
+    : public OpConversionPattern<ThreadwiseTransposeOp> {
+  using OpConversionPattern<ThreadwiseTransposeOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(ThreadwiseTransposeOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &b) const final;
+};
 } // end anonymous namespace
+
+LogicalResult ThreadwiseTransposeRewritePattern::matchAndRewrite(
+    ThreadwiseTransposeOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &b) const {
+  Location loc = op.getLoc();
+  auto sourceView = cast<TypedValue<MemRefType>>(adaptor.getSource());
+  auto destView = cast<TypedValue<MemRefType>>(adaptor.getDest());
+
+  ArrayRef<int64_t> loadShape =
+      sourceView.getType().cast<ShapedType>().getShape();
+  Type elemType = sourceView.getType().cast<MemRefType>().getElementType();
+  int64_t copyDPerThread = loadShape[1];
+  int64_t copyKPerThread = loadShape[0];
+  int64_t kpack = op.getKpack();
+
+  // We use kpackPerThread instead of kpack to cover edge cases where
+  // copyKPerThread is smaller than kpack
+  int64_t kpackPerThread = std::min(copyKPerThread, kpack);
+
+  Value rawLoadBuffer;
+  ArrayAttr loadBufferView;
+  bool needs64BitIdx;
+  std::tie(rawLoadBuffer, loadBufferView, needs64BitIdx) =
+      untransform(b, sourceView);
+  assert(!needs64BitIdx && "Registers shouldn't need 64-bit indexing");
+  ArrayRef<int64_t> rawLoadBufferShape =
+      rawLoadBuffer.getType().cast<ShapedType>().getShape();
+
+  Value rawStoreBuffer;
+  ArrayAttr storeBufferView;
+  std::tie(rawStoreBuffer, storeBufferView, needs64BitIdx) =
+      untransform(b, destView);
+  assert(!needs64BitIdx && "Registers shouldn't need 64-bit indexing");
+  ArrayRef<int64_t> rawStoreBufferShape =
+      rawStoreBuffer.getType().cast<ShapedType>().getShape();
+
+  Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
+  SmallVector<Value, 2> start(2, zero);
+  SmallVector<int64_t, 2> strides(2, 1);
+  int64_t vecLen = 1;
+  // The store buffer is a flattened < kouter x dPerThread x kpack >.
+  if (kpackPerThread == 1) {
+    // if kpack == 1, then we can do vectorized loads across d dimension from/to
+    // load/store buffer
+    vecLen = getMaxVectorizationForDatatype(loadBufferView, /*dim=*/1,
+                                            copyDPerThread, rawLoadBufferShape,
+                                            elemType);
+    vecLen = math_util::gcd(copyDPerThread, vecLen);
+    strides[1] = vecLen;
+  } else {
+    // if kpack > 1, then we are limited by vectorization in k dimension and it
+    // could be at most kpack.
+    vecLen = getMaxVectorizationForDatatype(loadBufferView, /*dim=*/0,
+                                            copyKPerThread, rawLoadBufferShape,
+                                            elemType);
+    vecLen = math_util::gcd(vecLen, kpackPerThread);
+    strides[0] = vecLen;
+  }
+  loadBufferView = collapseContiguousMerges(loadBufferView, rawLoadBufferShape);
+  storeBufferView =
+      collapseContiguousMerges(storeBufferView, rawStoreBufferShape);
+
+  // Run the packing loop
+  auto packLoop = b.create<TransformingForOp>(
+      loc, ArrayRef<ValueRange>{start, start},
+      ArrayRef<Attribute>{loadBufferView, storeBufferView},
+      /*bounds=*/loadShape,
+      /*strides=*/strides, false,
+      /*useIndexDiffs=*/false);
+  {
+    PatternRewriter::InsertionGuard outerGuard(b);
+    b.setInsertionPointToStart(packLoop.getBody());
+    Type loadType = vectorTypeOrSelf(elemType, vecLen);
+    auto val = b.create<InBoundsLoadOp>(loc, loadType, rawLoadBuffer,
+                                        packLoop.getLowerCoords(0));
+
+    b.create<InBoundsStoreOp>(loc, val, rawStoreBuffer,
+                              packLoop.getLowerCoords(1));
+  }
+  b.eraseOp(op);
+  return success();
+}
 
 LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
     ThreadwiseReadIntoOp op, OpAdaptor adaptor,
@@ -1332,6 +1423,7 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
   {
     ConversionTarget writeAllTarget(*ctx);
     writeAllTarget.addIllegalOp<ThreadwiseReadIntoOp, ThreadwiseWriteAllOp,
+                                ThreadwiseTransposeOp,
                                 BlockwiseBroadcastReduceOp, BlockwiseFillOp>();
     writeAllTarget.addLegalDialect<arith::ArithDialect, rock::RockDialect,
                                    memref::MemRefDialect, scf::SCFDialect,
@@ -1340,7 +1432,8 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns
         .add<ThreadwiseReadIntoRewritePattern, ThreadwiseWriteAllRewritePattern,
-             BlockwiseReduceRewritePattern, BlockwiseFillRewritePattern>(ctx);
+             ThreadwiseTransposeRewritePattern, BlockwiseReduceRewritePattern,
+             BlockwiseFillRewritePattern>(ctx);
     if (failed(applyPartialConversion(getOperation(), writeAllTarget,
                                       std::move(writeAllPatterns))))
       signalPassFailure();


### PR DESCRIPTION
This is to make the following IR generated in `gridwiseToBlockwisePass`: 
```
affine.for %arg3 = 0 to 12 {
      rock.threadwise_read_into ...
      rock.threadwise_read_into ...
      rock.transforming_for (%arg4) = {...} // -> packing A
      rock.transforming_for (%arg4) = {...} // -> packing B
      rock.lds_barrier
      rock.threadwise_write_all ...
      rock.threadwise_write_all ...
      rock.lds_barrier
      rock.blockwise_gemm_accel 
    }
```
To look like this:
```
affine.for %arg3 = 0 to 12 {
      rock.threadwise_read_into ...
      rock.threadwise_read_into ...
      rock.threadwise_transpose ... // -> packing A
      rock.threadwise_transpose ... // -> packing B
      rock.lds_barrier
      rock.threadwise_write_all ...
      rock.threadwise_write_all ...
      rock.lds_barrier
      rock.blockwise_gemm_accel 
    }
```