### PR TITLE
Fix trailing missing unit dims in transpose folding

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -522,7 +522,7 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
         // do the same for the last set of indices too
         // where it does not match upto the rank of the input.
         ReassociationIndices &lastIndices = newReassocIndicesSorted.back();
-        while (lastIndices.back() + 1 < inShape.size()) {
+        while (lastIndices.back() + 1 < (int64_t)inShape.size()) {
           lastIndices.push_back(lastIndices.back() + 1);
         }
 

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -519,6 +519,13 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
             theseIndices.push_back(theseIndices.back() + 1);
           }
         }
+        // do the same for the last set of indices too
+        // where it does not match upto the rank of the input.
+        ReassociationIndices &lastIndices = newReassocIndicesSorted.back();
+        while (lastIndices.back() + 1 < inShape.size()) {
+          lastIndices.push_back(lastIndices.back() + 1);
+        }
+
         for (size_t i = 0; i < newDims.size(); i++) {
           newDims[i] = dimMap[newDims[i]];
         }

--- a/mlir/test/fusion/pr-e2e/mixr-navi-tp-reshape.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-navi-tp-reshape.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen -fut mlir_transpose_reshape_dot_add --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel --verify-passes | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_transpose_reshape_dot_add_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+func.func @mlir_transpose_reshape_dot_add(%arg0: !migraphx.shaped<1x1001xf32, 0x1>, %arg1: !migraphx.shaped<1x1536x1x1xf32, 1536x1x1x1>, %arg2: !migraphx.shaped<1536x1001xf32, 1001x1>) -> !migraphx.shaped<1x1001xf32, 1001x1> {
+    %0 = migraphx.transpose %arg1 {permutation = [0, 2, 3, 1]} : <1x1536x1x1xf32, 1536x1x1x1> -> <1x1x1x1536xf32, 1536x1x1x1>
+    %1 = migraphx.reshape %0 {dims = [1, -1]} : <1x1x1x1536xf32, 1536x1x1x1> -> <1x1536xf32, 1536x1>
+    %2 = migraphx.dot %1, %arg2 : <1x1536xf32, 1536x1>, <1536x1001xf32, 1001x1> -> <1x1001xf32, 1001x1>
+    %3 = migraphx.add %2, %arg0 : <1x1001xf32, 1001x1>, <1x1001xf32, 0x1> -> <1x1001xf32, 1001x1>
+    return %3 : !migraphx.shaped<1x1001xf32, 1001x1>
+}


### PR DESCRIPTION
Extend the existing hot fix to cover the unit dim tail of re-associations
of the collapses encountered in transpose folding.

closes : https://github.com/ROCm/rocMLIR-internal/issues/1317