### PR TITLE
Add support for explicit broadcast in MIGraphX dialect

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosaPass.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Conversion/MIGraphXToTosa/MIGraphXToTosa.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MHAL/IR/MHAL.h"
 #include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Dialect/Tosa/Utils/QuantUtils.h"
@@ -44,7 +45,8 @@ public:
     auto &ctx = getContext();
     RewritePatternSet patterns(&ctx);
     ConversionTarget target(ctx);
-    target.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
+    target.addLegalDialect<tosa::TosaDialect, func::FuncDialect,
+                           mhal::MHALDialect>();
     target.addIllegalDialect<migraphx::MIGraphXDialect>();
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -41,6 +41,8 @@ static bool isZeroAttribute(Attribute value) {
     return isZeroAttribute(splatValue.getSplatValue<Attribute>());
   if (auto elementsValue = value.dyn_cast<ElementsAttr>())
     return llvm::all_of(elementsValue.getValues<Attribute>(), isZeroAttribute);
+  if (auto elementsValue = value.dyn_cast<DenseElementsAttr>())
+    return llvm::all_of(elementsValue.getValues<Attribute>(), isZeroAttribute);
   if (auto arrayValue = value.dyn_cast<ArrayAttr>())
     return llvm::all_of(arrayValue.getValue(), isZeroAttribute);
   return false;
@@ -254,6 +256,25 @@ public:
   }
 };
 
+static Value insertBroadcast(Value inp, ArrayRef<int64_t> outShape,
+                             Location loc, OpBuilder &b) {
+  ArrayRef<int64_t> inpShape = inp.getType().cast<ShapedType>().getShape();
+  bool broadcastDone = false;
+  rock::BottomUpTMBuilder broadcastDims(b, inpShape, loc);
+  for (unsigned int i = 0; i < outShape.size(); i++) {
+    if (inpShape[i] == 1 && outShape[i] != 1) {
+      broadcastDims.broadcast({i}, {outShape[i]});
+      broadcastDone = true;
+    } else {
+      broadcastDims.passThrough({i}, {i});
+    }
+  }
+  if (!broadcastDone) {
+    return inp;
+  }
+  return b.create<rock::TransformOp>(loc, inp, broadcastDims.get());
+}
+
 class MatMulConverter final : public OpConversionPattern<tosa::MatMulOp> {
 public:
   using OpConversionPattern<tosa::MatMulOp>::OpConversionPattern;
@@ -264,25 +285,6 @@ public:
         return UnitAttr::get(op->getContext());
     }
     return nullptr;
-  }
-
-  Value insertBroadcast(Value inp, ArrayRef<int64_t> outShape, Location loc,
-                        ConversionPatternRewriter &rw) const {
-    ArrayRef<int64_t> inpShape = inp.getType().cast<ShapedType>().getShape();
-    bool broadcastDone = false;
-    rock::BottomUpTMBuilder broadcastDims(rw, inpShape, loc);
-    for (unsigned int i = 0; i < outShape.size(); i++) {
-      if (inpShape[i] == 1 && outShape[i] != 1) {
-        broadcastDims.broadcast({i}, {outShape[i]});
-        broadcastDone = true;
-      } else {
-        broadcastDims.passThrough({i}, {i});
-      }
-    }
-    if (!broadcastDone) {
-      return inp;
-    }
-    return rw.create<rock::TransformOp>(loc, inp, broadcastDims.get());
   }
 
   std::tuple<int64_t, int64_t> getLastDims(UnitAttr transposed,
@@ -819,6 +821,42 @@ public:
   }
 };
 
