### PR TITLE
Simplify threadwise_accel_gemm to accept the [i,j,k] compute coordinates

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1214,7 +1214,7 @@ def Rock_ThreadwiseAccelGemmOp:
     Rock_Op<"threadwise_accel_gemm">,
     Arguments<(ins Arg<MemRefOf<NativeMemoryOpTypes>, "source register view A", [MemRead]>:$matrixA,
                    Arg<MemRefOf<NativeMemoryOpTypes>, "source register view B", [MemRead]>:$matrixB,
-                   Arg<MemRefOf<NativeMemoryOpTypes>, "dest register view C", [MemRead, MemWrite]>:$matrixC, Variadic<Index>:$extraIndicesC,
+                   Arg<MemRefOf<NativeMemoryOpTypes>, "dest register view C", [MemRead, MemWrite]>:$matrixC, Variadic<Index>:$computeIndices,
                    StrAttr:$arch,
                    Rock_GemmFeaturesAttr:$features,
                    RockAccelTuningParamAttrInterface:$params)> {
@@ -1226,7 +1226,7 @@ def Rock_ThreadwiseAccelGemmOp:
     Matrices A and B reside in LDS, the buffers live in registers, C is a vector
   }];
   let assemblyFormat = [{
-    $matrixC(`[` $extraIndicesC^ `]`)? `+` `` `=` $matrixA `*` $matrixB `features` `=` $features attr-dict
+    $matrixC `+` `` `=` $matrixA `*` $matrixB `at` `[` $computeIndices `]` `features` `=` $features attr-dict
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
   let hasVerifier = 1;

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1678,8 +1678,11 @@ LogicalResult ThreadwiseAccelGemmOp::verify() {
     return emitOpError("B shape should be [N,K]");
   if (aShape.back() != bShape.back())
     return emitOpError("A and B K dimensions don't match");
-  if (cShape.size() != 2 + getExtraIndicesC().size())
-    return emitOpError("C shape should be [extraIndices, M,N]");
+  if (cShape.size() != 2)
+    return emitOpError("C shape should be [M,N]");
+  if (getComputeIndices().size() != 3)
+    return emitOpError("ComputeIndices need to be a <i,j,k> tuple");
+
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -430,17 +430,19 @@ struct BlockwiseGemmAccelRewritePattern
     int64_t mRepeats = params.mRepeats;
     int64_t nRepeats = params.nRepeats;
     int64_t kBase = params.kBase;
+    int64_t kBasePerThread = params.kBasePerThread;
 
     auto tid = b.create<WorkitemIdOp>(loc, b.getIndexType());
 
     LLVM_DEBUG(llvm::dbgs()
                << "argVectorType A: " << argTypeA << "\n"
                << "argVectorType B: " << argTypeB << "\n"
-               << "k_base: " << kBase << "\n"
+               << "kBase: " << kBase << "\n"
                << "mPerWave: " << mPerWave << "\n"
                << "nPerWave: " << nPerWave << "\n"
                << "mRepeat: " << mRepeats << "\n"
                << "nRepeat: " << nRepeats << "\n"
+               << "kBasePerThread: " << kBasePerThread << "\n"
                << "kpackPerBlock: " << kpackPerBlock << "\n"
                << "bufferA type: " << adaptor.getBufferA().getType() << "\n"
                << "bufferB type: " << adaptor.getBufferB().getType() << "\n");
@@ -471,35 +473,40 @@ struct BlockwiseGemmAccelRewritePattern
     {
       OpBuilder::InsertionGuard guard(b);
       b.setInsertionPointToStart(mLoop.getBody());
-      Value m_i = mLoop.getInductionVar();
+      Value i = mLoop.getInductionVar();
 
       // regsA = read A from LDS
       b.create<ThreadwiseReadIntoOp>(loc, wrappedLDSBufferForLoadA,
                                      op.getBufferA(), b.getArrayAttr({}),
-                                     ValueRange{tid, m_i}, true, true);
+                                     ValueRange{tid, i}, true, true);
 
       auto nLoop = b.create<affine::AffineForOp>(loc, 0, nRepeats);
       {
         OpBuilder::InsertionGuard guard(b);
         b.setInsertionPointToStart(nLoop.getBody());
-        Value n_i = nLoop.getInductionVar();
+        Value j = nLoop.getInductionVar();
 
         // regsB = read B from LDS
         b.create<ThreadwiseReadIntoOp>(loc, wrappedLDSBufferForLoadB,
                                        op.getBufferB(), b.getArrayAttr({}),
-                                       ValueRange{tid, n_i}, true, true);
-
-        Value viewA = accelEmitterPtr->generateThreadwiseViewBufferA(
-            b, loc, adaptor.getBufferA());
-        Value viewB = accelEmitterPtr->generateThreadwiseViewBufferB(
-            b, loc, adaptor.getBufferB());
-        Value viewC = accelEmitterPtr->generateThreadwiseViewBufferC(
-            b, loc, adaptor.getMatrixC());
+                                       ValueRange{tid, j}, true, true);
 
         // regsC += regsA * regsB
-        b.create<ThreadwiseAccelGemmOp>(loc, viewA, viewB, viewC,
-                                        ValueRange{m_i, n_i}, arch,
-                                        op.getFeaturesAttr(), tuningParams);
+        auto kLoop = b.create<affine::AffineForOp>(loc, 0, kBasePerThread);
+        {
+          OpBuilder::InsertionGuard guard(b);
+          b.setInsertionPointToStart(kLoop.getBody());
+          Value viewA = accelEmitterPtr->generateThreadwiseViewBufferA(
+              b, loc, adaptor.getBufferA());
+          Value viewB = accelEmitterPtr->generateThreadwiseViewBufferB(
+              b, loc, adaptor.getBufferB());
+          Value viewC = accelEmitterPtr->generateThreadwiseViewBufferC(
+              b, loc, adaptor.getMatrixC());
+          Value k = kLoop.getInductionVar();
+          b.create<ThreadwiseAccelGemmOp>(loc, viewA, viewB, viewC,
+                                          ValueRange{i, j, k}, arch,
+                                          op.getFeaturesAttr(), tuningParams);
+        }
       }
     }
     b.eraseOp(op);

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1984,18 +1984,23 @@ struct GridwiseAttentionAccelRewritePattern
             rewriter.create<ThreadwiseReadIntoOp>(
                 loc, wrappedLDSBufferForLoadA, preAccelRegBufferK,
                 rewriter.getArrayAttr({}), ValueRange{tid, mi}, true, true);
-
-            Value viewA = accelEmitterPtrGemm0->generateThreadwiseViewBufferA(
-                rewriter, loc, preAccelRegBufferK);
-            Value viewB = accelEmitterPtrGemm0->generateThreadwiseViewBufferB(
-                rewriter, loc, preAccelRegBufferQ);
-            Value viewC = accelEmitterPtrGemm0->generateThreadwiseViewBufferC(
-                rewriter, loc, accRegBufferGemm0);
-
             // regsC += regsA * regsB
-            rewriter.create<ThreadwiseAccelGemmOp>(
-                loc, viewA, viewB, viewC, ValueRange{mi, ni}, op.getArchAttr(),
-                op.getFeaturesAttr(), op.getParams0Attr());
+            auto kLoop = rewriter.create<affine::AffineForOp>(
+                loc, 0, accelParamsGemm0.kBasePerThread);
+            {
+              OpBuilder::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToStart(kLoop.getBody());
+              Value viewA = accelEmitterPtrGemm0->generateThreadwiseViewBufferA(
+                  rewriter, loc, preAccelRegBufferK);
+              Value viewB = accelEmitterPtrGemm0->generateThreadwiseViewBufferB(
+                  rewriter, loc, preAccelRegBufferQ);
+              Value viewC = accelEmitterPtrGemm0->generateThreadwiseViewBufferC(
+                  rewriter, loc, accRegBufferGemm0);
+              Value ki = kLoop.getInductionVar();
+              rewriter.create<ThreadwiseAccelGemmOp>(
+                  loc, viewA, viewB, viewC, ValueRange{mi, ni, ki},
+                  op.getArchAttr(), op.getFeaturesAttr(), op.getParams0Attr());
+            }
           }
         }
       }
