### PR TITLE
Relax f16 threshold to cater for wmma

### DIFF
--- a/mlir/test/e2e/PrAttentionF16.toml
+++ b/mlir/test/e2e/PrAttentionF16.toml
@@ -1,6 +1,6 @@
 directory = "PrAttentionF16"
 prefix = "rocmlir-gen"
-suffix = "--operation attention -t f16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.02 -absDiff_threshold 0.02 -RMS_threshold 0.008 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention -t f16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.02 -absDiff_threshold 0.02 -RMS_threshold 0.01 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"


### PR DESCRIPTION
Navi3x may need a relaxed threshold to cater for f16 discrepancies.
 