+// We identify the pattern dummy add with implicit broadcasting
+// and rewrite it to be rock.transform broadcast
+class AddSplatZeroRewritePattern final : public OpRewritePattern<tosa::AddOp> {
+public:
+  using OpRewritePattern<tosa::AddOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(tosa::AddOp op,
+                                PatternRewriter &rw) const final {
+    Location loc = op.getLoc();
+    TypedValue<TensorType> inp1 = op.getInput1();
+    TypedValue<TensorType> inp2 = op.getInput2();
+    TypedValue<TensorType> out = op.getOutput();
+
+    TypedValue<TensorType> bcastInput;
+    if (arith::ConstantOp maybeZero = inp1.getDefiningOp<arith::ConstantOp>()) {
+      if (isZeroAttribute(maybeZero.getValue())) {
+        bcastInput = inp2;
+      }
+    }
+    if (arith::ConstantOp maybeZero = inp2.getDefiningOp<arith::ConstantOp>()) {
+      if (isZeroAttribute(maybeZero.getValue())) {
+        if (bcastInput) {
+          return rw.notifyMatchFailure(op, "both inputs are splat zeros");
+        }
+        bcastInput = inp1;
+      }
+    }
+    if (bcastInput) {
+      Value bcast =
+          insertBroadcast(bcastInput, out.getType().getShape(), loc, rw);
+      rw.replaceOp(op, bcast);
+      return success();
+    }
+    return rw.notifyMatchFailure(op, "none of the inputs are splat zeros");
+  }
+};
+
 } // namespace
 
 void tosa::populateTosaToRockConversionPatterns(MLIRContext *context,
@@ -830,5 +868,6 @@ void tosa::populateTosaToRockConversionPatterns(MLIRContext *context,
 void tosa::populateTosaToRockTensorConversionPatterns(
     MLIRContext *context, RewritePatternSet &patterns) {
   patterns.add<AttentionRewritePattern, TransposeRewritePattern,
-               CollapseExpandRewritePattern>(context);
+               CollapseExpandRewritePattern, AddSplatZeroRewritePattern>(
+      context);
 }

--- a/mlir/lib/Dialect/MIGraphX/MiGraphXTransform.cpp
+++ b/mlir/lib/Dialect/MIGraphX/MiGraphXTransform.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MHAL/IR/MHAL.h"
 #include "mlir/Dialect/MIGraphX/MIGraphXOps.h"
 #include "mlir/Dialect/MIGraphX/Passes.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
@@ -63,7 +64,7 @@ struct MIGraphXTransforms
     RewritePatternSet patterns(&ctx);
     ConversionTarget target(ctx);
     target.addLegalDialect<migraphx::MIGraphXDialect, func::FuncDialect,
-                           tosa::TosaDialect>();
+                           tosa::TosaDialect, mhal::MHALDialect>();
     target.addIllegalOp<migraphx::SqrtOp>();
     auto func = getOperation();
 

--- a/mlir/test/fusion/pr-e2e/mixr-sd-explicit-broadcasting.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-sd-explicit-broadcasting.mlir
@@ -1,21 +1,25 @@
-// RUN: rocmlir-driver -kernel-pipeline=migraphx %s | rocmlir-driver -host-pipeline=partition,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_reshape_convolution --verifier clone - | rocmlir-driver -c -arch %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_reshape_convolution_real --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
-// Note the fake wrapper function to make it look like this has already been partitioned,
-// since we want "partition" for the xmodel packaging but don't actually want to use
-// the partition logic.
-// This is an awkward hack that should be fixed Later (tm)
 module {
-  func.func @mlir_reshape_convolution_real(%arg0: tensor<1x1x16x1x16x1xf32>, %arg1: tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32> attributes {kernel = "mixr", num_cu = 48 : i64} {
+  func.func private @mlir_reshape_convolution_real__part_0(%arg0: tensor<1x1x16x1x16x1xf32> {func.read_access}, %arg1: tensor<1x1x3x3xf32> {func.read_access}) -> (tensor<1x1x32x32xf32> {func.write_access}) {
     %0 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 1, 16, 2, 16, 2]} : (tensor<1x1x16x1x16x1xf32>) -> tensor<1x1x16x2x16x2xf32>
     %1 = migraphx.reshape(%0) {dims = [2, 4, 32, 32]} : (tensor<1x1x16x2x16x2xf32>) -> tensor<1x1x32x32xf32>
     %2 = migraphx.convolution(%1, %arg1) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x1x32x32xf32>, tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32>
     return %2 : tensor<1x1x32x32xf32>
   }
-
-  func.func @mlir_reshape_convolution(%arg0: tensor<1x1x16x1x16x1xf32>, %arg1: tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32> {
-    %ret = call @mlir_reshape_convolution_real(%arg0, %arg1) : (tensor<1x1x16x1x16x1xf32>, tensor<1x1x3x3xf32>) -> (tensor<1x1x32x32xf32>)
-    return %ret : tensor<1x1x32x32xf32>
+  func.func @mlir_reshape_convolution_real(%arg0: tensor<1x1x16x1x16x1xf32>, %arg1: tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32> {
+    %token, %results = mhal.launch @mlir_reshape_convolution_real__part_0 (%arg0, %arg1) : (tensor<1x1x16x1x16x1xf32>, tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32>
+    mhal.await %token : !mhal.token
+    return %results : tensor<1x1x32x32xf32>
+  }
+  module @__xmodule_ attributes {mhal.arch = "##TOKEN_ARCH##", mhal.module} {
+    func.func private @mlir_reshape_convolution_real__part_0(%arg0: tensor<1x1x16x1x16x1xf32> {func.read_access}, %arg1: tensor<1x1x3x3xf32> {func.read_access}) -> (tensor<1x1x32x32xf32> {func.write_access}) attributes {kernel, original_func = @mlir_reshape_convolution_real__part_0} {
+      %0 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 1, 16, 2, 16, 2]} : (tensor<1x1x16x1x16x1xf32>) -> tensor<1x1x16x2x16x2xf32>
+      %1 = migraphx.reshape(%0) {dims = [2, 4, 32, 32]} : (tensor<1x1x16x2x16x2xf32>) -> tensor<1x1x32x32xf32>
+      %2 = migraphx.convolution(%1, %arg1) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x1x32x32xf32>, tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32>
+      return %2 : tensor<1x1x32x32xf32>
+    }
   }
 }
 

--- a/mlir/test/fusion/pr-e2e/mixr-sd-explicit-broadcasting.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-sd-explicit-broadcasting.mlir
@@ -1,0 +1,21 @@
+// RUN: rocmlir-driver -kernel-pipeline=migraphx %s | rocmlir-driver -host-pipeline=partition,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_reshape_convolution --verifier clone - | rocmlir-driver -c -arch %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+// Note the fake wrapper function to make it look like this has already been partitioned,
+// since we want "partition" for the xmodel packaging but don't actually want to use
+// the partition logic.
+// This is an awkward hack that should be fixed Later (tm)
+module {
+  func.func @mlir_reshape_convolution_real(%arg0: tensor<1x1x16x1x16x1xf32>, %arg1: tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32> attributes {kernel = "mixr", num_cu = 48 : i64} {
+    %0 = migraphx.multibroadcast(%arg0) {out_dyn_dims = [], out_lens = [1, 1, 16, 2, 16, 2]} : (tensor<1x1x16x1x16x1xf32>) -> tensor<1x1x16x2x16x2xf32>
+    %1 = migraphx.reshape(%0) {dims = [2, 4, 32, 32]} : (tensor<1x1x16x2x16x2xf32>) -> tensor<1x1x32x32xf32>
+    %2 = migraphx.convolution(%1, %arg1) {dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : (tensor<1x1x32x32xf32>, tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32>
+    return %2 : tensor<1x1x32x32xf32>
+  }
+
+  func.func @mlir_reshape_convolution(%arg0: tensor<1x1x16x1x16x1xf32>, %arg1: tensor<1x1x3x3xf32>) -> tensor<1x1x32x32xf32> {
+    %ret = call @mlir_reshape_convolution_real(%arg0, %arg1) : (tensor<1x1x16x1x16x1xf32>, tensor<1x1x3x3xf32>) -> (tensor<1x1x32x32xf32>)
+    return %ret : tensor<1x1x32x32xf32>
+  }
+}
+


### PR DESCRIPTION
This commit adds tosa.add with splat zero for explicit broadcasts. Then this pattern is identifed in RockToTosa conversion and replaced with a rock.transform broadcast.

The test exposed a further bug in the collapseContigousMerges where there are broadcasted dimensions that are padded and merged.

Moreover, due to unavailability of infra to test user-defined partitions based clone, I had to change the test to look similiar after partition pipeline has been run.

closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1128