### PR TITLE
[Attention] change math.exp to math.exp2

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1877,9 +1877,10 @@ struct GridwiseAttentionAccelRewritePattern
       // Scale gemm0 output by (1/ln2)
       // So that we can use exp2 instead of exp.
       Value ln2Recip = createConstantFloatOp(rewriter, loc, elemTypeQxK,
-                                        elemTypeQxK, 1.44269504);
-      scaleFirstGemmSplat(rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-                          gemm0OutSubTileViews, ln2Recip.getDefiningOp<arith::ConstantOp>().getValue());
+                                             elemTypeQxK, 1.44269504);
+      scaleFirstGemmSplat(
+          rewriter, loc, gridCoordsGemm0, gemm0OutBuffer, gemm0OutSubTileViews,
+          ln2Recip.getDefiningOp<arith::ConstantOp>().getValue());
 
       // Handle padding
       bool hasPadding =

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -225,14 +225,14 @@ void createTuningRange(TuningParamSet *newSpace, AttentionOp attnOp) {
     // add performant configs for tier1
     newSpace->tuningRange.push_back(
         cast<RockTuningParamAttrInterface>(b.getAttr<XdlopsGemmParamsAttr>(
-            /*kpackPerBlock=*/8, /*mPerBlock=*/128,
-            /*nPerBlock=*/64, /*kpack=*/8,
-            /*mPerWave=*/32, /*nPerWave=*/64, /*forceUnroll=*/true)));
+            /*kpackPerBlock=*/8, /*mPerBlock=*/64,
+            /*nPerBlock=*/128, /*kpack=*/8,
+            /*mPerWave=*/32, /*nPerWave=*/32, /*forceUnroll=*/true)));
     newSpace->tuningRange.push_back(
         cast<RockTuningParamAttrInterface>(b.getAttr<XdlopsGemmParamsAttr>(
-            /*kpackPerBlock=*/8, /*mPerBlock=*/32,
-            /*nPerBlock=*/128, /*kpack=*/4,
-            /*mPerWave=*/32, /*nPerWave=*/32, /*forceUnroll=*/true)));
+            /*kpackPerBlock=*/8, /*mPerBlock=*/64,
+            /*nPerBlock=*/64, /*kpack=*/8,
+            /*mPerWave=*/32, /*nPerWave=*/64, /*forceUnroll=*/true)));
 
     // add performant config for triton configs
     newSpace->tuningRange.push_back(

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -222,6 +222,29 @@ void createTuningRange(TuningParamSet *newSpace, AttentionOp attnOp) {
             /*nPerBlock=*/32, /*kpack=*/1,
             /*mPerWave=*/32, /*nPerWave=*/32, /*forceUnroll=*/true)));
 
+    // add performant configs for tier1
+    newSpace->tuningRange.push_back(
+        cast<RockTuningParamAttrInterface>(b.getAttr<XdlopsGemmParamsAttr>(
+            /*kpackPerBlock=*/8, /*mPerBlock=*/128,
+            /*nPerBlock=*/64, /*kpack=*/8,
+            /*mPerWave=*/32, /*nPerWave=*/64, /*forceUnroll=*/true)));
+    newSpace->tuningRange.push_back(
+        cast<RockTuningParamAttrInterface>(b.getAttr<XdlopsGemmParamsAttr>(
+            /*kpackPerBlock=*/8, /*mPerBlock=*/32,
+            /*nPerBlock=*/128, /*kpack=*/4,
+            /*mPerWave=*/32, /*nPerWave=*/32, /*forceUnroll=*/true)));
+
+    // add performant config for triton configs
+    newSpace->tuningRange.push_back(
+        cast<RockTuningParamAttrInterface>(b.getAttr<XdlopsGemmParamsAttr>(
+            /*kpackPerBlock=*/16, /*mPerBlock=*/128,
+            /*nPerBlock=*/128, /*kpack=*/8,
+            /*mPerWave=*/32, /*nPerWave=*/64, /*forceUnroll=*/true)));
+    newSpace->tuningRange.push_back(
+        cast<RockTuningParamAttrInterface>(b.getAttr<XdlopsGemmParamsAttr>(
+            /*kpackPerBlock=*/16, /*mPerBlock=*/128,
+            /*nPerBlock=*/128, /*kpack=*/8,
+            /*mPerWave=*/64, /*nPerWave=*/64, /*forceUnroll=*/true)));
   } else if (bitEnumContainsAll(currentFeatures, GemmFeatures::wmma)) {
     // Wmma
     PopulateParamsWmma tuningInfo;
@@ -339,6 +362,7 @@ LogicalResult getTuningProblemStr(rock::AttentionOp attnOp,
 
   TypedValue<ShapedType> queries = attnOp.getQueries();
   ArrayRef<int64_t> qShape = queries.getType().getShape();
+  int64_t g = qShape[0];
 
   // TransQ
   problemOS << "-transQ ";
@@ -380,6 +404,7 @@ LogicalResult getTuningProblemStr(rock::AttentionOp attnOp,
   } else {
     problemOS << "false" << sep;
   }
+  problemOS << "-g " << g << sep;
   problemOS << "-seq_len " << seqLen << sep;
   problemOS << "-head_dim " << numHeads;
   return success();

--- a/mlir/utils/performance/attention-configs
+++ b/mlir/utils/performance/attention-configs
@@ -3,3 +3,6 @@
 -transO false -transV false -transK true -transQ false -t f16 -g 64 -seq_len 4096 -head_dim 128
 -transO false -transV false -transK true -transQ false -t f16 -g 32 -seq_len 8192 -head_dim 128
 -transO false -transV false -transK true -transQ false -t f16 -g 16 -seq_len 16384 -head_dim 128
+# migraphx favourites
+-transO false -transV false -transK true -transQ false -t f16 -g 12 -seq_len 384 -head_dim 64
+-transO false -transV false -transK true -transQ false -t f16 -g 768 -seq_len 384 -head_dim 64


### PR DESCRIPTION
This commit changes the math.exp to be math.exp2
by performing a scaling of 1/ln2 to the gemm0 output.

closes : https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1264