### PR TITLE
Loosen the definition of migraphx.dequantizelinear, liberalize lowering

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/MIGraphXOps.td
@@ -310,7 +310,6 @@ def MIGraphX_DeQuantizeLinearOp :
     tensor[n,c,h,w] = to_float(tensor[n,c,h,w] - quantBias[c]) * quantScale[c]
   }];
   let assemblyFormat = "`(` operands `)` attr-dict `:` `(`type(operands)`)` `->` type(results)";
-  let hasVerifier = 1;
 }
 
 // Convolution operations

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -617,7 +617,16 @@ public:
 
     Value shifted = input;
     if (auto bias = op.getBias()) {
-      Type elementType = getShapedElementTy(input);
+      Type inElemTy = getShapedElementTy(input);
+      Type biasElemTy = getShapedElementTy(bias);
+      Type elementType =
+          inElemTy.getIntOrFloatBitWidth() <= biasElemTy.getIntOrFloatBitWidth()
+              ? biasElemTy
+              : inElemTy;
+      if (inElemTy != elementType)
+        input = createCastOp(rewriter, loc, elementType, shifted);
+      if (biasElemTy != elementType)
+        bias = createCastOp(rewriter, loc, elementType, bias);
       shifted = createOpAndInfer<tosa::SubOp>(rewriter, loc, elementType, input,
                                               bias);
     }

--- a/mlir/lib/Dialect/MIGraphX/MIGraphXOps.cpp
+++ b/mlir/lib/Dialect/MIGraphX/MIGraphXOps.cpp
@@ -40,23 +40,10 @@ void MIGraphXDialect::initialize() {
 #define GET_OP_CLASSES
 #include "mlir/Dialect/MIGraphX/MIGraphXOps.cpp.inc"
 
-static Type getShapedElementTy(Value v) {
-  return v.getType().cast<ShapedType>().getElementType();
-}
-
 OpFoldResult RecipOp::fold(FoldAdaptor operands) {
   // 1/(1/x) = x
   if (auto parentRecip = getInA().getDefiningOp<RecipOp>()) {
     return parentRecip.getInA();
   }
   return {};
-}
-
-LogicalResult DeQuantizeLinearOp::verify() {
-  if (auto bias = getBias()) {
-    auto input = getInput();
-    if (getShapedElementTy(bias) != getShapedElementTy(input))
-      return emitOpError() << "element type for bias and input doesn't match";
-  }
-  return success();
 }

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -28,6 +28,26 @@ module  {
     return %1 : tensor<1x112x112x64xf32>
   }
 
+  // CHECK-LABEL: func @dequantize_wide_bias
+  // CHECK: tosa.cast{{.*}}i32
+  // CHECK: tosa.sub{{.*}}i32
+  // CHECK: tosa.cast{{.*}}f32
+  // CHECK: tosa.mul
+  func.func @dequantize_wide_bias(%arg: tensor<1x112x112x64xi8>, %scale: tensor<64xf32>, %bias: tensor<64xi32>) -> tensor<1x112x112x64xf32> attributes {kernel = "mixr"} {
+    %1 = "migraphx.dequantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xi8>, tensor<64xf32>, tensor<64xi32>) -> tensor<1x112x112x64xf32>
+    return %1 : tensor<1x112x112x64xf32>
+  }
+
+  // CHECK-LABEL: func @dequantize_wide_input
+  // CHECK: tosa.cast{{.*}}i32
+  // CHECK: tosa.sub{{.*}}i32
+  // CHECK: tosa.cast{{.*}}f32
+  // CHECK: tosa.mul
+  func.func @dequantize_wide_input(%arg: tensor<1x112x112x64xi32>, %scale: tensor<64xf32>, %bias: tensor<64xi8>) -> tensor<1x112x112x64xf32> attributes {kernel = "mixr"} {
+    %1 = "migraphx.dequantizelinear"(%arg, %scale, %bias) : (tensor<1x112x112x64xi32>, tensor<64xf32>, tensor<64xi8>) -> tensor<1x112x112x64xf32>
+    return %1 : tensor<1x112x112x64xf32>
+  }
+
   // CHECK-LABEL: func @quantize_scale
   // CHECK: tosa.reciprocal
   // CHECK: tosa.mul


### PR DESCRIPTION
Fixes
https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1143

Per that ticket, MIGraphX is planning to change its dequantize operator to not require the input and bias to have the same type. This commit makes that change in our compilation process so what we won't break when they make this change.

This will have no impact in the current state of the MIGraphX repository.