### PR TITLE
Fix AlignTiling to reuse buffers when loading fusion arguments

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -864,13 +864,13 @@ LAGenericRewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
       b.setInsertionPoint(laGeneric);
     }
     Value newOutput = tileReadOp.getDest();
+    // Prevent SSA weirdness from register allocations introduced too late.
+    // Do this before calling addRegisterReadsForTiledOutput() as
+    // addRegisterReadsForTiledOutput() may move laGeneric.
+    b.moveBeforeIfNeeded(newOutput.getDefiningOp(), laGeneric);
     SmallVector<Value> newInputs;
     addRegisterReadsForTiledOutput(b, laGeneric, tileReadOp,
                                    globalCoordsToGenericViews, newInputs);
-
-    // Prevent SSA weirdness from register allocations introduced too late.
-    if (newOutput.getDefiningOp()->getBlock() == laGeneric.getBlock())
-      b.moveBeforeIfNeeded(newOutput.getDefiningOp(), laGeneric);
     reconfigureLAGeneric(b, laGeneric, newInputs, newOutput);
     b.eraseOp(tileReadOp);
     return success();

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -622,11 +622,11 @@ makeExtraInputTile(LinalgAlignRewriter &b, TiledOp tiledOp, Value src,
   LLVM_DEBUG(llvm::dbgs() << "Src type: " << src.getType()
                           << " tile type: " << tile.getType() << "\n");
 
-  // Reset the insertion point if laGeneric and tiledOp are in different blocks.
-  // Insert new transform operations and threadwiseReadIntoOp where
-  // linalg.generic is if linalg.generic reads from the output of tiledOp.
-  // Otherwise, if tiledOp reads from the output of linalg.generic, insert
-  // transformation and threadwiseReadIntoOp where tiledOp is.
+  // Reset the insertion point if laGeneric and tiledOp are in different blocks
+  // and tiledOp reads from the output of linalg.generic. In such cases, we
+  // should insert new transform operations and threadwiseReadIntoOp inside the
+  // block of tiledOp, as their arguments may depend on that control flow. Later
+  // we will also move linalg.generic into the block.
   if (laGeneric->getBlock() != tiledOp->getBlock() &&
       laGeneric.getOperation() != sink)
     b.setInsertionPoint(sink);

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -219,8 +219,7 @@ void LinalgAlignRewriter::moveBeforeIfNeeded(Operation *toMove,
   constexpr llvm::StringLiteral beforePrefix("   before  : ");
   logOpActivity(movePrefix, toMove);
   logOpActivity(beforePrefix, latestOp);
-  if (latestOp->getBlock() != toMove->getBlock() ||
-      latestOp->isBeforeInBlock(toMove))
+  if (latestOp->isBeforeInBlock(toMove))
     toMove->moveBefore(latestOp);
   else
     LLVM_DEBUG(logger.startLine() << "   No move needed.\n");
@@ -870,7 +869,8 @@ LAGenericRewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
                                    globalCoordsToGenericViews, newInputs);
 
     // Prevent SSA weirdness from register allocations introduced too late.
-    b.moveBeforeIfNeeded(newOutput.getDefiningOp(), laGeneric);
+    if (newOutput.getDefiningOp()->getBlock() == laGeneric.getBlock())
+      b.moveBeforeIfNeeded(newOutput.getDefiningOp(), laGeneric);
     reconfigureLAGeneric(b, laGeneric, newInputs, newOutput);
     b.eraseOp(tileReadOp);
     return success();

--- a/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
+++ b/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
@@ -1,0 +1,60 @@
+// RUN: rocmlir-driver --rock-linalg-align %s |./external/llvm-project/llvm/bin/FileCheck %s
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d1, d0 * 16 + d5 + d7, (d2 * 16 + d4) * 4 + d6)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4 floordiv 16, d4 mod 16, d5, 0)>
+
+// CHECK: [[MAP:.*]] = #rock.transform_map<#map by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{4, 16, 1} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>, <Unmerge{1, 16, 4} ["m_block", "m_thread", "m_iter"] at [2, 4, 6] -> ["m"] at [2]>, <AddDim{1} ["n_block"] at [3] -> [] at []>] bounds = [4, 64, 1, 1, 16, 16, 4, 1] -> [64, 64, 64]>
+#transform_map = #rock.transform_map<#map2 by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{4, 16, 1} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>, <Unmerge{1, 16, 4} ["m_block", "m_thread", "m_iter"] at [2, 4, 6] -> ["m"] at [2]>, <AddDim{1} ["n_block"] at [3] -> [] at []>] bounds = [4, 64, 1, 1, 16, 16, 4, 1] -> [64, 64, 64]>
+
+// CHECK: [[MAP1:.*]] = #rock.transform_map<#map1 by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{16, 16} ["tid"] at [4] -> ["m_thread", "k_thread"] at [4, 5]>, <Merge{4, 1} ["iter"] at [5] -> ["m_iter", "k_iter"] at [6, 7]>] bounds = [4, 64, 1, 1, 256, 4] -> [4, 64, 1, 1, 16, 16, 4, 1]>
+#transform_map1 = #rock.transform_map<#map3 by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{16, 16} ["tid"] at [4] -> ["m_thread", "k_thread"] at [4, 5]>, <Merge{4, 1} ["iter"] at [5] -> ["m_iter", "k_iter"] at [6, 7]>] bounds = [4, 64, 1, 1, 256, 4] -> [4, 64, 1, 1, 16, 16, 4, 1]>
+
+
+module {
+  // CHECK-LABEL: @rock_gemm
+  func.func @rock_gemm(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf32>, %arg2: memref<64x64x64xf32>, %arg3: memref<64x64x64xf32>) attributes {block_size = 256 : i32, grid_size = 64 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", wave_size = 32 : i32} {
+    %alloc = memref.alloc() : memref<64x64x64xf32>
+    linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg3 : memref<64x64x64xf16>, memref<64x64x64xf32>) outs(%alloc : memref<64x64x64xf32>) {
+    ^bb0(%in: f16, %in_10: f32, %out: f32):
+      %46 = arith.extf %in : f16 to f32
+      %47 = arith.addf %46, %in_10 : f32
+      linalg.yield %47 : f32
+    }
+    %c0 = arith.constant 0 : index
+    %1 = rock.workgroup_id : index
+    %2 = rock.workitem_id : index
+    %3 = rock.transform %alloc by #transform_map : memref<64x64x64xf32> to memref<4x64x1x1x16x16x4x1xf32>
+    %4 = rock.transform %3 by #transform_map1 : memref<4x64x1x1x16x16x4x1xf32> to memref<4x64x1x1x256x4xf32>
+    %out = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
+    %c1_1 = arith.constant 1 : index
+    %5 = arith.divui %1, %c1_1 : index
+    // CHECK: [[tiled_arg0:%.+]] = rock.alloc() : memref<4xf16
+    // CHECK-NEXT: [[arg0_tr:%.+]] = rock.transform %arg0 by [[MAP]]
+    // CHECK-NEXT: [[arg0_view:%.+]] = rock.transform [[arg0_tr]] by [[MAP1]]
+    // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg0_view]]) [{{.*}}] -> [[tiled_arg0]]
+    // CHECK: [[tiled_arg3:%.+]] = rock.alloc() : memref<4xf32
+    // CHECK-NEXT: [[arg3_tr:%.+]] = rock.transform %arg3 by [[MAP]]
+    // CHECK-NEXT: [[arg3_view:%.+]] = rock.transform [[arg3_tr]] by [[MAP1]]
+    // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_view]]) [{{.*}}] -> [[tiled_arg3]]
+    // CHECK: [[tiled_out:%.+]] = rock.alloc() : memref<4xf32
+    // CHECK-NEXT: linalg.generic
+    // CHECK-SAME: ins([[tiled_arg0]], [[tiled_arg3]]
+    // CHECK-SAME: outs([[tiled_out]]
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%c0, %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
+    // CHECK: [[arg0_alloc:%.+]] = rock.alloc() : memref<4xf16
+    // CHECK: [[arg3_alloc:%.+]] = rock.alloc() : memref<4xf32
+    affine.for %arg4 = 1 to 4 {
+      // CHECK: [[arg0_tf:%.+]] = rock.transform %arg0 by [[MAP]]
+      // CHECK-NEXT: [[arg0_v:%.+]] = rock.transform [[arg0_tf]] by [[MAP1]]
+      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg0_v]]) [%arg4, {{.*}}] -> [[arg0_alloc]]
+      // CHECK: [[arg3_tf:%.+]] = rock.transform %arg3 by [[MAP]]
+      // CHECK-NEXT: [[arg3_v:%.+]] = rock.transform [[arg3_tf]] by [[MAP1]]
+      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_v]]) [%arg4, {{.*}}] -> [[arg3_alloc]]
+      // CHECK: linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel"]} ins(%12, %13 : memref<4xf16, #gpu.address_space<private>>, memref<4xf32, #gpu.address_space<private>>) outs(%11 : memref<4xf32, #gpu.address_space<private>>) {
+      // CHECK-SAME: ins([[arg0_alloc]], [[arg3_alloc]]
+      // CHECK-SAME: outs([[tiled_out]]
+      rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%arg4,  %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
+++ b/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-driver --rock-linalg-align %s |./external/llvm-project/llvm/bin/FileCheck %s
+// RUN: rocmlir-driver --rock-linalg-align %s | FileCheck %s
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d1, d0 * 16 + d5 + d7, (d2 * 16 + d4) * 4 + d6)>
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4 floordiv 16, d4 mod 16, d5, 0)>

