### PR TITLE
Transform `extract(select(a,b))` into `select(extract(a),extract(b)))`

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/RockPrepareLLVM.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPrepareLLVM.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Rock/Passes.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/ADT/SmallBitVector.h"
 
@@ -39,6 +40,37 @@ namespace rock {
 using namespace mlir;
 
 namespace {
+
+// Simple rewrite to transform:
+//  %s = llvm.select structA, structB
+//  %ptr = llvm.extractvalue %s
+// Into :
+//  %ptrA = llvm.extractvalue %structA
+//  %ptrB = llvm.extractvalue %structB
+//  %s = llvm.select %ptrA, %ptrB
+struct SelectExtractRewritePattern
+    : public OpRewritePattern<LLVM::ExtractValueOp> {
+  using OpRewritePattern<LLVM::ExtractValueOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::ExtractValueOp op,
+                                PatternRewriter &rw) const override {
+    if (auto selectOp = dyn_cast_or_null<LLVM::SelectOp>(
+            op.getContainer().getDefiningOp())) {
+      auto loc = op->getLoc();
+      auto extractTrueValue = rw.create<LLVM::ExtractValueOp>(
+          loc, selectOp.getTrueValue(), op.getPosition());
+      auto extractFalseValue = rw.create<LLVM::ExtractValueOp>(
+          loc, selectOp.getFalseValue(), op.getPosition());
+      auto newSelectOp = rw.create<LLVM::SelectOp>(
+          loc, selectOp.getCondition(), extractTrueValue, extractFalseValue,
+          selectOp.getFastmathFlags());
+      rw.replaceOp(op, newSelectOp);
+      return success();
+    }
+    return failure();
+  }
+};
+
 struct RockPrepareLLVMPass
     : public rock::impl::RockPrepareLLVMPassBase<RockPrepareLLVMPass> {
   void runOnOperation() override;
@@ -189,4 +221,11 @@ void RockPrepareLLVMPass::runOnOperation() {
   });
 
   // 4. TODO: add some invariant.start calls once MLIR's got them.
+
+  // 5. Transform an extract of a select into a select of extracts
+  {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<SelectExtractRewritePattern>(patterns.getContext());
+    (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
+  }
 }

--- a/mlir/lib/Dialect/Rock/Transforms/RockPrepareLLVM.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPrepareLLVM.cpp
@@ -54,20 +54,21 @@ struct SelectExtractRewritePattern
 
   LogicalResult matchAndRewrite(LLVM::ExtractValueOp op,
                                 PatternRewriter &rw) const override {
-    if (auto selectOp = dyn_cast_or_null<LLVM::SelectOp>(
-            op.getContainer().getDefiningOp())) {
-      auto loc = op->getLoc();
-      auto extractTrueValue = rw.create<LLVM::ExtractValueOp>(
-          loc, selectOp.getTrueValue(), op.getPosition());
-      auto extractFalseValue = rw.create<LLVM::ExtractValueOp>(
-          loc, selectOp.getFalseValue(), op.getPosition());
-      auto newSelectOp = rw.create<LLVM::SelectOp>(
-          loc, selectOp.getCondition(), extractTrueValue, extractFalseValue,
-          selectOp.getFastmathFlags());
-      rw.replaceOp(op, newSelectOp);
-      return success();
-    }
-    return failure();
+    auto selectOp =
+        dyn_cast_or_null<LLVM::SelectOp>(op.getContainer().getDefiningOp());
+    if (!selectOp)
+      return failure();
+
+    auto loc = op->getLoc();
+    auto extractTrueValue = rw.create<LLVM::ExtractValueOp>(
+        loc, selectOp.getTrueValue(), op.getPosition());
+    auto extractFalseValue = rw.create<LLVM::ExtractValueOp>(
+        loc, selectOp.getFalseValue(), op.getPosition());
+    auto newSelectOp = rw.create<LLVM::SelectOp>(
+        loc, selectOp.getCondition(), extractTrueValue, extractFalseValue,
+        selectOp.getFastmathFlags());
+    rw.replaceOp(op, newSelectOp);
+    return success();
   }
 };
 


### PR DESCRIPTION
This is transforming the sequence:
```
a = select(struct0, struct1)
ptr = extractValue(a)
```
into
```
ptr0 = extractValue(struct0)
ptr1 = extractValue(struct1)
ptr = select(ptr0, ptr1)
```
In this way we can smoothly remove `memref`s before going into the translation. 

Before the PR:
```
$ mlir-to-asm.sh config | grep mask
v_cndmask_b32_e64 v64, 0, 1, s[2:3]
v_cndmask_b32_e64 v67, 0, 1, s[0:1]
.amdhsa_reserve_xnack_mask 1
```
After the PR:
```
$ mlir-to-asm.sh config | grep mask
.amdhsa_reserve_xnack_mask 1
```

Also, this PR will make SROA executing (but still failing). While before it was simply stopping because of the `insertvalue` left in the LLVM-IR. 