@@ -2175,17 +2180,26 @@ struct GridwiseAttentionAccelRewritePattern
                   rewriter.getArrayAttr({}), ValueRange{ni}, true, true);
             }
 
-            Value viewA = accelEmitterPtrGemm1->generateThreadwiseViewBufferA(
-                rewriter, loc, preAccelRegBufferV);
-            Value viewB = accelEmitterPtrGemm1->generateThreadwiseViewBufferB(
-                rewriter, loc, preAccelRegBufferQxK);
-            Value viewC = accelEmitterPtrGemm1->generateThreadwiseViewBufferC(
-                rewriter, loc, accRegBufferGemm1);
+            affine::AffineForOp kBasePerThreadLoop =
+                rewriter.create<affine::AffineForOp>(
+                    loc, 0, accelParamsGemm1.kBasePerThread, 1);
+            {
+              PatternRewriter::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToStart(kBasePerThreadLoop.getBody());
+              Value ki = kBasePerThreadLoop.getInductionVar();
 
-            // regsC += regsA * regsB
-            rewriter.create<ThreadwiseAccelGemmOp>(
-                loc, viewA, viewB, viewC, ValueRange{mi, ni}, op.getArchAttr(),
-                op.getFeaturesAttr(), op.getParams1Attr());
+              Value viewA = accelEmitterPtrGemm1->generateThreadwiseViewBufferA(
+                  rewriter, loc, preAccelRegBufferV);
+              Value viewB = accelEmitterPtrGemm1->generateThreadwiseViewBufferB(
+                  rewriter, loc, preAccelRegBufferQxK);
+              Value viewC = accelEmitterPtrGemm1->generateThreadwiseViewBufferC(
+                  rewriter, loc, accRegBufferGemm1);
+
+              // regsC += regsA * regsB
+              rewriter.create<ThreadwiseAccelGemmOp>(
+                  loc, viewA, viewB, viewC, ValueRange{mi, ni, ki},
+                  op.getArchAttr(), op.getFeaturesAttr(), op.getParams1Attr());
+            }
           }
         }
 

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -119,12 +119,10 @@ Value AccelEmitter::generateThreadwiseViewBufferC(PatternRewriter &b,
                                                   Location loc,
                                                   Value rawBufferC) {
   TopDownTMBuilder bufferCijTransform(
-      b, {"ci", "cj", "i", "j"},
-      {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats, 1, 1}, loc);
-  bufferCijTransform.ignore("i");
-  bufferCijTransform.ignore("j");
+      b, {"i", "j"}, {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats},
+      loc);
   bufferCijTransform.unmerge(
-      "offset", 0, {"ci", "cj"},
+      "offset", 0, {"i", "j"},
       {accelEmitterParams.mRepeats, accelEmitterParams.nRepeats});
   auto viewC = rock::transform(
       b, rawBufferC,

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
@@ -1,19 +1,19 @@
 // RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
 
-#transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (2*d0 + d1)> by [<AddDim{1} ["i"] at [2] -> [] at []>, <AddDim{1} ["j"] at [3] -> [] at []>, <Unmerge{2, 2} ["ci", "cj"] at [0, 1] -> ["offset"] at [0]>] bounds = [2, 2, 1, 1] -> [4]>
+#transform_map0 = #rock.transform_map<affine_map<(d0, d1) -> (2*d0 + d1)> by [<Unmerge{2, 2} ["i", "j"] at [0, 1] -> ["offset"] at [0]>] bounds = [2, 2] -> [4]>
 // CHECK: rock_accel_gemm_wmma
 func.func @rock_accel_gemm_wmma(%matrixA : memref<1x4xvector<16xf16>, 5>,
                                 %matrixB : memref<1x4xvector<16xf16>, 5>,
                                 %matrixC : memref<1x1xvector<8xf32>, 5>) {
   %c0 = arith.constant 0 : index
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = wmma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     params = #rock.wmma_gemm_params<
        mPerBlock = 16,
@@ -32,15 +32,16 @@ func.func @rock_accel_gemm_wmma_repeats(%matrixA : memref<1x4xvector<16xf16>, 5>
                                         %matrixB : memref<1x4xvector<16xf16>, 5>,
                                         %matrixC : memref<4xvector<8xf32>, 5>) {
   %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xf32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xf32>, 5>
-  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xf32>, 5> to memref<2x2x1x1xvector<8xf32>, 5>
-  rock.threadwise_accel_gemm %matrixCView[%c1, %c1] += %matrixA * %matrixB features = wmma {
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xf32>, 5> to memref<2x2xvector<8xf32>, 5>
+  rock.threadwise_accel_gemm %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     params = #rock.wmma_gemm_params<
        mPerBlock = 32,
@@ -50,7 +51,7 @@ func.func @rock_accel_gemm_wmma_repeats(%matrixA : memref<1x4xvector<16xf16>, 5>
        nPerWave = 32,
        kpack = 16,
        forceUnroll = true>
-     } : memref<2x2x1x1xvector<8xf32>, 5> += memref<1x4xvector<16xf16>, 5> * memref<1x4xvector<16xf16>, 5>
+     } : memref<2x2xvector<8xf32>, 5> += memref<1x4xvector<16xf16>, 5> * memref<1x4xvector<16xf16>, 5>
   return
 }
 
@@ -59,15 +60,16 @@ func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<1x4xvector<16xi8>
                                              %matrixB : memref<1x4xvector<16xi8>, 5>,
                                              %matrixC : memref<4xvector<8xi32>, 5>) {
   %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
-  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2x1x1xvector<8xi32>, 5>
-  rock.threadwise_accel_gemm %matrixCView[%c1, %c1] += %matrixA * %matrixB features = wmma {
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2xvector<8xi32>, 5>
+  rock.threadwise_accel_gemm %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     params = #rock.wmma_gemm_params<
        mPerBlock = 32,
@@ -77,7 +79,7 @@ func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<1x4xvector<16xi8>
        nPerWave = 32,
        kpack = 16,
        forceUnroll = true>
-     } : memref<2x2x1x1xvector<8xi32>, 5> += memref<1x4xvector<16xi8>, 5> * memref<1x4xvector<16xi8>, 5>
+     } : memref<2x2xvector<8xi32>, 5> += memref<1x4xvector<16xi8>, 5> * memref<1x4xvector<16xi8>, 5>
   return
 }
 
