### PR TITLE
Refactor accelGemmOp to accept views

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -835,7 +835,7 @@ def Rock_IndexDiffUpdateOp :
 defvar SupportedMemoryElems = [F32, F16, BF16, I8, I32, F8E5M2FNUZ, F8E4M3FNUZ];
 defvar NativeMemoryOpTypes = [F32, F16, BF16, I8, I32,
                            F8E5M2FNUZ, F8E4M3FNUZ,
-                           VectorOfLengthAndType<[2, 4, 8], [F32, I32]>,
+                           VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32]>,
                            VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
                            VectorOfLengthAndType<[2, 4, 8, 16],
                              [I8, F8E5M2FNUZ, F8E4M3FNUZ]>];
@@ -1203,15 +1203,12 @@ def Rock_ThreadwiseGemmOp:
   }];
   let hasVerifier = 1;
 }
-
-// accel_gemm
-def Rock_AccelGemmOp:
-    Rock_Op<"accel_gemm">,
-    Arguments<(ins Index:$mRepeat,
-                   Index:$nRepeat,
-                   Arg<MemRefRankOf<AccelArgTypes, [1]>, "source register A", [MemRead]>:$matrixA,
-                   Arg<MemRefRankOf<AccelArgTypes, [1]>, "source register B", [MemRead]>:$matrixB,
-                   Arg<MemRefRankOf<AccelResTypes , [1]>, "source register C", [MemRead, MemWrite]>:$matrixC,
+// threadwise_accel_gemm
+def Rock_ThreadwiseAccelGemmOp:
+    Rock_Op<"threadwise_accel_gemm">,
+    Arguments<(ins Arg<MemRefOf<NativeMemoryOpTypes>, "source register view A", [MemRead]>:$matrixA,
+                   Arg<MemRefOf<NativeMemoryOpTypes>, "source register view B", [MemRead]>:$matrixB,
+                   Arg<MemRefOf<NativeMemoryOpTypes>, "dest register view C", [MemRead, MemWrite]>:$matrixC, Variadic<Index>:$extraIndicesC,
                    StrAttr:$arch,
                    Rock_GemmFeaturesAttr:$features,
                    RockAccelTuningParamAttrInterface:$params)> {
@@ -1223,7 +1220,7 @@ def Rock_AccelGemmOp:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    $matrixC `+` `` `=` $matrixA`[`$mRepeat`]` `*` $matrixB`[`$nRepeat`]` `features` `=` $features attr-dict
+    $matrixC(`[` $extraIndicesC^ `]`)? `+` `` `=` $matrixA `*` $matrixB `features` `=` $features attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
   let hasVerifier = 1;

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -134,17 +134,22 @@ AccelEmitterParams MfmaEmitter::initAccelEmitterParams(
 
 void MfmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
                                      Value argB, Value bufferC,
-                                     Value regCOffset) {
+                                     ValueRange regCOffset) {
   MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
   int64_t mfmaNonKDim = mfmaAttr.mfmaNonKDim;
   auto imms = mfmaGroup.getImms();
   int64_t nResultVectors = imms.size();
+  Value nResultVectorsConst = b.create<ConstantIndexOp>(loc, nResultVectors);
   VectorType vectorType = mfmaGroup.getRetType();
+  auto outputOffset = llvm::to_vector(regCOffset);
   for (int64_t i = 0; i < nResultVectors; ++i) {
     Value offset = b.createOrFold<arith::ConstantIndexOp>(loc, i);
-    offset = b.create<AddIOp>(loc, offset, regCOffset);
-
-    auto vectorC = b.create<memref::LoadOp>(loc, vectorType, bufferC, offset);
+    offset = b.create<AddIOp>(
+        loc, offset,
+        b.create<MulIOp>(loc, outputOffset.back(), nResultVectorsConst));
+    outputOffset.back() = offset;
+    auto vectorC =
+        b.create<memref::LoadOp>(loc, vectorType, bufferC, outputOffset);
     auto mfma = b.create<amdgpu::MFMAOp>(
         loc, vectorType, mfmaNonKDim, mfmaNonKDim, mfmaAttr.k,
         mfmaAttr.blocksMfma, argA, argB, vectorC, /*cbsz=*/imms[i].cbsz,
@@ -153,7 +158,7 @@ void MfmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
         /*negateB=*/false, /*negateC=*/false);
     auto vectorD = mfma.getDestD();
 
-    b.create<memref::StoreOp>(loc, vectorD, bufferC, offset);
+    b.create<memref::StoreOp>(loc, vectorD, bufferC, outputOffset);
   }
 }
 
@@ -657,7 +662,7 @@ Value WmmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
 
 void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
                                      Value argB, Value bufferC,
-                                     Value regCOffset) {
+                                     ValueRange regCOffset) {
   VectorType vectorType = wmmaInsn.retType;
   auto vectorC = b.create<memref::LoadOp>(loc, vectorType, bufferC, regCOffset);
 

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -94,7 +94,7 @@ struct AccelEmitter {
   /// Emit the actual intrinsic in the threadwise operation
   virtual void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
                                   Value argB, Value bufferC,
-                                  Value regCOffset) = 0;
+                                  ValueRange regCOffset) = 0;
 
   /// Return a wrapped view of the LDS buffer tailored for the accelerator
   /// load pattern. This is similar to wrapLDSBufferForStore, but while storing
@@ -139,7 +139,7 @@ struct MfmaEmitter : public AccelEmitter {
               RockAccelTuningParamAttrInterface tuningParams);
 
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
-                          Value bufferC, Value regCOffset) override;
+                          Value bufferC, ValueRange regCOffset) override;
 
   virtual Value wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
                                      int64_t blockSize,
