### PR TITLE
[Attention] Replace 2nd blockwise_gemm with threadwise_gemm

### DIFF
--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -190,9 +190,29 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
     // CHECK-DAG: rock.threadwise_write_all {{.*}} %[[G1BregsKpack]] -> [](%[[viewG1BStoreTr3]])
     // CHECK-DAG: %[[view2G1BStore:.+]] = memref.view %[[ldsG0B]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
 
+    // Viewing LDS G1B tile buffer in MFMA layout
+    // CHECK-DAG: %[[viewG1BLoadTr0:.+]] = rock.transform %[[view2G1BStore]]
+    // CHECK-DAG: %[[viewG1BLoadTr1:.+]] = rock.transform %[[viewG1BLoadTr0]]
+    // CHECK-DAG: %[[viewG1BLoadTr2:.+]] = rock.transform %[[viewG1BLoadTr1]]
+    // CHECK-DAG: %[[viewG1BLoadTr3:.+]] = rock.transform %[[viewG1BLoadTr2]]
+
+    // Viewing LDS G1A tile buffer in MFMA layout
+    // CHECK-DAG: %[[viewG1ALoadTr0:.+]] = rock.transform %[[view2G1AStore]]
+    // CHECK-DAG: %[[viewG1ALoadTr1:.+]] = rock.transform %[[viewG1ALoadTr0]]
+    // CHECK-DAG: %[[viewG1ALoadTr2:.+]] = rock.transform %[[viewG1ALoadTr1]]
+    // CHECK-DAG: %[[viewG1ALoadTr3:.+]] = rock.transform %[[viewG1ALoadTr2]]
+
     // Gemm1
     // CHECK-DAG: rock.lds_barrier
-    // CHECK-DAG: rock.blockwise_gemm_accel %[[gemm1AccBuf]] += {{.*}} from %[[view2G1BStore]] * {{.*}} from %[[view2G1AStore]]
+    // CHECK: affine.for
+        // CHECK: affine.for
+          // CHECK: rock.threadwise_read_into {{.*}} [](%[[viewG1BLoadTr3]]) {{.*}} -> %[[preAccelRegB:.+]] :
+          // CHECK: rock.threadwise_read_into {{.*}} [](%[[viewG1ALoadTr3]]) {{.*}} -> %[[preAccelRegA:.+]] :
+          // CHECK: %[[bufferA:.*]] = rock.transform %[[preAccelRegB]]
+          // CHECK: %[[bufferB:.*]] = rock.transform %[[preAccelRegA]]
+          // CHECK: %[[bufferC:.*]] = rock.transform %[[gemm1AccBuf]]
+          // CHECK: rock.threadwise_accel_gemm %[[bufferC]]{{.*}} += %[[bufferA:.*]] * %[[bufferB:.*]]
+
     // CHECK: rock.transforming_for
       // CHECK: %[[tmp1:.+]] =  memref.load %[[gemm1AccBuf]][
       // CHECK: rock.in_bounds_store %[[tmp1]] -> %[[gemm1AccBufScalar:.+]][


### PR DESCRIPTION
This commit replaces the second blockwise_gemm operation
with threadwise_gemm operation and friends.

This is a stepping stone to analyze the LDS traffic used to
swizzle the gemm operands into accelerator layouts (MFMA/WMMA)
and to potentially remove unnecessary LDS traffic in future.

closes : https://github.com/ROCm/rocMLIR-internal/issues/1304 