### PR TITLE
Generalize and rename `threadwise_transpose`

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1303,27 +1303,27 @@ def Rock_InWarpTransposeOp :
     # !cast<string>(swizzleGroupSize) # ";\n";
 }
 
-def Rock_ThreadwiseTransposeOp :
-    Rock_Op<"threadwise_transpose">,
+def Rock_ThreadwiseCopyOp :
+    Rock_Op<"threadwise_copy">,
     AllElementTypesMatch<["source", "dest"]>,
     Arguments<(ins
       Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemRead]>:$source,
       Arg<MemRefOf<SupportedMemoryElems>, "detination view", [MemWrite]>:$dest,
-      I64Attr : $kpack,
       UnitAttr:$forceUnroll,
       UnitAttr:$useIndexDiffs
     )> {
-  let summary = "Threadwise register-to-register transpose";
+  let summary = "Threadwise register-to-register copy";
 
   let description = [{
-    `rock.threadwise_transpose` accepts a source view and a destination view and copy
-    data from source to destination.
+    `rock.threadwise_copy` accepts a source view and a destination view and copy
+    data from source to destination. The only requirements are that both `source` and
+    `dest` views have the same upper shape and that their transform stack lowers to a flat buffer
   }];
 
   let assemblyFormat = [{
     attr-dict $source  `->` $dest `:` type($source) `->` type($dest)
   }];
-  let hasVerifier = 0;
+  let hasVerifier = 1;
 }
 
 #endif // ROCK_OPS

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1474,6 +1474,15 @@ LogicalResult ThreadwiseWriteAllOp::verify() {
   return success();
 }
 