@@ -170,7 +170,7 @@ struct WmmaEmitter : public AccelEmitter {
               RockAccelTuningParamAttrInterface tuningParams);
 
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
-                          Value bufferC, Value regCOffset) override;
+                          Value bufferC, ValueRange regCOffset) override;
 
   virtual Value wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
                                      int64_t blockSize,

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -430,6 +430,7 @@ struct BlockwiseGemmAccelRewritePattern
     int64_t mRepeats = params.mRepeats;
     int64_t nRepeats = params.nRepeats;
     int64_t kBase = params.kBase;
+    int64_t kBasePerThread = params.kBasePerThread;
 
     auto tid = b.create<WorkitemIdOp>(loc, b.getIndexType());
 
@@ -489,11 +490,41 @@ struct BlockwiseGemmAccelRewritePattern
                                        op.getBufferB(), b.getArrayAttr({}),
                                        ValueRange{tid, n_i}, true, true);
 
+        // A view: A buffer is [0, K] so we can ignore `i`
+        TopDownTMBuilder bufferAikTransform(b, {"i", "k"}, {1, kBasePerThread},
+                                            loc);
+        bufferAikTransform.ignore("i");
+        bufferAikTransform.passThrough({"k"}, 0, {"k"});
+        auto bufferA = rock::transform(
+            b, adaptor.getBufferA(),
+            b.getArrayAttr(SmallVector<Attribute>{bufferAikTransform.get()}));
+
+        // B view: B buffer is [0, K] so we can ignore `j`
+        TopDownTMBuilder bufferBjkTransform(b, {"j", "k"}, {1, kBasePerThread},
+                                            loc);
+        bufferBjkTransform.ignore("j");
+        bufferBjkTransform.passThrough({"k"}, 0, {"k"});
+        auto bufferB = rock::transform(
+            b, adaptor.getBufferB(),
+            b.getArrayAttr(SmallVector<Attribute>{bufferBjkTransform.get()}));
+
+        // C view: C buffer is [mRepeats,nRepeats] and we need to write in
+        // [i,j]. So we "freeze" the `i` and `j` indices and provide the value
+        // of `i` and `j` as extra indices.
+        TopDownTMBuilder bufferCijTransform(b, {"ci", "cj", "i", "j"},
+                                            {mRepeats, nRepeats, 1, 1}, loc);
+        bufferCijTransform.ignore("i");
+        bufferCijTransform.ignore("j");
+        bufferCijTransform.unmerge("offset", 0, {"ci", "cj"},
+                                   {mRepeats, nRepeats});
+        auto bufferC = rock::transform(
+            b, adaptor.getMatrixC(),
+            b.getArrayAttr(SmallVector<Attribute>{bufferCijTransform.get()}));
+
         // regsC += regsA * regsB
