### PR TITLE
[BACKPORT][Attention] Fix cross-attention padding

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -106,7 +106,8 @@ struct InitParamsNonAccel : InitParams, Serializable<InitParamsNonAccel> {
 
   int64_t getKPack() { return 1; }
 
-  template <class Self, class F> static void visit(Self &&self, F f) {
+  template <class Self, class F>
+  static void visit(Self &&self, F f) {
     f(self.blockSize);
     f(self.gemmMPerBlock);
     f(self.gemmNPerBlock);
@@ -154,7 +155,8 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   bool gemmAThreadCopyMoreGemmK;
   bool gemmBThreadCopyMoreGemmKPack;
 
-  template <class Self, class F> static void visit(Self &&self, F f) {
+  template <class Self, class F>
+  static void visit(Self &&self, F f) {
     f(self.gemmMPerBlock);
     f(self.gemmNPerBlock);
     f(self.gemmKPerBlock);
@@ -166,14 +168,16 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   }
 };
 
-template <typename T> std::string genDebugForParams(T params) {
+template <typename T>
+std::string genDebugForParams(T params) {
   std::ostringstream os;
   params.visit(params, [&os](auto &arg) { os << arg << ","; });
   os << "\n";
   return os.str();
 }
 
-template <typename InitParamType> class BasePopulateParams {
+template <typename InitParamType>
+class BasePopulateParams {
 private:
   struct InitParamData {
     InitParamType paramSet;

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -252,7 +252,7 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
       requiredPadding(params0, gemm0Size).value_or(GemmSize{0, 0, 0, 0});
   GemmSize gemm1Size(/*g=*/queriesShape[0], /*m=*/valuesShape[2],
                      /*k=*/valuesShape[1],
-                     /*n=*/keysShape[2]);
+                     /*n=*/queriesShape[2]);
   GemmSize gemm1ExtraPad =
       requiredPadding(params1, gemm1Size).value_or(GemmSize{0, 0, 0, 0});
 

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1369,6 +1369,28 @@ struct GridwiseAttentionAccelRewritePattern
         });
   }
 
+  // This function will create a grid subtile view that has the unpadded
+  // coordinates if there were any padding involved in the gemm operands.
+  RegsAsMatrixSubTiles unpadGridSubTileView(PatternRewriter &rewriter,
+                                            Location loc,
+                                            RegsAsMatrixSubTiles subtileViews,
+                                            int64_t prePadDim1,
+                                            int64_t prePadDim2) const {
+    ArrayRef<int64_t> paddedShape = getLowerShape(subtileViews.gridSubTile);
+    TopDownTMBuilder viewBuilder{
+        rewriter, {"g", "paddedDim1", "paddedDim2"}, paddedShape, loc};
+    viewBuilder.passThrough("g");
+    // paddedShape is G x M x N
+    viewBuilder.pad(
+        {"paddedDim1", "paddedDim2"},
+        {0, paddedShape[1] - prePadDim1, 0, paddedShape[2] - prePadDim2});
+    TransformMapAttr padMap = viewBuilder.get();
+
+    subtileViews.gridSubTile = prependUpperViews(
+        rewriter, subtileViews.gridSubTile, rewriter.getArrayAttr({padMap}));
+    return subtileViews;
+  }
+
   // If padding is used in the kernel, this means the first gemm
   // will be done in a larger matrix. In typical, gemm kernels
   // the padded region in the output will just contain zeros. However,
@@ -1378,28 +1400,10 @@ struct GridwiseAttentionAccelRewritePattern
   // post normalization. Therefore, this function creates a trasnforming
   // for loop that overwrites out of bounds values of first gemm output
   // to be negative infinity.
-  void createFirstGemmNegInfPadding(PatternRewriter &rewriter, Location loc,
-                                    layout::GridCoordinates gridCoords,
-                                    Value gemm0OutBuffer,
-                                    RegsAsMatrixSubTiles gemm0OutSubTileViews,
-                                    int64_t prePadGemmM,
-                                    int64_t prePadGemmN) const {
-    // Append a pad rock.transform to be able query validity
-    // later to insert the special padded value
-    ArrayRef<int64_t> paddedShape =
-        getLowerShape(gemm0OutSubTileViews.gridSubTile);
-    TopDownTMBuilder viewBuilder{
-        rewriter, {"g", "paddedM", "paddedN"}, paddedShape, loc};
-    viewBuilder.passThrough("g");
-    // paddedShape is G x M x N
-    viewBuilder.pad({"paddedM", "paddedN"}, {0, paddedShape[1] - prePadGemmM, 0,
-                                             paddedShape[2] - prePadGemmN});
-    TransformMapAttr padMap = viewBuilder.get();
-
-    ArrayAttr transforms =
-        prependUpperViews(rewriter, gemm0OutSubTileViews.gridSubTile,
-                          rewriter.getArrayAttr({padMap}));
-
+  void createFirstGemmNegInfPadding(
+      PatternRewriter &rewriter, Location loc,
+      layout::GridCoordinates gridCoords, Value gemm0OutBuffer,
+      RegsAsMatrixSubTiles gemm0OutSubTileViews) const {
     MemRefType gemm0OutBufferType = gemm0OutBuffer.getType().cast<MemRefType>();
     auto negInfTyped = createConstantFloatOp(
         rewriter, loc, gemm0OutBufferType.getElementType(),
@@ -1414,7 +1418,8 @@ struct GridwiseAttentionAccelRewritePattern
         ArrayRef<ValueRange>{{gridCoords.g_block, gridCoords.m_block,
                               gridCoords.n_block, tid, zero},
                              {zero, zero, zero, zero, zero}},
-        ArrayRef<Attribute>{transforms, rewriter.getArrayAttr({})},
+        ArrayRef<Attribute>{gemm0OutSubTileViews.gridSubTile,
+                            rewriter.getArrayAttr({})},
         /*bounds=*/ArrayRef<int64_t>{1, 1, 1, 1, elementsInThreadBuffer},
         /*strides=*/ArrayRef<int64_t>{1, 1, 1, 1, 1},
         /*useIndexDiffs=*/true, /*forceUnroll=*/true);
@@ -1895,6 +1900,18 @@ struct GridwiseAttentionAccelRewritePattern
       }
       accelEmitterPtrGemm0->computeOutputConversion(
           rewriter, loc, accRegBufferGemm0, gemm0OutBuffer, forceUnroll);
+
+      int64_t prePadG0M = gemm0M;
+      if (op.getPrePadG0M().has_value()) {
+        prePadG0M = op.getPrePadG0M().value().getSExtValue();
+      }
+      int64_t prePadG0N = gemm0N;
+      if (op.getPrePadG0N().has_value()) {
+        prePadG0N = op.getPrePadG0N().value().getSExtValue();
+      }
+      RegsAsMatrixSubTiles gemm0OutSubTileViewsTrUnPadded =
+          unpadGridSubTileView(rewriter, loc, gemm0OutSubTileViewsTr, prePadG0N,
+                               prePadG0M);
       // Handle the first gemm scaling if present
       if (Value scaleIn = op.getScale()) {
         Value rawBuffer;
@@ -1909,10 +1926,12 @@ struct GridwiseAttentionAccelRewritePattern
                 "Only splat scale constant input is supported.");
           }
           scaleFirstGemmSplat(rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-                              gemm0OutSubTileViewsTr, maybeSplatAttr.value());
+                              gemm0OutSubTileViewsTrUnPadded,
+                              maybeSplatAttr.value());
         } else {
           scaleFirstGemm(rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
-                         gemm0OutSubTileViewsTr, scaleInBuffer, scaleIn);
+                         gemm0OutSubTileViewsTrUnPadded, scaleInBuffer,
+                         scaleIn);
         }
       }
       // Scale gemm0 output by (1/ln2)
