### PR TITLE
Fix incorrect logic around stores to length-1 memrefs

### DIFF
--- a/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
@@ -56,13 +56,14 @@ func.func @load_vector_oob(%mem: memref<1x2x3x4x8xf32>, %idx: index, %valid: i1)
 }
 
 // CHECK-LABEL: func.func @load_scalar
-// CHECK-SAME: (%[[mem:.*]]: memref<f32>, %[[idx:.*]]: index, %[[valid:.*]]: i1)
-func.func @load_scalar_empty_mem(%mem: memref<f32>, %idx: index, %valid: i1) -> f32 {
+// CHECK-SAME: (%[[mem:.*]]: memref<f32>, %[[idx:.*]]: index)
+func.func @load_scalar_empty_mem(%mem: memref<f32>, %idx: index) -> f32 {
+    %true = arith.constant true
     %c0 = arith.constant 0 : index
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
     // CHECK: %[[ret:.*]] = memref.load %[[cast]][] : memref<f32, #gpu.address_space<global>>
-    %ret = rock.global_load %mem[] if %valid
+    %ret = rock.global_load %mem[] if %true
         : memref<f32> -> f32
     // CHECK: return %[[ret]]
     return %ret : f32
@@ -155,13 +156,28 @@ func.func @store_vector_oob(%source: memref<5xf32, #gpu.address_space<private>>,
 }
 
 // CHECK-LABEL: func.func @store_scalar_in_scalar
-// CHECK-SAME: (%[[source:.*]]: memref<1xf32, #gpu.address_space<private>>, %[[mem:.*]]: memref<f32>, %[[valid:.*]]: i1)
-func.func @store_scalar_in_scalar(%source: memref<1xf32, #gpu.address_space<private>>, %mem: memref<f32>, %valid: i1) {
+// CHECK-SAME: (%[[source:.*]]: memref<1xf32, #gpu.address_space<private>>, %[[mem:.*]]: memref<f32>)
+func.func @store_scalar_in_scalar(%source: memref<1xf32, #gpu.address_space<private>>, %mem: memref<f32>) {
+    %true = arith.constant true
     %c0 = arith.constant 0 : index
     // CHECK-DAG: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
     // CHECK-DAG: %[[val:.*]] = memref.load %[[source]]
     // CHECK: memref.store %[[val]], %[[cast]]
+    rock.global_store set %source[%c0] -> %mem[] if %true
+        features = none {length = 1 : index}
+        : memref<1xf32, #gpu.address_space<private>> -> memref<f32>
+    return
+}
+
+// Some nightly tests failed if this wasn't a buffer store
+// CHECK-LABEL: func.func @store_in_scalar_maybe_oob
+// CHECK-SAME: (%[[source:.*]]: memref<1xf32, #gpu.address_space<private>>, %[[mem:.*]]: memref<f32>, %[[valid:.*]]: i1)
+func.func @store_in_scalar_maybe_oob(%source: memref<1xf32, #gpu.address_space<private>>, %mem: memref<f32>, %valid: i1) {
+    %c0 = arith.constant 0 : index
+    // CHECK-DAG: %[[val:.*]] = memref.load %[[source]]
+    // CHECK-DAG: %[[exp:.*]] = memref.expand_shape %[[mem]] []
+    // CHECK: amdgpu.raw_buffer_store %[[val]] -> %[[exp]]
     rock.global_store set %source[%c0] -> %mem[] if %valid
         features = none {length = 1 : index}
         : memref<1xf32, #gpu.address_space<private>> -> memref<f32>
@@ -271,11 +287,9 @@ func.func @add_scalar_to_scalar_valid(%source: memref<1xf32, #gpu.address_space<
 // CHECK-SAME: (%[[source:.*]]: memref<1xf32, #gpu.address_space<private>>, %[[mem:.*]]: memref<f32>, %[[valid:.*]]: i1)
 func.func @add_scalar_to_scalar_maybe_valid(%source: memref<1xf32, #gpu.address_space<private>>, %mem: memref<f32>, %valid: i1) {
     %c0 = arith.constant 0 : index
-    // CHECK-DAG: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
-    // CHECK-SAME: #gpu.address_space<global>
     // CHECK-DAG: %[[val:.*]] = memref.load %[[source]]
-    // CHECK-DAG: scf.if %[[valid]]
-    // CHECK: memref.atomic_rmw addf %[[val]], %[[cast]]
+    // CHECK-DAG: %[[exp:.*]] = memref.expand_shape %[[mem]] []
+    // CHECK: amdgpu.raw_buffer_atomic_fadd %[[val]] -> %[[exp]]
     rock.global_store atomic_add %source[%c0] -> %mem[] if %valid
         features = none {length = 1 : index}
         : memref<1xf32, #gpu.address_space<private>> -> memref<f32>


### PR DESCRIPTION
The code in #1211 was incorrect and led to colflicting stores to memref<1x1x...x1xT>s that were padded out because it erroniously ignored the validity bit.

This commit fixes the logic to always emit bounds checks in the presence of non-trivial validity logic, even if the final coordinate is 0D. This also improves the handling of such bounds checks by adding expand_shape calls to create a coordinate that the buffer bounds check trick can operate on.

(Honestly, it's surprising that this didn't come up with more failures.)

Fixes https://github.com/ROCm/rocMLIR-internal/issues/1321