### PR TITLE
Add support for first gemm scaling in attention kernels

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -727,23 +727,27 @@ struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
     return failure();
   }
 
-  Value normalizeScaleIn(PatternRewriter &rewriter, Location loc, TypedValue<TensorType> scaleIn) const {
-    if(!scaleIn){
+  Value normalizeScaleIn(PatternRewriter &rewriter, Location loc,
+                         TypedValue<TensorType> scaleIn) const {
+    if (!scaleIn) {
       return scaleIn;
     }
     ArrayRef<int64_t> scaleShape = scaleIn.getType().getShape();
-    SmallVector<int64_t, 4> reverseScaleShape = llvm::to_vector<4>(llvm::reverse(scaleShape));
+    SmallVector<int64_t, 4> reverseScaleShape =
+        llvm::to_vector<4>(llvm::reverse(scaleShape));
     SmallVector<int64_t, 4> normalizedShape;
     int collapsedBatchLen = 1;
-    for(int64_t dimLen : ArrayRef<int64_t>{reverseScaleShape}.slice(2)){
+    for (int64_t dimLen : ArrayRef<int64_t>{reverseScaleShape}.slice(2)) {
       collapsedBatchLen *= dimLen;
     }
     normalizedShape.push_back(collapsedBatchLen);
     normalizedShape.push_back(reverseScaleShape[1]);
     normalizedShape.push_back(reverseScaleShape[0]);
-    auto normalizedType = RankedTensorType::get(normalizedShape, scaleIn.getType().getElementType());
+    auto normalizedType = RankedTensorType::get(
+        normalizedShape, scaleIn.getType().getElementType());
     auto reshapeOp = rewriter.create<tosa::ReshapeOp>(
-          loc, normalizedType, scaleIn, rewriter.getDenseI64ArrayAttr(normalizedShape));
+        loc, normalizedType, scaleIn,
+        rewriter.getDenseI64ArrayAttr(normalizedShape));
     return reshapeOp;
   }
 

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -727,6 +727,26 @@ struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
     return failure();
   }
 
+  Value normalizeScaleIn(PatternRewriter &rewriter, Location loc, TypedValue<TensorType> scaleIn) const {
+    if(!scaleIn){
+      return scaleIn;
+    }
+    ArrayRef<int64_t> scaleShape = scaleIn.getType().getShape();
+    SmallVector<int64_t, 4> reverseScaleShape = llvm::to_vector<4>(llvm::reverse(scaleShape));
+    SmallVector<int64_t, 4> normalizedShape;
+    int collapsedBatchLen = 1;
+    for(int64_t dimLen : ArrayRef<int64_t>{reverseScaleShape}.slice(2)){
+      collapsedBatchLen *= dimLen;
+    }
+    normalizedShape.push_back(collapsedBatchLen);
+    normalizedShape.push_back(reverseScaleShape[1]);
+    normalizedShape.push_back(reverseScaleShape[0]);
+    auto normalizedType = RankedTensorType::get(normalizedShape, scaleIn.getType().getElementType());
+    auto reshapeOp = rewriter.create<tosa::ReshapeOp>(
+          loc, normalizedType, scaleIn, rewriter.getDenseI64ArrayAttr(normalizedShape));
+    return reshapeOp;
+  }
+
   LogicalResult match(tosa::MatMulOp op) const override {
     FailureOr<Value> softmaxInput = maybeSoftmax(op.getA());
     if (failed(softmaxInput)) {
@@ -770,7 +790,7 @@ struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
     std::tie(arch, num_cu, features) = getArchAttributes(op, op.getType());
     rock::AttentionOp attnOp = rewriter.create<rock::AttentionOp>(
         loc, outputType, firstMatMulOp.getA(), firstMatMulOp.getB(), op.getB(),
-        scaleInput, output,
+        normalizeScaleIn(rewriter, loc, scaleInput), output,
         // TODO(implement transpose fusion support here)
         /*qTransposed=*/nullptr,
         /*kTransposed=*/nullptr,

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -256,8 +256,9 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
                   gemm1ExtraPad.n);
 
   Value scale = nullptr;
-  if(Value scaleUnpadded = adaptor.getScale()){
-    scale = padMatrix(scaleUnpadded, rw, loc, "gemm1M", gemm0ExtraPad.m, "gemm1N", gemm0ExtraPad.n);
+  if (Value scaleUnpadded = adaptor.getScale()) {
+    scale = padMatrix(scaleUnpadded, rw, loc, "gemm1M", gemm0ExtraPad.m,
+                      "gemm1N", gemm0ExtraPad.n);
   }
   func::FuncOp func = op->getParentOfType<func::FuncOp>();
   IntegerAttr blockSizeAttr = func->getAttr("block_size").cast<IntegerAttr>();
@@ -271,10 +272,9 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
     prePadG0NAttr = rw.getIndexAttr(gemm0Size.n);
   }
   rw.replaceOpWithNewOp<GridwiseAttentionAccelOp>(
-      op, queries, keys, values,
-      scale, out,
-      op.getArchAttr(), op.getFeaturesAttr(), blockSizeAttr, gridSizeAttr,
-      prePadG0MAttr, prePadG0NAttr, params);
+      op, queries, keys, values, scale, out, op.getArchAttr(),
+      op.getFeaturesAttr(), blockSizeAttr, gridSizeAttr, prePadG0MAttr,
+      prePadG0NAttr, params);
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1303,75 +1303,73 @@ struct GridwiseAttentionAccelRewritePattern
     }
   }
 
