### PR TITLE
[BACKPORT] Fixes a bug in attention padding

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -832,7 +832,7 @@ struct BlockwiseReduceRewritePattern
           Value nrIter;
           if (threadViewShape[nrIterDim] > 1) {
             AffineForOp nrIterLoop = rewriter.create<AffineForOp>(
-                loc, 0, threadViewShape[nrIterDim] - 1, nrIterVectorLen);
+                loc, 0, threadViewShape[nrIterDim], nrIterVectorLen);
             // inside the loop.
             rewriter.setInsertionPointToStart(nrIterLoop.getBody());
             nrIter = nrIterLoop.getInductionVar();

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1367,7 +1367,7 @@ struct GridwiseAttentionAccelRewritePattern
     viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[1] - prePadGemmM, 0,
                                              paddedShape[2] - prePadGemmN});
     TransformMapAttr padMap = viewBuilder.get();
-                                            
+
     ArrayAttr transforms =
         prependUpperViews(rewriter, gemm0OutSubTileViews.gridSubTile,
                           rewriter.getArrayAttr({padMap}));

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1363,11 +1363,14 @@ struct GridwiseAttentionAccelRewritePattern
     TopDownTMBuilder viewBuilder{
         rewriter, {"g", "paddedM", "paddedN"}, paddedShape, loc};
     viewBuilder.passThrough("g");
-    viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[0] - prePadGemmM, 0,
-                                             paddedShape[1] - prePadGemmN});
+    // paddedShape is G x M x N
+    viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[1] - prePadGemmM, 0,
+                                             paddedShape[2] - prePadGemmN});
+    TransformMapAttr padMap = viewBuilder.get();
+                                            
     ArrayAttr transforms =
         prependUpperViews(rewriter, gemm0OutSubTileViews.gridSubTile,
-                          rewriter.getArrayAttr({viewBuilder.get()}));
+                          rewriter.getArrayAttr({padMap}));
 
     MemRefType gemm0OutBufferType = gemm0OutBuffer.getType().cast<MemRefType>();
     auto negInfTyped = createConstantFloatOp(
@@ -1867,11 +1870,13 @@ struct GridwiseAttentionAccelRewritePattern
       }
       // Scale gemm0 output by (1/ln2)
       // So that we can use exp2 instead of exp.
+#ifndef ROCK_DEBUG_ATTENTION_REMOVE_SOFTMAX
       Value ln2Recip = createConstantFloatOp(rewriter, loc, elemTypeQxK,
                                              elemTypeQxK, 1.44269504);
       scaleFirstGemmSplat(
           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer, gemm0OutSubTileViews,
           ln2Recip.getDefiningOp<arith::ConstantOp>().getValue());
+#endif
 
       // Handle padding
       bool hasPadding =

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -742,7 +742,6 @@ PopulateParamsWmma::initParametersFp16[PopulateParamsWmma::nInitParametersFp16] 
   {128, 64, 4, 64, 32, 8, true, true},
   {128, 64, 4, 32, 64, 8, true, true},
   {128, 32, 4, 32, 32, 8, true, true},
-  {128, 16, 8, 32, 64, 8, true, true},
   {64, 256, 4, 64, 64, 8, true, true},
   {64, 256, 2, 64, 64, 8, true, true},
   {64, 128, 4, 64, 32, 8, true, true},

--- a/mlir/test/e2e/PrAttentionF16.toml
+++ b/mlir/test/e2e/PrAttentionF16.toml
@@ -29,3 +29,7 @@ config = "-seq_len 256 -head_dim 128 -perf_config 128,128,32,64,64,4,1,1"
 
 [[suite.test]]
 config = "-seq_len 64 -head_dim 64"
+
+# Check a padding config
+[[suite.test]]
+config = "-seq_len 64 -head_dim 64 -perf_config 256,64,4,64,64,8,1,1"


### PR DESCRIPTION
This commit effectively fixes two things:
1.) There was a bug in interpreting coordinates for padding in attention kernels
2.) There was a wrong bound in init loop for reductions.

This fixes all that.