### PR TITLE
FP8 truncation in software

### DIFF
--- a/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-O3.ll
+++ b/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-O3.ll
@@ -1,0 +1,205 @@
+$unsigned char cast_to_f8<2u, 5u>(float) = comdat any
+
+$unsigned char cast_to_f8<3u, 4u>(float) = comdat any
+
+@v = external local_unnamed_addr global float, align 4
+@e4m3 = external local_unnamed_addr global i8, align 1
+@e5m2 = external local_unnamed_addr global i8, align 1
+
+define dso_local noundef i32 @main() local_unnamed_addr #0 {
+entry:
+  %0 = load float, ptr @v, align 4
+  %call = tail call noundef zeroext i8 @unsigned char cast_to_f8<2u, 5u>(float)(float noundef %0)
+  store i8 %call, ptr @e4m3, align 1
+  %1 = load float, ptr @v, align 4
+  %call1 = tail call noundef zeroext i8 @unsigned char cast_to_f8<3u, 4u>(float)(float noundef %1)
+  store i8 %call1, ptr @e5m2, align 1
+  ret i32 0
+}
+
+; unsigned char cast_to_f8<2u, 5u>(float)
+define linkonce_odr dso_local noundef zeroext i8 @e5m2(float noundef %f_x) local_unnamed_addr #1 comdat {
+entry:
+  %0 = bitcast float %f_x to i32
+  %and1 = and i32 %0, 8388607
+  %shr = lshr i32 %0, 23
+  %and2 = and i32 %shr, 255
+  %1 = lshr i32 %0, 24
+  %shl = and i32 %1, 128
+  %and4 = and i32 %0, 2139095040
+  %cmp = icmp eq i32 %and4, 2139095040
+  br i1 %cmp, label %cleanup91, label %if.end
+
+if.end:
+  %cmp5 = icmp eq i32 %and2, 0
+  br i1 %cmp5, label %cleanup91, label %if.end7
+
+if.end7:
+  %sub = add nsw i32 %and2, -127
+  %cmp8 = icmp ult i32 %and2, 113
+  %sub10 = sub nsw i32 112, %and2
+  %exponent_diff.0 = select i1 %cmp8, i32 %sub10, i32 0
+  %add12 = or i32 %and1, 8388608
+  %2 = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 10)
+  %notmask = shl nsw i32 -2097152, %2
+  %sub16 = xor i32 %notmask, -1
+  %and17 = and i32 %add12, %sub16
+  %sub21 = add nsw i32 %exponent_diff.0, 20
+  %.sroa.speculated140 = tail call i32 @llvm.umin.i32(i32 %sub21, i32 31)
+  %shl23 = shl nuw i32 1, %.sroa.speculated140
+  %cmp24 = icmp eq i32 %and17, %shl23
+  %cmp25 = icmp sgt i32 %exponent_diff.0, 0
+  %.sroa.speculated = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 31)
+  %shr30 = select i1 %cmp25, i32 %.sroa.speculated, i32 0
+  %mantissa.0 = lshr i32 %add12, %shr30
+  %add40 = add nsw i32 %sub, %exponent_diff.0
+  %and38 = lshr i32 %mantissa.0, 23
+  %3 = or i32 %and38, -2
+  %add41 = add nsw i32 %add40, %3
+  %sub43 = add nsw i32 %add41, 17
+  %and44 = lshr i32 %mantissa.0, 21
+  %4 = and i32 %and44, 1
+  %sext = add nuw nsw i32 %4, 2097151
+  %cond51 = select i1 %cmp24, i32 %sext, i32 0
+  %cond54 = add nuw nsw i32 %cond51, %mantissa.0
+  %and55 = and i32 %cond54, 2097151
+  %add56 = add nuw nsw i32 %and55, %mantissa.0
+  %cmp57 = icmp ne i32 %sub43, 0
+  %and58 = and i32 %add56, 8388608
+  %tobool59.not = icmp eq i32 %and58, 0
+  %or.cond133 = select i1 %cmp57, i1 true, i1 %tobool59.not
+  br i1 %or.cond133, label %if.else61, label %if.end76
+
+if.else61:
+  %tobool63.not = icmp ugt i32 %add56, 16777215
+  %inc = add nsw i32 %add41, 18
+  %f8_exponent.0 = select i1 %tobool63.not, i32 %inc, i32 %sub43
+  %cmp69 = icmp sgt i32 %f8_exponent.0, 31
+  br i1 %cmp69, label %if.then70, label %if.end71
+
+if.then70:
+  %5 = trunc i32 %1 to i8
+  %conv = or i8 %5, 127
+  br label %cleanup91
+
+if.end71:
+  %shr65 = zext i1 %tobool63.not to i32
+  %mantissa.1 = lshr i32 %add56, %shr65
+  %cmp72 = icmp eq i32 %f8_exponent.0, 0
+  %cmp74 = icmp ult i32 %mantissa.1, 2097152
+  %or.cond = select i1 %cmp72, i1 %cmp74, i1 false
+  br i1 %or.cond, label %cleanup91, label %if.end76
+
+if.end76:
+  %f8_exponent.0150160 = phi i32 [ %f8_exponent.0, %if.end71 ], [ 1, %if.end7 ]
+  %shr68152159.in = phi i32 [ %mantissa.1, %if.end71 ], [ %add56, %if.end7 ]
+  %shr68152159 = lshr i32 %shr68152159.in, 21
+  %and77 = and i32 %shr68152159, 3
+  %shl79 = shl nsw i32 %f8_exponent.0150160, 2
+  %or = or i32 %shl79, %shl
+  %or80 = or i32 %or, %and77
+  %conv81 = trunc i32 %or80 to i8
+  br label %cleanup91
+
+cleanup91:
+  %retval.1 = phi i8 [ -128, %entry ], [ 0, %if.end ], [ %conv, %if.then70 ], [ %conv81, %if.end76 ], [ 0, %if.end71 ]
+  ret i8 %retval.1
+}
+
+; unsigned char cast_to_f8<3u, 4u>
+define linkonce_odr dso_local noundef zeroext i8 @e4m3(float)(float noundef %f_x) local_unnamed_addr #2 comdat {
+entry:
+  %0 = bitcast float %f_x to i32
+  %and1 = and i32 %0, 8388607
+  %shr = lshr i32 %0, 23
+  %and2 = and i32 %shr, 255
+  %1 = lshr i32 %0, 24
+  %shl = and i32 %1, 128
+  %and4 = and i32 %0, 2139095040
+  %cmp = icmp eq i32 %and4, 2139095040
+  br i1 %cmp, label %cleanup91, label %if.end
+
+if.end:
+  %cmp5 = icmp eq i32 %and2, 0
+  br i1 %cmp5, label %cleanup91, label %if.end7
+
+if.end7:
+  %sub = add nsw i32 %and2, -127
+  %cmp8 = icmp ult i32 %and2, 121
+  %sub10 = sub nsw i32 120, %and2
+  %exponent_diff.0 = select i1 %cmp8, i32 %sub10, i32 0
+  %add12 = or i32 %and1, 8388608
+  %2 = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 11)
+  %notmask = shl nsw i32 -1048576, %2
+  %sub16 = xor i32 %notmask, -1
+  %and17 = and i32 %add12, %sub16
+  %sub21 = add nsw i32 %exponent_diff.0, 19
+  %.sroa.speculated140 = tail call i32 @llvm.umin.i32(i32 %sub21, i32 31)
+  %shl23 = shl nuw i32 1, %.sroa.speculated140
+  %cmp24 = icmp eq i32 %and17, %shl23
+  %cmp25 = icmp sgt i32 %exponent_diff.0, 0
+  %.sroa.speculated = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 31)
+  %shr30 = select i1 %cmp25, i32 %.sroa.speculated, i32 0
+  %mantissa.0 = lshr i32 %add12, %shr30
+  %add40 = add nsw i32 %sub, %exponent_diff.0
+  %and38 = lshr i32 %mantissa.0, 23
+  %3 = or i32 %and38, -2
+  %add41 = add nsw i32 %add40, %3
+  %sub43 = add nsw i32 %add41, 9
+  %and44 = lshr i32 %mantissa.0, 20
+  %4 = and i32 %and44, 1
+  %sext = add nuw nsw i32 %4, 1048575
+  %cond51 = select i1 %cmp24, i32 %sext, i32 0
+  %cond54 = add nuw nsw i32 %cond51, %mantissa.0
+  %and55 = and i32 %cond54, 1048575
+  %add56 = add nuw nsw i32 %and55, %mantissa.0
+  %cmp57 = icmp ne i32 %sub43, 0
+  %and58 = and i32 %add56, 8388608
+  %tobool59.not = icmp eq i32 %and58, 0
+  %or.cond133 = select i1 %cmp57, i1 true, i1 %tobool59.not
+  br i1 %or.cond133, label %if.else61, label %if.end76
+
+if.else61:
+  %tobool63.not = icmp ugt i32 %add56, 16777215
+  %inc = add nsw i32 %add41, 10
+  %f8_exponent.0 = select i1 %tobool63.not, i32 %inc, i32 %sub43
+  %cmp69 = icmp sgt i32 %f8_exponent.0, 15
+  br i1 %cmp69, label %if.then70, label %if.end71
+
+if.then70:
+  %5 = trunc i32 %1 to i8
+  %conv = or i8 %5, 127
+  br label %cleanup91
+
+if.end71:
+  %shr65 = zext i1 %tobool63.not to i32
+  %mantissa.1 = lshr i32 %add56, %shr65
+  %cmp72 = icmp eq i32 %f8_exponent.0, 0
+  %cmp74 = icmp ult i32 %mantissa.1, 1048576
+  %or.cond = select i1 %cmp72, i1 %cmp74, i1 false
+  br i1 %or.cond, label %cleanup91, label %if.end76
+
+if.end76:
+  %f8_exponent.0150160 = phi i32 [ %f8_exponent.0, %if.end71 ], [ 1, %if.end7 ]
+  %shr68152159.in = phi i32 [ %mantissa.1, %if.end71 ], [ %add56, %if.end7 ]
+  %shr68152159 = lshr i32 %shr68152159.in, 20
+  %and77 = and i32 %shr68152159, 7
+  %shl79 = shl nsw i32 %f8_exponent.0150160, 3
+  %or = or i32 %shl79, %shl
+  %or80 = or i32 %or, %and77
+  %conv81 = trunc i32 %or80 to i8
+  br label %cleanup91
+
+cleanup91:
+  %retval.1 = phi i8 [ -128, %entry ], [ 0, %if.end ], [ %conv, %if.then70 ], [ %conv81, %if.end76 ], [ 0, %if.end71 ]
+  ret i8 %retval.1
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata) #3
+
+declare i32 @llvm.umin.i32(i32, i32) #3
+
+attributes #0 = { mustprogress norecurse uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { mustprogress noinline uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { mustprogress noinline nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-cleaned.cpp
+++ b/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-cleaned.cpp
@@ -1,0 +1,135 @@
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+template <uint32_t Wm, uint32_t We>
+__attribute__((noinline)) uint8_t constexpr cast_to_f8(float f_x) {
+  static_assert(Wm + We == 7, "Wm+We==7");
+
+  const uint32_t mfmt = 23;
+  uint32_t x = 0;
+  memcpy(&x, &f_x, sizeof(uint32_t));
+
+  uint32_t head = x & 0xFF800000;
+  uint32_t mantissa = x & 0x7FFFFF;
+  int exponent = (head >> 23) & 0xFF;
+  uint32_t sign = head >> 31;
+  uint32_t bias = 127;
+
+  uint32_t signed_all_ones =
+      (sign << 7) + ((((1 << We) - 1) << Wm) + ((1 << Wm) - 1));
+
+  // Calcualte maximum singed value FLT_MAX, FLT_MIN
+  uint32_t signed_max = signed_all_ones;
+  // Deal with inf and NaNs
+  if (((x & 0x7F800000) == 0x7F800000))
+    return 0x80;
+  // handle zero and send denormals to 0
+  if (exponent == 0)
+    return 0;
+
+  /* First need to check if it is normal or denorm as there is a difference of
+  implict 1 Then need to adjust the exponent to align with the F8 exponent, in
+  the meanwhile, shift The mantissa. Then for stochastic rounding, add rng to
+  mantissa and truncate. And for RNE, no need to add rng. Then probably need to
+  check whether there is carry and adjust exponent and mantissa again*/
+
+  // For IEEE bias mode, the bias is 2^(k-1) -1 where k is the width of exponent
+  // bits
+  const int f8_bias = (1 << (We - 1u)) - 1 + 1;
+  const int f8_denormal_act_exponent =
+      1 - f8_bias; // actual exponent of f8 denormal
+  /* act_exponent is the actual exponent of fp32/fp16 (after subtracting bias)
+  f8_exponent is the converted f8 exponent with bias encoding
+  exponent_diff is the diff between fp32/fp16 exponent and f8 exponent,
+  the difference needs to be adjusted and mantissa shifted*/
+  int act_exponent = exponent - bias;
+  int f8_exponent = 0;
+  int exponent_diff = 0;
+  // fp32/fp16 is normal with implicit 1
+  if (act_exponent <= f8_denormal_act_exponent) {
+    /* This is the case where fp32/fp16 is normal but it is in f8 denormal
+    range. For example fp8 FNUZ mode, denormal exponent is -7, but if the
+    fp32/fp16 actual exponent is -7, it is actually larger due to the implict 1,
+    Therefore it needs to be adjust to -6 and mantissa shift right by 1.
+    So for fp32/fp16, exponent -8 is the cut point to convert to fp8 FNUZ */
+    exponent_diff = f8_denormal_act_exponent - act_exponent;
+  } else {             // both fp32/fp16 and f8 are in normal range
+    exponent_diff = 0; // exponent_diff=0 does not mean there is no difference
+                       // for this case,
+    // act_exponent could be larger. Just that it does not need shift mantissa
+  }
+  mantissa += (1u << mfmt); // Add the implicit 1 into mantissa
+
+  // need to know whether the number is right in the middle of two adjacent fp8
+  // numbers. use  max value of 31 to avoid undefined behaviour
+  bool midpoint =
+      (mantissa & ((1u << std::min(31u, mfmt - Wm + exponent_diff)) - 1)) ==
+      (1u << std::min(31u, mfmt - Wm + exponent_diff - 1));
+  /* This part is a bit tricky. The judgment of whether it is a tie needs to be
+  done before we shift right as shift right could rip off some residual part and
+  make something not midpoint look like midpoint. For example, the fp16 number
+  0x1002 (0 00100 0000000010), it is larger than midpoint, but after shift right
+  by 4 bits, it would look like midpoint.
+  */
+
+  if (exponent_diff > 0)
+    mantissa >>= std::min(31u, uint32_t(exponent_diff));
+  else if (exponent_diff == -1)
+    mantissa <<= -exponent_diff;
+  bool implicit_one = mantissa & (1 << mfmt);
+  // if there is no implict 1, it  means the f8 is denormal and need to adjust
+  // to denorm exponent
+  f8_exponent = (act_exponent + exponent_diff) /*actual f8 exponent*/ +
+                f8_bias - (implicit_one ? 0 : 1);
+
+  // Now we have the exponent and mantissa adjusted
+  uint32_t drop_mask = (1u << (mfmt - Wm)) - 1;
+  bool odd =
+      mantissa &
+      (1u << (mfmt -
+              Wm)); // if the least significant bit that is not truncated is 1
+  /*
+  This part is doing rounding by adding mantissa part that is going to get
+  dropped. e.g. if the dropped part for less than 0.5 than it would round down.
+  if the dropped part is more than 0.5 then it would round up by rolling carry
+  to LSB of retained mantissa. For the mid point when bit pattern is like this
+  for Odd: `xy1:10000000` for Odd and `xy0:10000000` for the Even.  where `:` is
+  delimiter for dropped v/s retained part. For the odd case : this will add
+  xy1:10000000 + 000:10000000 which would roll over carry to LSB of retained
+  part making it RNE.
+  For the even case : this will add xy0:10000000 + 000:01111111 which would
+  round down and keep number Even
+  */
+  mantissa +=
+      (midpoint ? (odd ? mantissa : mantissa - 1) : mantissa) & drop_mask;
+
+  // Now we deal with overflow
+  if (f8_exponent == 0 and ((1 << mfmt) & mantissa)) {
+    f8_exponent = 1; // denormal overflow to become normal, promote exponent
+  } else if ((1 << (mfmt + 1)) & mantissa) {
+    mantissa >>= 1;
+    f8_exponent++;
+  }
+
+  mantissa >>= (mfmt - Wm);
+
+  // above range: quantize to maximum possible float of the same sign
+  // for e5m2 case, max_exp is 14, since exp = 15 is reserved for Infs and Nans
+  const int max_exp = (1 << We) - 1;
+  if (f8_exponent > max_exp) {
+    return signed_max;
+  }
+
+  if (f8_exponent == 0 and mantissa == 0)
+    return 0;
+  mantissa &= (1 << Wm) - 1;
+  return (sign << 7) | (f8_exponent << Wm) | mantissa;
+}
+
+extern float v;
+extern uint8_t e4m3, e5m2;
+int main() {
+  e4m3 = cast_to_f8<3, 4>(v);
+  e5m2 = cast_to_f8<2, 5>(v);
+}

