### PR TITLE
Refactor rock-blockwise-gemm-to-threadwise pass

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1126,8 +1126,6 @@ def Rock_BlockwiseGemmAccelOp:
                    I32Attr:$inNPerThread,
                    UnitAttr:$rotateMWithK,
                    UnitAttr:$rotateNWithK,
-                   Index:$waveOffsetA,
-                   Index:$waveOffsetB,
                    MemRefOf<AccelArgTypes>:$bufferA,
                    MemRefOf<AccelArgTypes>:$bufferB,
                    MemRefOf<AccelResTypes>:$matrixC,
@@ -1145,8 +1143,8 @@ def Rock_BlockwiseGemmAccelOp:
     scalars when kpack is 1.
   }];
   let assemblyFormat = [{
-    $matrixC `+` `` `=` $bufferA `from` $matrixA `[` $waveOffsetA `]` `*`
-                        $bufferB `from` $matrixB `[` $waveOffsetB `]` `features` `=` $features attr-dict
+    $matrixC `+` `` `=` $bufferA `from` $matrixA `*`
+                        $bufferB `from` $matrixB `features` `=` $features attr-dict
     `:` type($matrixC) `+` `` `=` type($bufferA) `from` type($matrixA) `*`
                                   type($bufferB) `from` type($matrixB)
   }];

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -807,8 +807,8 @@ def Rock_IndexDiffUpdateOp :
 defvar SupportedMemoryElems = [F32, F16, BF16, I8, I32, F8E5M2FNUZ, F8E4M3FNUZ];
 defvar NativeMemoryOpTypes = [F32, F16, BF16, I8, I32,
                            F8E5M2FNUZ, F8E4M3FNUZ,
-                           VectorOfLengthAndType<[2, 4], [F32, I32]>,
-                           VectorOfLengthAndType<[2, 4, 8], [F16, BF16]>,
+                           VectorOfLengthAndType<[2, 4, 8], [F32, I32]>,
+                           VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
                            VectorOfLengthAndType<[2, 4, 8, 16],
                              [I8, F8E5M2FNUZ, F8E4M3FNUZ]>];
 
@@ -935,9 +935,8 @@ def Rock_GlobalStoreOp :
 def Rock_ThreadwiseReadIntoOp :
     Rock_Op<"threadwise_read_into">,
     AllElementTypesMatch<["source", "dest"]>,