--- a/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
+++ b/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
@@ -11,8 +11,8 @@
 
 
 module {
-  // CHECK-LABEL: @rock_gemm
-  func.func @rock_gemm(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf32>, %arg2: memref<64x64x64xf32>, %arg3: memref<64x64x64xf32>) attributes {block_size = 256 : i32, grid_size = 64 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", wave_size = 32 : i32} {
+  // CHECK-LABEL: @rock_gemm_1
+  func.func @rock_gemm_1(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf32>, %arg2: memref<64x64x64xf32>, %arg3: memref<64x64x64xf32>) attributes {block_size = 256 : i32, grid_size = 64 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", wave_size = 32 : i32} {
     %alloc = memref.alloc() : memref<64x64x64xf32>
     linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg3 : memref<64x64x64xf16>, memref<64x64x64xf32>) outs(%alloc : memref<64x64x64xf32>) {
     ^bb0(%in: f16, %in_10: f32, %out: f32):
@@ -25,8 +25,7 @@ module {
     %2 = rock.workitem_id : index
     %3 = rock.transform %alloc by #transform_map : memref<64x64x64xf32> to memref<4x64x1x1x16x16x4x1xf32>
     %4 = rock.transform %3 by #transform_map1 : memref<4x64x1x1x16x16x4x1xf32> to memref<4x64x1x1x256x4xf32>
-    // CHECK: [[tiled_out_1:%.+]] = rock.alloc() : memref<2xf32
-    // CHECK: [[tiled_out:%.+]] = rock.alloc() : memref<4xf32
+    // CHECK: [[out_alloc:%.+]] = rock.alloc() : memref<4xf32
     %out = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
     %c1_1 = arith.constant 1 : index
     %5 = arith.divui %1, %c1_1 : index
@@ -40,13 +39,83 @@ module {
     // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_view]]) [{{.*}}] -> [[tiled_arg3]]
     // CHECK-NEXT: linalg.generic
     // CHECK-SAME: ins([[tiled_arg0]], [[tiled_arg3]]
-    // CHECK-SAME: outs([[tiled_out]]
+    // CHECK-SAME: outs([[out_alloc]]
     rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%c0, %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
     // CHECK: [[arg0_alloc:%.+]] = rock.alloc() : memref<4xf16
     // CHECK: [[arg3_alloc:%.+]] = rock.alloc() : memref<4xf32
-    // CHECK: [[arg0_alloc_1:%.+]] = rock.alloc() : memref<2xf16
-    // CHECK: [[arg3_alloc_1:%.+]] = rock.alloc() : memref<2xf32
+    affine.for %arg4 = 1 to 4 {
+      // CHECK: [[arg0_tf:%.+]] = rock.transform %arg0 by [[MAP]]
+      // CHECK-NEXT: [[arg0_v:%.+]] = rock.transform [[arg0_tf]] by [[MAP1]]
+      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg0_v]]) [%arg4, {{.*}}] -> [[arg0_alloc]]
+      // CHECK: [[arg3_tf:%.+]] = rock.transform %arg3 by [[MAP]]
+      // CHECK-NEXT: [[arg3_v:%.+]] = rock.transform [[arg3_tf]] by [[MAP1]]
+      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_v]]) [%arg4, {{.*}}] -> [[arg3_alloc]]
+      // CHECK: linalg.generic
+      // CHECK-SAME: ins([[arg0_alloc]], [[arg3_alloc]]
+      // CHECK-SAME: outs([[out_alloc]]
+      rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%arg4,  %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
+    }
+    return
+  }
+
+  // CHECK-LABEL: @rock_gemm_2
+  func.func @rock_gemm_2(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf16>, %arg2: memref<64x64x64xf32>, %arg3: memref<64x64x64xf32>) attributes {block_size = 256 : i32, grid_size = 64 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", wave_size = 32 : i32} {
+    %alloc = memref.alloc() : memref<64x64x64xf32>
+    linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg3 : memref<64x64x64xf16>, memref<64x64x64xf32>) outs(%alloc : memref<64x64x64xf32>) {
+    ^bb0(%in: f16, %in_10: f32, %out: f32):
+      %46 = arith.extf %in : f16 to f32
+      %47 = arith.addf %46, %in_10 : f32
+      linalg.yield %47 : f32
+    }
+    %alloc_0 = memref.alloc() : memref<64x64x64xf32>
+    linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg1 : memref<64x64x64xf16>) outs(%alloc_0 : memref<64x64x64xf32>) {
+    ^bb0(%in: f16, %out: f32):
+      %43 = arith.extf %in : f16 to f32
+      linalg.yield %43 : f32
+    }
+    %c0 = arith.constant 0 : index
+    %1 = rock.workgroup_id : index
+    %2 = rock.workitem_id : index
+    %3 = rock.transform %alloc by #transform_map : memref<64x64x64xf32> to memref<4x64x1x1x16x16x4x1xf32>
+    %4 = rock.transform %3 by #transform_map1 : memref<4x64x1x1x16x16x4x1xf32> to memref<4x64x1x1x256x4xf32>
+    // CHECK: [[tiled_out:%.+]] = rock.alloc() : memref<2xf32
+    // CHECK: [[out:%.+]] = rock.alloc() : memref<4xf32
+    // CHECK: [[tiled_out_1:%.+]] = rock.alloc() : memref<2xf32
+    // CHECK: [[out_1:%.+]] = rock.alloc() : memref<4xf32
+    %9 = rock.transform %alloc_0 by #transform_map : memref<64x64x64xf32> to memref<4x64x1x1x16x16x1x4xf32>
+    %10 = rock.transform %9 by #transform_map1 : memref<4x64x1x1x16x16x1x4xf32> to memref<4x64x1x1x256x4xf32>
+    %out = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
+    %out_1 = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
+    %c1_1 = arith.constant 1 : index
+    %5 = arith.divui %1, %c1_1 : index
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%c0, %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
+
+    // CHECK: [[tiled_arg1:%.+]] = rock.alloc() : memref<4xf16
+    // CHECK-NEXT: [[arg1_tr:%.+]] = rock.transform %arg1 by [[MAP]]
+    // CHECK-NEXT: [[arg1_view:%.+]] = rock.transform [[arg1_tr]] by [[MAP1]]
+    // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg1_view]]) [{{.*}}] -> [[tiled_arg1]]
+    // CHECK-NEXT: linalg.generic
+    // CHECK-SAME: ins([[tiled_arg1]]
+    // CHECK-SAME: outs([[out_1]]
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%10) [%c0, %2, %2, %5, %5] -> %out_1 : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
+
+    // CHECK: [[tiled_arg0:%.+]] = rock.alloc() : memref<4xf16
+    // CHECK-NEXT: [[arg0_tr:%.+]] = rock.transform %arg0 by [[MAP]]
+    // CHECK-NEXT: [[arg0_view:%.+]] = rock.transform [[arg0_tr]] by [[MAP1]]
+    // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg0_view]]) [{{.*}}] -> [[tiled_arg0]]
+    // CHECK: [[tiled_arg3:%.+]] = rock.alloc() : memref<4xf32
+    // CHECK-NEXT: [[arg3_tr:%.+]] = rock.transform %arg3 by [[MAP]]
+    // CHECK-NEXT: [[arg3_view:%.+]] = rock.transform [[arg3_tr]] by [[MAP1]]
+    // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_view]]) [{{.*}}] -> [[tiled_arg3]]
+    // CHECK-NEXT: linalg.generic
+    // CHECK-SAME: ins([[tiled_arg0]], [[tiled_arg3]]
+    // CHECK-SAME: outs([[out]]
+
     %tiled_out = rock.alloc() : memref<2xf32, #gpu.address_space<private>>
