### PR TITLE
Update tuning key support for fp8 convolutions

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -489,14 +489,28 @@ LogicalResult getTuningProblemStr(rock::RockGemmWrapperInterface gemmIF,
     // Please keep these in sync with mlir/utils/performance/perfRunner.py
 
     // OP datatype
-    if (inType.getElementType().isF32()) {
+    Type inElemType = inType.getElementType();
+    Type filElemType = filType.getElementType();
+    if (inElemType.isF32()) {
       problemOS << "conv ";
-    } else if (inType.getElementType().isF16()) {
+    } else if (inElemType.isF16()) {
       problemOS << "convfp16 ";
-    } else if (inType.getElementType().isBF16()) {
+    } else if (inElemType.isBF16()) {
       problemOS << "convbfp16 ";
-    } else if (inType.getElementType().isInteger(8)) {
+    } else if (inElemType.isInteger(8)) {
       problemOS << "convint8 ";
+    } else if (inElemType.isFloat8E4M3FNUZ() &&
+               filElemType.isFloat8E4M3FNUZ()) {
+      problemOS << "convfp8_fp8 ";
+    } else if (inElemType.isFloat8E4M3FNUZ() &&
+               filElemType.isFloat8E5M2FNUZ()) {
+      problemOS << "convfp8_bf8 ";
+    } else if (inElemType.isFloat8E5M2FNUZ() &&
+               filElemType.isFloat8E4M3FNUZ()) {
+      problemOS << "convbf8_fp8 ";
+    } else if (inElemType.isFloat8E5M2FNUZ() &&
+               filElemType.isFloat8E5M2FNUZ()) {
+      problemOS << "convbf8_bf8 ";
     } else {
       return failure();
     }

--- a/mlir/test/rocmlir-gen/gemm-misc-options.mlir
+++ b/mlir/test/rocmlir-gen/gemm-misc-options.mlir
@@ -4,5 +4,7 @@
 // ATOMIC_ADD-SAME: storeMethod = atomic_add
 // RUN: rocmlir-gen --emit-tuning-key -p --arch gfx900 | FileCheck %s --check-prefix=CONV
 // CONV: amdgcn-amd-amdhsa:gfx900   {{.*}}     conv -F 1 -f GNCHW -I NGCHW -O NGCHW -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
+// RUN: rocmlir-gen --emit-tuning-key -p -t fp8_fp8 --arch gfx900 | FileCheck %s --check-prefix=CONVFP8
+// CONVFP8: amdgcn-amd-amdhsa:gfx900   {{.*}}     convfp8_fp8 -F 1 -f GNCHW -I NGCHW -O NGCHW -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
 // RUN: rocmlir-gen --arch gfx908 --operation gemm -p --emit-tuning-key | FileCheck %s --check-prefix=GEMM
 // GEMM: amdgcn-amd-amdhsa:gfx908   {{.*}}     -t f32 -out_datatype f32 -transA false -transB false -g 1 -m 1024 -n 512 -k 769

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -35,7 +35,9 @@ LAYOUTS = ['NHWC', 'NCHW']
 
 DATA_TYPES_GEMM = ['f32', 'f16', 'i8']
 DATA_TYPES_ATTENTION = ['f32', 'f16']
-OUTPUT_DATA_TYPES_MAP = {'f32':'f32', 'f16':'f16', 'i8':'i32'}
+OUTPUT_DATA_TYPES_MAP = {'f32': 'f32', 'f16': 'f16', 'i8': 'i32',
+                         'fp8_fp8': 'f32', 'fp8_bf8': 'f32', 'bf8_fp8': 'f32',
+                         'bf8_bf8': 'f32'}
 
 # Compiled regexp object used for extracting elapsed time from MIOpenDriver's output
 ELAPSED_TIME_RE = re.compile(r"Elapsed: ([0-9\.]*) ms")
@@ -351,6 +353,14 @@ class ConvConfiguration(PerfConfiguration):
             dataType = 'bf16'
         elif argv[0] == 'convint8':
             dataType = 'i8'
+        elif argv[0] == 'convfp8_fp8':
+            dataType = 'fp8_fp8'
+        elif argv[0] == 'convfp8_bf8':
+            dataType = 'fp8_bf8'
+        elif argv[0] == 'convbf8_fp8':
+            dataType = 'bf8_fp8'
+        elif argv[0] == 'convbf8_bf8':
+            dataType = 'bf8_bf8'
 
         layout = None
         try:


### PR DESCRIPTION
Work in MIGraphX reveleased that our tuning key generator will fail (return -1) for fp8 data types. This commit fixes the issue in a rather short-term way.