### PR TITLE
Added `numCU` to `perfRunner.py` and `tuningRunner.py`

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -475,6 +475,11 @@ LogicalResult getTuningProblemStr(ModuleOp &mod, SmallVectorImpl<char> &out) {
     return failure();
   }
 
+  if (out.back() == sep) {
+    // remove trailing whitespace
+    out.pop_back();
+  }
+
   return success();
 }
 

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -147,8 +147,15 @@ def read_tuning_db(path: Optional[str]) -> MaybeTuningDb:
                 if line.startswith('#'):
                     continue
                 entries = line.split('\t')
+
+                # note: legecy format has 3 entries
                 if len(entries) == 3:
                     arch, config, perfConfig = entries
+                    ret[arch, config] = perfConfig
+
+                # note: new format has 4 entries
+                if len(entries) == 4:
+                    arch, _, config, perfConfig = entries
                     ret[arch, config] = perfConfig
                 else:
                     print("Warning: Malformed tuning database entry:", line)

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -320,10 +320,10 @@ def main(args=None):
 
     # Note, appending results here to allow multiple config sets
     with open(parsed_args.output, 'a') as outFile:
-        print("# arch\ttestVector\tperfConfig", file=outFile)
+        print("# arch\tnumCUs\ttestVector\tperfConfig", file=outFile)
         for testVector, perfConfig in winners.items():
             print(f"Arch = {arch}({numCU} CUs), vector = '{testVector}', perfConfig = {perfConfig}")
-            print(f"{arch}\t{testVector}\t{perfConfig}", file=outFile)
+            print(f"{arch}\t{numCU}\t{testVector}\t{perfConfig}", file=outFile)
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
* `perfTuner.py` accepts the legacy and new config formats - i.e., with and without `num_cu`
* `tuningRunner.py` generate tuning config according to the new format - i.e., with `num_cu`
* fixed trailing whitespace problem in `getTuningProblemStr`

Closes ROCmSoftwarePlatform/rocMLIR-internal#1104