+    %tiled_out_1 = rock.alloc() : memref<2xf32, #gpu.address_space<private>>
+    // CHECK: [[arg1_alloc:%.+]] = rock.alloc() : memref<2xf16
+    // CHECK: [[arg0_alloc:%.+]] = rock.alloc() : memref<2xf16
+    // CHECK: [[arg3_alloc:%.+]] = rock.alloc() : memref<2xf32
     affine.for %arg4 = 1 to 4 {
       // CHECK: [[arg0_tf:%.+]] = rock.transform %arg0 by [[MAP]]
       // CHECK-NEXT: [[arg0_v:%.+]] = rock.transform [[arg0_tf]] by [[MAP1]]
@@ -57,17 +126,15 @@ module {
       // CHECK: linalg.generic
       // CHECK-SAME: ins([[arg0_alloc]], [[arg3_alloc]]
       // CHECK-SAME: outs([[tiled_out]]
-      rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%arg4,  %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
-      // CHECK: [[arg0_tf_1:%.+]] = rock.transform %arg0 by [[MAP]]
-      // CHECK-NEXT: [[arg0_v_1:%.+]] = rock.transform [[arg0_tf_1]] by [[MAP1]]
-      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg0_v_1]]) [%arg4, {{.*}}] -> [[arg0_alloc_1]]
-      // CHECK: [[arg3_tf_1:%.+]] = rock.transform %arg3 by [[MAP]]
-      // CHECK-NEXT: [[arg3_v_1:%.+]] = rock.transform [[arg3_tf_1]] by [[MAP1]]
-      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_v_1]]) [%arg4, {{.*}}] -> [[arg3_alloc_1]]
-      // CHECK: linalg.generic
-      // CHECK-SAME: ins([[arg0_alloc_1]], [[arg3_alloc_1]]
-      // CHECK-SAME: outs([[tiled_out_1]]
       rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%arg4,  %2, %2, %5, %5] -> %tiled_out : memref<4x64x1x1x256x4xf32> -> memref<2xf32, #gpu.address_space<private>>