--- a/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-e4m3.ll
+++ b/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-e4m3.ll
@@ -1,0 +1,89 @@
+define linkonce_odr dso_local noundef zeroext i8 @e4m3(float)(float noundef %f_x) local_unnamed_addr #2 comdat {
+entry:
+  %0 = bitcast float %f_x to i32
+  %and1 = and i32 %0, 8388607
+  %shr = lshr i32 %0, 23
+  %and2 = and i32 %shr, 255
+  %1 = lshr i32 %0, 24
+  %shl = and i32 %1, 128
+  %and4 = and i32 %0, 2139095040
+  %cmp = icmp eq i32 %and4, 2139095040
+  br i1 %cmp, label %cleanup91, label %if.end
+
+if.end:
+  %cmp5 = icmp eq i32 %and2, 0
+  br i1 %cmp5, label %cleanup91, label %if.end7
+
+if.end7:
+  %sub = add nsw i32 %and2, -127
+  %cmp8 = icmp ult i32 %and2, 121
+  %sub10 = sub nsw i32 120, %and2
+  %exponent_diff.0 = select i1 %cmp8, i32 %sub10, i32 0
+  %add12 = or i32 %and1, 8388608
+  %2 = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 11)
+  %notmask = shl nsw i32 -1048576, %2
+  %sub16 = xor i32 %notmask, -1
+  %and17 = and i32 %add12, %sub16
+  %sub21 = add nsw i32 %exponent_diff.0, 19
+  %.sroa.speculated140 = tail call i32 @llvm.umin.i32(i32 %sub21, i32 31)
+  %shl23 = shl nuw i32 1, %.sroa.speculated140
+  %cmp24 = icmp eq i32 %and17, %shl23
+  %cmp25 = icmp sgt i32 %exponent_diff.0, 0
+  %.sroa.speculated = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 31)
+  %shr30 = select i1 %cmp25, i32 %.sroa.speculated, i32 0
+  %mantissa.0 = lshr i32 %add12, %shr30
+  %add40 = add nsw i32 %sub, %exponent_diff.0
+  %and38 = lshr i32 %mantissa.0, 23
+  %3 = or i32 %and38, -2
+  %add41 = add nsw i32 %add40, %3
+  %sub43 = add nsw i32 %add41, 9
+  %and44 = lshr i32 %mantissa.0, 20
+  %4 = and i32 %and44, 1
+  %sext = add nuw nsw i32 %4, 1048575
+  %cond51 = select i1 %cmp24, i32 %sext, i32 0
+  %cond54 = add nuw nsw i32 %cond51, %mantissa.0
+  %and55 = and i32 %cond54, 1048575
+  %add56 = add nuw nsw i32 %and55, %mantissa.0
+  %cmp57 = icmp ne i32 %sub43, 0
+  %and58 = and i32 %add56, 8388608
+  %tobool59.not = icmp eq i32 %and58, 0
+  %or.cond133 = select i1 %cmp57, i1 true, i1 %tobool59.not
+  br i1 %or.cond133, label %if.else61, label %if.end76
+
+if.else61:
+  %tobool63.not = icmp ugt i32 %add56, 16777215
+  %inc = add nsw i32 %add41, 10
+  %f8_exponent.0 = select i1 %tobool63.not, i32 %inc, i32 %sub43
+  %cmp69 = icmp sgt i32 %f8_exponent.0, 15
+  br i1 %cmp69, label %if.then70, label %if.end71
+
+if.then70:
+  %5 = trunc i32 %1 to i8
+  %conv = or i8 %5, 127
+  br label %cleanup91
+
+if.end71:
+  %shr65 = zext i1 %tobool63.not to i32
+  %mantissa.1 = lshr i32 %add56, %shr65
+  %cmp72 = icmp eq i32 %f8_exponent.0, 0
+  %cmp74 = icmp ult i32 %mantissa.1, 1048576
+  %or.cond = select i1 %cmp72, i1 %cmp74, i1 false
+  br i1 %or.cond, label %cleanup91, label %if.end76
+
+if.end76:
+  %f8_exponent.0150160 = phi i32 [ %f8_exponent.0, %if.end71 ], [ 1, %if.end7 ]
+  %shr68152159.in = phi i32 [ %mantissa.1, %if.end71 ], [ %add56, %if.end7 ]
+  %shr68152159 = lshr i32 %shr68152159.in, 20
+  %and77 = and i32 %shr68152159, 7
+  %shl79 = shl nsw i32 %f8_exponent.0150160, 3
+  %or = or i32 %shl79, %shl
+  %or80 = or i32 %or, %and77
+  %conv81 = trunc i32 %or80 to i8
+  br label %cleanup91
+
+cleanup91:
+  %retval.1 = phi i8 [ -128, %entry ], [ 0, %if.end ], [ %conv, %if.then70 ], [ %conv81, %if.end76 ], [ 0, %if.end71 ]
+  ret i8 %retval.1
+}
+
+declare i32 @llvm.umin.i32(i32, i32)

