### PR TITLE
[CI] remove pre-installed rocMLIR from MIGraphXDeps

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -12,6 +12,10 @@ RUN wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/AMDMIGraphX/${MI
     && wget https://raw.githubusercontent.com/ROCmSoftwarePlatform/AMDMIGraphX/${MIGRAPHX_REF}/rbuild.ini
 RUN echo $(git ls-remote https://github.com/ROCmSoftwarePlatform/AMDMIGraphX ${MIGRAPHX_REF}) > migraphx-deps-commit-hash
 RUN rbuild prepare -d $PWD -s develop --cxx=/opt/rocm/llvm/bin/clang++ --cc=/opt/rocm/llvm/bin/clang
+# Remove rocMLIR version as per MIGraphX requirements
+# as this image is being used for CI with tip of rocMLIR
+# that will be built in the job.
+RUN cget remove -p $PWD ROCmSoftwarePlatform/rocMLIR -y
 # Download models for testing
 RUN wget https://github.com/onnx/models/raw/ba629906dd91872def671e70177c5544e0ea9e02/vision/classification/resnet/model/resnet50-v1-7.onnx
 RUN wget https://github.com/stefankoncarevic/Onnx_models/raw/master/bert_base_cased_1.onnx


### PR DESCRIPTION
This commit removes the rocMLIR that get installed
as per the requirements of MIGraphX as this image
is being used for CI with tip of rocMLIR develop.