### PR TITLE
[Attention] Fix cross-attention padding

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -324,7 +324,7 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
       requiredPadding(params0, gemm0Size).value_or(GemmSize{0, 0, 0, 0});
   GemmSize gemm1Size(/*g=*/queriesShape[0], /*m=*/valuesShape[2],
                      /*k=*/valuesShape[1],
-                     /*n=*/keysShape[2]);
+                     /*n=*/queriesShape[2]);
   GemmSize gemm1ExtraPad =
       requiredPadding(params1, gemm1Size).value_or(GemmSize{0, 0, 0, 0});
 

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1363,8 +1363,9 @@ struct GridwiseAttentionAccelRewritePattern
         rewriter, {"g", "paddedDim1", "paddedDim2"}, paddedShape, loc};
     viewBuilder.passThrough("g");
     // paddedShape is G x M x N
-    viewBuilder.pad({"paddedDim1", "paddedDim2"}, {0, paddedShape[1] - prePadDim1, 0,
-                                             paddedShape[2] - prePadDim2});
+    viewBuilder.pad(
+        {"paddedDim1", "paddedDim2"},
+        {0, paddedShape[1] - prePadDim1, 0, paddedShape[2] - prePadDim2});
     TransformMapAttr padMap = viewBuilder.get();
 
     subtileViews.gridSubTile = prependUpperViews(
@@ -1381,10 +1382,10 @@ struct GridwiseAttentionAccelRewritePattern
   // post normalization. Therefore, this function creates a trasnforming
   // for loop that overwrites out of bounds values of first gemm output
   // to be negative infinity.
-  void createFirstGemmNegInfPadding(PatternRewriter &rewriter, Location loc,
-                                    layout::GridCoordinates gridCoords,
-                                    Value gemm0OutBuffer,
-                                    RegsAsMatrixSubTiles gemm0OutSubTileViews) const {
+  void createFirstGemmNegInfPadding(
+      PatternRewriter &rewriter, Location loc,
+      layout::GridCoordinates gridCoords, Value gemm0OutBuffer,
+      RegsAsMatrixSubTiles gemm0OutSubTileViews) const {
     MemRefType gemm0OutBufferType = gemm0OutBuffer.getType().cast<MemRefType>();
     auto negInfTyped = createConstantFloatOp(
         rewriter, loc, gemm0OutBufferType.getElementType(),
@@ -1399,7 +1400,8 @@ struct GridwiseAttentionAccelRewritePattern
         ArrayRef<ValueRange>{{gridCoords.g_block, gridCoords.m_block,
                               gridCoords.n_block, tid, zero},
                              {zero, zero, zero, zero, zero}},
-        ArrayRef<Attribute>{gemm0OutSubTileViews.gridSubTile, rewriter.getArrayAttr({})},
+        ArrayRef<Attribute>{gemm0OutSubTileViews.gridSubTile,
+                            rewriter.getArrayAttr({})},
         /*bounds=*/ArrayRef<int64_t>{1, 1, 1, 1, elementsInThreadBuffer},
         /*strides=*/ArrayRef<int64_t>{1, 1, 1, 1, 1},
         /*useIndexDiffs=*/true, /*forceUnroll=*/true);
@@ -2042,7 +2044,8 @@ struct GridwiseAttentionAccelRewritePattern
           op.getPrePadG0M().has_value() || op.getPrePadG0N().has_value();
       if (hasPadding) {
         createFirstGemmNegInfPadding(rewriter, loc, gridCoordsGemm0,
-                                     gemm0OutBuffer, gemm0OutSubTileViewsTrUnPadded);
+                                     gemm0OutBuffer,
+                                     gemm0OutSubTileViewsTrUnPadded);
       }
 
       APInt reductionAxis = APInt(64, 1);

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1351,6 +1351,27 @@ struct GridwiseAttentionAccelRewritePattern
     return ret;
   }
 
+  // This function will create a grid subtile view that has the unpadded
+  // coordinates if there were any padding involved in the gemm operands.
+  RegsAsMatrixSubTiles unpadGridSubTileView(PatternRewriter &rewriter,
+                                            Location loc,
+                                            RegsAsMatrixSubTiles subtileViews,
+                                            int64_t prePadDim1,
+                                            int64_t prePadDim2) const {
+    ArrayRef<int64_t> paddedShape = getLowerShape(subtileViews.gridSubTile);
+    TopDownTMBuilder viewBuilder{
+        rewriter, {"g", "paddedDim1", "paddedDim2"}, paddedShape, loc};
+    viewBuilder.passThrough("g");
+    // paddedShape is G x M x N
+    viewBuilder.pad({"paddedDim1", "paddedDim2"}, {0, paddedShape[1] - prePadDim1, 0,
+                                             paddedShape[2] - prePadDim2});
+    TransformMapAttr padMap = viewBuilder.get();
+
+    subtileViews.gridSubTile = prependUpperViews(
+        rewriter, subtileViews.gridSubTile, rewriter.getArrayAttr({padMap}));
+    return subtileViews;
+  }
+
   // If padding is used in the kernel, this means the first gemm
   // will be done in a larger matrix. In typical, gemm kernels
   // the padded region in the output will just contain zeros. However,
@@ -1363,25 +1384,7 @@ struct GridwiseAttentionAccelRewritePattern
   void createFirstGemmNegInfPadding(PatternRewriter &rewriter, Location loc,
                                     layout::GridCoordinates gridCoords,
                                     Value gemm0OutBuffer,
-                                    RegsAsMatrixSubTiles gemm0OutSubTileViews,
-                                    int64_t prePadGemmM,
-                                    int64_t prePadGemmN) const {
-    // Append a pad rock.transform to be able query validity
-    // later to insert the special padded value
-    ArrayRef<int64_t> paddedShape =
-        getLowerShape(gemm0OutSubTileViews.gridSubTile);
-    TopDownTMBuilder viewBuilder{
-        rewriter, {"g", "paddedM", "paddedN"}, paddedShape, loc};
-    viewBuilder.passThrough("g");
-    // paddedShape is G x M x N
-    viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[1] - prePadGemmM, 0,
-                                             paddedShape[2] - prePadGemmN});
-    TransformMapAttr padMap = viewBuilder.get();
-
-    ArrayAttr transforms =
-        prependUpperViews(rewriter, gemm0OutSubTileViews.gridSubTile,
-                          rewriter.getArrayAttr({padMap}));
-
+                                    RegsAsMatrixSubTiles gemm0OutSubTileViews) const {
     MemRefType gemm0OutBufferType = gemm0OutBuffer.getType().cast<MemRefType>();
     auto negInfTyped = createConstantFloatOp(
         rewriter, loc, gemm0OutBufferType.getElementType(),
@@ -1396,7 +1399,7 @@ struct GridwiseAttentionAccelRewritePattern
         ArrayRef<ValueRange>{{gridCoords.g_block, gridCoords.m_block,
                               gridCoords.n_block, tid, zero},
                              {zero, zero, zero, zero, zero}},
-        ArrayRef<Attribute>{transforms, rewriter.getArrayAttr({})},
+        ArrayRef<Attribute>{gemm0OutSubTileViews.gridSubTile, rewriter.getArrayAttr({})},
         /*bounds=*/ArrayRef<int64_t>{1, 1, 1, 1, elementsInThreadBuffer},
         /*strides=*/ArrayRef<int64_t>{1, 1, 1, 1, 1},
         /*useIndexDiffs=*/true, /*forceUnroll=*/true);
@@ -2008,10 +2011,22 @@ struct GridwiseAttentionAccelRewritePattern
       accelEmitterPtrGemm0->computeOutputConversion(
           rewriter, loc, accRegBufferGemm0, gemm0OutBuffer, forceUnroll);
 
+      int64_t prePadG0M = gemm0M;
+      if (op.getPrePadG0M().has_value()) {
+        prePadG0M = op.getPrePadG0M().value().getSExtValue();
+      }
+      int64_t prePadG0N = gemm0N;
+      if (op.getPrePadG0N().has_value()) {
+        prePadG0N = op.getPrePadG0N().value().getSExtValue();
+      }
+      RegsAsMatrixSubTiles gemm0OutSubTileViewsTrUnPadded =
+          unpadGridSubTileView(rewriter, loc, gemm0OutSubTileViewsTr, prePadG0N,
+                               prePadG0M);
+
       // Align the preSoftmaxElementWise (if any) linalg.generic to
       // be performed on the output of the first gemm.
       postProcessFirstGemm(rewriter, loc, op, gridCoordsGemm0, gemm0OutBuffer,
-                           gemm0OutSubTileViewsTr);
+                           gemm0OutSubTileViewsTrUnPadded);
       // Scale gemm0 output by (1/ln2)
       // So that we can use exp2 instead of exp.
 #ifndef ROCK_DEBUG_ATTENTION_REMOVE_SOFTMAX