--- a/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-e5m2.ll
+++ b/mlir/docs/fnuz-float-software-truncation-sources/fp8-trunc-e5m2.ll
@@ -1,0 +1,89 @@
+define linkonce_odr dso_local noundef zeroext i8 @e5m2(float noundef %f_x) local_unnamed_addr #1 comdat {
+entry:
+  %0 = bitcast float %f_x to i32
+  %and1 = and i32 %0, 8388607
+  %shr = lshr i32 %0, 23
+  %and2 = and i32 %shr, 255
+  %1 = lshr i32 %0, 24
+  %shl = and i32 %1, 128
+  %and4 = and i32 %0, 2139095040
+  %cmp = icmp eq i32 %and4, 2139095040
+  br i1 %cmp, label %cleanup91, label %if.end
+
+if.end:
+  %cmp5 = icmp eq i32 %and2, 0
+  br i1 %cmp5, label %cleanup91, label %if.end7
+
+if.end7:
+  %sub = add nsw i32 %and2, -127
+  %cmp8 = icmp ult i32 %and2, 113
+  %sub10 = sub nsw i32 112, %and2
+  %exponent_diff.0 = select i1 %cmp8, i32 %sub10, i32 0
+  %add12 = or i32 %and1, 8388608
+  %2 = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 10)
+  %notmask = shl nsw i32 -2097152, %2
+  %sub16 = xor i32 %notmask, -1
+  %and17 = and i32 %add12, %sub16
+  %sub21 = add nsw i32 %exponent_diff.0, 20
+  %.sroa.speculated140 = tail call i32 @llvm.umin.i32(i32 %sub21, i32 31)
+  %shl23 = shl nuw i32 1, %.sroa.speculated140
+  %cmp24 = icmp eq i32 %and17, %shl23
+  %cmp25 = icmp sgt i32 %exponent_diff.0, 0
+  %.sroa.speculated = tail call i32 @llvm.umin.i32(i32 %exponent_diff.0, i32 31)
+  %shr30 = select i1 %cmp25, i32 %.sroa.speculated, i32 0
+  %mantissa.0 = lshr i32 %add12, %shr30
+  %add40 = add nsw i32 %sub, %exponent_diff.0
+  %and38 = lshr i32 %mantissa.0, 23
+  %3 = or i32 %and38, -2
+  %add41 = add nsw i32 %add40, %3
+  %sub43 = add nsw i32 %add41, 17
+  %and44 = lshr i32 %mantissa.0, 21
+  %4 = and i32 %and44, 1
+  %sext = add nuw nsw i32 %4, 2097151
+  %cond51 = select i1 %cmp24, i32 %sext, i32 0
+  %cond54 = add nuw nsw i32 %cond51, %mantissa.0
+  %and55 = and i32 %cond54, 2097151
+  %add56 = add nuw nsw i32 %and55, %mantissa.0
+  %cmp57 = icmp ne i32 %sub43, 0
+  %and58 = and i32 %add56, 8388608
+  %tobool59.not = icmp eq i32 %and58, 0
+  %or.cond133 = select i1 %cmp57, i1 true, i1 %tobool59.not
+  br i1 %or.cond133, label %if.else61, label %if.end76
+
+if.else61:
+  %tobool63.not = icmp ugt i32 %add56, 16777215
+  %inc = add nsw i32 %add41, 18
+  %f8_exponent.0 = select i1 %tobool63.not, i32 %inc, i32 %sub43
+  %cmp69 = icmp sgt i32 %f8_exponent.0, 31
+  br i1 %cmp69, label %if.then70, label %if.end71
+
+if.then70:
+  %5 = trunc i32 %1 to i8
+  %conv = or i8 %5, 127
+  br label %cleanup91
+
+if.end71:
+  %shr65 = zext i1 %tobool63.not to i32
+  %mantissa.1 = lshr i32 %add56, %shr65
+  %cmp72 = icmp eq i32 %f8_exponent.0, 0
+  %cmp74 = icmp ult i32 %mantissa.1, 2097152
+  %or.cond = select i1 %cmp72, i1 %cmp74, i1 false
+  br i1 %or.cond, label %cleanup91, label %if.end76
+
+if.end76:
+  %f8_exponent.0150160 = phi i32 [ %f8_exponent.0, %if.end71 ], [ 1, %if.end7 ]
+  %shr68152159.in = phi i32 [ %mantissa.1, %if.end71 ], [ %add56, %if.end7 ]
+  %shr68152159 = lshr i32 %shr68152159.in, 21
+  %and77 = and i32 %shr68152159, 3
+  %shl79 = shl nsw i32 %f8_exponent.0150160, 2
+  %or = or i32 %shl79, %shl
+  %or80 = or i32 %or, %and77
+  %conv81 = trunc i32 %or80 to i8
+  br label %cleanup91
+
+cleanup91:
+  %retval.1 = phi i8 [ -128, %entry ], [ 0, %if.end ], [ %conv, %if.then70 ], [ %conv81, %if.end76 ], [ 0, %if.end71 ]
+  ret i8 %retval.1
+}
+
+declare i32 @llvm.umin.i32(i32, i32)

--- a/mlir/include/mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h
+++ b/mlir/include/mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h
@@ -18,11 +18,17 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+class FlatSymbolRefAttr;
 
 #define GEN_PASS_DECL_EMULATEFP8EXTTRUNCPASS
 #include "mlir/Conversion/RocMLIRPasses.h.inc"
 