-    Arguments<(ins Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemRead]>:$source,
-      Arg<MemRefRankOf<SupportedMemoryElems, [1]>,
-        "destination registers", [MemWrite]>:$dest,
+    Arguments<(ins Arg<MemRefOf<NativeMemoryOpTypes>, "source view", [MemRead]>:$source,
+      Arg<MemRefOf<NativeMemoryOpTypes>, "destination registers", [MemWrite]>:$dest,
       TransformMapArrayAttr:$extraViews,
       Variadic<Index>:$extraIndices,
       UnitAttr:$forceUnroll,

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1425,10 +1425,16 @@ LogicalResult InBoundsStoreOp::verify() {
 //===-----------------------------------------------------===//
 LogicalResult ThreadwiseReadIntoOp::verify() {
   MemRefType destType = getDest().getType();
-  Attribute memSpaceAttr = destType.getMemorySpace();
-  auto gpuMemSpaceAttr = memSpaceAttr.dyn_cast_or_null<gpu::AddressSpaceAttr>();
-  if (memSpaceAttr && (!gpuMemSpaceAttr || gpuMemSpaceAttr.getValue() !=
-                                               gpu::AddressSpace::Private))
+  MemRefType srcType = getSource().getType();
+  Attribute dstMemSpaceAttr = destType.getMemorySpace();
+  Attribute srcMemSpaceAttr = srcType.getMemorySpace();
+  auto gpuDstMemSpaceAttr =
+      dstMemSpaceAttr.dyn_cast_or_null<gpu::AddressSpaceAttr>();
+  auto gpuSrcMemSpaceAttr =
+      srcMemSpaceAttr.dyn_cast_or_null<gpu::AddressSpaceAttr>();
+  if (dstMemSpaceAttr &&
+      (!gpuDstMemSpaceAttr ||
+       gpuDstMemSpaceAttr.getValue() != gpu::AddressSpace::Private))
     return emitOpError("dest must be private registers");
   ArrayAttr extraViews = getExtraViews();
   ArrayRef<int64_t> inputShape;
@@ -1444,6 +1450,23 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
   } else if (inputShape.size() != extraIdxCount + 1) {
     return emitOpError("source view must be extraIndices + 1");
   }
+
+  // Add more constraints if we see vector buffers (e.g.,
+  // memref<Kxvector<vxf16>>)
+  VectorType srcVectorType = srcType.getElementType().dyn_cast<VectorType>();
+  VectorType dstVectorType = destType.getElementType().dyn_cast<VectorType>();
+  if ((srcVectorType || dstVectorType) &&
+      gpuSrcMemSpaceAttr.getValue() != gpu::AddressSpace::Workgroup)
+    return emitOpError("Vector buffers are only allowed when we read from LDS");
+  if (srcVectorType && dstVectorType) {
+    int64_t srcVectorLen = srcVectorType.getNumElements();
+    int64_t dstVectorLen = dstVectorType.getNumElements();
+    if ((srcVectorLen > dstVectorLen && srcVectorLen % dstVectorLen != 0) ||
+        (dstVectorLen > srcVectorLen && dstVectorLen % dstVectorLen != 0))
+      return emitOpError(
+          "Vector buffers vector's lengths need to be evenly divisible");
+  }
+
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -196,7 +196,7 @@ void rock::buildBackendPipeline(OpPassManager &pm,
   gpuPm.addPass(memref::createExpandStridedMetadataPass());
   gpuPm.addPass(createLowerGpuOpsToROCDLOpsPass(
       options.chip, /*indexBitwidth=*/kDeriveIndexBitwidthFromDataLayout,
-      /*useBarePtrCallConv=*/true));
+      /*useBarePtrCallConv=*/true, gpu::amd::Runtime::Unknown));
   gpuPm.addPass(rock::createRockPrepareLLVMPass());
   if (options.compile)
     gpuPm.addPass(createGpuSerializeToHsacoPass(

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -96,14 +96,10 @@ struct AccelEmitter {
                                   Value argB, Value bufferC,
                                   Value regCOffset) = 0;
 
-  /// Compute the correct lds source offset when loading data from shared memory
-  /// into registers. The pseudo-code of the lds-to-register loops is as follows
-  /// for(index_t m_i = 0; m_i < mRepeats; ++m_i)
-  ///   for(index_t k_i = 0; k_i < KPerThread; ++k_i)
-  ///       sourceOffset = computeLdsSourceOffset(d_i, k_i, dPerBlock,
-  ///       baseOffset)
-  ///       ...
-  /// In the above loop `d` can be either `m` or `n`.
+  /// Return a wrapped view of the LDS buffer tailored for the accelerator
+  /// load pattern. This is similar to wrapLDSBufferForStore, but while storing
+  /// in LDS follows a similar pattern among accelerators, loading from LDS
+  /// is dependent on the type of accelerator we are targeting
   virtual Value wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
                                      int64_t blockSize,
                                      int64_t dInCopyPerThread, StringRef dName,

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -104,11 +104,10 @@ struct AccelEmitter {
   ///       baseOffset)
   ///       ...
   /// In the above loop `d` can be either `m` or `n`.
-  virtual Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
-                                       OpBuilder &dBuilder, Value d_i,
-                                       OpBuilder &builder, Value dPerBlock,
-                                       Location loc, Value baseOffset,
-                                       Value dWaves, Value laneId) = 0;
+  virtual Value wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
+                                     int64_t blockSize,
+                                     int64_t dInCopyPerThread, StringRef dName,
+                                     bool rotateDWithK) = 0;
 
   /// Validate the accelerator structure
   virtual LogicalResult validateAcceleratorProperties() { return success(); };
@@ -146,11 +145,10 @@ struct MfmaEmitter : public AccelEmitter {
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
                           Value bufferC, Value regCOffset) override;
 
-  Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
-                               OpBuilder &dBuilder, Value d_i,
-                               OpBuilder &builder, Value dPerBlock,
-                               Location loc, Value baseOffset, Value dWaves,
-                               Value laneId) override;
+  virtual Value wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
+                                     int64_t blockSize,
+                                     int64_t dInCopyPerThread, StringRef dName,
+                                     bool rotateDWithK) override;
 
   RegsAsMatrixSubTiles computeOutputTransforms(
       PatternRewriter &b, Location loc, int64_t mLen, int64_t nLen,
@@ -178,11 +176,10 @@ struct WmmaEmitter : public AccelEmitter {
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
                           Value bufferC, Value regCOffset) override;
 
-  Value computeLdsSourceOffset(OpBuilder &kBuilder, Value k_i,
-                               OpBuilder &dBuilder, Value d_i,
-                               OpBuilder &builder, Value dPerBlock,
-                               Location loc, Value baseOffset, Value dWaves,
-                               Value laneId) override;
+  virtual Value wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
+                                     int64_t blockSize,
+                                     int64_t dInCopyPerThread, StringRef dName,
+                                     bool rotateDWithK) override;
 
   RegsAsMatrixSubTiles computeOutputTransforms(
       PatternRewriter &b, Location loc, int64_t mLen, int64_t nLen,

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -392,7 +392,6 @@ struct BlockwiseGemmRewritePattern
 //===----------------------------------------------------------------------===//
 // BlockwiseGemmAccel lowering.
 //===----------------------------------------------------------------------===//
-
 struct BlockwiseGemmAccelRewritePattern
     : public OpConversionPattern<BlockwiseGemmAccelOp> {
   using OpConversionPattern<BlockwiseGemmAccelOp>::OpConversionPattern;
@@ -404,9 +403,9 @@ struct BlockwiseGemmAccelRewritePattern
 
     StringAttr arch = op.getArchAttr();
     RockAccelTuningParamAttrInterface tuningParams = op.getParams();
-    int64_t M = tuningParams.getMPerBlock();
-    int64_t N = tuningParams.getNPerBlock();
-    int64_t K = tuningParams.getKpackPerBlock();
+    int64_t mPerBlock = tuningParams.getMPerBlock();
+    int64_t nPerBlock = tuningParams.getNPerBlock();
+    int64_t kpackPerBlock = tuningParams.getKpackPerBlock();
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();
     int64_t KPack = tuningParams.getKpack();
@@ -423,8 +422,8 @@ struct BlockwiseGemmAccelRewritePattern
 
     Value sourceOffsetA = adaptor.getWaveOffsetA();
     Value sourceOffsetB = adaptor.getWaveOffsetB();
-    int64_t mWaves = M / mPerWave;
-    int64_t nWaves = N / nPerWave;
+    int64_t mWaves = mPerBlock / mPerWave;
+    int64_t nWaves = nPerBlock / nPerWave;
 
     auto accelEmitterPtr = rock::accel::AccelEmitter::select(
         op.getFeatures(), dataTypeA, dataTypeB, arch, tuningParams);
@@ -448,9 +447,6 @@ struct BlockwiseGemmAccelRewritePattern
     int64_t copyNPerThread = op.getInNPerThread();
 
     auto tid = b.create<WorkitemIdOp>(loc, b.getIndexType());
-    const int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
-    auto laneId =
-        b.create<RemUIOp>(loc, tid, b.create<ConstantIndexOp>(loc, waveSize));
 
     LLVM_DEBUG(llvm::dbgs()
                << "argVectorType A: " << argTypeA << "\n"
@@ -460,149 +456,62 @@ struct BlockwiseGemmAccelRewritePattern
                << "nPerWave: " << nPerWave << "\n"
                << "mRepeat: " << mRepeats << "\n"
                << "nRepeat: " << nRepeats << "\n"
-               << "K: " << K << "\n"
+               << "K: " << kpackPerBlock << "\n"
                << "bufferA type: " << adaptor.getBufferA().getType() << "\n"
                << "bufferB type: " << adaptor.getBufferB().getType() << "\n");
 
-    Value MConstantOp = b.create<ConstantIndexOp>(loc, M);
-    Value NConstantOp = b.create<ConstantIndexOp>(loc, N);
-
-    Value mPerAccelConstantOp = b.create<ConstantIndexOp>(loc, mPerAccel);
-    Value nPerAccelConstantOp = b.create<ConstantIndexOp>(loc, nPerAccel);
-
-    Value bufferA = adaptor.getBufferA();
-    Value bufferB = adaptor.getBufferB();
-
-    Value KPerThreadConstantOp = b.create<ConstantIndexOp>(loc, kpackPerThread);
-
-    auto ldsToRegisterCopy = [&](Location loc, OpBuilder mnb, OpBuilder kb,
-                                 Value sourceBase, Value mn_i, Value MN,
-                                 Value k_i, Value K, Value mnPerMfmaGroup,
-                                 Value mnWaves, Type ldsBufferElemType,
-                                 Type dataType, Value ldsOrig, Value regDest,
-                                 bool rotateDWithK, int64_t copyMNPerThread) {
-      // Compute source offset
-      Value sourceOffset = accelEmitterPtr->computeLdsSourceOffset(
-          kb, k_i, mnb, mn_i, b, MN, loc, sourceBase, mnWaves, laneId);
-
-      // If the dimension `d` has been rotated to minimize bank conflicts we
-      // want to apply the same rotation reading from LDS. This rotation happens
-      // in `wrapLDSforStore` from
-      // mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp which
-      // needs to be kept in sync with this function
-      if (rotateDWithK) {
-        Value col = kb.create<arith::RemUIOp>(loc, sourceOffset, MN);
-        Value row = kb.create<arith::DivUIOp>(loc, sourceOffset, MN);
-        Value offset = row;
-        if (KPack == 1) {
-          Value stride =
-              kb.create<arith::ConstantIndexOp>(loc, copyMNPerThread);
-          offset = kb.create<arith::MulIOp>(loc, row, stride);
-        }
-        col = kb.create<arith::AddIOp>(loc, col, offset);
-        col = kb.create<arith::RemUIOp>(loc, col, MN);
-        sourceOffset = kb.create<arith::AddIOp>(
-            loc, kb.create<arith::MulIOp>(loc, row, MN), col);
-      }
-
-      Value value = kb.create<memref::LoadOp>(loc, ldsBufferElemType, ldsOrig,
-                                              sourceOffset);
-
-      auto bufferType = regDest.getType().cast<MemRefType>();
-      Type bufferElementType = bufferType.getElementType();
-
-      // We're loading in units of kPack, but storing in units of k_base.
-      if (KPack == kBase) {
-        Value destOffset = k_i;
-        kb.create<memref::StoreOp>(loc, value, regDest, ValueRange{destOffset});
-      } else if (KPack > kBase) {
-        int64_t numStores = KPack / kBase;
-        Value baseDestOffset = kb.createOrFold<arith::MulIOp>(
-            loc, k_i, kb.createOrFold<arith::ConstantIndexOp>(loc, numStores));
-        for (int64_t i = 0; i < numStores; ++i) {
-          Value sliceStart =
-              kb.createOrFold<arith::ConstantIndexOp>(loc, kBase * i);
-          Value slice = kb.create<ExtractSliceOp>(loc, bufferElementType, value,
-                                                  sliceStart);
-          Value destOffset = kb.createOrFold<arith::AddIOp>(
-              loc, baseDestOffset,
-              kb.createOrFold<arith::ConstantIndexOp>(loc, i));
-          kb.create<memref::StoreOp>(loc, slice, regDest,
-                                     ValueRange{destOffset});
-        }
-      } else if (KPack < kBase) {
-        // Here we are gathering loaded values into vectors for passing into
-        // MFMAs.
-        Value destValsPerKpack =
-            kb.createOrFold<arith::ConstantIndexOp>(loc, kBase / KPack);
-        // This is fine, since the inputs to MFMAs are contiguous in the k
-        // dimension.
-        Value destOffset =
-            kb.createOrFold<arith::DivUIOp>(loc, k_i, destValsPerKpack);
-        Value destVecPart =
-            kb.createOrFold<arith::RemUIOp>(loc, k_i, destValsPerKpack);
-        Value destSlicePos = kb.createOrFold<arith::MulIOp>(
-            loc, destVecPart,
-            b.createOrFold<arith::ConstantIndexOp>(loc, KPack));
-        Value destVec = kb.create<memref::LoadOp>(
-            loc, bufferElementType, regDest, ValueRange{destOffset});
-        Value newDestVec = kb.create<InsertSliceOp>(
-            loc, bufferElementType, value, destVec, destSlicePos);
-        kb.create<memref::StoreOp>(loc, newDestVec, regDest,
-                                   ValueRange{destOffset});
-      }
-    };
-
-    auto ldsToRegisterCopyKdim =
-        [&](OpBuilder outerLoopB, affine::AffineForOp outerLoopBodyOp,
-            Value sourceBase, Value MN, Value mnPerMfmaGroup, Value mnWaves,
-            Type ldsBufferElemType, Type dataType, Value ldsOrig, Value regDest,
-            bool rotateDWithK, int64_t copyMNPerThread) {
-          auto innerLoopK =
-              outerLoopB.create<affine::AffineForOp>(loc, 0, kpackPerThread);
-          auto ilkb =
-              ConversionPatternRewriter::atBlockBegin(innerLoopK.getBody());
-          {
-            OpBuilder::InsertionGuard guard(b);
-            b.setInsertionPoint(outerLoopBodyOp);
-            OpBuilder::InsertionGuard guardBody(outerLoopB);
-            outerLoopB.setInsertionPointToStart(outerLoopBodyOp.getBody());
-            ldsToRegisterCopy(loc, outerLoopB, ilkb, sourceBase,
-                              outerLoopBodyOp.getInductionVar(), MN,
-                              innerLoopK.getInductionVar(),
-                              KPerThreadConstantOp, mnPerMfmaGroup, mnWaves,
-                              ldsBufferElemType, dataType, ldsOrig, regDest,
-                              rotateDWithK, copyMNPerThread);
-          }
-        };
-
-    // load A from LDS into registers
+    // The following loop nest hardcodes the following loop schedule:
+    //
     // for(index_t m_i = 0; m_i < mRepeats; ++m_i)
-    //   for(index_t k_i = 0; k_i < KPerThread; ++k_i)
-    //       ldsToRegisterCopy[m_i, k_i]
-    auto outerLoopM = b.create<affine::AffineForOp>(loc, 0, mRepeats);
-    auto olmb = ConversionPatternRewriter::atBlockBegin(outerLoopM.getBody());
-    ldsToRegisterCopyKdim(olmb, outerLoopM, sourceOffsetA, MConstantOp,
-                          mPerAccelConstantOp, mWavesConstantOp,
-                          bufferElemTypeA, dataTypeA, op.getMatrixA(), bufferA,
-                          op.getRotateMWithK(), copyMPerThread);
+    //   regsA = threadwise_readinto[m_i, :]
+    //   for(index_t n_i = 0; n_i<nRepeats; ++n_i)
+    //       regsB = threadwise_readint[n_i, :]
+    //       threadwise_gemm(regsA, regsB)
+    //
+    // Which mimics:
+    // https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/develop/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp#L304
+    //
+    // Please note that different schedules might exist, so this can be
+    // considered a temporary hack until we have a proper way of "searching"
+    // through different schedules (either heuristically or automatically)
 
-    // load B from LDS into registers
-    // for(index_t n_i = 0; n_i < mRepeats; ++n_i)
-    //   for(index_t k_i = 0; k_i < KPerThread; ++k_i)
-    //       ldsToRegisterCopy[n_i, k_i]
-    auto outerLoopN = olmb.create<affine::AffineForOp>(loc, 0, nRepeats);
-    auto olnb = ConversionPatternRewriter::atBlockBegin(outerLoopN.getBody());
-    ldsToRegisterCopyKdim(olnb, outerLoopN, sourceOffsetB, NConstantOp,
-                          nPerAccelConstantOp, nWavesConstantOp,
-                          bufferElemTypeB, dataTypeB, op.getMatrixB(), bufferB,
-                          op.getRotateNWithK(), copyNPerThread);
+    Value wrappedLDSBufferForLoadA = accelEmitterPtr->wrapLDSBufferForLoad(
+        b, loc, op.getMatrixA(), op.getBlockSize(), op.getInMPerThread(), "m",
+        op.getRotateMWithK());
+    Value wrappedLDSBufferForLoadB = accelEmitterPtr->wrapLDSBufferForLoad(
+        b, loc, op.getMatrixB(), op.getBlockSize(), op.getInNPerThread(), "n",
+        op.getRotateNWithK());
 
+    auto mLoop = b.create<affine::AffineForOp>(loc, 0, mRepeats);
+    {
+      OpBuilder::InsertionGuard guard(b);
+      b.setInsertionPointToStart(mLoop.getBody());
+      Value m_i = mLoop.getInductionVar();
+
+      // regsA = read A from LDS
+      b.create<ThreadwiseReadIntoOp>(loc, wrappedLDSBufferForLoadA,
+                                     op.getBufferA(), b.getArrayAttr({}),
+                                     ValueRange{tid, m_i}, true, true);
+
+      auto nLoop = b.create<affine::AffineForOp>(loc, 0, nRepeats);
+      {
+        OpBuilder::InsertionGuard guard(b);
+        b.setInsertionPointToStart(nLoop.getBody());
+        Value n_i = nLoop.getInductionVar();
+
+        // regsB = read B from LDS
+        b.create<ThreadwiseReadIntoOp>(loc, wrappedLDSBufferForLoadB,
+                                       op.getBufferB(), b.getArrayAttr({}),
+                                       ValueRange{tid, n_i}, true, true);
+
+        // regsC += regsA * regsB
+        b.create<AccelGemmOp>(loc, mLoop.getInductionVar(),
+                              nLoop.getInductionVar(), adaptor.getBufferA(),
+                              adaptor.getBufferB(), adaptor.getMatrixC(), arch,
+                              op.getFeaturesAttr(), tuningParams);
+      }
+    }
     b.eraseOp(op);
-    olnb.create<AccelGemmOp>(loc, outerLoopM.getInductionVar(),
-                             outerLoopN.getInductionVar(), adaptor.getBufferA(),
-                             adaptor.getBufferB(), adaptor.getMatrixC(), arch,
-                             op.getFeaturesAttr(), tuningParams);
     return success();
   }
 };