@@ -86,15 +88,16 @@ func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<1x2xvecto
                                                      %matrixB : memref<1x2xvector<16xi8>, 5>,
                                                      %matrixC : memref<4xvector<8xi32>, 5>) {
   %c1 = arith.constant 1 : index
+  %c0 = arith.constant 1 : index
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 1, 1, 2]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
   // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
-  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2x1x1xvector<8xi32>, 5>
-  rock.threadwise_accel_gemm %matrixCView[%c1, %c1] += %matrixA * %matrixB features = wmma {
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2xvector<8xi32>, 5>
+  rock.threadwise_accel_gemm %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     params = #rock.wmma_gemm_params<
        mPerBlock = 32,
@@ -104,6 +107,6 @@ func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<1x2xvecto
        nPerWave = 16,
        kpack = 16,
        forceUnroll = true>
-     } : memref<2x2x1x1xvector<8xi32>, 5> += memref<1x2xvector<16xi8>, 5> * memref<1x2xvector<16xi8>, 5>
+     } : memref<2x2xvector<8xi32>, 5> += memref<1x2xvector<16xi8>, 5> * memref<1x2xvector<16xi8>, 5>
   return
 }

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s | FileCheck %s
 
-#transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (2*d0 + d1)> by [<AddDim{1} ["i"] at [2] -> [] at []>, <AddDim{1} ["j"] at [3] -> [] at []>, <Unmerge{1, 2} ["ci", "cj"] at [0, 1] -> ["offset"] at [0]>] bounds = [1, 2, 1, 1] -> [2]>
-#transform_map1 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (2*d0 + d1)> by [<AddDim{1} ["i"] at [2] -> [] at []>, <AddDim{1} ["j"] at [3] -> [] at []>, <Unmerge{2, 2} ["ci", "cj"] at [0, 1] -> ["offset"] at [0]>] bounds = [2, 2, 1, 1] -> [4]>
+#transform_map0 = #rock.transform_map<affine_map<(d0, d1) -> (2*d0 + d1)> by [<Unmerge{1, 2} ["ci", "cj"] at [0, 1] -> ["offset"] at [0]>] bounds = [1, 2] -> [2]>
+#transform_map1 = #rock.transform_map<affine_map<(d0, d1) -> (2*d0 + d1)> by [<Unmerge{2, 2} ["ci", "cj"] at [0, 1] -> ["offset"] at [0]>] bounds = [2, 2] -> [4]>
 
 func.func @rock_accel_gemm_reduction_nokpack(%matrixA : memref<1x2xf32, 5>,
                                                  %matrixB : memref<1x2xf32, 5>,
@@ -9,14 +9,14 @@ func.func @rock_accel_gemm_reduction_nokpack(%matrixA : memref<1x2xf32, 5>,
   // CHECK-LABEL: func.func @rock_accel_gemm_reduction_nokpack
   // CHECK-SAME: ([[ABuf:%.+]]: memref<1x2xf32, 5>, [[BBuf:%.+]]: memref<1x2xf32, 5>, [[CBuf:%.+]]: memref<2xvector<16xf32>, 5>)
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 1, 1, 2]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: [[a:%.+]] = memref.load [[ABuf]]
   // CHECK: [[b:%.+]] = memref.load [[BBuf]]
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
-  %matrixCView = rock.transform %matrixC by #transform_map0: memref<2xvector<16xf32>, 5> to memref<1x2x1x1xvector<16xf32>, 5>
-  rock.threadwise_accel_gemm %matrixCView[%c0, %c0] += %matrixA * %matrixB features = mfma {
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<2xvector<16xf32>, 5> to memref<1x2xvector<16xf32>, 5>
+  rock.threadwise_accel_gemm %matrixCView += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
        kpackPerBlock = 4,
@@ -26,7 +26,7 @@ func.func @rock_accel_gemm_reduction_nokpack(%matrixA : memref<1x2xf32, 5>,
        nPerBlock = 64,
        nPerWave = 32,
        forceUnroll = true>
-     } : memref<1x2x1x1xvector<16xf32>, 5> += memref<1x2xf32, 5> * memref<1x2xf32, 5>
+     } : memref<1x2xvector<16xf32>, 5> += memref<1x2xf32, 5> * memref<1x2xf32, 5>
   return
 }
 