+LogicalResult ThreadwiseCopyOp::verify() {
+  auto srcShape = getSource().getType().getShape();
+  auto dstShape = getDest().getType().getShape();
+  if (dstShape != srcShape)
+    return emitOpError("Source and dest shape need to have the same shape.");
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // BlockwiseGemmOp
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -521,8 +521,8 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     ArrayAttr storeBufferAViews =
         invertTransforms(b, loc, maybeALdsStoreViews->threadSubTile);
     Value viewStoreBufferA = transform(b, storeBufferA, storeBufferAViews);
-    auto packALoop = b.create<ThreadwiseTransposeOp>(
-        loc, viewLoadBufferA, viewStoreBufferA, kpack, useIndexDiffs, true);
+    auto packALoop = b.create<ThreadwiseCopyOp>(
+        loc, viewLoadBufferA, viewStoreBufferA, useIndexDiffs, true);
     ArrayAttr loadBufferBViews =
         invertTransforms(b, loc, maybeBBufferViews->threadSubTile);
     Value viewLoadBufferB = transform(b, loadBufferB, loadBufferBViews);
@@ -540,8 +540,8 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     ArrayAttr storeBufferBViews =
         invertTransforms(b, loc, maybeBLdsStoreViews->threadSubTile);
     Value viewStoreBufferB = transform(b, storeBufferB, storeBufferBViews);
-    auto packBLoop = b.create<ThreadwiseTransposeOp>(
-        loc, viewLoadBufferB, viewStoreBufferB, kpack, useIndexDiffs, true);
+    auto packBLoop = b.create<ThreadwiseCopyOp>(
+        loc, viewLoadBufferB, viewStoreBufferB, useIndexDiffs, true);
 
     Type ldsReadTypeA = vectorTypeOrSelf(elementTypeA, kpack);
     FailureOr<Value> maybeWrappedLdsA = wrapLDSBufferForStore(
@@ -720,8 +720,8 @@ struct GridwiseAttentionAccelRewritePattern
     // The following is fine for software pipelining optimization as it could be
     // considered "compute". In future, consider refactoring the following loop
     // to be a single reg->reg op avoid verbose IR at this level.
-    rewriter.create<ThreadwiseTransposeOp>(loc, regBuffer, viewStoreBuffer,
-                                           kpack, false, false);
+    rewriter.create<ThreadwiseCopyOp>(loc, regBuffer, viewStoreBuffer, false,
+                                      false);
     Type ldsReadType = vectorTypeOrSelf(elemType, kpack);
     FailureOr<Value> maybeWrappedLds = wrapLDSBufferForStore(
         rewriter, loc, ldsTileByteBuffer, ldsReadType, kpacksPerBlock,
@@ -1846,8 +1846,8 @@ struct GridwiseGemmAccelRewritePattern
     ArrayAttr storeBufferAViews =
         invertTransforms(b, loc, maybeALdsStoreViews->threadSubTile);
     Value viewStoreBufferA = transform(b, storeBufferA, storeBufferAViews);
-    auto packALoop = b.create<ThreadwiseTransposeOp>(
-        loc, viewLoadBufferA, viewStoreBufferA, kpack, false, false);
+    auto packALoop = b.create<ThreadwiseCopyOp>(loc, viewLoadBufferA,
+                                                viewStoreBufferA, false, false);
     ArrayAttr loadBufferBViews =
         invertTransforms(b, loc, maybeBBufferViews->threadSubTile);
     Value viewLoadBufferB = transform(b, loadBufferB, loadBufferBViews);
@@ -1865,8 +1865,8 @@ struct GridwiseGemmAccelRewritePattern
     ArrayAttr storeBufferBViews =
         invertTransforms(b, loc, maybeBLdsStoreViews->threadSubTile);
     Value viewStoreBufferB = transform(b, storeBufferB, storeBufferBViews);
-    auto packBLoop = b.create<ThreadwiseTransposeOp>(
-        loc, viewLoadBufferB, viewStoreBufferB, kpack, false, false);
+    auto packBLoop = b.create<ThreadwiseCopyOp>(loc, viewLoadBufferB,
+                                                viewStoreBufferB, false, false);
     // Obtain Accelerator-related attributes.
     int64_t mPerWave = tuningParams.getMPerWave();
     int64_t nPerWave = tuningParams.getNPerWave();

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1485,7 +1485,10 @@ ArrayAttr mlir::rock::invertTransforms(OpBuilder &b, Location loc,
   SmallVector<Attribute, 4> invertedTrs;
   for (Attribute tr : llvm::reverse(transforms)) {
     TransformMapAttr trMap = tr.cast<TransformMapAttr>();
-    invertedTrs.push_back(invertTransformMap(b, trMap, loc));
+    TransformMapAttr invertedTrMap = invertTransformMap(b, trMap, loc);
+    if (!invertedTrMap)
+      return {};
+    invertedTrs.push_back(invertedTrMap);
   }
   return b.getArrayAttr(invertedTrs);
 }

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -42,7 +42,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
       // CHECK-DAG: %[[G0AregsTr1:.+]] = rock.transform %[[G0AregsTr0]] by
       // CHECK: %[[G0AregsKpackTr0:.+]] = rock.transform %[[G0AregsKpack:.+]] by
       // CHECK-DAG: %[[G0AregsKpackTr1:.+]] = rock.transform %[[G0AregsKpackTr0:.+]] by
-      // CHECK-DAG: rock.threadwise_transpose {{.*}} %[[G0AregsTr1]] -> %[[G0AregsKpackTr1]]
+      // CHECK-DAG: rock.threadwise_copy %[[G0AregsTr1]] -> %[[G0AregsKpackTr1]]
 
       // Viewing G0 LDS A tile buffer
       // CHECK-DAG: %[[viewG0AStore:.+]] = memref.view %[[ldsG0A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
@@ -65,7 +65,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
       // CHECK-DAG: %[[G0BregsTr1:.+]] = rock.transform %[[G0BregsTr0]] by
       // CHECK: %[[G0BregsKpackTr0:.+]] = rock.transform %[[G0BregsKpack:.+]] by
       // CHECK-DAG: %[[G0BregsKpackTr1:.+]] = rock.transform %[[G0BregsKpackTr0:.+]] by
-      // CHECK-DAG: rock.threadwise_transpose {{.*}} %[[G0BregsTr1]] -> %[[G0BregsKpackTr1]]
+      // CHECK-DAG: rock.threadwise_copy %[[G0BregsTr1]] -> %[[G0BregsKpackTr1]]
 
       // Viewing G0 LDS B tile buffer
       // CHECK-DAG: %[[viewG0BStore:.+]] = memref.view %[[ldsG0B]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
@@ -102,7 +102,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
     // CHECK-DAG: %[[G1AregsKpackTr2:.+]] = rock.transform %[[G1AregsKpackTr1]] by
     // CHECK-DAG: %[[G1AregsKpackTr3:.+]] = rock.transform %[[G1AregsKpackTr2]] by
 
-    // CHECK-DAG: rock.threadwise_transpose {{.*}} %[[gemm0NormExpTr3]] -> %[[G1AregsKpackTr3]]
+    // CHECK-DAG: rock.threadwise_copy %[[gemm0NormExpTr3]] -> %[[G1AregsKpackTr3]]
 
     // Viewing G1 LDS A tile buffer
     // CHECK-DAG: %[[viewG1AStore:.+]] = memref.view %[[ldsG1A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
@@ -129,7 +129,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
     // CHECK-DAG: %[[G1BregsTr1:.+]] = rock.transform %[[G1BregsTr0]] by
     // CHECK: %[[G1BregsKpackTr0:.+]] = rock.transform %[[G1BregsKpack:.+]] by
     // CHECK-DAG: %[[G1BregsKpackTr1:.+]] = rock.transform %[[G1BregsKpackTr0:.+]] by
-    // CHECK-DAG: rock.threadwise_transpose {{.*}} %[[G1BregsTr1]] -> %[[G1BregsKpackTr1]]
+    // CHECK-DAG: rock.threadwise_copy %[[G1BregsTr1]] -> %[[G1BregsKpackTr1]]
 
     // Viewing G1 LDS B tile buffer
     // CHECK-DAG: %[[viewG1BStore:.+]] = memref.view %[[ldsG1B]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>

--- a/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
@@ -1,0 +1,47 @@
+// RUN: rocmlir-opt --rock-blockwise-gemm-to-threadwise %s | FileCheck %s
+#map5 = affine_map<(d0, d1) -> (d0 * 8 + d1)>
+#map6 = affine_map<(d0, d1) -> (d1, d0)>
+#map7 = affine_map<(d0, d1, d2) -> ((d0 * 2 + d1) * 8 + d2)>
+#map8 = affine_map<(d0, d1) -> (0, d1, d0)>
+
+#transform_map5 = #rock.transform_map<#map5 by [<Unmerge{2, 8} ["m_iter", "k_iter"] at [0, 1] -> ["iter"] at [0]>] bounds = [2, 8] -> [16]>
+#transform_map6 = #rock.transform_map<#map6 by [<Merge{8} ["k"] at [0] -> ["k_iter"] at [1]>, <Merge{2} ["m"] at [1] -> ["m_iter"] at [0]>] bounds = [8, 2] -> [2, 8]>
+#transform_map7 = #rock.transform_map<#map7 by [<Unmerge{1, 2, 8} ["kouterPerThread", "m_iter", "kpackPerThread"] at [0, 1, 2] -> ["iter"] at [0]>] bounds = [1, 2, 8] -> [16]>
+#transform_map8 = #rock.transform_map<#map8 by [<Merge{1, 8} ["k"] at [0] -> ["kouterPerThread", "kpackPerThread"] at [0, 2]>, <Merge{2} ["m"] at [1] -> ["m_iter"] at [1]>] bounds = [8, 2] -> [1, 2, 8]>
+
+
+// CHECK-LABEL: func.func @rock_threadwise_memcopy
+func.func @rock_threadwise_memcopy(%input : memref<16xf16, #gpu.address_space<private>>,  %output : memref<16xf16, #gpu.address_space<private>>)  {
+    // source
+    %21 = rock.transform %input by #transform_map5 : memref<16xf16, #gpu.address_space<private>> to memref<2x8xf16, #gpu.address_space<private>>
+    %22 = rock.transform %21 by #transform_map6 : memref<2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+
+    // dest
+    %23 = rock.transform %output by #transform_map7 : memref<16xf16, #gpu.address_space<private>> to memref<1x2x8xf16, #gpu.address_space<private>>
+    %24 = rock.transform %23 by #transform_map8 : memref<1x2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+
+    // copy from source to dest
+    // CHECK: rock.transforming_for
+    // CHECK: strides [8]
+    rock.threadwise_copy %22 -> %24 : memref<8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
+    return
+}
+
+// If we use an embed instead of a Unmerge, we cannot invert the map. This should still work, but we won't be able to run the vectorizer
+#transform_map7_noinv = #rock.transform_map<#map7 by [<Embed{16, 8, 1} ["kouterPerThread", "m_iter", "kpackPerThread"] at [0, 1, 2] -> ["iter"] at [0]>] bounds = [1, 2, 8] -> [16]>
+// CHECK-LABEL: func.func @rock_threadwise_memcopy_no_inversion
+func.func @rock_threadwise_memcopy_no_inversion(%input : memref<16xf16, #gpu.address_space<private>>,  %output : memref<16xf16, #gpu.address_space<private>>)  {
+    // source
+    %21 = rock.transform %input by #transform_map5 : memref<16xf16, #gpu.address_space<private>> to memref<2x8xf16, #gpu.address_space<private>>
+    %22 = rock.transform %21 by #transform_map6 : memref<2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+
+    // dest
+    %23 = rock.transform %output by #transform_map7_noinv : memref<16xf16, #gpu.address_space<private>> to memref<1x2x8xf16, #gpu.address_space<private>>
+    %24 = rock.transform %23 by #transform_map8 : memref<1x2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+
+    // copy from source to dest
+    // CHECK: rock.transforming_for
+    // CHECK: strides [1, 1]
+    rock.threadwise_copy %22 -> %24 : memref<8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
+    return
+}


### PR DESCRIPTION
Fixes https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1160

I generalized `threadwise_transpose` to accept any source/dest view and renamed it `threadwise_copy`

Thanks @manupak  for the guidance!