@@ -624,307 +533,7 @@ struct ThreadwiseWriteAllRewritePattern
                                 ConversionPatternRewriter &b) const final;
 };
 
-struct ThreadwiseCopyRewritePattern
-    : public OpConversionPattern<ThreadwiseCopyOp> {
-  using OpConversionPattern<ThreadwiseCopyOp>::OpConversionPattern;
-
-  LogicalResult matchAndRewrite(ThreadwiseCopyOp op, OpAdaptor adaptor,
-                                ConversionPatternRewriter &b) const final;
-};
 } // end anonymous namespace
-
-LogicalResult ThreadwiseCopyRewritePattern::matchAndRewrite(
-    ThreadwiseCopyOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &b) const {
-  Location loc = op.getLoc();
-  auto sourceView = cast<TypedValue<MemRefType>>(adaptor.getSource());
-  auto destView = cast<TypedValue<MemRefType>>(adaptor.getDest());
-
-  auto [rawLoadBuffer, loadBufferView, sourceNeeds64BitIdx] =
-      untransform(b, sourceView);
-  auto [rawStoreBuffer, storeBufferView, dstNeeds64BitIdx] =
-      untransform(b, destView);
-
-  assert(!sourceNeeds64BitIdx && "Registers shouldn't need 64-bit indexing");
-  assert(!dstNeeds64BitIdx && "Registers shouldn't need 64-bit indexing");
-  ArrayRef<int64_t> rawLoadBufferShape =
-      rawLoadBuffer.getType().cast<ShapedType>().getShape();
-  ArrayRef<int64_t> rawStoreBufferShape =
-      rawStoreBuffer.getType().cast<ShapedType>().getShape();
-  if (rawLoadBufferShape.size() != 1)
-    return op.emitOpError("Raw load buffers have to be flat.");
-  if (rawStoreBufferShape.size() != 1)
-    return op.emitOpError("Raw store buffers have to be flat.");
-
-  Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
-  auto srcViewShape = op.getSource().getType().getShape();
-  Type elemType = sourceView.getType().cast<MemRefType>().getElementType();
-
-  // Basic copy loop. Copy element by element from src to dest view
-  ArrayAttr copyFromView = loadBufferView;
-  ArrayAttr copyToView = storeBufferView;
-  SmallVector<Value> start(srcViewShape.size(), zero);
-  SmallVector<int64_t> strides(srcViewShape.size(), 1);
-  SmallVector<int64_t> bounds = llvm::to_vector(srcViewShape);
-  int64_t vecLen = 1;
-
-  // If we can invert the store view, we can easily find out the common
-  // vectorization length
-  auto storeBufferViewInverted = invertTransforms(b, loc, storeBufferView);
-  if (storeBufferViewInverted) {
-    auto srcToDstView =
-        prependUpperViews(b, storeBufferViewInverted, loadBufferView);
-    int64_t maxVlen = 128 / elemType.getIntOrFloatBitWidth();
-    vecLen = getMaxVectorizationForDatatype(srcToDstView, /*dim=*/0, maxVlen,
-                                            rawStoreBufferShape, elemType);
-
-    copyFromView = collapseContiguousMerges(srcToDstView, rawStoreBufferShape);
-    copyToView = b.getArrayAttr({});
-
-    start = SmallVector<Value>{zero};
-    strides = SmallVector<int64_t>{vecLen};
-    bounds = llvm::to_vector(rawStoreBufferShape);
-  }
-
-  auto copyLoop =
-      b.create<TransformingForOp>(loc, ArrayRef<ValueRange>{start, start},
-                                  ArrayRef<Attribute>{copyFromView, copyToView},
-                                  /*bounds=*/bounds,
-                                  /*strides=*/strides, false,
-                                  /*useIndexDiffs=*/false);
-  {
-    PatternRewriter::InsertionGuard outerGuard(b);
-    b.setInsertionPointToStart(copyLoop.getBody());
-    Type loadType = vectorTypeOrSelf(elemType, vecLen);
-    auto val = b.create<InBoundsLoadOp>(loc, loadType, rawLoadBuffer,
-                                        copyLoop.getLowerCoords(0));
-    b.create<InBoundsStoreOp>(loc, val, rawStoreBuffer,
-                              copyLoop.getLowerCoords(1));
-  }
-  b.eraseOp(op);
-  return success();
-}
-
-/// Amend the operation chain (and computed shape) for a read/write to add a
-/// length-1 iteration index to 0-dimensional (scalar) buffers.
-static void addIterationIndexIfScalar(PatternRewriter &b, Location loc,
-                                      ArrayRef<int64_t> &shape,
-                                      ArrayAttr &extraViews) {
-  if (!shape.empty())
-    return;
-  TopDownTMBuilder addZero(b, {"zero"}, {1}, loc);
-  addZero.ignore("zero");
-  TransformMapAttr addZeroAttr = addZero.get();
-  shape = addZeroAttr.getUpperBounds().asArrayRef();
-  SmallVector<Attribute, 4> views = {addZeroAttr};
-  if (extraViews)
-    views.append(extraViews.begin(), extraViews.end());
-  extraViews = b.getArrayAttr(views);
-}
-
-LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
-    ThreadwiseReadIntoOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &b) const {
-  Location loc = op.getLoc();
-  auto sourceView = cast<TypedValue<MemRefType>>(adaptor.getSource());
-  ArrayAttr extraViews = op.getExtraViews();
-  auto dest = cast<TypedValue<MemRefType>>(adaptor.getDest());
-  ArrayRef<int64_t> inputShape;
-  if (extraViews.empty())
-    inputShape = sourceView.getType().getShape();
-  else
-    inputShape = extraViews[0].cast<TransformMapAttr>().getUpperBounds();
-  addIterationIndexIfScalar(b, loc, inputShape, extraViews);
-
-  auto [buffer, transforms, needs64BitIdx] =
-      untransform(b, sourceView, extraViews);
-
-  int64_t numValues = dest.getType().getNumElements();
-  MemRefType srcBufferType = buffer.getType().cast<MemRefType>();
-  ArrayRef<int64_t> bufferShape = srcBufferType.getShape();
-  size_t extraIdxCount = op.getExtraIndices().size();
-
-  // Unless specified it is assumed to be global
-  gpu::AddressSpace srcAddrSpace = gpu::AddressSpace::Global;
-  if (srcBufferType.getMemorySpace()) {
-    srcAddrSpace =
-        srcBufferType.getMemorySpace().cast<gpu::AddressSpaceAttr>().getValue();
-  }
-
-  // We are vectorizing in the iter dimension, not block ID or thread ID
-  auto elementType = sourceView.getType().getElementType();
-  int64_t vectorLen = getMaxVectorizationForDatatype(
-      transforms, /*dim=*/extraIdxCount, numValues, bufferShape, elementType);
-  LLVM_DEBUG(llvm::dbgs() << "Max vectorization for read_into = " << vectorLen
-                          << "\n");
-
-  Type loadType = vectorTypeOrSelf(elementType, vectorLen);
-  bool forceUnroll = op.getForceUnroll();
-  bool useIndexDiffs = op.getUseIndexDiffs();
-
-  // In the future, this might get merged into the vectorizer.
-  transforms = collapseContiguousMerges(transforms, bufferShape);
-
-  // Constant / consistent arguments
-  Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
-
-  SmallVector<Value, 3> readStartCoords =
-      llvm::to_vector<3>(op.getExtraIndices());
-  readStartCoords.push_back(zero);
-  SmallVector<int64_t, 3> bounds(readStartCoords.size() - 1, 1);
-  bounds.push_back(numValues);
-  SmallVector<int64_t, 3> strides(readStartCoords.size() - 1, 1);
-  strides.push_back(vectorLen);
-
-  auto loadLoop = b.create<TransformingForOp>(
-      loc, ArrayRef<ValueRange>{readStartCoords, readStartCoords},
-      ArrayRef<Attribute>{transforms, b.getArrayAttr({})}, bounds, strides,
-      forceUnroll, useIndexDiffs);
-  {
-    OpBuilder::InsertionGuard guard(b);
-    b.setInsertionPointToStart(loadLoop.getBody());
-    if (srcAddrSpace == gpu::AddressSpace::Global) {
-      Value loaded = b.create<GlobalLoadOp>(
-          loc, loadType, buffer, loadLoop.getValidity(/*domain=*/0),
-          loadLoop.getLowerCoords(/*domain=*/0), needs64BitIdx);
-      b.create<InBoundsStoreOp>(loc, loaded, dest,
-                                loadLoop.getLowerCoords(
-                                    /*domain=*/1)[extraIdxCount]);
-    } else {
-      if (needs64BitIdx)
-        return b.notifyMatchFailure(
-            loc, "non-global address spaces must have 32-bit pointers");
-      TypedValue<IntegerType> valid = loadLoop.getValidity(/*domain=*/0);
-      scf::IfOp ifb =
-          b.create<scf::IfOp>(loc, loadType, valid, /*withElseRegion=*/true);
-      {
-        OpBuilder thenb = ifb.getThenBodyBuilder();
-        Value loaded = thenb.create<InBoundsLoadOp>(
-            loc, loadType, buffer, loadLoop.getLowerCoords(/*domain=*/0));
-        thenb.create<scf::YieldOp>(loc, loaded);
-      }
-      {
-        OpBuilder elseb = ifb.getElseBodyBuilder();
-        Value zeroVal = createZeroConstantOp(elseb, loc, loadType);
-        elseb.create<scf::YieldOp>(loc, zeroVal);
-      }
-      b.create<InBoundsStoreOp>(loc, ifb.getResult(0), dest,
-                                loadLoop.getLowerCoords(
-                                    /*domain=*/1)[extraIdxCount]);
-    }
-  }
-  b.eraseOp(op);
-  return success();
-}
-
-LogicalResult ThreadwiseWriteAllRewritePattern::matchAndRewrite(
-    ThreadwiseWriteAllOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &b) const {
-  Location loc = op.getLoc();
-
-  auto source = cast<TypedValue<MemRefType>>(adaptor.getSource());
-  auto destView = cast<TypedValue<MemRefType>>(adaptor.getDest());
-
-  ArrayAttr extraViews = op.getExtraViews();
-  ArrayRef<int64_t> outputShape;
-  if (extraViews.empty())
-    outputShape = destView.getType().getShape();
-  else
-    outputShape = extraViews[0].cast<TransformMapAttr>().getUpperBounds();
-  addIterationIndexIfScalar(b, loc, outputShape, extraViews);
-
-  auto [buffer, transforms, needs64BitIdx] =
-      untransform(b, destView, extraViews);
-
-  MemRefType dstBufferType = buffer.getType().cast<MemRefType>();
-  ArrayRef<int64_t> bufferShape = dstBufferType.getShape();
-  size_t extraIdxCount = op.getExtraIndices().size();
-
-  // Unless specified it is assumed to be global
-  gpu::AddressSpace dstAddrSpace = gpu::AddressSpace::Global;
-  if (dstBufferType.getMemorySpace()) {
-    dstAddrSpace =
-        dstBufferType.getMemorySpace().cast<gpu::AddressSpaceAttr>().getValue();
-  }
-  int64_t iterLen = outputShape[extraIdxCount];
-  auto destElemType = buffer.getType().cast<MemRefType>().getElementType();
-  // We are vectorizing in the iter dimension, not block ID or thread ID
-  int64_t maxVecLen = iterLen;
-  Type elementType = destElemType;
-  int64_t implicitStride = 1;
-  // If the dest is already being viewed as vector-typed, there's no good
-  // mechanism to, for example, store a vector<8xf32> as two consecutive
-  // vector<4xf32>s, and there's unlikely to be any performance benefit from
-  // doing so. Therefore, don't bother.
-  if (auto elemVecType = destElemType.dyn_cast<VectorType>()) {
-    implicitStride = elemVecType.getNumElements();
-    maxVecLen = elemVecType.getNumElements();
-    elementType = elemVecType.getElementType();
-  }
-  int64_t vectorLen = getMaxVectorizationForDatatype(
-      transforms, /*dim=*/extraIdxCount, maxVecLen, bufferShape, elementType,
-      implicitStride);
-  LLVM_DEBUG(llvm::dbgs() << "Max vectorization for write_all = " << vectorLen
-                          << "\n");
-
-  bool forceUnroll = op.getForceUnroll();
-  bool useIndexDiffs = op.getUseIndexDiffs();
-
-  transforms = collapseContiguousMerges(transforms, bufferShape);
-
-  // Constant / consistent arguments
-  Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
-
-  SmallVector<Value, 3> writeStartCoords =
-      llvm::to_vector<3>(op.getExtraIndices());
-  writeStartCoords.push_back(zero);
-  SmallVector<int64_t, 3> bounds(writeStartCoords.size() - 1, 1);
-  bounds.push_back(iterLen);
-  SmallVector<int64_t, 3> strides(writeStartCoords.size() - 1, 1);
-  strides.push_back(vectorLen);
-
-  auto outLoop = b.create<TransformingForOp>(
-      loc, ArrayRef<ValueRange>{writeStartCoords, writeStartCoords},
-      ArrayRef<Attribute>{b.getArrayAttr({}), transforms}, bounds, strides,
-      forceUnroll, useIndexDiffs);
-  {
-    OpBuilder::InsertionGuard guard(b);
-    b.setInsertionPointToStart(outLoop.getBody());
-    if (dstAddrSpace == gpu::AddressSpace::Global) {
-      b.create<GlobalStoreOp>(loc, source, buffer, b.getIndexAttr(vectorLen),
-                              op.getFeaturesAttr(), op.getStoreMethodAttr(),
-                              outLoop.getLowerCoords(
-                                  /*domain=*/0)[extraIdxCount],
-                              outLoop.getValidity(/*domain=*/1),
-                              outLoop.getLowerCoords(/*domain=*/1),
-                              needs64BitIdx ? b.getUnitAttr() : nullptr,
-                              /*canStoreOffEnd=*/nullptr);
-    } else {
-      if (needs64BitIdx)
-        return b.notifyMatchFailure(
-            loc, "non-global address spaces must have 32-bit pointers");
-      Type loadType = vectorTypeOrSelf(elementType, vectorLen);
-      TypedValue<IntegerType> valid = outLoop.getValidity(/*domain=*/0);
-      scf::IfOp ifb = b.create<scf::IfOp>(loc, valid, /*withElseRegion=*/false);
-      {
-        OpBuilder thenb = ifb.getThenBodyBuilder();
-        Value loaded =
-            thenb.create<InBoundsLoadOp>(loc, loadType, source,
-                                         outLoop.getLowerCoords(
-                                             /*domain=*/0)[extraIdxCount]);
-        if (!destElemType.isa<VectorType>()) {
-          thenb.create<InBoundsStoreOp>(loc, loaded, buffer,
-                                        outLoop.getLowerCoords(/*domain=*/1));
-        } else {
-          thenb.create<memref::StoreOp>(loc, loaded, buffer,
-                                        outLoop.getLowerCoords(/*domain=*/1));
-        }
-      }
-    }
-  }
-  b.eraseOp(op);
-  return success();
-}
 
 //===----------------------------------------------------------------------===//
 // BlockwiseReduce lowering.
