### PR TITLE
Replacing ROCmSoftwarePlatform with ROCm

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/CMakeLists.txt
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/CMakeLists.txt
@@ -3,7 +3,7 @@ function(add_linalg_ods_yaml_gen yaml_ast_file output_file)
   set(YAML_AST_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/${yaml_ast_file})
   set(GEN_ODS_FILE ${CMAKE_CURRENT_BINARY_DIR}/${output_file}.yamlgen.td)
   set(GEN_CPP_FILE ${CMAKE_CURRENT_BINARY_DIR}/${output_file}.yamlgen.cpp.inc)
-  # Note: workaround for https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/524
+  # Note: workaround for https://github.com/ROCm/rocMLIR-internal/issues/524
   set(DUMMY_FILE ${CMAKE_CURRENT_BINARY_DIR}/dummy)
   set_source_files_properties(
     ${GEN_ODS_FILE}

--- a/mlir/docs/Rock/tensor_layout.md
+++ b/mlir/docs/Rock/tensor_layout.md
@@ -37,7 +37,7 @@ weight_groups = tf.split(axis=3, num_or_size_splits=groups,value=weights)
 YXCK=>YXCGK
 <br/>
 ##### but tensorflow will  transform filter from YXCK to KYXC, weights layout become [GKYXC]:
-https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/blob/develop-upstream/tensorflow/core/kernels/conv_ops.cc#L1040-L1048
+https://github.com/ROCm/tensorflow-upstream/blob/develop-upstream/tensorflow/core/kernels/conv_ops.cc#L1040-L1048
 weight_groups = tf.split(axis=3, num_or_size_splits=groups,value=weights)
 YXCK=>YXCGK , after transform => GKYXC
 <br/>
@@ -51,7 +51,7 @@ conv = tf.concat(axis=3, values=output_groups)
 ### NCHW
 <br/>
 <br/>
-match Rock: https://github.com/ROCmSoftwarePlatform/Rock/blob/35142af8a2978d2cb4e3d7854553767943057841/test/cpu_conv.hpp#L85
+match Rock: https://github.com/ROCm/Rock/blob/35142af8a2978d2cb4e3d7854553767943057841/test/cpu_conv.hpp#L85
 #### input:[NGCHW]
 #### filter:[GKCYX] <= tensorflow transform filter from YXCK to KCYX
 #### output:[NGKHW]

--- a/mlir/lib/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.cpp
+++ b/mlir/lib/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.cpp
@@ -198,7 +198,7 @@ void Fp8ExtToTableLookupPattern::rewrite(
 /// range instead of being rounded to NaN.
 ///
 /// Based off
-/// https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/a41cd5c0b493bbb7d21078f1a842675ff824d2b7/src/include/migraphx/float8_impl.hpp#L37
+/// https://github.com/ROCm/AMDMIGraphX/blob/a41cd5c0b493bbb7d21078f1a842675ff824d2b7/src/include/migraphx/float8_impl.hpp#L37
 /// but trimmed (Clip = true, NegativeZeroNan = true) and run through
 /// clang -O3 on godbolt to get LLVM IR that I could mechanically recreate.
 /// See mlir/docs/fnuz-float-software-truncation-sources/

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -157,7 +157,7 @@ struct BlockwiseFillRewritePattern
 //===----------------------------------------------------------------------===//
 
 // The structure of this lowing is documented at
-// https://github.com/ROCmSoftwarePlatform/rocMLIR/issues/719
+// https://github.com/ROCm/rocMLIR/issues/719
 struct BlockwiseGemmRewritePattern
     : public OpConversionPattern<BlockwiseGemmOp> {
   using OpConversionPattern<BlockwiseGemmOp>::OpConversionPattern;
@@ -456,7 +456,7 @@ struct BlockwiseGemmAccelRewritePattern
     //       threadwise_gemm(regsA, regsB)
     //
     // Which mimics:
-    // https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/develop/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp#L304
+    // https://github.com/ROCm/composable_kernel/blob/develop/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp#L304
     //
     // Please note that different schedules might exist, so this can be
     // considered a temporary hack until we have a proper way of "searching"

--- a/mlir/test/e2e/conv2d_regression_bwd.toml
+++ b/mlir/test/e2e/conv2d_regression_bwd.toml
@@ -47,7 +47,7 @@ config = "-groupsize=1 -batchsize=64 -in_channels=64 -out_channels=64 -in_h=4 -i
 ## The following configs are reported from various tickets
 
 ############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/70 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/70 #
 ############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=16 -in_channels=32 -out_channels=32 -in_h=14 -in_w=14 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"
@@ -71,7 +71,7 @@ config = "-groupsize=1 -batchsize=64 -in_channels=32 -out_channels=32 -in_h=14 -
 config = "-groupsize=1 -batchsize=64 -in_channels=64 -out_channels=64 -in_h=14 -in_w=14 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"
 
 #############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/127 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/127 #
 #############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=128 -in_channels=256 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"
@@ -83,7 +83,7 @@ config = "-groupsize=1 -batchsize=512 -in_channels=256 -out_channels=512 -in_h=7
 config = "-groupsize=1 -batchsize=64 -in_channels=256 -out_channels=64 -in_h=56 -in_w=56 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"
 
 ############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/71 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/71 #
 ############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=32 -in_channels=32 -out_channels=32 -in_h=7 -in_w=7 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
@@ -92,7 +92,7 @@ config = "-groupsize=1 -batchsize=32 -in_channels=32 -out_channels=32 -in_h=7 -i
 config = "-groupsize=1 -batchsize=64 -in_channels=32 -out_channels=32 -in_h=7 -in_w=7 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
 
 #############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/136 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/136 #
 #############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=256 -in_channels=32 -out_channels=32 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=2 -conv_stride_w=2 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"

--- a/mlir/test/e2e/conv2d_regression_fwd.toml
+++ b/mlir/test/e2e/conv2d_regression_fwd.toml
@@ -133,7 +133,7 @@ config = "-groupsize=1 -batchsize=256 -in_channels=64 -out_channels=64 -in_h=56 
 ## The following configs are reported from various tickets
 
 ############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/41 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/41 #
 ############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=16 -in_w=16 -fil_h=3 -fil_w=3 -dilation_h=2 -dilation_w=2 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
@@ -172,7 +172,7 @@ config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 
 config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=5 -fil_w=5 -dilation_h=2 -dilation_w=2 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
 
 ############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/40 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/40 #
 ############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=64 -in_h=32 -in_w=32 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
@@ -190,7 +190,7 @@ config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 
 config = "-groupsize=1 -batchsize=64 -in_channels=8 -out_channels=128 -in_h=16 -in_w=64 -fil_h=3 -fil_w=5 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
 
 #############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/114 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/114 #
 #############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
@@ -205,7 +205,7 @@ config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 
 config = "-groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 -dilation_h=2 -dilation_w=2 -conv_stride_h=2 -conv_stride_w=2 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
 
 #############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/136 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/136 #
 #############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=32 -in_channels=1 -out_channels=64 -in_h=14 -in_w=14 -fil_h=14 -fil_w=14 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"
@@ -214,7 +214,7 @@ config = "-groupsize=1 -batchsize=32 -in_channels=1 -out_channels=64 -in_h=14 -i
 config = "-groupsize=1 -batchsize=32 -in_channels=1 -out_channels=32 -in_h=14 -in_w=14 -fil_h=14 -fil_w=14 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"
 
 #############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/155 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/155 #
 #############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=64 -in_channels=4 -out_channels=64 -in_h=4 -in_w=4 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"

--- a/mlir/test/e2e/conv2d_regression_fwd_navi3x.toml
+++ b/mlir/test/e2e/conv2d_regression_fwd_navi3x.toml
@@ -29,7 +29,7 @@ config = "-p -rand_side filter"
 config = "-p -rand_side input"
 
 #############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/127 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/127 #
 #############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=128 -in_channels=256 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"

--- a/mlir/test/e2e/conv2d_regression_fwd_nonNavi3x.toml
+++ b/mlir/test/e2e/conv2d_regression_fwd_nonNavi3x.toml
@@ -29,7 +29,7 @@ config = "-p -rand_side filter"
 config = "-p -rand_side input"
 
 #############################################################################################
-# Cases reported in https://github.com/ROCmSoftwarePlatform/llvm-project-private/issues/127 #
+# Cases reported in https://github.com/ROCm/rocMLIR-internal/issues/127 #
 #############################################################################################
 [[suite.test]]
 config = "-groupsize=1 -batchsize=128 -in_channels=256 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1"

--- a/mlir/test/fusion/linalg-generic-const-initializer.mlir
+++ b/mlir/test/fusion/linalg-generic-const-initializer.mlir
@@ -16,7 +16,7 @@
 #transform_map27 = #rock.transform_map<#map24 by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>, <AddDim{1} ["exp2"] at [2] -> [] at []>] bounds = [1, 1, 1] -> []>
 #transform_map28 = #rock.transform_map<#map25 by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <Broadcast{1} ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>] bounds = [32, 384, 3072] -> [1, 1, 1]>
 // A cut down version of the input from
-// https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/1098
+// https://github.com/ROCm/rocMLIR-internal/issues/1098
 // right before it headed down to linalg.generic. The actuall gemm part has been
 // removed for test simplicity.
 module {

--- a/mlir/test/fusion/linalg-generic-sigmoid-elementwise-block.mlir
+++ b/mlir/test/fusion/linalg-generic-sigmoid-elementwise-block.mlir
@@ -16,7 +16,7 @@
 #transform_map35 = #rock.transform_map<#map22 by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <PassThrough ["dim0"] at [1] -> ["dim0"] at [0]>] bounds = [1, 5] -> [5]>
 #transform_map36 = #rock.transform_map<#map10 by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>] bounds = [2, 5] -> [1, 5]>
 // Cut down version of a MIGraphX test that triggered a crash, see
-// https://github.com/ROCmSoftwarePlatform/rocMLIR/issues/1188
+// https://github.com/ROCm/rocMLIR/issues/1188
 // Arguments have been rearranged to make pattern matching easier.
 
 module {

--- a/mlir/test/fusion/nightly-misc-e2e/issue-940.mlir
+++ b/mlir/test/fusion/nightly-misc-e2e/issue-940.mlir
@@ -1,4 +1,4 @@
-// The test case that was used to reproduce https://github.com/ROCmSoftwarePlatform/rocMLIR-internal/issues/940
+// The test case that was used to reproduce https://github.com/ROCm/rocMLIR-internal/issues/940
 // RUN: rocmlir-opt --migraphx-transform --canonicalize --migraphx-to-tosa %s | rocmlir-driver -host-pipeline partition,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -fut mlir_dot --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
 // ALLOW_RETRIES: 2
 

--- a/mlir/test/rocmlir-driver/shuffleNet_v2.mlir
+++ b/mlir/test/rocmlir-driver/shuffleNet_v2.mlir
@@ -1,4 +1,4 @@
-// The test was extracted from the ShuffleNet_V2 model of MIGraphX. https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/issues/2315
+// The test was extracted from the ShuffleNet_V2 model of MIGraphX. https://github.com/ROCm/AMDMIGraphX/issues/2315
 // RUN: rocmlir-driver -kernel-pipeline migraphx,highlevel %s | rocmlir-opt
 
 module {

--- a/mlir/utils/buildbot/README
+++ b/mlir/utils/buildbot/README
@@ -1,6 +1,6 @@
 To start up the buildbot:
 
-  git clone https://github.com/ROCmSoftwarePlatform/rocMLIR.git
+  git clone https://github.com/ROCm/rocMLIR.git
   cd ./rocMLIR/mlir/utils/buildbot
   export BUILDBOT_PORT=9990
   export BUILDBOT_MASTER=lab.llvm.org

--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -130,7 +130,7 @@ RUN wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.34-linux-glibc2
 
 # python setup for tuna
 # --ignore-installed because of problems upgrading PyYAML.  See also -U.
-ADD "https://raw.githubusercontent.com/ROCmSoftwarePlatform/MITuna/develop/requirements.txt" tuna-requirements.txt
+ADD "https://raw.githubusercontent.com/ROCm/MITuna/develop/requirements.txt" tuna-requirements.txt
 RUN python3 -m venv /tuna-venv && . /tuna-venv/bin/activate && \
     python3 -m pip install -r tuna-requirements.txt --ignore-installed && \
     python3 -m pip install scipy pandas

--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -15,7 +15,7 @@ RUN rbuild prepare -d $PWD -s develop --cxx=/opt/rocm/llvm/bin/clang++ --cc=/opt
 # Remove rocMLIR version as per MIGraphX requirements
 # as this image is being used for CI with tip of rocMLIR
 # that will be built in the job.
-RUN cget remove -p $PWD ROCmSoftwarePlatform/rocMLIR -y
+RUN cget remove -p $PWD ROCm/rocMLIR -y
 # Download models for testing
 RUN wget https://github.com/onnx/models/raw/ba629906dd91872def671e70177c5544e0ea9e02/vision/classification/resnet/model/resnet50-v1-7.onnx
 RUN wget https://github.com/stefankoncarevic/Onnx_models/raw/master/bert_base_cased_1.onnx

--- a/mlir/utils/jenkins/Jenkinsfile.migraphxintegration
+++ b/mlir/utils/jenkins/Jenkinsfile.migraphxintegration
@@ -33,8 +33,8 @@ echo "int8:$int8"
 echo "checkFor:$checkFor"
 
 docker run -itd --device=/dev/kfd --device=/dev/dri  -v /nas/models:/models --group-add video --hostname migraphx --name migraphx rocm/mlir-migraphx-ci:latest
-docker exec migraphx bash -c "git clone -b $mlir_branch https://github.com/ROCmSoftwarePlatform/rocMLIR.git"
-docker exec migraphx bash -c "git clone -b $migraphx_branch https://github.com/ROCmSoftwarePlatform/AMDMIGraphX.git"
+docker exec migraphx bash -c "git clone -b $mlir_branch https://github.com/ROCm/rocMLIR.git"
+docker exec migraphx bash -c "git clone -b $migraphx_branch https://github.com/ROCm/AMDMIGraphX.git"
 
 docker exec migraphx bash -c "cd rocMLIR/; mkdir build; cd build"
 docker exec -w /rocMLIR/build migraphx bash -c "cmake -G Ninja -DBUILD_FAT_LIBROCKCOMPILER=ON .. && ninja package && cmake --install . --prefix /MIGraphXDeps"

--- a/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
+++ b/mlir/utils/performance/rocblas-benchmark-driver/rocblas-benchmark-driver.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // With much credit to
-// https://github.com/ROCmSoftwarePlatform/rocBLAS-Examples/blob/develop/Level-3/gemm_strided_batched/gemm_strided_batched.cpp
+// https://github.com/ROCm/rocBLAS-Examples/blob/develop/Level-3/gemm_strided_batched/gemm_strided_batched.cpp
 
 // Include common utility functions
 #include "../common/benchmarkUtils.h"
@@ -48,7 +48,7 @@ static rocblas_datatype getRocblasType(bool isOut,
 }
 
 /// This code is taken from
-/// https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/84a8f450f20521242b74bd803824673739d6e858/src/targets/gpu/rocblas.cpp
+/// https://github.com/ROCm/AMDMIGraphX/blob/84a8f450f20521242b74bd803824673739d6e858/src/targets/gpu/rocblas.cpp
 /// and is used to set the GEMM compute type (i.e., the type of the GEMM
 /// accumulation buffer)
 bool get_compute_fp32_flag() {

--- a/mlir/utils/tuna/tuna-script.sh
+++ b/mlir/utils/tuna/tuna-script.sh
@@ -16,7 +16,7 @@ function mysql_setup_generic
 function tuna_setup
 {
 #     rm -rf /tmp/MITuna
-#     git clone --branch pf-tuna-rocmlir-3 http://github.com/ROCmSoftwarePlatform/MITuna.git /tmp/MITuna
+#     git clone --branch pf-tuna-rocmlir-3 http://github.com/ROCm/MITuna.git /tmp/MITuna
 
     source /tuna-venv/bin/activate
     #export TUNA_DIR=/tmp/MITuna

--- a/mlir/utils/widgets/tune_MLIR_kernels.sh
+++ b/mlir/utils/widgets/tune_MLIR_kernels.sh
@@ -51,7 +51,7 @@ gitCheckoutMIOpen() {
         popd
     else
         echo ">>> git clone MIOpen@${miopen_branch}"
-        git clone -b ${miopen_branch} https://github.com/ROCmSoftwarePlatform/MIOpen.git
+        git clone -b ${miopen_branch} https://github.com/ROCm/MIOpen.git
     fi
 }
 


### PR DESCRIPTION
Renaming performed by:

> find ./ -type f -exec sed -i -e 's/ROCmSoftwarePlatform/ROCm/g' {} \;
    find ./ -type f -exec sed -i -e 's/llvm-project-private/rocMLIR-internal/g' {} \;