### PR TITLE
Fix transpose/collapse_shape soundness issues in TosaToRock

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -479,11 +479,30 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
         llvm::SmallDenseSet<int64_t> preTpUnitDims;
         for (ReassociationIndices indices : reassocIndices) {
           ReassociationIndices newReassocIdx;
-          for (size_t i = 0; i < indices.size(); i++) {
+          size_t numNonUnitDimsMerged = 0;
+          for (size_t i = 0, e = indices.size(); i < e; ++i) {
             if (inShape[indices[i]] == 1) {
               preTpUnitDims.insert(dims[indices[i]]);
+            } else {
+              numNonUnitDimsMerged += 1;
             }
             newReassocIdx.push_back(dims[indices[i]]);
+          }
+          if (numNonUnitDimsMerged > 1) {
+            // Per MIGraphX bug #2692, this transpsoe/collaspe swap logic
+            // will be incorrect in cases like the following
+            //   %0 = expand_shape [[0], [1, 2], [3]] %arg0 : tensor<7x6x5xT> to
+            //   tensor<7x3x2x5xT> %1 = transpose %0, [0, 2, 1, 3] :
+            //   tensor<7x2x3x5xT> %2 = collapse_shape [[0], [1, 2], [2]] %1 :
+            //   tensor<7x2x3x5xT> to tensor<7x6x5xT>
+            // by way of creating a trivial expand/collapse pair that isn't
+            // correct.
+            //
+            // Therefore, as a sledgehammer fix, don't handle any cases where
+            // non-trivial collapses are performed.
+            return rewriter.notifyMatchFailure(
+                op, "abandoning attempt to interchange transpose and "
+                    "non-trivial collapse");
           }
           if (newReassocIdx.size() > 1) {
             llvm::sort(newReassocIdx);

--- a/mlir/test/Conversion/TosaToRock/migraphx-2692-nontrivial-collapse-shapes.mlir
+++ b/mlir/test/Conversion/TosaToRock/migraphx-2692-nontrivial-collapse-shapes.mlir
@@ -1,0 +1,34 @@
+// RUN: rocmlir-opt -tosa-to-rock %s -o - | FileCheck %s
+// COM: From the MIGraphX-generated module
+// COM: func.func @mlir_reshape_transpose_reshape_convolution(%arg0: !migraphx.shaped<1x116x28x28xf32, 90944x784x28x1>, %arg1: !migraphx.shaped<116x1x3x3xf32, 9x9x3x1>) -> !migraphx.shaped<1x116x14x14xf32, 22736x196x14x1> attributes {arch = "gfx1100", kernel = "mixr"} {    %0 = migraphx.reshape %arg0 {dims = [1, 2, 58, 28, 28]} : <1x116x28x28xf32, 90944x784x28x1> -> <1x2x58x28x28xf32, 90944x45472x784x28x1>
+// COM:   %1 = migraphx.transpose %0 {permutation = [0, 2, 1, 3, 4]} : <1x2x58x28x28xf32, 90944x45472x784x28x1> -> <1x58x2x28x28xf32, 90944x784x45472x28x1>
+// COM:   %2 = migraphx.reshape %1 {dims = [1, -1, 28, 28]} : <1x58x2x28x28xf32, 90944x784x45472x28x1> -> <1x116x28x28xf32, 90944x784x28x1>
+// COM:   %3 = migraphx.convolution %2, %arg1 {dilation = [1, 1], group = 116 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : <1x116x28x28xf32, 90944x784x28x1>, <116x1x3x3xf32, 9x9x3x1> -> <1x116x14x14xf32, 22736x196x14x1>
+// COM:   return %3 : !migraphx.shaped<1x116x14x14xf32, 22736x196x14x1>
+// COM: }
+// COM: which contains non-trivial slicing-and-dicing of a dimension,
+// COM: showing a previous unsoundness in tosa-to-rock's handling of
+// COM: transpose/collapse_shape pairs.
+
+// CHECK-LABEL: @mlir_reshape_transpose_reshape_convolution
+func.func @mlir_reshape_transpose_reshape_convolution(%arg0: tensor<1x116x28x28xf32>, %arg1: tensor<116x1x3x3xf32>) -> tensor<1x116x14x14xf32> attributes {arch = "gfx1100", kernel = "mixr"} {
+  // COM: These'll get turned to transforms by -rock-view-to-transform in real compilations
+  // CHECK: [[EXPANDED:%.+]] = tensor.expand_shape %{{.*}} {{\[}}[0], [1, 2], [3], [4]]
+  // CHECK: [[GC_TR:%.+]] = "tosa.transpose"([[EXPANDED]], %{{.*}}) : (tensor<1x2x58x28x28xf32>, tensor<5xi64>) -> tensor<1x58x2x28x28xf32>
+  // CHECK: [[COLLAPSED:%.+]] = tensor.collapse_shape [[GC_TR]] {{\[}}[0], [1, 2], [3], [4]]
+  // CHECK: [[GROUP_SPLIT:%.+]] = rock.transform [[COLLAPSED]] {{.*}} : tensor<1x116x28x28xf32> to tensor<1x116x1x28x28xf32>
+  // CHECK: rock.conv2d(%{{.*}}, [[GROUP_SPLIT]], %{{.*}})
+  // CHECK-SAME: input_layout = ["ni", "gi", "ci", "hi", "wi"]
+  %expanded = tensor.expand_shape %arg0 [[0], [1, 2], [3], [4]] : tensor<1x116x28x28xf32> into tensor<1x2x58x28x28xf32>
+  %0 = "tosa.const"() <{value = dense<[0, 2, 1, 3, 4]> : tensor<5xi64>}> : () -> tensor<5xi64>
+  %1 = "tosa.transpose"(%expanded, %0) : (tensor<1x2x58x28x28xf32>, tensor<5xi64>) -> tensor<1x58x2x28x28xf32>
+  %collapsed = tensor.collapse_shape %1 [[0], [1, 2], [3], [4]] : tensor<1x58x2x28x28xf32> into tensor<1x116x28x28xf32>
+  %2 = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi64>}> : () -> tensor<4xi64>
+  %3 = "tosa.transpose"(%collapsed, %2) : (tensor<1x116x28x28xf32>, tensor<4xi64>) -> tensor<1x28x28x116xf32>
+  %4 = "tosa.transpose"(%arg1, %2) : (tensor<116x1x3x3xf32>, tensor<4xi64>) -> tensor<116x3x3x1xf32>
+  %5 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<116xf32>}> : () -> tensor<116xf32>
+  %6 = "tosa.conv2d"(%3, %4, %5) <{dilation = array<i64: 1, 1>, group = 116 : i64, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 2, 2>}> : (tensor<1x28x28x116xf32>, tensor<116x3x3x1xf32>, tensor<116xf32>) -> tensor<1x14x14x116xf32>
+  %7 = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi64>}> : () -> tensor<4xi64>
+  %8 = "tosa.transpose"(%6, %7) : (tensor<1x14x14x116xf32>, tensor<4xi64>) -> tensor<1x116x14x14xf32>
+  return %8 : tensor<1x116x14x14xf32>
+}


