### PR TITLE
Fix Dockerfile.migraphx-ci

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -15,7 +15,9 @@ RUN rbuild prepare -d $PWD -s develop --cxx=/opt/rocm/llvm/bin/clang++ --cc=/opt
 # Remove rocMLIR version as per MIGraphX requirements
 # as this image is being used for CI with tip of rocMLIR
 # that will be built in the job.
-RUN cget remove -p $PWD ROCm/rocMLIR -y
+# The rocMLIR package name should exactly match : https://github.com/ROCm/AMDMIGraphX/blob/develop/requirements.txt#L31
+# Otherwise, that package will not be uninstalled and we will be testing always against that.
+RUN cget remove -p $PWD ROCmSoftwarePlatform/rocMLIR -y
 # Download models for testing
 RUN wget https://github.com/onnx/models/raw/ba629906dd91872def671e70177c5544e0ea9e02/vision/classification/resnet/model/resnet50-v1-7.onnx
 RUN wget https://github.com/stefankoncarevic/Onnx_models/raw/master/bert_base_cased_1.onnx


### PR DESCRIPTION
We should only be changing the removal package
name once MIGraphX has changed the package name.
Currently, there is a mismatch between the package we try to remove and what MIGraphX installs - This commit fixes this.