@@ -36,14 +36,14 @@ func.func @rock_accel_gemm_reduction_kpack_f32(%matrixA : memref<1x2xf32, 5>,
   // CHECK-LABEL: func.func @rock_accel_gemm_reduction_kpack_f32
   // CHECK-SAME: ([[ABuf:%.+]]: memref<1x2xf32, 5>, [[BBuf:%.+]]: memref<1x2xf32, 5>, [[CBuf:%.+]]: memref<4xvector<16xf32>, 5>)
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 1, 1, 2]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: [[a:%.+]] = memref.load [[ABuf]]
   // CHECK: [[b:%.+]] = memref.load [[BBuf]]
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : f32, f32, vector<16xf32>
   %c0 = arith.constant 0 : index
-  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<16xf32>, 5> to memref<2x2x1x1xvector<16xf32>, 5>
-  rock.threadwise_accel_gemm %matrixCView[%c0, %c0] += %matrixA * %matrixB features = mfma {
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<16xf32>, 5> to memref<2x2xvector<16xf32>, 5>
+  rock.threadwise_accel_gemm %matrixCView += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 2,
@@ -53,7 +53,7 @@ func.func @rock_accel_gemm_reduction_kpack_f32(%matrixA : memref<1x2xf32, 5>,
       nPerBlock = 128,
       nPerWave = 64,
       forceUnroll = true>
-  } : memref<2x2x1x1xvector<16xf32>, 5> += memref<1x2xf32, 5> * memref<1x2xf32, 5>
+  } : memref<2x2xvector<16xf32>, 5> += memref<1x2xf32, 5> * memref<1x2xf32, 5>
   return
 }
 
