### PR TITLE
Generalized `rock::ZeroInitKernelOp` ->  `rock::InitKernelOp`

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -245,18 +245,19 @@ def Rock_AttentionOp :
   }];
 }
 
-def Rock_ZeroInitKernelOp :
-    Rock_Op<"zero_init_kernel", []>,
+def Rock_InitKernelOp :
+    Rock_Op<"init_kernel", []>,
     Arguments<(ins AnyTensorOrMemRef:$buffer,
                   Rock_GemmFeaturesAttr:$features,
+                  OptionalAttr<AnyAttrOf<[F32Attr, I32Attr]>>:$initValueAttr,
                   OptionalAttr<I32Attr>:$blockSize,
                   OptionalAttr<I32Attr>:$gridSize,
                   OptionalAttr<IndexAttr>:$elemsPerThread)>,
     Results<(outs Optional<AnyTensor>:$result)> {
-  let summary = "Zero-initialize a buffer";
+  let summary = "initialize a buffer";
 
   let description = [{
-    Zero-initialize a given buffer.
+    Initialize a given buffer.
 
     This operation is meant to operate as its own kernel, and is needed
     for correctness in some cases (backwards data kernels where not all

--- a/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/Conv2dGenerator.cpp
@@ -899,6 +899,7 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module, int rawKernelId,
     args = {func.getArgument(0), func.getArgument(1), func.getArgument(2),
             func.getArgument(3)};
   }
+
   switch (config.operation.value()) {
   case ConvOpType::Fwd: {
     auto convOp = builder.create<Conv2DOp>(builder.getUnknownLoc(),
@@ -908,9 +909,10 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module, int rawKernelId,
   case ConvOpType::BwdData: {
     if (kernelId < 0) {
       // zero init input tensor
-      auto zeroInit = builder.create<ZeroInitKernelOp>(
+      auto zeroInit = builder.create<InitKernelOp>(
           builder.getUnknownLoc(), /*resultType=*/TypeRange{}, args[1],
-          features, /*blockSize=*/nullptr, /*gridSize=*/nullptr,
+          features, /*initValueAttr=*/nullptr,
+          /*blockSize=*/nullptr, /*gridSize=*/nullptr,
           /*elemsPerThread=*/nullptr);
       block->push_front(zeroInit);
     } else {
@@ -927,9 +929,9 @@ LogicalResult Conv2dGenerator::genConvModule(ModuleOp &module, int rawKernelId,
     bool hasUtilities = (kernelCount > 1);
     if (hasUtilities && kernelId == 0) {
       // If there is a workspace, zero-init it, otherwise fill the filter tensor
-      auto zeroInitOp = builder.create<ZeroInitKernelOp>(
+      auto zeroInitOp = builder.create<InitKernelOp>(
           builder.getUnknownLoc(), /*resultType=*/TypeRange{},
-          args[hasWorkspace ? 3 : 0], features,
+          args[hasWorkspace ? 3 : 0], features, /*initValueAttr=*/nullptr,
           /*blockSize=*/nullptr, /*gridSize=*/nullptr,
           /*elemsPerThread=*/nullptr);
       block->push_front(zeroInitOp);

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -70,7 +70,7 @@ void AffixTuningParameters::runOnOperation() {
     }
   });
   func.walk(
-      [&](ZeroInitKernelOp op) { setUtilityKernelSizes(op.getBuffer(), op); });
+      [&](InitKernelOp op) { setUtilityKernelSizes(op.getBuffer(), op); });
   func.walk([&](ConvertingCopyKernelOp op) {
     setUtilityKernelSizes(op.getInput(), op);
   });

--- a/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -225,8 +225,7 @@ void mlir::rock::registerBufferizableOpInterfaceExternalModels(
 
     // While these utility kernels aren't gemm wrappers, strictly, they still
     // bufferize like them
-    ZeroInitKernelOp::attachInterface<GemmLikeInterface<ZeroInitKernelOp>>(
-        *ctx);
+    InitKernelOp::attachInterface<GemmLikeInterface<InitKernelOp>>(*ctx);
     ConvertingCopyKernelOp::attachInterface<
         GemmLikeInterface<ConvertingCopyKernelOp>>(*ctx);
     AttentionOp::attachInterface<GemmLikeInterface<AttentionOp>>(*ctx);

--- a/mlir/test/Dialect/Rock/ops.mlir
+++ b/mlir/test/Dialect/Rock/ops.mlir
@@ -264,12 +264,12 @@ func.func @rock_in_warp_transpose(%v : vector<8xf32>) -> vector<8xf32> {
 // CHECK: rock.in_warp_transpose
 
 
-func.func @zero_init_kernel(%arg0 : memref<2x4xf32>) {
-  rock.zero_init_kernel %arg0 features = none : memref<2x4xf32>
+func.func @init_kernel(%arg0 : memref<2x4xf32>) {
+  rock.init_kernel %arg0 features = none : memref<2x4xf32>
   func.return
 }
-// CHECK-LABEL func.func @zero_init_kernel
-// CHECK: rock.zero_init_kernel
+// CHECK-LABEL func.func @init_kernel
+// CHECK: rock.init_kernel
 
 func.func @converting_copy_kernel(%arg0 : memref<2x4xf32>, %arg1: memref<2x4xf16>) {
   rock.converting_copy_kernel %arg0 to %arg1 features = none : memref<2x4xf32> to memref<2x4xf16>

--- a/mlir/test/mlir-rock-lib/populate_bwd.mlir
+++ b/mlir/test/mlir-rock-lib/populate_bwd.mlir
@@ -53,5 +53,5 @@
 // BIN2: ELF
 // TUNING2_0: globalSize=100352, localSize=64
 // TUNING2_1: globalSize{{.*}}localSize{{.*}}
-// DRIVER2: rock.zero_init_kernel %arg1 features = dot : memref<256x1x1024x14x14xf32>
+// DRIVER2: rock.init_kernel %arg1 features =  dot : memref<256x1x1024x14x14xf32>
 // DRIVER2: rock.conv2d_bwd_data(%arg0, %arg1, %arg2) features = dot {arch = "amdgcn-amd-amdhsa:gfx906", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], kernelId = 0 : index, numCU = 64 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [2 : i32, 2 : i32]} : memref<1x2048x1024x1x1xf32>, memref<256x1x1024x14x14xf32>, memref<256x1x2048x7x7xf32>

--- a/mlir/test/mlir-rock-lib/populate_bww.mlir
+++ b/mlir/test/mlir-rock-lib/populate_bww.mlir
@@ -27,7 +27,7 @@
 // BIN2: ELF
 // TUNING2_0: globalSize=2048, localSize=64
 // TUNING2_1: globalSize{{.*}}localSize{{.*}}
-// DRIVER2: rock.zero_init_kernel %arg0 features = mfma|dot|atomic_add : memref<1x1024x1024x1x1xf32>
+// DRIVER2: rock.init_kernel %arg0 features = mfma|dot|atomic_add : memref<1x1024x1024x1x1xf32>
 // DRIVER2: rock.conv2d_bwd_weight(%arg0, %arg1, %arg2) features = mfma|dot|atomic_add {arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], numCU = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 
 ////////////////////////////////////////////
@@ -48,6 +48,6 @@
 // TUNING3_0: globalSize=2048, localSize=64
 // TUNING3_1: globalSize{{.*}}localSize{{.*}}
 // TUNING3_2: globalSize=2048, localSize=64
-// DRIVER3: rock.zero_init_kernel %arg3 features = mfma|dot|atomic_add : memref<1x1024x1024x1x1xf32>
+// DRIVER3: rock.init_kernel %arg3 features =  mfma|dot|atomic_add : memref<1x1024x1024x1x1xf32>
 // DRIVER3: rock.conv2d_bwd_weight(%arg0, %arg1, %arg2, %arg3) features = mfma|dot|atomic_add {arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-", dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], numCU = 120 : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} : memref<1x1024x1024x1x1xf16>, memref<64x1x1024x14x14xf16>, memref<64x1x1024x14x14xf16>, memref<1x1024x1024x1x1xf32>
 // DRIVER3: rock.converting_copy_kernel %arg3 to %arg0 features = mfma|dot|atomic_add : memref<1x1024x1024x1x1xf32> to memref<1x1024x1024x1x1xf16>

--- a/mlir/test/rocmlir-driver/populate_bwd_multi_kernels.mlir
+++ b/mlir/test/rocmlir-driver/populate_bwd_multi_kernels.mlir
@@ -18,8 +18,8 @@
 // STRIDE2_GKYXC: {{rock.gemm.*kernelId = 2 : index.*}}
 // STRIDE2_GKYXC: {{rock.gemm.*kernelId = 3 : index.*}}
 
-// STRIDE2_1x1_TOP_LEVEL: rock.zero_init_kernel %arg1 features = {{.*}} : memref<32x1x32x14x14xf32>
+// STRIDE2_1x1_TOP_LEVEL: rock.init_kernel %arg1 features = {{.*}} : memref<32x1x32x14x14xf32>
 // STRIDE2_1x1_TOP_LEVEL: rock.conv2d_bwd_data(%arg0, %arg1, %arg2) features = {{.*}} {arch = {{.*}}, dilations = [1 : i32, 1 : i32], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], kernelId = 0 : index, numCU = {{.*}} : i32, output_layout = ["no", "go", "ko", "ho", "wo"], padding = [1 : i32, 1 : i32, 1 : i32, 1 : i32], strides = [2 : i32, 2 : i32]} : memref<1x32x32x1x1xf32>, memref<32x1x32x14x14xf32>, memref<32x1x32x8x8xf32>
 
-// STRIDE2_1x1_LOWERING-NOT: rock.zero_init_kernel
+// STRIDE2_1x1_LOWERING-NOT: rock.init_kernel
 // STRIDE2_1x1_LOWERING: {{rock.gemm.*kernelId = 0 : index.*}}


### PR DESCRIPTION
* Added an optional attr. which can specify init. value
* The buffer will be filled with zeros if the init. value is not provided

Closes ROCm/rocMLIR-internal#1324