### PR TITLE
Remove broadcast handling from vectorization / contiguous merges

### DIFF
--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -248,8 +248,6 @@ struct DimInfo {
   TransformMapAttr transformMap; // Map to which the dimension belongs
   TransformAttr transform;       // Transform to which the dimension belongs
   size_t positionInMerge; // Position of the dimension inside the transform
-  bool isBroadcast;       // Is this a broadcast dimension?
-  bool isPadded;          // Is this a padded dimension?
 
   // Utility function to return a transform pair <map,transform>
   std::pair<TransformMapAttr, TransformAttr> transformPair() {
@@ -308,18 +306,9 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
       if (keyJ.transformPair() != keyI.transformPair())
         break;
 
-      // b) Unmerge parameters need to match merge parameters. Note that if
-      // the merge dimension goes through a Broadcast (before getting unmerged),
-      // this should be taken into account (i.e., the new parameter should be 1)
-      // However, if its padded, we should not be using 1 as the actual length
-      // becomes important.
-      int64_t dimJ = mergeJDims[posJ];
-      int64_t paramOrBroadcast =
-          (dimToMerge[dimJ].isBroadcast && !dimToMerge[dimJ].isPadded)
-              ? 1
-              : mergeJParams[posJ];
-
-      if (params[j] != paramOrBroadcast)
+      // b) Unmerge parameters need to match merge parameters.
+      int64_t expectedLength = mergeJParams[posJ];
+      if (params[j] != expectedLength)
         break;
 
       groupCandidate.push_back(mergeJDims[posJ]);
@@ -336,15 +325,14 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
       for (auto d : groupCandidate)
         contiguousGroups[keyI.transformPair()].unionSets(lowerDim, d);
 
-      // We also want to add the singleton/broadcast dimensions of the merge the
+      // We also want to add the singleton dimensions of the merge the
       // groupCandidate belongs to. In this way we cover for situations like
       // - Merge{8,1,3}, <AddDim at [1]>, <Unmerge{8,3}>
-      // - Merge{8,2,3}, <Broadcast at [1]>, <Unmerge{8,1,3}>
       for (auto pair : llvm::zip(keyI.transform.getLowerDims(),
                                  keyI.transform.getParams())) {
         int64_t d = std::get<0>(pair);
         int64_t p = std::get<1>(pair);
-        if (p == 1 || dimToMerge[d].isBroadcast)
+        if (p == 1)
           contiguousGroups[keyI.transformPair()].unionSets(lowerDim, d);
       }
     }
@@ -379,8 +367,7 @@ ContiguousMergesMap findContiguousGroups(ArrayAttr transforms,
       switch (transformType) {
       case TransformType::Merge:
         for (size_t i = 0; i < lowerDims.size(); i++) {
-          thisDimToMerge[lowerDims[i]] = {transformMap, transform, i, false,
-                                          dimToMerge[upperDims[0]].isPadded};
+          thisDimToMerge[lowerDims[i]] = {transformMap, transform, i};
         }
         break;
       // AddDim drops dimensions down a hole, while ConstDim conjures them
@@ -443,34 +430,16 @@ ContiguousMergesMap findContiguousGroups(ArrayAttr transforms,
         break;
       }
 
-      case TransformType::Pad:
-        for (auto pair : llvm::zip(upperDims, lowerDims)) {
-          uint32_t u = std::get<0>(pair);
-          uint32_t l = std::get<1>(pair);
-          thisDimToMerge[l] = dimToMerge[u];
-          thisDimToMerge[l].isPadded = true;
-        }
-        break;
       case TransformType::PassThrough:
       case TransformType::Slice:
+      case TransformType::Pad:
+      case TransformType::Broadcast:
         // We only care about how these transformations shuffle
         // the dimensions
         for (auto pair : llvm::zip(upperDims, lowerDims)) {
           uint32_t u = std::get<0>(pair);
           uint32_t l = std::get<1>(pair);
           thisDimToMerge[l] = dimToMerge[u];
-        }
-        break;
-      case TransformType::Broadcast:
-        // Flag the dimensions we are broadcasting, if the broadcast
-        // parameter is 1
-        for (auto pair : llvm::zip(upperDims, lowerDims, params)) {
-          uint32_t u = std::get<0>(pair);
-          uint32_t l = std::get<1>(pair);
-          uint32_t p = std::get<2>(pair);
-          thisDimToMerge[l] = dimToMerge[u];
-          if (p == 1)
-            thisDimToMerge[l].isBroadcast = true;
         }
         break;
       case TransformType::Unmerge:

--- a/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
+++ b/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
@@ -316,7 +316,9 @@ func.func @test_vectorization() {
   %36 = "get_length"() {transforms = [#transform_merge_7, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
   // CHECK-NEXT: result = 4
   %37 = "get_length"() {transforms = [#transform_merge_7, #transform_shuffle_5, #transform_unmerge_8], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
-  // CHECK-NEXT: result = 4
+  // Note: this isn't 4 because making sure the 8 part is divided by the
+  // broadcast length is important.
+  // CHECK-NEXT: result = 1
   %38 = "get_length"() {transforms = [#transform_merge_9, #transform_shuffle_6, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
   // CHECK-NEXT: result = 4
   %39 = "get_length"() {transforms = [#transform_merge, #transform_inject_unit_const, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)


### PR DESCRIPTION
We have ran into the following error case from an MIGraphX unit test (MLIR integration tests for this to follow Later (tm)):

- %aRaw : tensor<2x1x2x3>
- %aBcast = broadcast %aRaw to tensor<2x3x2x3>
- %aMergeBatch = merge{2, 3} %aBcast to tensor<6x2x3> rock.gemm ... %aMergeBatch * ...

The contiguos merge handling code would rewrite the merge{2, 3} to a merge{1, 6}, and then the optimization that v mod 1 == 0 would kick in, which would mean that the read would always read from the first batch (causing the second half of the matrix multiply to be incorrect).

Because of possibilities like this, I don't think we can have the clever "vectorize even in the presence of some broadcasts" setup we had before this commit, as I can't see any way to make it correct in general.

To put it another way, if you have the maps
(d0, d1, d2, d3) -> (d0, 0, d2, d3) # broadcast
and
(d0, d1, d2) -> (d0 / 3, d0 % 3, d1, d2) # merge
you can't optimize the merge to
(d0, d1, d2) -> (0, d0, d1, d2)
which is what our code was doing.

This commit therefor removes the isBroadcast field from all the vectorization tracking structs, and updates the unit tests.