@@ -63,14 +63,14 @@ func.func @rock_accel_gemm_reduction_kpack_i8(%matrixA : memref<1x4xvector<4xi8>
   // CHECK-LABEL: func.func @rock_accel_gemm_reduction_kpack_i8
   // CHECK-SAME: ([[ABuf:%.+]]: memref<1x4xvector<4xi8>, 5>, [[BBuf:%.+]]: memref<1x4xvector<4xi8>, 5>, [[CBuf:%.+]]: memref<1x1xvector<16xi32>, 5>)
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: [[a:%.+]] = memref.load [[ABuf]]
   // CHECK: [[b:%.+]] = memref.load [[BBuf]]
   // CHECK: [[c:%.+]] = memref.load [[CBuf]]
   // CHECK: amdgpu.mfma [[a]] * [[b]] + [[c]] {{.*}} : vector<4xi8>, vector<4xi8>, vector<16xi32>
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -92,12 +92,12 @@ func.func @accel_gemm_gfx90a_i8(%matrixA : memref<1x4xvector<4xi8>, 5>,
                                                  %matrixC : memref<1x1xvector<16xi32>, 5>) {
   // CHECK-LABEL  func.func @accel_gemm_gfx90a_i8
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: amdgpu.mfma
   // CHECK-SAME: blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -116,12 +116,12 @@ func.func @accel_gemm_gfx940_i8(%matrixA : memref<1x4xvector<8xi8>, 5>,
                                                  %matrixC : memref<1x1xvector<16xi32>, 5>) {
   // CHECK-LABEL: func.func @accel_gemm_gfx940_i8
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: amdgpu.mfma
   // CHECK-SAME  blocks = 1 : i32, k = 16 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT  amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -140,12 +140,12 @@ func.func @accel_gemm_gfx908_bf16(%matrixA : memref<1x4xvector<2xbf16>, 5>,
                                                  %matrixC : memref<1x1xvector<16xf32>, 5>) {
   // CHECK-LABEL: func.func @accel_gemm_gfx908_bf16
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: amdgpu.mfma
   // CHECK-SAME: blocks = 1 : i32, k = 4 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx908",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -164,12 +164,12 @@ func.func @accel_gemm_gfx90a_bf16(%matrixA : memref<1x4xvector<4xbf16>, 5>,
                                                  %matrixC : memref<1x1xvector<16xf32>, 5>) {
   // CHECK-LABEL: func.func @accel_gemm_gfx90a_bf16
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: amdgpu.mfma
   // CHECK-SAME: blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 4,
@@ -188,14 +188,14 @@ func.func @accel_gemm_fp8_bf8(%matrixA : memref<1x4xvector<8xf8E4M3FNUZ>, #gpu.a
                                %matrixC : memref<4xvector<16xf32>, #gpu.address_space<private>>) {
   // CHECK-LABEL: func.func @accel_gemm_fp8_bf8
   // CHECK: rock.transforming_for
-  // CHECK-SAME: bounds [1, 1, 1, 1, 4]
+  // CHECK-SAME: bounds [1, 1, 1]
   // CHECK: amdgpu.mfma
   // CHECK-SAME: blocks = 1 : i32, k = 16 : i32, m = 32 : i32, n = 32 : i32
   // CHECK-SAME:   vector<8xf8E4M3FNUZ>, vector<8xf8E5M2FNUZ>, vector<16xf32>
   // CHECK-NOT: amdgpu.mfma
   %c0 = arith.constant 0 : index
-  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<16xf32>, #gpu.address_space<private>> to memref<2x2x1x1xvector<16xf32>, #gpu.address_space<private>>
-  rock.threadwise_accel_gemm %matrixCView[%c0, %c0] += %matrixA * %matrixB features = mfma {
+  %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<16xf32>, #gpu.address_space<private>> to memref<2x2xvector<16xf32>, #gpu.address_space<private>>
+  rock.threadwise_accel_gemm %matrixCView += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx940",
     params = #rock.xdlops_gemm_params<
       kpackPerBlock = 8,
@@ -205,6 +205,6 @@ func.func @accel_gemm_fp8_bf8(%matrixA : memref<1x4xvector<8xf8E4M3FNUZ>, #gpu.a
       mPerWave = 64,
       nPerWave = 64,
       forceUnroll = true>
-  } : memref<2x2x1x1xvector<16xf32>, #gpu.address_space<private>> += memref<1x4xvector<8xf8E4M3FNUZ>, #gpu.address_space<private>> * memref<1x4xvector<8xf8E5M2FNUZ>, #gpu.address_space<private>>
+  } : memref<2x2xvector<16xf32>, #gpu.address_space<private>> += memref<1x4xvector<8xf8E4M3FNUZ>, #gpu.address_space<private>> * memref<1x4xvector<8xf8E5M2FNUZ>, #gpu.address_space<private>>
   return
 }

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -28,7 +28,7 @@ func.func @rock_xdlops_gemm_accel_one_result_f16(%matrixA : memref<1x4xvector<4x
                                                 %matrixB : memref<1x4xvector<4xf16>, 5>,
                                                 %matrixC : memref<1x1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma{
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma{
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,
@@ -51,7 +51,7 @@ func.func @rock_xdlops_gemm_accel_two_results_f16(%matrixA : memref<1x4xvector<4
                                                %matrixB : memref<1x4xvector<4xf16>, 5>,
                                                %matrixC : memref<1x1xvector<32xf32>, 5>) {
   %c0 = arith.constant 0 : index
-  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB features = mfma {
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     params = #rock.xdlops_gemm_params<
       mPerBlock = 256,


### PR DESCRIPTION
This should be the final change to allow me to decide how the microkernel [m,n,k] loop is going to be scheduled. 

This is stemming from a discussion I had with @manupak few weeks back. 

The idea is to have `threadwise_accel_gemm` to not generate any loop. We provide `viewA[i,k]`, `viewB[j,k]`, and `viewC[i,j]` and a triple of `computeIndices = [i0,j0,k0]`. Those indices are passed down to access the buffers.  and we generate `C[i0,j0] += A[i0,k0]*B[j0,k0]`. 

In this way the user of `threadwise_accel_gemm` can decide the scheduling order without having to change the transformations (and this also simplifies the lowering a bit). 