### PR TITLE
[ArchDB] Fixed ArchDB settings for Navi in WGP mode (#1325)

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/AmdArchDb.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/AmdArchDb.h
@@ -22,6 +22,7 @@ struct AmdArchInfo {
   int64_t totalSGPRPerEU;
   int64_t totalVGPRPerEU;
   int64_t totalSharedMemPerCU;
+  int64_t maxSharedMemPerWG; // Not always the same as SharedMemPerCU
   int64_t numEUPerCU;
   int64_t minNumCU;
   bool hasFp8ConversionInstrs;
@@ -29,13 +30,13 @@ struct AmdArchInfo {
   constexpr AmdArchInfo(GemmFeatures defaultFeatures, int64_t waveSize,
                         int64_t maxWavesPerEU, int64_t totalSGPRPerEU,
                         int64_t totalVGPRPerEU, int64_t sharedMemPerCU,
-                        int64_t numEUPerCU, int64_t minNumCU,
-                        bool hasFp8ConversionInstrs)
+                        int64_t sharedMemPerWG, int64_t numEUPerCU,
+                        int64_t minNumCU, bool hasFp8ConversionInstrs)
       : defaultFeatures(defaultFeatures), waveSize(waveSize),
         maxWavesPerEU(maxWavesPerEU), totalSGPRPerEU(totalSGPRPerEU),
         totalVGPRPerEU(totalVGPRPerEU), totalSharedMemPerCU(sharedMemPerCU),
-        numEUPerCU(numEUPerCU), minNumCU(minNumCU),
-        hasFp8ConversionInstrs(hasFp8ConversionInstrs) {}
+        maxSharedMemPerWG(sharedMemPerWG), numEUPerCU(numEUPerCU),
+        minNumCU(minNumCU), hasFp8ConversionInstrs(hasFp8ConversionInstrs) {}
 
   /// Get the default features for the pari <arch, datatype>
   GemmFeatures getDefaultFeatures(Type dataType);

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -255,7 +255,7 @@ static LogicalResult checkLDSSize(Operation *op, int64_t aBufferBytes,
   }
 
   if (arch) {
-    const int64_t ldsSize = rock::lookupArchInfo(arch).totalSharedMemPerCU;
+    const int64_t ldsSize = rock::lookupArchInfo(arch).maxSharedMemPerWG;
 
     return success(ldsBytes <= ldsSize);
   }


### PR DESCRIPTION
  The compiler backend defaults to WGP mode on Navi arch. Updated the
  AmdArchDB settings accordingly.
  Also added a new field for `maxSharedMemPerWG` since in WGP mode
  a WG may only allocate up to half the shared mem size.

https://github.com/ROCm/rocMLIR-internal/issues/1325