### PR TITLE
Add Bank conflicts information to perfRunner.

### DIFF
--- a/mlir/utils/performance/results.txt
+++ b/mlir/utils/performance/results.txt
@@ -1,0 +1,1 @@
+pmc: LDSBankConflict

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -102,7 +102,7 @@ def getWinningConfig(tuningOutput, config, allData, options: Options):
             nanoSeconds = float(time)
 
         config.setPerfConfig(perfConfig)
-        entry = config.tableEntry(nanoSeconds)
+        entry = config.tableEntry(nanoSeconds, np.nan)
         allData.append(entry)
         theseTFlops = entry['TFlops']
         if not np.isnan(theseTFlops) and theseTFlops > maxTFlops:


### PR DESCRIPTION
I used rocprof to find out the bank conflict information for convolution and gemm. During the mlir benchmark in the output .csv file there is a column containing the results for all configurations. The percentage of GPUTime LDS is stalled by bank
conflicts. Value range: 0% (optimal) to 100% (bad).
