### PR TITLE
Add --fused option to the benchmark driver

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -716,7 +716,8 @@ struct CollapseExpandRewritePattern
 struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
   using OpRewritePattern<tosa::MatMulOp>::OpRewritePattern;
 
-  template <typename TosaOp> TosaOp getDefiningNonReshapeOp(Value val) const {
+  template <typename TosaOp>
+  TosaOp getDefiningNonReshapeOp(Value val) const {
     while (val.getDefiningOp<tensor::CollapseShapeOp>() ||
            val.getDefiningOp<tensor::ExpandShapeOp>()) {
       val = val.getDefiningOp()->getOperand(0);

--- a/mlir/utils/jenkins/static-checks/clang-tidy.ignore
+++ b/mlir/utils/jenkins/static-checks/clang-tidy.ignore
@@ -2,5 +2,6 @@
 # Files to be ignored by clang-tidy. Will not appear in short report and inline comments.
 mlir/examples/standalone
 mlir/test
+mlir/utils/performance/ck-benchmark-driver
 build/
 

--- a/mlir/utils/performance/common/benchmarkUtils.cpp
+++ b/mlir/utils/performance/common/benchmarkUtils.cpp
@@ -90,6 +90,7 @@ void printUsage(const std::string &name) {
                "(f32|f16|bf16|i8) \n [-transA=(True|False)] "
                "[-transB=(True|False)] \n "
                "[--kernel-repeats numKernelRepeats]\n";
+               "[--fused]\n";
 }
 
 // Get a pattern to fill the input tensors. This is because we want to avoid
@@ -190,7 +191,7 @@ BenchmarkArgs parseCommandLine(const std::string &name, int argc, char **argv) {
   //
   // -operation gemm -t dataType --arch arch -out_datatype dataType --num_cu
   // numCU -g G -m M -k K -n N -transA={True/False} -transB={True/False}
-  // --kernel-repeats=reps --perf_config=
+  // --kernel-repeats=reps --fused --perf_config=
   //
   // issued by the perfRunner.py script
   BenchmarkArgs res;
@@ -221,6 +222,8 @@ BenchmarkArgs parseCommandLine(const std::string &name, int argc, char **argv) {
       i++;
     } else if (arg == "--kernel-repeats") {
       res.kernelRepeats = atoi(argv[++i]);
+    } else if (arg == "--fused"){
+      res.fused = true;
     } else {
       std::cerr << "Invalid argument!\n";
       printUsage(name);

--- a/mlir/utils/performance/common/benchmarkUtils.cpp
+++ b/mlir/utils/performance/common/benchmarkUtils.cpp
@@ -89,8 +89,8 @@ void printUsage(const std::string &name) {
             << " -g numGroups -m numOutRows -n numOutCols -k numReductions -t "
                "(f32|f16|bf16|i8) \n [-transA=(True|False)] "
                "[-transB=(True|False)] \n "
-               "[--kernel-repeats numKernelRepeats]\n";
-               "[--fused]\n";
+               "[--kernel-repeats numKernelRepeats]\n"
+               "[--fusion=(fastgelu_add_add)]\n";
 }
 
 // Get a pattern to fill the input tensors. This is because we want to avoid
@@ -191,7 +191,7 @@ BenchmarkArgs parseCommandLine(const std::string &name, int argc, char **argv) {
   //
   // -operation gemm -t dataType --arch arch -out_datatype dataType --num_cu
   // numCU -g G -m M -k K -n N -transA={True/False} -transB={True/False}
-  // --kernel-repeats=reps --fused --perf_config=
+  // --kernel-repeats=reps --fusion --perf_config=
   //
   // issued by the perfRunner.py script
   BenchmarkArgs res;
@@ -222,8 +222,10 @@ BenchmarkArgs parseCommandLine(const std::string &name, int argc, char **argv) {
       i++;
     } else if (arg == "--kernel-repeats") {
       res.kernelRepeats = atoi(argv[++i]);
-    } else if (arg == "--fused"){
-      res.fused = true;
+    } else if (arg.rfind("--fusion=", 0) == 0) {
+      const int lenTransB = std::string("--fusion=").length();
+      std::string value = arg.substr(lenTransB);
+      res.fusion = value;
     } else {
       std::cerr << "Invalid argument!\n";
       printUsage(name);

--- a/mlir/utils/performance/common/benchmarkUtils.h
+++ b/mlir/utils/performance/common/benchmarkUtils.h
@@ -27,7 +27,7 @@ struct BenchmarkArgs {
 
   bool transposeA{false};
   bool transposeB{false};
-  bool fused{false};
+  std::string fusion{""};
   int kernelRepeats{1};
 };
 

--- a/mlir/utils/performance/common/benchmarkUtils.h
+++ b/mlir/utils/performance/common/benchmarkUtils.h
@@ -27,6 +27,7 @@ struct BenchmarkArgs {
 
   bool transposeA{false};
   bool transposeB{false};
+  bool fused{false};
   int kernelRepeats{1};
 };
 


### PR DESCRIPTION
This is adding the possibility to test fusion in CK. In CK we need to specify which fusion we want at compile time. So, unless we don't want to go through the hurdle of jit compiling, we have to stick to a specific fusion. I picked the one whose tuning DB is used in MIGraphx: `FastGelu(A*B+D0+D1)`. 