### PR TITLE
Cleanup duplicated code for threadwise accel gemm views

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -88,6 +88,44 @@ void AccelEmitter::computeOutputConversion(PatternRewriter &b, Location loc,
   }
 }
 
+Value AccelEmitter::generateThreadwiseViewBufferA(PatternRewriter &b, Location loc, Value rawBufferA){
+  TopDownTMBuilder bufferAikTransform(b, {"i", "k"}, {1, accelEmitterParams.kBasePerThread}, loc);
+  bufferAikTransform.ignore("i");
+  bufferAikTransform.passThrough({"k"}, 0, {"k"});
+  auto viewA =
+      rock::transform(b, rawBufferA,
+                      b.getArrayAttr(SmallVector<Attribute>{
+                          bufferAikTransform.get()}));
+  return viewA;
+}
+
+Value AccelEmitter::generateThreadwiseViewBufferB(PatternRewriter &b, Location loc, Value rawBufferB){
+  TopDownTMBuilder bufferBjkTransform(b, {"j", "k"},
+                                                {1, accelEmitterParams.kBasePerThread}, loc);
+  bufferBjkTransform.ignore("j");
+  bufferBjkTransform.passThrough({"k"}, 0, {"k"});
+  auto viewB =
+      rock::transform(b, rawBufferB,
+                      b.getArrayAttr(SmallVector<Attribute>{
+                          bufferBjkTransform.get()}));
+  return viewB;
+}
+
+Value AccelEmitter::generateThreadwiseViewBufferC(PatternRewriter &b, Location loc, Value rawBufferC){
+  TopDownTMBuilder bufferCijTransform(
+                b, {"ci", "cj", "i", "j"}, {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats, 1, 1},
+                loc);
+            bufferCijTransform.ignore("i");
+            bufferCijTransform.ignore("j");
+            bufferCijTransform.unmerge("offset", 0, {"ci", "cj"},
+                                       {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats});
+            auto viewC =
+                rock::transform(b, rawBufferC,
+                                b.getArrayAttr(SmallVector<Attribute>{
+                                    bufferCijTransform.get()}));
+  return viewC;
+}
+
 // **************************
 // Mfma accelerator interface
 // **************************

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.cpp
@@ -88,41 +88,46 @@ void AccelEmitter::computeOutputConversion(PatternRewriter &b, Location loc,
   }
 }
 
