### PR TITLE
Implemeted Split-K GEMM with coord. trans.

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/Tuning/Serializable.h"
+#include <optional>
 
 namespace llvm {
 class raw_ostream;
@@ -57,7 +58,9 @@ GemmSize calculatePaddedGemmSize(const InitParams &params, GemmSize gemmSize,
 /// a given gemm size requires. Returns None if no padding is needed. The
 /// values in the returned gemm context represent the number of 0s that need to
 /// be added to the given dimension.
-std::optional<GemmSize> requiredPadding(Attribute params, GemmSize gemmSize);
+std::optional<GemmSize>
+requiredPadding(Attribute params, GemmSize gemmSize,
+                std::optional<GemmSize> scale = std::nullopt);
 
 /// Store information useful for populating perf configurations
 struct PopulateParamsInfo {

--- a/mlir/test/e2e/gemm_split_k.cfg
+++ b/mlir/test/e2e/gemm_split_k.cfg
@@ -1,0 +1,2 @@
+if not 'atomic_add' in config.features:
+  config.unsupported = True

--- a/mlir/test/e2e/gemm_split_k.toml
+++ b/mlir/test/e2e/gemm_split_k.toml
@@ -3,13 +3,13 @@ prefix = "rocmlir-gen"
 suffix = "--operation gemm --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
-name = "storeMethod"
-values = ["set", "atomic_add"]
-prefix = "--store-method="
+name = "splitKFactor"
+values = ["0", "1", "2", "3", "4", "5"]
+prefix = "--split-k="
 
 [[axis]]
 name = "data type"
-values = ["f32", "f16 -RMS_threshold=1e-3"]
+values = ["f32", "f16"]
 prefix = "-t "
 
 ## Gemm variants

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2286,7 +2286,7 @@ static void getAttentionTypes(SmallVectorImpl<Type> &result,
 
 template <typename TosaOp, typename... Args>
 static TosaOp createOpAndInfer(OpBuilder &builder, Location loc, Type elemType,
-                               Args &&... args) {
+                               Args &&...args) {
   auto op =
       builder.create<TosaOp>(loc, UnrankedTensorType::get(elemType), args...);
   InferShapedTypeOpInterface shapeInterface =

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -274,6 +274,10 @@ static llvm::cl::opt<bool>
                llvm::cl::desc("whether matrix C is GxMxN (default) or GxNxM"),
                llvm::cl::init(false));
 
+static llvm::cl::opt<int64_t>
+    splitkFactor("split-k", llvm::cl::desc("split-k factor"),
+                 llvm::cl::value_desc("positive integer"), llvm::cl::init(1));
+
 static llvm::cl::opt<rock::StoreMethod> storeMethod(
     "store-method", llvm::cl::desc("storage method for gemm"),
     llvm::cl::values(
@@ -2218,6 +2222,9 @@ static func::FuncOp createGpuGemmKernel(ModuleOp module,
 
   if (!params.perfConfig.empty())
     gemm->setAttr("perf_config", b.getStringAttr(params.perfConfig));
+
+  gemm->setAttr("split-k-factor", b.getI32IntegerAttr(splitkFactor));
+
   b.create<func::ReturnOp>(loc);
 
   module.push_back(func);
@@ -2279,7 +2286,7 @@ static void getAttentionTypes(SmallVectorImpl<Type> &result,
 
 template <typename TosaOp, typename... Args>
 static TosaOp createOpAndInfer(OpBuilder &builder, Location loc, Type elemType,
-                               Args &&...args) {
+                               Args &&... args) {
   auto op =
       builder.create<TosaOp>(loc, UnrankedTensorType::get(elemType), args...);
   InferShapedTypeOpInterface shapeInterface =


### PR DESCRIPTION
Hi,

Here is my implementation of `split-k` with coordinate transformations. 

I talked to @manupak and he mentioned that it would be better to avoid `embed` because it is an `irreversible` transformation.
Currently, I cannot come up to an implementation of `split-k` without `embed`.


Closes ROCm/rocMLIR-internal#1380