@@ -2026,17 +2041,8 @@ struct GridwiseAttentionAccelRewritePattern
       bool hasPadding =
           op.getPrePadG0M().has_value() || op.getPrePadG0N().has_value();
       if (hasPadding) {
-        int64_t prePadG0M = gemm0M;
-        if (op.getPrePadG0M().has_value()) {
-          prePadG0M = op.getPrePadG0M().value().getSExtValue();
-        }
-        int64_t prePadG0N = gemm0N;
-        if (op.getPrePadG0N().has_value()) {
-          prePadG0N = op.getPrePadG0N().value().getSExtValue();
-        }
         createFirstGemmNegInfPadding(rewriter, loc, gridCoordsGemm0,
-                                     gemm0OutBuffer, gemm0OutSubTileViewsTr,
-                                     prePadG0M, prePadG0N);
+                                     gemm0OutBuffer, gemm0OutSubTileViewsTrUnPadded);
       }
 
       APInt reductionAxis = APInt(64, 1);

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-attention/f16/mixr-attention-sdxl-cross-attention.mlir
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-attention/f16/mixr-attention-sdxl-cross-attention.mlir
@@ -1,0 +1,32 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -fut mlir_attention_wrapper -relDiff_threshold 0.02 -absDiff_threshold 0.02 -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+
+module {
+    func.func private @mlir_attention(%arg0: !migraphx.shaped<2x4096x640xf16, 2621440x640x1>, 
+                                      %arg1: !migraphx.shaped<2x77x1280xf16, 98560x1280x1>, 
+                                      %arg2: !migraphx.shaped<2x77x1280xf16, 98560x1280x1>) 
+                                      -> !migraphx.shaped<20x4096x64xf16, 262144x64x1> 
+                                      // attributes {arch = "gfx942:sramecc+:xnack-", kernel = "mixr", num_cu = 304 : i64} 
+                                      {
+    %0 = migraphx.literal(dense<1.250000e-01> : tensor<1xf16>) : <1xf16, 0>
+    %1 = migraphx.reshape %arg0 {dims = [2, 4096, 10, 64]} : <2x4096x640xf16, 2621440x640x1> -> <2x4096x10x64xf16, 2621440x640x64x1>
+    %2 = migraphx.transpose %1 {permutation = [0, 2, 1, 3]} : <2x4096x10x64xf16, 2621440x640x64x1> -> <2x10x4096x64xf16, 2621440x64x640x1>
+    %3 = migraphx.reshape %2 {dims = [20, 4096, 64]} : <2x10x4096x64xf16, 2621440x64x640x1> -> <20x4096x64xf16, 262144x64x1>
+    %4 = migraphx.reshape %arg1 {dims = [2, 77, 2, 10, 64]} : <2x77x1280xf16, 98560x1280x1> -> <2x77x2x10x64xf16, 98560x1280x640x64x1>
+    %5 = migraphx.transpose %4 {permutation = [2, 0, 3, 1, 4]} : <2x77x2x10x64xf16, 98560x1280x640x64x1> -> <2x2x10x77x64xf16, 640x98560x64x1280x1>
+    %6 = migraphx.slice %5 {axes = [0], ends = [1], starts = [0]} : <2x2x10x77x64xf16, 640x98560x64x1280x1> -> <1x2x10x77x64xf16, 640x98560x64x1280x1>
+    %7 = migraphx.reshape %6 {dims = [20, 77, 64]} : <1x2x10x77x64xf16, 640x98560x64x1280x1> -> <20x77x64xf16, 4928x64x1>
+    %8 = migraphx.transpose %7 {permutation = [0, 2, 1]} : <20x77x64xf16, 4928x64x1> -> <20x64x77xf16, 4928x1x64>
+    %9 = migraphx.dot %3, %8 : <20x4096x64xf16, 262144x64x1>, <20x64x77xf16, 4928x1x64> -> <20x4096x77xf16, 315392x77x1>
+    %10 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [20, 4096, 77]} : <1xf16, 0> -> <20x4096x77xf16, 0x0x0>
+    %11 = migraphx.mul %9, %10 : <20x4096x77xf16, 315392x77x1>, <20x4096x77xf16, 0x0x0> -> <20x4096x77xf16, 315392x77x1>
+    %12 = migraphx.softmax %11 {axis = 2 : i64} : <20x4096x77xf16, 315392x77x1> -> <20x4096x77xf16, 315392x77x1>
+    %13 = migraphx.reshape %arg2 {dims = [2, 77, 2, 10, 64]} : <2x77x1280xf16, 98560x1280x1> -> <2x77x2x10x64xf16, 98560x1280x640x64x1>
+    %14 = migraphx.transpose %13 {permutation = [2, 0, 3, 1, 4]} : <2x77x2x10x64xf16, 98560x1280x640x64x1> -> <2x2x10x77x64xf16, 640x98560x64x1280x1>
+    %15 = migraphx.slice %14 {axes = [0], ends = [2], starts = [1]} : <2x2x10x77x64xf16, 640x98560x64x1280x1> -> <1x2x10x77x64xf16, 640x98560x64x1280x1>
+    %16 = migraphx.reshape %15 {dims = [20, 77, 64]} : <1x2x10x77x64xf16, 640x98560x64x1280x1> -> <20x77x64xf16, 4928x64x1>
+    %17 = migraphx.dot %12, %16 : <20x4096x77xf16, 315392x77x1>, <20x77x64xf16, 4928x64x1> -> <20x4096x64xf16, 262144x64x1>
+    return %17 : !migraphx.shaped<20x4096x64xf16, 262144x64x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale-cross.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale-cross.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x128x64xf32, 8192x64x1> {func.read_access},
+                                    %arg1: !migraphx.shaped<1x64x27xf32, 1728x27x1> {func.read_access},
+                                    %arg2: !migraphx.shaped<1x27x64xf32, 1728x64x1> {func.read_access},
+                                    %arg3: !migraphx.shaped<1x128x27xf32, 3456x27x1> {func.read_access}) 
+                                    -> (!migraphx.shaped<1x128x64xf32, 8192x64x1> {func.write_access}) {
+    %0 = migraphx.dot %arg0, %arg1: <1x128x64xf32, 8192x64x1>, <1x64x27xf32, 1728x27x1> -> <1x128x27xf32, 3456x27x1>
+    %biased = migraphx.mul %0, %arg3 : <1x128x27xf32, 3456x27x1>, <1x128x27xf32, 3456x27x1> -> <1x128x27xf32, 3456x27x1>
+    %1 = migraphx.softmax %biased{axis = 2 : i64} : <1x128x27xf32, 3456x27x1> -> <1x128x27xf32, 3456x27x1>
+    %2 = migraphx.dot %1, %arg2: <1x128x27xf32, 3456x27x1>, <1x27x64xf32, 1728x64x1> -> <1x128x64xf32, 8192x64x1>
+    return %2 : !migraphx.shaped<1x128x64xf32, 8192x64x1>
+  }
+}


### PR DESCRIPTION
The padding application was wrong for
where gemm0 had : k0 x m * k0 x n0
and gemm1 had : n0 x m * n0 x n1

where m != n0 in cross-attention