### PR TITLE
Add the possibility to re-multibuffer

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
+++ b/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
@@ -16,23 +16,23 @@
 namespace mlir {
 
 namespace rock {
-FailureOr<SmallVector<rock::GpuAllocOp>> multiBuffer(RewriterBase &rewriter,
-                                                     rock::GpuAllocOp allocOp,
-                                                     unsigned multiplier,
-                                                     bool skipOverrideAnalysis);
-
-FailureOr<SmallVector<rock::GpuAllocOp>> multiBuffer(rock::GpuAllocOp allocOp,
-                                                     unsigned multiplier,
-                                                     bool skipOverrideAnalysis);
+LogicalResult multiBuffer(RewriterBase &rewriter, rock::GpuAllocOp allocOp,
+                          SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
+                          unsigned multiplier, bool skipOverrideAnalysis);
 
 FailureOr<SmallVector<rock::GpuAllocOp>>
-updateMultiBuffer(RewriterBase &rewriter, Location loc,
-                  ArrayRef<rock::GpuAllocOp> multiBuffer,
-                  unsigned newMultiplier);
+multiBuffer(rock::GpuAllocOp allocOp,
+            SmallVectorImpl<rock::GpuAllocOp> &newAllocs, unsigned multiplier,
+            bool skipOverrideAnalysis);
 
-FailureOr<SmallVector<rock::GpuAllocOp>>
-updateMultiBuffer(ArrayRef<rock::GpuAllocOp> multiBuffer,
-                  unsigned newMultiplier);
+LogicalResult updateMultiBuffer(RewriterBase &rewriter, Location loc,
+                                ArrayRef<rock::GpuAllocOp> multiBuffer,
+                                SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
+                                unsigned newMultiplier);
+
+LogicalResult updateMultiBuffer(ArrayRef<rock::GpuAllocOp> multiBuffer,
+                                SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
+                                unsigned newMultiplier);
 
 } // namespace rock
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
+++ b/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
@@ -16,14 +16,24 @@
 namespace mlir {
 
 namespace rock {
-FailureOr<SmallVector<Value>> multiBuffer(RewriterBase &rewriter,
-                                          rock::GpuAllocOp allocOp,
-                                          unsigned multiplier,
-                                          bool skipOverrideAnalysis);
+FailureOr<SmallVector<rock::GpuAllocOp>> multiBuffer(RewriterBase &rewriter,
+                                                     rock::GpuAllocOp allocOp,
+                                                     unsigned multiplier,
+                                                     bool skipOverrideAnalysis);
 
-FailureOr<SmallVector<Value>> multiBuffer(rock::GpuAllocOp allocOp,
-                                          unsigned multiplier,
-                                          bool skipOverrideAnalysis);
+FailureOr<SmallVector<rock::GpuAllocOp>> multiBuffer(rock::GpuAllocOp allocOp,
+                                                     unsigned multiplier,
+                                                     bool skipOverrideAnalysis);
+
+FailureOr<SmallVector<rock::GpuAllocOp>>
+updateMultiBuffer(RewriterBase &rewriter, Location loc,
+                  ArrayRef<rock::GpuAllocOp> multiBuffer,
+                  unsigned newMultiplier);
+
+FailureOr<SmallVector<rock::GpuAllocOp>>
+updateMultiBuffer(ArrayRef<rock::GpuAllocOp> multiBuffer,
+                  unsigned newMultiplier);
+
 } // namespace rock
 } // namespace mlir
 

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -190,7 +190,7 @@ struct PushBarrierDownRewritePattern
 // idea is to represent the dependencies through a DAG with
 // the set of shared resources on the the edges
 DagType createDependencyGraph(ArrayRef<rock::StageOp> stages,
-                              const DenseSet<rock::GpuAllocOp> &allocs) {
+                              const SetVector<rock::GpuAllocOp> &allocs) {
   // Mapping resource->[stages using the given resource]
   DenseMap<rock::StageOp, DenseMap<rock::GpuAllocOp, MemoryAccessType>>
       resourceMap;
@@ -249,7 +249,7 @@ getDependencies(rock::StageOp stage0, rock::StageOp stage1, DagType &dag) {
 
 // Function to create the schedule of the current set of stages
 void createSchedule(SmallVector<rock::StageOp> &stages,
-                    const DenseSet<rock::GpuAllocOp> &resources, int64_t ii,
+                    const SetVector<rock::GpuAllocOp> &resources, int64_t ii,
                     ScheduleType &schedule,
                     DenseMap<rock::GpuAllocOp, int> &multiBuffers) {
   // Create the dependency graph
@@ -386,8 +386,9 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
         multiBuffers[buffer] = factor;
 
     // Add the parallel stages
-    for (auto stage : parallelStages)
+    for (auto stage : parallelStages) {
       schedule.push_back({stage, stageIter[stage]});
+    }
   }
 }
 
@@ -440,7 +441,7 @@ rock::StageOp placeEmptyStage(IRRewriter &rewriter, Location loc,
 // does not have to know how `placeBarrier` internally works.
 void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
                    ArrayRef<rock::StageOp> stages,
-                   DenseSet<rock::GpuAllocOp> &allocs,
+                   SetVector<rock::GpuAllocOp> &allocs,
                    SmallVector<rock::StageOp> &extendedStages,
                    int64_t &initiationInterval) {
   DagType dag = createDependencyGraph(stages, allocs);
@@ -522,6 +523,43 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
   initiationInterval *= 2;
 }
 
+bool checkIfPipeliningSupported(scf::ForOp forOp) {
+  auto rockPipelineAttrName = rock::PipelineAttr::getMnemonic();
+  while (scf::ForOp parentLoop = forOp->getParentOfType<scf::ForOp>()) {
+    if (parentLoop->hasAttr(rockPipelineAttrName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Return a list of the loops in the function `func` that represents
+// in level order in a list.
+SmallVector<scf::ForOp> collectLoopLevels(mlir::func::FuncOp func) {
+  SmallVector<scf::ForOp> loops;
+
+  unsigned curLevelPos = 0;
+  unsigned curLevelLen = 0;
+  func.walk([&](scf::ForOp forOp) {
+    loops.push_back(forOp);
+    curLevelLen++;
+  });
+
+  while (curLevelLen) {
+    unsigned nextLevelLen = 0;
+    for (unsigned i = 0; i < curLevelLen; i++) {
+      loops[curLevelPos + i].getBody()->walk([&](scf::ForOp forOp) {
+        loops.push_back(forOp);
+        nextLevelLen++;
+      });
+    }
+    curLevelPos += curLevelLen;
+    curLevelLen = nextLevelLen;
+  }
+
+  return loops;
+}
+
 struct RockPipeline : public rock::impl::RockPipelinePassBase<RockPipeline> {
   using rock::impl::RockPipelinePassBase<RockPipeline>::RockPipelinePassBase;
   void runOnOperation() override;
@@ -535,35 +573,54 @@ void RockPipeline::runOnOperation() {
   Location loc = func->getLoc();
   IRRewriter rewriter(ctx);
 
-  std::map<Operation *, SmallVector<rock::GpuAllocOp>> ldsAllocMap;
-  llvm::DenseSet<rock::GpuAllocOp> allocs;
+  llvm::SetVector<rock::GpuAllocOp> singleAllocs;
+  llvm::SetVector<rock::GpuAllocOp> multiAllocs;
+  func.walk([&](rock::GpuAllocOp alloc) { singleAllocs.insert(alloc); });
+  // Always (try to) multi-buffer by one
+  for (auto alloc : singleAllocs) {
+    auto maybeMultiAlloc = rock::multiBuffer(rewriter, alloc, 1, true);
+    if (succeeded(maybeMultiAlloc)) {
+      auto multiAlloc = maybeMultiAlloc.value();
+      multiAllocs.insert(multiAlloc.begin(), multiAlloc.end());
+    } else {
+      multiAllocs.insert(alloc);
+    }
+  }
 
   // Collect the global resources (i.e., the memory allocations)
   // Note: we can only have two kind of memory:
   // - Registers
   // - LDS
-  func.walk([&](rock::GpuAllocOp alloc) { allocs.insert(alloc); });
-
   DenseMap<rock::GpuAllocOp, int> multiBufferFactors;
-  llvm::DenseMap<scf::ForOp, ScheduleType> scheduleMap;
-  for (auto res : allocs)
+  llvm::MapVector<scf::ForOp, ScheduleType> scheduleMap;
+  for (auto res : multiAllocs)
     multiBufferFactors[res] = 1;
 
   auto rockPipelineAttrName = rock::PipelineAttr::getMnemonic();
-  bool isNestedPipelining = false;
-  func.walk([&](scf::ForOp forOp) -> WalkResult {
+
+  // Maybe this might be a bit too much for now, but we are a compiler
+  // after all. So let's try to be generic. We collect all loops
+  // in a level traversal order of the loop nests
+  SmallVector<scf::ForOp> loops = collectLoopLevels(func);
+
+  // Filter out loops that don't need pipelining
+  // and check for nested-pipelining for loops that do need to
+  // be pipelened. We pipeline from the innermost to the outermost loop,
+  // hence traverse the list in a reverse order (from the bottom levels to
+  // the top levels)
+  SmallVector<scf::ForOp> loopsToPipeline;
+  for (auto forOp : llvm::reverse(loops)) {
+    if (forOp->hasAttr(rockPipelineAttrName)) {
+      if (checkIfPipeliningSupported(forOp)) {
+        emitError(loc, "Nested pipelining is not supported yet!\n");
+        return signalPassFailure();
+      }
+      loopsToPipeline.push_back(forOp);
+    }
+  }
+
+  for (auto forOp : loopsToPipeline) {
     SmallVector<rock::StageOp> stages;
-
-    if (!forOp->hasAttrOfType<rock::PipelineAttr>(rockPipelineAttrName))
-      return WalkResult::advance();
-
-    forOp.getBody()->walk([&](scf::ForOp nestedFor) {
-      if (nestedFor->hasAttr(rockPipelineAttrName))
-        isNestedPipelining = true;
-    });
-
-    if (isNestedPipelining)
-      return WalkResult::interrupt();
 
     // Get the initiation interval (II)
     int64_t ii = forOp->removeAttr(rockPipelineAttrName)
@@ -585,37 +642,29 @@ void RockPipeline::runOnOperation() {
 
     // Insert the barriers as new stages
     SmallVector<rock::StageOp> extendedStages;
-    placeBarriers(rewriter, loc, forOp, stages, allocs, extendedStages, ii);
+    placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages,
+                  ii);
 
     ScheduleType schedule;
-    createSchedule(extendedStages, allocs, ii, schedule, multiBufferFactors);
+    createSchedule(extendedStages, multiAllocs, ii, schedule,
+                   multiBufferFactors);
 
-    scheduleMap[forOp] = schedule;
-    // Annotate the operation that defines the boundary of the `forOp`. This
-    // is because, at the end of the pass, we will remove any barrier at the
-    // boundary (because they are not useful)
-    return WalkResult::advance();
-  });
+    RewritePatternSet patterns(&getContext());
+    mlir::scf::PipeliningOption options;
+    options.getScheduleFn = [&](scf::ForOp curFurOp, ScheduleType &sched) {
+      if (curFurOp == forOp)
+        sched = schedule;
+    };
 
-  if (isNestedPipelining) {
-    emitError(loc, "Nested pipelining is not supported yet!\n");
-    return signalPassFailure();
+    scf::populateSCFLoopPipeliningPatterns(patterns, options);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
   }
 
-  // Multi-buffer(if needed)
-  bool isMultiBufferingFailed = false;
-  for (auto [alloc, factor] : multiBufferFactors) {
-    if (factor > 1) {
-      if (failed(rock::multiBuffer(rewriter, alloc, factor, true))) {
-        isMultiBufferingFailed = true;
-        break;
-      }
-    }
-  }
-  if (isMultiBufferingFailed) {
-    emitError(loc, "Multi buffering failed to apply!\n");
-    return signalPassFailure();
-  }
+  // Remulti-buffer(if needed). Now we know what all the loops need, hence
+  // we can safely allocate the right amount of resources in the function
+  for (auto [alloc, factor] : multiBufferFactors)
+    if (factor > 1)
+      (void)rock::updateMultiBuffer(rewriter, loc, {alloc}, factor);
 
   // Check we didn't push memory too far
   DenseMap<AddressSpace, size_t> gpuMemoryBytes;
@@ -627,17 +676,6 @@ void RockPipeline::runOnOperation() {
   if (gpuMemoryBytes[AddressSpace::Workgroup] > size_t(64 * 1024)) {
     emitError(loc, "LDS consumption is more than 64K!\n");
     return signalPassFailure();
-  }
-
-  // Pipeline the loops
-  {
-    RewritePatternSet patterns(&getContext());
-    mlir::scf::PipeliningOption options;
-    options.getScheduleFn = [&](scf::ForOp op, ScheduleType &sched) {
-      sched = scheduleMap[op];
-    };
-    scf::populateSCFLoopPipeliningPatterns(patterns, options);
-    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
   }
 
   // Cleanup the stages

--- a/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
@@ -8,26 +8,31 @@ func.func @fp8_bf8_xdlops(%arg0: memref<1x128x128xf8E4M3FNUZ>, %arg1: memref<1x1
   // CHECK: %[[ldsB:.+]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
 
   // CHECK: %[[viewAStore:.+]] = memref.view %[[ldsA]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
-  // CHECK: %[[viewAStoreTr0:.+]] = rock.transform %[[viewAStore]]
+  // CHECK: %[[viewBStore:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewAGemm:.+]] = memref.view %[[ldsA]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
+  // CHECK: %[[viewBGemm:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
+
+  // CHECK: %[[viewAStoreMB:.+]] = rock.extract_multibuffer(%[[viewAStore]])
+  // CHECK: %[[viewAStoreTr0:.+]] = rock.transform %[[viewAStoreMB]]
   // CHECK: %[[viewAStoreTr1:.+]] = rock.transform %[[viewAStoreTr0]]
   // CHECK: %[[viewAStoreTr2:.+]] = rock.transform %[[viewAStoreTr1]]
   // CHECK: %[[viewAStoreTr3:.+]] = rock.transform %[[viewAStoreTr2]]
+  // CHECK: rock.threadwise_write_all {{.*}} -> [](%[[viewAStoreTr3]])
 
-  // CHECK: %[[viewBStore:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
-  // CHECK: %[[viewBStoreTr0:.+]] = rock.transform %[[viewBStore]]
+  // CHECK: %[[viewBStoreMB:.+]] = rock.extract_multibuffer(%[[viewBStore]])
+  // CHECK: %[[viewBStoreTr0:.+]] = rock.transform %[[viewBStoreMB]]
   // CHECK: %[[viewBStoreTr1:.+]] = rock.transform %[[viewBStoreTr0]]
   // CHECK: %[[viewBStoreTr2:.+]] = rock.transform %[[viewBStoreTr1]]
   // CHECK: %[[viewBStoreTr3:.+]] = rock.transform %[[viewBStoreTr2]]
 
-  // CHECK: %[[viewAGemm:.+]] = memref.view %[[ldsA]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E4M3FNUZ>, #gpu.address_space<workgroup>>
-  // CHECK: %[[viewBGemm:.+]] = memref.view %[[ldsB]][{{.*}}][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<1024xvector<8xf8E5M2FNUZ>, #gpu.address_space<workgroup>>
 
-  // CHECK: rock.threadwise_write_all {{.*}} -> [](%[[viewAStoreTr3]])
   // CHECK: rock.threadwise_write_all {{.*}} -> [](%[[viewBStoreTr3]])
+  // CHECK: %[[viewAGemmMB:.+]] = rock.extract_multibuffer(%[[viewAGemm]])
+  // CHECK: %[[viewBGemmMB:.+]] = rock.extract_multibuffer(%[[viewBGemm]])
 
   // CHECK: rock.blockwise_gemm_accel
-  // CHECK-SAME %[[viewAGemm]]
-  // CHECK-SAME: %[[viewBGemm]]
+  // CHECK-SAME: %[[viewAGemmMB]]
+  // CHECK-SAME: %[[viewBGemmMB]]
   rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) features =  mfma|dot|atomic_add {arch = "amdgcn-amd-amdhsa:gfx940", blockSize = 256 : i32, gridSize = 900 : i32, numCU = 228 : i32, params = #xdlops_gemm_params} : memref<1x128x128xf8E4M3FNUZ>, memref<1x128x115200xf8E5M2FNUZ>, memref<1x128x115200xf32>
   return
 }

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -82,18 +82,22 @@ func.func @rock_pipeline_3_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     // CHECK: %[[rawLds:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
     // CHECK: %[[rawRegA:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
     // CHECK: %[[rawRegB:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
-    // CHECK: memref.view %[[rawLds]]
-    // CHECK: memref.view %[[rawRegA]]
-    // CHECK: memref.view %[[rawRegB]]
+    // CHECK: %[[ldsView:.*]] = memref.view %[[rawLds]]
+    // CHECK: %[[regAView:.*]] = memref.view %[[rawRegA]]
+    // CHECK: %[[regBView:.*]] = memref.view %[[rawRegB]]
 
     // CHECK: name = "S0"
     // CHECK: name = "__bwd_barrier__"
     // CHECK: name = "S1"
     // CHECK: scf.for
       // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[regAView]])
       // CHECK name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView]])
       // CHECK name = "S2"
       // CHECK: name = "__bwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[regAView]])
+      // CHECK: rock.extract_multibuffer(%[[ldsView]])
       // CHECK: name = "S1"
     // CHECK: name = "__fwd_barrier__"
     // CHECK name = "S2"
@@ -138,15 +142,19 @@ func.func @rock_pipeline_3_stages_ii_3(%input : memref<16xi8, #gpu.address_space
     // CHECK: %[[rawLds:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
     // CHECK: %[[rawRegA:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
     // CHECK: %[[rawRegB:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
-    // CHECK: memref.view %[[rawLds]]
-    // CHECK: memref.view %[[rawRegA]]
-    // CHECK: memref.view %[[rawRegB]]
+    // CHECK: %[[ldsView:.*]] = memref.view %[[rawLds]]
+    // CHECK: %[[regAView:.*]] = memref.view %[[rawRegA]]
+    // CHECK: %[[regBView:.*]] = memref.view %[[rawRegB]]
 
     // CHECK: scf.for
       // CHECK: name = "__bwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[regAView]])
       // CHECK: name = "S0"
+      // CKECK: rock.extract_multibuffer(%[[ldsView]])
+      // CHECK: rock.extract_multibuffer(%[[regAView]])
       // CHECK: name = "S1"
       // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView]])
       // CHECK: name = "S2"
     scf.for %arg3 = %c0 to %c16 step %c1 {
       rock.stage {

--- a/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
@@ -60,10 +60,12 @@ static LogicalResult testMultiBuffering(func::FuncOp f) {
       newFactor = reMultiBufferAttr.getInt();
       alloc.first->removeAttr(kReMultiBuffer);
     }
-    auto maybeBuffers =
-        rock::multiBuffer(rewriter, alloc.first, alloc.second, true);
-    if (newFactor && succeeded(maybeBuffers)) {
-      (void)rock::updateMultiBuffer(rewriter, loc, maybeBuffers.value(),
+    SmallVector<rock::GpuAllocOp> mbAllocs;
+    auto mb =
+        rock::multiBuffer(rewriter, alloc.first, mbAllocs, alloc.second, true);
+    if (newFactor && succeeded(mb)) {
+      SmallVector<rock::GpuAllocOp> newAllocs;
+      (void)rock::updateMultiBuffer(rewriter, loc, mbAllocs, newAllocs,
                                     newFactor);
     }
   }

--- a/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
@@ -37,6 +37,7 @@ struct MultiBufferingTestPass
 } // end namespace
 
 static const StringLiteral kMultiBuffer = "__multibuffer__";
+static const StringLiteral kReMultiBuffer = "__remultibuffer__";
 
 static LogicalResult testMultiBuffering(func::FuncOp f) {
   SmallVector<std::pair<rock::GpuAllocOp, int64_t>> toMultibuffer;
@@ -48,9 +49,24 @@ static LogicalResult testMultiBuffering(func::FuncOp f) {
       op->removeAttr(kMultiBuffer);
     }
   });
+  IRRewriter rewriter(f->getContext());
+  Location loc = f.getLoc();
 
-  for (auto alloc : toMultibuffer)
-    (void)rock::multiBuffer(alloc.first, alloc.second, true);
+  for (auto alloc : toMultibuffer) {
+    int newFactor = 0;
+    if (alloc.first->hasAttr(kReMultiBuffer)) {
+      auto reMultiBufferAttr =
+          alloc.first->getAttrOfType<IntegerAttr>(kReMultiBuffer);
+      newFactor = reMultiBufferAttr.getInt();
+      alloc.first->removeAttr(kReMultiBuffer);
+    }
+    auto maybeBuffers =
+        rock::multiBuffer(rewriter, alloc.first, alloc.second, true);
+    if (newFactor && succeeded(maybeBuffers)) {
+      (void)rock::updateMultiBuffer(rewriter, loc, maybeBuffers.value(),
+                                    newFactor);
+    }
+  }
 
   return success();
 }


### PR DESCRIPTION
In theory this means we can start pipelining nested loops. 

Before:
- Create the schedule and collect the buffer factor
- Create multiple buffers
- Pipeline the loop

Now:
- Multibuffer by `1` all the allocs we can 
- for every loop
-- Create the schedule and collect the buffer factor
-- Pipeline the loop
- Create multiple buffers

I am attaching a perf diff, which is flat (only a glitch, that I was not able to reproduce)
[perf_diff.zip](https://github.com/ROCm/rocMLIR/files/14100463/perf_diff.zip)
