### PR TITLE
[Attention] Implement a proper fusion between first gemm and softmax

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -203,50 +203,6 @@ def Rock_ReduceOp :
   }];
 }
 
-// def Rock_AttentionOp :
-//   Rock_Op<"attention", [AllElementTypesMatch<["queries", "keys", "values", "scale", "bias"]>,
-//                                              AttrSizedOperandSegments]>,
-//   Arguments<(ins
-//     Arg<TensorOrMemRefOf<[F32, F16]>, "queries", [MemRead]>:$queries,
-//     Arg<TensorOrMemRefOf<[F32, F16]>, "keys", [MemRead]>:$keys,
-//     Arg<TensorOrMemRefOf<[F32, F16]>, "values", [MemRead]>:$values,
-//     Arg<Optional<TensorOrMemRefOf<[F32, F16]>>, "scale", [MemRead]>:$scale,
-//     Arg<Optional<TensorOrMemRefOf<[F32, F16]>>, "bias", [MemRead]>:$bias,
-//     Arg<TensorOrMemRefOf<[F32, F16]>, "output", [MemRead, MemWrite]>:$out,
-//     UnitAttr:$qTransposed,
-//     UnitAttr:$kTransposed,
-//     UnitAttr:$vTransposed,
-//     UnitAttr:$oTransposed,
-//     StrAttr:$arch,
-//     Rock_GemmFeaturesAttr:$features,
-//     OptionalAttr<RockTuningParamAttrInterface>:$params0,
-//     OptionalAttr<RockTuningParamAttrInterface>:$params1
-//   )>,
-//   Results<(outs Optional<TensorOf<[F32, F16]>>:$result)> {
-//   let summary = "Attention operation of transformer models";
-//   let description = [{
-//     Performs the operation out = SOFTMAX((queries * keys) .* scale) * values.
-
-//     This operation performs attention mechanism of transformer models.
-
-//     Those creating a `rock.attention` must specify the GPU architecture being targetted
-//     and the number of compute units (numCu) available. The parameters
-//     `gridSize`, and `blockSize` are optional as they can be inferred by
-//     a tuning process or a heuristic, but they must be set before the `attention` is
-//     lowered into the `gridwise_attention` stage of the code generation pipeline.
-
-//     `features` specifies what hardware features can be used in the generated code.
-//   }];
-//   let hasVerifier = 1;
-//   let assemblyFormat = [{
-//     `(` operands `)` `features` `=` $features attr-dict
-//     `:` type(operands) (`->` type($result)^)?
-//   }];
-//   let extraClassDeclaration = [{
-//     ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperands().back(); }
-//   }];
-// }
-
 def Rock_AttentionOp :
   Rock_Op<"attention", [AllElementTypesMatch<["queries", "keys", "values"]>]>,
   Arguments<(ins

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -247,6 +247,48 @@ def Rock_AttentionOp :
   }];
 }
 
+def Rock_AttentionOpV2 :
+  Rock_Op<"attentionv2", [AllElementTypesMatch<["queries", "keys", "values"]>]>,
+  Arguments<(ins
+    Arg<TensorOrMemRefOf<[F32, F16]>, "queries", [MemRead]>:$queries,
+    Arg<TensorOrMemRefOf<[F32, F16]>, "keys", [MemRead]>:$keys,
+    Arg<TensorOrMemRefOf<[F32, F16]>, "values", [MemRead]>:$values,
+    Variadic<AnyType>:$preSoftmaxElemWiseInputs,
+    Arg<TensorOrMemRefOf<[F32, F16]>, "output", [MemRead, MemWrite]>:$out,
+    UnitAttr:$qTransposed,
+    UnitAttr:$kTransposed,
+    UnitAttr:$vTransposed,
+    UnitAttr:$oTransposed,
+    StrAttr:$arch,
+    Rock_GemmFeaturesAttr:$features,
+    OptionalAttr<RockTuningParamAttrInterface>:$params0,
+    OptionalAttr<RockTuningParamAttrInterface>:$params1
+  )>,
+  Results<(outs Optional<TensorOf<[F32, F16]>>:$result)> {
+  let summary = "Attention operation of transformer models";
+  let description = [{
+    Performs the operation out = SOFTMAX((queries * keys) .* scale) * values.
+
+    This operation performs attention mechanism of transformer models.
+
+    Those creating a `rock.attention` must specify the GPU architecture being targetted
+    and the number of compute units (numCu) available. The parameters
+    `gridSize`, and `blockSize` are optional as they can be inferred by
+    a tuning process or a heuristic, but they must be set before the `attention` is
+    lowered into the `gridwise_attention` stage of the code generation pipeline.
+
+    `features` specifies what hardware features can be used in the generated code.
+  }];
+  let regions = (region AnyRegion:$preSoftmaxBody);
+    let assemblyFormat = [{
+    `(` operands `)` `features` `=` $features `preSoftmaxOps` `=` $preSoftmaxBody attr-dict
+    `:` type(operands) (`->` type($result)^)?
+  }];
+  let extraClassDeclaration = [{
+    ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperands().back(); }
+  }];
+}
+
 def Rock_InitKernelOp :
     Rock_Op<"init_kernel", []>,
     Arguments<(ins AnyTensorOrMemRef:$buffer,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -237,9 +237,16 @@ def Rock_AttentionOp :
   }];
   let hasVerifier = 1;
   let regions = (region AnyRegion:$preSoftmaxBody);
-    let assemblyFormat = [{
-    `(` operands `)` `features` `=` $features `preSoftmaxOps` `=` $preSoftmaxBody attr-dict
-    `:` type(operands) (`->` type($result)^)?
+  // let assemblyFormat = [{
+  //   `(` operands `)` `features` `=` $features `preSoftmaxOps` `=` $preSoftmaxBody attr-dict
+  //   `:` type(operands) (`->` type($result)^)?
+  // }];
+  let assemblyFormat = [{
+    `{` `\n`
+        ` ` `qk` `=` (`tr` $qTransposed^)? $queries `*` (`tr` $kTransposed^)? $keys `:` type($queries) `,` type($keys) `\n`
+        (`qk` `=` `elementwise` `otherIns` `(` $preSoftmaxElemWiseInputs^ `:` type($preSoftmaxElemWiseInputs) `)` $preSoftmaxBody `\n`)?
+        (`tr` $oTransposed^)? $out `=` `softmax` `(` `qk` `)` `*` (`tr` $vTransposed^)? $values `:` type($values) `->` type($out) `\n`
+    `}` attr-dict (`->` type($result)^)?
   }];
   let extraClassDeclaration = [{
     ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperands().back(); }

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -203,15 +203,57 @@ def Rock_ReduceOp :
   }];
 }
 
+// def Rock_AttentionOp :
+//   Rock_Op<"attention", [AllElementTypesMatch<["queries", "keys", "values", "scale", "bias"]>,
+//                                              AttrSizedOperandSegments]>,
+//   Arguments<(ins
+//     Arg<TensorOrMemRefOf<[F32, F16]>, "queries", [MemRead]>:$queries,
+//     Arg<TensorOrMemRefOf<[F32, F16]>, "keys", [MemRead]>:$keys,
+//     Arg<TensorOrMemRefOf<[F32, F16]>, "values", [MemRead]>:$values,
+//     Arg<Optional<TensorOrMemRefOf<[F32, F16]>>, "scale", [MemRead]>:$scale,
+//     Arg<Optional<TensorOrMemRefOf<[F32, F16]>>, "bias", [MemRead]>:$bias,
+//     Arg<TensorOrMemRefOf<[F32, F16]>, "output", [MemRead, MemWrite]>:$out,
+//     UnitAttr:$qTransposed,
+//     UnitAttr:$kTransposed,
+//     UnitAttr:$vTransposed,
+//     UnitAttr:$oTransposed,
+//     StrAttr:$arch,
+//     Rock_GemmFeaturesAttr:$features,
+//     OptionalAttr<RockTuningParamAttrInterface>:$params0,
+//     OptionalAttr<RockTuningParamAttrInterface>:$params1
+//   )>,
+//   Results<(outs Optional<TensorOf<[F32, F16]>>:$result)> {
+//   let summary = "Attention operation of transformer models";
+//   let description = [{
+//     Performs the operation out = SOFTMAX((queries * keys) .* scale) * values.
+
+//     This operation performs attention mechanism of transformer models.
+
+//     Those creating a `rock.attention` must specify the GPU architecture being targetted
+//     and the number of compute units (numCu) available. The parameters
+//     `gridSize`, and `blockSize` are optional as they can be inferred by
+//     a tuning process or a heuristic, but they must be set before the `attention` is
+//     lowered into the `gridwise_attention` stage of the code generation pipeline.
+
+//     `features` specifies what hardware features can be used in the generated code.
+//   }];
+//   let hasVerifier = 1;
+//   let assemblyFormat = [{
+//     `(` operands `)` `features` `=` $features attr-dict
+//     `:` type(operands) (`->` type($result)^)?
+//   }];
+//   let extraClassDeclaration = [{
+//     ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperands().back(); }
+//   }];
+// }
+
 def Rock_AttentionOp :
