### PR TITLE
Disable tuning fallback, as it interferes with tuning

### DIFF
--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -134,7 +134,7 @@ MLIR_CAPI_EXPORTED bool mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
   auto *passMan = unwrap(pm);
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::rock::KernelOptions kOpts;
-  kOpts.tuningFallback = true;
+  kOpts.tuningFallback = false;
   mlir::rock::buildKernelPipeline(*passMan, kOpts);
   llvm::StringRef archStr(arch);
   mlir::RocmDeviceName devName;


### PR DESCRIPTION
The tuning fallback option was added to the MIGraphX integration in

I can't find any rationale for why we added this, but I think it might have had to do with concerns that stale tuning data would cause model-wide failures.

Given that this is throwing off our ability to tune the model and to actually know what we're tuning, I'm disabling this fallback behavior in this commit. From now on, passing a value of `perf_config` that doesn't correspond to an applicable config will cause compilation failure, just like in MLIR's native flow.