-        b.create<AccelGemmOp>(loc, mLoop.getInductionVar(),
-                              nLoop.getInductionVar(), adaptor.getBufferA(),
-                              adaptor.getBufferB(), adaptor.getMatrixC(), arch,
-                              op.getFeaturesAttr(), tuningParams);
+        b.create<ThreadwiseAccelGemmOp>(loc, bufferA, bufferB, bufferC,
+                                        ValueRange{m_i, n_i}, arch,
+                                        op.getFeaturesAttr(), tuningParams);
       }
     }
     b.eraseOp(op);

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -94,7 +94,10 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
       // CHECK: affine.for
         // CHECK: affine.for
           // CHECK: rock.threadwise_read_into {{.*}} [](%[[view2G0BStoreTr3]]) {{.*}} -> %[[preAccelRegB:.+]] :
-          // CHECK: rock.accel_gemm %[[gemm0AccBuf]] += %[[preAccelRegA]]{{.*}} * %[[preAccelRegB]]{{.*}}
+          // CHECK: %[[bufferA:.*]] = rock.transform %[[preAccelRegA]]
+          // CHECK: %[[bufferB:.*]] = rock.transform %[[preAccelRegB]]
+          // CHECK: %[[bufferC:.*]] = rock.transform %[[gemm0AccBuf]]
+          // CHECK: rock.threadwise_accel_gemm %[[bufferC]]{{.*}} += %[[bufferA:.*]] * %[[bufferB:.*]]
 
     // End of inner gemm0 KpacksPerBlock loop
     // CHECK: }
@@ -206,7 +209,6 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
       // CHECK-DAG: %[[attnOutBufMul:.+]] = arith.mulf %[[attnOutVal]], %[[maxdiffexp]]
       // CHECK-DAG: %[[newattnOutVal:.+]] = arith.addf %[[attnOutBufMul]], %[[gemm1Val]]
       // CHECK-DAG: rock.in_bounds_store %[[newattnOutVal]] -> %[[attnOutBuf]]
-      
     // CHECK : }
   // CHECK : }
   // CHECK : rock.threadwise_write_all {{.*}} %[[attnOutBuf]] -> {{.*}}(%[[O]])

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -7,7 +7,7 @@
 func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2xf32>, #wg>, %matrixB : memref<256xvector<2xf32>, #wg>,
                                                 %bufferA : memref<4xf32, #priv>, %bufferB : memref<4xf32, #priv>,
                                                 %matrixC : memref<4xvector<16xf32>, #priv>) {
