### PR TITLE
Fix windows regression caused by 3cff247

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -445,7 +445,7 @@ SerializeToHsacoPass::createHsaco(const SmallVectorImpl<char> &isaBinary) {
   // A proper fix would be to change createTemporaryFile to close the file
   // after it opens it or to change closeFile to accept an int. Both changes
   // require changing core LLVM code so this workaround was done.
-#if _WIN32
+#ifdef _WIN32
   llvm::sys::fs::file_t tempHscacoFilePtr = 0;
   *reinterpret_cast<int*>(&tempHscacoFilePtr) = tempHsacoFD;
   llvm::sys::fs::closeFile(tempHscacoFilePtr);


### PR DESCRIPTION
# Root Cause

This was caused by commit caused by 3cff247d0f8b35b8c8e356b3a02e9a74bea1674f "[mlir] Fix file leak in SeralizeToHsaco (#1257)"

This change caused the following error:
rocMLIR\external\llvm-project\mlir\lib\Dialect\GPU\Transforms\SerializeToHsaco.cpp(439): error C2664: 'std::error_code llvm::sys::fs::closeFile(llvm::sys::fs::file_t &)': cannot convert argument 1 from 'int' to 'llvm::sys::fs::file_t &'

# Fix

LLVM on Windows uses void* for file_t instead of int. CloseFile accepts this as a parameter and eventually uses it as an int anyway.

The least impactful fix is to initialize a file_t and set the lower int values to the int for the file descriptor. A direct reinterpret_cast from int to void* generates a warning about type sizes since int is 32-bit on Windows.