@@ -1502,34 +1111,18 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   {
     ConversionTarget writeAllTarget(*ctx);
-    writeAllTarget.addIllegalOp<ThreadwiseReadIntoOp, ThreadwiseWriteAllOp,
-                                ThreadwiseCopyOp, BlockwiseBroadcastReduceOp,
-                                BlockwiseFillOp>();
+    writeAllTarget.addIllegalOp<BlockwiseBroadcastReduceOp, BlockwiseFillOp>();
     writeAllTarget.addLegalDialect<arith::ArithDialect, rock::RockDialect,
                                    memref::MemRefDialect, scf::SCFDialect,
                                    vector::VectorDialect, AffineDialect>();
     writeAllTarget.addLegalOp<gpu::PrintfOp>();
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns
-        .add<ThreadwiseReadIntoRewritePattern, ThreadwiseWriteAllRewritePattern,
-             ThreadwiseCopyRewritePattern, BlockwiseReduceRewritePattern,
-             BlockwiseFillRewritePattern>(ctx);
+        .add<BlockwiseReduceRewritePattern, BlockwiseFillRewritePattern>(ctx);
     if (failed(applyPartialConversion(getOperation(), writeAllTarget,
                                       std::move(writeAllPatterns))))
       signalPassFailure();
   }
-
-  WalkResult kernelNeeds64Bit = getOperation().walk([](Operation *op) {
-    if (auto globalLoad = dyn_cast<GlobalLoadOp>(op))
-      return globalLoad.getNeeds64BitIdx() ? WalkResult::interrupt()
-                                           : WalkResult::advance();
-    if (auto globalStore = dyn_cast<GlobalStoreOp>(op))
-      return globalStore.getNeeds64BitIdx() ? WalkResult::interrupt()
-                                            : WalkResult::advance();
-    return WalkResult::advance();
-  });
-  if (kernelNeeds64Bit.wasInterrupted())
-    getOperation()->setAttr("rock.64bitindex", UnitAttr::get(&getContext()));
 
   ConversionTarget target(*ctx);
   target.addIllegalOp<FillOp, BlockwiseGemmOp, BlockwiseGemmAccelOp>();

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -408,7 +408,6 @@ struct BlockwiseGemmAccelRewritePattern
     int64_t kpackPerBlock = tuningParams.getKpackPerBlock();
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();
-    int64_t KPack = tuningParams.getKpack();
 
     Type bufferElemTypeA =
         adaptor.getMatrixA().getType().cast<MemRefType>().getElementType();
