### PR TITLE
Add support for `raw_buffer_atomic_fadd` in the fp16 case using packed logic

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -261,8 +261,8 @@ def AMDGPU_RawBufferAtomicCmpswapOp :
 // Raw buffer atomic floating point add
 def AMDGPU_RawBufferAtomicFaddOp :
     AMDGPU_Op<"raw_buffer_atomic_fadd", [AllElementTypesMatch<["value", "memref"]>,
-      AttrSizedOperandSegments]>,
-    Arguments<(ins F32:$value,
+    AttrSizedOperandSegments]>,
+    Arguments<(ins AnyTypeOf<[F32, VectorOfLengthAndType<[2], [F16]>]>:$value,
                    Arg<AnyMemRef, "buffer to operate on", [MemRead, MemWrite]>:$memref,
                    Variadic<I32>:$indices,
                    DefaultValuedAttr<BoolAttr, "true">:$boundsCheck,

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -109,15 +109,18 @@ struct RawBufferOpLowering : public ConvertOpToLLVMPattern<GpuOp> {
             rewriter.getIntegerType(floatType.getWidth()));
     }
     if (auto dataVector = dyn_cast<VectorType>(wantedDataType)) {
+      uint32_t vecLen = dataVector.getNumElements();
       uint32_t elemBits = dataVector.getElementTypeBitWidth();
-      uint32_t totalBits = elemBits * dataVector.getNumElements();
+      uint32_t totalBits = elemBits * vecLen;
+      bool usePackedFp16 =
+          dyn_cast_or_null<RawBufferAtomicFaddOp>(*gpuOp) && vecLen == 2;
       if (totalBits > maxVectorOpWidth)
         return gpuOp.emitOpError(
             "Total width of loads or stores must be no more than " +
             Twine(maxVectorOpWidth) + " bits, but we call for " +
             Twine(totalBits) +
             " bits. This should've been caught in validation");
-      if (elemBits < 32) {
+      else if (!usePackedFp16 && elemBits < 32) {
         if (totalBits > 32) {
           if (totalBits % 32 != 0)
             return gpuOp.emitOpError("Load or store of more than 32-bits that "

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -895,14 +895,14 @@ static Value computeMemRefNumElements(OpBuilder &b, Location loc,
 static void atomicFp16AddAligned(OpBuilder &b, Location loc, Value data,
                                  Value dest, ArrayRef<Value> coords) {
 
-
-  assert(data.getType().isa<ShapedType>() && "Data needs to have a shape!");
-  ArrayRef<int64_t> shape = cast<ShapedType>(data.getType()).getShape();
-  assert(coords.size() == shape.size() && "Shape and coordinates should have the same size!");
+  assert(dest.getType().isa<ShapedType>() && "Data needs to have a shape!");
+  ArrayRef<int64_t> shape = cast<ShapedType>(dest.getType()).getShape();
+  assert(coords.size() == shape.size() &&
+         "Shape and coordinates should have the same size!");
 
   // Get the last non-unit dimension
   int64_t lastNonUnitDim = shape.size() - 1;
-  while(shape[lastNonUnitDim] == 1 && lastNonUnitDim >= 0)
+  while (shape[lastNonUnitDim] == 1 && lastNonUnitDim >= 0)
     lastNonUnitDim--;
   const bool useBufferOobChecks = true;
   const int packedVectorLen = 2;
@@ -912,8 +912,8 @@ static void atomicFp16AddAligned(OpBuilder &b, Location loc, Value data,
   Value two = b.create<arith::ConstantIntOp>(loc, 2, 32);
 
   // Extended packed data to use with the intrinsic
-  Value dataExt =
-      createZeroConstantOp(b, loc, vectorTypeOrSelf(b.getF16Type(), packedVectorLen));
+  Value dataExt = createZeroConstantOp(
+      b, loc, vectorTypeOrSelf(b.getF16Type(), packedVectorLen));
   Value dataExt0 = b.create<vector::InsertElementOp>(loc, data, dataExt, zero);
   Value dataExt1 = b.create<vector::InsertElementOp>(loc, data, dataExt, one);
 
@@ -924,8 +924,8 @@ static void atomicFp16AddAligned(OpBuilder &b, Location loc, Value data,
       b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, alignment, zero);
 
   // Step back data and address
-  Value selectAddress =
-      b.create<arith::SelectOp>(loc, notAligns, stepBack, coords[lastNonUnitDim]);
+  Value selectAddress = b.create<arith::SelectOp>(loc, notAligns, stepBack,
+                                                  coords[lastNonUnitDim]);
   Value selectDataExt =
       b.create<arith::SelectOp>(loc, notAligns, dataExt0, dataExt1);
 


### PR DESCRIPTION
With this PR `raw_buffer_atomic_fadd` now supports (2-sized) vectors of fp16. 

Specific profile test case (using PR https://github.com/ROCm/rocMLIR/pull/1440):
```
a) --kernel-repeats 10   -t f16 -out_datatype f16 -g 1 -m 2 -k 1280 -n 4480 --perf_config=32,32,8,16,16,8,1,1
1.71972 TFlops
b) --kernel-repeats 10  --spilt-k 4 --transC=true  -t f16 -out_datatype f16 -g 1 -m 2 -k 1280 -n 4480 --perf_config=32,32,8,16,16,8,1,1
2.39983 TFlops
c) --kernel-repeats 10  --split-k 4 -t f16 -out_datatype f16 -g 1 -m 2 -k 1280 -n 4480 --perf_config=32,32,8,16,16,8,1,1
2.43473 TFlops
```
The difference between b) and c) is that in b) the matrix in a "good" vectorizable shape, while in c) the matrix is not and we pad every fp16 element in a vector of 2 elements to use the intrinsic (but the perf still seems good)
