### PR TITLE
[Attention] Fix G1MPerBlock Derivation

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -210,17 +210,18 @@ static InitParamsAccel deriveGemm1TuningParams(OpBuilder &builder,
   // is increased beyond gemm0MPerBlock when getMPerWave
   // is less than 32 (i.e. 16).
   int64_t gemm1M = op.getOTransposed() ? oShape[1] : oShape[2];
-  if (gemm0TuningParams.getMPerWave() >= 32 &&
-      gemm0TuningParams.getMPerBlock() < gemm1M) {
-    gemm1M = math_util::integer_least_multiple(
-        gemm1M, gemm0TuningParams.getMPerBlock());
-    Type gemm1ElemType =
+  // This is good enough heuristic for now to guard from cases where
+  // head dimension exceed 256 for i8, 128 for f16 and 64 for for f32
+  Type gemm1ElemType =
         op.getValues().getType().cast<ShapedType>().getElementType();
-    int64_t gemm1ElemTypeByteWidth = gemm1ElemType.getIntOrFloatBitWidth() / 8;
-    // This is good enough heuristic for now to guard from cases where
-    // head dimension exceed 256 for i8, 128 for f16 and 64 for for f32
-    int64_t gemm1MUpperBound = 256 / gemm1ElemTypeByteWidth;
-    gemm1MPerBlock = std::min(gemm1M, gemm1MUpperBound);
+  int64_t gemm1ElemTypeByteWidth = gemm1ElemType.getIntOrFloatBitWidth() / 8;
+  int64_t gemm1MUpperBound = 256 / gemm1ElemTypeByteWidth;
+  gemm1M = math_util::integer_least_multiple(
+           gemm1M, gemm0TuningParams.getMPerBlock());
+  int64_t gemm1MPerBlockNew = std::min(gemm1M, gemm1MUpperBound);
+  if (gemm0TuningParams.getMPerWave() >= 32 &&
+      gemm0TuningParams.getMPerBlock() < gemm1MPerBlockNew) {
+    gemm1MPerBlock = gemm1MPerBlockNew;
   }
   int64_t gemm1KPack = gemm0TuningParams.getKpack();
   return InitParamsAccel(

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -213,11 +213,11 @@ static InitParamsAccel deriveGemm1TuningParams(OpBuilder &builder,
   // This is good enough heuristic for now to guard from cases where
   // head dimension exceed 256 for i8, 128 for f16 and 64 for for f32
   Type gemm1ElemType =
-        op.getValues().getType().cast<ShapedType>().getElementType();
+      op.getValues().getType().cast<ShapedType>().getElementType();
   int64_t gemm1ElemTypeByteWidth = gemm1ElemType.getIntOrFloatBitWidth() / 8;
   int64_t gemm1MUpperBound = 256 / gemm1ElemTypeByteWidth;
-  gemm1M = math_util::integer_least_multiple(
-           gemm1M, gemm0TuningParams.getMPerBlock());
+  gemm1M = math_util::integer_least_multiple(gemm1M,
+                                             gemm0TuningParams.getMPerBlock());
   int64_t gemm1MPerBlockNew = std::min(gemm1M, gemm1MUpperBound);
   if (gemm0TuningParams.getMPerWave() >= 32 &&
       gemm0TuningParams.getMPerBlock() < gemm1MPerBlockNew) {


### PR DESCRIPTION
Currently, if the G0MPerBlock is larger than
the upper bound heurstic used to increase G1MPerBlock
this will result in creating zeros.

This commit fixes this by restricting the guard
to ensure we only ever to do an increase in G1MPerBlock
by doing the whole calculation before assignment

closes : https://github.com/ROCm/rocMLIR-internal/issues/1396