-void addEmulateFp8ExtTruncPatterns(RewritePatternSet &patterns);
+// The arguments are functions for converting a float (fp32) to the relevant
+// type. If the attribute is `nullptr`, then that truncation pattern is
+// disabled.
+void addEmulateFp8ExtTruncPatterns(RewritePatternSet &patterns,
+                                   FlatSymbolRefAttr f8E4M3FNUZTruncFunc,
+                                   FlatSymbolRefAttr f8E5M2FNUZTruncFunc);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h
+++ b/mlir/include/mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h
@@ -1,4 +1,4 @@
-//===-- Fp8ExtToTables pass declarations ----------------*- C++ -*-===//
+//===-- EmulateFp8ExtTrunc pass declarations ----------------*- C++ -*-===//
 //
 // Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
 // Exceptions. See https://llvm.org/LICENSE.txt for license information.
@@ -11,18 +11,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_CONVERSION_FP8EXTTOTABLES_FP8EXTTOTABLES_H
-#define MLIR_CONVERSION_FP8EXTTOTABLES_FP8EXTTOTABLES_H
+#ifndef MLIR_CONVERSION_EMULATEFP8EXTTRUNC_EMULATEFP8EXTTRUNC_H
+#define MLIR_CONVERSION_EMULATEFP8EXTTRUNC_EMULATEFP8EXTTRUNC_H
 
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
 
-#define GEN_PASS_DECL_FP8EXTTOTABLESPASS
+#define GEN_PASS_DECL_EMULATEFP8EXTTRUNCPASS
 #include "mlir/Conversion/RocMLIRPasses.h.inc"
 
-void addFp8ExtToTablesPatterns(RewritePatternSet &patterns);
+void addEmulateFp8ExtTruncPatterns(RewritePatternSet &patterns);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/RocMLIRPasses.h
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.h
@@ -9,7 +9,7 @@
 #ifndef MLIR_CONVERSION_ROCMLIRPASSES_H
 #define MLIR_CONVERSION_ROCMLIRPASSES_H
 
-#include "mlir/Conversion/Fp8ExtToTables/Fp8ExtToTables.h"
+#include "mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h"
 #include "mlir/Conversion/GPUToMIGraphX/GPUToMIGraphX.h"
 #include "mlir/Conversion/MIGraphXToTosa/MIGraphXToTosa.h"
 #include "mlir/Conversion/Passes.h"

