### PR TITLE
enable FP8 for the quantizelinear and dequantizelinar

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -196,9 +196,9 @@ def MIGraphX_QuantizeLinearOp :
 
 def MIGraphX_DeQuantizeLinearOp :
     MIGraphX_Op<"dequantizelinear", [AllElementTypesMatch<["scale", "output"]>]>,
-    Arguments<(ins MIXRShapedOf<[AnyInteger, F8E4M3FNUZ, F8E5M2FNUZ]>:$input,
+    Arguments<(ins MIXRShapedOf<[AnyInteger, AnyFloat, F8E4M3FNUZ, F8E5M2FNUZ]>:$input,
                    MIXRShapedOf<[AnyFloat]>:$scale,
-                   Optional<MIXRShapedOf<[AnyInteger, F8E4M3FNUZ, F8E5M2FNUZ]>>:$bias)>,
+                   Optional<MIXRShapedOf<[AnyInteger, AnyFloat, F8E4M3FNUZ, F8E5M2FNUZ]>>:$bias)>,
 	  Results<(outs MIXRShapedOf<[AnyFloat]>:$output)> {
   let summary = "Channelwise dequantization";
   let description = [{

--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -181,8 +181,8 @@ def MIGraphX_QuantizeLinearOp :
     MIGraphX_Op<"quantizelinear", [AllElementTypesMatch<["input", "scale"]>]>,
     Arguments<(ins MIXRShapedOf<[AnyFloat]>:$input,
                    MIXRShapedOf<[AnyFloat]>:$scale,
-                   Optional<MIXRShapedOf<[AnyInteger]>>:$bias)>,
-	  Results<(outs MIXRShapedOf<[AnyInteger]>:$output)> {
+                   Optional<MIXRShapedOf<[AnyInteger, F8E4M3FNUZ, F8E5M2FNUZ]>>:$bias)>,
+	  Results<(outs MIXRShapedOf<[AnyInteger, F8E4M3FNUZ, F8E5M2FNUZ]>:$output)> {
   let summary = "Channelwise quantization";
   let description = [{
     Quantization tensor channelwise. It computes the following:
@@ -196,9 +196,9 @@ def MIGraphX_QuantizeLinearOp :
 
 def MIGraphX_DeQuantizeLinearOp :
     MIGraphX_Op<"dequantizelinear", [AllElementTypesMatch<["scale", "output"]>]>,
-    Arguments<(ins MIXRShapedOf<[AnyInteger]>:$input,
+    Arguments<(ins MIXRShapedOf<[AnyInteger, F8E4M3FNUZ, F8E5M2FNUZ]>:$input,
                    MIXRShapedOf<[AnyFloat]>:$scale,
-                   Optional<MIXRShapedOf<[AnyInteger]>>:$bias)>,
+                   Optional<MIXRShapedOf<[AnyInteger, F8E4M3FNUZ, F8E5M2FNUZ]>>:$bias)>,
 	  Results<(outs MIXRShapedOf<[AnyFloat]>:$output)> {
   let summary = "Channelwise dequantization";
   let description = [{


### PR DESCRIPTION
With these changes, 
and MIGraphx branch "mobilenet_fp8" which has changes for the simplify_qdq changes to work with FP8 in MIGraphx, 
I am able to run mobilenet in FP8. 