-Value AccelEmitter::generateThreadwiseViewBufferA(PatternRewriter &b, Location loc, Value rawBufferA){
-  TopDownTMBuilder bufferAikTransform(b, {"i", "k"}, {1, accelEmitterParams.kBasePerThread}, loc);
+Value AccelEmitter::generateThreadwiseViewBufferA(PatternRewriter &b,
+                                                  Location loc,
+                                                  Value rawBufferA) {
+  TopDownTMBuilder bufferAikTransform(
+      b, {"i", "k"}, {1, accelEmitterParams.kBasePerThread}, loc);
   bufferAikTransform.ignore("i");
   bufferAikTransform.passThrough({"k"}, 0, {"k"});
-  auto viewA =
-      rock::transform(b, rawBufferA,
-                      b.getArrayAttr(SmallVector<Attribute>{
-                          bufferAikTransform.get()}));
+  auto viewA = rock::transform(
+      b, rawBufferA,
+      b.getArrayAttr(SmallVector<Attribute>{bufferAikTransform.get()}));
   return viewA;
 }
 
-Value AccelEmitter::generateThreadwiseViewBufferB(PatternRewriter &b, Location loc, Value rawBufferB){
-  TopDownTMBuilder bufferBjkTransform(b, {"j", "k"},
-                                                {1, accelEmitterParams.kBasePerThread}, loc);
+Value AccelEmitter::generateThreadwiseViewBufferB(PatternRewriter &b,
+                                                  Location loc,
+                                                  Value rawBufferB) {
+  TopDownTMBuilder bufferBjkTransform(
+      b, {"j", "k"}, {1, accelEmitterParams.kBasePerThread}, loc);
   bufferBjkTransform.ignore("j");
   bufferBjkTransform.passThrough({"k"}, 0, {"k"});
-  auto viewB =
-      rock::transform(b, rawBufferB,
-                      b.getArrayAttr(SmallVector<Attribute>{
-                          bufferBjkTransform.get()}));
+  auto viewB = rock::transform(
+      b, rawBufferB,
+      b.getArrayAttr(SmallVector<Attribute>{bufferBjkTransform.get()}));
   return viewB;
 }
 
-Value AccelEmitter::generateThreadwiseViewBufferC(PatternRewriter &b, Location loc, Value rawBufferC){
+Value AccelEmitter::generateThreadwiseViewBufferC(PatternRewriter &b,
+                                                  Location loc,
+                                                  Value rawBufferC) {
   TopDownTMBuilder bufferCijTransform(
-                b, {"ci", "cj", "i", "j"}, {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats, 1, 1},
-                loc);
-            bufferCijTransform.ignore("i");
-            bufferCijTransform.ignore("j");
-            bufferCijTransform.unmerge("offset", 0, {"ci", "cj"},
-                                       {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats});
-            auto viewC =
-                rock::transform(b, rawBufferC,
-                                b.getArrayAttr(SmallVector<Attribute>{
-                                    bufferCijTransform.get()}));
+      b, {"ci", "cj", "i", "j"},
+      {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats, 1, 1}, loc);
+  bufferCijTransform.ignore("i");
+  bufferCijTransform.ignore("j");
+  bufferCijTransform.unmerge(
+      "offset", 0, {"ci", "cj"},
+      {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats});
+  auto viewC = rock::transform(
+      b, rawBufferC,
+      b.getArrayAttr(SmallVector<Attribute>{bufferCijTransform.get()}));
   return viewC;
 }
 

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -122,13 +122,16 @@ struct AccelEmitter {
                                Value convertedC, bool forceUnroll);
 
   // A view: A buffer is [0, K] so we can ignore `i`
-  Value generateThreadwiseViewBufferA(PatternRewriter &b, Location loc, Value rawBufferA);
+  Value generateThreadwiseViewBufferA(PatternRewriter &b, Location loc,
+                                      Value rawBufferA);
   // B view: B buffer is [0, K] so we can ignore `j`
-  Value generateThreadwiseViewBufferB(PatternRewriter &b, Location loc, Value rawBufferB);
+  Value generateThreadwiseViewBufferB(PatternRewriter &b, Location loc,
+                                      Value rawBufferB);
   // C view: C buffer is [mRepeats,nRepeats] and we need to write in
   // [i,j]. So we "freeze" the `i` and `j` indices and provide the value
   // of `i` and `j` as extra indices.
-  Value generateThreadwiseViewBufferC(PatternRewriter &b, Location loc, Value rawBufferC);
+  Value generateThreadwiseViewBufferC(PatternRewriter &b, Location loc,
+                                      Value rawBufferC);
 
   /// Return the accelerator parameters
   AccelEmitterParams getParams() const { return accelEmitterParams; }

--- a/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
+++ b/mlir/lib/Dialect/Rock/Transforms/AccelEmitter.h
@@ -121,6 +121,15 @@ struct AccelEmitter {
   void computeOutputConversion(PatternRewriter &b, Location loc, Value regDest,
                                Value convertedC, bool forceUnroll);
 
+  // A view: A buffer is [0, K] so we can ignore `i`
+  Value generateThreadwiseViewBufferA(PatternRewriter &b, Location loc, Value rawBufferA);
+  // B view: B buffer is [0, K] so we can ignore `j`
+  Value generateThreadwiseViewBufferB(PatternRewriter &b, Location loc, Value rawBufferB);
+  // C view: C buffer is [mRepeats,nRepeats] and we need to write in
+  // [i,j]. So we "freeze" the `i` and `j` indices and provide the value
+  // of `i` and `j` as extra indices.
+  Value generateThreadwiseViewBufferC(PatternRewriter &b, Location loc, Value rawBufferC);
+
   /// Return the accelerator parameters
   AccelEmitterParams getParams() const { return accelEmitterParams; }
 

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -490,9 +490,12 @@ struct BlockwiseGemmAccelRewritePattern
                                        op.getBufferB(), b.getArrayAttr({}),
                                        ValueRange{tid, n_i}, true, true);
 
-        Value viewA = accelEmitterPtr->generateThreadwiseViewBufferA(b, loc, adaptor.getBufferA());
-        Value viewB = accelEmitterPtr->generateThreadwiseViewBufferB(b, loc, adaptor.getBufferB());
-        Value viewC = accelEmitterPtr->generateThreadwiseViewBufferC(b, loc, adaptor.getMatrixC());
+        Value viewA = accelEmitterPtr->generateThreadwiseViewBufferA(
+            b, loc, adaptor.getBufferA());
+        Value viewB = accelEmitterPtr->generateThreadwiseViewBufferB(
+            b, loc, adaptor.getBufferB());
+        Value viewC = accelEmitterPtr->generateThreadwiseViewBufferC(
+            b, loc, adaptor.getMatrixC());
 
         // regsC += regsA * regsB
         b.create<ThreadwiseAccelGemmOp>(loc, viewA, viewB, viewC,

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1866,14 +1866,17 @@ struct GridwiseAttentionAccelRewritePattern
             int64_t mRepeats = accelParamsGemm0.mRepeats;
             int64_t nRepeats = accelParamsGemm0.nRepeats;
 
-            Value viewA = accelEmitterPtrGemm0->generateThreadwiseViewBufferA(rewriter, loc, preAccelRegBufferQ);
-            Value viewB = accelEmitterPtrGemm0->generateThreadwiseViewBufferB(rewriter, loc, preAccelRegBufferK);
-            Value viewC = accelEmitterPtrGemm0->generateThreadwiseViewBufferC(rewriter, loc, accRegBufferGemm0);
+            Value viewA = accelEmitterPtrGemm0->generateThreadwiseViewBufferA(
+                rewriter, loc, preAccelRegBufferQ);
+            Value viewB = accelEmitterPtrGemm0->generateThreadwiseViewBufferB(
+                rewriter, loc, preAccelRegBufferK);
+            Value viewC = accelEmitterPtrGemm0->generateThreadwiseViewBufferC(
+                rewriter, loc, accRegBufferGemm0);
 
             // regsC += regsA * regsB
             rewriter.create<ThreadwiseAccelGemmOp>(
-                loc, viewA, viewB, viewC, ValueRange{mi, n_i},
-                op.getArchAttr(), op.getFeaturesAttr(), op.getParamsAttr());
+                loc, viewA, viewB, viewC, ValueRange{mi, n_i}, op.getArchAttr(),
+                op.getFeaturesAttr(), op.getParamsAttr());
           }
         }
       }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1866,39 +1866,13 @@ struct GridwiseAttentionAccelRewritePattern
             int64_t mRepeats = accelParamsGemm0.mRepeats;
             int64_t nRepeats = accelParamsGemm0.nRepeats;
 
