### PR TITLE
Use ROCm Clang everywhere

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -6,7 +6,9 @@ void buildProject(String target, String cmakeOpts) {
             buildType: 'RelWithDebInfo',\
             installation: 'InSearchPath',\
             steps: [[args: target]],\
-            cmakeArgs: "$cmakeOpts"
+            cmakeArgs: """-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+              -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+              ${cmakeOpts}"""
     }
 }
 
@@ -29,7 +31,10 @@ void buildMIGraphX(String cmakeOpts) {
         buildDir: 'build',\
         buildType: 'Release',\
         installation: 'InSearchPath',\
-        cmakeArgs: "${cmakeOpts}"
+        cmakeArgs: """-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+                      -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+                     ${cmakeOpts}
+                     """
     sh 'cd build; make -j $(nproc)'
 }
 

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -5,7 +5,9 @@ void buildProject(String target, String cmakeOpts) {
             buildType: 'RelWithDebInfo',\
             installation: 'InSearchPath',\
             steps: [[args: target]],\
-            cmakeArgs: "$cmakeOpts"
+            cmakeArgs: """-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+              -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+              ${cmakeOpts}"""
     }
 }
 

--- a/mlir/utils/jenkins/Jenkinsfile.release
+++ b/mlir/utils/jenkins/Jenkinsfile.release
@@ -5,7 +5,10 @@ void buildProject(String target, String cmakeOpts) {
         buildType: 'RelWithDebInfo',\
         installation: 'InSearchPath',\
         steps: [[args: target]],\
-        cmakeArgs: "$cmakeOpts"
+        cmakeArgs: """-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+          -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+          ${cmakeOpts}"""
+
 }
 
 void showEnv() {


### PR DESCRIPTION
Our previous attempt to migrate to ROCm clang missed a bunch of spots, most importantly actually building rocMLIR itself. Since MIGraphX builds us whith ROCm clang, there's no reason not to switch that setting ourselves.

This blocks #1256 landing