### PR TITLE
Fix rocmlir-gen on running bufferization pipeline

### DIFF
--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3627,7 +3627,9 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (applyBufferizationPipeline.getValue()) {
+  // Running the bufferization pipeline when rocmlir-gen is actually
+  // generating a kernel.
+  if (applyBufferizationPipeline.getValue() && !hasUserKernel) {
     PassManager pm(module->getName(), PassManager::Nesting::Implicit);
 
     rock::BufferizeOptions bufferizeOptions;


### PR DESCRIPTION
This commit adds a guard to not run bufferization
pipeline when a kernel is not being generated by
rocmlir-gen.