### PR TITLE
Fix barrier placement during the pipeline pass.

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -94,36 +94,6 @@ AddressSpace getAddressSpace(rock::GpuAllocOp alloc) {
   return gpu::AddressSpace::Global;
 }
 
-// Simple rewrite pass to remove the stages
-struct RemoveStagesRewritePattern : public OpRewritePattern<rock::StageOp> {
-  using OpRewritePattern<rock::StageOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(rock::StageOp op,
-                                PatternRewriter &rw) const override {
-    Block *sourceBlock = &op.getRegion().front();
-    rw.eraseOp(sourceBlock->getTerminator());
-    if (!sourceBlock->empty()) {
-      rw.inlineBlockBefore(sourceBlock, op);
-    }
-    rw.eraseOp(op);
-    return failure();
-  }
-};
-
-struct RemoveBackToBackBarriersRewritePattern
-    : public OpRewritePattern<rock::LDSBarrierOp> {
-  using OpRewritePattern<rock::LDSBarrierOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(rock::LDSBarrierOp op,
-                                PatternRewriter &rw) const override {
-    if (dyn_cast<rock::LDSBarrierOp>(op->getNextNode())) {
-      op->getNextNode()->erase();
-      return success();
-    }
-    return failure();
-  }
-};
-
 // Given an operation and its operand, find out what kind of access (if any)
 // the operation does on the operand
 MemoryAccessType getOperandAccessType(Operation *op, Value operand) {
@@ -135,6 +105,81 @@ MemoryAccessType getOperandAccessType(Operation *op, Value operand) {
     return MemoryAccessType::UNKNOWN;
   }
 }
+
+// Simple rewrite pass to remove the stages and backward barriers in the
+// prologue and in the Epilogue
+struct RemoveStagesRewritePattern : public OpRewritePattern<rock::StageOp> {
+  using OpRewritePattern<rock::StageOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(rock::StageOp op,
+                                PatternRewriter &rw) const override {
+    Block *sourceBlock = &op.getRegion().front();
+    rw.eraseOp(sourceBlock->getTerminator());
+    bool isRemovableBarrier = (op.getName() == "__bwd_barrier__" &&
+                               !dyn_cast<scf::ForOp>(op->getParentOp()));
+    if (!sourceBlock->empty() && !isRemovableBarrier) {
+      rw.inlineBlockBefore(sourceBlock, op);
+    }
+    rw.eraseOp(op);
+    return failure();
+  }
+};
+
+// Simple rewrite pass to remove back-to-back barriers
+struct RemoveBackToBackBarriersRewritePattern
+    : public OpRewritePattern<rock::LDSBarrierOp> {
+  using OpRewritePattern<rock::LDSBarrierOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(rock::LDSBarrierOp op,
+                                PatternRewriter &rw) const override {
+    if (dyn_cast_or_null<rock::LDSBarrierOp>(op->getNextNode())) {
+      op->getNextNode()->erase();
+      return success();
+    }
+    return failure();
+  }
+};
+
+// Simple rewrite pass to hoist operations that do not
+// access LDS before the barriers
+struct PushBarrierDownRewritePattern
+    : public OpRewritePattern<rock::LDSBarrierOp> {
+  using OpRewritePattern<rock::LDSBarrierOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(rock::LDSBarrierOp op,
+                                PatternRewriter &rw) const override {
+    Operation *nextOp = op->getNextNode();
+
+    // Make sure that there is a nextOp
+    if (!nextOp)
+      return failure();
+
+    // Don't go over the terminator
+    if (!nextOp->getNextNode())
+      return failure();
+
+    // We assume that operations that have a body may modify LDS
+    if (nextOp->getNumRegions() > 0)
+      return failure();
+
+    bool moveDown = true;
+    // Make sure that the "nextOp" doesn't modify LDS
+    for (Value operand : nextOp->getOperands()) {
+      auto maybeAlloc = rock::findAlloc(operand);
+      if (succeeded(maybeAlloc) &&
+          getAddressSpace(*maybeAlloc) == AddressSpace::Workgroup)
+        moveDown = false;
+    }
+
+    if (moveDown) {
+      rw.setInsertionPointAfter(nextOp);
+      rw.create<rock::LDSBarrierOp>(nextOp->getLoc());
+      rw.eraseOp(op);
+      return success();
+    }
+    return failure();
+  }
+};
 
 // Create a dependency graph of the given set of stages. The
 // idea is to represent the dependencies through a DAG with
