### PR TITLE
[hotfix] Fix crashes on shufflenet v2 by guarding erases

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -515,7 +515,8 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
           rewriter.eraseOp(newCollapseShapeOp);
           return failure();
         }
-        rewriter.eraseOp(op);
+        if (op->use_empty())
+          rewriter.eraseOp(op);
       } else if (auto op = dyn_cast<tensor::ExpandShapeOp>(use.getOwner())) {
         return rewriter.notifyMatchFailure(
             op, "We dont support expand shapes yet.");
@@ -585,7 +586,8 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
       }
     }
 
-    b.eraseOp(top);
+    if (top.use_empty())
+      b.eraseOp(top);
     return success();
   }
 };


### PR DESCRIPTION
This commit stops the assertion we were hitting from tripping, and releavels that those erase calls aren't actually needed, since the model compiles without incident otherwise.

The issue involved hasn't been 'properly' debugged, but this works, so.

Fixes https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/issues/2315