### PR TITLE
Ignore Navi3x failures in CI

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -466,16 +466,14 @@ pipeline {
                         }
                         steps {
                             script {
-                                if ( codepath == 'navi3x' ) {
-                                    catchError(buildResult: 'SUCCESS', stageResult: null) {
-                                      timeout(time: 2, activity: true, unit: 'MINUTES') {
+                                if ( "${CODEPATH}" == 'navi3x' ) {
+                                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                         check_RockE2ETests_Navi3x(true)
-                                      }
                                     }
                                 }
                                 else {
-                                    build_fixedE2ETests(codepath)
-                                    preMergeCheck(codepath)
+                                    build_fixedE2ETests("${CODEPATH}")
+                                    preMergeCheck("${CODEPATH}")
                                     timeout(time: 60, activity: true, unit: 'MINUTES') {
                                         sh 'cd build; ninja check-mlir check-rocmlir'
                                     }
@@ -494,10 +492,8 @@ pipeline {
                         steps {
                             script {
                                 if ( "${CODEPATH}" == 'navi3x') {
-                                    catchError(buildResult: 'SUCCESS', stageResult: null) {
-                                      timeout(time: 2, activity: true, unit: 'MINUTES') {
+                                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                         check_RockE2ETests_Navi3x(false)
-                                      }
                                     }
                                 }
                                 else
@@ -547,7 +543,12 @@ pipeline {
                 }
                 post {
                     unsuccessful {
-                        rebootNode()
+                        script {
+                            // Ignore Navi3x failures
+                            if ( "${CODEPATH}" != 'navi3x') {
+                                rebootNode()
+                            }
+                        }
                     }
                     always {
                         cleanWs()

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -467,7 +467,7 @@ pipeline {
                         steps {
                             script {
                                 if ( codepath == 'navi3x' ) {
-                                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                    catchError(buildResult: 'SUCCESS', stageResult: 'null') {
                                         check_RockE2ETests_Navi3x(true)
                                     }
                                 }
@@ -492,7 +492,7 @@ pipeline {
                         steps {
                             script {
                                 if ( "${CODEPATH}" == 'navi3x') {
-                                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                    catchError(buildResult: 'SUCCESS', stageResult: 'null') {
                                         check_RockE2ETests_Navi3x(false)
                                     }
                                 }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -467,7 +467,7 @@ pipeline {
                         steps {
                             script {
                                 if ( codepath == 'navi3x' ) {
-                                    catchError(buildResult: 'SUCCESS', stageResult: 'null') {
+                                    catchError(buildResult: 'SUCCESS', stageResult: null) {
                                         check_RockE2ETests_Navi3x(true)
                                     }
                                 }
@@ -492,7 +492,7 @@ pipeline {
                         steps {
                             script {
                                 if ( "${CODEPATH}" == 'navi3x') {
-                                    catchError(buildResult: 'SUCCESS', stageResult: 'null') {
+                                    catchError(buildResult: 'SUCCESS', stageResult: null) {
                                         check_RockE2ETests_Navi3x(false)
                                     }
                                 }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -468,7 +468,9 @@ pipeline {
                             script {
                                 if ( codepath == 'navi3x' ) {
                                     catchError(buildResult: 'SUCCESS', stageResult: null) {
+                                      timeout(time: 2, activity: true, unit: 'MINUTES') {
                                         check_RockE2ETests_Navi3x(true)
+                                      }
                                     }
                                 }
                                 else {
@@ -493,7 +495,9 @@ pipeline {
                             script {
                                 if ( "${CODEPATH}" == 'navi3x') {
                                     catchError(buildResult: 'SUCCESS', stageResult: null) {
+                                      timeout(time: 2, activity: true, unit: 'MINUTES') {
                                         check_RockE2ETests_Navi3x(false)
+                                      }
                                     }
                                 }
                                 else


### PR DESCRIPTION
[This build](http://rocmhead.amd.com:8080/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-1260/22/pipeline/) showed Ci pipelines continue when a Navi3x stage has a timeout.