### PR TITLE
Hoist the multi-buffer broadcast from the transform stack

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -361,6 +361,7 @@ LogicalResult ThreadwiseCopyRewritePattern::matchAndRewrite(
     strides = SmallVector<int64_t>{vecLen};
     bounds = SmallVector<int64_t>{rawStoreBufferShape.back()};
   }
+
   // Extend start
   SmallVector<Value> extendedStart(op.getExtraIndicesSource());
   extendedStart.insert(extendedStart.end(), op.getExtraIndicesDest().begin(),

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -361,7 +361,6 @@ LogicalResult ThreadwiseCopyRewritePattern::matchAndRewrite(
     strides = SmallVector<int64_t>{vecLen};
     bounds = SmallVector<int64_t>{rawStoreBufferShape.back()};
   }
-
   // Extend start
   SmallVector<Value> extendedStart(op.getExtraIndicesSource());
   extendedStart.insert(extendedStart.end(), op.getExtraIndicesDest().begin(),

--- a/mlir/test/Dialect/Rock/test_multi_buffer.mlir
+++ b/mlir/test/Dialect/Rock/test_multi_buffer.mlir
@@ -143,9 +143,9 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
       rock.threadwise_copy %22 -> %24 : memref<8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
       rock.threadwise_copy %26 -> %28 : memref<8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
       // CHECK: %[[mbIndex1:.*]] = affine.apply {{.*}}(%arg3)
-      // CHECK: %[[subview0:.*]] = memref.subview
-      // CHECK: %[[mbIndex0:.*]] = affine.apply {{.*}}(%arg3)
-      // CHECK: rock.threadwise_write_all {{.*}} %[[subview0]] -> [](%[[t7]]) [%[[mbIndex0]], %6] by  set : memref<16xf16, strided<[1], offset: ?>, #gpu.address_space<private>> -> memref<2x256x16xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[subview0:.*]] = memref.subview {{.*}}[%[[mbIndex1]], 0]
+      // CHECK: %[[mbIndex2:.*]] = affine.apply {{.*}}(%arg3)
+      // CHECK: rock.threadwise_write_all {{.*}} %[[subview0]] -> [](%[[t7]]) [%[[mbIndex2]], %6] by  set : memref<16xf16, strided<[1], offset: ?>, #gpu.address_space<private>> -> memref<2x256x16xvector<8xf16>, #gpu.address_space<workgroup>>
       rock.threadwise_write_all features =  mfma|dot|atomic_add {forceUnroll, useIndexDiffs} %19 -> [](%37) [%6] by  set : memref<16xf16, #gpu.address_space<private>> -> memref<256x16xvector<8xf16>, #gpu.address_space<workgroup>>
       rock.threadwise_write_all features =  mfma|dot|atomic_add {forceUnroll, useIndexDiffs} %20 -> [](%41) [%6] by  set : memref<16xf16, #gpu.address_space<private>> -> memref<256x16xvector<8xf16>, #gpu.address_space<workgroup>>
       rock.lds_barrier


### PR DESCRIPTION
We should hoist the `Broadcast` out of the multi-buffer transform stack, in this way we won't affect the stack invertibility. THis means that the `Broadcast` transform becomes a `i%multiBufferFactor` affine map. 