-  void scaleFirstGemm(PatternRewriter &rewriter, 
-                      Location loc, 
-                      layout::GridCoordinates gridCoords,
-                      Value gemm0OutBuffer, 
-                      RegsAsMatrixSubTiles gemm0OutViews,
-                      Value scaleInBuffer, 
+  void scaleFirstGemm(PatternRewriter &rewriter, Location loc,
+                      layout::GridCoordinates gridCoords, Value gemm0OutBuffer,
+                      RegsAsMatrixSubTiles gemm0OutViews, Value scaleInBuffer,
                       Value scaleInput) const {
     // Get current workitem ID.
     auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
-    rewriter.create<ThreadwiseReadIntoOp>(loc, 
-                                          scaleInput, 
-                                          scaleInBuffer, 
-                                          gemm0OutViews.gridSubTile,
-                                          ValueRange{gridCoords.g_block, gridCoords.m_block, gridCoords.n_block, tid},
-                                          true, true);
+    rewriter.create<ThreadwiseReadIntoOp>(
+        loc, scaleInput, scaleInBuffer, gemm0OutViews.gridSubTile,
+        ValueRange{gridCoords.g_block, gridCoords.m_block, gridCoords.n_block,
+                   tid},
+        true, true);
     rewriter.create<linalg::ElemwiseBinaryOp>(
-          loc, ValueRange{gemm0OutBuffer, scaleInBuffer},
-          ValueRange{gemm0OutBuffer},
-          ArrayRef<NamedAttribute>{
-              rewriter.getNamedAttr("fun",
-                                    rewriter.getAttr<linalg::BinaryFnAttr>(
-                                        linalg::BinaryFn::mul)),
-              rewriter.getNamedAttr("cast",
-                                    rewriter.getAttr<linalg::TypeFnAttr>(
-                                        linalg::TypeFn::cast_signed))});
+        loc, ValueRange{gemm0OutBuffer, scaleInBuffer},
+        ValueRange{gemm0OutBuffer},
+        ArrayRef<NamedAttribute>{
+            rewriter.getNamedAttr("fun", rewriter.getAttr<linalg::BinaryFnAttr>(
+                                             linalg::BinaryFn::mul)),
+            rewriter.getNamedAttr("cast", rewriter.getAttr<linalg::TypeFnAttr>(
+                                              linalg::TypeFn::cast_signed))});
   }
 
