### PR TITLE
Fix wmma bug stemmed from LDS reduction algorithm

### DIFF
--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -286,11 +286,13 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
       // Unit lengths don't affect the mergeability logic, if they come from
       // another transform. If the unit length is in the Merge, this can
       // be swapped during the Unmerge, e.g., Merge{2,16,1}->Unmerge{2,1,16}.
-      // In this case we want to carry on the usual checks, since we want to prevent
-      // the dimensions to be collapsed. Indeed, if collapsing happens we would end up
-      // with a Merge{1,1,...,C} transform which would be uncorrectly scaled in the Unmerge
+      // In this case we want to carry on the usual checks, since we want to
+      // prevent the dimensions to be collapsed. Indeed, if collapsing happens
+      // we would end up with a Merge{1,1,...,C} transform which would be
+      // uncorrectly scaled in the Unmerge
       //
-      // TODO: fix the `collapseContiguousDims` function to properly handle this case
+      // TODO: fix the `collapseContiguousDims` function to properly handle this
+      // case
       if (params[j] == 1 && !keyJ.transform)
         continue;
 

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -286,7 +286,11 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
       // Unit lengths don't affect the mergeability logic, if they come from
       // another transform. If the unit length is in the Merge, this can
       // be swapped during the Unmerge, e.g., Merge{2,16,1}->Unmerge{2,1,16}.
-      // In this case we want to carry on the usual checks
+      // In this case we want to carry on the usual checks, since we want to prevent
+      // the dimensions to be collapsed. Indeed, if collapsing happens we would end up
+      // with a Merge{1,1,...,C} transform which would be uncorrectly scaled in the Unmerge
+      //
+      // TODO: fix the `collapseContiguousDims` function to properly handle this case
       if (params[j] == 1 && !keyJ.transform)
         continue;
 

--- a/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
+++ b/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
@@ -184,6 +184,22 @@
   by [<Embed{1, 1, 1} ["x", "a", "b"] at [0, 1, 2] -> ["d"] at [0]>]
   bounds = [4, 2, 8] -> [13]>
 
+
+#transform_map_merge_gemm = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 16, d2 mod 16, 0)>
+by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>,
+    <PassThrough ["gemmM"] at [1] -> ["gemmM"] at [1]>,
+    <Merge{48, 16, 1} ["gemmN"] at [2] -> ["n_block", "n_iter", "n_tid"] at [2, 3, 4]>] bounds = [1, 16, 768] -> [1, 16, 48, 16, 1]>
+
+#transform_map_unmerge_gemm =  #rock.transform_map<affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, (d2 + d4) * 16 + d3)>
+by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>,
+     <PassThrough ["gemmM"] at [1] -> ["gemmM"] at [1]>,
+     <Unmerge{48, 1, 16} ["n_block", "n_tid", "n_iter"] at [2, 4, 3] -> ["gemmN"] at [2]>] bounds = [1, 16, 48, 16, 1] -> [1, 16, 768]>
+
+#transform_map_pad_gemm =  #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>,
+    <Pad{0, 15} ["gemmMPad"] at [1] -> ["gemmM"] at [1]>,
+    <PassThrough ["gemmN"] at [2] -> ["gemmN"] at [2]>] bounds = [1, 16, 768] -> [1, 1, 768]>
+
 // iso-coefficient embed alignment checks
 #transform_map_over_vec_top1 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4 floordiv 4, d4 mod 4, d5 floordiv 4, d5 mod 4)> by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{16, 4} ["tid"] at [4] -> ["n_thread", "k_thread"] at [4, 5]>, <Merge{4, 4} ["iter"] at [5] -> ["n_iter", "k_iter"] at [6, 7]>] bounds = [16, 1, 2, 45, 64, 16] -> [16, 1, 2, 45, 16, 4, 4, 4]>
 #transform_map_over_vec_top2 = #rock.transform_map<affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d1, (d0 * 4 + d5) * 4 + d7, (d3 * 16 + d4) * 4 + d6)> by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{16, 4, 4} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>, <Unmerge{45, 16, 4} ["n_block", "n_thread", "n_iter"] at [3, 4, 6] -> ["n"] at [2]>, <AddDim{2} ["m_block"] at [2] -> [] at []>] bounds = [16, 1, 2, 45, 16, 4, 4, 4] -> [1, 256, 2880]>
@@ -320,6 +336,13 @@ func.func @test_vectorization() {
   %42 = "get_length"() {transforms = [#transform_map_over_vec_bottom1, #transform_map_over_vec_bottom2, #transform_map_over_vec_bottom3], in_dim = 1 : index, max_len = 16 : index} : () -> (memref<64x1x64x4x4xf32>)
   // CHECK-NEXT: result = 1
   %43 = "get_length"() {transforms = [#transform_map_over_vec_top1, #transform_map_over_vec_top2, #transform_map_over_vec_bottom1, #transform_map_over_vec_bottom2, #transform_map_over_vec_bottom3], in_dim = 5 : index, max_len = 16 : index} : () -> (memref<64x1x64x4x4xf32>)
+
+  // Unit dimension gets swapped during Merge/Unmerge
+  // TODO: we should make sure that this test passes for the right reason. Indeed, the reason why we can vectorize this transformation is because the singleton dimension, for vectorization
+  // purposes, can be ignored. However, we need to make sure that the engine does not signal that `{d0, d1, d2}` are contiguous, because they aren't.
+  // Signalling them as contiguous leads to a flattening of the Merge dimension space when `collapseContiguousMerges` is called.
+  // CHECK-NEXT: result = 4
+  %44 = "get_length"() {transforms = [#transform_map_merge_gemm, #transform_map_unmerge_gemm], in_dim = 2 : index, max_len = 4 : index} : () -> (memref<1x16x768xf32>)
   func.return
 }
 


### PR DESCRIPTION
Second attempt to fix https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1119

There seems to be a bug in `unmerge`. 

Broadly speaking, if we consider three dimensions `d0`,`d1`,`d2` and  `d1` is always `0` (i.e., its length is `1`) there should be no difference between:
1.  `unmerge{2,1,16}` 
2. `unmerge{2,4,4}` 
3.  `unmerge{2,2,16}` 
4.  `unmerge{2,16,1}`

But 1 does not work, while 2,3,4 work. Unfortunately we are hitting a case where 1 is needed. 

If I move the `unmerge(2,1,16}` to an `embed{16,16,1}` this  seems to work fine.

I am adopting this solution for now, but I will spend some more time investigating this. If it is a simple fix, I will update this PR, otherwise I will create a ticket to track this bug. 