-  // CHECK:  rock.accel_gemm
+  // CHECK:  rock.threadwise_accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize= 256 : i32,
@@ -29,7 +29,7 @@ func.func @rock_blockwise_gemm_accel_two_results(%matrixA : memref<256xvector<2x
 func.func @rock_blockwise_gemm_accel_one_result(%matrixA : memref<128xvector<8xi8>, #wg>, %matrixB : memref<128xvector<8xi8>, #wg>,
                                                %bufferA : memref<1xvector<4xi8>, #priv>, %bufferB : memref<1xvector<4xi8>, #priv>,
                                                %matrixC : memref<1xvector<16xi32>, #priv>) {
-  // CHECK:  rock.accel_gemm
+  // CHECK:  rock.threadwise_accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
@@ -53,7 +53,7 @@ func.func @rock_blockwise_gemm_accel_fp8_bf8(%matrixA : memref<1024xvector<8xf8E
                                           %bufferA : memref<4xvector<8xf8E4M3FNUZ>, #gpu.address_space<private>>,
                                           %bufferB : memref<4xvector<8xf8E5M2FNUZ>, #gpu.address_space<private>>,
                                           %matrixC : memref<4xvector<16xf32>, #gpu.address_space<private>>) {
-  // CHECK:  rock.accel_gemm
+  // CHECK:  rock.threadwise_accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     blockSize = 256 : i32,

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -9,7 +9,7 @@ func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<8xf16>, #w
   // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 1
   // CHECK: rock.threadwise_read_into
-  // CHECK: rock.accel_gemm
+  // CHECK: rock.threadwise_accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 32 : i32,
@@ -34,7 +34,7 @@ func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector
   // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 1
   // CHECK: rock.threadwise_read_into
-  // CHECK:  rock.accel_gemm
+  // CHECK:  rock.threadwise_accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,
@@ -59,7 +59,7 @@ func.func @rock_blockwise_gemm_accel_wmma_int8(%matrixA : memref<32xvector<16xi8
   // CHECK: rock.threadwise_read_into
   // CHECK: affine.for {{.*}} = 0 to 2
   // CHECK: rock.threadwise_read_into
-  // CHECK:  rock.accel_gemm
+  // CHECK:  rock.threadwise_accel_gemm
   rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 128 : i32,

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
@@ -1,18 +1,19 @@
 // RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
 
+#transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (2*d0 + d1)> by [<AddDim{1} ["i"] at [2] -> [] at []>, <AddDim{1} ["j"] at [3] -> [] at []>, <Unmerge{2, 2} ["ci", "cj"] at [0, 1] -> ["offset"] at [0]>] bounds = [2, 2, 1, 1] -> [4]>
 // CHECK: rock_accel_gemm_wmma
-func.func @rock_accel_gemm_wmma(%matrixA : memref<1xvector<16xf16>, 5>,
-                                %matrixB : memref<1xvector<16xf16>, 5>,
-                                %matrixC : memref<1xvector<8xf32>, 5>) {
+func.func @rock_accel_gemm_wmma(%matrixA : memref<1x4xvector<16xf16>, 5>,
+                                %matrixB : memref<1x4xvector<16xf16>, 5>,
+                                %matrixC : memref<1x1xvector<8xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [4]
-  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1xvector<16xf16>, 5>
-  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1xvector<16xf16>, 5>
-  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1xvector<8xf32>, 5>
+  // CHECK-SAME: bounds [1, 1, 4]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
-  // CHECK: memref.store {{.*}}, {{.*}} : memref<1xvector<8xf32>, 5>
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = wmma {
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     params = #rock.wmma_gemm_params<
        mPerBlock = 16,
@@ -22,49 +23,24 @@ func.func @rock_accel_gemm_wmma(%matrixA : memref<1xvector<16xf16>, 5>,
        nPerWave = 16,
        kpack = 16,
        forceUnroll = true>
-     } : memref<1xvector<8xf32>, 5> += memref<1xvector<16xf16>, 5> * memref<1xvector<16xf16>, 5>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x4xvector<16xf16>, 5> * memref<1x4xvector<16xf16>, 5>
   return
 }
 
 // CHECK: rock_accel_gemm_wmma_repeats
-func.func @rock_accel_gemm_wmma_repeats(%matrixA : memref<4xvector<16xf16>, 5>,
-                                        %matrixB : memref<4xvector<16xf16>, 5>,
+func.func @rock_accel_gemm_wmma_repeats(%matrixA : memref<1x4xvector<16xf16>, 5>,
+                                        %matrixB : memref<1x4xvector<16xf16>, 5>,
                                         %matrixC : memref<4xvector<8xf32>, 5>) {
   %c1 = arith.constant 1 : index
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [2]
-  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4xvector<16xf16>, 5>
-  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4xvector<16xf16>, 5>
+  // CHECK-SAME: bounds [1, 1, 1, 1, 4]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xf32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xf32>, 5>
-  rock.accel_gemm %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
-    arch = "amdgcn-amd-amdhsa:gfx1100",
-    params = #rock.wmma_gemm_params<
-       mPerBlock = 32,
-       nPerBlock = 32,
-       kpackPerBlock = 2,
-       mPerWave = 32,
-       nPerWave = 32,
-       kpack = 16,
-       forceUnroll = true>
-     } : memref<4xvector<8xf32>, 5> += memref<4xvector<16xf16>, 5> * memref<4xvector<16xf16>, 5>
-  return
-}
-
-// CHECK: rock_accel_gemm_wmma_repeats_int8
-func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<4xvector<16xi8>, 5>,
-                                             %matrixB : memref<4xvector<16xi8>, 5>,
-                                             %matrixC : memref<4xvector<8xi32>, 5>) {
-  %c1 = arith.constant 1 : index
-  // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [4]
-  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4xvector<16xi8>, 5>
-  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4xvector<16xi8>, 5>
-  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
-  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
-  // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
-  rock.accel_gemm %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xf32>, 5> to memref<2x2x1x1xvector<8xf32>, 5>
+  rock.threadwise_accel_gemm %matrixCView[%c1, %c1] += %matrixA * %matrixB features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     params = #rock.wmma_gemm_params<
        mPerBlock = 32,
@@ -74,23 +50,51 @@ func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<4xvector<16xi8>, 
        nPerWave = 32,
        kpack = 16,
        forceUnroll = true>
-     } : memref<4xvector<8xi32>, 5> += memref<4xvector<16xi8>, 5> * memref<4xvector<16xi8>, 5>
+     } : memref<2x2x1x1xvector<8xf32>, 5> += memref<1x4xvector<16xf16>, 5> * memref<1x4xvector<16xf16>, 5>
+  return
+}
+
+// CHECK: rock_accel_gemm_wmma_repeats_int8
+func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<1x4xvector<16xi8>, 5>,
+                                             %matrixB : memref<1x4xvector<16xi8>, 5>,
+                                             %matrixC : memref<4xvector<8xi32>, 5>) {
+  %c1 = arith.constant 1 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1, 1, 4]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
+  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2x1x1xvector<8xi32>, 5>
+  rock.threadwise_accel_gemm %matrixCView[%c1, %c1] += %matrixA * %matrixB features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 32,
+       nPerBlock = 32,
+       kpackPerBlock = 4,
+       mPerWave = 32,
+       nPerWave = 32,
+       kpack = 16,
+       forceUnroll = true>
+     } : memref<2x2x1x1xvector<8xi32>, 5> += memref<1x4xvector<16xi8>, 5> * memref<1x4xvector<16xi8>, 5>
   return
 }
 
 // CHECK: rock_accel_gemm_wmma_partial_repeats_int8