-  FailureOr<TypedAttr> getSplatGlobalConstant(memref::GetGlobalOp getGlobalOp) const {
-    auto *symbolTableOp = getGlobalOp->getParentWithTrait<OpTrait::SymbolTable>();
+  FailureOr<TypedAttr>
+  getSplatGlobalConstant(memref::GetGlobalOp getGlobalOp) const {
+    auto *symbolTableOp =
+        getGlobalOp->getParentWithTrait<OpTrait::SymbolTable>();
     if (!symbolTableOp)
-        return failure();
+      return failure();
     auto global = dyn_cast_or_null<memref::GlobalOp>(
         SymbolTable::lookupSymbolIn(symbolTableOp, getGlobalOp.getNameAttr()));
     if (!global)
-        return failure();
-    auto cstAttr =
-        llvm::dyn_cast_or_null<DenseElementsAttr>(global.getConstantInitValue());
+      return failure();
+    auto cstAttr = llvm::dyn_cast_or_null<DenseElementsAttr>(
+        global.getConstantInitValue());
     if (!cstAttr)
-        return failure();
+      return failure();
     if (auto splatAttr = llvm::dyn_cast<SplatElementsAttr>(cstAttr))
-        return splatAttr.getSplatValue<TypedAttr>();
+      return splatAttr.getSplatValue<TypedAttr>();
     return failure();
   }
 
-   void scaleFirstGemmSplat(PatternRewriter &rewriter, 
-                            Location loc, 
-                            layout::GridCoordinates gridCoords,
-                            Value gemm0OutBuffer, 
-                            RegsAsMatrixSubTiles gemm0OutViews,
-                            TypedAttr splatVal) const {
+  void scaleFirstGemmSplat(PatternRewriter &rewriter, Location loc,
+                           layout::GridCoordinates gridCoords,
+                           Value gemm0OutBuffer,
+                           RegsAsMatrixSubTiles gemm0OutViews,
+                           TypedAttr splatVal) const {
     MemRefType bufType = gemm0OutBuffer.getType().cast<MemRefType>();
     SmallVector<AffineMap, 2> indexingMaps{
         2, rewriter.getMultiDimIdentityMap(bufType.getRank())};
     SmallVector<utils::IteratorType> iteratorTypes(
         bufType.getRank(), utils::IteratorType::parallel);
     rewriter.create<linalg::GenericOp>(
-        loc, ValueRange(gemm0OutBuffer), ValueRange(gemm0OutBuffer), indexingMaps, iteratorTypes,
+        loc, ValueRange(gemm0OutBuffer), ValueRange(gemm0OutBuffer),
+        indexingMaps, iteratorTypes,
         [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
-          Value splatScalarConst = nestedBuilder.create<arith::ConstantOp>(loc, bufType.getElementType(), splatVal);
+          Value splatScalarConst = nestedBuilder.create<arith::ConstantOp>(
+              loc, bufType.getElementType(), splatVal);
           Value mul;
-          if(bufType.getElementType().isIntOrIndex()){
-            mul = nestedBuilder.create<arith::MulIOp>(loc, args[0], splatScalarConst);
-          }
-          else{
-            mul = nestedBuilder.create<arith::MulFOp>(loc, args[0], splatScalarConst);
+          if (bufType.getElementType().isIntOrIndex()) {
+            mul = nestedBuilder.create<arith::MulIOp>(loc, args[0],
+                                                      splatScalarConst);
+          } else {
+            mul = nestedBuilder.create<arith::MulFOp>(loc, args[0],
+                                                      splatScalarConst);
           }
           nestedBuilder.create<linalg::YieldOp>(nestedLoc, mul);
         });
-    }
+  }
 
   LogicalResult matchAndRewrite(GridwiseAttentionAccelOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1460,8 +1458,9 @@ struct GridwiseAttentionAccelRewritePattern
     Value gemm0OutBuffer =
         createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
     Value scaleInBuffer;
-    if(TypedValue<MemRefType> scaleIn = op.getScale()){
-        scaleInBuffer = createBufferForGemmOut(loc, scaleIn.getType().getElementType(), accelParamsGemm0, rewriter);
+    if (TypedValue<MemRefType> scaleIn = op.getScale()) {
+      scaleInBuffer = createBufferForGemmOut(
+          loc, scaleIn.getType().getElementType(), accelParamsGemm0, rewriter);
     }
 
     // Buffers for reductions
@@ -1502,15 +1501,22 @@ struct GridwiseAttentionAccelRewritePattern
     // gemm1 will happen after reductions are done;
     // Therefore, we re-use that LDS buffer.
     // The reduction buffer being larger is still
-    // acceptable; we just need a subview of that. 
-    int64_t gemm1LDSByteBufferSize = gemm0MPerBlock * gemm0NPerBlock * getByteWidth(elemTypeV);
-    if(ldsReductionWorkspaceByteBuffer.getType().cast<MemRefType>().getNumElements() < gemm1LDSByteBufferSize){
-        return op.emitError("ldsReductionWorkspaceByteBuffer should not be less than gemm1LDSByteBufferSize.");
+    // acceptable; we just need a subview of that.
+    int64_t gemm1LDSByteBufferSize =
+        gemm0MPerBlock * gemm0NPerBlock * getByteWidth(elemTypeV);
+    if (ldsReductionWorkspaceByteBuffer.getType()
+            .cast<MemRefType>()
+            .getNumElements() < gemm1LDSByteBufferSize) {
+      return op.emitError("ldsReductionWorkspaceByteBuffer should not be less "
+                          "than gemm1LDSByteBufferSize.");
     }
     auto gemm1LDSByteBufferAType =
-        MemRefType::get({gemm1LDSByteBufferSize}, rewriter.getI8Type(), AffineMap{},
-                        workgroupMemoryAddressSpace);
-    Value gemm1LDSByteBufferA = rewriter.create<memref::SubViewOp>(loc, gemm1LDSByteBufferAType, ldsReductionWorkspaceByteBuffer, ArrayRef<int64_t>{0}, ArrayRef<int64_t>{gemm1LDSByteBufferSize}, ArrayRef<int64_t>{1});
+        MemRefType::get({gemm1LDSByteBufferSize}, rewriter.getI8Type(),
+                        AffineMap{}, workgroupMemoryAddressSpace);
+    Value gemm1LDSByteBufferA = rewriter.create<memref::SubViewOp>(
+        loc, gemm1LDSByteBufferAType, ldsReductionWorkspaceByteBuffer,
+        ArrayRef<int64_t>{0}, ArrayRef<int64_t>{gemm1LDSByteBufferSize},
+        ArrayRef<int64_t>{1});
     // Value gemm1LDSByteBufferA = ldsReductionWorkspaceByteBuffer;
     auto [preAccelRegBufferQxK, preAccelRegBufferV] =
         createRegInterrimBufferForAccel(loc, accelParamsGemm1, rewriter);
@@ -1653,21 +1659,27 @@ struct GridwiseAttentionAccelRewritePattern
       }
       accelEmitterPtrGemm0->computeOutputConversion(
           rewriter, loc, accRegBufferGemm0, gemm0OutBuffer, forceUnroll);
-        if(Value scaleIn = op.getScale()){
-            Value rawBuffer;
-            std::tie(rawBuffer, std::ignore, std::ignore) = untransform(rewriter, scaleIn);
-            if(memref::GetGlobalOp constScale = rawBuffer.getDefiningOp<memref::GetGlobalOp>()){
-                FailureOr<TypedAttr> maybeSplatAttr = getSplatGlobalConstant(constScale);
-                if(failed(maybeSplatAttr)){
-                    return op.emitError("Only splat scale constant input is supported."); 
-                }
-                scaleFirstGemmSplat(rewriter, loc, gridCoordsGemm0, gemm0OutBuffer, gemm0OutSubTileViews, maybeSplatAttr.value());
-            }
-            else{
-                scaleFirstGemm(rewriter, loc, gridCoordsGemm0, gemm0OutBuffer, gemm0OutSubTileViews, scaleInBuffer, scaleIn);
-            }
+      // Handle the first gemm scaling if present
+      if (Value scaleIn = op.getScale()) {
+        Value rawBuffer;
+        std::tie(rawBuffer, std::ignore, std::ignore) =
+            untransform(rewriter, scaleIn);
+        if (memref::GetGlobalOp constScale =
+                rawBuffer.getDefiningOp<memref::GetGlobalOp>()) {
+          FailureOr<TypedAttr> maybeSplatAttr =
+              getSplatGlobalConstant(constScale);
+          if (failed(maybeSplatAttr)) {
+            return op.emitError(
+                "Only splat scale constant input is supported.");
+          }
+          scaleFirstGemmSplat(rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
+                              gemm0OutSubTileViews, maybeSplatAttr.value());
+        } else {
+          scaleFirstGemm(rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
+                         gemm0OutSubTileViews, scaleInBuffer, scaleIn);
         }
-        
+      }
+      // Handle padding
       bool hasPadding =
           op.getPrePadG0M().has_value() || op.getPrePadG0N().has_value();
       if (hasPadding) {

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1326,12 +1326,8 @@ struct GridwiseAttentionAccelRewritePattern
 
   FailureOr<TypedAttr>
   getSplatGlobalConstant(memref::GetGlobalOp getGlobalOp) const {
-    auto *symbolTableOp =
-        getGlobalOp->getParentWithTrait<OpTrait::SymbolTable>();
-    if (!symbolTableOp)
-      return failure();
-    auto global = dyn_cast_or_null<memref::GlobalOp>(
-        SymbolTable::lookupSymbolIn(symbolTableOp, getGlobalOp.getNameAttr()));
+    auto global = SymbolTable::lookupNearestSymbolFrom<memref::GlobalOp>(
+        getGlobalOp, getGlobalOp.getNameAttr());
     if (!global)
       return failure();
     auto cstAttr = llvm::dyn_cast_or_null<DenseElementsAttr>(

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1517,7 +1517,6 @@ struct GridwiseAttentionAccelRewritePattern
         loc, gemm1LDSByteBufferAType, ldsReductionWorkspaceByteBuffer,
         ArrayRef<int64_t>{0}, ArrayRef<int64_t>{gemm1LDSByteBufferSize},
         ArrayRef<int64_t>{1});
-    // Value gemm1LDSByteBufferA = ldsReductionWorkspaceByteBuffer;
     auto [preAccelRegBufferQxK, preAccelRegBufferV] =
         createRegInterrimBufferForAccel(loc, accelParamsGemm1, rewriter);
     Value accRegBufferGemm1 =

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-attention.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-attention.mlir
@@ -49,3 +49,25 @@ func.func @self_attention_with_reshapes(%arg0: tensor<1x12x384x64xf32>, %arg1: t
   %expanded_3 = tensor.expand_shape %7 [[0, 1], [2], [3]] : tensor<12x384x64xf32> into tensor<1x12x384x64xf32>
   return %expanded_3 : tensor<1x12x384x64xf32>
 }
+
+// CHECK: rock.attention
+func.func @self_attention_with_4d_scale(%arg0: tensor<1x12x256x256xf32> , %arg1: tensor<1x12x256x256xf32>, %arg2: tensor<1x12x256x256xf32>, %arg3: tensor<1x12x256x256xf32>) -> (tensor<1x12x256x256xf32>) attributes {kernel, arch = ""} {
+  %cst = arith.constant dense<[0, 1, 3, 2]> : tensor<4xi64>
+  %0 = "tosa.transpose"(%arg3, %cst) : (tensor<1x12x256x256xf32>, tensor<4xi64>) -> tensor<1x12x256x256xf32>
+  %collapsed = tensor.collapse_shape %arg2 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %collapsed_0 = tensor.collapse_shape %0 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %1 = "tosa.matmul"(%collapsed, %collapsed_0) : (tensor<12x256x256xf32>, tensor<12x256x256xf32>) -> tensor<12x256x256xf32>
+  %expanded = tensor.expand_shape %1 [[0, 1], [2], [3]] : tensor<12x256x256xf32> into tensor<1x12x256x256xf32>
+  %2 = "tosa.mul"(%expanded, %arg1) <{shift = 0 : i32}> : (tensor<1x12x256x256xf32>, tensor<1x12x256x256xf32>) -> tensor<1x12x256x256xf32>
+  %3 = "tosa.reduce_max"(%2) <{axis = 3 : i64}> : (tensor<1x12x256x256xf32>) -> tensor<1x12x256x1xf32>
+  %4 = "tosa.sub"(%2, %3) : (tensor<1x12x256x256xf32>, tensor<1x12x256x1xf32>) -> tensor<1x12x256x256xf32>
+  %5 = "tosa.exp"(%4) : (tensor<1x12x256x256xf32>) -> tensor<1x12x256x256xf32>
+  %6 = "tosa.reduce_sum"(%5) <{axis = 3 : i64}> : (tensor<1x12x256x256xf32>) -> tensor<1x12x256x1xf32>
+  %7 = "tosa.reciprocal"(%6) : (tensor<1x12x256x1xf32>) -> tensor<1x12x256x1xf32>
+  %8 = "tosa.mul"(%5, %7) <{shift = 0 : i32}> : (tensor<1x12x256x256xf32>, tensor<1x12x256x1xf32>) -> tensor<1x12x256x256xf32>
+  %collapsed_1 = tensor.collapse_shape %8 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %collapsed_2 = tensor.collapse_shape %arg0 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %9 = "tosa.matmul"(%collapsed_1, %collapsed_2) : (tensor<12x256x256xf32>, tensor<12x256x256xf32>) -> tensor<12x256x256xf32>
+  %expanded_3 = tensor.expand_shape %9 [[0, 1], [2], [3]] : tensor<12x256x256xf32> into tensor<1x12x256x256xf32>
+  return %expanded_3 : tensor<1x12x256x256xf32>
+}

--- a/mlir/test/e2e/PrAttentionF16.toml
+++ b/mlir/test/e2e/PrAttentionF16.toml
@@ -1,6 +1,6 @@
 directory = "PrAttentionF16"
 prefix = "rocmlir-gen"
-suffix = "--operation attention -t f16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.02 -absDiff_threshold 0.02 -RMS_threshold 0.01 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention -t f16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.02 -absDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"
@@ -11,6 +11,11 @@ prefix = "--operation "
 name = "transK"
 values = ["true", "false"]
 prefix = "--transK="
+
+[[axis]]
+name = "scale"
+values = ["true", "false"]
+prefix = "--with-attn-scale="
 
 ## attention variant
 [[suite]]

--- a/mlir/test/e2e/PrAttentionF32.toml
+++ b/mlir/test/e2e/PrAttentionF32.toml
@@ -12,6 +12,11 @@ name = "transK"
 values = ["true", "false"]
 prefix = "--transK="
 
+[[axis]]
+name = "scale"
+values = ["true", "false"]
+prefix = "--with-attn-scale="
+
 ## attention variant
 [[suite]]
 name = "pr_attention_f32"

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-const-scale.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-const-scale.mlir
@@ -2,22 +2,26 @@
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
-  func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}, %arg3: tensor<1x7x7xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) {
+  func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) {
     %0 = migraphx.dot(%arg0, %arg1): (tensor<1x7x3xf32>, tensor<1x3x7xf32>) -> tensor<1x7x7xf32>
-    %scaled = migraphx.mul(%0, %arg3) : (tensor<1x7x7xf32>, tensor<1x7x7xf32>) -> tensor<1x7x7xf32>
+    %cst = "tosa.const"() {value = dense<1.250000e-01> : tensor<1xf32>} : () -> tensor<1xf32>
+    %cst1 = migraphx.multibroadcast(%cst) {out_dyn_dims = [], out_lens = [1, 7, 7]} : (tensor<1xf32>) -> tensor<1x7x7xf32>
+    %scaled = migraphx.mul(%0, %cst1) : (tensor<1x7x7xf32>, tensor<1x7x7xf32>) -> tensor<1x7x7xf32>
     %1 = migraphx.softmax(%scaled){axis = 2 : i64} : tensor<1x7x7xf32> -> tensor<1x7x7xf32>
     %2 = migraphx.dot(%1, %arg2): (tensor<1x7x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
     return %2 : tensor<1x7x3xf32>
   }
-  func.func @mlir_attention_wrapper(%arg0: tensor<1x7x3xf32>, %arg1: tensor<1x3x7xf32>,  %arg2: tensor<1x7x3xf32>, %arg3: tensor<1x7x7xf32>) -> tensor<1x7x3xf32> {
-    %token, %results = mhal.launch @mlir_attention (%arg0, %arg1, %arg2, %arg3) : (tensor<1x7x3xf32>, tensor<1x3x7xf32>, tensor<1x7x3xf32>, tensor<1x7x7xf32>) -> tensor<1x7x3xf32>
+  func.func @mlir_attention_wrapper(%arg0: tensor<1x7x3xf32>, %arg1: tensor<1x3x7xf32>,  %arg2: tensor<1x7x3xf32>) -> tensor<1x7x3xf32> {
+    %token, %results = mhal.launch @mlir_attention (%arg0, %arg1, %arg2) : (tensor<1x7x3xf32>, tensor<1x3x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
     mhal.await %token : !mhal.token
     return %results : tensor<1x7x3xf32>
   }
   module @__xmodule_ attributes {mhal.arch = "##TOKEN_ARCH##", mhal.module} {
-    func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}, %arg3: tensor<1x7x7xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) attributes {kernel, original_func = @mlir_attention} {
+    func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) attributes {kernel, original_func = @mlir_attention} {
       %0 = migraphx.dot(%arg0, %arg1): (tensor<1x7x3xf32>, tensor<1x3x7xf32>) -> tensor<1x7x7xf32>
-      %scaled = migraphx.mul(%0, %arg3) : (tensor<1x7x7xf32>, tensor<1x7x7xf32>) -> tensor<1x7x7xf32>
+      %cst = "tosa.const"() {value = dense<1.250000e-01> : tensor<1xf32>} : () -> tensor<1xf32>
+      %cst1 = migraphx.multibroadcast(%cst) {out_dyn_dims = [], out_lens = [1, 7, 7]} : (tensor<1xf32>) -> tensor<1x7x7xf32>
+      %scaled = migraphx.mul(%0, %cst1) : (tensor<1x7x7xf32>, tensor<1x7x7xf32>) -> tensor<1x7x7xf32>
       %1 = migraphx.softmax(%scaled){axis = 2 : i64} : tensor<1x7x7xf32> -> tensor<1x7x7xf32>
       %2 = migraphx.dot(%1, %arg2): (tensor<1x7x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
       return %2 : tensor<1x7x3xf32>

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale.mlir
@@ -1,0 +1,30 @@
+// RUN: sed -e s/##TOKEN_ARCH##/%arch/g %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004 --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) {
+    %0 = migraphx.dot(%arg0, %arg1): (tensor<1x7x3xf32>, tensor<1x3x7xf32>) -> tensor<1x7x7xf32>
+    %cst = "tosa.const"() {value = dense<1.250000e-01> : tensor<1xf32>} : () -> tensor<1xf32>
+    %cst1 = migraphx.multibroadcast(%cst) {out_dyn_dims = [], out_lens = [1, 7, 7]} : (tensor<1xf32>) -> tensor<1x7x7xf32>
+    %scaled = migraphx.mul(%0, %cst1) : (tensor<1x7x7xf32>, tensor<1x7x7xf32>) -> tensor<1x7x7xf32>
+    %1 = migraphx.softmax(%scaled){axis = 2 : i64} : tensor<1x7x7xf32> -> tensor<1x7x7xf32>
+    %2 = migraphx.dot(%1, %arg2): (tensor<1x7x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
+    return %2 : tensor<1x7x3xf32>
+  }
+  func.func @mlir_attention_wrapper(%arg0: tensor<1x7x3xf32>, %arg1: tensor<1x3x7xf32>,  %arg2: tensor<1x7x3xf32>) -> tensor<1x7x3xf32> {
+    %token, %results = mhal.launch @mlir_attention (%arg0, %arg1, %arg2) : (tensor<1x7x3xf32>, tensor<1x3x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
+    mhal.await %token : !mhal.token
+    return %results : tensor<1x7x3xf32>
+  }
+  module @__xmodule_ attributes {mhal.arch = "##TOKEN_ARCH##", mhal.module} {
+    func.func private @mlir_attention(%arg0: tensor<1x7x3xf32> {func.read_access}, %arg1: tensor<1x3x7xf32> {func.read_access}, %arg2: tensor<1x7x3xf32> {func.read_access}) -> (tensor<1x7x3xf32> {func.write_access}) attributes {kernel, original_func = @mlir_attention} {
+      %0 = migraphx.dot(%arg0, %arg1): (tensor<1x7x3xf32>, tensor<1x3x7xf32>) -> tensor<1x7x7xf32>
+      %cst = "tosa.const"() {value = dense<1.250000e-01> : tensor<1xf32>} : () -> tensor<1xf32>
+      %cst1 = migraphx.multibroadcast(%cst) {out_dyn_dims = [], out_lens = [1, 7, 7]} : (tensor<1xf32>) -> tensor<1x7x7xf32>
+      %scaled = migraphx.mul(%0, %cst1) : (tensor<1x7x7xf32>, tensor<1x7x7xf32>) -> tensor<1x7x7xf32>
+      %1 = migraphx.softmax(%scaled){axis = 2 : i64} : tensor<1x7x7xf32> -> tensor<1x7x7xf32>
+      %2 = migraphx.dot(%1, %arg2): (tensor<1x7x7xf32>, tensor<1x7x3xf32>) -> tensor<1x7x3xf32>
+      return %2 : tensor<1x7x3xf32>
+    }
+  }
+}


### PR DESCRIPTION
This commit adds support for scaling the first gemm output of attention kernels.
Additionally support for splat constant scale tensors are also added as they are quite common
with migraphx cases we are interested in supporting.

closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1094
