### PR TITLE
Update migraphx.quant_dot to take fp8 inputs

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -473,7 +473,7 @@ class MIGraphX_DotOpBase<string mnemonic, list<Type> inputTypes=[], list<Type> o
 }
 
 def MIGraphX_QuantDotOp :
-    MIGraphX_DotOpBase<"quant_dot", [I8], [I32]>{
+    MIGraphX_DotOpBase<"quant_dot", [F8E4M3FNUZ, F8E5M2FNUZ, I8], [F32, I32]>{
   let summary = "Dot product of quantized tensors";
   let description = [{
     The `migraphx.quant_dot` op computes the dot product of two tensors.

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -175,6 +175,13 @@ module  {
      return %0 : !migraphx.shaped<2x256x768xi32, 196608x768x1>
   }
 
+  // CHECK-LABEL: func.func @quant_matmul_fp8
+  // CHECK: tosa.matmul
+  func.func @quant_matmul_fp8(%arg0: !migraphx.shaped<1x12x1024x64xf8E4M3FNUZ, 786432x64x768x1>, %arg1: !migraphx.shaped<1x12x64x1024xf8E4M3FNUZ, 786432x64x1x768>) -> !migraphx.shaped<1x12x1024x1024xf32, 12582912x1048576x1024x1> {
+    %0 = migraphx.quant_dot %arg0, %arg1 : <1x12x1024x64xf8E4M3FNUZ, 786432x64x768x1>, <1x12x64x1024xf8E4M3FNUZ, 786432x64x1x768> -> <1x12x1024x1024xf32, 12582912x1048576x1024x1>
+     return %0 : !migraphx.shaped<1x12x1024x1024xf32, 12582912x1048576x1024x1>
+  }
+
   // CHECK-LABEL: func.func @matmul_larger_batch
   // CHECK: tosa.matmul
   func.func @matmul_larger_batch(%arg0: !migraphx.shaped<2x16x256x384xf32, 1572864x98304x384x1>, %arg1: !migraphx.shaped<2x16x384x768xf32, 4718592x294912x768x1>) -> !migraphx.shaped<2x16x256x768xf32, 3145728x196608x768x1> {

--- a/mlir/utils/performance/common/benchmarkUtils.h
+++ b/mlir/utils/performance/common/benchmarkUtils.h
@@ -12,6 +12,7 @@
 #define MLIR_UTILS_PERFORMANCE_COMMON_BENCHMARKUTILS_H
 
 #include "hip/hip_runtime.h"
+#include <string>
 
 // Common options to the different benchmark drivers
 


### PR DESCRIPTION
While previous commits updated migraphx.quant_convolution to handle fp8 inputs, quant_dot was omittted from the update, causing errors during testing in MIGraphX.

This commit updates migraphx.quant_dot and tests the lowering to Tosa.

In addition, we fix a compilation error on the ROCm 6.0 clang on Ubuntu 22.04 by explicitly #including <string> in the benchmark headers.