### PR TITLE
Create CODEOWNERS file to resolve SWDEV-436548

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ravil-mobile @krzysz00 @jerryyin @giuseros @manupak @sjw36 @yiqian1 @djramic @pcf000 @stefankoncarevic


### PR DESCRIPTION
For detailed context please refer to https://ontrack-internal.amd.com/browse/SWDEV-436548

In this initial PR I'm including everyone. In the future we can add finer granular control according to example in [pytorch codeowners](https://github.com/ROCmSoftwarePlatform/pytorch/blob/main/CODEOWNERS)