### PR TITLE
Improve rpath handling, add workaround for ROCm asan builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,25 +84,27 @@ message(STATUS "LLVM_EXTERNAL_LIB_DIR: ${LLVM_EXTERNAL_LIB_DIR}")
 list(PREPEND CMAKE_BUILD_RPATH "${LLVM_EXTERNAL_LIB_DIR}")
 ### Workaround ROCm address sanitizer build not being able to propagate LD_LIBRARY_PATH
 ### Remove when https://github.com/pfultz2/cget/issues/110 is fixed.
-if ("$ENV{ADDRESS_SANITIZER}" STREQUAL "ON")
-  message("Address sanitizer workarounds")
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
-    OUTPUT_VARIABLE clang_asan_lib_file
-    ERROR_VARIABLE clang_stderr
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE clang_exit_code)
-  if (NOT "${clang_exit_code}" STREQUAL "0")
-    message(FATAL_ERROR
+if (DEFINED ENV{ADDRESS_SANITIZER})
+  if ($ENV{ADDRESS_SANITIZER} MATCHES "ON")
+    message("Address sanitizer workarounds")
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
+      OUTPUT_VARIABLE clang_asan_lib_file
+      ERROR_VARIABLE clang_stderr
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE clang_exit_code)
+    if (NOT "${clang_exit_code}" STREQUAL "0")
+      message(FATAL_ERROR
       "Unable to invoke clang to find asan lib dir: ${clang_stderr}")
+    endif()
+    file(TO_CMAKE_PATH "${clang_asan_lib_file}" clang_asan_lib_file_cmake)
+    get_filename_component(clang_asan_lib_dir "${clang_asan_lib_file_cmake}" DIRECTORY)
+    message(STATUS "Asan lib directory ${clang_asan_lib_dir}")
+    list(APPEND CMAKE_BUILD_RPATH "${clang_asan_lib_dir}")
   endif()
-  file(TO_CMAKE_PATH "${clang_asan_lib_file}" clang_asan_lib_file)
-  get_filename_component(clang_asan_lib_dir "${clag_asan_lib_file}" DIRECTORY)
-  list(APPEND CMAKE_BUILD_RPATH "${clang_asan_lib_dir}")
 endif()
 ### End workaround
