### PR TITLE
Fix attention padding kernels

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -427,6 +427,8 @@ def Rock_GridwiseAttentionAccelOp :
                    Rock_GemmFeaturesAttr:$features,
                    I32Attr:$blockSize,
                    I32Attr:$gridSize,
+                   OptionalAttr<I32Attr>:$prePadG0M,
+                   OptionalAttr<I32Attr>:$prePadG0N,
                    RockAccelTuningParamAttrInterface:$params)> {
   let summary = "Gridwise attention accelerated version";
   let description = [{

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -427,8 +427,8 @@ def Rock_GridwiseAttentionAccelOp :
                    Rock_GemmFeaturesAttr:$features,
                    I32Attr:$blockSize,
                    I32Attr:$gridSize,
-                   OptionalAttr<I32Attr>:$prePadG0M,
-                   OptionalAttr<I32Attr>:$prePadG0N,
+                   OptionalAttr<IndexAttr>:$prePadG0M,
+                   OptionalAttr<IndexAttr>:$prePadG0N,
                    RockAccelTuningParamAttrInterface:$params)> {
   let summary = "Gridwise attention accelerated version";
   let description = [{

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -257,12 +257,19 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
   func::FuncOp func = op->getParentOfType<func::FuncOp>();
   IntegerAttr blockSizeAttr = func->getAttr("block_size").cast<IntegerAttr>();
   IntegerAttr gridSizeAttr = func->getAttr("grid_size").cast<IntegerAttr>();
-
+  IntegerAttr prePadG0MAttr;
+  if (gemm0ExtraPad.m) {
+    prePadG0MAttr = rw.getI32IntegerAttr(gemm0Size.m);
+  }
+  IntegerAttr prePadG0NAttr;
+  if (gemm0ExtraPad.n) {
+    prePadG0NAttr = rw.getI32IntegerAttr(gemm0Size.n);
+  }
   rw.replaceOpWithNewOp<GridwiseAttentionAccelOp>(
       op, queries, keys, values,
       /*TODO(enable scale here once implemented)*/ nullptr, out,
       op.getArchAttr(), op.getFeaturesAttr(), blockSizeAttr, gridSizeAttr,
-      params);
+      prePadG0MAttr, prePadG0NAttr, params);
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -259,11 +259,11 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
   IntegerAttr gridSizeAttr = func->getAttr("grid_size").cast<IntegerAttr>();
   IntegerAttr prePadG0MAttr;
   if (gemm0ExtraPad.m) {
-    prePadG0MAttr = rw.getI32IntegerAttr(gemm0Size.m);
+    prePadG0MAttr = rw.getIndexAttr(gemm0Size.m);
   }
   IntegerAttr prePadG0NAttr;
   if (gemm0ExtraPad.n) {
-    prePadG0NAttr = rw.getI32IntegerAttr(gemm0Size.n);
+    prePadG0NAttr = rw.getIndexAttr(gemm0Size.n);
   }
   rw.replaceOpWithNewOp<GridwiseAttentionAccelOp>(
       op, queries, keys, values,

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -100,7 +100,7 @@ func.func @rock_attention_tr_padded(%arg0: memref<1x49x7xf32>, %arg1: memref<1x7
   // CHECK-DAG: %[[paddedV:.*]] = rock.transform %[[v]] by {{.*}} : memref<1x49x7xf32> to memref<1x52x8xf32>
   // CHECK-DAG: %[[paddedO:.*]] = rock.transform %[[o]] by {{.*}} : memref<1x49x7xf32> to memref<1x64x8xf32>
   // CHECK: rock.gridwise_attention_accel(%[[paddedTrQ]], %[[paddedK]], %[[paddedV]], %[[paddedO]])
-  // CHECK-SAME: prePadG0M = 49 : i32, prePadG0N = 49 : i32
+  // CHECK-SAME: prePadG0M = 49 : index, prePadG0N = 49 : index
   rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add {
     arch = "amdgcn-amd-amdhsa:gfx908",
     params = #xldops_attn_params

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -100,6 +100,7 @@ func.func @rock_attention_tr_padded(%arg0: memref<1x49x7xf32>, %arg1: memref<1x7
   // CHECK-DAG: %[[paddedV:.*]] = rock.transform %[[v]] by {{.*}} : memref<1x49x7xf32> to memref<1x52x8xf32>
   // CHECK-DAG: %[[paddedO:.*]] = rock.transform %[[o]] by {{.*}} : memref<1x49x7xf32> to memref<1x64x8xf32>
   // CHECK: rock.gridwise_attention_accel(%[[paddedTrQ]], %[[paddedK]], %[[paddedV]], %[[paddedO]])
+  // CHECK-SAME: prePadG0M = 49 : i32, prePadG0N = 49 : i32
   rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add {
     arch = "amdgcn-amd-amdhsa:gfx908",
     params = #xldops_attn_params

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded.mlir
@@ -1,0 +1,24 @@
+// RUN: sed -e s/##TOKEN_ARCH##/%arch/g %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004 --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) {
+    %0 = migraphx.dot(%arg0, %arg1): (tensor<1x7x3xf32>, tensor<1x3x7xf32>) -> tensor<1x7x7xf32>
+    %1 = migraphx.softmax(%0){axis = 2 : i64} : tensor<1x7x7xf32> -> tensor<1x7x7xf32>
+    %2 = migraphx.dot(%1, %arg2): (tensor<1x7x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
+    return %2 : tensor<1x7x3xf32>
+  }
+  func.func @mlir_attention_wrapper(%arg0: tensor<1x7x3xf32>, %arg1: tensor<1x3x7xf32>,  %arg2: tensor<1x7x3xf32>) -> tensor<1x7x3xf32> {
+    %token, %results = mhal.launch @mlir_attention (%arg0, %arg1, %arg2) : (tensor<1x7x3xf32>, tensor<1x3x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
+    mhal.await %token : !mhal.token
+    return %results : tensor<1x7x3xf32>
+  }
+  module @__xmodule_ attributes {mhal.arch = "##TOKEN_ARCH##", mhal.module} {
+    func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) attributes {kernel, original_func = @mlir_attention} {
+      %0 = migraphx.dot(%arg0, %arg1): (tensor<1x7x3xf32>, tensor<1x3x7xf32>) -> tensor<1x7x7xf32>
+      %1 = migraphx.softmax(%0){axis = 2 : i64} : tensor<1x7x7xf32> -> tensor<1x7x7xf32>
+      %2 = migraphx.dot(%1, %arg2): (tensor<1x7x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
+      return %2 : tensor<1x7x3xf32>
+    }
+  }
+}


### PR DESCRIPTION
Padded attention kernels wont just
work out of the box as (implicit) gemm
kernels.

This is because attention kernels does a
softmax normalization after the first gemm
and having additional zeros -- zero not being
the least value in the range -- is going to affect the normalization.

Therefore, this commit introduces a mid-kernel
overwrite to first gemm output to make the out
of bound values to be negative infinity.

closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1146