+
+      // CHECK: [[arg1_tf:%.+]] = rock.transform %arg1 by [[MAP]]
+      // CHECK: [[arg1_v:%.+]] = rock.transform [[arg1_tf]] by [[MAP1]]
+      // CHECK: rock.threadwise_read_into {{.*}} []([[arg1_v]]) [%arg4, {{.*}}] -> [[arg1_alloc]]
+      // CHECK: linalg.generic
+      // CHECK-SAME: ins([[arg1_alloc]]
+      // CHECK-SAME: outs([[tiled_out_1]]
+      rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%10) [%arg4,  %2, %2, %5, %5] -> %tiled_out_1 : memref<4x64x1x1x256x4xf32> -> memref<2xf32, #gpu.address_space<private>>
     }
     return
   }

--- a/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
+++ b/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
@@ -25,6 +25,7 @@ module {
     %2 = rock.workitem_id : index
     %3 = rock.transform %alloc by #transform_map : memref<64x64x64xf32> to memref<4x64x1x1x16x16x4x1xf32>
     %4 = rock.transform %3 by #transform_map1 : memref<4x64x1x1x16x16x4x1xf32> to memref<4x64x1x1x256x4xf32>
+    // CHECK: [[tiled_out_1:%.+]] = rock.alloc() : memref<2xf32
     // CHECK: [[tiled_out:%.+]] = rock.alloc() : memref<4xf32
     %out = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
     %c1_1 = arith.constant 1 : index
@@ -45,7 +46,6 @@ module {
     // CHECK: [[arg3_alloc:%.+]] = rock.alloc() : memref<4xf32
     // CHECK: [[arg0_alloc_1:%.+]] = rock.alloc() : memref<2xf16
     // CHECK: [[arg3_alloc_1:%.+]] = rock.alloc() : memref<2xf32
-    // CHECK: [[tiled_out_1:%.+]] = rock.alloc() : memref<2xf32
     %tiled_out = rock.alloc() : memref<2xf32, #gpu.address_space<private>>
     affine.for %arg4 = 1 to 4 {
       // CHECK: [[arg0_tf:%.+]] = rock.transform %arg0 by [[MAP]]

--- a/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
+++ b/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
@@ -11,7 +11,6 @@
 
 
 module {
-  // CHECK-LABEL: @rock_gemm_1
   func.func @rock_gemm_1(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf32>, %arg2: memref<64x64x64xf32>, %arg3: memref<64x64x64xf32>) attributes {block_size = 256 : i32, grid_size = 64 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", wave_size = 32 : i32} {
     %alloc = memref.alloc() : memref<64x64x64xf32>
     linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg3 : memref<64x64x64xf16>, memref<64x64x64xf32>) outs(%alloc : memref<64x64x64xf32>) {
@@ -58,7 +57,6 @@ module {
     return
   }
 
-  // CHECK-LABEL: @rock_gemm_2
   func.func @rock_gemm_2(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf16>, %arg2: memref<64x64x64xf32>, %arg3: memref<64x64x64xf32>) attributes {block_size = 256 : i32, grid_size = 64 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", wave_size = 32 : i32} {
     %alloc = memref.alloc() : memref<64x64x64xf32>
     linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg3 : memref<64x64x64xf16>, memref<64x64x64xf32>) outs(%alloc : memref<64x64x64xf32>) {

--- a/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
+++ b/mlir/test/fusion/linalg-generic-reuse-buffers.mlir
@@ -3,10 +3,10 @@
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d1, d0 * 16 + d5 + d7, (d2 * 16 + d4) * 4 + d6)>
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4 floordiv 16, d4 mod 16, d5, 0)>
 
-// CHECK: [[MAP:.*]] = #rock.transform_map<#map by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{4, 16, 1} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>, <Unmerge{1, 16, 4} ["m_block", "m_thread", "m_iter"] at [2, 4, 6] -> ["m"] at [2]>, <AddDim{1} ["n_block"] at [3] -> [] at []>] bounds = [4, 64, 1, 1, 16, 16, 4, 1] -> [64, 64, 64]>
+// CHECK-DAG: [[MAP:.*]] = #rock.transform_map<#map{{.*}} by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{4, 16, 1} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>, <Unmerge{1, 16, 4} ["m_block", "m_thread", "m_iter"] at [2, 4, 6] -> ["m"] at [2]>, <AddDim{1} ["n_block"] at [3] -> [] at []>] bounds = [4, 64, 1, 1, 16, 16, 4, 1] -> [64, 64, 64]>
 #transform_map = #rock.transform_map<#map2 by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{4, 16, 1} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>, <Unmerge{1, 16, 4} ["m_block", "m_thread", "m_iter"] at [2, 4, 6] -> ["m"] at [2]>, <AddDim{1} ["n_block"] at [3] -> [] at []>] bounds = [4, 64, 1, 1, 16, 16, 4, 1] -> [64, 64, 64]>
 
-// CHECK: [[MAP1:.*]] = #rock.transform_map<#map1 by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{16, 16} ["tid"] at [4] -> ["m_thread", "k_thread"] at [4, 5]>, <Merge{4, 1} ["iter"] at [5] -> ["m_iter", "k_iter"] at [6, 7]>] bounds = [4, 64, 1, 1, 256, 4] -> [4, 64, 1, 1, 16, 16, 4, 1]>
+// CHECK-DAG: [[MAP1:.*]] = #rock.transform_map<#map{{.*}} by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{16, 16} ["tid"] at [4] -> ["m_thread", "k_thread"] at [4, 5]>, <Merge{4, 1} ["iter"] at [5] -> ["m_iter", "k_iter"] at [6, 7]>] bounds = [4, 64, 1, 1, 256, 4] -> [4, 64, 1, 1, 16, 16, 4, 1]>
 #transform_map1 = #rock.transform_map<#map3 by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{16, 16} ["tid"] at [4] -> ["m_thread", "k_thread"] at [4, 5]>, <Merge{4, 1} ["iter"] at [5] -> ["m_iter", "k_iter"] at [6, 7]>] bounds = [4, 64, 1, 1, 256, 4] -> [4, 64, 1, 1, 16, 16, 4, 1]>
 
 
@@ -25,6 +25,7 @@ module {
     %2 = rock.workitem_id : index
     %3 = rock.transform %alloc by #transform_map : memref<64x64x64xf32> to memref<4x64x1x1x16x16x4x1xf32>
     %4 = rock.transform %3 by #transform_map1 : memref<4x64x1x1x16x16x4x1xf32> to memref<4x64x1x1x256x4xf32>
+    // CHECK: [[tiled_out:%.+]] = rock.alloc() : memref<4xf32
     %out = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
     %c1_1 = arith.constant 1 : index
     %5 = arith.divui %1, %c1_1 : index
@@ -36,13 +37,16 @@ module {
     // CHECK-NEXT: [[arg3_tr:%.+]] = rock.transform %arg3 by [[MAP]]
     // CHECK-NEXT: [[arg3_view:%.+]] = rock.transform [[arg3_tr]] by [[MAP1]]
     // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_view]]) [{{.*}}] -> [[tiled_arg3]]
-    // CHECK: [[tiled_out:%.+]] = rock.alloc() : memref<4xf32
     // CHECK-NEXT: linalg.generic
     // CHECK-SAME: ins([[tiled_arg0]], [[tiled_arg3]]
     // CHECK-SAME: outs([[tiled_out]]
     rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%c0, %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
     // CHECK: [[arg0_alloc:%.+]] = rock.alloc() : memref<4xf16
     // CHECK: [[arg3_alloc:%.+]] = rock.alloc() : memref<4xf32
+    // CHECK: [[arg0_alloc_1:%.+]] = rock.alloc() : memref<2xf16
+    // CHECK: [[arg3_alloc_1:%.+]] = rock.alloc() : memref<2xf32
+    // CHECK: [[tiled_out_1:%.+]] = rock.alloc() : memref<2xf32
+    %tiled_out = rock.alloc() : memref<2xf32, #gpu.address_space<private>>
     affine.for %arg4 = 1 to 4 {
       // CHECK: [[arg0_tf:%.+]] = rock.transform %arg0 by [[MAP]]
       // CHECK-NEXT: [[arg0_v:%.+]] = rock.transform [[arg0_tf]] by [[MAP1]]
@@ -50,10 +54,20 @@ module {
       // CHECK: [[arg3_tf:%.+]] = rock.transform %arg3 by [[MAP]]
       // CHECK-NEXT: [[arg3_v:%.+]] = rock.transform [[arg3_tf]] by [[MAP1]]
       // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_v]]) [%arg4, {{.*}}] -> [[arg3_alloc]]
-      // CHECK: linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel"]} ins(%12, %13 : memref<4xf16, #gpu.address_space<private>>, memref<4xf32, #gpu.address_space<private>>) outs(%11 : memref<4xf32, #gpu.address_space<private>>) {
+      // CHECK: linalg.generic
       // CHECK-SAME: ins([[arg0_alloc]], [[arg3_alloc]]
       // CHECK-SAME: outs([[tiled_out]]
       rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%arg4,  %2, %2, %5, %5] -> %out : memref<4x64x1x1x256x4xf32> -> memref<4xf32, #gpu.address_space<private>>
+      // CHECK: [[arg0_tf_1:%.+]] = rock.transform %arg0 by [[MAP]]
+      // CHECK-NEXT: [[arg0_v_1:%.+]] = rock.transform [[arg0_tf_1]] by [[MAP1]]
+      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg0_v_1]]) [%arg4, {{.*}}] -> [[arg0_alloc_1]]
+      // CHECK: [[arg3_tf_1:%.+]] = rock.transform %arg3 by [[MAP]]
+      // CHECK-NEXT: [[arg3_v_1:%.+]] = rock.transform [[arg3_tf_1]] by [[MAP1]]
+      // CHECK-NEXT: rock.threadwise_read_into {{.*}} []([[arg3_v_1]]) [%arg4, {{.*}}] -> [[arg3_alloc_1]]
+      // CHECK: linalg.generic
+      // CHECK-SAME: ins([[arg0_alloc_1]], [[arg3_alloc_1]]
+      // CHECK-SAME: outs([[tiled_out_1]]
+      rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%arg4,  %2, %2, %5, %5] -> %tiled_out : memref<4x64x1x1x256x4xf32> -> memref<2xf32, #gpu.address_space<private>>
     }
     return
   }

--- a/mlir/test/fusion/linalg-generic-sigmoid-elementwise-block.mlir
+++ b/mlir/test/fusion/linalg-generic-sigmoid-elementwise-block.mlir
@@ -34,6 +34,7 @@ module {
     %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<2x5xf32>
     %alloc_13 = memref.alloc() {alignment = 64 : i64} : memref<2x5xf32>
 
+    // CHECK: [[cst_alloc0:%.+]] = rock.alloc() : memref<16xf32
     // CHECK: [[arg0_alloc:%.+]] = rock.alloc() : memref<16xf32
     // CHECK-NEXT: [[arg0_group:%.+]] = rock.transform [[arg0]]
     // CHECK-SAME: memref<2x5xf32> to memref<1x2x5xf32>
@@ -50,7 +51,6 @@ module {
     // CHECK-NEXT: rock.threadwise_read_into
     // CHECK-SAME: [[arg1_padded]]
     // CHECK-SAME: [[arg1_alloc]]
-    // CHECK-NEXT: [[cst_alloc0:%.+]] = rock.alloc() : memref<16xf32
     // CHECK-NEXT: linalg.generic
     // CHECK-SAME: ins([[arg0_alloc]], [[arg1_alloc]]
     // CHECK-SAME: outs([[cst_alloc0]]
@@ -58,9 +58,9 @@ module {
     // Since the original allocation is read twice by the second generic, we
     // have two copies of said generic floating around, as is needed for general
     // correctness.
+    // CHECK: [[cst_alloc1:%.+]] = rock.alloc
     // CHECK: rock.threadwise_read_into
     // CHECK: rock.threadwise_read_into
-    // CHECK-NEXT: [[cst_alloc1:%.+]] = rock.alloc
     // CHECK-NEXT: linalg.generic
     // CHECK-SAME: outs([[cst_alloc1]]
     linalg.generic {indexing_maps = [#map20, #map20, #map20], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : memref<2x5xf32>, memref<2x5xf32>) outs(%alloc_13 : memref<2x5xf32>) {

--- a/mlir/test/fusion/rock-gemm-align-tiling-multiple-args.mlir
+++ b/mlir/test/fusion/rock-gemm-align-tiling-multiple-args.mlir
@@ -9,6 +9,6 @@ func.func @rock_gemm(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf32>, %
     linalg.yield %2 : f32
   }
   %0 = rock.transform %alloc by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemmK", "gemmM"] at [1, 2] -> ["gemmK", "gemmM"] at [2, 1]>] bounds = [64, 64, 64] -> [64, 64, 64]> : memref<64x64x64xf32> to memref<64x64x64xf32>
-  rock.gridwise_gemm %arg2 = %0 * %arg1 features =  dot|atomic_add|atomic_fmax_f32 {gridSize = 64 : i32, numCU = 48 : i32, params = #rock.general_gemm_params<blockSize = 256, kPerBlock = 16, mPerBlock = 64, nPerBlock = 64, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1>} : memref<64x64x64xf32> = memref<64x64x64xf32> * memref<64x64x64xf32>
+  rock.gridwise_gemm %arg2 = %0 * %arg1 features =  dot|atomic_add|atomic_fmax_f32 {gridSize = 64 : i32, numCU = 48 : i32, params = #rock.general_gemm_params<blockSize = 256, kPerBlock = 16, mPerBlock = 64, nPerBlock = 64, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1, splitKFactor = 1>} : memref<64x64x64xf32> = memref<64x64x64xf32> * memref<64x64x64xf32>
   return
 }

--- a/mlir/test/fusion/rock-gemm-align-tiling-multiple-args.mlir
+++ b/mlir/test/fusion/rock-gemm-align-tiling-multiple-args.mlir
@@ -1,0 +1,14 @@
+// RUN: rocmlir-driver --rock-gridwise-gemm-to-blockwise --rock-blockwise-gemm-to-threadwise --rock-linalg-align --verify-passes %s | rocmlir-opt
+
+func.func @rock_gemm(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf32>, %arg2: memref<64x64x64xf32>, %arg3: memref<64x64x64xf32>) attributes {block_size = 256 : i32, grid_size = 64 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", wave_size = 32 : i32} {
+  %alloc = memref.alloc() : memref<64x64x64xf32>
+  linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg3 : memref<64x64x64xf16>, memref<64x64x64xf32>) outs(%alloc : memref<64x64x64xf32>) {
+  ^bb0(%in: f16, %in_0: f32, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.addf %1, %in_0 : f32
+    linalg.yield %2 : f32
+  }
+  %0 = rock.transform %alloc by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemmK", "gemmM"] at [1, 2] -> ["gemmK", "gemmM"] at [2, 1]>] bounds = [64, 64, 64] -> [64, 64, 64]> : memref<64x64x64xf32> to memref<64x64x64xf32>
+  rock.gridwise_gemm %arg2 = %0 * %arg1 features =  dot|atomic_add|atomic_fmax_f32 {gridSize = 64 : i32, numCU = 48 : i32, params = #rock.general_gemm_params<blockSize = 256, kPerBlock = 16, mPerBlock = 64, nPerBlock = 64, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1>} : memref<64x64x64xf32> = memref<64x64x64xf32> * memref<64x64x64xf32>
+  return
+}


### PR DESCRIPTION
Fixes https://github.com/ROCm/rocMLIR-internal/issues/1419