### PR DESCRIPTION
Fixes https://github.com/ROCm/AMDMIGraphX/issues/2692

Candidate for backport to 6.1.

The problematic transformation arises in the following context, simplified from the original issue slightly:

```
%0 = expand_shape(%arg0, ...) : tensor<7x6x5xf32> to tensor<7x3x2x5xf32>
%1 = transpose(%0, [0, 2, 1, 3]) : tensor<7x3x2x5xf32> to %tensor<7x2x3x5xf32>
%2 = collapse_shape(%1, ...) : tensor<7x2x3x5xf32> to tensor<7x6x5xf32>
```

Previously, our code for rewriting transpose(collapse_shape) to simply collapse_shape - which is important for ensuring we cleanly pattern-match even when we're adding and removing unit dimensions all over the place to match broadcasting requirments or operation specifications - would rewrite such the code such that this entire reshape/transpose/reshape chain was deleted.

That deletion led to incorrect results, because the within-dimension tranposition that that sequence of operations specifies is semantacially menaingful.

Due the complexity and pile of hacks that is
the collapse/trpnspose rewriter, I was unable to fully diagnose exactly how we end up making this mistake in a reasonable time.

However, based on the reasonable assumption that we have this rewrite to account for stray unit dimensions, I have simply added a guard such that collapse_shape operations that perform non-trivial concatentations (like the 2x3 -> 6 one above) cannot have transposes folden into them, as we have no way to ensure that those dimensions are not the results of some previous expand_shape or similar operation.

This change required updating an existing test that relied on the old behavior.