-  Rock_Op<"attention", [AllElementTypesMatch<["queries", "keys", "values", "scale", "bias"]>,
-                                             AttrSizedOperandSegments]>,
+  Rock_Op<"attention", [AllElementTypesMatch<["queries", "keys", "values"]>]>,
   Arguments<(ins
     Arg<TensorOrMemRefOf<[F32, F16]>, "queries", [MemRead]>:$queries,
     Arg<TensorOrMemRefOf<[F32, F16]>, "keys", [MemRead]>:$keys,
     Arg<TensorOrMemRefOf<[F32, F16]>, "values", [MemRead]>:$values,
-    Arg<Optional<TensorOrMemRefOf<[F32, F16]>>, "scale", [MemRead]>:$scale,
-    Arg<Optional<TensorOrMemRefOf<[F32, F16]>>, "bias", [MemRead]>:$bias,
+    Variadic<TensorOrMemRefOf<[F32, F16]>>:$preSoftmaxElemWiseInputs,
     Arg<TensorOrMemRefOf<[F32, F16]>, "output", [MemRead, MemWrite]>:$out,
     UnitAttr:$qTransposed,
     UnitAttr:$kTransposed,
@@ -238,47 +280,6 @@ def Rock_AttentionOp :
     `features` specifies what hardware features can be used in the generated code.
   }];
   let hasVerifier = 1;
-  let assemblyFormat = [{
-    `(` operands `)` `features` `=` $features attr-dict
-    `:` type(operands) (`->` type($result)^)?
-  }];
-  let extraClassDeclaration = [{
-    ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperands().back(); }
-  }];
-}
-
-def Rock_AttentionOpV2 :
-  Rock_Op<"attentionv2", [AllElementTypesMatch<["queries", "keys", "values"]>]>,
-  Arguments<(ins
-    Arg<TensorOrMemRefOf<[F32, F16]>, "queries", [MemRead]>:$queries,
-    Arg<TensorOrMemRefOf<[F32, F16]>, "keys", [MemRead]>:$keys,
-    Arg<TensorOrMemRefOf<[F32, F16]>, "values", [MemRead]>:$values,
-    Variadic<AnyType>:$preSoftmaxElemWiseInputs,
-    Arg<TensorOrMemRefOf<[F32, F16]>, "output", [MemRead, MemWrite]>:$out,
-    UnitAttr:$qTransposed,
-    UnitAttr:$kTransposed,
-    UnitAttr:$vTransposed,
-    UnitAttr:$oTransposed,
-    StrAttr:$arch,
-    Rock_GemmFeaturesAttr:$features,
-    OptionalAttr<RockTuningParamAttrInterface>:$params0,
-    OptionalAttr<RockTuningParamAttrInterface>:$params1
-  )>,
-  Results<(outs Optional<TensorOf<[F32, F16]>>:$result)> {
-  let summary = "Attention operation of transformer models";
-  let description = [{
-    Performs the operation out = SOFTMAX((queries * keys) .* scale) * values.
-
-    This operation performs attention mechanism of transformer models.
-
-    Those creating a `rock.attention` must specify the GPU architecture being targetted
-    and the number of compute units (numCu) available. The parameters
-    `gridSize`, and `blockSize` are optional as they can be inferred by
-    a tuning process or a heuristic, but they must be set before the `attention` is
-    lowered into the `gridwise_attention` stage of the code generation pipeline.
-
-    `features` specifies what hardware features can be used in the generated code.
-  }];
   let regions = (region AnyRegion:$preSoftmaxBody);
     let assemblyFormat = [{
     `(` operands `)` `features` `=` $features `preSoftmaxOps` `=` $preSoftmaxBody attr-dict
@@ -466,12 +467,11 @@ def Rock_GridwiseGemmAccelOp :
 
 // gridwise_attention_accel
 def Rock_GridwiseAttentionAccelOp :
-    Rock_Op<"gridwise_attention_accel", [AttrSizedOperandSegments]>,
+    Rock_Op<"gridwise_attention_accel">,
     Arguments<(ins MemRefRankOf<[F32, F16], [3]>:$queries,
                    MemRefRankOf<[F32, F16], [3]>:$keys,
                    MemRefRankOf<[F32, F16], [3]>:$values,
-                   Optional<MemRefRankOf<[F32, F16], [3]>>:$scale,
-                   Optional<MemRefRankOf<[F32, F16], [3]>>:$bias,
+                   Variadic<TensorOrMemRefOf<[F32, F16]>>:$preSoftmaxElemWiseInputs,
                    MemRefRankOf<[F32, F16], [3]>:$out,
                    StrAttr:$arch,
                    Rock_GemmFeaturesAttr:$features,
@@ -486,8 +486,9 @@ def Rock_GridwiseAttentionAccelOp :
   let description = [{
     The `rock.gridwise_attention_accel` op computes gridwise attention with acceleration.
   }];
+  let regions = (region AnyRegion:$preSoftmaxBody);
   let assemblyFormat = [{
-    `(` operands `)` `features` `=` $features attr-dict `:` type(operands)
+    `(` operands `)` `features` `=` $features `preSoftmaxOps` `=` $preSoftmaxBody attr-dict `:` type(operands)
   }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
@@ -32,6 +32,9 @@ Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source);
 /// Utility function to get the number of bytes a value of type `type` takes up.
 int64_t getByteWidth(Type type);
 
+// Utility function to get a MemRef as a tensor
+Value getAsTensor(OpBuilder& builder, Location loc, mlir::Value value, bool isWritable = false);
+
 } // namespace rock
 } // namespace mlir
 

--- a/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
@@ -33,7 +33,8 @@ Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source);
 int64_t getByteWidth(Type type);
 
 // Utility function to get a MemRef as a tensor
-Value getAsTensor(OpBuilder& builder, Location loc, mlir::Value value, bool isWritable = false);
+Value getAsTensor(OpBuilder &builder, Location loc, mlir::Value value,
+                  bool isWritable = false);
 
 } // namespace rock
 } // namespace mlir

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1956,9 +1956,11 @@ LogicalResult AttentionOp::verify() {
   }
 
   // for (Value otherElemWiseInput : getPreSoftmaxElemWiseInputs()){
