### PR TITLE
[BACKPORT] Remove broadcast handling from vectorization / contiguous merges

### DIFF
--- a/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
+++ b/mlir/test/Dialect/Rock/test_vectorization_inference.mlir
@@ -316,7 +316,9 @@ func.func @test_vectorization() {
   %36 = "get_length"() {transforms = [#transform_merge_7, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
   // CHECK-NEXT: result = 4
   %37 = "get_length"() {transforms = [#transform_merge_7, #transform_shuffle_5, #transform_unmerge_8], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
-  // CHECK-NEXT: result = 4
+  // Note: this isn't 4 because making sure the 8 part is divided by the
+  // broadcast length is important.
+  // CHECK-NEXT: result = 1
   %38 = "get_length"() {transforms = [#transform_merge_9, #transform_shuffle_6, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)
   // CHECK-NEXT: result = 4
   %39 = "get_length"() {transforms = [#transform_merge, #transform_inject_unit_const, #transform_unmerge_7], in_dim = 0 : index, max_len = 4 : index} : () -> (memref<24xf32>)


### PR DESCRIPTION
We have ran into the following error case from an MIGraphX unit test (MLIR integration tests for this to follow Later (tm)):

- %aRaw : tensor<2x1x2x3>
- %aBcast = broadcast %aRaw to tensor<2x3x2x3>
- %aMergeBatch = merge{2, 3} %aBcast to tensor<6x2x3> rock.gemm ... %aMergeBatch * ...

The contiguos merge handling code would rewrite the merge{2, 3} to a merge{1, 6}, and then the optimization that v mod 1 == 0 would kick in, which would mean that the read would always read from the first batch (causing the second half of the matrix multiply to be incorrect).

Because of possibilities like this, I don't think we can have the clever "vectorize even in the presence of some broadcasts" setup we had before this commit, as I can't see any way to make it correct in general.

To put it another way, if you have the maps
(d0, d1, d2, d3) -> (d0, 0, d2, d3) # broadcast
and
(d0, d1, d2) -> (d0 / 3, d0 % 3, d1, d2) # merge
you can't optimize the merge to
(d0, d1, d2) -> (0, d0, d1, d2)
which is what our code was doing.

This commit therefor removes the isBroadcast field from all the vectorization tracking structs, and updates the unit tests.