### PR TITLE
Add -gz to compiler flags in debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ endif()
 # Set policy CMP0057 to support IN_LIST operators
 cmake_policy(SET CMP0057 NEW)
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND (CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo))
+  message(STATUS "Adding -gz to compile flags")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -gz")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gz")
+endif()
+
 # Rock dialect.
 set(ROCMLIR_DRIVER_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build E2E tests for Rock driver")
 set(ROCMLIR_DRIVER_RANDOM_DATA_SEED "none" CACHE STRING "Enable E2E tests using random data")


### PR DESCRIPTION
As a tentative fix for
https://ontrack-internal.amd.com/browse/SWDEV-423466 , compress our debug symbols in debug or relwithdebinfo builds.

I haven't tested if this'll work, and I haven't tested this backported onto whatever commit MIOpen builds us with, so this is more here for testing.