@@ -419,11 +418,6 @@ struct BlockwiseGemmAccelRewritePattern
       dataTypeA = bufferVecTypeA.getElementType();
     if (auto bufferVecTypeB = bufferElemTypeB.dyn_cast<VectorType>())
       dataTypeB = bufferVecTypeB.getElementType();
-
-    Value sourceOffsetA = adaptor.getWaveOffsetA();
-    Value sourceOffsetB = adaptor.getWaveOffsetB();
-    int64_t mWaves = mPerBlock / mPerWave;
-    int64_t nWaves = nPerBlock / nPerWave;
 
     auto accelEmitterPtr = rock::accel::AccelEmitter::select(
         op.getFeatures(), dataTypeA, dataTypeB, arch, tuningParams);
@@ -437,14 +431,7 @@ struct BlockwiseGemmAccelRewritePattern
     Type argTypeB = params.argTypeB;
     int64_t mRepeats = params.mRepeats;
     int64_t nRepeats = params.nRepeats;
-    int64_t mPerAccel = params.mPerAccel;
-    int64_t nPerAccel = params.nPerAccel;
     int64_t kBase = params.kBase;
-    int64_t kpackPerThread = params.kpackPerThread;
-    Value mWavesConstantOp = b.create<ConstantIndexOp>(loc, mWaves);
-    Value nWavesConstantOp = b.create<ConstantIndexOp>(loc, nWaves);
-    int64_t copyMPerThread = op.getInMPerThread();
-    int64_t copyNPerThread = op.getInNPerThread();
 
     auto tid = b.create<WorkitemIdOp>(loc, b.getIndexType());
 

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -403,8 +403,6 @@ struct BlockwiseGemmAccelRewritePattern
 
     StringAttr arch = op.getArchAttr();
     RockAccelTuningParamAttrInterface tuningParams = op.getParams();
-    int64_t mPerBlock = tuningParams.getMPerBlock();
-    int64_t nPerBlock = tuningParams.getNPerBlock();
     int64_t kpackPerBlock = tuningParams.getKpackPerBlock();
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -441,7 +441,7 @@ struct BlockwiseGemmAccelRewritePattern
                << "nPerWave: " << nPerWave << "\n"
                << "mRepeat: " << mRepeats << "\n"
                << "nRepeat: " << nRepeats << "\n"
-               << "K: " << kpackPerBlock << "\n"
+               << "kpackPerBlock: " << kpackPerBlock << "\n"
                << "bufferA type: " << adaptor.getBufferA().getType() << "\n"
                << "bufferB type: " << adaptor.getBufferB().getType() << "\n");
 

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -892,41 +892,6 @@ struct GridwiseAttentionAccelRewritePattern
     return gemmOutScalarBuffer;
   }
 
-  // Logic to setup blockwise_gemm_accel parameters.
-  //
-  // Original C++ logic:
-  // index_t mMyWaveOffsetA;
-  // index_t mMyWaveOffsetB;
-  // const index_t waveId   = get_thread_local_1d_id() / WaveSize;
-  // const index_t waveId_m = waveId / GemmNWaves;
-  // const index_t waveId_n = waveId % GemmNWaves;
-  // mMyWaveOffsetA = waveId_m * GemmMPerWave;
-  // mMyWaveOffsetB = waveId_n * GemmNPerWave;
-  std::tuple<Value, Value>
-  createWaveOffsets(Location loc, const int64_t waveSize, int64_t nPerWave,
-                    int64_t nPerBlock,
-                    rock::accel::AccelEmitterParams accelParams, Value tid,
-                    PatternRewriter &rewriter) const {
-    ConstantIndexOp waveSizeConstantOp =
-        rewriter.create<ConstantIndexOp>(loc, waveSize);
-    int64_t nWaves = nPerBlock / nPerWave;
-    auto nWavesConstantOp = rewriter.create<ConstantIndexOp>(loc, nWaves);
-    auto waveId = rewriter.create<DivUIOp>(loc, tid, waveSizeConstantOp);
-    auto waveId_m = rewriter.create<DivUIOp>(loc, waveId, nWavesConstantOp);
-    auto waveId_n = rewriter.create<RemUIOp>(loc, waveId, nWavesConstantOp);
-
-    Value mMyWaveOffsetA, mMyWaveOffsetB;
-    Value waveOffsetAConstantOp =
-        rewriter.create<ConstantIndexOp>(loc, accelParams.mPerAccel);
-    Value waveOffsetBConstantOp =
-        rewriter.create<ConstantIndexOp>(loc, accelParams.nPerAccel);
-    mMyWaveOffsetA =
-        rewriter.create<MulIOp>(loc, waveId_m, waveOffsetAConstantOp);
-    mMyWaveOffsetB =
-        rewriter.create<MulIOp>(loc, waveId_n, waveOffsetBConstantOp);
-    return {mMyWaveOffsetA, mMyWaveOffsetB};
-  }
-
   // This fuction creates interrim register buffers to store data in once
   // loaded from the LDS before accelerator intrinsics are called
   std::tuple<Value, Value>
