### PR TITLE
Fix missing directory creation that broke Makefile-based builds

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -166,6 +166,7 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
     # compilation, and the only time that device library gets pulled in is for
     # printf(), which we use the hip version of anyway.
     list(REMOVE_ITEM device_lib_targets "opencl")
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Transforms)
     add_custom_command(OUTPUT Transforms/AmdDeviceLibs.cpp.inc
       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/AmdDeviceLibsIncGen.py
       ARGS

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -939,7 +939,7 @@ pipeline {
                     stage("Install MIGraphX Dependencies") {
                         steps {
                             // Package and install current checkout of rocMLIR as MIGraphX dependency.
-                            sh 'cget -p ${WORKSPACE}/MIGraphXDeps install ${WORKSPACE} -DBUILD_FAT_LIBROCKCOMPILER=On'
+                            sh 'cget -p ${WORKSPACE}/MIGraphXDeps install ${WORKSPACE} -DBUILD_FAT_LIBROCKCOMPILER=On -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang'
                         }
                     }
                     stage("Build MIGraphX with MLIR") {


### PR DESCRIPTION
Turns out that when we build rocMLIR with `make`, the script to gather up the device libraries was running before the directory that the autogenerated file was meant to go in was created.

This commit fixes that by creating said directory at configure time.