-func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<2xvector<16xi8>, 5>,
-                                                     %matrixB : memref<2xvector<16xi8>, 5>,
-                                                     %matrixC : memref<2xvector<8xi32>, 5>) {
+func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<1x2xvector<16xi8>, 5>,
+                                                     %matrixB : memref<1x2xvector<16xi8>, 5>,
+                                                     %matrixC : memref<4xvector<8xi32>, 5>) {
   %c1 = arith.constant 1 : index
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [2]
-  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<2xvector<16xi8>, 5>
-  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<2xvector<16xi8>, 5>
-  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<2xvector<8xi32>, 5>
+  // CHECK-SAME: bounds [1, 1, 1, 1, 2]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
-  // CHECK: memref.store {{.*}}, {{.*}} : memref<2xvector<8xi32>, 5>
-  rock.accel_gemm %matrixC += %matrixA[%c1] * %matrixB[%c1] features = wmma {
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2x1x1xvector<8xi32>, 5>
+  rock.threadwise_accel_gemm %matrixCView[%c1, %c1] += %matrixA * %matrixB features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     params = #rock.wmma_gemm_params<
        mPerBlock = 32,
@@ -100,6 +104,6 @@ func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<2xvector<
        nPerWave = 16,
        kpack = 16,
        forceUnroll = true>
-     } : memref<2xvector<8xi32>, 5> += memref<2xvector<16xi8>, 5> * memref<2xvector<16xi8>, 5>
+     } : memref<2x2x1x1xvector<8xi32>, 5> += memref<1x2xvector<16xi8>, 5> * memref<1x2xvector<16xi8>, 5>
   return
 }

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -24,11 +24,11 @@ func.func @rock_blockwise_gemm_f16(%A : memref<8x128x1xf16, 3>, %B : memref<8x12
 
 // ----
 
-func.func @rock_xdlops_gemm_accel_one_result_f16(%matrixA : memref<4xvector<4xf16>, 5>,
-                                                %matrixB : memref<4xvector<4xf16>, 5>,
-                                                %matrixC : memref<1xvector<32xf32>, 5>) {
+func.func @rock_xdlops_gemm_accel_one_result_f16(%matrixA : memref<1x4xvector<4xf16>, 5>,
+                                                %matrixB : memref<1x4xvector<4xf16>, 5>,
+                                                %matrixC : memref<1x1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma{
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -38,20 +38,20 @@ func.func @rock_xdlops_gemm_accel_one_result_f16(%matrixA : memref<4xvector<4xf1
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<1xvector<32xf32>, 5> += memref<4xvector<4xf16>, 5> * memref<4xvector<4xf16>, 5>
+  } : memref<1x1xvector<32xf32>, 5> += memref<1x4xvector<4xf16>, 5> * memref<1x4xvector<4xf16>, 5>
   return
 }
 
 // CHECK-LABEL: func.func @rock_xdlops_gemm_accel_one_result_f16
-//  CHECK: rock.accel_gemm
+//  CHECK: rock.threadwise_accel_gemm
 
 // ----
 
-func.func @rock_xdlops_gemm_accel_two_results_f16(%matrixA : memref<4xvector<4xf16>, 5>,
-                                               %matrixB : memref<4xvector<4xf16>, 5>,
-                                               %matrixC : memref<1xvector<32xf32>, 5>) {
+func.func @rock_xdlops_gemm_accel_two_results_f16(%matrixA : memref<1x4xvector<4xf16>, 5>,
+                                               %matrixB : memref<1x4xvector<4xf16>, 5>,
+                                               %matrixC : memref<1x1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.accel_gemm %matrixC += %matrixA[%c0] * %matrixB[%c0] features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -61,12 +61,12 @@ func.func @rock_xdlops_gemm_accel_two_results_f16(%matrixA : memref<4xvector<4xf
       nPerWave = 64,
       kpack = 1,
       forceUnroll = true>
-  } : memref<1xvector<32xf32>, 5> += memref<4xvector<4xf16>, 5> * memref<4xvector<4xf16>, 5>
+  } : memref<1x1xvector<32xf32>, 5> += memref<1x4xvector<4xf16>, 5> * memref<1x4xvector<4xf16>, 5>
   return
 }
 
 // CHECK-LABEL: func.func @rock_xdlops_gemm_accel_two_results_f16
-//  CHECK: rock.accel_gemm
+//  CHECK: rock.threadwise_accel_gemm
 
 // ----
 


### PR DESCRIPTION
Second attempt to refactor `threadwise_accel_gemm`. 

The high level idea is to pass views to the operator, in this way the operator is more expressive and can be used in different loop schedules (`i,j,k`, `k,i,j`, etc...) by simply changing the transformation maps. 

The operator now accepts the following views:
-  `[i,k]` for `A` 
-  `[j,k]` for `B` 
- `[i,j]` for `C` 
And will loop over `i,j,k` doing `C[i,j] += accel(A[i,k], B[j,k])`. 

This makes the operator very similar to the non-accel counterpart, which should facilitate the unification process between accel and non-accel paths (cc @djramic). 