### PR TITLE
Reduce LDS buffers to 2 in attention kernels.

### DIFF
--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1571,7 +1571,8 @@ LogicalResult GridwiseAttentionAccelOp::verify() {
                                (elemTypeV.getIntOrFloatBitWidth() / 8);
   int64_t gemm1BLdsSizeBytes =
       (gemm0NPerBlock * gemm1N) * (elemTypeV.getIntOrFloatBitWidth() / 8);
-  int64_t totalLDSSize = std::max(gemm0ALdsSizeBytes, gemm1ALdsSizeBytes) + std::max(gemm0BLdsSizeBytes, gemm1BLdsSizeBytes);
+  int64_t totalLDSSize = std::max(gemm0ALdsSizeBytes, gemm1ALdsSizeBytes) +
+                         std::max(gemm0BLdsSizeBytes, gemm1BLdsSizeBytes);
   if (totalLDSSize > 64 * 1024) {
     return emitError() << "totalLDSSize (" << totalLDSSize
                        << ") exceeds 64KB\n";

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1571,8 +1571,7 @@ LogicalResult GridwiseAttentionAccelOp::verify() {
                                (elemTypeV.getIntOrFloatBitWidth() / 8);
   int64_t gemm1BLdsSizeBytes =
       (gemm0NPerBlock * gemm1N) * (elemTypeV.getIntOrFloatBitWidth() / 8);
-  int64_t totalLDSSize = gemm0ALdsSizeBytes + gemm0BLdsSizeBytes +
-                         gemm1ALdsSizeBytes + gemm1BLdsSizeBytes;
+  int64_t totalLDSSize = std::max(gemm0ALdsSizeBytes, gemm1ALdsSizeBytes) + std::max(gemm0BLdsSizeBytes, gemm1BLdsSizeBytes);
   if (totalLDSSize > 64 * 1024) {
     return emitError() << "totalLDSSize (" << totalLDSSize
                        << ") exceeds 64KB\n";

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1516,8 +1516,6 @@ struct GridwiseAttentionAccelRewritePattern
     SmallVector<int64_t, 3> gemm0BidGridLengths = {gemm0G, gemm0MBlocks,
                                                    gemm0NBlocks};
 
-    // Value ldsReductionWorkspaceByteBuffer = createLDSByteBuffer(
-    //     rewriter, loc, gemm0MPerBlock * gemm0NPerBlock, elemTypeQxK);
     TypedValue<MemRefType> ldsReductionWorkspaceBuffer =
         viewBufferAs(rewriter, ldsReductionWorkspaceByteBuffer, elemTypeQxK);
 
@@ -1546,26 +1544,7 @@ struct GridwiseAttentionAccelRewritePattern
     }
     Value gemm0ExpOutBufferToLDS =
         createBufferForGemmOut(loc, elemTypeV, accelParamsGemm0, rewriter);
-    // // gemm1 will happen after reductions are done;
-    // // Therefore, we re-use that LDS buffer.
-    // // The reduction buffer being larger is still
-    // // acceptable; we just need a subview of that.
-    // int64_t gemm1LDSByteBufferSize =
-    //     gemm0MPerBlock * gemm0NPerBlock * getByteWidth(elemTypeV);
-    // if (ldsReductionWorkspaceByteBuffer.getType()
-    //         .cast<MemRefType>()
-    //         .getNumElements() < gemm1LDSByteBufferSize) {
-    //   return op.emitError("ldsReductionWorkspaceByteBuffer should not be less
-    //   "
-    //                       "than gemm1LDSByteBufferSize.");
-    // }
-    // auto gemm1LDSByteBufferAType =
-    //     MemRefType::get({gemm1LDSByteBufferSize}, rewriter.getI8Type(),
-    //                     AffineMap{}, workgroupMemoryAddressSpace);
-    // Value gemm1LDSByteBufferA = rewriter.create<memref::SubViewOp>(
-    //     loc, gemm1LDSByteBufferAType, ldsReductionWorkspaceByteBuffer,
-    //     ArrayRef<int64_t>{0}, ArrayRef<int64_t>{gemm1LDSByteBufferSize},
-    //     ArrayRef<int64_t>{1});
+
     auto [preAccelRegBufferQxK, preAccelRegBufferV] =
         createRegInterrimBufferForAccel(loc, accelParamsGemm1, rewriter);
     Value accRegBufferGemm1 =

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -11,9 +11,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
   // CHECK: %[[QTr0:.+]] = rock.transform %[[Q]] by
   // CHECK: %[[ldsG0A:.+]] = rock.alloc() : memref<4096xi8, #gpu.address_space<workgroup>>
   // CHECK: %[[ldsG0B:.+]] = rock.alloc() : memref<4096xi8, #gpu.address_space<workgroup>>
-  // CHECK: %[[ldsG1A:.+]] = rock.alloc() : memref<4096xi8, #gpu.address_space<workgroup>>
-  // CHECK: %[[ldsReductionWS:.+]] = memref.view %[[ldsG1A]][
-  // CHECK: %[[ldsG1B:.+]] = rock.alloc() : memref<4096xi8, #gpu.address_space<workgroup>>
+  // CHECK: %[[ldsReductionWS:.+]] = memref.view %[[ldsG0A]][
 
   // init maxRow buffer
   // CHECK-DAG: rock.fill(%[[maxRowBuf:.+]], %[[negInf]])
@@ -105,7 +103,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
     // CHECK-DAG: rock.threadwise_copy %[[gemm0NormExpTr3]] -> %[[G1AregsKpackTr3]]
 
     // Viewing G1 LDS A tile buffer
-    // CHECK-DAG: %[[viewG1AStore:.+]] = memref.view %[[ldsG1A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[viewG1AStore:.+]] = memref.view %[[ldsG0A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
     // CHECK-DAG: %[[viewG1AStoreTr0:.+]] = rock.transform %[[viewG1AStore]]
     // CHECK-DAG: %[[viewG1AStoreTr1:.+]] = rock.transform %[[viewG1AStoreTr0]]
     // CHECK-DAG: %[[viewG1AStoreTr2:.+]] = rock.transform %[[viewG1AStoreTr1]]
@@ -117,7 +115,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
 
     // Store to LDS G1A tile buffer
     // CHECK-DAG: rock.threadwise_write_all {{.*}} %[[G1AregsKpack]] -> [](%[[viewG1AStoreTr7]])
-    // CHECK-DAG: %[[view2G1AStore:.+]] = memref.view %[[ldsG1A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[view2G1AStore:.+]] = memref.view %[[ldsG0A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
 
     // Load G1B tile from global to regs
     // CHECK-DAG: %[[VTr0:.+]] = rock.transform %[[V]] by
@@ -132,7 +130,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
     // CHECK-DAG: rock.threadwise_copy %[[G1BregsTr1]] -> %[[G1BregsKpackTr1]]
 
     // Viewing G1 LDS B tile buffer
-    // CHECK-DAG: %[[viewG1BStore:.+]] = memref.view %[[ldsG1B]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[viewG1BStore:.+]] = memref.view %[[ldsG0B]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
     // CHECK-DAG: %[[viewG1BStoreTr0:.+]] = rock.transform %[[viewG1BStore]]
     // CHECK-DAG: %[[viewG1BStoreTr1:.+]] = rock.transform %[[viewG1BStoreTr0]]
     // CHECK-DAG: %[[viewG1BStoreTr2:.+]] = rock.transform %[[viewG1BStoreTr1]]
@@ -140,7 +138,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
 
     // Store to LDS G1B tile buffer
     // CHECK-DAG: rock.threadwise_write_all {{.*}} %[[G1BregsKpack]] -> [](%[[viewG1BStoreTr3]])
-    // CHECK-DAG: %[[view2G1BStore:.+]] = memref.view %[[ldsG1B]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[view2G1BStore:.+]] = memref.view %[[ldsG0B]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
 
     // Gemm1
     // CHECK-DAG: rock.lds_barrier


### PR DESCRIPTION
This commit changes the attention kernel to re-use LDS buffers
between the GEMMs.

closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1217