### PR TITLE
Embed device libraries into build to minimize runtime requirements

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/AmdDeviceLibsIncGen.py
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/AmdDeviceLibsIncGen.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# AMDDeviceLibsIncGen.py - embed device library bitcode as string constants
+#
+# Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+# Exceptions. See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (c) 2022 Advanced Micro Devices INc.
+#
+# Despite being in upstream directories, this is rocMLIR specific code that
+# lets us embed the AMD device libraries as string constants
+
+import sys
+from pathlib import Path
+from typing import List
+
+def as_signed(byte: int) -> int:
+  """Return the input byte as a signed value, that is, map [128, 255] to
+  [-128, -1]."""
+  if byte >= 128:
+    return byte - 256
+  return byte
+
+def generate(outputPath: Path, rocmPath: Path, libs: List[str]) -> None:
+  bcPath = rocmPath / "amdgcn" / "bitcode"
+  with outputPath.open("w") as out:
+    for lib in libs:
+      with (bcPath / (lib + ".bc")).open("rb") as libFile:
+        bcBytes = libFile.read()
+      bcLen = len(bcBytes)
+      print(f"static constexpr size_t {lib}_size = {bcLen};", file=out)
+      print("""#if defined __GNUC__
+__attribute__((aligned (4096)))
+#elif defined _MSC_VER
+__declspec(align(4096))
+#endif""", file=out)
+      print(f"static constexpr char {lib}_bytes[{lib}_size + 1] = {{", file=out)
+      for i, byte in enumerate(bcBytes):
+        print(f"{as_signed(byte):+4},", file=out, end=("\n" if i % 8 == 0 else " "))
+      # Terminating null pointer needed for
+      print("0x00};", file=out)
+    print("static constexpr std::initializer_list<std::pair<llvm::StringRef, llvm::StringRef>> allLibList = {", file=out)
+    for lib in libs:
+      print(f"{{\"{lib}.bc\", llvm::StringRef({lib}_bytes, {lib}_size)}},", file=out)
+    print("};", file=out)
+    print("""static const llvm::StringMap<llvm::StringRef>& getDeviceLibraries() {
+static const llvm::StringMap<llvm::StringRef> allLibs(allLibList);
+return allLibs;
+}""", file=out)
+
+if __name__ == '__main__':
+  generate(Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3:])

--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -141,6 +141,56 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
       "LLD is not enabled, please reconfigure llvm build")
   endif()
 
+  ### rocMLIR-specific incantations to embed device libraries statically.
+  ### This is menat to let us embed the device libraries into a static library.
+  if (NOT DEFINED ROCM_PATH)
+    if (NOT DEFINED ENV{ROCM_PATH})
+      set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to which ROCm has been installed")
+    else()
+      set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which ROCm has been installed")
+    endif()
+  endif()
+  # A lot of the ROCm CMake files expect to find their own dependencies in
+  # CMAKE_PREFIX_PATH and don't respect PATHS or HINTS :( .
+  # Therefore, temporarily add the ROCm path to CMAKE_PREFIX_PATH so we can
+  # find the device libraries, then remove it
+  set(REAL_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+  list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
+  find_package(AMDDeviceLibs CONFIG)
+  set(CMAKE_PREFIX_PATH "${REAL_CMAKE_PREFIX_PATH}")
+  if(AMDDeviceLibs_FOUND)
+    set(device_lib_targets ${AMD_DEVICE_LIBS_TARGETS})
+    # Filter out control constants, since we set those inline
+    list(FILTER device_lib_targets EXCLUDE REGEX "^oclc_")
+    # None of our stuff uses opencl functions or functionality during
+    # compilation, and the only time that device library gets pulled in is for
+    # printf(), which we use the hip version of anyway.
+    list(REMOVE_ITEM device_lib_targets "opencl")
+    add_custom_command(OUTPUT Transforms/AmdDeviceLibs.cpp.inc
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/AmdDeviceLibsIncGen.py
+      ARGS
+        ${CMAKE_CURRENT_BINARY_DIR}/Transforms/AmdDeviceLibs.cpp.inc
+        ${AMD_DEVICE_LIBS_PREFIX}
+        ${device_lib_targets}
+      DEPENDS
+        AmdDeviceLibsIncGen.py
+        ${AMD_DEVICE_LIBS_TARGETS}
+      COMMENT "Generating device libraries include package"
+    )
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES Transforms/AmdDeviceLibs.cpp.inc)
+    add_custom_target(AmdDeviceLibsIncGen DEPENDS Transforms/AmdDeviceLibs.cpp.inc)
+    set_property(SOURCE Transforms/SerializeToHsaco.cpp APPEND
+      PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Transforms/AmdDeviceLibs.cpp.inc)
+    add_dependencies(obj.MLIRGPUTransforms AmdDeviceLibsIncGen)
+    target_compile_definitions(obj.MLIRGPUTransforms
+      PRIVATE
+      ROCMLIR_DEVICE_LIBS_PACKAGED=1
+    )
+
+  else()
+    message(NOTICE "Device libraries not found during builds, assuming we can find them at runtime")
+  endif()
+  ### End rocMLIR-specific hackery
   set(DEFAULT_ROCM_PATH "/opt/rocm" CACHE PATH "Fallback path to search for ROCm installs")
   target_compile_definitions(obj.MLIRGPUTransforms
     PRIVATE


### PR DESCRIPTION
Fixes
https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1142

Patch SerializeToHsaco (we'll need to do a version of this again when we move to the new compilation infrastructure) and its cmake to find the device libraries at bulid time (if possible) and embed them (by way of a convenient little Python script) into the compilation of SerilazieToHsaco. This'll allow our stuff to work even when there's no /opt/rocm or we can't find it.

( @lamb-j since you're not an available reviewer but should see this )