### PR TITLE
Fixes a bug in attention padding

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -340,11 +340,12 @@ public:
   LogicalResult couldBePerformant(const PopulateParamsInfo &info,
                                   const InitParamsAccel &params) override;
 
-protected:
   virtual LogicalResult isValidBlockwiseGemm(const InitParamsAccel &param,
                                              Type dataTypeA, Type dataTypeB,
                                              StringRef arch,
                                              uint32_t blockSize) = 0;
+
+protected:
   // if can't select config from above , use this config to do
   // padding kernel for example , GEMMK/block is 16 , if your gemmK is  13 , we
   // add more 3 gemmk.
@@ -396,12 +397,12 @@ public:
   Attribute
   getGemmParamsAttr(OpBuilder &builder,
                     const InitParamsAccel &validParams) const override;
-
-protected:
   LogicalResult isValidBlockwiseGemm(const InitParamsAccel &param,
                                      Type dataTypeA, Type dataTypeB,
                                      StringRef arch,
                                      uint32_t blockSize) override;
+
+protected:
   LogicalResult specificCouldBePerformant(const InitParamsAccel &params,
                                           Type dataTypeA,
                                           Type dataTypeB) override;
@@ -430,12 +431,12 @@ public:
   getGemmParamsAttr(OpBuilder &builder,
                     const InitParamsAccel &validParams) const override;
 
-protected:
   LogicalResult isValidBlockwiseGemm(const InitParamsAccel &param,
                                      Type dataTypeA, Type dataTypeB,
                                      StringRef arch,
                                      uint32_t blockSize) override;
 
+protected:
   LogicalResult specificCouldBePerformant(const InitParamsAccel &params,
                                           Type dataTypeA,
                                           Type dataTypeB) override;

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -832,7 +832,7 @@ struct BlockwiseReduceRewritePattern
           Value nrIter;
           if (threadViewShape[nrIterDim] > 1) {
             AffineForOp nrIterLoop = rewriter.create<AffineForOp>(
-                loc, 0, threadViewShape[nrIterDim] - 1, nrIterVectorLen);
+                loc, 0, threadViewShape[nrIterDim], nrIterVectorLen);
             // inside the loop.
             rewriter.setInsertionPointToStart(nrIterLoop.getBody());
             nrIter = nrIterLoop.getInductionVar();

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1367,7 +1367,7 @@ struct GridwiseAttentionAccelRewritePattern
     viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[1] - prePadGemmM, 0,
                                              paddedShape[2] - prePadGemmN});
     TransformMapAttr padMap = viewBuilder.get();
-                                            
+
     ArrayAttr transforms =
         prependUpperViews(rewriter, gemm0OutSubTileViews.gridSubTile,
                           rewriter.getArrayAttr({padMap}));

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1363,11 +1363,14 @@ struct GridwiseAttentionAccelRewritePattern
     TopDownTMBuilder viewBuilder{
         rewriter, {"g", "paddedM", "paddedN"}, paddedShape, loc};
     viewBuilder.passThrough("g");
-    viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[0] - prePadGemmM, 0,
-                                             paddedShape[1] - prePadGemmN});
+    // paddedShape is G x M x N
+    viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[1] - prePadGemmM, 0,
+                                             paddedShape[2] - prePadGemmN});
+    TransformMapAttr padMap = viewBuilder.get();
+                                            
     ArrayAttr transforms =
         prependUpperViews(rewriter, gemm0OutSubTileViews.gridSubTile,
-                          rewriter.getArrayAttr({viewBuilder.get()}));
+                          rewriter.getArrayAttr({padMap}));
 
     MemRefType gemm0OutBufferType = gemm0OutBuffer.getType().cast<MemRefType>();
     auto negInfTyped = createConstantFloatOp(
@@ -1867,11 +1870,13 @@ struct GridwiseAttentionAccelRewritePattern
       }
       // Scale gemm0 output by (1/ln2)
       // So that we can use exp2 instead of exp.
+#ifndef ROCK_DEBUG_ATTENTION_REMOVE_SOFTMAX
       Value ln2Recip = createConstantFloatOp(rewriter, loc, elemTypeQxK,
                                              elemTypeQxK, 1.44269504);
       scaleFirstGemmSplat(
           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer, gemm0OutSubTileViews,
           ln2Recip.getDefiningOp<arith::ConstantOp>().getValue());
+#endif
 
       // Handle padding
       bool hasPadding =

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -742,7 +742,6 @@ PopulateParamsWmma::initParametersFp16[PopulateParamsWmma::nInitParametersFp16] 
   {128, 64, 4, 64, 32, 8, true, true},
   {128, 64, 4, 32, 64, 8, true, true},
   {128, 32, 4, 32, 32, 8, true, true},
-  {128, 16, 8, 32, 64, 8, true, true},
   {64, 256, 4, 64, 64, 8, true, true},
   {64, 256, 2, 64, 64, 8, true, true},
   {64, 128, 4, 64, 32, 8, true, true},

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -368,3 +368,13 @@ func.func @rock_gemm_xdlops_fp8_bf8(%a : memref<1x72x128xf8E4M3FNUZ>, %b : memre
   } : memref<1x128x115200xf32> = memref<1x72x128xf8E4M3FNUZ> * memref<1x72x115200xf8E5M2FNUZ>
   return
 }
+
+// CHECK-LABEL: func.func @rock_attention_default
+// CHECK-SAME: block_size = 32
+// CHECK-SAME: grid_size = 24
+func.func @rock_attention_default(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // CHECK: rock.attention
+  // CHECK-SAME: #rock.wmma_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, forceUnroll = true>
+  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
+  return
+}

--- a/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
@@ -7,9 +7,3 @@ func.func @rock_attention_invalid_perf_config(%arg0: memref<1x384x64xf16>, %arg1
   rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, perf_config = "128,16,8,32,64,8,1,1"} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
   return
 }
-
-func.func @rock_attention_invalid_perf_config_format(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
-  // expected-error @+1 {{perf config string has an incorrect format}}
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, perf_config = "128,16"} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
-  return
-}

--- a/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
@@ -1,0 +1,15 @@
+// This tests the error handling in the rock-affix-params pass
+
+// RUN: rocmlir-opt -rock-affix-params %s -verify-diagnostics
+
+func.func @rock_attention_invalid_perf_config(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // expected-error @+1 {{The provided perf config is not valid}}
+  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, perf_config = "128,16,8,32,64,8,1,1"} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
+  return
+}
+
+func.func @rock_attention_invalid_perf_config_format(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // expected-error @+1 {{perf config string has an incorrect format}}
+  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, perf_config = "128,16"} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
+  return
+}

--- a/mlir/test/e2e/PrAttentionF16.toml
+++ b/mlir/test/e2e/PrAttentionF16.toml
@@ -29,3 +29,7 @@ config = "-seq_len 256 -head_dim 128 -perf_config 128,128,32,64,64,4,1,1"
 
 [[suite.test]]
 config = "-seq_len 64 -head_dim 64"
+
+# Check a padding config
+[[suite.test]]
+config = "-seq_len 64 -head_dim 64 -perf_config 256,64,4,64,64,8,1,1"


### PR DESCRIPTION
This commit effectively fixes two things:
1) There was a bug in interpreting coordinates for padding in attention kernels
2) There was a wrong bound in init loop for reductions.

This fixes all that.
closes :  https://github.com/ROCm/rocMLIR-internal/issues/1281