### PR TITLE
Remove the -q from invocation of parameterSweeps.py, or it'll trip the activity timeout.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -307,7 +307,7 @@ void check_randomE2ETests(String codepath) {
 void parameterSweep(String CONFIG, String codepath) {
     timeout(time: 300, activity: true, unit: 'MINUTES') {
         dir('build') {
-            sh """python3 ./bin/parameterSweeps.py -q -j 5 ${CONFIG}"""
+            sh """python3 ./bin/parameterSweeps.py -j 5 ${CONFIG}"""
         }
     }
 }


### PR DESCRIPTION
I had removed it to take some bulk out of the logs, but the mfma sweeps take 9.5 hours and the timeout is 5 hours and if there's nothing printed, it takes that as no activity and kills it.