### PR TITLE
Add support for tuningRunner to tune post highlevel modules

### DIFF
--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -133,13 +133,17 @@ def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
             # Note, we don't need the -ph, this goes to the tuning driver
             kernelGenCommand = paths.mlir_paths.rocmlir_gen_path + ' ' + commandLineOptions
             kernelGen = subprocess.Popen(kernelGenCommand.split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-            tuningLoop = subprocess.Popen([paths.mlir_paths.rocmlir_tuning_driver_path, f"--tuning-space={options.tuningSpaceKind}"],
-                stdin=kernelGen.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            tuningLoop = subprocess.Popen(
+                [paths.mlir_paths.rocmlir_tuning_driver_path, f"--tuning-space={options.tuningSpaceKind}"],
+                stdin=kernelGen.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             kernelGen.stdout.close()
         else:
             # pipe to rocmlir_gen --emit-tuning-key
-            tuningKey = subprocess.Popen([paths.mlir_paths.rocmlir_gen_path, '--emit-tuning-key', testVector],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            tuningKey = subprocess.Popen(
+                [paths.mlir_paths.rocmlir_gen_path, '--emit-tuning-key', testVector],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             output, _ = tuningKey.communicate()
             result = output.decode('utf-8').strip().split('\t')
             print(f"Tuning:{result[2]} from {testVector}", file=sys.stderr)


### PR DESCRIPTION
This commit allows tuningRunner to tune modules that have
 rock operations in it -- usually what you see after highlevel.