### PR TITLE
Force-add gfx11xx to rocprof in Dockerfile.

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -134,3 +134,6 @@ ADD "https://raw.githubusercontent.com/ROCmSoftwarePlatform/MITuna/develop/requi
 RUN python3 -m venv /tuna-venv && . /tuna-venv/bin/activate && \
     python3 -m pip install -r tuna-requirements.txt --ignore-installed && \
     python3 -m pip install scipy pandas
+
+# Workaround for 6.0.0 rocprof not supporting navi3x:  add it to list.
+RUN sed --in-place 's/gfx94x")/gfx94x","gfx11xx")/' /opt/rocm/bin/rocprof


### PR DESCRIPTION
We have a problem with rocprof not supporting gfx1100, which is navi3x.  We can't work around it with the existing rocprof, but we can modify rocprof in our docker image.  This patch does that, adding gfx11xx to the list of supported GPUs, while we wait for an official patch.

(rocprofv2, btw, doesn't accept the "--stats" option that we use, and therefore isn't a drop-in replacement.)