--- a/mlir/include/mlir/Conversion/RocMLIRPasses.td
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.td
@@ -88,10 +88,15 @@ def GPUToMIGraphXPass : Pass<"gpu-to-migraphx", "::mlir::func::FuncOp"> {
 //===----------------------------------------------------------------------===//
 
 def EmulateFp8ExtTruncPass : Pass<"emulate-fp8-ext-trunc"> {
-  let summary = "Lower arith.extf on fp8 types to table lookup";
+  let summary = "Emulate arith.extf/truncf on fp8 types";
   let description = [{
-    Pass that converts arith.extf on 8-bit float types to a lookup in a
-    constant table.
+    Pass that emulates arith.extf and arith.truncf on 8-bit float types
+    so as to allow testing on non-MI-300 platforms.
+
+    arith.extf is converted into lookups in a table generated at
+    code generation-time.
+
+    arith.truncf gets converted to calls to functions which this pass inserts.
 
     This is a quick implementation that provides the mimimal functionality to
     test 8-bit float kernels.
@@ -102,6 +107,8 @@ def EmulateFp8ExtTruncPass : Pass<"emulate-fp8-ext-trunc"> {
 
   let dependentDialects = [
     "arith::ArithDialect",
+    "cf::ControlFlowDialect",
+    "func::FuncDialect",
     "memref::MemRefDialect",
     "vector::VectorDialect",
   ];

--- a/mlir/include/mlir/Conversion/RocMLIRPasses.td
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.td
@@ -84,10 +84,10 @@ def GPUToMIGraphXPass : Pass<"gpu-to-migraphx", "::mlir::func::FuncOp"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Fp8ExtToTables
+// EmulateFp8ExtTrunc
 //===----------------------------------------------------------------------===//
 
-def Fp8ExtToTablesPass : Pass<"fp8-ext-to-tables"> {
+def EmulateFp8ExtTruncPass : Pass<"emulate-fp8-ext-trunc"> {
   let summary = "Lower arith.extf on fp8 types to table lookup";
   let description = [{
     Pass that converts arith.extf on 8-bit float types to a lookup in a

--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -4,7 +4,7 @@
 #add_subdirectory(AVX512ToLLVM)
 #add_subdirectory(ComplexToLLVM)
 #add_subdirectory(GPUCommon)
-add_subdirectory(Fp8ExtToTables)
+add_subdirectory(EmulateFp8ExtTrunc)
 add_subdirectory(GPUToMIGraphX)
 #add_subdirectory(GPUToNVVM)
 #add_subdirectory(GPUToROCDL)

--- a/mlir/lib/Conversion/EmulateFp8ExtTrunc/CMakeLists.txt
+++ b/mlir/lib/Conversion/EmulateFp8ExtTrunc/CMakeLists.txt
@@ -16,6 +16,8 @@ target_link_libraries(RocmlirEmulateFp8ExtTrunc
   MLIRTransformUtils
   MLIRSupport
   MLIRArithDialect
+  MLIRControlFlowDialect
+  MLIRFuncDialect
   MLIRMemRefDialect
   MLIRVectorDialect
 )

--- a/mlir/lib/Conversion/EmulateFp8ExtTrunc/CMakeLists.txt
+++ b/mlir/lib/Conversion/EmulateFp8ExtTrunc/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_rocmlir_conversion_library(RocmlirFp8ExtToTables
-  Fp8ExtToTables.cpp
+add_rocmlir_conversion_library(RocmlirEmulateFp8ExtTrunc
+  EmulateFp8ExtTrunc.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Arith
@@ -9,7 +9,7 @@ add_rocmlir_conversion_library(RocmlirFp8ExtToTables
   RocMLIRConversionPassIncGen
 )
 
-target_link_libraries(RocmlirFp8ExtToTables
+target_link_libraries(RocmlirEmulateFp8ExtTrunc
   PUBLIC
   MLIRIR
   MLIRPass

--- a/mlir/lib/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.cpp
+++ b/mlir/lib/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.cpp
@@ -14,15 +14,21 @@
 #include "mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace mlir {
@@ -49,6 +55,22 @@ struct Fp8ExtToTableLookupPattern final : public OpConversionPattern<ExtFOp> {
   void rewrite(ExtFOp op, OpAdaptor adaptor,
                ConversionPatternRewriter &rewriter) const override;
 };
+
+struct Fp8TruncToCallPattern final : public OpConversionPattern<TruncFOp> {
+  FlatSymbolRefAttr f8E4M3FNUZFunc;
+  FlatSymbolRefAttr f8E5M2FNUZFunc;
+
+  // The functions are optional - if they aren't provided for a type (the null
+  // attribute is sent in) the pattern will not apply.
+  Fp8TruncToCallPattern(MLIRContext *ctx, FlatSymbolRefAttr f8E4M3FNUZFunc,
+                        FlatSymbolRefAttr f8E5M2FNUZFunc)
+      : OpConversionPattern<TruncFOp>::OpConversionPattern(ctx),
+        f8E4M3FNUZFunc(f8E4M3FNUZFunc), f8E5M2FNUZFunc(f8E5M2FNUZFunc) {}
+
+  LogicalResult match(TruncFOp op) const override;
+  void rewrite(TruncFOp op, OpAdaptor adaptor,
+               ConversionPatternRewriter &rewriter) const override;
+};
 } // namespace
 
 static bool isFp8(Type t) {
@@ -56,20 +78,16 @@ static bool isFp8(Type t) {
          t.isFloat8E4M3FNUZ();
 }
 
-static LogicalResult canRewriteToTable(ExtFOp op) {
-  Type inType = op.getIn().getType();
-  Type inElemType = getElementTypeOrSelf(inType);
-  if (!isFp8(inElemType))
+static LogicalResult canBeConverted(Type t) {
+  if (!isFp8(getElementTypeOrSelf(t)))
     return failure();
-  if (isa<FloatType>(inType))
-    return success();
-  if (auto vecType = dyn_cast<VectorType>(inType))
+  if (auto vecType = dyn_cast<VectorType>(t))
     return success(vecType.hasStaticShape());
-  return failure();
+  return success();
 }
 
 LogicalResult Fp8ExtToTableLookupPattern::match(ExtFOp op) const {
-  return canRewriteToTable(op);
+  return canBeConverted(op.getIn().getType());
 }
 
 static Value getFloatValueTableFor(Type elementType, Operation *op,
@@ -129,13 +147,11 @@ void Fp8ExtToTableLookupPattern::rewrite(
 
   Value table = getFloatValueTableFor(elemType, op, rewriter);
   auto oneToFloat = [&](Value fp8) -> Value {
-    Value bitcast =
-        rewriter.create<arith::BitcastOp>(loc, rewriter.getI8Type(), fp8);
+    Value bitcast = rewriter.create<BitcastOp>(loc, rewriter.getI8Type(), fp8);
     // Don't sign-extend the byte when index casting.
-    Value i32 =
-        rewriter.create<arith::ExtUIOp>(loc, rewriter.getI32Type(), bitcast);
+    Value i32 = rewriter.create<ExtUIOp>(loc, rewriter.getI32Type(), bitcast);
     Value index =
-        rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(), i32);
+        rewriter.create<IndexCastOp>(loc, rewriter.getIndexType(), i32);
     Value extended = rewriter.create<memref::LoadOp>(loc, table, index);
     return extended;
   };
@@ -144,9 +160,9 @@ void Fp8ExtToTableLookupPattern::rewrite(
     if (outElemType.isF32())
       return floats;
     if (outElemType.getIntOrFloatBitWidth() < 32)
-      return rewriter.create<arith::TruncFOp>(loc, outType, floats);
+      return rewriter.create<TruncFOp>(loc, outType, floats);
     if (outElemType.getIntOrFloatBitWidth() > 32)
-      return rewriter.create<arith::ExtFOp>(loc, outType, floats);
+      return rewriter.create<ExtFOp>(loc, outType, floats);
     llvm_unreachable("f32 is the only 32-bit float type");
   };
   auto inVecType = dyn_cast<VectorType>(inType);
@@ -157,8 +173,8 @@ void Fp8ExtToTableLookupPattern::rewrite(
   VectorType floatVecType = inVecType.clone(f32);
   Value floats = rewriter.createOrFold<vector::SplatOp>(
       loc,
-      rewriter.createOrFold<arith::ConstantOp>(loc, f32,
-                                               rewriter.getF32FloatAttr(0.0f)),
+      rewriter.createOrFold<ConstantOp>(loc, f32,
+                                        rewriter.getF32FloatAttr(0.0f)),
       floatVecType);
   SmallVector<int64_t> strides = computeStrides(inVecType.getShape());
   for (int64_t i = 0, e = inVecType.getNumElements(); i < e; ++i) {
@@ -172,8 +188,255 @@ void Fp8ExtToTableLookupPattern::rewrite(
   return rewriter.replaceOp(op, ret);
 }
 
-void mlir::addEmulateFp8ExtTruncPatterns(RewritePatternSet &patterns) {
+/// Creates a function that trunctates input floats to the 8-bit `ooutTYpe`,
+/// where `outType` is one of the NANOO float types (f8E4M3FNUZ or f8E5M2FNUZ),
+/// and inserts it into `module`, returning a reference to the inserted
+/// function.
+///
+/// This truncation saturates: values too large in absolute value to be
+/// represented by the maximum value of `outType` are clamped into `outType`'s
+/// range instead of being rounded to NaN.
+///
+/// Based off
+/// https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/a41cd5c0b493bbb7d21078f1a842675ff824d2b7/src/include/migraphx/float8_impl.hpp#L37
+/// but trimmed (Clip = true, NegativeZeroNan = true) and run through
+/// clang -O3 on godbolt to get LLVM IR that I could mechanically recreate.
+/// See mlir/docs/fnuz-float-software-truncation-sources/
+/// for the inputs to and outputs of this process.
+static FlatSymbolRefAttr makeFp8TruncFunction(Location loc, FloatType outType,
+                                              Operation *module) {
+  ImplicitLocOpBuilder b(loc, loc.getContext());
+  SymbolTable symtab(module);
+
+  SmallString<32> funcName;
+  (Twine("_rocmlir_trunc_f32_to_") +
+   (TypeSwitch<FloatType, StringRef>(outType)
+        .Case<Float8E4M3FNUZType>(
+            [](auto ignored) -> StringRef { return "f8E4M3FNUZ"; })
+        .Case<Float8E5M2FNUZType>(
+            [](auto ignored) -> StringRef { return "f8E5M2FNUZ"; })
+        .Default([](auto ignored) -> StringRef { return "unknownERROR"; })))
+      .toVector(funcName);
+  auto func = func::FuncOp::create(
+      loc, funcName, b.getFunctionType({b.getF32Type()}, {outType}));
+  StringAttr realFuncName = symtab.insert(func);
+  auto symbolRef = FlatSymbolRefAttr::get(realFuncName);
+  symtab.setSymbolVisibility(func, SymbolTable::Visibility::Private);
+
+  Block *entry = func.addEntryBlock();
+  b.setInsertionPointToStart(entry);
+  Value in = entry->getArgument(0);
+
+  Type i32 = b.getI32Type();
+  Type i8 = b.getI8Type();
+  auto i32Const = [&](uint32_t value) -> Value {
+    return b.createOrFold<ConstantOp>(i32, b.getI32IntegerAttr(value));
+  };
+  // Created here so we can branch to it, will be inserted last
+  Block *ret = new Block();
+  ret->addArgument(outType, loc);
+
+  Value bits = b.create<BitcastOp>(i32, in);
+  const llvm::fltSemantics &outSem = outType.getFloatSemantics();
+
+  Value and1 = b.create<AndIOp>(bits, i32Const((1u << 23u) - 1));
+  Value shr = b.create<ShRUIOp>(bits, i32Const(23));
+  Value and2 = b.create<AndIOp>(shr, i32Const(0xff));
+  Value ir1 = b.create<ShRUIOp>(bits, i32Const(24));
+  Value shl = b.create<AndIOp>(ir1, i32Const(128));
+  Value infNanConst = i32Const(0x7f800000);
+  Value and4 = b.create<AndIOp>(bits, infNanConst);
+  Value cmp = b.create<CmpIOp>(CmpIPredicate::eq, and4, infNanConst);
+
+  Block *notInfNan = func.addBlock();
+  Value outNan = b.create<ConstantFloatOp>(APFloat::getQNaN(outSem), outType);
+  b.create<cf::CondBranchOp>(cmp, ret, ValueRange{outNan}, notInfNan,
+                             ValueRange{});
+  b.setInsertionPointToStart(notInfNan);
+
+  // A deviation from the MIGraphX: denormals are zero here
+  Value cmp5 = b.create<CmpIOp>(CmpIPredicate::eq, and2, i32Const(0));
+  Value outZero = b.create<ConstantFloatOp>(APFloat::getZero(outSem), outType);
+  Block *notZero = func.addBlock();
+  b.create<cf::CondBranchOp>(cmp5, ret, ValueRange{outZero}, notZero,
+                             ValueRange{});
+  b.setInsertionPointToStart(notZero);
+
+  // For some reason, this is off by one
+  uint32_t mBits = outType.getFPMantissaWidth() - 1;
+  uint32_t eBits = 7 - mBits;
+  Value sub = b.create<AddIOp>(and2, i32Const(-127));
+  Value reducedConst1 = i32Const(127 - ((1 << (eBits - 1)) - 2));
+  Value cmp8 = b.create<CmpIOp>(CmpIPredicate::ult, and2, reducedConst1);
+  Value reducedConst2 = i32Const(127 - ((1 << (eBits - 1)) - 1));
+  Value sub10 = b.create<SubIOp>(reducedConst2, and2);
+  Value exponentDiff0 = b.create<SelectOp>(cmp8, sub10, i32Const(0));
+
+  Value add12 = b.create<OrIOp>(and1, i32Const(1 << 23));
+  Value ir2 = b.create<MinUIOp>(exponentDiff0, i32Const(15 - eBits));
+  Value notmaskConst = i32Const(~((1 << (16 + eBits)) - 1));
+  Value notmask = b.create<ShLIOp>(notmaskConst, ir2);
+  Value sub16 = b.create<XOrIOp>(notmask, i32Const(-1));
+  Value and17 = b.create<AndIOp>(add12, sub16);
+  Value sub21 = b.create<AddIOp>(exponentDiff0, i32Const(15 + eBits));
+  Value sroaSpeculataed140 = b.create<MinUIOp>(sub21, i32Const(31));
+  Value shl23 = b.create<ShLIOp>(i32Const(1), sroaSpeculataed140);
+  Value cmp24 = b.create<CmpIOp>(CmpIPredicate::eq, and17, shl23);
+  Value cmp25 =
+      b.create<CmpIOp>(CmpIPredicate::sgt, exponentDiff0, i32Const(0));
+  Value sroaSpeculated = b.create<MinUIOp>(exponentDiff0, i32Const(31));
+  Value shr30 = b.create<SelectOp>(cmp25, sroaSpeculated, i32Const(0));
+  Value mantissa0 = b.create<ShRUIOp>(add12, shr30);
+
+  Value add40 = b.create<AddIOp>(sub, exponentDiff0);
+  Value and38 = b.create<ShRUIOp>(mantissa0, i32Const(23));
+  Value ir3 = b.create<OrIOp>(and38, i32Const(-2));
+  Value add41 = b.create<AddIOp>(add40, ir3);
+  Value sub43 = b.create<AddIOp>(add41, i32Const((1 << (eBits - 1)) + 1));
+  Value and44 = b.create<ShRUIOp>(mantissa0, i32Const(16 + eBits));
+  Value ir4 = b.create<AndIOp>(and44, i32Const(1));
+  Value resolvedConst3 = i32Const((1 << (16 + eBits)) - 1);
+  Value sext = b.create<AddIOp>(ir4, resolvedConst3);
+  Value cond51 = b.create<SelectOp>(cmp24, sext, i32Const(0));
+  Value cond54 = b.create<AddIOp>(cond51, mantissa0);
+  Value and55 = b.create<AndIOp>(cond54, resolvedConst3);
+  Value add56 = b.create<AddIOp>(and55, mantissa0);
+  Value cmp57 = b.create<CmpIOp>(CmpIPredicate::ne, sub43, i32Const(0));
+  Value and58 = b.create<AndIOp>(add56, i32Const(1 << 23));
+  Value tobool59Not = b.create<CmpIOp>(CmpIPredicate::eq, and58, i32Const(0));
+  Value trueConst = b.create<ConstantIntOp>(true, 1);
+  Value brCond133 = b.create<SelectOp>(cmp57, trueConst, tobool59Not);
+
+  Block *ifElse61 = func.addBlock();
+  Block *ifThen70 = func.addBlock();
+  Block *ifEnd71 = func.addBlock();
+  Block *ifEnd76 = func.addBlock();
+  ifEnd76->addArguments({i32, i32}, {loc, loc});
+  Value oneConst = i32Const(1);
+  b.create<cf::CondBranchOp>(brCond133, ifElse61, ValueRange{}, ifEnd76,
+                             ValueRange{oneConst, add56});
+
+  b.setInsertionPointToStart(ifElse61);
+  Value tobool63Not =
+      b.create<CmpIOp>(CmpIPredicate::ugt, add56, i32Const((1 << 24) - 1));
+  Value incConst = i32Const((1 << (eBits - 1)) + 2);
+  Value inc = b.create<AddIOp>(add41, incConst);
+  Value f8Exponent0 = b.create<SelectOp>(tobool63Not, inc, sub43);
+  Value cmp69 = b.create<CmpIOp>(CmpIPredicate::sgt, f8Exponent0,
+                                 i32Const((1 << eBits) - 1));
+  b.create<cf::CondBranchOp>(cmp69, ifThen70, ValueRange{}, ifEnd71,
+                             ValueRange{});
+
+  b.setInsertionPointToStart(ifThen70);
+  Value ir5 = b.create<TruncIOp>(i8, ir1);
+  Value conv =
+      b.create<OrIOp>(ir5, b.create<ConstantIntOp>(127, b.getI8Type()));
+  Value convOut = b.create<BitcastOp>(outType, conv);
+  b.create<cf::BranchOp>(ret, convOut);
+
+  b.setInsertionPointToStart(ifEnd71);
+  Value shr65 = b.create<ExtUIOp>(i32, tobool63Not);
+  Value mantissa1 = b.create<ShRUIOp>(add56, shr65);
+  Value cmp72 = b.create<CmpIOp>(CmpIPredicate::eq, f8Exponent0, i32Const(0));
+  Value cmp74 = b.create<CmpIOp>(CmpIPredicate::ult, mantissa1,
+                                 i32Const(1 << (16 + eBits)));
+  Value falseConst = b.create<ConstantIntOp>(false, 1);
+  Value brCond = b.create<SelectOp>(cmp72, cmp74, falseConst);
+  b.create<cf::CondBranchOp>(brCond, ret, ValueRange{outZero}, ifEnd76,
+                             ValueRange{f8Exponent0, mantissa1});
+
+  b.setInsertionPointToStart(ifEnd76);
+  Value f8Exponent015 = ifEnd76->getArgument(0);
+  Value shr681In = ifEnd76->getArgument(1);
+  Value shr681 = b.create<ShRUIOp>(shr681In, i32Const(16 + eBits));
+  Value and77 = b.create<AndIOp>(shr681, i32Const((1 << mBits) - 1));
+  Value shl79 = b.create<ShLIOp>(f8Exponent015, i32Const(mBits));
+  Value irOr = b.create<OrIOp>(shl79, shl);
+  Value or80 = b.create<OrIOp>(irOr, and77);
+  Value conv81 = b.create<TruncIOp>(i8, or80);
+  Value conv81Out = b.create<BitcastOp>(outType, conv81);
+  b.create<cf::BranchOp>(ret, ValueRange{conv81Out});
+
+  func.push_back(ret);
+  b.setInsertionPointToStart(ret);
+  Value retVal = ret->getArgument(0);
+  b.create<func::ReturnOp>(retVal);
+
+  return symbolRef;
+}
+
+LogicalResult Fp8TruncToCallPattern::match(TruncFOp op) const {
+  if (failed(canBeConverted(op.getResult().getType())))
+    return failure();
+  Type resType = getElementTypeOrSelf(op.getOut().getType());
+  if (resType.isFloat8E4M3FN() && !f8E4M3FNUZFunc)
+    return failure();
+  if (resType.isFloat8E5M2FNUZ() && !f8E5M2FNUZFunc)
+    return failure();
+  return success();
+}
+
+static Type cloneOrReplace(Type t, Type newElementType) {
+  if (auto shaped = dyn_cast<ShapedType>(t))
+    return shaped.clone(newElementType);
+  return newElementType;
+}
+
+void Fp8TruncToCallPattern::rewrite(TruncFOp op, OpAdaptor adaptor,
+                                    ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+  Value rawIn = adaptor.getIn();
+  Type rawInType = rawIn.getType();
+  Type rawInElemType = getElementTypeOrSelf(rawInType);
+  Type outType = op.getOut().getType();
+  FloatType outElemType = cast<FloatType>(getElementTypeOrSelf(outType));
+
+  FlatSymbolRefAttr func = TypeSwitch<Type, FlatSymbolRefAttr>(outElemType)
+                               .Case<Float8E4M3FNUZType>(
+                                   [&](auto ignored) { return f8E4M3FNUZFunc; })
+                               .Case<Float8E5M2FNUZType>(
+                                   [&](auto ignored) { return f8E5M2FNUZFunc; })
+                               .Default([](auto ignored) { return nullptr; });
+
+  auto oneToOut = [&](Value f32) -> Value {
+    auto call = rewriter.create<func::CallOp>(loc, func, outElemType, f32);
+    return call.getResult(0);
+  };
+
+  Type inType = cloneOrReplace(rawInType, rewriter.getF32Type());
+  Value in = rawIn;
+  if (rawInElemType.getIntOrFloatBitWidth() < 32)
+    in = rewriter.create<arith::ExtFOp>(loc, inType, rawIn);
+  else if (rawInElemType.getIntOrFloatBitWidth() > 32)
+    in = rewriter.create<arith::TruncFOp>(loc, inType, rawIn);
+
+  auto inVecType = dyn_cast<VectorType>(inType);
+  if (!inVecType)
+    return rewriter.replaceOp(op, oneToOut(in));
+
+  VectorType retVecType = inVecType.clone(outElemType);
+  Value rets = rewriter.createOrFold<vector::SplatOp>(
+      loc,
+      rewriter.createOrFold<ConstantFloatOp>(
+          loc, APFloat::getZero(outElemType.getFloatSemantics()), outElemType),
+      retVecType);
+  SmallVector<int64_t> strides = computeStrides(inVecType.getShape());
+  for (int64_t i = 0, e = inVecType.getNumElements(); i < e; ++i) {
+    SmallVector<int64_t> idx = delinearize(i, strides);
+    Value scalar =
+        rewriter.create<vector::ExtractOp>(loc, adaptor.getIn(), idx);
+    Value truncated = oneToOut(scalar);
+    rets = rewriter.create<vector::InsertOp>(loc, truncated, rets, idx);
+  }
+  return rewriter.replaceOp(op, rets);
+}
+
+void mlir::addEmulateFp8ExtTruncPatterns(
+    RewritePatternSet &patterns, FlatSymbolRefAttr f8E4M3FNUZTruncFunc,
+    FlatSymbolRefAttr f8E5M2FNUZTruncFunc) {
   patterns.add<Fp8ExtToTableLookupPattern>(patterns.getContext());
+  patterns.add<Fp8TruncToCallPattern>(patterns.getContext(),
+                                      f8E4M3FNUZTruncFunc, f8E5M2FNUZTruncFunc);
 }
 
 void EmulateFp8ExtTruncPass::runOnOperation() {
@@ -187,12 +450,37 @@ void EmulateFp8ExtTruncPass::runOnOperation() {
 
   MLIRContext *ctx = &getContext();
   ConversionTarget target(getContext());
-  target.addLegalDialect<arith::ArithDialect, memref::MemRefDialect,
-                         vector::VectorDialect>();
+  target.addLegalDialect<arith::ArithDialect, func::FuncDialect,
+                         memref::MemRefDialect, vector::VectorDialect>();
   target.addDynamicallyLegalOp<arith::ExtFOp>(
-      [](ExtFOp op) { return failed(canRewriteToTable(op)); });
+      [](ExtFOp op) { return failed(canBeConverted(op.getIn().getType())); });
+  target.addDynamicallyLegalOp<arith::TruncFOp>([](TruncFOp op) {
+    return failed(canBeConverted(op.getOut().getType()));
+  });
+
+  FlatSymbolRefAttr f8E4M3FNUZTruncFunc = nullptr;
+  FlatSymbolRefAttr f8E5M2FNUZTruncFunc = nullptr;
+  SmallVector<Location> f8E4M3FNUZLocs, f8E5M2FNUZLocs;
+  op->walk([&](TruncFOp op) {
+    Type outElemType = getElementTypeOrSelf(op.getOut().getType());
+    if (outElemType.isFloat8E4M3FNUZ())
+      f8E4M3FNUZLocs.push_back(op->getLoc());
+    else if (outElemType.isFloat8E5M2FNUZ())
+      f8E5M2FNUZLocs.push_back(op->getLoc());
+  });
+
+  if (!f8E4M3FNUZLocs.empty()) {
+    f8E4M3FNUZTruncFunc = makeFp8TruncFunction(
+        FusedLoc::get(ctx, f8E4M3FNUZLocs), Float8E4M3FNUZType::get(ctx), op);
+  }
+  if (!f8E5M2FNUZLocs.empty()) {
+    f8E5M2FNUZTruncFunc = makeFp8TruncFunction(
+        FusedLoc::get(ctx, f8E5M2FNUZLocs), Float8E5M2FNUZType::get(ctx), op);
+  }
+
   RewritePatternSet rewrites(ctx);
-  addEmulateFp8ExtTruncPatterns(rewrites);
+  addEmulateFp8ExtTruncPatterns(rewrites, f8E4M3FNUZTruncFunc,
+                                f8E5M2FNUZTruncFunc);
   if (failed(applyPartialConversion(op, target, std::move(rewrites))))
     return signalPassFailure();
 }

--- a/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
@@ -17,7 +17,7 @@ add_rocmlir_dialect_library(MLIRRockPipeline
   MLIRRockOps
   MLIRRockTransforms
   MLIRRockUtility
-  RocmlirFp8ExtToTables
+  RocmlirEmulateFp8ExtTrunc
 
   # Upstream dialect libraries we need to load that we don't directly depend on
   MLIRBufferizationTransformOps

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -22,7 +22,7 @@
 
 #include "mlir/Dialect/Rock/Pipelines/Pipelines.h"
 #include "mlir/Conversion/ArithToAMDGPU/ArithToAMDGPU.h"
-#include "mlir/Conversion/Fp8ExtToTables/Fp8ExtToTables.h"
+#include "mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h"
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Conversion/RockToGPU/RockToGPU.h"
@@ -179,7 +179,7 @@ void rock::buildBackendPipeline(OpPassManager &pm,
   // Leave off --convert-arith-to-amdgpu if not targetting gfx94x+.
   /* rocmlir-opt --strip-debuginfo
    *   --convert-arith-to-amdgpu
-   *   --fp8-ext-to-tables
+   *   --emulate-fp8-ext-trunc
    *   "--amdgpu-emulate-atomics=chipset=$chip"
    *   --arith-emulate-unsupported-floats="source-types=bf16 target-type=f32"
    *   "--convert-gpu-to-rocdl=chipset=$chip index-bitwidth=32"
@@ -201,7 +201,7 @@ void rock::buildBackendPipeline(OpPassManager &pm,
     gpuPm.addPass(createArithToAMDGPUConversionPass(options));
     gpuPm.addPass(createArithToAMDGPUConversionPass());
   } else {
-    gpuPm.addPass(createFp8ExtToTablesPass());
+    gpuPm.addPass(createEmulateFp8ExtTruncPass());
   }
   gpuPm.addPass(memref::createExpandStridedMetadataPass());
   // We need to lower affine again, because the expand strided metadata pass
@@ -225,7 +225,7 @@ void rock::buildBackendPipeline(OpPassManager &pm,
   // Quick hack around the facct that our host code runner pipeline can't
   // include our fp8 extf implmenentation becasue of MHAL's organization. That
   // pass will ideally be nicely implemented and upstreamed Later (tm).
-  pm.addPass(createFp8ExtToTablesPass());
+  pm.addPass(createEmulateFp8ExtTruncPass());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Conversion/EmulateFp8ExtTrunc/Integration/lit.local.cfg
+++ b/mlir/test/Conversion/EmulateFp8ExtTrunc/Integration/lit.local.cfg
@@ -1,0 +1,4 @@
+# This'll run whenever we're not building a fat library build, and isn't
+# controlled by the e2e test switches.
+if not config.enable_rock_driver_any_e2e_test or config.no_AMD_GPU:
+  config.unsupported = True

--- a/mlir/test/Conversion/EmulateFp8ExtTrunc/Integration/roundtrip.mlir
+++ b/mlir/test/Conversion/EmulateFp8ExtTrunc/Integration/roundtrip.mlir
@@ -1,0 +1,103 @@
+// COM: This is a host-side test and doesn't require a GPU
+// RUN: sed -e 's/##TYPE##/f8E4M3FNUZ/g' %s | \
+// RUN: rocmlir-opt -emulate-fp8-ext-trunc - | \
+// RUN: rocmlir-driver --host-pipeline=runner | \
+// RUN: mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | \
+// RUN: FileCheck %s --check-prefixes=CHECK,F8E4M3FNUZ
+
+// RUN: sed -e 's/##TYPE##/f8E5M2FNUZ/g' %s | \
+// RUN: rocmlir-opt -emulate-fp8-ext-trunc - | \
+// RUN: rocmlir-driver --host-pipeline=runner | \
+// RUN: mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | \
+// RUN: FileCheck %s --check-prefixes=CHECK,F8E5M2FNUZ
+
+func.func private @printCString(!llvm.ptr) -> ()
+func.func private @printI64(i64) -> ()
+func.func private @printF32(f32) -> ()
+func.func private @printNewline() -> ()
+func.func private @printComma() -> ()
+
+func.func @testTruncExt(%id : i64, %input: f32) {
+  %truncated = arith.truncf %input : f32 to ##TYPE##
+  %expanded = arith.extf %truncated : ##TYPE## to f32
+  call @printI64(%id) : (i64) -> ()
+  call @printComma() : () -> ()
+  call @printF32(%expanded) : (f32) -> ()
+  call @printNewline() : () -> ()
+  return
+}
+
+llvm.mlir.global internal constant @strFail("FAIL: ")
+func.func @printFail(%wanted : i8, %got : i8, %intermediate : f32) {
+  %strFail = llvm.mlir.addressof @strFail : !llvm.ptr
+  call @printCString(%strFail) : (!llvm.ptr) -> ()
+  %wantedExt = arith.extui %wanted : i8 to i64
+  %gotExt = arith.extui %got : i8 to i64
+  call @printI64(%wantedExt) : (i64) -> ()
+  call @printComma() : () -> ()
+  call @printI64(%gotExt) : (i64) -> ()
+  call @printComma() : () -> ()
+  call @printF32(%intermediate) : (f32) -> ()
+  call @printNewline() : () -> ()
+  return
+}
+
+func.func @testAllExtTrunc() {
+  %idx0 = arith.constant 0 : index
+  %idx1 = arith.constant 1 : index
+  %idx256 = arith.constant 256 : index
+
+  scf.for %idxI = %idx0 to %idx256 step %idx1 {
+    %i = arith.index_cast %idxI : index to i8
+    %iF8 = arith.bitcast %i : i8 to ##TYPE##
+    %iFloat = arith.extf %iF8 : ##TYPE## to f32
+    %oF8 = arith.truncf %iFloat : f32 to ##TYPE##
+    %o = arith.bitcast %oF8 : ##TYPE## to i8
+    %mismatch = arith.cmpi ne, %i, %o : i8
+    scf.if %mismatch {
+      func.call @printFail(%i, %o, %iFloat) : (i8, i8, f32) -> ()
+    }
+  }
+  return
+}
+
+func.func @main() {
+  %id0 = arith.constant 0 : i64
+  %in0 = arith.constant 0.0 : f32
+  // CHECK: 0, 0
+  call @testTruncExt(%id0, %in0) : (i64, f32) -> ()
+
+  %id1 = arith.constant 1 : i64
+  %in1 = arith.constant -0.0 : f32
+  // CHECK: 1, 0
+  call @testTruncExt(%id1, %in1) : (i64, f32) -> ()
+
+  %id2 = arith.constant 2 : i64
+  %in2 = arith.constant 0x7f800000  : f32
+  // CHECK: 2, nan
+  call @testTruncExt(%id2, %in2) : (i64, f32) -> ()
+
+  %id3 = arith.constant 3 : i64
+  // COM: Largest e5m2
+  %in3 = arith.constant 57344.0 : f32
+  // F8E5M2FNUZ: 3, 57344
+  // F8E4M3FNUZ: 3, 240
+  call @testTruncExt(%id3, %in3) : (i64, f32) -> ()
+
+  %id4 = arith.constant 4 : i64
+  %in4 = arith.constant -57344.0 : f32
+  // F8E5M2FNUZ: 4, -57344
+  // F8E4M3FNUZ: 4, -240
+  call @testTruncExt(%id4, %in4) : (i64, f32) -> ()
+
+  %id5 = arith.constant 5 : i64
+  %in5 = arith.constant 240.0 : f32
+  // COM: Not enough mantissa
+  // F8E5M2FNUZ: 5, 256
+  // F8E4M3FNUZ: 5, 240
+  call @testTruncExt(%id5, %in5) : (i64, f32) -> ()
+
+  // CHECK-NOT: FAIL
+  call @testAllExtTrunc() : () -> ()
+  return
+}

--- a/mlir/test/Conversion/EmulateFp8ExtTrunc/emulate-fp8-ext-trunc.mlir
+++ b/mlir/test/Conversion/EmulateFp8ExtTrunc/emulate-fp8-ext-trunc.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-opt -fp8-ext-to-tables -split-input-file %s | FileCheck %s
+// RUN: rocmlir-opt -emulate-fp8-ext-trunc -split-input-file %s | FileCheck %s
 
 module {
   func.func @ext_scalar(%arg0: f8E5M2FNUZ) -> f16 {

--- a/mlir/test/Conversion/EmulateFp8ExtTrunc/emulate-fp8-ext-trunc.mlir
+++ b/mlir/test/Conversion/EmulateFp8ExtTrunc/emulate-fp8-ext-trunc.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-opt -emulate-fp8-ext-trunc -split-input-file %s | FileCheck %s
+// RUN: rocmlir-opt -pass-pipeline='builtin.module(gpu.module(emulate-fp8-ext-trunc),emulate-fp8-ext-trunc)' -split-input-file %s | FileCheck %s
 
 module {
   func.func @ext_scalar(%arg0: f8E5M2FNUZ) -> f16 {
@@ -14,6 +14,17 @@ module {
     %ret = arith.extf %arg0 : f8E5M2FNUZ to f16
     return %ret : f16
   }
+
+  // CHECK-LABEL: @trunc_scalar
+  // CHECK-SAME: ([[ARG0:%.+]]: f16)
+  func.func @trunc_scalar(%arg0: f16) -> f8E5M2FNUZ {
+    // CHECK: [[EXT:%.+]] = arith.extf [[ARG0]] : f16 to f32
+    // CHECK: [[TRUNC:%.+]] = call @_rocmlir_trunc_f32_to_f8E5M2FNUZ([[EXT]])
+    // CHECK: return [[TRUNC]]
+    %ret = arith.truncf %arg0 : f16 to f8E5M2FNUZ
+    return %ret : f8E5M2FNUZ
+  }
+  // CHECK-LABEL: func.func private @_rocmlir_trunc_f32_to_f8E5M2FNUZ
   // CHECK-LABEL: memref.global "private" constant @__rocmlir_extf_tbl_f8E5M2FNUZ
 }
 
@@ -35,6 +46,17 @@ module {
     %ret = arith.extf %arg0 : vector<2x2xf8E4M3FNUZ> to vector<2x2xf32>
     func.return %ret : vector<2x2xf32>
   }
+  func.func @trunc_vector(%arg0: vector<2x2xf32>) -> vector<2x2xf8E4M3FNUZ> {
+  // CHECK-LABEL: @trunc_vector
+  // CHECK-SAME: ([[ARG0:%.+]]: vector<2x2xf32>)
+  // CHECK: [[RET0:%.+]] = arith.constant dense<0.000000e+00> : vector<2x2xf8E4M3FNUZ>
+  // CHECK: [[IN0:%.+]] = vector.extract [[ARG0]][0, 0]
+  // CHECK: [[TRUNC0:%.+]] = call @_rocmlir_trunc_f32_to_f8E4M3FNUZ([[IN0]])
+  // CHECK: [[RET1:%.+]] = vector.insert [[TRUNC0]], [[RET0]] [0, 0] : f8E4M3FNUZ into vector<2x2xf8E4M3FNUZ>
+  // ...
+    %ret = arith.truncf %arg0 : vector<2x2xf32> to vector<2x2xf8E4M3FNUZ>
+    func.return %ret : vector<2x2xf8E4M3FNUZ>
+  }
 }
 
 // -----
@@ -51,6 +73,27 @@ module attributes {gpu.container_module} {
     // CHECK: gpu.return
     // CHECK-NEXT: }
     // CHECK-NEXT: memref.global "private" constant @__rocmlir_extf_tbl_f8E4M3FNUZ
+    // CHECK-NEXT: }
+    // CHECK-NEXT: }
+  }
+}
+
+// -----
+
+// Test that the function gets inserted inside GPU modules if relevant.
+module attributes {gpu.container_module} {
+  gpu.module @kernel_mod {
+    gpu.func @kernel(%arg0: f64, %arg1: memref<1xf8E4M3FNUZ>) kernel {
+      %c0 = arith.constant 0 : index
+      %ret = arith.truncf %arg0 : f64 to f8E4M3FNUZ
+      memref.store %ret, %arg1[%c0] : memref<1xf8E4M3FNUZ>
+      gpu.return
+    }
+    // CHECK: gpu.return
+    // CHECK-NEXT: }
+    // CHECK-NEXT: func.func private @_rocmlir_trunc_f32_to_f8E4M3FNUZ
+    // CHECK: return
+    // CHECK-NEXT: }
     // CHECK-NEXT: }
     // CHECK-NEXT: }
   }

--- a/mlir/test/rocmlir-driver/pipelines.mlir
+++ b/mlir/test/rocmlir-driver/pipelines.mlir
@@ -38,7 +38,7 @@
 // BINARY-NEXT: {{^}}builtin.module(strip-debuginfo,
 // BINARY-SAME: gpu.module(amdgpu-emulate-atomics{chipset=gfx90a},
 // BINARY-SAME: arith-emulate-unsupported-floats{source-types=bf16,f8E4M3FNUZ,f8E5M2FNUZ target-type=f32},
-// BINARY-SAME: fp8-ext-to-tables,
+// BINARY-SAME: emulate-fp8-ext-trunc,
 // BINARY-SAME: expand-strided-metadata,
 // BINARY-SAME: convert-gpu-to-rocdl{chipset=gfx90a index-bitwidth=0 runtime=HIP use-bare-ptr-memref-call-conv=true use-opaque-pointers=true},
 // BINARY-SAME: llvm.func(canonicalize{  max-iterations=10 max-num-rewrites=-1 region-simplify=true test-convergence=false top-down=true},
@@ -46,7 +46,7 @@
 // BINARY-SAME: rock-prepare-llvm),
 // BINARY-SAME: gpu-to-hsaco{chip=gfx90a dump-ptx=false features= gpu-binary-annotation=gpu.binary opt-level=3 rocm-path= triple=amdgcn-amd-amdhsa},
 // BINARY-SAME: rock-check-residency),
-// BINARY-SAME: fp8-ext-to-tables){{$}}
+// BINARY-SAME: emulate-fp8-ext-trunc){{$}}
 
 // BINARY_MI300: Kernel pipeline:
 // BINARY_MI300-NEXT: {{^}}builtin.module(strip-debuginfo,
@@ -60,7 +60,7 @@
 // BINARY_MI300-SAME: rock-prepare-llvm),
 // BINARY_MI300-SAME: gpu-to-hsaco{chip=gfx940 dump-ptx=false features= gpu-binary-annotation=gpu.binary opt-level=3 rocm-path= triple=amdgcn-amd-amdhsa},
 // BINARY_MI300-SAME: rock-check-residency),
-// BINARY_MI300-SAME: fp8-ext-to-tables){{$}}
+// BINARY_MI300-SAME: emulate-fp8-ext-trunc){{$}}
 
 // PARTITION: Partitioner pipeline:
 // PARTITION-NEXT: {{^}}builtin.module(func.func(tosa-make-broadcastable),

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2964,24 +2964,13 @@ static LogicalResult populateHostHarnessLogic(
   bool heuristicValidation =
       !genVerifierKeepPerfConfig && !genParams.perfConfig.empty();
   bool isSmallFloatIn = false;
-  bool isFp8 = false;
-
-  if (!genParams.types.empty()) {
-    if (auto ftype = genParams.types[0].dyn_cast<FloatType>()) {
+  if (!genParams.types.empty())
+    if (auto ftype = genParams.types[0].dyn_cast<FloatType>())
       isSmallFloatIn = ftype.getWidth() < 32;
-      isFp8 = ftype.isFloat8E4M3FNUZ() || ftype.isFloat8E5M2FNUZ();
-    }
-  }
   bool gpuValidation = validationType == "gpu" &&
                        ((hasAccel || isSmallFloatIn) || heuristicValidation);
 
   bool isRandom = (randomSeed != "fixed" && randomSeed != "none");
-  if (isRandom && isFp8) {
-    llvm::errs() << "WARNING: Random values not supported for fp8, defaulting "
-                    "to -rand fixed\n";
-    randomSeed = "fixed";
-    isRandom = false;
-  }
 
   if (isRandom) {
     auto seedFunc = makeFuncDecl(module, "seedRandomValues", {b.getI32Type()});

--- a/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
+++ b/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
@@ -204,5 +204,5 @@ MLIRRockTransforms
 MLIRRockTuning
 MLIRRockUtility
 MLIRTosaToRock
-RocmlirFp8ExtToTables
+RocmlirEmulateFp8ExtTrunc
 )


### PR DESCRIPTION
Rename the fp8-ext-to-tables to emulate-fp8-ext-trunc to be more accurate to what it's doing

fp8 truncation is implemented by generating fp8 truncation functions
for a given fp8 type following the IR created by running MIGraphX's
truncation functions (with template branches we don't want removed)
through -O3 on godbolt and manually inputting the LLVM IR as arith
dialect code while re-generalizing the constants.

I've commited all the intermediate sources so people can try to
reproduce this in the future.

(No, I don't understand what -O3 did, I just wanted something less
paintful than trying to SSA-ify some very imperative C++ by hand.)

This commit also includes integration tests that verify (on the host)
that the truncation function does what it's expected to do.

Fixes https://github.com/ROCm/rocMLIR-internal/issues/1271

And revert the old rocmlir-gen hotfix that disabled using random f8 values for our tests.