### PR TITLE
Fix the blocksize check in the tuning stage

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -603,7 +603,7 @@ LogicalResult PopulateParamsXDL::isValidBlockwiseGemm(
   }
 
   // Reject invalid blockSize
-  int64_t kPerBlock = param.gemmKPerBlock;
+  int64_t kPerBlock = param.gemmKPerBlock * param.gemmKPack;
   int64_t mPerBlock = param.gemmMPerBlock;
   int64_t nPerBlock = param.gemmNPerBlock;
   if (!isValidBlockSize(blockSize, kPerBlock, mPerBlock, nPerBlock)) {

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -194,7 +194,7 @@ static bool constructAndTraverseIr(MlirContext ctx) {
       mlirRockTuningSpaceCreate(module, RocmlirTuningParamSetKindFull);
   printf("Got tuning space,\n");
   unsigned fNum = mlirRockTuningGetNumParams(tuningSpace);
-  // CHECK: full set = 357
+  // CHECK: full set = 461
   printf("full set = %u\n", fNum);
   MlirRockTuningParam tuningParam = mlirRockTuningParamCreate();
   MlirRockTuningTable tuningTable = mlirRockTuningTableCreate();

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -441,3 +441,20 @@ func.func @rock_attention_large(%arg0: memref<1x16384x512xf32>, %arg1: memref<1x
   } {arch = "gfx942:sramecc+:xnack-", features = #rock<GemmFeatures mfma|dot|atomic_add>, perf_config = "128,128,2,64,64,8,1,1"}
   return
 }
+
+// CHECK-LABEL: func.func @rock_conv2d_tuning
+// GRID-LABEL: func.func @rock_conv2d_tuning
+func.func @rock_conv2d_tuning(%arg0: memref<1x1x1x3x3xf32>, %arg1: memref<64x1x1x14x14xf32>, %arg2: memref<64x1x1x14x14xf32>) attributes {kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+  rock.conv2d(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add {
+    arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-",
+    dilations = [1 : i32, 1 : i32],
+    filter_layout = ["g", "k", "c", "y", "x"],
+    input_layout = ["ni", "gi", "ci", "hi", "wi"],
+    numCU = 110 : i32,
+    output_layout = ["no", "go", "ko", "ho", "wo"],
+    padding = [1 : i32, 1 : i32, 1 : i32, 1 : i32],
+    perf_config = "32,128,4,32,32,4,1,1",
+    strides = [1 : i32, 1 : i32]} : memref<1x1x1x3x3xf32>, memref<64x1x1x14x14xf32>, memref<64x1x1x14x14xf32>
+
+  return
+}


### PR DESCRIPTION
Make the blocksize check in tuning to be aligned with what GridwiseGemmToBlockwise.cpp does.

Fix https://github.com/ROCm/rocMLIR/issues/1429