### PR TITLE
[AMDGPU] Work around apparent problems with large gfx11 store clauses

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIInsertHardClauses.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIInsertHardClauses.cpp
@@ -47,6 +47,9 @@ namespace {
 // instruction, but the hardware documentation (at least for GFX11) says that
 // 63 is the maximum allowed.
 constexpr unsigned MaxInstructionsInClause = 63;
+// There's some weird hardware behavior we've seen with large store clauses on
+// gfx11, try to work around this.
+constexpr unsigned MaxInstructionsInVmemStoreClause = 32;
 
 enum HardClauseType {
   // For GFX10:
@@ -224,6 +227,8 @@ public:
         }
 
         if (CI.Length == MaxInstructionsInClause ||
+            (CI.Type == HARDCLAUSE_VMEM_STORE &&
+             CI.Length == MaxInstructionsInVmemStoreClause) ||
             (CI.Length && Type != HARDCLAUSE_INTERNAL &&
              Type != HARDCLAUSE_IGNORE &&
              (Type != CI.Type ||


### PR DESCRIPTION
Empirically, this change removes a runtime hang we've observede in some kernels, that has been debugged to a large clause full of buffer stores that was followed by more buffer stores. It's currently unknown why this change works, whether 32 is the correct value for the relevant magic constant, etc.

The following is the only difference in the generated assembly for the problematic input with and without this patch:

```
--- /home/kdrewnia/migraphx-fusion-hang-1161/kernel-our-binary-pipeline.s       2023-09-29 17:08:19.490926930 +0000
+++ /home/kdrewnia/migraphx-fusion-hang-1161/s-clause-shrink-workaround.s       2023-10-02 16:28:49.385340832 +0000
@@ -1608,7 +1608,7 @@ s_barrier
        v_minmax_f32 v5, v5, 0x7f7fffff, 0
        s_delay_alu instid0(VALU_DEP_3)
        v_minmax_f32 v8, v8, 0x7f7fffff, 0
-       s_clause 0x3e
+       s_clause 0x1f
        buffer_store_b32 v158, v0, s[12:15], 0 offen
        buffer_store_b32 v160, v71, s[12:15], 0 offen offset:2176
        buffer_store_b32 v164, v67, s[12:15], 0 offen offset:256
@@ -1641,6 +1641,7 @@ s_barrier
        buffer_store_b32 v134, v107, s[12:15], 0 offen
        buffer_store_b32 v135, v108, s[12:15], 0 offen
        buffer_store_b32 v122, v103, s[12:15], 0 offen
+       s_clause 0x1f
        buffer_store_b32 v25, v51, s[12:15], 0 offen
        buffer_store_b32 v26, v52, s[12:15], 0 offen offset:2176
        buffer_store_b32 v27, v53, s[12:15], 0 offen offset:256
```

Fixes
https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1161

Performance on our GEMM tests is essentially flat with this change.