### PR TITLE
Allow threadwise copy to accept extra source/dest indices

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1334,11 +1334,13 @@ def Rock_InWarpTransposeOp :
 }
 
 def Rock_ThreadwiseCopyOp :
-    Rock_Op<"threadwise_copy">,
+    Rock_Op<"threadwise_copy", [AttrSizedOperandSegments]>,
     AllElementTypesMatch<["source", "dest"]>,
     Arguments<(ins
       Arg<MemRefOf<SupportedMemoryElems>, "source view", [MemRead]>:$source,
+      Variadic<Index>:$extraIndicesSource,
       Arg<MemRefOf<SupportedMemoryElems>, "detination view", [MemWrite]>:$dest,
+      Variadic<Index>:$extraIndicesDest,
       UnitAttr:$forceUnroll,
       UnitAttr:$useIndexDiffs
     )> {
@@ -1351,8 +1353,14 @@ def Rock_ThreadwiseCopyOp :
   }];
 
   let assemblyFormat = [{
-    attr-dict $source  `->` $dest `:` type($source) `->` type($dest)
+    attr-dict $source (`[` $extraIndicesSource^ `]`)? `->` $dest (`[` $extraIndicesDest^ `]`)? `:` type($source) `->` type($dest)
   }];
+
+  let builders = [
+    // Custom builder to not specify the extra indices
+    OpBuilder<(ins "Value":$source, "Value":$dest, CArg<"bool","false">:$forceUnroll, CArg<"bool","false">:$useIndexDiffs),
+                    [{ build($_builder, $_state, source, {}, dest, {}, forceUnroll, useIndexDiffs); }]>
+  ];
   let hasVerifier = 1;
 }
 

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -162,6 +162,16 @@ void convertDimStridestoSizes(ArrayRef<int64_t> orderedDimStrides,
 ArrayAttr prependUpperViews(OpBuilder &b, ArrayAttr viewsToPrepend,
                             ArrayAttr existingViews);
 
+// Given a `transform` stack [d0, ..., dn] -> .. -> (t0, ..., tm) it is useful
+// to add a passthrough index propagated top to bottom:
+//  [d0, ..., dP-1, (extra0, ..., extraL), dP, ... dn] -> (t0, ...,tP-1,
+//  (extra0, ..., extraL), tP..., tm)
+// The position P where we want the new variables to appear can be specified by
+// the `pos` input parameter. The parameter `length` represents the size of the
+// new dimensions to be inserted
+ArrayAttr addPassThroughIndices(OpBuilder &b, ArrayAttr transforms,
+                                ArrayRef<int64_t> lengths, int64_t pos);
+
 ArrayRef<int64_t> getLowerShape(ArrayAttr transformStack);
 
 } // end namespace rock

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1582,8 +1582,16 @@ LogicalResult ThreadwiseWriteAllOp::verify() {
 LogicalResult ThreadwiseCopyOp::verify() {
   auto srcShape = getSource().getType().getShape();
   auto dstShape = getDest().getType().getShape();
-  if (dstShape != srcShape)
-    return emitOpError("Source and dest shape need to have the same shape.");
+  // We can ignore the external indices, if there are any
+  size_t extraIndicesDestSize = getExtraIndicesDest().size();
+  size_t extraIndicesSourceSize = getExtraIndicesSource().size();
+  SmallVector<int64_t> unextendedSrcShape(
+      srcShape.begin() + extraIndicesSourceSize, srcShape.end());
+  SmallVector<int64_t> unextendedDstShape(
+      dstShape.begin() + extraIndicesDestSize, dstShape.end());
+  if (unextendedDstShape != unextendedSrcShape)
+    return emitOpError(
+        "Un-extended source and dest buffers need to have the same shape.");
 
   return success();
 }

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -327,7 +327,8 @@ LogicalResult ThreadwiseCopyRewritePattern::matchAndRewrite(
   if (rawLoadBufferShape.size() > extraIndicesSourceSize + 1)
     return op.emitOpError("Raw load buffers have to be flat or multi buffers.");
   if (rawStoreBufferShape.size() > extraIndicesDestSize + 1)
-    return op.emitOpError("Raw store buffers have to be flat or muti buffers.");
+    return op.emitOpError(
+        "Raw store buffers have to be flat or multi buffers.");
 
   Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
   Type elemType = sourceView.getType().cast<MemRefType>().getElementType();
@@ -363,9 +364,9 @@ LogicalResult ThreadwiseCopyRewritePattern::matchAndRewrite(
 
   // Extend start
   SmallVector<Value> extendedStart(op.getExtraIndicesSource());
-  extendedStart.insert(extendedStart.begin(), op.getExtraIndicesDest().begin(),
+  extendedStart.insert(extendedStart.end(), op.getExtraIndicesDest().begin(),
                        op.getExtraIndicesDest().end());
-  extendedStart.insert(extendedStart.begin(), start.begin(), start.end());
+  extendedStart.insert(extendedStart.end(), start.begin(), start.end());
 
   // Extend bounds
   SmallVector<int64_t> extendedBounds(

--- a/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
@@ -58,6 +58,7 @@ func.func @rock_threadwise_memcopy_no_inversion(%input : memref<16xf16, #gpu.add
 }
 
 // CHECK-LABEL: func.func @rock_threadwise_memcopy_extraindices
+// CHECK: ({{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[i:.*]]: index, %[[j:.*]]: index)
 func.func @rock_threadwise_memcopy_extraindices(%input : memref<2x16xf16, #gpu.address_space<private>>,
                                                 %input1 : memref<16xf16, #gpu.address_space<private>>,
                                                 %output : memref<2x16xf16, #gpu.address_space<private>>,
@@ -79,15 +80,18 @@ func.func @rock_threadwise_memcopy_extraindices(%input : memref<2x16xf16, #gpu.a
     %28 = rock.transform %27 by #transform_map8 : memref<1x2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
 
     // copy from source to dest
-    // CHECK: rock.transforming_for
+    // CHECK: %[[c00:.*]] = arith.constant 0 : index
+    // CHECK: rock.transforming_for ({{.*}}) = [{{.*}}, {{.*}}, {{.*}}](%[[i]], %[[j]], %[[c00]])
     // CHECK: strides [1, 1, 8]
     rock.threadwise_copy %22[%i]-> %24[%j] : memref<2x8x2xf16, #gpu.address_space<private>> -> memref<2x8x2xf16, #gpu.address_space<private>>
 
-    // CHECK: rock.transforming_for
+    // CHECK: %[[c01:.*]] = arith.constant 0 : index
+    // CHECK: rock.transforming_for ({{.*}}) = [{{.*}}, {{.*}}](%[[j]], %[[c01]])
     // CHECK: strides [1, 8]
     rock.threadwise_copy %26 -> %24[%j] : memref<8x2xf16, #gpu.address_space<private>> -> memref<2x8x2xf16, #gpu.address_space<private>>
 
-    // CHECK: rock.transforming_for
+    // CHECK: %[[c02:.*]] = arith.constant 0 : index
+    // CHECK: rock.transforming_for ({{.*}}) = [{{.*}}, {{.*}}](%[[i]], %[[c02]], %[[c02]])
     // CHECK: strides [1, 1, 1]
     rock.threadwise_copy %22[%i]-> %28 : memref<2x8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
 

--- a/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_copy.mlir
@@ -4,10 +4,21 @@
 #map7 = affine_map<(d0, d1, d2) -> ((d0 * 2 + d1) * 8 + d2)>
 #map8 = affine_map<(d0, d1) -> (0, d1, d0)>
 
+#map9 = affine_map<(d0, d1, d2) -> (d0, d1 * 8 + d2)>
+#map10 = affine_map<(d0, d1, d2) -> (d0, d2, d1)>
+#map11 = affine_map<(d0, d1, d2, d3) -> (d0, (d1 * 2 + d2) * 8 + d3)>
+#map12 = affine_map<(d0, d1, d2) -> (d0, 0, d2, d1)>
+
 #transform_map5 = #rock.transform_map<#map5 by [<Unmerge{2, 8} ["m_iter", "k_iter"] at [0, 1] -> ["iter"] at [0]>] bounds = [2, 8] -> [16]>
 #transform_map6 = #rock.transform_map<#map6 by [<Merge{8} ["k"] at [0] -> ["k_iter"] at [1]>, <Merge{2} ["m"] at [1] -> ["m_iter"] at [0]>] bounds = [8, 2] -> [2, 8]>
 #transform_map7 = #rock.transform_map<#map7 by [<Unmerge{1, 2, 8} ["kouterPerThread", "m_iter", "kpackPerThread"] at [0, 1, 2] -> ["iter"] at [0]>] bounds = [1, 2, 8] -> [16]>
 #transform_map8 = #rock.transform_map<#map8 by [<Merge{1, 8} ["k"] at [0] -> ["kouterPerThread", "kpackPerThread"] at [0, 2]>, <Merge{2} ["m"] at [1] -> ["m_iter"] at [1]>] bounds = [8, 2] -> [1, 2, 8]>
+
+// Multi maps
+#transform_map9 = #rock.transform_map<#map9 by [<PassThrough ["i"] at [0] -> ["i"] at [0]>, <Unmerge{2, 8} ["m_iter", "k_iter"] at [1, 2] -> ["iter"] at [1]>] bounds = [2, 2, 8] -> [2, 16]>
+#transform_map10 = #rock.transform_map<#map10 by [<PassThrough ["i"] at [0] -> ["i"] at [0]>, <Merge{8} ["k"] at [1] -> ["k_iter"] at [2]>, <Merge{2} ["m"] at [2] -> ["m_iter"] at [1]>] bounds = [2, 8, 2] -> [2, 2, 8]>
+#transform_map11 = #rock.transform_map<#map11 by [<PassThrough ["j"] at [0] -> ["j"] at [0]>, <Unmerge{1, 2, 8} ["kouterPerThread", "m_iter", "kpackPerThread"] at [1, 2, 3] -> ["iter"] at [1]>] bounds = [2, 1, 2, 8] -> [2, 16]>
+#transform_map12 = #rock.transform_map<#map12 by [<PassThrough ["j"] at [0] -> ["j"] at [0]>, <Merge{1, 8} ["k"] at [1] -> ["kouterPerThread", "kpackPerThread"] at [1, 3]>, <Merge{2} ["m"] at [2] -> ["m_iter"] at [2]>] bounds = [2, 8, 2] -> [2, 1, 2, 8]>
 
 
 // CHECK-LABEL: func.func @rock_threadwise_memcopy
@@ -43,5 +54,42 @@ func.func @rock_threadwise_memcopy_no_inversion(%input : memref<16xf16, #gpu.add
     // CHECK: rock.transforming_for
     // CHECK: strides [1, 1]
     rock.threadwise_copy %22 -> %24 : memref<8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
+    return
+}
+
+// CHECK-LABEL: func.func @rock_threadwise_memcopy_extraindices
+func.func @rock_threadwise_memcopy_extraindices(%input : memref<2x16xf16, #gpu.address_space<private>>,
+                                                %input1 : memref<16xf16, #gpu.address_space<private>>,
+                                                %output : memref<2x16xf16, #gpu.address_space<private>>,
+                                                %output1 : memref<16xf16, #gpu.address_space<private>>, %i : index, %j : index)  {
+    // source(multibuffer)
+    %21 = rock.transform %input by #transform_map9 : memref<2x16xf16, #gpu.address_space<private>> to memref<2x2x8xf16, #gpu.address_space<private>>
+    %22 = rock.transform %21 by #transform_map10 : memref<2x2x8xf16, #gpu.address_space<private>> to memref<2x8x2xf16, #gpu.address_space<private>>
+
+    // source(single buffer)
+    %25 = rock.transform %input1 by #transform_map5 : memref<16xf16, #gpu.address_space<private>> to memref<2x8xf16, #gpu.address_space<private>>
+    %26 = rock.transform %25 by #transform_map6 : memref<2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+
+    // dest
+    %23 = rock.transform %output by #transform_map11 : memref<2x16xf16, #gpu.address_space<private>> to memref<2x1x2x8xf16, #gpu.address_space<private>>
+    %24 = rock.transform %23 by #transform_map12 : memref<2x1x2x8xf16, #gpu.address_space<private>> to memref<2x8x2xf16, #gpu.address_space<private>>
+
+    // dest(multibuffer/non-invertible)
+    %27 = rock.transform %output1 by #transform_map7_noinv : memref<16xf16, #gpu.address_space<private>> to memref<1x2x8xf16, #gpu.address_space<private>>
+    %28 = rock.transform %27 by #transform_map8 : memref<1x2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+
+    // copy from source to dest
+    // CHECK: rock.transforming_for
+    // CHECK: strides [1, 1, 8]
+    rock.threadwise_copy %22[%i]-> %24[%j] : memref<2x8x2xf16, #gpu.address_space<private>> -> memref<2x8x2xf16, #gpu.address_space<private>>
+
+    // CHECK: rock.transforming_for
+    // CHECK: strides [1, 8]
+    rock.threadwise_copy %26 -> %24[%j] : memref<8x2xf16, #gpu.address_space<private>> -> memref<2x8x2xf16, #gpu.address_space<private>>
+
+    // CHECK: rock.transforming_for
+    // CHECK: strides [1, 1, 1]
+    rock.threadwise_copy %22[%i]-> %28 : memref<2x8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
+
     return
 }


### PR DESCRIPTION
I had to extend `threadwise_copy` to accept extra indices. The issue with this operator is that it is the only one accepting views on both input/output (which means more troubles). I ended up "normalizing" both views. 

The normalization process is as follows:
- If input view is `[extraIndicesSource, inputView]`
- If output view is `[extraIndicesDest, outputView]'
- The normalized input view is `[extrIndicesSource, extraIndicesDest, inputView]` and the normalized output view is `[extraIndicesSource, extraIndicesDest, outputView]`. 

The "dummy" indices will be dealt directly inside the transforming loop (bottom of the transform stack). I had to do this normalization for two reasons
a) `trnsforming_for` views need accept the same number of variables (same stride and same bounds)
b) I cannot simply `AddDim` the spurious dimensiona, because that would hinder the invertibility of the transform (hence its vectorization). 