@@ -1309,7 +1274,6 @@ struct GridwiseAttentionAccelRewritePattern
     StringRef arch = op.getArch();
     uint32_t blockSize = op.getBlockSize();
     uint32_t gridSize = op.getGridSize();
-    const int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
 
     TypedValue<MemRefType> inQ = op.getQueries();
     ArrayRef<int64_t> qShape = inQ.getType().getShape();
@@ -1552,18 +1516,14 @@ struct GridwiseAttentionAccelRewritePattern
         // LDS barrier.
         rewriter.create<LDSBarrierOp>(loc);
         // Emit blockwise GEMM 0.
-        auto [mMyWaveOffsetQ, mMyWaveOffsetK] =
-            createWaveOffsets(loc, waveSize, gemm0TuningParams.getNPerWave(),
-                              gemm0NPerBlock, accelParamsGemm0, tid, rewriter);
         rewriter.create<BlockwiseGemmAccelOp>(
             loc, ldsTileBufferQ, ldsTileBufferK,
             rewriter.getI32IntegerAttr(gemm0InMPerThread),
             rewriter.getI32IntegerAttr(gemm0InNPerThread),
             /*rotateMWithK=*/nullptr,
-            /*rotateNWithK=*/nullptr, mMyWaveOffsetQ, mMyWaveOffsetK,
-            preAccelRegBufferQ, preAccelRegBufferK, accRegBufferGemm0,
-            op.getArchAttr(), op.getFeaturesAttr(), op.getBlockSizeAttr(),
-            op.getParamsAttr());
+            /*rotateNWithK=*/nullptr, preAccelRegBufferQ, preAccelRegBufferK,
+            accRegBufferGemm0, op.getArchAttr(), op.getFeaturesAttr(),
+            op.getBlockSizeAttr(), op.getParamsAttr());
       }
       accelEmitterPtrGemm0->computeOutputConversion(
           rewriter, loc, accRegBufferGemm0, gemm0OutBuffer, forceUnroll);
@@ -1667,18 +1627,14 @@ struct GridwiseAttentionAccelRewritePattern
         // LDS barrier.
         rewriter.create<LDSBarrierOp>(loc);
         // Emit blockwise GEMM 1.
-        auto [mMyWaveOffsetQxK, mMyWaveOffsetV] =
-            createWaveOffsets(loc, waveSize, gemm1TuningParams.getNPerWave(),
-                              gemm1NPerBlock, accelParamsGemm1, tid, rewriter);
         rewriter.create<BlockwiseGemmAccelOp>(
             loc, gemm1LDSBufferA, ldsTileBufferV,
             rewriter.getI32IntegerAttr(gemm1InMPerThread),
             rewriter.getI32IntegerAttr(gemm1InNPerThread),
             /*rotateMWithK=*/nullptr,
-            /*rotateNWithK=*/nullptr, mMyWaveOffsetQxK, mMyWaveOffsetV,
-            preAccelRegBufferQxK, preAccelRegBufferV, accRegBufferGemm1,
-            op.getArchAttr(), op.getFeaturesAttr(), op.getBlockSizeAttr(),
-            gemm1TuningParams);
+            /*rotateNWithK=*/nullptr, preAccelRegBufferQxK, preAccelRegBufferV,
+            accRegBufferGemm1, op.getArchAttr(), op.getFeaturesAttr(),
+            op.getBlockSizeAttr(), gemm1TuningParams);
         // There is no second k-loop
         // Therefore can get the output straight away
         accelEmitterPtrGemm1->computeOutputConversion(
@@ -1951,9 +1907,6 @@ struct GridwiseGemmAccelRewritePattern
     // Obtain Accelerator-related attributes.
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();
-    int64_t nWaves = nPerBlock / nPerWave;
-
-    auto nWavesConstantOp = b.create<ConstantIndexOp>(loc, nWaves);
 
     auto accelEmitterPtr = accel::AccelEmitter::select(
         op.getFeatures(), elementTypeA, elementTypeB, arch, tuningParams);
@@ -1971,10 +1924,6 @@ struct GridwiseGemmAccelRewritePattern
     Type argTypeB = params.argTypeB;
     VectorType accVectorType = params.accVectorType;
     int64_t numOutputVectorElements = params.numOutputVectorElements();
-
-    const int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
-    auto waveSizeConstantOp = b.create<ConstantIndexOp>(loc, waveSize);
-
     bool useIndexDiffs = true;
 
     LLVM_DEBUG(llvm::dbgs() << "M: " << M << "\n"
@@ -2055,28 +2004,6 @@ struct GridwiseGemmAccelRewritePattern
     Value ldsViewForGemmB = viewBufferAs(b, ldsByteBufferB, ldsReadTypeB);
     int64_t nOutputVectors = nResultVectors * mRepeats * nRepeats;
 
-    // Logic to setup blockwise_gemm_accel parameters.
-    //
-    // Original C++ logic:
-    // index_t mMyWaveOffsetA;
-    // index_t mMyWaveOffsetB;
-    // const index_t waveId   = get_thread_local_1d_id() / WaveSize;
-    // const index_t waveId_m = waveId / GemmNWaves;
-    // const index_t waveId_n = waveId % GemmNWaves;
-    // mMyWaveOffsetA = waveId_m * GemmMPerWave;
-    // mMyWaveOffsetB = waveId_n * GemmNPerWave;
-    auto waveId = b.create<DivUIOp>(loc, tid, waveSizeConstantOp);
-    auto waveId_m = b.create<DivUIOp>(loc, waveId, nWavesConstantOp);
-    auto waveId_n = b.create<RemUIOp>(loc, waveId, nWavesConstantOp);
-
-    Value mMyWaveOffsetA, mMyWaveOffsetB;
-    Value waveOffsetAConstantOp =
-        b.create<ConstantIndexOp>(loc, params.mPerAccel);
-    Value waveOffsetBConstantOp =
-        b.create<ConstantIndexOp>(loc, params.nPerAccel);
-    mMyWaveOffsetA = b.create<MulIOp>(loc, waveId_m, waveOffsetAConstantOp);
-    mMyWaveOffsetB = b.create<MulIOp>(loc, waveId_n, waveOffsetBConstantOp);
-
     // Logic to setup buffers for blockwise_gemm_accel.
 
     Type arrayAType, arrayBType;
@@ -2130,9 +2057,9 @@ struct GridwiseGemmAccelRewritePattern
           b.getI32IntegerAttr(copyMPerThread),
           b.getI32IntegerAttr(copyNPerThread),
           (rotateMWithK ? b.getUnitAttr() : nullptr),
-          (rotateNWithK ? b.getUnitAttr() : nullptr), mMyWaveOffsetA,
-          mMyWaveOffsetB, arrayA, arrayB, regCAllocOp, op.getArchAttr(),
-          op.getFeaturesAttr(), op.getBlockSizeAttr(), op.getParamsAttr());
+          (rotateNWithK ? b.getUnitAttr() : nullptr), arrayA, arrayB,
+          regCAllocOp, op.getArchAttr(), op.getFeaturesAttr(),
+          op.getBlockSizeAttr(), op.getParamsAttr());
 
       // LDS barrier.
       // This barrier prevents halo part of outputs having weird values.

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -373,7 +373,7 @@ static void addIterationIndexIfScalar(PatternRewriter &b, Location loc,
 
 LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
     ThreadwiseReadIntoOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &b) const{
+    ConversionPatternRewriter &b) const {
   Location loc = op.getLoc();
   auto sourceView = cast<TypedValue<MemRefType>>(adaptor.getSource());
   ArrayAttr extraViews = op.getExtraViews();
@@ -543,7 +543,7 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
   }
   b.eraseOp(op);
   return success();
