### PR TITLE
[BACKPORT] Fix handling of mid-tensor unit dims in transpose/collapse folding 

### DIFF
--- a/mlir/test/Conversion/TosaToRock/collapse-shape-mid-transpose-unit-dims.mlir
+++ b/mlir/test/Conversion/TosaToRock/collapse-shape-mid-transpose-unit-dims.mlir
@@ -1,0 +1,11 @@
+// RUN: rocmlir-opt -tosa-to-rock %s | FileCheck %s
+// CHECK-LABEL: @mlir_transpose_dot
+func.func @mlir_transpose_dot(%arg0: tensor<1x1x5x4xf32>, %arg1: tensor<1x1x5x3xf32>) -> tensor<1x1x4x3xf32> attributes {arch = "gfx1100", kernel = "mixr", num_cu = 48 : i64} {  %cst = arith.constant dense<[0, 1, 3, 2]> : tensor<4xi64>
+  %0 = "tosa.transpose"(%arg0, %cst) : (tensor<1x1x5x4xf32>, tensor<4xi64>) -> tensor<1x1x4x5xf32>
+  %collapsed = tensor.collapse_shape %0 [[0, 1], [2], [3]] : tensor<1x1x4x5xf32> into tensor<1x4x5xf32>
+  %collapsed_0 = tensor.collapse_shape %arg1 [[0, 1], [2], [3]] : tensor<1x1x5x3xf32> into tensor<1x5x3xf32>
+  // CHECK: rock.gemm
+  %1 = "tosa.matmul"(%collapsed, %collapsed_0) : (tensor<1x4x5xf32>, tensor<1x5x3xf32>) -> tensor<1x4x3xf32>
+  %expanded = tensor.expand_shape %1 [[0, 1], [2], [3]] : tensor<1x4x3xf32> into tensor<1x1x4x3xf32>
+  return %expanded : tensor<1x1x4x3xf32>
+}

--- a/mlir/utils/widgets/tune_MLIR_kernels.sh
+++ b/mlir/utils/widgets/tune_MLIR_kernels.sh
@@ -64,6 +64,7 @@ buildlibrockCompiler() {
           -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
           -DCMAKE_BUILD_TYPE=Release # or RelWithDebInfo
     cd build-static
+    rm ./lib/librockCompiler.a
     ninja
     rm -rf ${WORKSPACE}/MIOpenDeps
     cmake --install . --prefix ${WORKSPACE}/MIOpenDeps


### PR DESCRIPTION
See develop PR #1297 

This commit fixes one of the failure cases in
https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/issues/2365 (specifically, it handles the crash, not the numerical accuracy problems, which are still under investigation)

The cause of the crash was attempts to transpose merging on the following sequence of operations:

%t = transpose(%rawA) [0, 1, 3, 2] : tensor<1x1xKxM> to tensor<1x1xMxK>
%a = collapse_shape %t [[0, 1], [2], [3]] : tensor<1x1xMxK> to rock.gemm %c = %a * %b ...

The problem arose because the logic in the collapse shape folder didn't correctly handle the case where the unit dimensions it peeled out of the collapse.

The peeling code code was probably needed so that we could still, for example, combine transpose [0, 2, 3, 1] : tensor<Ax1xBxC> to tensor<AxBxCx1> with collapse_shape [[0, 1], [2], [3]], even though a naive remapping of the reassociation experessions would lead to non-continuous dimensions being merged.
The problem was that it created the set of reassociation expressions [[0], [2], [3]], which triggered assertions in tensor::CollapseShape that all the dimensions (other than the ones on the ends) had to be listed in order.

This should fix the issue in general, but it's possible we'll want to investegate all that code and rip it out if we do problem key v2.

(Also, update a utility script to make sure that static library builds actually rebuild the static library)