### PR TITLE
Enable performance tests on Navi3x

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -817,74 +817,29 @@ pipeline {
                     }
                     stage("Test MLIR vs MIOpen/rocBLAS") {
                         steps {
-                            script {
-                                dir('build') {
-                                    sh 'date --utc +%Y-%m-%d > perf-run-date'
-                                    // Run MLIR vs MIOpend perf benchmarks.
-                                    try {
-                                        timeout(time: 60, activity: true, unit: 'MINUTES') {
-                                            sh """python3 ./bin/perfRunner.py --op=conv --batch_all \
-                                               --configs_file=${WORKSPACE}/mlir/utils/performance/conv-configs \
-                                               --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
-                                            sh 'python3 ./bin/createPerformanceReports.py ${CHIP} MIOpen'
-                                            sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
-                                        }
-                                    } catch (Exception e ){
-                                        if ( "${CHIP}" == 'gfx1100' )
-                                            currentBuild.result = 'SUCCESS'
-                                        else
-                                            currentBuild.result = 'FAILURE'
-                                    }
-                                    // Run MLIR vs rocBLAS perf benchmarks
-                                    try {
-                                        timeout(time: 60, activity: true, unit: 'MINUTES') {
-                                            sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
-                                               --configs_file=${WORKSPACE}/mlir/utils/performance/gemm-configs \
-                                               --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
-                                            sh 'python3 ./bin/createPerformanceReports.py ${CHIP} rocBLAS'
-                                            sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
-                                        }
-                                    } catch (Exception e ){
-                                        if ( "${CHIP}" == 'gfx1100' )
-                                            currentBuild.result = 'SUCCESS'
-                                        else
-                                            currentBuild.result = 'FAILURE'
-                                    }
-                                }
+                            dir('build') {
+                                sh 'date --utc +%Y-%m-%d > perf-run-date'
+                                // Run MLIR vs MIOpend perf benchmarks.
+                                sh """python3 ./bin/perfRunner.py --op=conv --batch_all \
+                                       --configs_file=${WORKSPACE}/mlir/utils/performance/conv-configs \
+                                       --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
+                                // Run MLIR vs rocBLAS perf benchmarks
+                                sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
+                                       --configs_file=${WORKSPACE}/mlir/utils/performance/gemm-configs \
+                                       --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
                             }
                         }
                     }
                     stage("Test Fusion") {
                         steps {
-                            script {
-                                dir('build') {
-                                    // Run fusion resnet50 perf benchmarks
-                                    try {
-                                        timeout(time: 30, activity: true, unit: 'MINUTES') {
-                                            sh """python3 ./bin/perfRunner.py --op=fusion \
+                            dir('build') {
+                                // Run fusion resnet50 perf benchmarks
+                                sh """python3 ./bin/perfRunner.py --op=fusion \
           --test_dir=${WORKSPACE}/mlir/test/fusion/resnet50-e2e/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
-                                        }
-                                    } catch (Exception e ) {
-                                        if ( "${CHIP}" == 'gfx1100' )
-                                            currentBuild.result = 'SUCCESS'
-                                        else
-                                            currentBuild.result = 'FAILURE'
-                                    }
-                                    // Run bert perf benchmarks
-                                   try {
-                                        timeout(time: 30, activity: true, unit: 'MINUTES') {
-                                            sh """python3 ./bin/perfRunner.py --op fusion \
+                                // Run bert perf benchmarks
+                                sh """python3 ./bin/perfRunner.py --op fusion \
           --test_dir=${WORKSPACE}/mlir/test/xmir/bert-torch-tosa-e2e/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
-                                            sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
-                                        }
-                                  } catch (Exception e ) {
-                                      if ( "${CHIP}" == 'gfx1100' )
-                                          currentBuild.result = 'SUCCESS'
-                                      else
-                                            currentBuild.result = 'FAILURE'
-                                  }
-                              }
-                          }
+                            }
                         }
                     }
                     stage("Test MLIR vs CK") {
@@ -922,10 +877,15 @@ pipeline {
                             }
                         }
                     }
-                    stage("Publish performance reports") {
+                    stage("Create performance reports") {
                         steps {
                             dir('build') {
                                 sh 'ls -l'
+                                sh 'python3 ./bin/createPerformanceReports.py ${CHIP} MIOpen'
+                                sh 'python3 ./bin/createPerformanceReports.py ${CHIP} rocBLAS'
+                                sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
+                                sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
+                                sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
                                 sh 'mkdir -p reports && cp ./*.html reports'
                             }
                             postProcessPerfRes("${CHIP}")

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -120,22 +120,24 @@ void postProcessPerfRes(String chip) {
         reportName: "Performance report for ${chip}"
     ])
 
+  if (fileExists("build/${chip}_mlir_vs_miopen_perf_for_plot.csv")) {
     plot csvFileName: "${chip}_plot-nightly-perf-results-000001.csv",\
         csvSeries: [[file: "build/${chip}_mlir_vs_miopen_perf_for_plot.csv", displayTableFlag: false]],\
         title: "Test performance summary ${chip}, Conv",\
         yaxis: 'TFlops',\
         style: 'line',\
         group: 'Performance plots'
-
+  }
+  if (fileExists("build/${chip}_mlir_vs_rocblas_perf_for_plot.csv")) {
     plot csvFileName: "${chip}_plot-nightly-perf-results-gemm-000001.csv",\
         csvSeries: [[file: "build/${chip}_mlir_vs_rocblas_perf_for_plot.csv", displayTableFlag: false]],\
         title: "Test performance summary ${chip}, GEMM",\
         yaxis: 'TFlops',\
         style: 'line',\
         group: 'Performance plots'
-
+  }
     // Save results for future comparison
-    archiveArtifacts artifacts: 'build/*_mlir_*.csv,build/perf-run-date', onlyIfSuccessful: true
+    archiveArtifacts artifacts: 'build/*_mlir_*.csv,build/perf-run-date', allowEmptyArchive: true, onlyIfSuccessful: true
 }
 
 //makes sure multiple builds are not triggered for branch indexing
@@ -187,6 +189,10 @@ String getLabelFromChip(String chip) {
             // For [Tune MLIR Kernels] and [Performance report] stages,
             // fix the vm-5 workstation for testing
             return "mlir && vm-5"
+        case "gfx1100":
+            return "mlir && gfx1100"
+        case "gfx1101":
+            return "mlir && gfx1101"
     }
 }
 
@@ -555,9 +561,7 @@ pipeline {
                 }
                 post {
                     unsuccessful {
-                        script {
-                                rebootNode()
-                        }
+                        rebootNode()
                     }
                     always {
                         cleanWs()
@@ -751,7 +755,7 @@ pipeline {
                 axes {
                     axis {
                         name 'CHIP'
-                        values 'gfx906', 'gfx908', 'gfx90a', 'gfx1030'
+                        values 'gfx906', 'gfx908', 'gfx90a', 'gfx1030', 'gfx1100'
                     }
                 }
                 when {
@@ -813,29 +817,74 @@ pipeline {
                     }
                     stage("Test MLIR vs MIOpen/rocBLAS") {
                         steps {
-                            dir('build') {
-                                sh 'date --utc +%Y-%m-%d > perf-run-date'
-                                // Run MLIR vs MIOpend perf benchmarks.
-                                sh """python3 ./bin/perfRunner.py --op=conv --batch_all \
-                                       --configs_file=${WORKSPACE}/mlir/utils/performance/conv-configs \
-                                       --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
-                                // Run MLIR vs rocBLAS perf benchmarks
-                                sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
-                                       --configs_file=${WORKSPACE}/mlir/utils/performance/gemm-configs \
-                                       --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
+                            script {
+                                dir('build') {
+                                    sh 'date --utc +%Y-%m-%d > perf-run-date'
+                                    // Run MLIR vs MIOpend perf benchmarks.
+                                    try {
+                                        timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                            sh """python3 ./bin/perfRunner.py --op=conv --batch_all \
+                                               --configs_file=${WORKSPACE}/mlir/utils/performance/conv-configs \
+                                               --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
+                                            sh 'python3 ./bin/createPerformanceReports.py ${CHIP} MIOpen'
+                                            sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
+                                        }
+                                    } catch (Exception e ){
+                                        if ( "${CHIP}" == 'gfx1100' )
+                                            currentBuild.result = 'SUCCESS'
+                                        else
+                                            currentBuild.result = 'FAILURE'
+                                    }
+                                    // Run MLIR vs rocBLAS perf benchmarks
+                                    try {
+                                        timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                            sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
+                                               --configs_file=${WORKSPACE}/mlir/utils/performance/gemm-configs \
+                                               --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv"""
+                                            sh 'python3 ./bin/createPerformanceReports.py ${CHIP} rocBLAS'
+                                            sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
+                                        }
+                                    } catch (Exception e ){
+                                        if ( "${CHIP}" == 'gfx1100' )
+                                            currentBuild.result = 'SUCCESS'
+                                        else
+                                            currentBuild.result = 'FAILURE'
+                                    }
+                                }
                             }
                         }
                     }
                     stage("Test Fusion") {
                         steps {
-                            dir('build') {
-                                // Run fusion resnet50 perf benchmarks
-                                sh """python3 ./bin/perfRunner.py --op=fusion \
+                            script {
+                                dir('build') {
+                                    // Run fusion resnet50 perf benchmarks
+                                    try {
+                                        timeout(time: 30, activity: true, unit: 'MINUTES') {
+                                            sh """python3 ./bin/perfRunner.py --op=fusion \
           --test_dir=${WORKSPACE}/mlir/test/fusion/resnet50-e2e/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
-                                // Run bert perf benchmarks
-                                sh """python3 ./bin/perfRunner.py --op fusion \
+                                        }
+                                    } catch (Exception e ) {
+                                        if ( "${CHIP}" == 'gfx1100' )
+                                            currentBuild.result = 'SUCCESS'
+                                        else
+                                            currentBuild.result = 'FAILURE'
+                                    }
+                                    // Run bert perf benchmarks
+                                   try {
+                                        timeout(time: 30, activity: true, unit: 'MINUTES') {
+                                            sh """python3 ./bin/perfRunner.py --op fusion \
           --test_dir=${WORKSPACE}/mlir/test/xmir/bert-torch-tosa-e2e/ --tuning_db=${WORKSPACE}/build/tuning_fusion_${CHIP}.tsv"""
-                            }
+                                            sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
+                                        }
+                                  } catch (Exception e ) {
+                                      if ( "${CHIP}" == 'gfx1100' )
+                                          currentBuild.result = 'SUCCESS'
+                                      else
+                                            currentBuild.result = 'FAILURE'
+                                  }
+                              }
+                          }
                         }
                     }
                     stage("Test MLIR vs CK") {
@@ -873,15 +922,10 @@ pipeline {
                             }
                         }
                     }
-                    stage("Create performance reports") {
+                    stage("Publish performance reports") {
                         steps {
                             dir('build') {
                                 sh 'ls -l'
-                                sh 'python3 ./bin/createPerformanceReports.py ${CHIP} MIOpen'
-                                sh 'python3 ./bin/createPerformanceReports.py ${CHIP} rocBLAS'
-                                sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
-                                sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
-                                sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_rocblas_perf.csv ./${CHIP}_mlir_vs_rocblas_perf.csv'
                                 sh 'mkdir -p reports && cp ./*.html reports'
                             }
                             postProcessPerfRes("${CHIP}")

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -27,7 +27,10 @@ ROUND_DIGITS = 2
 
 def geoMean(data):
     maskedData = np.ma.masked_where(~(np.isfinite(data) & (data > 0)), data)
-    means = scipy.stats.gmean(maskedData)
+    if maskedData.count() == 0:
+        means = 0
+    else:
+        means = scipy.stats.gmean(maskedData)
     return means
 
 def colorForSpeedups(value):


### PR DESCRIPTION
See [Navi3x performance reports](http://rocmhead.amd.com:8080/job/MLIR/job/mlir/view/change-requests/job/PR-1276/21/Performance_20report_20for_20gfx1100/).

It turned out that perfRunner.py already takes care of timeout cases. There is no need to try to catch timeouts in Jenkinsfile.