-            TopDownTMBuilder bufferAikTransform(rewriter, {"i", "k"},
-                                                {1, kBasePerThread}, loc);
-            bufferAikTransform.ignore("i");
-            bufferAikTransform.passThrough({"k"}, 0, {"k"});
-            auto bufferA =
-                rock::transform(rewriter, preAccelRegBufferQ,
-                                rewriter.getArrayAttr(SmallVector<Attribute>{
-                                    bufferAikTransform.get()}));
-
-            TopDownTMBuilder bufferBjkTransform(rewriter, {"j", "k"},
-                                                {1, kBasePerThread}, loc);
-            bufferBjkTransform.ignore("j");
-            bufferBjkTransform.passThrough({"k"}, 0, {"k"});
-            auto bufferB =
-                rock::transform(rewriter, preAccelRegBufferK,
-                                rewriter.getArrayAttr(SmallVector<Attribute>{
-                                    bufferBjkTransform.get()}));
-
-            TopDownTMBuilder bufferCijTransform(
-                rewriter, {"ci", "cj", "i", "j"}, {mRepeats, nRepeats, 1, 1},
-                loc);
-            bufferCijTransform.ignore("i");
-            bufferCijTransform.ignore("j");
-            bufferCijTransform.unmerge("offset", 0, {"ci", "cj"},
-                                       {mRepeats, nRepeats});
-            auto bufferC =
-                rock::transform(rewriter, accRegBufferGemm0,
-                                rewriter.getArrayAttr(SmallVector<Attribute>{
-                                    bufferCijTransform.get()}));
+            Value viewA = accelEmitterPtrGemm0->generateThreadwiseViewBufferA(rewriter, loc, preAccelRegBufferQ);
+            Value viewB = accelEmitterPtrGemm0->generateThreadwiseViewBufferB(rewriter, loc, preAccelRegBufferK);
+            Value viewC = accelEmitterPtrGemm0->generateThreadwiseViewBufferC(rewriter, loc, accRegBufferGemm0);
 
             // regsC += regsA * regsB
             rewriter.create<ThreadwiseAccelGemmOp>(
-                loc, bufferA, bufferB, bufferC, ValueRange{mi, n_i},
+                loc, viewA, viewB, viewC, ValueRange{mi, n_i},
                 op.getArchAttr(), op.getFeaturesAttr(), op.getParamsAttr());
           }
         }


### PR DESCRIPTION
We had code duplication to create views as required by ThreadwiseAccelGemm op.
(Im not 100% sure why ?)

This PR factors that code into AccelEmitters.