### PR TITLE
Update device library finding to prepend ROCM_PATH, use hipconfig

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -167,6 +167,7 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
   find_package(AMDDeviceLibs CONFIG)
   set(CMAKE_PREFIX_PATH "${REAL_CMAKE_PREFIX_PATH}")
   if(AMDDeviceLibs_FOUND)
+    message(STATUS "AMD device libs prefix: ${AMD_DEVICE_LIBS_PREFIX}")
     set(device_lib_targets ${AMD_DEVICE_LIBS_TARGETS})
     # Filter out control constants, since we set those inline
     list(FILTER device_lib_targets EXCLUDE REGEX "^oclc_")

--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -145,7 +145,15 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
   ### This is menat to let us embed the device libraries into a static library.
   if (NOT DEFINED ROCM_PATH)
     if (NOT DEFINED ENV{ROCM_PATH})
-      set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to which ROCm has been installed")
+      find_program(HIPCONFIG hipconfig NAMES PATHS /opt/rocm/bin
+        DOC "Path to hipconfig, used to find ROCm device libraries")
+      if (NOT HIPCONFIG)
+        set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to which ROCm has been installed")
+      else()
+        exec_program(${HIPCONFIG} ARGS "--rocmpath"
+          OUTPUT_VARIABLE HIPCONFIG_ROCM_PATH)
+        set(ROCM_PATH ${HIPCONFIG_ROCM_PATH} CACHE PATH "Path to which ROCm has been installed")
+      endif()
     else()
       set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which ROCm has been installed")
     endif()
@@ -155,7 +163,7 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
   # Therefore, temporarily add the ROCm path to CMAKE_PREFIX_PATH so we can
   # find the device libraries, then remove it
   set(REAL_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
-  list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
+  list(PREPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/hip")
   find_package(AMDDeviceLibs CONFIG)
   set(CMAKE_PREFIX_PATH "${REAL_CMAKE_PREFIX_PATH}")
   if(AMDDeviceLibs_FOUND)


### PR DESCRIPTION
Fixes #1415

Because our static library build wants to avoid runtime dependencies on (the location of) ROCm, but we need the device libraries for math functions, we pull the device libraries into a #include-able file at configure time. A recent bug report showed the build system picking up the wrong value for ROCM_PATH, leading to the device libraries not being findable. This commit, hopefully, addresses that issue.