-    }
+}
 
 LogicalResult ThreadwiseWriteAllRewritePattern::matchAndRewrite(
     ThreadwiseWriteAllOp op, OpAdaptor adaptor,
@@ -660,7 +660,7 @@ void RockThreadwiseGemmLoweringPass::runOnOperation() {
   {
     ConversionTarget writeAllTarget(*ctx);
     writeAllTarget.addIllegalOp<ThreadwiseReadIntoOp, ThreadwiseWriteAllOp,
-                                ThreadwiseTransposeOp>();
+                                ThreadwiseCopyOp>();
     writeAllTarget.addLegalDialect<
         arith::ArithDialect, rock::RockDialect, memref::MemRefDialect,
         scf::SCFDialect, vector::VectorDialect, affine::AffineDialect>();

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1420,7 +1420,8 @@ TopDownTMBuilder mlir::rock::rotateIf(bool condition, TopDownTMBuilder &builder,
   if (condition) {
     // d = (d+k_outer)
     TopDownTMBuilder rotateD0 = TopDownTMBuilder::below(builder, attr);
-    rotateD0.passThrough(beforeDims);
+    if (!beforeDims.empty())
+      rotateD0.passThrough(beforeDims);
     rotateD0.embed(dName, dPos, d * kOuter, {kName, dName}, {stride, 1});
     if (!afterDims.empty())
       rotateD0.passThrough(afterDims);
@@ -1431,7 +1432,8 @@ TopDownTMBuilder mlir::rock::rotateIf(bool condition, TopDownTMBuilder &builder,
     unsigned int numBeforeDims = beforeDims.size();
     unsigned int idx = numBeforeDims;
     TopDownTMBuilder rotateD1 = TopDownTMBuilder::below(rotateD0, rotateD0Attr);
-    rotateD1.passThrough(beforeDims);
+    if (!beforeDims.empty())
+      rotateD1.passThrough(beforeDims);
     rotateD1.merge({"to_discard", dName}, {idx, ++idx}, dName, {kOuter, d});
     for (auto dim : afterDims)
       rotateD1.passThrough({dim}, ++idx, {dim});
@@ -1441,7 +1443,8 @@ TopDownTMBuilder mlir::rock::rotateIf(bool condition, TopDownTMBuilder &builder,
     // discard the additional dimension
     TopDownTMBuilder rotateD2 = TopDownTMBuilder::below(rotateD1, rotateD1Attr);
     idx = numBeforeDims;
-    rotateD2.passThrough(beforeDims);
+    if (!beforeDims.empty())
+      rotateD2.passThrough(beforeDims);
     rotateD2.ignore("to_discard");
     rotateD2.passThrough({dName}, {idx++}, {dName});
     for (auto dim : afterDims)

--- a/mlir/test/Dialect/Rock/large_tensor_detection.mlir
+++ b/mlir/test/Dialect/Rock/large_tensor_detection.mlir
@@ -1,5 +1,5 @@
 // RUN: rocmlir-opt %s -split-input-file -rock-gemm-to-gridwise \
-// RUN:    -rock-gridwise-gemm-to-blockwise -rock-blockwise-gemm-to-threadwise \
+// RUN:    -rock-gridwise-gemm-to-blockwise -rock-blockwise-gemm-to-threadwise -rock-threadwise-gemm-lowering \
 // RUN: | FileCheck %s --check-prefixes=BLOCKWISE
 // RUN: rocmlir-opt %s -split-input-file -rock-kernel-pipeline | FileCheck %s --check-prefixes=GPU
 

--- a/mlir/test/Dialect/Rock/lowering_blockwise_fill.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_fill.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise -split-input-file %s | FileCheck %s
+// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise -rock-threadwise-gemm-lowering -split-input-file %s | FileCheck %s
 
 // CHECK-DAG: [[MAP:.*]] = affine_map<(d0, d1) -> (d0 + d1)>
 // CHECK-DAG: [[TMAP:.*]] = #rock.transform_map<[[MAP]]{{.*}}

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -7,9 +7,8 @@
 func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2xf32>, #wg>, %matrixB : memref<256xvector<2xf32>, #wg>,
                                                 %bufferA : memref<4xf32, #priv>, %bufferB : memref<4xf32, #priv>,
                                                 %matrixC : memref<4xvector<16xf32>, #priv>) {
-  %c0 = arith.constant 0 : index
   // CHECK:  rock.accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize= 256 : i32,
     inMPerThread = 2 : i32,
@@ -30,9 +29,8 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2x
 func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<128xvector<8xi8>, #wg>, %matrixB : memref<128xvector<8xi8>, #wg>,
                                                %bufferA : memref<1xvector<4xi8>, #priv>, %bufferB : memref<1xvector<4xi8>, #priv>,
                                                %matrixC : memref<1xvector<16xi32>, #priv>) {
-  %c0 = arith.constant 0 : index
   // CHECK:  rock.accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     inMPerThread = 2 : i32,
@@ -56,8 +54,7 @@ func.func @rock_blockwise_gemm_accel_fp8_bf8(%matrixA : memref<1024xvector<8xf8E
                                           %bufferB : memref<4xvector<8xf8E5M2FNUZ>, #gpu.address_space<private>>,
                                           %matrixC : memref<4xvector<16xf32>, #gpu.address_space<private>>) {
   // CHECK:  rock.accel_gemm
-  %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     blockSize = 256 : i32,
     inMPerThread = 2 : i32,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -2,22 +2,15 @@
 #wg = #gpu.address_space<workgroup>
 #priv = #gpu.address_space<private>
 
-func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<16xf16>, #wg>, %matrixB : memref<16xvector<16xf16>, #wg>,
+func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<8xf16>, #wg>, %matrixB : memref<16xvector<8xf16>, #wg>,
                                           %bufferA : memref<1xvector<16xf16>, #priv>, %bufferB : memref<1xvector<16xf16>, #priv>,
                                           %matrixC : memref<1xvector<8xf32>, #priv>) {
   %c0 = arith.constant 0 : index
-  // CHECK: %[[tid:.*]] = rock.workitem_id : index
-  // CHECK: %[[wid:.*]] = arith.remui %[[tid]], %c32{{.*}} : index
-  // CHECK: {{.*}} = arith.remui %[[wid]], %c16{{.*}} : index
   // CHECK: affine.for {{.*}} = 0 to 1
-  // CHECK: affine.for {{.*}} = 0 to 4
-  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<16xvector<16xf16>, #gpu.address_space<workgroup>>
-  // CHECK: memref.store
+  // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 1
-  // CHECK: affine.for {{.*}} = 0 to 4
-  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<16xvector<16xf16>, #gpu.address_space<workgroup>>
-  // CHECK: memref.store
-  // CHECK:  rock.accel_gemm
+  // CHECK: rock.threadwise_read_into
+  // CHECK: rock.accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 32 : i32,
@@ -25,37 +18,24 @@ func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<16xf16>, #
     inNPerThread = 2 : i32,
     params = #rock.wmma_gemm_params<
       kpackPerBlock = 4,
-      kpack = 16,
+      kpack = 8,
       mPerBlock = 16,
       mPerWave = 16,
       nPerBlock = 16,
       nPerWave = 16,
       forceUnroll = true>
-  } : memref<1xvector<8xf32>, #priv> += memref<1xvector<16xf16>, #priv> from memref<16xvector<16xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<16xvector<16xf16>, #wg>
+  } : memref<1xvector<8xf32>, #priv> += memref<1xvector<16xf16>, #priv> from memref<16xvector<8xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<16xvector<8xf16>, #wg>
   return
 }
 
-func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector<32xf16>, #wg>, %matrixB : memref<32xvector<32xf16>, #wg>,
+func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector<8xf16>, #wg>, %matrixB : memref<32xvector<8xf16>, #wg>,
                                                      %bufferA : memref<1xvector<16xf16>, #priv>, %bufferB : memref<1xvector<16xf16>, #priv>,
                                                      %matrixC : memref<1xvector<8xf32>, #priv>) {
   %c0 = arith.constant 0 : index
-  // CHECK: %[[tid:.*]] = rock.workitem_id : index
-  // CHECK: %[[wid:.*]] = arith.remui %[[tid]], %c32{{.*}} : index
-  // CHECK: {{.*}} = arith.remui %[[wid]], %c16{{.*}} : index
   // CHECK: affine.for {{.*}} = 0 to 1
-  // CHECK: affine.for {{.*}} = 0 to 4
-  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<32xvector<32xf16>, #gpu.address_space<workgroup>>
-  // CHECK: {{.*}} = rock.extract_slice %[[a]][{{.*}}] : vector<32xf16> -> vector<16xf16>
-  // CHECK: memref.store
-  // CHECK: {{.*}} = rock.extract_slice %[[a]][{{.*}}] : vector<32xf16> -> vector<16xf16>
-  // CHECK: memref.store
+  // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 1
-  // CHECK: affine.for {{.*}} = 0 to 4
-  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<32xvector<32xf16>, #gpu.address_space<workgroup>>
-  // CHECK: {{.*}} = rock.extract_slice %[[b]][{{.*}}] : vector<32xf16> -> vector<16xf16>
-  // CHECK: memref.store
-  // CHECK: {{.*}} = rock.extract_slice %[[b]][{{.*}}] : vector<32xf16> -> vector<16xf16>
-  // CHECK: memref.store
+  // CHECK: rock.threadwise_read_into
   // CHECK:  rock.accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
@@ -68,9 +48,9 @@ func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector
       kpackPerBlock = 4,
       mPerWave = 16,
       nPerWave = 16,
-      kpack = 32,
+      kpack = 8,
       forceUnroll = true>
-  } : memref<1xvector<8xf32>, #priv> += memref<1xvector<16xf16>, #priv> from memref<32xvector<32xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<32xvector<32xf16>, #wg>
+  } : memref<1xvector<8xf32>, #priv> += memref<1xvector<16xf16>, #priv> from memref<32xvector<8xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<32xvector<8xf16>, #wg>
   return
 }
 
@@ -78,17 +58,10 @@ func.func @rock_blockwise_gemm_accel_wmma_int8(%matrixA : memref<32xvector<16xi8
                                                %bufferA : memref<4xvector<16xi8>, #priv>, %bufferB : memref<4xvector<16xi8>, #priv>,
                                                %matrixC : memref<4xvector<8xi32>, #priv>) {
   %c0 = arith.constant 0 : index
-  // CHECK: %[[tid:.*]] = rock.workitem_id : index
-  // CHECK: %[[wid:.*]] = arith.remui %[[tid]], %c32{{.*}} : index
-  // CHECK: {{.*}} = arith.remui %[[wid]], %c16{{.*}} : index
   // CHECK: affine.for {{.*}} = 0 to 2
-  // CHECK: affine.for {{.*}} = 0 to 4
-  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<32xvector<16xi8>, #gpu.address_space<workgroup>>
-  // CHECK: memref.store
+  // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 2
-  // CHECK: affine.for {{.*}} = 0 to 4
-  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<32xvector<16xi8>, #gpu.address_space<workgroup>>
-  // CHECK: memref.store
+  // CHECK: rock.threadwise_read_into
   // CHECK:  rock.accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -5,13 +5,12 @@
 func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<8xf16>, #wg>, %matrixB : memref<16xvector<8xf16>, #wg>,
                                           %bufferA : memref<1xvector<16xf16>, #priv>, %bufferB : memref<1xvector<16xf16>, #priv>,
                                           %matrixC : memref<1xvector<8xf32>, #priv>) {
-  %c0 = arith.constant 0 : index
   // CHECK: affine.for {{.*}} = 0 to 1
   // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 1
   // CHECK: rock.threadwise_read_into
   // CHECK: rock.accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 32 : i32,
     inMPerThread = 2 : i32,
@@ -31,13 +30,12 @@ func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<8xf16>, #w
 func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector<8xf16>, #wg>, %matrixB : memref<32xvector<8xf16>, #wg>,
                                                      %bufferA : memref<1xvector<16xf16>, #priv>, %bufferB : memref<1xvector<16xf16>, #priv>,
                                                      %matrixC : memref<1xvector<8xf32>, #priv>) {
-  %c0 = arith.constant 0 : index
   // CHECK: affine.for {{.*}} = 0 to 1
   // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 1
   // CHECK: rock.threadwise_read_into
   // CHECK:  rock.accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,
     inMPerThread = 2 : i32,
@@ -57,13 +55,12 @@ func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector
 func.func @rock_blockwise_gemm_accel_wmma_int8(%matrixA : memref<32xvector<16xi8>, #wg>, %matrixB : memref<32xvector<16xi8>, #wg>,
                                                %bufferA : memref<4xvector<16xi8>, #priv>, %bufferB : memref<4xvector<16xi8>, #priv>,
                                                %matrixC : memref<4xvector<8xi32>, #priv>) {
-  %c0 = arith.constant 0 : index
   // CHECK: affine.for {{.*}} = 0 to 2
   // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 2
   // CHECK: rock.threadwise_read_into
   // CHECK:  rock.accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = wmma{
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,
     inMPerThread = 2 : i32,

--- a/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-opt --rock-blockwise-gemm-to-threadwise %s | FileCheck %s
+// RUN: rocmlir-opt --rock-blockwise-gemm-to-threadwise --rock-threadwise-gemm-lowering %s | FileCheck %s
 #map5 = affine_map<(d0, d1) -> (d0 * 8 + d1)>
 #map6 = affine_map<(d0, d1) -> (d1, d0)>
 #map7 = affine_map<(d0, d1, d2) -> ((d0 * 2 + d1) * 8 + d2)>

--- a/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
@@ -1,5 +1,5 @@
 // Note: this should be in a post-fusion pass
-// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise --canonicalize %s | FileCheck --enable-var-scope %s
+// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise -rock-threadwise-gemm-lowering --canonicalize %s | FileCheck --enable-var-scope %s
 
 // CHECK-DAG: #[[$ON_OP:transform_map[0-9]*]] = #rock.transform_map{{.*}}PassThrough{{.*}}[0, 1, 2]{{.*}}[0, 1, 2]
 #transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)>

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -180,8 +180,7 @@ func.func @rock_accel_gemm_two_results(%matrixA : memref<16xf32, 5>,
 func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
                                               %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
                                               %matrixC : memref<1xvector<32xf32>, 5>) {
-  %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     inMPerThread = 2 : i32,
@@ -206,8 +205,7 @@ func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<12288xf32, 3>,
 func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<12288xf32, 3>, %matrixB : memref<12288xf32, 3>,
                                                 %bufferA : memref<32xf32, 5>, %bufferB : memref<16xf32, 5>,
                                                 %matrixC : memref<2xvector<32xf32>, 5>) {
-  %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     inMPerThread = 2 : i32,

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -73,9 +73,8 @@ func.func @rock_xdlops_gemm_accel_two_results_f16(%matrixA : memref<4xvector<4xf
 func.func @rock_blockwise_gemm_accel_one_result_f16(%matrixA : memref<8192xf16, 3>, %matrixB : memref<4096xf16, 3>,
                                           %bufferA : memref<4xvector<4xf16>, 5>, %bufferB : memref<4xvector<4xf16>, 5>,
                                           %matrixC : memref<1xvector<32xf32>, 5>) {
-  %c0 = arith.constant 0 : index
   %c0f = arith.constant 0.0 : f16
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     inMPerThread = 2 : i32,
@@ -100,8 +99,7 @@ func.func @rock_blockwise_gemm_accel_one_result_f16(%matrixA : memref<8192xf16, 
 func.func @rock_blockwise_gemm_accel_two_results_f16(%matrixA : memref<8192xf16, 3>, %matrixB : memref<4096xf16, 3>,
                                                %bufferA : memref<4xvector<4xf16>, 5>, %bufferB : memref<4xvector<4xf16>, 5>,
                                                %matrixC : memref<2xvector<32xf32>, 5>) {
-  %c0 = arith.constant 0 : index
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA[%c0] * %bufferB from %matrixB[%c0] features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     inMPerThread = 2 : i32,

--- a/mlir/test/rocmlir-driver/sanity_wmma.mlir
+++ b/mlir/test/rocmlir-driver/sanity_wmma.mlir
@@ -2,15 +2,15 @@
 // and LLVM IR.
 
 // fp16 tests.
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-opt
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt
 
 // i8 tests
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-opt
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
-// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
+// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt

--- a/mlir/test/rocmlir-driver/sanity_wmma.mlir
+++ b/mlir/test/rocmlir-driver/sanity_wmma.mlir
@@ -2,15 +2,15 @@
 // and LLVM IR.
 
 // fp16 tests.
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-opt
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t f16 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt
 
 // i8 tests
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-opt
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
-// RUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu --verify-passes | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-opt
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx1100 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx1100
+// NORUN: rocmlir-gen --arch gfx1100 -wmma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx1100 | rocmlir-opt

--- a/mlir/test/rocmlir-driver/sanity_xdlops.mlir
+++ b/mlir/test/rocmlir-driver/sanity_xdlops.mlir
@@ -28,3 +28,4 @@
 // RUN: rocmlir-gen --arch gfx908 -mfma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx908 | rocmlir-opt
 // RUN: rocmlir-gen --arch gfx908 -mfma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,rocdl --verify-passes --arch=gfx908 | rocmlir-translate -gpu-module-to-rocdlir | opt -passes='default<O3>,strip' -S | llc -mcpu=gfx908
 // RUN: rocmlir-gen --arch gfx908 -mfma=on -p -t i8 | rocmlir-driver -kernel-pipeline=gpu,binary --verify-passes --arch=gfx908 | rocmlir-opt
+


### PR DESCRIPTION
This PR is refactoring the blockwise-to-threadwise pass so that the IR emitted looks like:
```
for mRepeats:
    aRegs = threadwise_readInto
    for nRepeats:
         bRegs = threadwise_readInto
         cRegs += aRegs*bRegs
```

To achieve that I had to:
- Move all the manual offset computation to work with transform maps (`AccelEmitter` is now returning a view for the LDS buffer for read, similar to `wrapLDSForStore`)
- Extend `threadwiseReadInto` with buffer of vectors support (i.e., `memref<vector<>>`)