-
 
 # Set up the build for the LLVM/MLIR git-submodule
 include(cmake/llvm-project.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ message(STATUS "LLVM_EXTERNAL_LIB_DIR: ${LLVM_EXTERNAL_LIB_DIR}")
 list(PREPEND CMAKE_BUILD_RPATH "${LLVM_EXTERNAL_LIB_DIR}")
 ### Workaround ROCm address sanitizer build not being able to propagate LD_LIBRARY_PATH
 ### Remove when https://github.com/pfultz2/cget/issues/110 is fixed.
-if (ENV{ADDRESS_SANITIZER})
+if ("$ENV{ADDRESS_SANITIZER}" STREQUAL "ON")
   message("Address sanitizer workarounds")
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,8 @@ include(cmake/mlir-hal.cmake)
 
 if(NOT WIN32)
     # Update the build-tree RPATH
-    set(CMAKE_BUILD_RPATH "${ROCMLIR_LIB_DIR};${LLVM_EXTERNAL_LIB_DIR}")
-    message(STATUS "CMAKE_BUILD_RPATH: ${CMAKE_BUILD_RPATH}")
+    list(PREPEND CMAKE_BUILD_RPATH "${ROCMLIR_LIB_DIR}")
+    message(STATUS "Final CMAKE_BUILD_RPATH: ${CMAKE_BUILD_RPATH}")
 endif()
 
 # Set up the build for the rocMLIR dialects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,36 @@ else()
   set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 1 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
 endif()
 
+# Pointers to external llvm build, needed here to set up rpath project-wide
+set(LLVM_EXTERNAL_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project")
+set(LLVM_EXTERNAL_BIN_DIR "${LLVM_EXTERNAL_BUILD_DIR}/llvm/bin")
+set(LLVM_EXTERNAL_LIB_DIR "${LLVM_EXTERNAL_BUILD_DIR}/llvm/lib")
+
+message(STATUS "LLVM_EXTERNAL_BIN_DIR: ${LLVM_EXTERNAL_BIN_DIR}")
+message(STATUS "LLVM_EXTERNAL_LIB_DIR: ${LLVM_EXTERNAL_LIB_DIR}")
+list(PREPEND CMAKE_BUILD_RPATH "${LLVM_EXTERNAL_LIB_DIR}")
+### Workaround ROCm address sanitizer build not being able to propagate LD_LIBRARY_PATH
+### Remove when https://github.com/pfultz2/cget/issues/110 is fixed.
+if (ENV{ADDRESS_SANITIZER})
+  message("Address sanitizer workarounds")
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
+    OUTPUT_VARIABLE clang_asan_lib_file
+    ERROR_VARIABLE clang_stderr
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE clang_exit_code)
+  if (NOT "${clang_exit_code}" STREQUAL "0")
+    message(FATAL_ERROR
+      "Unable to invoke clang to find asan lib dir: ${clang_stderr}")
+  endif()
+  file(TO_CMAKE_PATH "${clang_asan_lib_file}" clang_asan_lib_file)
+  get_filename_component(clang_asan_lib_dir "${clag_asan_lib_file}" DIRECTORY)
+  list(APPEND CMAKE_BUILD_RPATH "${clang_asan_lib_dir}")
+endif()
+### End workaround
+
+
 # Set up the build for the LLVM/MLIR git-submodule
 include(cmake/llvm-project.cmake)
 include(cmake/mlir-hal.cmake)

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -1,14 +1,7 @@
 message(STATUS "Adding LLVM git-submodule src dependency")
 
 set(LLVM_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project")
-set(LLVM_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/llvm-project")
-
-# Pointers to: external LLVM bins/libs
-set(LLVM_EXTERNAL_BIN_DIR "${LLVM_BINARY_DIR}/llvm/bin" CACHE PATH "")
-set(LLVM_EXTERNAL_LIB_DIR "${LLVM_BINARY_DIR}/llvm/lib" CACHE PATH "")
-
-message(STATUS "LLVM_EXTERNAL_BIN_DIR: ${LLVM_EXTERNAL_BIN_DIR}")
-message(STATUS "LLVM_EXTERNAL_LIB_DIR: ${LLVM_EXTERNAL_LIB_DIR}")
+set(LLVM_BINARY_DIR "${LLVM_EXTERNAL_BUILD_DIR}")
 
 # Passed to lit.site.cfg.py.so that the out of tree Standalone dialect test
 # can find MLIR's CMake configuration
@@ -68,32 +61,7 @@ list(APPEND LLVM_INCLUDE_DIRS
   ${LLVM_BINARY_DIR}/llvm/include
 )
 
-# Linker flags
-list(PREPEND CMAKE_BUILD_RPATH "${LLVM_EXTERNAL_LIB_DIR}")
-### Workaround ROCm address sanitizer build not being able to propagate LD_LIBRARY_PATH
-### Remove when https://github.com/pfultz2/cget/issues/110 is fixed.
-if (ENV{ADDRESS_SANITIZER})
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
-    OUTPUT_VARIABLE clang_asan_lib_file
-    ERROR_VARIABLE clang_stderr
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE clang_exit_code)
-  if (NOT "${clang_exit_code}" STREQUAL "0")
-    message(FATAL_ERROR
-      "Unable to invoke clang to find asan lib dir: ${clang_stderr}")
-  endif()
-  file(TO_CMAKE_PATH "${clang_asan_lib_file}" clang_asan_lib_file)
-  get_filename_component(clang_asan_lib_dir "${clag_asan_lib_file}" DIRECTORY)
-  list(APPEND CMAKE_BUILD_RPATH "${clang_asan_lib_dir}")
-endif()
-### End workaround
-
 add_subdirectory("${LLVM_PROJECT_DIR}/llvm" "external/llvm-project/llvm" EXCLUDE_FROM_ALL)
-
-# Propagate the RPATH settings up to rocMLIR, since we need them there too
-set(CMAKE_BUILD_RPATH ${CMAKE_BUILD_RPATH} PARENT_SCOPE)
 
 function(add_rocmlir_dialect_library name)
   set_property(GLOBAL APPEND PROPERTY ROCMLIR_DIALECT_LIBS ${name})


### PR DESCRIPTION
1. Don't reset the build rpath in the main CMake file, but instead prepend the rocmlir library directory
2. Use an already defined LLVM_EXTERNAL_LIB_DIR variable to set up the build rpath before adding in the LLVM project
3. Pass the rpath back up from configuring llvm-project, thus ensuring any settings made in that include stick around for the rocmlir parts of the build so that we don't have to duplicate them.

Note that in all cases this is the *build* rpath, which isn't used when executables (or shared libraries) are installed, so this will only affect stuff like tablegen.