### PR TITLE
Add libaio1 to Dockerfile so we can do non-root mysqld install for Tuna during CI

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -117,6 +117,7 @@ RUN apt-get update && rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
   cmake=3.22.1-0kitware1ubuntu20.04.1 \
   kitware-archive-keyring \
   libsqlite3-dev \
-  parallel && \
+  parallel \
+  libaio1 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Simplest way to do local mysqld for Tuna integration is a non-root install of the generic version during CI:
 * Dockerfile install is elaborate, because mysql-server package wants systemd which isn't there.
 * CI jobs don't run as root, which means no apt-get.
 * First two points mean CI must start mysqld itself, but not being root causes problems for package version.

Non-root install of generic version avoids permission issues and also uses a socket which avoids network and password issues.  libaio1 is a prereq and its installation *does* have to be done as root.