@@ -1938,8 +1957,8 @@ struct GridwiseAttentionAccelRewritePattern
           prePadG0N = op.getPrePadG0N().value().getSExtValue();
         }
         createFirstGemmNegInfPadding(rewriter, loc, gridCoordsGemm0,
-                                     gemm0OutBuffer, gemm0OutSubTileViewsTr,
-                                     prePadG0M, prePadG0N);
+                                     gemm0OutBuffer,
+                                     gemm0OutSubTileViewsTrUnPadded);
       }
 
       APInt reductionAxis = APInt(64, 1);

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale-cross.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-padded-scale-cross.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x128x64xf32, 8192x64x1> {func.read_access},
+                                    %arg1: !migraphx.shaped<1x64x27xf32, 1728x27x1> {func.read_access},
+                                    %arg2: !migraphx.shaped<1x27x64xf32, 1728x64x1> {func.read_access},
+                                    %arg3: !migraphx.shaped<1x128x27xf32, 3456x27x1> {func.read_access}) 
+                                    -> (!migraphx.shaped<1x128x64xf32, 8192x64x1> {func.write_access}) {
+    %0 = migraphx.dot %arg0, %arg1: <1x128x64xf32, 8192x64x1>, <1x64x27xf32, 1728x27x1> -> <1x128x27xf32, 3456x27x1>
+    %biased = migraphx.mul %0, %arg3 : <1x128x27xf32, 3456x27x1>, <1x128x27xf32, 3456x27x1> -> <1x128x27xf32, 3456x27x1>
+    %1 = migraphx.softmax %biased{axis = 2 : i64} : <1x128x27xf32, 3456x27x1> -> <1x128x27xf32, 3456x27x1>
+    %2 = migraphx.dot %1, %arg2: <1x128x27xf32, 3456x27x1>, <1x27x64xf32, 1728x64x1> -> <1x128x64xf32, 8192x64x1>
+    return %2 : !migraphx.shaped<1x128x64xf32, 8192x64x1>
+  }
+}


### PR DESCRIPTION
Original PR : https://github.com/ROCm/rocMLIR/pull/1424

Original Description : 

The padding application was wrong for
where gemm0 had : k0 x m * k0 x n0
and gemm1 had : n0 x m * n0 x n1

where m != n0 in cross-attention