### PR TITLE
Fix errors in MIGraphX fusion tests

### DIFF
--- a/mlir/test/fusion/resnet50-e2e/mixr-resnet-fusion-case-3.mlir
+++ b/mlir/test/fusion/resnet50-e2e/mixr-resnet-fusion-case-3.mlir
@@ -3,7 +3,7 @@
 // CLONE: [1 1 1]
 
 module {
-  func.func @test(%arg0: !migraphx.shaped<1x128x28x28xf32, 0x1x0x0>, %arg1: !migraphx.shaped<1x512x28x28xf32, 401408x784x28x1>, %arg2: !migraphx.shaped<128x512x1x1xf32, 0x1x0x0>) -> !migraphx.shaped<1x128x28x28xf32, 100352x784x28x1> {
+  func.func @test(%arg0: !migraphx.shaped<1x128x28x28xf32, 0x1x0x0>, %arg1: !migraphx.shaped<1x512x28x28xf32, 401408x784x28x1>, %arg2: !migraphx.shaped<128x512x1x1xf32, 512x1x1x1>) -> !migraphx.shaped<1x128x28x28xf32, 100352x784x28x1> {
     %1 = migraphx.convolution %arg1, %arg2 {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : <1x512x28x28xf32, 401408x784x28x1>, <128x512x1x1xf32, 512x1x1x1> -> <1x128x28x28xf32, 100352x784x28x1>
     %2 = migraphx.add %1, %arg0 : <1x128x28x28xf32, 100352x784x28x1>, <1x128x28x28xf32, 0x1x0x0> -> <1x128x28x28xf32, 100352x784x28x1>
     %3 = migraphx.relu %2 : <1x128x28x28xf32, 100352x784x28x1> -> <1x128x28x28xf32, 100352x784x28x1>

--- a/mlir/test/fusion/resnet50-e2e/mixr-resnet-fusion-case-5.mlir
+++ b/mlir/test/fusion/resnet50-e2e/mixr-resnet-fusion-case-5.mlir
@@ -3,7 +3,7 @@
 // CLONE: [1 1 1]
 
 module {
-  func.func @test(%arg0: !migraphx.shaped<1x64x56x56xf32, 0x1x0x0>, %arg1: !migraphx.shaped<1x256x56x56xf32, 802816x3136x56x1>, %arg2: !migraphx.shaped<64x256x1x1xf32, 0x1x0x0>) -> !migraphx.shaped<1x64x56x56xf32, 200704x3136x56x1> {
+  func.func @test(%arg0: !migraphx.shaped<1x64x56x56xf32, 0x1x0x0>, %arg1: !migraphx.shaped<1x256x56x56xf32, 802816x3136x56x1>, %arg2: !migraphx.shaped<64x256x1x1xf32, 256x1x1x1>) -> !migraphx.shaped<1x64x56x56xf32, 200704x3136x56x1> {
     %1 = migraphx.convolution %arg1, %arg2 {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : <1x256x56x56xf32, 802816x3136x56x1>, <64x256x1x1xf32, 256x1x1x1> -> <1x64x56x56xf32, 200704x3136x56x1>
     %2 = migraphx.add %1, %arg0 : <1x64x56x56xf32, 200704x3136x56x1>, <1x64x56x56xf32, 0x1x0x0> -> <1x64x56x56xf32, 200704x3136x56x1>
     %3 = migraphx.relu %2 : <1x64x56x56xf32, 200704x3136x56x1> -> <1x64x56x56xf32, 200704x3136x56x1>


### PR DESCRIPTION
When converting some nightly end-to-end tests, I mistakenly make the filter arguments to the convolutions in cases 3 and 5 breadcaseted tensors in the argument list (in addition to making the inttended bias tensor a broadcasted argument). This led to IR-level type mismatches, which caused test failures.

This commit resolves the issue.