### PR TITLE
Update CODEOWNERS to just Jerry and Simon

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ravil-mobile @krzysz00 @jerryyin @giuseros @manupak @sjw36 @yiqian1 @djramic @pcf000 @stefankoncarevic
+* @jerryyin @sjw36


### PR DESCRIPTION
 - For internal PRs: feature owner can find a internal reviewer. Feel free to edit the reviewer list and remove both of us.
 - For external PRs: Jerry/Simon to review or assign reviewers.

This will help reduce the amount of noise to everyone.