-  //   ShapedType otherElemWiseInputType = otherElemWiseInput.getType().cast<ShapedType>();
-  //   if (vType.getRank() != otherElemWiseInputType.getRank()) {
-  //     return emitError("other elementwie inputs needs to be of same rank to main inputs");
+  //   ShapedType otherElemWiseInputType =
+  //   otherElemWiseInput.getType().cast<ShapedType>(); if (vType.getRank() !=
+  //   otherElemWiseInputType.getRank()) {
+  //     return emitError("other elementwie inputs needs to be of same rank to
+  //     main inputs");
   //   }
   // }
 

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -14,10 +14,10 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Rock/IR/AccelEmitter.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -1693,13 +1693,12 @@ LogicalResult GridwiseAttentionAccelOp::verify() {
   if (gemm0NPerBlock % gemm0kpack != 0) {
     return emitError("NPerBlock should be divisble by kpack.");
   }
-  
+
   int64_t linalgOpCount = 0;
-  getPreSoftmaxBody().walk([&](linalg::GenericOp genOp){
-    linalgOpCount ++;
-  });
-  if(linalgOpCount > 1){
-    return emitError("More than 1 linalg generic op found in pre softmax fusion point.");
+  getPreSoftmaxBody().walk([&](linalg::GenericOp genOp) { linalgOpCount++; });
+  if (linalgOpCount > 1) {
+    return emitError(
+        "More than 1 linalg generic op found in pre softmax fusion point.");
   }
   return success();
 }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1961,17 +1961,10 @@ LogicalResult AttentionOp::verify() {
     return emitError("reduction dimensions of second gemm do not match");
   }
 
-  if (TypedValue<ShapedType> scale = getScale()) {
-    ShapedType scaleType = scale.getType();
-    if (vType.getRank() != scaleType.getRank()) {
-      return emitError("scale needs to be of same rank to other inputs");
-    }
-  }
-
-  if (TypedValue<ShapedType> bias = getBias()) {
-    ShapedType biasType = bias.getType();
-    if (vType.getRank() != biasType.getRank()) {
-      return emitError("bias needs to be of same rank to other inputs");
+  for (Value otherElemWiseInput : getPreSoftmaxElemWiseInputs()){
+    ShapedType otherElemWiseInputType = otherElemWiseInput.getType().cast<ShapedType>();
+    if (vType.getRank() != otherElemWiseInputType.getRank()) {
+      return emitError("other elementwie inputs needs to be of same rank to main inputs");
     }
   }
 

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Rock/IR/AccelEmitter.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -1691,6 +1692,14 @@ LogicalResult GridwiseAttentionAccelOp::verify() {
   int64_t gemm0NPerBlock = gemm0TuningParams.getNPerBlock();
   if (gemm0NPerBlock % gemm0kpack != 0) {
     return emitError("NPerBlock should be divisble by kpack.");
+  }
+  
+  int64_t linalgOpCount = 0;
+  getPreSoftmaxBody().walk([&](linalg::GenericOp genOp){
+    linalgOpCount ++;
+  });
+  if(linalgOpCount > 1){
+    return emitError("More than 1 linalg generic op found in pre softmax fusion point.");
   }
   return success();
 }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1954,16 +1954,6 @@ LogicalResult AttentionOp::verify() {
   if (keyN != valueK) {
     return emitError("reduction dimensions of second gemm do not match");
   }
-
-  // for (Value otherElemWiseInput : getPreSoftmaxElemWiseInputs()){
-  //   ShapedType otherElemWiseInputType =
-  //   otherElemWiseInput.getType().cast<ShapedType>(); if (vType.getRank() !=
-  //   otherElemWiseInputType.getRank()) {
-  //     return emitError("other elementwie inputs needs to be of same rank to
-  //     main inputs");
-  //   }
-  // }
-
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1961,12 +1961,12 @@ LogicalResult AttentionOp::verify() {
     return emitError("reduction dimensions of second gemm do not match");
   }
 
-  for (Value otherElemWiseInput : getPreSoftmaxElemWiseInputs()){
-    ShapedType otherElemWiseInputType = otherElemWiseInput.getType().cast<ShapedType>();
-    if (vType.getRank() != otherElemWiseInputType.getRank()) {
-      return emitError("other elementwie inputs needs to be of same rank to main inputs");
-    }
-  }
+  // for (Value otherElemWiseInput : getPreSoftmaxElemWiseInputs()){
+  //   ShapedType otherElemWiseInputType = otherElemWiseInput.getType().cast<ShapedType>();
+  //   if (vType.getRank() != otherElemWiseInputType.getRank()) {
+  //     return emitError("other elementwie inputs needs to be of same rank to main inputs");
+  //   }
+  // }
 
   return success();
 }

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -557,13 +557,11 @@ struct BlockwiseReduceRewritePattern
     SmallVector<StringRef, 4> upperNameRefs;
     tensorToLDSViewBuilder.getStartNames(upperNameRefs);
 
-    int64_t nonReduceMergeDimSize = 1;
     SmallVector<StringRef, 4> nonReduceNameRefs;
     SmallVector<unsigned, 4> nonReduceDims;
     SmallVector<int64_t, 4> nonReduceDimSizes;
     for (auto [dim, dimSize] : llvm::enumerate(lowestShape)) {
       if (dim != (size_t)reduceAxis) {
-        nonReduceMergeDimSize *= dimSize;
         nonReduceNameRefs.push_back(upperNameRefs[dim]);
         nonReduceDims.push_back(dim);
         nonReduceDimSizes.push_back(dimSize);

--- a/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -91,13 +91,12 @@ struct GemmLikeInterface
     if (!outBuffer) {
       return op->emitOpError("Couldn't find output argument\n");
     }
-    if(op->getNumRegions() == 1){
+    if (op->getNumRegions() == 1) {
       auto newOp = cloneWithoutRegions(
-      rewriter, op, /*newResultTypes=*/TypeRange{}, bufferArgs);
+          rewriter, op, /*newResultTypes=*/TypeRange{}, bufferArgs);
       rewriter.inlineRegionBefore(op->getRegion(0), newOp->getRegion(0),
                                   newOp->getRegion(0).begin());
-    }
-    else{
+    } else {
       rewriter.create<Concrete>(op->getLoc(), TypeRange{}, bufferArgs,
                                 op->getAttrs());
     }

--- a/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -238,7 +238,6 @@ void mlir::rock::registerBufferizableOpInterfaceExternalModels(
     ConvertingCopyKernelOp::attachInterface<
         GemmLikeInterface<ConvertingCopyKernelOp>>(*ctx);
     AttentionOp::attachInterface<GemmLikeInterface<AttentionOp>>(*ctx);
-    AttentionOpV2::attachInterface<GemmLikeInterface<AttentionOpV2>>(*ctx);
 
     TransformOp::attachInterface<TransformOpInterface>(*ctx);
     TensorUntransformCastOp::attachInterface<TensorUntransformCastOpInterface>(

--- a/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -91,16 +91,7 @@ struct GemmLikeInterface
     if (!outBuffer) {
       return op->emitOpError("Couldn't find output argument\n");
     }
-    if (op->getNumRegions() == 1) {
-      auto newOp = cloneWithoutRegions(
-          rewriter, op, /*newResultTypes=*/TypeRange{}, bufferArgs);
-      rewriter.inlineRegionBefore(op->getRegion(0), newOp->getRegion(0),
-                                  newOp->getRegion(0).begin());
-    } else {
-      rewriter.create<Concrete>(op->getLoc(), TypeRange{}, bufferArgs,
-                                op->getAttrs());
-    }
-
+    clone(rewriter, op, /*newResultTypes=*/TypeRange{}, bufferArgs);
     replaceOpWithBufferizedValues(rewriter, op, outBuffer);
     return success();
   }

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -296,10 +296,10 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
                   gemm1ExtraPad.m);
 
   SmallVector<Value, 2> otherElemWiseInputs;
-  for (Value otherElemwiseInput : adaptor.getPreSoftmaxElemWiseInputs()){
-    otherElemwiseInput = padMatrix(otherElemwiseInput, rw, loc, "gemm1N", gemm0ExtraPad.n,
-                         "gemm1M", gemm0ExtraPad.m);
-    otherElemWiseInputs.push_back(otherElemwiseInput);              
+  for (Value otherElemwiseInput : adaptor.getPreSoftmaxElemWiseInputs()) {
+    otherElemwiseInput = padMatrix(otherElemwiseInput, rw, loc, "gemm1N",
+                                   gemm0ExtraPad.n, "gemm1M", gemm0ExtraPad.m);
+    otherElemWiseInputs.push_back(otherElemwiseInput);
   }
 
   func::FuncOp func = op->getParentOfType<func::FuncOp>();
@@ -318,7 +318,8 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
       op.getFeaturesAttr(), blockSizeAttr, gridSizeAttr,
       /*disableQBypassLDS=*/nullptr, prePadG0MAttr, prePadG0NAttr, params0,
       params1);
-  rw.inlineRegionBefore(op.getPreSoftmaxBody(), newOp.getPreSoftmaxBody(), newOp.getPreSoftmaxBody().begin());
+  rw.inlineRegionBefore(op.getPreSoftmaxBody(), newOp.getPreSoftmaxBody(),
+                        newOp.getPreSoftmaxBody().begin());
   rw.replaceOp(op, newOp);
   return success();
 }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1729,16 +1729,16 @@ struct GridwiseAttentionAccelRewritePattern
     // support fp32/fp16 This should be guranteed by op verifiers.
     Value gemm0OutBuffer =
         createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
-    Value scaleInBuffer;
-    if (TypedValue<MemRefType> scaleIn = op.getScale()) {
-      scaleInBuffer = createBufferForGemmOut(
-          loc, scaleIn.getType().getElementType(), accelParamsGemm0, rewriter);
-    }
-    Value biasInBuffer;
-    if (TypedValue<MemRefType> biasIn = op.getBias()) {
-      biasInBuffer = createBufferForGemmOut(
-          loc, biasIn.getType().getElementType(), accelParamsGemm0, rewriter);
-    }
+    // Value scaleInBuffer;
+    // if (TypedValue<MemRefType> scaleIn = op.getScale()) {
+    //   scaleInBuffer = createBufferForGemmOut(
+    //       loc, scaleIn.getType().getElementType(), accelParamsGemm0, rewriter);
+    // }
+    // Value biasInBuffer;
+    // if (TypedValue<MemRefType> biasIn = op.getBias()) {
+    //   biasInBuffer = createBufferForGemmOut(
+    //       loc, biasIn.getType().getElementType(), accelParamsGemm0, rewriter);
+    // }
 
     // Buffers for reductions
     SmallVector<StringRef, 3> bidGridOrder = {"g_block", "m_block", "n_block"};
@@ -1976,50 +1976,50 @@ struct GridwiseAttentionAccelRewritePattern
       }
       accelEmitterPtrGemm0->computeOutputConversion(
           rewriter, loc, accRegBufferGemm0, gemm0OutBuffer, forceUnroll);
-      // Handle the first gemm scaling if present
-      if (Value scaleIn = op.getScale()) {
-        Value rawBuffer;
-        std::tie(rawBuffer, std::ignore, std::ignore) =
-            untransform(rewriter, scaleIn);
-        if (memref::GetGlobalOp constScale =
-                rawBuffer.getDefiningOp<memref::GetGlobalOp>()) {
-          FailureOr<TypedAttr> maybeSplatAttr =
-              getSplatGlobalConstant(constScale);
-          if (failed(maybeSplatAttr)) {
-            return op.emitError(
-                "Only splat scale constant input is supported.");
-          }
-          postProcessFirstGemmSplat<ElementwiseMultOp>(
-              rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-              gemm0OutSubTileViewsTr, maybeSplatAttr.value());
-        } else {
-          postProcessFirstGemm<linalg::BinaryFn::mul>(
-              rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-              gemm0OutSubTileViewsTr, scaleInBuffer, scaleIn);
-        }
-      }
+    //   // Handle the first gemm scaling if present
+    //   if (Value scaleIn = op.getScale()) {
+    //     Value rawBuffer;
+    //     std::tie(rawBuffer, std::ignore, std::ignore) =
+    //         untransform(rewriter, scaleIn);
+    //     if (memref::GetGlobalOp constScale =
+    //             rawBuffer.getDefiningOp<memref::GetGlobalOp>()) {
+    //       FailureOr<TypedAttr> maybeSplatAttr =
+    //           getSplatGlobalConstant(constScale);
+    //       if (failed(maybeSplatAttr)) {
+    //         return op.emitError(
+    //             "Only splat scale constant input is supported.");
+    //       }
+    //       postProcessFirstGemmSplat<ElementwiseMultOp>(
+    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
+    //           gemm0OutSubTileViewsTr, maybeSplatAttr.value());
+    //     } else {
+    //       postProcessFirstGemm<linalg::BinaryFn::mul>(
+    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
+    //           gemm0OutSubTileViewsTr, scaleInBuffer, scaleIn);
+    //     }
+    //   }
 
-      if (Value biasIn = op.getBias()) {
-        Value rawBuffer;
-        std::tie(rawBuffer, std::ignore, std::ignore) =
-            untransform(rewriter, biasIn);
-        if (memref::GetGlobalOp constScale =
-                rawBuffer.getDefiningOp<memref::GetGlobalOp>()) {
-          FailureOr<TypedAttr> maybeSplatAttr =
-              getSplatGlobalConstant(constScale);
-          if (failed(maybeSplatAttr)) {
-            return op.emitError(
-                "Only splat scale constant input is supported.");
-          }
-          postProcessFirstGemmSplat<ElementwiseAddOp>(
-              rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-              gemm0OutSubTileViewsTr, maybeSplatAttr.value());
-        } else {
-          postProcessFirstGemm<linalg::BinaryFn::add>(
-              rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-              gemm0OutSubTileViewsTr, biasInBuffer, biasIn);
-        }
-      }
+    //   if (Value biasIn = op.getBias()) {
+    //     Value rawBuffer;
+    //     std::tie(rawBuffer, std::ignore, std::ignore) =
+    //         untransform(rewriter, biasIn);
+    //     if (memref::GetGlobalOp constScale =
+    //             rawBuffer.getDefiningOp<memref::GetGlobalOp>()) {
+    //       FailureOr<TypedAttr> maybeSplatAttr =
+    //           getSplatGlobalConstant(constScale);
+    //       if (failed(maybeSplatAttr)) {
+    //         return op.emitError(
+    //             "Only splat scale constant input is supported.");
+    //       }
+    //       postProcessFirstGemmSplat<ElementwiseAddOp>(
+    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
+    //           gemm0OutSubTileViewsTr, maybeSplatAttr.value());
+    //     } else {
+    //       postProcessFirstGemm<linalg::BinaryFn::add>(
+    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
+    //           gemm0OutSubTileViewsTr, biasInBuffer, biasIn);
+    //     }
+    //   }
 
       // Scale gemm0 output by (1/ln2)
       // So that we can use exp2 instead of exp.

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -192,7 +192,6 @@ static FailureOr<Value> wrapLDSBufferForStore(OpBuilder &b, Location loc,
   }
 
   if (bufferShape[0] != kOuter * d * kpack * getByteWidth(dataType)) {
-    assert(false);
     return emitError(loc, "LDS buffer should have ")
            << kOuter * d * kpack * getByteWidth(dataType)
            << " elements but has " << bufferShape[0];

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1454,24 +1454,47 @@ struct GridwiseAttentionAccelRewritePattern
   void postProcessFirstGemm(PatternRewriter &rewriter, Location loc, GridwiseAttentionAccelOp op,
                             layout::GridCoordinates gridCoords, Value gemm0OutBuffer, 
                             RegsAsMatrixSubTiles gemm0OutViews) const {
-    auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
-    SmallVector<Value> inputTileBuffers;
-    inputTileBuffers.push_back(gemm0OutBuffer);
-    MemRefType bufType = gemm0OutBuffer.getType().cast<MemRefType>();
-    for (auto otherInput : op.getPreSoftmaxElemWiseInputs()) {
-        auto tileBuffer = rewriter.create<rock::GpuAllocOp>(loc, bufType);
-        rewriter.create<ThreadwiseReadIntoOp>(
-        loc, otherInput, tileBuffer, gemm0OutViews.gridSubTile,
-        ValueRange{gridCoords.g_block, gridCoords.m_block, gridCoords.n_block,
-                tid},
-        true, true);
-        inputTileBuffers.push_back(tileBuffer);
-    }
-    // Output is overwriting the same input buffer
-    inputTileBuffers.push_back(gemm0OutBuffer);
-    linalg::GenericOp newLinalgOp;
     op.getPreSoftmaxBody().walk([&](linalg::GenericOp genOp){
-        llvm::errs() << "found linalg genric.\n";
+        auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
+        SmallVector<Value> inputTileBuffers;
+        inputTileBuffers.push_back(gemm0OutBuffer);
+        MemRefType bufType = gemm0OutBuffer.getType().cast<MemRefType>();
+
+        //Obtain transform stack from gemmOutput to linalg generic input.
+        ArrayAttr linalgToGemmOutMaps;
+        std::tie(std::ignore, linalgToGemmOutMaps, std::ignore) = untransform(rewriter, genOp.getInputs()[0]);
+        //The obtained transforms will be linalg generic being the upperview
+        //leading to gemmOutput being the lowerview. However, we need to construct
+        // the following sequence : 
+        // (bid, tid, iter) > ... > [gemmOutput: k x d] 
+        //                        > invertTr(linalg input to gemmOutput maps)
+        //                        > (linalgOtherInput to op arg maps)
+        ArrayAttr linalgGridSubTileMaps = gemm0OutViews.gridSubTile;
+        ArrayAttr GemmOutToLinalgMaps = invertTransforms(rewriter, loc, linalgToGemmOutMaps);
+        if(!GemmOutToLinalgMaps.empty()){
+            linalgGridSubTileMaps = prependUpperViews(rewriter, linalgGridSubTileMaps, GemmOutToLinalgMaps);
+        }
+
+        for (auto [idx, otherInput] : llvm::enumerate(op.getPreSoftmaxElemWiseInputs())) {
+            auto tileBuffer = rewriter.create<rock::GpuAllocOp>(loc, bufType);
+            auto genOpInput = genOp.getInputs()[idx + 1];
+            ArrayAttr linalgToOtherInputMaps;
+            std::tie(std::ignore, linalgToOtherInputMaps, std::ignore) = untransform(rewriter, genOpInput);
+            ArrayAttr GemmOutToOtherInputMaps = linalgGridSubTileMaps;
+            if(!linalgToOtherInputMaps.empty()){
+                GemmOutToOtherInputMaps = prependUpperViews(rewriter, linalgGridSubTileMaps, linalgToOtherInputMaps);
+            }
+            rewriter.create<ThreadwiseReadIntoOp>(
+            loc, otherInput, tileBuffer, GemmOutToOtherInputMaps,
+            ValueRange{gridCoords.g_block, gridCoords.m_block, gridCoords.n_block,
+                    tid},
+            true, true);
+            inputTileBuffers.push_back(tileBuffer);
+        }
+        // Output is overwriting the same input buffer
+        inputTileBuffers.push_back(gemm0OutBuffer);
+        linalg::GenericOp newLinalgOp;
+
         mlir::IRMapping mapper;
         for (auto [operand, tilebuffer] : llvm::zip(genOp->getOperands(), inputTileBuffers)){
             mapper.map(operand, tilebuffer);

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1420,43 +1420,6 @@ struct GridwiseAttentionAccelRewritePattern
     }
   }
 
-  template <linalg::BinaryFn BinaryFnEnumValue>
-  void postProcessFirstGemm(PatternRewriter &rewriter, Location loc,
-                            layout::GridCoordinates gridCoords,
-                            Value gemm0OutBuffer,
-                            RegsAsMatrixSubTiles gemm0OutViews, Value inBuffer,
-                            Value input) const {
-    // Get current workitem ID.
-    auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
-    rewriter.create<ThreadwiseReadIntoOp>(
-        loc, input, inBuffer, gemm0OutViews.gridSubTile,
-        ValueRange{gridCoords.g_block, gridCoords.m_block, gridCoords.n_block,
-                   tid},
-        true, true);
-    rewriter.create<linalg::ElemwiseBinaryOp>(
-        loc, ValueRange{gemm0OutBuffer, inBuffer}, ValueRange{gemm0OutBuffer},
-        ArrayRef<NamedAttribute>{
-            rewriter.getNamedAttr("fun", rewriter.getAttr<linalg::BinaryFnAttr>(
-                                             BinaryFnEnumValue)),
-            rewriter.getNamedAttr("cast", rewriter.getAttr<linalg::TypeFnAttr>(
-                                              linalg::TypeFn::cast_signed))});
-  }
-
-  FailureOr<TypedAttr>
-  getSplatGlobalConstant(memref::GetGlobalOp getGlobalOp) const {
-    auto global = SymbolTable::lookupNearestSymbolFrom<memref::GlobalOp>(
-        getGlobalOp, getGlobalOp.getNameAttr());
-    if (!global)
-      return failure();
-    auto cstAttr = llvm::dyn_cast_or_null<DenseElementsAttr>(
-        global.getConstantInitValue());
-    if (!cstAttr)
-      return failure();
-    if (auto splatAttr = llvm::dyn_cast<SplatElementsAttr>(cstAttr))
-      return splatAttr.getSplatValue<TypedAttr>();
-    return failure();
-  }
-
   template <typename ElementwiseOpType>
   void postProcessFirstGemmSplat(PatternRewriter &rewriter, Location loc,
                                  layout::GridCoordinates gridCoords,
@@ -1486,6 +1449,43 @@ struct GridwiseAttentionAccelRewritePattern
           }
           nestedBuilder.create<linalg::YieldOp>(nestedLoc, elementwiseOp);
         });
+  }
+
+  void postProcessFirstGemm(PatternRewriter &rewriter, Location loc, GridwiseAttentionAccelOp op,
+                            layout::GridCoordinates gridCoords, Value gemm0OutBuffer, 
+                            RegsAsMatrixSubTiles gemm0OutViews) const {
+    auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
+    SmallVector<Value> inputTileBuffers;
+    inputTileBuffers.push_back(gemm0OutBuffer);
+    MemRefType bufType = gemm0OutBuffer.getType().cast<MemRefType>();
+    for (auto otherInput : op.getPreSoftmaxElemWiseInputs()) {
+        auto tileBuffer = rewriter.create<rock::GpuAllocOp>(loc, bufType);
+        rewriter.create<ThreadwiseReadIntoOp>(
+        loc, otherInput, tileBuffer, gemm0OutViews.gridSubTile,
+        ValueRange{gridCoords.g_block, gridCoords.m_block, gridCoords.n_block,
+                tid},
+        true, true);
+        inputTileBuffers.push_back(tileBuffer);
+    }
+    // Output is overwriting the same input buffer
+    inputTileBuffers.push_back(gemm0OutBuffer);
+    linalg::GenericOp newLinalgOp;
+    op.getPreSoftmaxBody().walk([&](linalg::GenericOp genOp){
+        llvm::errs() << "found linalg genric.\n";
+        mlir::IRMapping mapper;
+        for (auto [operand, tilebuffer] : llvm::zip(genOp->getOperands(), inputTileBuffers)){
+            mapper.map(operand, tilebuffer);
+        }
+        newLinalgOp = cast<linalg::GenericOp>(rewriter.clone(*genOp, mapper));
+        SmallVector<AffineMap> indexingMaps;
+        for (size_t i = 0 ; i < inputTileBuffers.size(); i++){
+            indexingMaps.push_back(rewriter.getMultiDimIdentityMap(1));
+        }
+        newLinalgOp.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr(indexingMaps));
+        SmallVector<Attribute, 5> iteratorTypes;
+        iteratorTypes.resize(1, linalg::IteratorTypeAttr::get(rewriter.getContext(), utils::IteratorType::parallel));
+        newLinalgOp.setIteratorTypesAttr(rewriter.getArrayAttr(iteratorTypes));
+    });
   }
 
   void loadGemmOperandsFromLDSToRegs(
@@ -1729,16 +1729,6 @@ struct GridwiseAttentionAccelRewritePattern
     // support fp32/fp16 This should be guranteed by op verifiers.
     Value gemm0OutBuffer =
         createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
-    // Value scaleInBuffer;
-    // if (TypedValue<MemRefType> scaleIn = op.getScale()) {
-    //   scaleInBuffer = createBufferForGemmOut(
-    //       loc, scaleIn.getType().getElementType(), accelParamsGemm0, rewriter);
-    // }
-    // Value biasInBuffer;
-    // if (TypedValue<MemRefType> biasIn = op.getBias()) {
-    //   biasInBuffer = createBufferForGemmOut(
-    //       loc, biasIn.getType().getElementType(), accelParamsGemm0, rewriter);
-    // }
 
     // Buffers for reductions
     SmallVector<StringRef, 3> bidGridOrder = {"g_block", "m_block", "n_block"};
@@ -1976,51 +1966,10 @@ struct GridwiseAttentionAccelRewritePattern
       }
       accelEmitterPtrGemm0->computeOutputConversion(
           rewriter, loc, accRegBufferGemm0, gemm0OutBuffer, forceUnroll);
-    //   // Handle the first gemm scaling if present
-    //   if (Value scaleIn = op.getScale()) {
-    //     Value rawBuffer;
-    //     std::tie(rawBuffer, std::ignore, std::ignore) =
-    //         untransform(rewriter, scaleIn);
-    //     if (memref::GetGlobalOp constScale =
-    //             rawBuffer.getDefiningOp<memref::GetGlobalOp>()) {
-    //       FailureOr<TypedAttr> maybeSplatAttr =
-    //           getSplatGlobalConstant(constScale);
-    //       if (failed(maybeSplatAttr)) {
-    //         return op.emitError(
-    //             "Only splat scale constant input is supported.");
-    //       }
-    //       postProcessFirstGemmSplat<ElementwiseMultOp>(
-    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-    //           gemm0OutSubTileViewsTr, maybeSplatAttr.value());
-    //     } else {
-    //       postProcessFirstGemm<linalg::BinaryFn::mul>(
-    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-    //           gemm0OutSubTileViewsTr, scaleInBuffer, scaleIn);
-    //     }
-    //   }
-
-    //   if (Value biasIn = op.getBias()) {
-    //     Value rawBuffer;
-    //     std::tie(rawBuffer, std::ignore, std::ignore) =
-    //         untransform(rewriter, biasIn);
-    //     if (memref::GetGlobalOp constScale =
-    //             rawBuffer.getDefiningOp<memref::GetGlobalOp>()) {
-    //       FailureOr<TypedAttr> maybeSplatAttr =
-    //           getSplatGlobalConstant(constScale);
-    //       if (failed(maybeSplatAttr)) {
-    //         return op.emitError(
-    //             "Only splat scale constant input is supported.");
-    //       }
-    //       postProcessFirstGemmSplat<ElementwiseAddOp>(
-    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-    //           gemm0OutSubTileViewsTr, maybeSplatAttr.value());
-    //     } else {
-    //       postProcessFirstGemm<linalg::BinaryFn::add>(
-    //           rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-    //           gemm0OutSubTileViewsTr, biasInBuffer, biasIn);
-    //     }
-    //   }
-
+    
+      // Align the preSoftmaxElementWise (if any) linalg.generic to
+      // be performed on the output of the first gemm.
+      postProcessFirstGemm(rewriter, loc, op, gridCoordsGemm0, gemm0OutBuffer, gemm0OutSubTileViewsTr);
       // Scale gemm0 output by (1/ln2)
       // So that we can use exp2 instead of exp.
 #ifndef ROCK_DEBUG_ATTENTION_REMOVE_SOFTMAX

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -445,13 +445,6 @@ LogicalResult getTuningProblemStr(rock::AttentionOp attnOp,
   else
     problemOS << "false" << sep;
 
-  // scale
-  problemOS << "-with-attn-scale ";
-  if (attnOp.getScale()) {
-    problemOS << "true" << sep;
-  } else {
-    problemOS << "false" << sep;
-  }
   problemOS << "-g " << g << sep;
   problemOS << "-seq_len " << seqLen << sep;
   problemOS << "-head_dim " << numHeads;

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -9,12 +9,12 @@
 #include "mlir/Dialect/Rock/utility/builderUtils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
-#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
@@ -178,11 +178,12 @@ int64_t getByteWidth(Type type) {
   return type.getIntOrFloatBitWidth() / 8;
 }
 
-Value getAsTensor(OpBuilder& builder, Location loc, mlir::Value value, bool isWritable) {
-    constexpr bool isRestrict{true};
-    Value origTensor = builder.create<bufferization::ToTensorOp>(
-        loc, value, isRestrict, isWritable);
-    return origTensor;
+Value getAsTensor(OpBuilder &builder, Location loc, mlir::Value value,
+                  bool isWritable) {
+  constexpr bool isRestrict{true};
+  Value origTensor = builder.create<bufferization::ToTensorOp>(
+      loc, value, isRestrict, isWritable);
+  return origTensor;
 }
 
 } // namespace rock

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
@@ -176,5 +177,13 @@ int64_t getByteWidth(Type type) {
     return (vecType.getElementTypeBitWidth() * vecType.getNumElements()) / 8;
   return type.getIntOrFloatBitWidth() / 8;
 }
+
+Value getAsTensor(OpBuilder& builder, Location loc, mlir::Value value, bool isWritable) {
+    constexpr bool isRestrict{true};
+    Value origTensor = builder.create<bufferization::ToTensorOp>(
+        loc, value, isRestrict, isWritable);
+    return origTensor;
+}
+
 } // namespace rock
 } // namespace mlir

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -374,7 +374,7 @@ func.func @rock_gemm_xdlops_fp8_bf8(%a : memref<1x72x128xf8E4M3FNUZ>, %b : memre
 // CHECK-SAME: grid_size = 24
 func.func @rock_attention_default(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   // CHECK: rock.attention
-  // CHECK-SAME: #rock.wmma_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, forceUnroll = true>
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
+  // CHECK-NEXT: #rock.wmma_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, forceUnroll = true>
+  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma preSoftmaxOps = {} {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
   return
 }

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -374,7 +374,10 @@ func.func @rock_gemm_xdlops_fp8_bf8(%a : memref<1x72x128xf8E4M3FNUZ>, %b : memre
 // CHECK-SAME: grid_size = 24
 func.func @rock_attention_default(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   // CHECK: rock.attention
-  // CHECK-NEXT: #rock.wmma_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, forceUnroll = true>
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma preSoftmaxOps = {} {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
+  // CHECK: #rock.wmma_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, forceUnroll = true>
+  rock.attention{
+   qk = %arg0 * tr %arg1 : memref<1x384x64xf16>, memref<1x384x64xf16>
+   %arg3 = softmax(qk) * %arg2 : memref<1x384x64xf16> -> memref<1x384x64xf16>
+  } {arch = "amdgcn-amd-amdhsa:gfx1100", features = #rock<GemmFeatures dot|atomic_add|atomic_fmax_f32|wmma>}
   return
 }

--- a/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
@@ -4,6 +4,6 @@
 
 func.func @rock_attention_invalid_perf_config(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   // expected-error @+1 {{The provided perf config is not valid}}
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, perf_config = "128,16,8,32,64,8,1,1", operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
+  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma preSoftmaxOps = {}{arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, perf_config = "128,16,8,32,64,8,1,1", operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
   return
 }

--- a/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
@@ -4,6 +4,9 @@
 
 func.func @rock_attention_invalid_perf_config(%arg0: memref<1x384x64xf16>, %arg1: memref<1x384x64xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   // expected-error @+1 {{The provided perf config is not valid}}
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  dot|atomic_add|atomic_fmax_f32|wmma preSoftmaxOps = {}{arch = "amdgcn-amd-amdhsa:gfx1100", kTransposed, perf_config = "128,16,8,32,64,8,1,1", operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>} : memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>, memref<1x384x64xf16>
+  rock.attention{
+    qk = %arg0 * tr %arg1 : memref<1x384x64xf16>, memref<1x384x64xf16>
+    %arg3 = softmax(qk) * %arg2 : memref<1x384x64xf16> -> memref<1x384x64xf16>
+  } {arch = "amdgcn-amd-amdhsa:gfx1100", features = #rock<GemmFeatures dot|atomic_add|atomic_fmax_f32|wmma>, perf_config = "128,16,8,32,64,8,1,1"}
   return
 }

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -84,7 +84,7 @@ func.func @gemm_transposed_from_gridwise(%a: memref<1x128x72xf32>, %b: memref<1x
 // CHECK-SAME: (%[[q:.*]]: memref<1x64x1024xf32>, %[[k:.*]]: memref<1x64x1024xf32>, %[[v:.*]]: memref<1x1024x64xf32>, %[[o:.*]]: memref<1x64x1024xf32>)
 func.func @rock_attention_simple(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x64x1024xf32>, %arg2: memref<1x1024x64xf32>, %arg3: memref<1x64x1024xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908", block_size = 64 : i32, grid_size = 1024 : i32} {
   // CHECK: rock.gridwise_attention_accel(%[[q]], %[[k]], %[[v]], %[[o]])
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add {
+  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add preSoftmaxOps = {} {
     arch = "amdgcn-amd-amdhsa:gfx908",
     params0 = #xldops_attn_params_g0,
     params1 = #xldops_attn_params_g1,
@@ -103,8 +103,8 @@ func.func @rock_attention_tr_padded(%arg0: memref<1x49x7xf32>, %arg1: memref<1x7
   // CHECK-DAG: %[[paddedV:.*]] = rock.transform %[[v]] by {{.*}} : memref<1x49x7xf32> to memref<1x64x32xf32>
   // CHECK-DAG: %[[paddedO:.*]] = rock.transform %[[o]] by {{.*}} : memref<1x49x7xf32> to memref<1x64x32xf32>
   // CHECK: rock.gridwise_attention_accel(%[[paddedTrQ]], %[[paddedK]], %[[paddedV]], %[[paddedO]])
-  // CHECK-SAME: prePadG0M = 49 : index, prePadG0N = 49 : index
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add {
+  // CHECK-NEXT: prePadG0M = 49 : index, prePadG0N = 49 : index
+  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add preSoftmaxOps = {} {
     arch = "amdgcn-amd-amdhsa:gfx908",
     params0 = #xldops_attn_params_g0,
     params1 = #xldops_attn_params_g1,

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -81,16 +81,18 @@ func.func @gemm_transposed_from_gridwise(%a: memref<1x128x72xf32>, %b: memref<1x
 }
 
 // CHECK-LABEL: func.func @rock_attention_simple
-// CHECK-SAME: (%[[q:.*]]: memref<1x64x1024xf32>, %[[k:.*]]: memref<1x64x1024xf32>, %[[v:.*]]: memref<1x1024x64xf32>, %[[o:.*]]: memref<1x64x1024xf32>)
-func.func @rock_attention_simple(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x64x1024xf32>, %arg2: memref<1x1024x64xf32>, %arg3: memref<1x64x1024xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908", block_size = 64 : i32, grid_size = 1024 : i32} {
+// CHECK-SAME: (%[[q:.*]]: memref<1x64x1024xf32>, %[[k:.*]]: memref<1x64x1024xf32>, %[[v:.*]]: memref<1x1024x64xf32>, %[[o:.*]]: memref<1x1024x64xf32>)
+func.func @rock_attention_simple(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x64x1024xf32>, %arg2: memref<1x1024x64xf32>, %arg3: memref<1x1024x64xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908", block_size = 64 : i32, grid_size = 1024 : i32} {
   // CHECK: rock.gridwise_attention_accel(%[[q]], %[[k]], %[[v]], %[[o]])
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add preSoftmaxOps = {} {
-    arch = "amdgcn-amd-amdhsa:gfx908",
+  rock.attention{
+     qk = tr %arg0 * %arg1 : memref<1x64x1024xf32>, memref<1x64x1024xf32>
+     %arg3 = softmax(qk) * %arg2 : memref<1x1024x64xf32> -> memref<1x1024x64xf32>
+  } {
+    arch = "amdgcn-amd-amdhsa:gfx908", 
+    features = #rock<GemmFeatures mfma|dot|atomic_add>,
     params0 = #xldops_attn_params_g0,
-    params1 = #xldops_attn_params_g1,
-    qTransposed,
-    operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>
-  } : memref<1x64x1024xf32>, memref<1x64x1024xf32>, memref<1x1024x64xf32>, memref<1x64x1024xf32>
+    params1 = #xldops_attn_params_g1
+  }
   return
 }
 
@@ -104,11 +106,14 @@ func.func @rock_attention_tr_padded(%arg0: memref<1x49x7xf32>, %arg1: memref<1x7
   // CHECK-DAG: %[[paddedO:.*]] = rock.transform %[[o]] by {{.*}} : memref<1x49x7xf32> to memref<1x64x32xf32>
   // CHECK: rock.gridwise_attention_accel(%[[paddedTrQ]], %[[paddedK]], %[[paddedV]], %[[paddedO]])
   // CHECK-NEXT: prePadG0M = 49 : index, prePadG0N = 49 : index
-  rock.attention(%arg0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add preSoftmaxOps = {} {
-    arch = "amdgcn-amd-amdhsa:gfx908",
+  rock.attention{
+    qk = %arg0 * %arg1 : memref<1x49x7xf32>, memref<1x7x49xf32>
+    %arg3 = softmax(qk) * %arg2 : memref<1x49x7xf32> -> memref<1x49x7xf32>
+  } {
+    arch = "amdgcn-amd-amdhsa:gfx908", 
+    features = #rock<GemmFeatures mfma|dot|atomic_add>,
     params0 = #xldops_attn_params_g0,
-    params1 = #xldops_attn_params_g1,
-    operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 1>
-  } :  memref<1x49x7xf32>, memref<1x7x49xf32>, memref<1x49x7xf32>, memref<1x49x7xf32>
+    params1 = #xldops_attn_params_g1
+  }
   return
 }

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -233,7 +233,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx908"} {
 
   func.func @gridwise_attn_simple(%arg0: memref<1x384x64xf32>, %arg1: memref<1x64x384xf32>, %arg2: memref<1x384x64xf32>, %arg3: memref<1x384x64xf32>) attributes {block_size = 64 : i32, grid_size = 24 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-"} {
     %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 384] -> [1, 384, 64]> : memref<1x384x64xf32> to memref<1x64x384xf32>
-    rock.gridwise_attention_accel(%0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add {
+    rock.gridwise_attention_accel(%0, %arg1, %arg2, %arg3) features =  mfma|dot|atomic_add preSoftmaxOps = {} {
       arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-",
       blockSize = 64 : i32,
       gridSize = 24 : i32,

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-complex-tree-elemwise.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-complex-tree-elemwise.mlir
@@ -1,0 +1,28 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1> {func.read_access}, 
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1> {func.read_access}, 
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1> {func.read_access},
+
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1> {func.read_access},
+                                    %arg4: !migraphx.shaped<1x7x7xf32, 49x7x1> {func.read_access},
+
+                                    %arg5: !migraphx.shaped<1x7x7xf32, 49x7x1> {func.read_access},
+                                    %arg6: !migraphx.shaped<1x7x7xf32, 49x7x1> {func.read_access},
+
+                                    %arg7: !migraphx.shaped<1x7x7xf32, 49x7x1> {func.read_access})
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1> {func.write_access}) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    // Inputs that that undergo leaf level elemwise ops
+    %sub = migraphx.sub %arg3, %arg4: <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %add = migraphx.add %arg5, %arg6: <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    // second level
+    %scaled = migraphx.mul %0, %sub : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %biased = migraphx.add %scaled, %add : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.softmax %biased{axis = 2 : i64} : <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %2 = migraphx.dot %1, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %2 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale-bias-exp.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale-bias-exp.mlir
@@ -1,0 +1,19 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1> {func.read_access}, 
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1> {func.read_access}, 
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1> {func.read_access}, 
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1> {func.read_access},
+                                    %arg4: !migraphx.shaped<1x7x7xf32, 49x7x1> {func.read_access})
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1> {func.write_access}) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %scaled = migraphx.mul %0, %arg3 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %exp = migraphx.exp %scaled : <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %biased = migraphx.add %exp, %arg4 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.softmax %biased{axis = 2 : i64} : <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %2 = migraphx.dot %1, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %2 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-scale-reshape-4d.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-scale-reshape-4d.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1> {func.read_access}, 
+                            %arg1: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1> {func.read_access}, 
+                            %arg2: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1> {func.read_access}, 
+                            %arg3: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1> {func.read_access}) 
+                            -> (!migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1> {func.write_access}) {
+    %0 = migraphx.transpose %arg3 {permutation = [0, 1, 3, 2]} : <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    %1 = migraphx.dot %arg2, %0 : <1x4x32x32xf32, 4096x1024x32x1>, <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    %2 = migraphx.mul %1, %arg1 : <1x4x32x32xf32, 4096x1024x32x1>, <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    %3 = migraphx.softmax %2 {axis = 3 : i64} : <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    %4 = migraphx.dot %3, %arg0 : <1x4x32x32xf32, 4096x1024x32x1>, <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    return %4 : !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1>
+  }
+}

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -11,7 +11,10 @@
 // CHECK_SCALE-SAME: %[[output:.*4]]: memref<1x1024x32xf32>)
 // CHECK_SCALE-SAME: attributes {kernel, mhal.arch = "[[$ARCH]]"}
 
-// CHECK_SCALE-NEXT: rock.attention(%[[queries]], %[[keys]], %[[values]], %[[scale]], %[[output]])
+// CHECK_SCALE-NEXT: rock.attention
+// CHECK_SCALE-NEXT: qk = %[[queries]] * %[[keys]]
+// CHECK_SCALE-NEXT: qk = elementwise otherIns(%[[scale]]
+// CHECK_SCALE: %[[output]] = softmax(qk) * %[[values]]
 // CHECK_SCALE: return
 
 // CHECK_SCALE-LABEL: func.func @host_naive_attention
@@ -39,7 +42,9 @@
 // CHECK_NO_SCALE-SAME: %[[output:.*3]]: memref<1x1024x32xf32>)
 // CHECK_NO_SCALE-SAME: attributes {kernel, mhal.arch = "[[$ARCH]]"}
 
-// CHECK_NO_SCALE-NEXT: rock.attention(%[[queries]], %[[keys]], %[[values]], %[[output]])
+// CHECK_NO_SCALE-NEXT: rock.attention
+// CHECK_NO_SCALE-NEXT: qk = %[[queries]] * %[[keys]]
+// CHECK_NO_SCALE: %[[output]] = softmax(qk) * %[[values]]
 // CHECK_NO_SCALE: return
 
 // CHECK_NO_SCALE-LABEL: func.func @host_naive_attention

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2308,7 +2308,6 @@ static func::FuncOp createGpuAttentionKernel(ModuleOp module,
     builder.setInsertionPointToStart(preSoftmaxElemwiseBlock);
     ShapedType qType = queries.getType().cast<ShapedType>();
     ArrayRef<int64_t> qShape = qType.getShape();
-    ArrayRef<int64_t> kShape = keys.getType().cast<ShapedType>().getShape();
     MemRefType qkMemRefType = MemRefType::get(
         {qShape[0], sequenceLength, sequenceLength}, qType.getElementType());
     Value qkMemRef = preSoftmaxElemwiseBlock->addArgument(qkMemRefType, loc);

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2235,6 +2235,24 @@ static void getAttentionTypes(SmallVectorImpl<Type> &result,
   result.push_back(outType);
 }
 
+template <typename TosaOp, typename... Args>
+static TosaOp createOpAndInfer(OpBuilder &builder, Location loc, Type elemType,
+                               Args &&...args) {
+  auto op =
+      builder.create<TosaOp>(loc, UnrankedTensorType::get(elemType), args...);
+  InferShapedTypeOpInterface shapeInterface =
+      cast<InferShapedTypeOpInterface>(op.getOperation());
+  SmallVector<ShapedTypeComponents> returnShape;
+  LogicalResult shapeInferenceStatus = shapeInterface.inferReturnTypeComponents(
+      op.getContext(), op.getLoc(), op->getOperands(), op->getAttrDictionary(),
+      op->getPropertiesStorage(), op->getRegions(), returnShape);
+  assert(shapeInferenceStatus.succeeded());
+  Type newOutTy = RankedTensorType::get({returnShape[0].getDims()}, elemType);
+  auto result = op->getResult(0);
+  result.setType(newOutTy);
+  return op;
+}
+
 static func::FuncOp createGpuAttentionKernel(ModuleOp module,
                                              const GenParams &params) {
   MLIRContext *ctx = module.getContext();
@@ -2267,17 +2285,52 @@ static func::FuncOp createGpuAttentionKernel(ModuleOp module,
   Value output;
   Value bias;
 
+  SmallVector<Value> elemwiseInputs;
   unsigned optionalArgsCounter{3};
-  if (hasAttnScale)
+  if (hasAttnScale) {
     scale = block->getArgument(optionalArgsCounter++);
-  if (hasAttnBias)
+    elemwiseInputs.push_back(scale);
+  }
+  if (hasAttnBias) {
     bias = block->getArgument(optionalArgsCounter++);
+    elemwiseInputs.push_back(bias);
+  }
   output = block->getArgument(optionalArgsCounter);
 
   auto attention = builder.create<rock::AttentionOp>(
-      loc, TypeRange{}, queries, keys, values, scale, bias, output, transposeQ,
+      loc, TypeRange{}, queries, keys, values, elemwiseInputs, output, transposeQ,
       transposeK, transposeV, transposeO, archAttr, params.features,
       /*params0=*/nullptr, /*params1=*/nullptr);
+  {
+    Block* preSoftmaxElemwiseBlock = &attention.getPreSoftmaxBody().emplaceBlock();
+    PatternRewriter::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(preSoftmaxElemwiseBlock);
+    ShapedType qType = queries.getType().cast<ShapedType>();
+    ArrayRef<int64_t> qShape = qType.getShape();
+    ArrayRef<int64_t> kShape = keys.getType().cast<ShapedType>().getShape();
+    MemRefType qkMemRefType = MemRefType::get({qShape[0], sequenceLength, sequenceLength}, qType.getElementType());
+    Value qkMemRef = preSoftmaxElemwiseBlock->addArgument(qkMemRefType, loc);
+    Value qkTensor = rock::getAsTensor(builder, loc, qkMemRef);
+    if (hasAttnScale) {
+      ShapedType scaleType = scale.getType().cast<ShapedType>();
+      Value scaleMemRef = preSoftmaxElemwiseBlock->addArgument(MemRefType::get(scaleType.getShape(), scaleType.getElementType()), loc);
+      Value scaleTensor = rock::getAsTensor(builder, loc, scaleMemRef);
+      qkTensor = createOpAndInfer<tosa::MulOp>(builder, loc, qType.getElementType(), qkTensor,
+                                             scaleTensor, /*shift=*/0);
+    }
+    if (hasAttnBias) {
+      ShapedType biasType = bias.getType().cast<ShapedType>();
+      Value biasMemRef = preSoftmaxElemwiseBlock->addArgument(MemRefType::get(biasType.getShape(), biasType.getElementType()), loc);
+      Value biasTensor = rock::getAsTensor(builder, loc, biasMemRef);
+      qkTensor = createOpAndInfer<tosa::AddOp>(builder, loc, qType.getElementType(), qkTensor,
+                                             biasTensor);
+    }
+    Value resMemref = builder.create<bufferization::ToMemrefOp>(loc, qkMemRefType, qkTensor);
+    Value outMemref = preSoftmaxElemwiseBlock->addArgument(qkMemRefType, loc);
+    builder.create<memref::CopyOp>(loc, resMemref, outMemref);
+    builder.create<rock::YieldOp>(loc);
+  }
+  
   if (!params.perfConfig.empty())
     attention->setAttr("perf_config", builder.getStringAttr(params.perfConfig));
 
@@ -2362,24 +2415,6 @@ static func::FuncOp createCpuGemmKernelWithMlir(ModuleOp module,
 
   b.create<func::ReturnOp>(loc);
   return func;
-}
-
-template <typename TosaOp, typename... Args>
-static TosaOp createOpAndInfer(OpBuilder &builder, Location loc, Type elemType,
-                               Args &&...args) {
-  auto op =
-      builder.create<TosaOp>(loc, UnrankedTensorType::get(elemType), args...);
-  InferShapedTypeOpInterface shapeInterface =
-      cast<InferShapedTypeOpInterface>(op.getOperation());
-  SmallVector<ShapedTypeComponents> returnShape;
-  LogicalResult shapeInferenceStatus = shapeInterface.inferReturnTypeComponents(
-      op.getContext(), op.getLoc(), op->getOperands(), op->getAttrDictionary(),
-      op->getPropertiesStorage(), op->getRegions(), returnShape);
-  assert(shapeInferenceStatus.succeeded());
-  Type newOutTy = RankedTensorType::get({returnShape[0].getDims()}, elemType);
-  auto result = op->getResult(0);
-  result.setType(newOutTy);
-  return op;
 }
 
 static Value transposeMatrix(OpBuilder &builder, Location loc, Value src,
@@ -3584,7 +3619,9 @@ int main(int argc, char **argv) {
       llvm::errs() << "Host logic populated failed.\n";
       exit(1);
     }
-    if (applyBufferizationPipeline.getValue()) {
+  }
+
+  if (applyBufferizationPipeline.getValue()) {
       PassManager pm(module->getName(), PassManager::Nesting::Implicit);
 
       rock::BufferizeOptions bufferizeOptions;
@@ -3595,7 +3632,6 @@ int main(int argc, char **argv) {
         llvm::errs() << "failed to apply rocm bufferize pipeline.\n";
         exit(1);
       }
-    }
   }
 
   // Set up the output file.


### PR DESCRIPTION
The current code for generating attention kernels only accepted two optional inputs
that could be used to mul (scale) and add (bias) between the first gemm and the softmax.

However, going forward we need squeeze in a arbitrary dequantization schemes that is
composed of element wise operations. Therefore, as a pre-requisite to that this PR
implements a generic fusion point between the first gemm and softmax.

The said tree is implemented as an inverted tree where the root of the tree is the softmax input
and one leaf being the first gemm output. Other leaves can reach farther as long as elementwise operations
go. Moreover, this PR add support to fused reshape-like ops as well because they are quite common
in graphs we get from MIGraphX that has rank > 3 and we do squeeze them to be rank = 3 around gemms because
tosa only support rank=3 matmuls. 

Future work : 

However, the code done here fundamentally can fuse any operator that lowers
to rock.transform, into the tree with 1 restriction : the path between the first gemm output leaf to the next branching point
in the tree should contain an invertible rock.transform.

closes : https://github.com/ROCm/rocMLIR-internal/issues/1368