### PR TITLE
Fix gemm and attention toCommandLine order to match Tuna output.

### DIFF
--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -687,7 +687,7 @@ class GemmConfiguration(PerfConfiguration):
     def toCommandLine(self):
         return (f"-t {self.dataType} -out_datatype {self.outDataType} "
                 + f"-transA {str(self.transA).lower()} -transB {str(self.transB).lower()} "
-                + f"-g {self.g} -m {self.m} -k {self.k} -n {self.n}")
+                + f"-g {self.g} -m {self.m} -n {self.n} -k {self.k}")
 
     def __init__(self, dtype: str, outDataType: str, g: int, m: int, k: int, n: int,
                  transA: bool, transB: bool, arch: str, numCU: int, perf_config: str = ''):
@@ -841,9 +841,10 @@ class AttentionConfiguration(PerfConfiguration):
         return cls(dtype, g, seq_len, head_dim, with_attn_scale, transQ, transK, transV, transO, arch, numCU, perf_config)
 
     def toCommandLine(self):
-        return (f"-transO {str(self.transO).lower()} -transV {str(self.transV).lower()} "
-                + f"-transK {str(self.transK).lower()} -transQ {str(self.transQ).lower()} "
-                + f"-t {self.dataType} -g {self.g} "
+        return (f"-t {self.dataType} "
+                + f"-transQ {str(self.transQ).lower()} -transK {str(self.transK).lower()} "
+                + f"-transV {str(self.transV).lower()} -transO {str(self.transO).lower()} "
+                + f"-g {self.g} "
                 + f"-seq_len {str(self.seq_len)} -head_dim {str(self.head_dim)} "
                 + f"-with-attn-scale {str(self.with_attn_scale).lower()}")
 


### PR DESCRIPTION
I tried to create a canonical order of options in the .tsv file produced by tuning and in the configs generated in perfRunner.py, so the configs would reliably be found in the .tsv -- it's a simple string match.  Unfortunately, I messed up the order in a couple of places and perf-configs were not found.  That ended up producing NaNs in the output when comparing against rocBLAS, which led to "FAILED" in the html report, and also caused occasional outright test failures.