@@ -307,13 +352,10 @@ DagType pruneGraph(DagType dag) {
 // empty stage will contain an `lds_barrier` if `isBarrier` is set to true
 rock::StageOp placeEmptyStage(IRRewriter &rewriter, Location loc,
                               rock::StageOp stage, bool isBarrier,
-                              bool isBefore) {
+                              StringRef name) {
   PatternRewriter::InsertionGuard guard(rewriter);
-  if (isBefore)
-    rewriter.setInsertionPoint(stage);
-  else
-    rewriter.setInsertionPointAfter(stage);
-  auto barrierStage = rewriter.create<rock::StageOp>(loc, "barrier");
+  rewriter.setInsertionPoint(stage);
+  auto barrierStage = rewriter.create<rock::StageOp>(loc, name);
   rewriter.setInsertionPointToStart(&barrierStage.getRegion().emplaceBlock());
   if (isBarrier) {
     rewriter.create<rock::LDSBarrierOp>(loc);
@@ -336,28 +378,79 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
   DagType dag = createDependencyGraph(stages, allocs);
   dag = pruneGraph(dag);
 
-  extendedStages.push_back(stages[0]);
-  for (size_t i = 0; i < stages.size() - 1; i++) {
-    bool placeBarrier = dag[stages[i]].contains(stages[i + 1]);
-    bool before = true;
-    auto barrierStage =
-        placeEmptyStage(rewriter, loc, stages[i + 1], placeBarrier, before);
-    extendedStages.push_back(barrierStage);
-    extendedStages.push_back(stages[i + 1]);
-  }
-  // Place a barrier after the last stage. This barrier is necessary to take
-  // into consideration the loop carried dependencies when pipelining. However,
-  // this might introduce an unnecessary barrier as the last operation of the
-  // epilogue. We will take care of removing this barrier at the end of the pass
   auto maybeNumIterations =
       rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
-  if (!maybeNumIterations.has_value() ||
-      (maybeNumIterations.has_value() && maybeNumIterations.value() > 1)) {
-    const bool placeBarrier = true;
-    const bool after = false;
-    extendedStages.push_back(
-        placeEmptyStage(rewriter, loc, stages.back(), placeBarrier, after));
+
+  // If there is a loop, we probably need a backward barrier, i.e.,
+  // an LDS barrier that takes the loop dependency into account
+  const bool addBackwardBarrier =
+      (!maybeNumIterations.has_value() ||
+       (maybeNumIterations.has_value() && maybeNumIterations.value() > 1));
+
+  DenseMap<rock::StageOp, int> timeSlotMap;
+  int timeSlot = 0;
+  for (auto stage : stages) {
+    timeSlotMap[stage] = (timeSlot % initiationInterval);
+    timeSlot++;
   }
+
+  // Algorithm for barrier placment:
+  // a. Add forward barriers to address the dependency in the basic block
+  // b. Add backward barriers to account for loop carried dependency
+  // c. Add empty stages to make the pipeline balanced, so that we can double up
+  //    the initiation interval and let the pipeline transformation automaticall
+  //    do the work for us
+  DenseSet<rock::StageOp> forwardStages;
+
+  // a. Place forward barriers
+  for (auto [source, edges] : dag) {
+    for (auto [sink, deps] : edges) {
+      if (!forwardStages.contains(sink)) {
+        forwardStages.insert(sink);
+      }
+    }
+  }
+
+  // b. If necessary, place a single backward barrier
+  rock::StageOp backwardStage;
+  if (addBackwardBarrier) {
+    // b.1 find the last sink of a dependendency
+    rock::StageOp lastSink;
+    for (auto stage : llvm::reverse(stages)) {
+      if (forwardStages.contains(stage)) {
+        lastSink = stage;
+        break;
+      }
+    }
+
+    // b.2 find the first stage not in the same timeslot. This will be
+    // the placement for the backward barrier.
+    for (auto stage : stages) {
+      if (timeSlotMap[stage] != timeSlotMap[lastSink]) {
+        backwardStage = stage;
+        break;
+      }
+    }
+  }
+
+  // c. Insert fwd/bwd barriers or empty stages
+  for (auto stage : stages) {
+    rock::StageOp additionalStage;
+    if (forwardStages.contains(stage)) {
+      additionalStage = placeEmptyStage(rewriter, loc, stage,
+                                        /**isBarrier=*/true, "__fwd_barrier__");
+    } else if (backwardStage == stage) {
+      additionalStage = placeEmptyStage(rewriter, loc, stage,
+                                        /**isBarrier=*/true, "__bwd_barrier__");
+    } else {
+      additionalStage = placeEmptyStage(
+          rewriter, loc, stage, /**isBarrier=*/false, "__empty_stage__");
+    }
+    extendedStages.push_back(additionalStage);
+    extendedStages.push_back(stage);
+  }
+
+  // d. Update the initiation interval
   initiationInterval *= 2;
 }
 
@@ -385,7 +478,6 @@ void RockPipeline::runOnOperation() {
 
   DenseMap<rock::GpuAllocOp, int> multiBufferFactors;
   llvm::DenseMap<scf::ForOp, ScheduleType> scheduleMap;
-  llvm::DenseMap<scf::ForOp, Operation *> nextOpMap;
   for (auto res : allocs)
     multiBufferFactors[res] = 1;
 
@@ -434,8 +526,6 @@ void RockPipeline::runOnOperation() {
     // Annotate the operation that defines the boundary of the `forOp`. This
     // is because, at the end of the pass, we will remove any barrier at the
     // boundary (because they are not useful)
-    nextOpMap[forOp] = forOp->getNextNode();
-
     return WalkResult::advance();
   });
 
@@ -480,15 +570,9 @@ void RockPipeline::runOnOperation() {
   {
     if (removeStages) {
       RewritePatternSet patterns(&getContext());
-      patterns.add<RemoveStagesRewritePattern,
-                   RemoveBackToBackBarriersRewritePattern>(&getContext());
+      patterns.add<RemoveStagesRewritePattern, PushBarrierDownRewritePattern>(
+          &getContext());
       (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
     }
-  }
-
-  // Cleanup unwanted barriers
-  for (auto [forOp, nextOp] : nextOpMap) {
-    if (dyn_cast<rock::LDSBarrierOp>(nextOp->getPrevNode()))
-      nextOp->getPrevNode()->erase();
   }
 }

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -24,16 +24,16 @@ func.func @rock_pipeline_3_stages_ii_1(%input : memref<16xi8, #gpu.address_space
     // CHECK: name = "S0"
     // CHECK: name = "S0"
     // CHECK: name = "S1"
-    // CHECK: lds_barrier
-    // CHECK: scf.for
+    // CHECK scf.for
+      // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "S0"
       // CHECK: name = "S1"
       // CHECK: name = "S2"
-      // CHECK: lds_barrier
-    // CHECK: }
-    // CHECK: name = "S1"
-    // CHECK: name = "S2"
-    // CHECK: lds_barrier
+    // CHECK }
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK name = "S1"
+    // CHECK name = "S2"
+    // CHECK: name = "__fwd_barrier__"
     // CHECK: name = "S2"
     scf.for %arg3 = %c0 to %c16 step %c1 {
       rock.stage {
@@ -82,15 +82,16 @@ func.func @rock_pipeline_3_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     // CHECK: memref.view %[[rawRegB]]
 
     // CHECK: name = "S0"
+    // CHECK: name = "__bwd_barrier__"
     // CHECK: name = "S1"
-    // CHECK: lds_barrier
     // CHECK: scf.for
-      // CHECK: name = "S0"
-      // CHECK: name = "S2"
-      // CHECK: lds_barrier
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK name = "S0"
+      // CHECK name = "S2"
+      // CHECK: name = "__bwd_barrier__"
       // CHECK: name = "S1"
-      // CHECK: lds_barrier
-    // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK name = "S2"
     scf.for %arg3 = %c0 to %c16 step %c1 {
       rock.stage {
         %a = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>
@@ -137,11 +138,11 @@ func.func @rock_pipeline_3_stages_ii_3(%input : memref<16xi8, #gpu.address_space
     // CHECK: memref.view %[[rawRegB]]
 
     // CHECK: scf.for
+      // CHECK: name = "__bwd_barrier__"
       // CHECK: name = "S0"
       // CHECK: name = "S1"
-      // CHECK: lds_barrier
+      // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "S2"
-      // CHECK: lds_barrier
     scf.for %arg3 = %c0 to %c16 step %c1 {
       rock.stage {
         %a = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>
@@ -184,19 +185,19 @@ func.func @rock_pipeline_4_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     // CHECK: memref.view %[[rawReg]]
 
     // CHECK: name = "S0"
-    // CHECK: lds_barrier
+    // CHECK: name = "__fwd_barrier__"
     // CHECK: name = "S1"
-    // CHECK: lds_barrier
-    // CHECK: scf.for
+    // CHECK scf.for
+      // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "S0"
       // CHECK: name = "S2"
-      // CHECK: lds_barrier
-      // CHECK: name = "S1"
-      // CHECK: name = "S3"
-      // CHECK: lds_barrier
-    // CHECK: name = "S2"
-    // CHECK: lds_barrier
-    // CHECK: name = "S3"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK name = "S1"
+      // CHECK name = "S3"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK name = "S3"
     scf.for %arg3 = %c0 to %c16 step %c1 {
       rock.stage {
         %tmp = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>


### PR DESCRIPTION
This is fixing the regression we are experiencing here: http://rocmhead.amd.com:8080/job/MLIR/job/mlir-nightly-all/1011/Performance_20report_20for_20gfx90a/

The high level idea of the fix is to instrument the pipeline so that the **backward lds barrier** is going to be at the beginning of the pipelined loop and not at the end. In this way we can push it down hosting non-LDS operation before barriering and we can have the global loads happening after the LDS writes, giving them time to hide their latency. 

While this "works", the choice of a different pipeline structure should be the subject of an analysis (but let's worry about that later :) ). 

I am attaching a comparison with the original performance from commit 27c0a1fb76df805440ed63800c593dc2aec3765f

[comparison.zip](https://github.com/ROCmSoftwarePlatform/rocMLIR/files/13516805/comparison.zip)

As we can observe it is mostly flat, with few spikes that are just glitches (I was not able to reproduce the only "red" we have on the report. 

