### PR TITLE
Check blocksize during tuning

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -85,6 +85,10 @@ bool isAccel(GemmFeatures features);
 // in memory.
 bool is4GBMemoryType(ShapedType type);
 
+// Return true if the Block size is valid
+bool isValidBlockSize(int64_t blockSize, int64_t kPerBlock, int64_t mPerBlock,
+                      int64_t nPerBlock);
+
 // Heuristic logic to compute KBlock for backward weight atomic add kernel.
 // The logic is adopted from MIOpen.
 //

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -430,11 +430,12 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     // Get current workitem ID.
     auto tid = b.create<WorkitemIdOp>(loc, b.getIndexType());
 
-    int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
-    int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
-    if (aCopyPerThread == 0 || bCopyPerThread == 0) {
+    if (!isValidBlockSize(blockSize, kPerBlock, mPerBlock, nPerBlock)) {
       return emitError(loc) << "Block size too large, rejecting as invalid.\n";
     }
+
+    int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
+    int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
 
     auto maybeCopyAPerThread = computeCopyPerThread(
         elementTypeA, aCopyPerThread, kPerBlock, mPerBlock, kpack, loc);
@@ -2294,11 +2295,13 @@ struct GridwiseGemmAccelRewritePattern
     GemmDimension aVectorDim;
     GemmDimension bVectorDim;
 
-    int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
-    int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
-    if (aCopyPerThread == 0 || bCopyPerThread == 0) {
+    if (!isValidBlockSize(blockSize, kPerBlock, mPerBlock, nPerBlock)) {
       return emitError(loc) << "Block size too large, rejecting as invalid.\n";
     }
+
+    int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
+    int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
+
     int64_t aCopyKpacksPerThread =
         math_util::integer_divide_ceil(aCopyPerThread, kpack);
     int64_t bCopyKpacksPerThread =

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -672,6 +672,17 @@ LogicalResult PopulateParamsXDL::isValidBlockwiseGemm(
     return failure();
   }
 
+  // Reject invalid blockSize
+  int64_t kPerBlock = param.gemmKPerBlock;
+  int64_t mPerBlock = param.gemmMPerBlock;
+  int64_t nPerBlock = param.gemmNPerBlock;
+  int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
+  int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
+  if (aCopyPerThread == 0 || bCopyPerThread == 0) {
+    LLVM_DEBUG(llvm::dbgs() << "tuning: Block size too large.\n");
+    return failure();
+  }
+
   // Sledgehammer hotfix because not unrolling sometimes makes the register
   // allocator break. This should be refined quickly.
   if (param.gemmAThreadCopyMoreGemmK == false) {

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -676,9 +676,7 @@ LogicalResult PopulateParamsXDL::isValidBlockwiseGemm(
   int64_t kPerBlock = param.gemmKPerBlock;
   int64_t mPerBlock = param.gemmMPerBlock;
   int64_t nPerBlock = param.gemmNPerBlock;
-  int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
-  int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
-  if (aCopyPerThread == 0 || bCopyPerThread == 0) {
+  if (!isValidBlockSize(blockSize, kPerBlock, mPerBlock, nPerBlock)) {
     LLVM_DEBUG(llvm::dbgs() << "tuning: Block size too large.\n");
     return failure();
   }

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -21,6 +21,13 @@
 using namespace mlir;
 using namespace mlir::rock;
 
+bool mlir::rock::isValidBlockSize(int64_t blockSize, int64_t kPerBlock,
+                                  int64_t mPerBlock, int64_t nPerBlock) {
+  int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
+  int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
+  return (aCopyPerThread != 0 && bCopyPerThread != 0);
+}
+
 bool mlir::rock::isWrWAtomicKernel(GemmFeatures features, Type dataType,
                                    bool requiredPadding) {
   return isAccel(features) &&

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -194,7 +194,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
       mlirRockTuningSpaceCreate(module, RocmlirTuningParamSetKindFull);
   printf("Got tuning space,\n");
   unsigned fNum = mlirRockTuningGetNumParams(tuningSpace);
-  // CHECK: full set = 522
+  // CHECK: full set = 357
   printf("full set = %u\n", fNum);
   MlirRockTuningParam tuningParam = mlirRockTuningParamCreate();
   MlirRockTuningTable tuningTable = mlirRockTuningTableCreate();
@@ -229,7 +229,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
     mlirRockTuningSetParam(tuningClone, tuningParam);
     if (mlirLogicalResultIsFailure(
             mlirPassManagerRunOnOp(applicabilityPm, tuningCloneOp))) {
-      // CHECK: Perfconfig "4,64,4,4,64,1,1,1" is not applicable
+      // CHECK-NOT: Perfconfig "4,64,4,4,64,1,1,1" is not applicable
       printf("Perfconfig \"%s\" is not applicable to the problem string(%s)\n",
              paramStr, problemKey);
       mlirModuleDestroy(tuningClone);

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -229,7 +229,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
     mlirRockTuningSetParam(tuningClone, tuningParam);
     if (mlirLogicalResultIsFailure(
             mlirPassManagerRunOnOp(applicabilityPm, tuningCloneOp))) {
-      // CHECK-NOT: Perfconfig "4,64,4,4,64,1,1,1" is not applicable
+      // CHECK-NOT: is not applicable
       printf("Perfconfig \"%s\" is not applicable to the problem string(%s)\n",
              paramStr, problemKey);
       mlirModuleDestroy(tuningClone);


### PR DESCRIPTION
Copy the blockSize check from the gridwise-to-blockwise pass into the rock-tuning-parameter phase to rule out invalid tuning parameters at an early stage. 