### PR TITLE
Fix returned lengths of the tuning string APIs

### DIFF
--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -80,7 +80,7 @@ size_t mlirRockTuningParamToString(MlirRockTuningParam param, char *buf,
   SmallString<ROCMLIR_TUNING_PARAM_STRING_BUFSZ> perfConfig;
   paramEntry->param.getPerfConfigStr(perfConfig);
   strncpy(buf, perfConfig.c_str(), bufLen);
-  return perfConfig.size() + 1;
+  return perfConfig.size();
 }
 
 MLIR_CAPI_EXPORTED
@@ -136,5 +136,5 @@ MLIR_CAPI_EXPORTED size_t mlirRockTuningGetKey(MlirModule module, char *buf,
   if (failed(rock::getTuningProblemStr(mod, perfStr)))
     return (size_t)(-1);
   strncpy(buf, perfStr.c_str(), bufLen);
-  return perfStr.size() + 1;
+  return perfStr.size();
 }

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -475,7 +475,7 @@ LogicalResult getTuningProblemStr(ModuleOp &mod, SmallVectorImpl<char> &out) {
     return failure();
   }
 
-  if (out.back() == sep) {
+  while (out.back() == sep) {
     // remove trailing whitespace
     out.pop_back();
   }


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1129

The documentation said we wouldn't add the trailing null byte to the size of the string returned, but the implementation did do this.

This commit should fix the issue.

It might also fix the lack of performance gain from tuning, if the null byte was sneaking in.