### PR TITLE
Fix a bug when using atomicFadd in the fp16 scalar case

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -39,6 +39,9 @@ def ROCDL_Dialect : Dialect {
     static constexpr ::llvm::StringLiteral getMinWavesPerEu() {
       return ::llvm::StringLiteral("rocdl.waves_per_eu");
     }
+    static constexpr ::llvm::StringLiteral getUnsafeFpAtomics() {
+      return ::llvm::StringLiteral("rocdl.unsafe_fp_atomics");
+    }
 
     /// The address space value that represents global memory.
     static constexpr unsigned kGlobalMemoryAddressSpace = 1;

--- a/external/llvm-project/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
+++ b/external/llvm-project/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
@@ -150,6 +150,15 @@ public:
       attrValueStream << value.getInt();
       llvmFunc->addFnAttr("amdgpu-waves-per-eu", llvmAttrValue);
     }
+    if (ROCDL::ROCDLDialect::getUnsafeFpAtomics() == attribute.getName()) {
+      auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
+      llvm::Function *llvmFunc =
+          moduleTranslation.lookupFunction(func.getName());
+      llvm::SmallString<8> llvmAttrValue;
+      llvm::raw_svector_ostream attrValueStream(llvmAttrValue);
+      attrValueStream << "true";
+      llvmFunc->addFnAttr("amdgpu-unsafe-fp-atomics", llvmAttrValue);
+    }
 
     // Set reqd_work_group_size metadata
     if (ROCDL::ROCDLDialect::getReqdWorkGroupSizeAttrName() ==

--- a/external/llvm-project/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
+++ b/external/llvm-project/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
@@ -152,11 +152,15 @@ public:
     }
     if (ROCDL::ROCDLDialect::getUnsafeFpAtomics() == attribute.getName()) {
       auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
+      if (!func)
+        return failure();
+      auto value = attribute.getValue().dyn_cast<BoolAttr>();
+
       llvm::Function *llvmFunc =
           moduleTranslation.lookupFunction(func.getName());
       llvm::SmallString<8> llvmAttrValue;
       llvm::raw_svector_ostream attrValueStream(llvmAttrValue);
-      attrValueStream << "true";
+      attrValueStream << value.getValue();
       llvmFunc->addFnAttr("amdgpu-unsafe-fp-atomics", llvmAttrValue);
     }
 

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -223,6 +223,18 @@ void LowerRockOpsToGPUPass::runOnOperation() {
     b.setInsertionPointToEnd(&gpuFuncEntry);
     b.create<cf::BranchOp>(loc, clonedFuncEntry);
 
+    // Detect if we are using `atomic_rmw fadd` and ask LLVM to
+    // use intrinsics instead of CAS loops
+    funcBody.walk([&](memref::AtomicRMWOp op) -> WalkResult {
+      auto type = op.getMemRefType().getElementType();
+      if (op.getKind() == arith::AtomicRMWKind::addf &&
+          (type.isF32() || type.isF16())) {
+        gpuFunc->setAttr("rocdl.unsafe_fp_atomics", b.getUnitAttr());
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+
     // Clone in global constants
     llvm::SmallDenseMap<SymbolRefAttr, FlatSymbolRefAttr> clonedConsts;
     WalkResult result = funcBody.walk([&](memref::GetGlobalOp op)

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1182,7 +1182,8 @@ struct GlobalStoreRewritePattern : public OpRewritePattern<GlobalStoreOp> {
     // this.
     StoreMethod memoryOp = op.getStoreMethod();
     bool isAtomic = memoryOp != StoreMethod::Set;
-    bool isAtomicFadd = memoryOp == StoreMethod::AtomicAdd && elemTy.isF16();
+    bool isAtomicFadd = memoryOp == StoreMethod::AtomicAdd &&
+                        (elemTy.isF16() || elemTy.isF32());
     bool useBufferOps =
         !hasI64Idx && (numBytes.trunc(32).isNegative() || emitOobChecks ||
                        op.getCanStoreOffEnd() || isAtomicFadd);

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -930,7 +930,7 @@ static void atomicFp16AddAligned(OpBuilder &b, Location loc, Value data,
       b.create<arith::SelectOp>(loc, notAligns, dataExt1, dataExt0);
 
   SmallVector<Value> alignedCoords(coords);
-  alignedCoords.back() = selectAddress;
+  alignedCoords[lastNonUnitDim] = selectAddress;
   // TODO(giuseros): This should lower to a amdgcn_global_atomic_fadd when we
   // don't need oob checks.
   b.create<amdgpu::RawBufferAtomicFaddOp>(loc, selectDataExt, dest,

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -965,7 +965,11 @@ static void atomicFp16AddAligned(OpBuilder &b, Location loc, Value data,
         loc, arith::CmpIPredicate::ult, address, lastElem);
     auto guard = b.create<scf::IfOp>(loc, isNotLastElem, true);
     b.setInsertionPointToStart(&guard.getElseRegion().front());
-    b.create<memref::AtomicRMWOp>(loc, AtomicRMWKind::addf, data, dest, coords);
+    SmallVector<Value> indexCoords;
+    for (auto c : coords)
+      indexCoords.push_back(b.create<IndexCastOp>(loc, b.getIndexType(), c));
+    b.create<memref::AtomicRMWOp>(loc, AtomicRMWKind::addf, data, dest,
+                                  indexCoords);
     b.setInsertionPointToStart(&guard.getThenRegion().front());
   }
 

--- a/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
@@ -232,10 +232,8 @@ func.func @store_scalar_oob_large(%source: memref<5xf32, #gpu.address_space<priv
 func.func @add_scalar_in_bounds(%source: memref<5xf32, #gpu.address_space<private>>, %mem: memref<1x2x3x4x8xf32>) {
     %c0 = arith.constant 0 : index
     %true = arith.constant true
-    // CHECK-DAG: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
-    // CHECK-SAME: #gpu.address_space<global>
     // CHECK-DAG: %[[val:.*]] = memref.load %[[source]]
-    // CHECK: memref.atomic_rmw addf %[[val]], %[[cast]]
+    // CHECK: amdgpu.raw_buffer_atomic_fadd
     rock.global_store atomic_add %source[%c0] -> %mem[%c0, %c0, %c0, %c0, %c0] if %true
         features = none {length = 1 : index}
         : memref<5xf32, #gpu.address_space<private>> -> memref<1x2x3x4x8xf32>
@@ -300,11 +298,8 @@ func.func @add_vector_in_bounds(%source: memref<5xf32, #gpu.address_space<privat
 func.func @add_scalar_to_scalar_valid(%source: memref<1xf32, #gpu.address_space<private>>, %mem: memref<f32>) {
     %c0 = arith.constant 0 : index
     %true = arith.constant true
-    // CHECK-DAG: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
-    // CHECK-SAME: #gpu.address_space<global>
-    // CHECK-DAG: %[[val:.*]] = memref.load %[[source]]
-    // CHECK-NOT: scf.if
-    // CHECK: memref.atomic_rmw addf %[[val]], %[[cast]]
+    // CHECK: %[[val:.*]] = memref.load %[[source]]
+    // CHECK: amdgpu.raw_buffer_atomic_fadd {boundsCheck = false} %[[val]] -> %[[mem]]
     rock.global_store atomic_add %source[%c0] -> %mem[] if %true
         features = none {length = 1 : index}
         : memref<1xf32, #gpu.address_space<private>> -> memref<f32>


### PR DESCRIPTION
So there was a simple bug to fix, but the main issue was that we were not always selecting the atomicFadd intrinsic when doing an atomic Fp16/Fp32 addition (that's why I didn't catch the bug before). 

I enabled the buffer operation (i.e., the intrinsics) for all the atomics Fp16/Fp32 cases. @krzysz00 can you take a look? Is there a reason why we were not always enabling the intrinsic?

FYI, using atomics I always see accuracy degradation. 

```
./bin/rocmlir-gen --arch gfx90a -pv   --operation gemm -t f16 -g 1 -m 256 -k 512 -n 256  --perf_config 64,64,16,32,32,4,1,1,1 -split-k 2 | ./bin/rocmlir-driver -c | ../mlir/utils/widgets/rocm-run 
Number of elements: 65536
maxAbsDiff info: maxAbsDiff = 0.250000 (valNum = 309.50000, gpuNum = 309.25000), average absDiff = 5.6e-02
maxRelDiff info: maxRelDiff = 8.1e-04 (valNum = 309.5000000000, gpuNum = 309.2500000000), average relDiff = 1.8e-04
RMS = 3.8e-04
Histogram of relDiff: 
        relDiff = 0     : 50915/65536 (77.690125%)
     0 < relDiff < 1e-06: 0/65536 (0.000000%)
1e-06 < relDiff <= 1e-05: 0/65536 (0.000000%)
1e-05 < relDiff <= 1e-04: 0/65536 (0.000000%)
1e-04 < relDiff <= 1e-03: 14621/65536 (22.309875%)
1e-03 < relDiff <= 1e-02: 0/65536 (0.000000%)
1e-02 < relDiff <= 1e-01: 0/65536 (0.000000%)
1e-01 < relDiff <= 1e+00: 0/65536 (0.000000%)
1e+00 < relDiff < inf   : 0/65536 (0.000000%)
        relDiff = inf   : 0/65536 (0.000000%)
[0 1 1]
```
This happens with the CAS loop and with the atomic intrinsics. 