### PR TITLE
Bump rocMLIR supported major version up for ROCm 6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15.1)
 
 # Allow VERSION for projects, as expected in CMake 3.0+
 cmake_policy(SET CMP0048 NEW)
-project(rocMLIR VERSION 1.1.0 LANGUAGES CXX C)
+project(rocMLIR VERSION 2.0.0 LANGUAGES CXX C)
 
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
 if(POLICY CMP0116)


### PR DESCRIPTION
In this release, we have switched our frontend from MIOpen to MIGraphX. I believe this justifies a major version bump:
 - 1.x.x releases we claim support for MIOpen
 - 2.x.x releases we deprecated MIOpen support and transition to MIGraphX