### PR TITLE
Fix CK build steps in CI

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -22,7 +22,7 @@ void buildCK(String cmakeOpts) {
                       -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
                      ${cmakeOpts}
                      """
-    sh 'cd build; make -j $(nproc) device_operations'
+    sh 'cd build; make -j $(nproc)'
 }
 
 void buildMIGraphX(String cmakeOpts) {
@@ -915,7 +915,7 @@ pipeline {
                                         -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                         -DCMAKE_BUILD_TYPE=Release
                                         ''')
-                                    sh 'cd build/library; make install; cp ../composable_kernelConfig*.cmake ${WORKSPACE}/composable_kernel/build/CKInstallDir/lib/cmake/composable_kernel'
+                                    sh 'cd build; make install'
                                     sh 'echo `git rev-parse HEAD`'
                                 }
                                 sh 'rm build/CMakeCache.txt'

--- a/mlir/utils/performance/ck-benchmark-driver/CMakeLists.txt
+++ b/mlir/utils/performance/ck-benchmark-driver/CMakeLists.txt
@@ -1,11 +1,12 @@
-find_package(composable_kernel 1.0.0 COMPONENTS device_operations CONFIG)
+find_package(composable_kernel 1.1.0 COMPONENTS device_gemm_operations CONFIG)
 
 if (composable_kernel_FOUND)
   find_package(hip REQUIRED PATHS /opt/rocm)
-  set(LIBS composable_kernel::device_operations hip::device benchmark-driver-utils)
+  set(LIBS composable_kernel::device_gemm_operations hip::device benchmark-driver-utils)
 
   add_executable(ck-benchmark-driver EXCLUDE_FROM_ALL ck-benchmark-driver.cpp)
   target_link_libraries(ck-benchmark-driver PRIVATE ${LIBS})
+  target_compile_options(ck-benchmark-driver PRIVATE "-std=c++17")
   set_target_properties(ck-benchmark-driver
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"


### PR DESCRIPTION
This PR should bring CK build process back to life in our CI. Main changes:
- In the `Jenkinsfile` I build all CK now[. This is the suggested way to build](https://github.com/ROCmSoftwarePlatform/composable_kernel), and I think we should stick to it
- In the `CMakeLists.txt`  I had to specify a `device_gemm_operations` component for the `ck-benchmark-driver` target. Unfortunately, I was not able to add all the components to the target. It looks like they don't export a `composable_kernel_LIBS` or `composable_kernel_INCLUDE_DIRS`. Cmakers better than me can have an opinion on how to do that in a better way (cc @sjw36 , @yiqian1 , @krzysz00 , @manupak )