### PR TITLE
Added `removeUpperDims` utility

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -230,12 +230,13 @@ Value addPassThroughIndices(OpBuilder &b, Value transformed,
 
 ArrayRef<int64_t> getLowerShape(ArrayAttr transformStack);
 
-ArrayAttr removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
-                          const SetVector<int64_t> &removeeIndices);
+FailureOr<ArrayAttr>
+removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
+                const SetVector<StringRef> &removeDimNamesSet);
 
-ArrayAttr removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
-                          const SetVector<StringRef> &removeeDimNames);
-
+FailureOr<ArrayAttr>
+removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
+                const SetVector<int64_t> &removeIndicesSet);
 } // end namespace rock
 } // end namespace mlir
 #endif

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -230,6 +230,12 @@ Value addPassThroughIndices(OpBuilder &b, Value transformed,
 
 ArrayRef<int64_t> getLowerShape(ArrayAttr transformStack);
 
+ArrayAttr removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
+                          const SetVector<int64_t> &removeeIndices);
+
+ArrayAttr removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
+                          const SetVector<StringRef> &removeeDimNames);
+
 } // end namespace rock
 } // end namespace mlir
 #endif

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -230,13 +230,12 @@ Value addPassThroughIndices(OpBuilder &b, Value transformed,
 
 ArrayRef<int64_t> getLowerShape(ArrayAttr transformStack);
 
-FailureOr<ArrayAttr>
-removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
-                const SetVector<StringRef> &removeDimNamesSet);
+FailureOr<ArrayAttr> removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
+                                     SetVector<int64_t> removeIndicesSet);
 
 FailureOr<ArrayAttr>
 removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
-                const SetVector<int64_t> &removeIndicesSet);
+                const SetVector<StringRef> &removeDimNamesSet);
 } // end namespace rock
 } // end namespace mlir
 #endif

--- a/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
+++ b/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
@@ -1,17 +1,53 @@
-// RUN: rocmlir-opt -rock-transform-maps-utils-test -allow-unregistered-dialect %s | FileCheck %s
+// RUN: rocmlir-opt -rock-transform-maps-utils-test -allow-unregistered-dialect --mlir-print-local-scope --mlir-disable-threading %s | FileCheck %s
 
-// CHECK-LABEL: @test_transform_ex1
-func.func @test_transform_ex1(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_indices = [0, 2]} {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
-  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
-  return %2 : memref<4x256x64xf32>
+// CHECK-LABEL: test transform_ex1
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]>
+func.func @transform_ex1(%arg0: memref<4x1x32xf32>) -> memref<4x32xf32>
+  attributes {
+    remove_dims_by_names = ["A"]
+  } {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : memref<4x1x32xf32> to memref<1x4x32xf32>
+  %1= rock.transform %0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
+  return %1 : memref<4x32xf32>
 }
 
-// CHECK-LABEL: @test_transform_ex2
-func.func @test_transform_ex2(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_names = ["A", "C"]} {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
-  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
-  return %2 : memref<4x256x64xf32>
+// CHECK-LABEL: test transform_ex2
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>] bounds = [4] -> [1, 4]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["B", "A"] at [0, 1] -> ["A", "B"] at [0, 1]>] bounds = [1, 4] -> [4, 1]>
+func.func @transform_ex2(%arg0: memref<4x1x32xf32>) -> memref<4x32xf32>
+  attributes {
+    remove_dims_by_names = ["B"]
+  } {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : memref<4x1x32xf32> to memref<1x4x32xf32>
+  %1= rock.transform %0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["B"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
+  return %1 : memref<4x32xf32>
 }
+
+// CHECK-LABEL: test transform_ex3
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["B"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]>
+func.func @transform_ex3(%arg0: memref<4x1x32xf32>) -> memref<4x32xf32>
+  attributes {
+    remove_dims_by_names = ["X"]
+  } {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : memref<4x1x32xf32> to memref<1x4x32xf32>
+  %1= rock.transform %0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["B"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
+  return %1 : memref<4x32xf32>
+}
+
+// CHECK-LABEL1: @test_transform_ex6
+//func.func @test_transform_ex6(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_indices = [0, 2]} {
+//  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+//  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+//  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
+//  return %2 : memref<4x256x64xf32>
+//}
+
+//// CHECK-LABEL1: @test_transform_ex7
+//func.func @test_transform_ex7(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_names = ["A", "C"]} {
+//  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+//  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+//  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
+//  return %2 : memref<4x256x64xf32>
+//}

--- a/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
+++ b/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
@@ -1,119 +1,173 @@
-// RUN: rocmlir-opt -rock-transform-maps-utils-test -allow-unregistered-dialect --mlir-print-local-scope --mlir-disable-threading %s | FileCheck %s
+// RUN: rocmlir-opt -rock-transform-maps-utils-test -allow-unregistered-dialect --mlir-print-local-scope %s | FileCheck %s
 
-// CHECK-LABEL: test0 transform_ex1
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]>
+#tr0_ex0 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]>
+#tr1_ex0 = #rock.transform_map<affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]>
 
-// CHECK-LABEL: test1 transform_ex1
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>] bounds = [4] -> [1, 4]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "A"] at [0, 1] -> ["A", "B"] at [1, 0]>] bounds = [1, 4] -> [4, 1]>
-
-// CHECK-LABEL: test2 transform_ex1
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]>
-
-func.func @transform_ex1(%arg0: memref<4x1x32xf32>) -> memref<4x32xf32>
-  attributes {
-    remove_dims_by_names = {
-      test0 = ["A"],
-      test1 = ["C"],
-      test2 = ["X"]}
-  } {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : memref<4x1x32xf32> to memref<1x4x32xf32>
-  %1= rock.transform %0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
-  return %1 : memref<4x32xf32>
+// CHECK-LABEL: @transform_ex0_t0
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<32xf32>]])
+func.func @transform_ex0_t0(%arg0: memref<4x1x32xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]> : [[orig_shape]] to memref<32xf32>
+  %0 = rock.transform %arg0 by #tr0_ex0 : memref<4x1x32xf32> to memref<1x4x32xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]> : memref<32xf32> to memref<32xf32>
+  %1 = rock.transform %0 by #tr1_ex0 : memref<1x4x32xf32> to memref<4x32xf32>
+  "remove_dims"(%1) {names_to_drop = ["A"]} : (memref<4x32xf32>) -> ()
+  return
 }
 
-// CHECK-LABEL: test0 transform_ex2
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "C"] at [0, 2] -> ["A", "C"] at [0, 2]>, <Unmerge{256} ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 256, 64] -> [1, 256, 64]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 256, 64] -> [1, 64, 256]>
-
-// CHECK-LABEL: test1 transform_ex2
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "C"] at [0, 2] -> ["A", "C"] at [0, 2]>, <Unmerge{4} ["D"] at [1] -> ["B"] at [1]>] bounds = [1, 4, 64] -> [1, 4, 64]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 4, 64] -> [1, 64, 4]>
-
-// CHECK-LABEL: test2 transform_ex2
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A", "C"] at [0, 1] -> ["A", "C"] at [0, 1]>] bounds = [1, 64] -> [1, 64]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["C"] at [1] -> ["C"] at [1]>] bounds = [1, 64] -> [1, 64]>
-
-// CHECK-LABEL: test3 transform_ex2
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0 * 256 + d1)> by [<Unmerge{4, 256} ["D", "B"] at [0, 1] -> ["B"] at [0]>] bounds = [4, 256] -> [1024]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["B"] at [0] -> ["B"] at [0]>] bounds = [1024] -> [1024]>
-
-func.func @transform_ex2(%arg0: memref<1x64x1024xf32>) -> memref<1x4x256x64xf32>
-  attributes {
-    remove_dims_by_names = {
-      test0 = ["D"],
-      test1 = ["B"],
-      test2 = ["B", "D"],
-      test3 = ["A", "C"]
-    }
-  } {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
-  return %1 : memref<1x4x256x64xf32>
+// CHECK-LABEL: @transform_ex0_t1
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<4x1xf32>]])
+func.func @transform_ex0_t1(%arg0: memref<4x1x32xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "A"] at [0, 1] -> ["A", "B"] at [1, 0]>] bounds = [1, 4] -> [4, 1]> : [[orig_shape]] to memref<1x4xf32>
+  %0 = rock.transform %arg0 by #tr0_ex0 : memref<4x1x32xf32> to memref<1x4x32xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0) -> (0, d0)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>] bounds = [4] -> [1, 4]> : memref<1x4xf32> to memref<4xf32>
+  %1 = rock.transform %0 by #tr1_ex0 : memref<1x4x32xf32> to memref<4x32xf32>
+  "remove_dims"(%1) {names_to_drop = ["C"]} : (memref<4x32xf32>) -> ()
+  return
 }
 
-// CHECK-LABEL: test0 transform_ex3
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [0, 1]>] bounds = [1024, 64] -> [1024, 64]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [1, 0]>] bounds = [1024, 64] -> [64, 1024]>
-
-// CHECK-LABEL: test1 transform_ex3
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0 mod 32, d1)> by [<Broadcast{32} ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [32, 1024] -> [1, 1024]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 1024] -> [1, 1024]>
-
-func.func @transform_ex3(%arg0: memref<1x64x1024xf32>) -> memref<32x1024x64xf32>
-  attributes {
-    remove_dims_by_names = {
-      test0 = ["A"],
-      test1 = ["C"]
-    }
-  } {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-  %1 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (0, d1, d2)> by [<Broadcast{32} ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [1, 2]>] bounds = [32, 1024, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<32x1024x64xf32>
-  return %1 : memref<32x1024x64xf32>
+// CHECK-LABEL: @transform_ex0_t2
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<4x1x32xf32>]])
+func.func @transform_ex0_t2(%arg0: memref<4x1x32xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : [[orig_shape]] to memref<1x4x32xf32>
+  %0 = rock.transform %arg0 by #tr0_ex0 : memref<4x1x32xf32> to memref<1x4x32xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
+  %1 = rock.transform %0 by #tr1_ex0 : memref<1x4x32xf32> to memref<4x32xf32>
+  "remove_dims"(%1) {names_to_drop = ["X"]} : (memref<4x32xf32>) -> ()
+  return
 }
 
-// CHECK-LABEL: test0 transform_ex4
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<ConstDim{0, 1} [] at [] -> ["B"] at [0]>, <PassThrough ["C"] at [0] -> ["C"] at [1]>] bounds = [64] -> [1024, 64]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [1, 0]>] bounds = [1024, 64] -> [64, 1024]>
 
-// CHECK-LABEL: test1 transform_ex4
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <ConstDim{0, 1} [] at [] -> ["B"] at [1]>] bounds = [1] -> [1, 1024]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 1024] -> [1, 1024]>
+#tr0_ex1 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]>
+#tr1_ex1 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]>
 
-// CHECK-LABEL: test2 transform_ex4
-// CHECK-NEXT: #rock.transform_map<affine_map<() -> (0)> by [<ConstDim{0, 1} [] at [] -> ["B"] at [0]>] bounds = [] -> [1024]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["B"] at [0] -> ["B"] at [0]>] bounds = [1024] -> [1024]>
-
-func.func @transform_ex4(%arg0: memref<1x64x1024xf32>) -> memref<1x64xf32>
-  attributes {
-    remove_dims_by_names = {
-      test0 = ["A"],
-      test1 = ["C"],
-      test2 = ["A", "C"]
-    }
-  } {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-  %1 = rock.transform %0 by <affine_map<(d0, d2) -> (d0, 0, d2)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <ConstDim{0, 1} [] at [] -> ["B"] at [1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [1, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x64xf32>
-  return %1 : memref<1x64xf32>
+// CHECK-LABEL: @transform_ex1_t0
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1x64x256xf32>]])
+func.func @transform_ex1_t0(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 256, 64] -> [1, 64, 256]> : [[orig_shape]] to memref<1x256x64xf32>
+  %0 = rock.transform %arg0 by #tr0_ex1 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "C"] at [0, 2] -> ["A", "C"] at [0, 2]>, <Unmerge{256} ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 256, 64] -> [1, 256, 64]> : memref<1x256x64xf32> to memref<1x256x64xf32>
+  %1 = rock.transform %0 by #tr1_ex1 : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["D"]} : (memref<1x4x256x64xf32>) -> ()
+  return
 }
 
-// CHECK-LABEL: test0 transform_ex5
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "B", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 1024, 64] -> [1, 1024, 64]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]>
+// CHECK-LABEL: @transform_ex1_t1
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1x64x4xf32>]])
+func.func @transform_ex1_t1(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 4, 64] -> [1, 64, 4]> : [[orig_shape]] to memref<1x4x64xf32>
+  %0 = rock.transform %arg0 by #tr0_ex1 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "C"] at [0, 2] -> ["A", "C"] at [0, 2]>, <Unmerge{4} ["D"] at [1] -> ["B"] at [1]>] bounds = [1, 4, 64] -> [1, 4, 64]> : memref<1x4x64xf32> to memref<1x4x64xf32>
+  %1 = rock.transform %0 by #tr1_ex1 : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["B"]} : (memref<1x4x256x64xf32>) -> ()
+  return
+}
 
-// CHECK-LABEL: test1 transform_ex5
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> ()> by [<AddDim{8} ["X"] at [0] -> [] at []>] bounds = [8] -> []>
+// CHECK-LABEL: @transform_ex1_t2
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1x64xf32>]])
+func.func @transform_ex1_t2(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["C"] at [1] -> ["C"] at [1]>] bounds = [1, 64] -> [1, 64]> : [[orig_shape]] to memref<1x64xf32>
+  %0 = rock.transform %arg0 by #tr0_ex1 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A", "C"] at [0, 1] -> ["A", "C"] at [0, 1]>] bounds = [1, 64] -> [1, 64]> : memref<1x64xf32> to memref<1x64xf32>
+  %1 = rock.transform %0 by #tr1_ex1 : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["B", "D"]} : (memref<1x4x256x64xf32>) -> ()
+  return
+}
 
-func.func @transform_ex5(%arg0: memref<1x64x1024xf32>) -> memref<1x8x1024x64xf32>
-  attributes {
-    remove_dims_by_names = {
-      test0 = ["X"],
-      test1 = ["A", "B", "C"]
-    }
-  } {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)> by [<AddDim{8} ["X"] at [1] -> [] at []>, <PassThrough ["A", "B", "C"] at [0, 2, 3] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 8, 1024, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x8x1024x64xf32>
-  return %1 : memref<1x8x1024x64xf32>
+// CHECK-LABEL: @transform_ex1_t3
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1024xf32>]])
+func.func @transform_ex1_t3(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0) -> (d0)> by [<PassThrough ["B"] at [0] -> ["B"] at [0]>] bounds = [1024] -> [1024]> : [[orig_shape]] to memref<1024xf32>
+  %0 = rock.transform %arg0 by #tr0_ex1 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1) -> (d0 * 256 + d1)> by [<Unmerge{4, 256} ["D", "B"] at [0, 1] -> ["B"] at [0]>] bounds = [4, 256] -> [1024]> : memref<1024xf32> to memref<4x256xf32>
+  %1 = rock.transform %0 by #tr1_ex1 : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["A", "C"]} : (memref<1x4x256x64xf32>) -> ()
+  return
+}
+
+
+#tr0_ex2 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]>
+#tr1_ex2 = #rock.transform_map<affine_map<(d0, d1, d2) -> (0, d1, d2)> by [<Broadcast{32} ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [1, 2]>] bounds = [32, 1024, 64] -> [1, 1024, 64]>
+
+// CHECK-LABEL: @transform_ex2_t0
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<64x1024xf32>]])
+func.func @transform_ex2_t0(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [1, 0]>] bounds = [1024, 64] -> [64, 1024]> : [[orig_shape]] to memref<1024x64xf32>
+  %0 = rock.transform %arg0 by #tr0_ex2 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [0, 1]>] bounds = [1024, 64] -> [1024, 64]> : memref<1024x64xf32> to memref<1024x64xf32>
+  %1 = rock.transform %0 by #tr1_ex2 : memref<1x1024x64xf32> to memref<32x1024x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["A"]} : (memref<32x1024x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: @transform_ex2_t1
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1x1024xf32>]])
+func.func @transform_ex2_t1(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 1024] -> [1, 1024]> : [[orig_shape]] to memref<1x1024xf32>
+  %0 = rock.transform %arg0 by #tr0_ex2 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1) -> (d0 mod 32, d1)> by [<Broadcast{32} ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [32, 1024] -> [1, 1024]> : memref<1x1024xf32> to memref<32x1024xf32>
+  %1 = rock.transform %0 by #tr1_ex2 : memref<1x1024x64xf32> to memref<32x1024x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["C"]} : (memref<32x1024x64xf32>) -> ()
+  return
+}
+
+
+#tr0_ex3 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]>
+#tr1_ex3 = #rock.transform_map<affine_map<(d0, d2) -> (d0, 0, d2)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <ConstDim{0, 1} [] at [] -> ["B"] at [1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [1, 64] -> [1, 1024, 64]>
+
+// CHECK-LABEL: @transform_ex3_t0
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<64x1024xf32>]])
+func.func @transform_ex3_t0(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [1, 0]>] bounds = [1024, 64] -> [64, 1024]> : [[orig_shape]] to memref<1024x64xf32>
+  %0 = rock.transform %arg0 by #tr0_ex3 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0) -> (0, d0)> by [<ConstDim{0, 1} [] at [] -> ["B"] at [0]>, <PassThrough ["C"] at [0] -> ["C"] at [1]>] bounds = [64] -> [1024, 64]> : memref<1024x64xf32> to memref<64xf32>
+  %1 = rock.transform %0 by #tr1_ex3 : memref<1x1024x64xf32> to memref<1x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["A"]} : (memref<1x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: @transform_ex3_t1
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1x1024xf32>]])
+func.func @transform_ex3_t1(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 1024] -> [1, 1024]> : [[orig_shape]] to memref<1x1024xf32>
+  %0 = rock.transform %arg0 by #tr0_ex3 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0) -> (d0, 0)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <ConstDim{0, 1} [] at [] -> ["B"] at [1]>] bounds = [1] -> [1, 1024]> : memref<1x1024xf32> to memref<1xf32>
+  %1 = rock.transform %0 by #tr1_ex3 : memref<1x1024x64xf32> to memref<1x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["C"]} : (memref<1x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: @transform_ex3_t2
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1024xf32>]])
+func.func @transform_ex3_t2(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0) -> (d0)> by [<PassThrough ["B"] at [0] -> ["B"] at [0]>] bounds = [1024] -> [1024]> : [[orig_shape]] to memref<1024xf32>
+  %0 = rock.transform %arg0 by #tr0_ex3 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<() -> (0)> by [<ConstDim{0, 1} [] at [] -> ["B"] at [0]>] bounds = [] -> [1024]> : memref<1024xf32> to memref<f32>
+  %1 = rock.transform %0 by #tr1_ex3 : memref<1x1024x64xf32> to memref<1x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["A", "C"]} : (memref<1x64xf32>) -> ()
+  return
+}
+
+
+#tr0_ex4 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]>
+#tr1_ex4 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)> by [<AddDim{8} ["X"] at [1] -> [] at []>, <PassThrough ["A", "B", "C"] at [0, 2, 3] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 8, 1024, 64] -> [1, 1024, 64]>
+
+// CHECK-LABEL: @transform_ex4_t0
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<1x64x1024xf32>]])
+func.func @transform_ex4_t0(%arg0: memref<1x64x1024xf32>) {
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : [[orig_shape]] to memref<1x1024x64xf32>
+  %0 = rock.transform %arg0 by #tr0_ex4 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next1:%.*]] = rock.transform [[next0]] by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "B", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 1024, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x1024x64xf32>
+  %1 = rock.transform %0 by #tr1_ex4 : memref<1x1024x64xf32> to memref<1x8x1024x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["X"]} : (memref<1x8x1024x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: @transform_ex4_t1
+// CHECK-SAME: ([[orig:%.*]]: [[orig_shape:memref<f32>]])
+func.func @transform_ex4_t1(%arg0: memref<1x64x1024xf32>) {
+  %0 = rock.transform %arg0 by #tr0_ex4 : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  // CHECK-NEXT: [[next0:%.*]] = rock.transform [[orig]] by <affine_map<(d0) -> ()> by [<AddDim{8} ["X"] at [0] -> [] at []>] bounds = [8] -> []> : [[orig_shape]] to memref<8xf32>
+  %1 = rock.transform %0 by #tr1_ex4 : memref<1x1024x64xf32> to memref<1x8x1024x64xf32>
+  "remove_dims"(%1) {names_to_drop = ["A", "B", "C"]} : (memref<1x8x1024x64xf32>) -> ()
+  return
 }

--- a/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
+++ b/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-opt -rock-transform-maps-utils-test -allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK-LABEL: @test_transform_ex1
+func.func @test_transform_ex1(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_indices = [0, 2]} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
+  return %2 : memref<4x256x64xf32>
+}
+
+// CHECK-LABEL: @test_transform_ex2
+func.func @test_transform_ex2(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_names = ["A", "C"]} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
+  return %2 : memref<4x256x64xf32>
+}

--- a/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
+++ b/mlir/test/Dialect/Rock/test_transformation_maps_utils.mlir
@@ -1,53 +1,119 @@
 // RUN: rocmlir-opt -rock-transform-maps-utils-test -allow-unregistered-dialect --mlir-print-local-scope --mlir-disable-threading %s | FileCheck %s
 
-// CHECK-LABEL: test transform_ex1
+// CHECK-LABEL: test0 transform_ex1
 // CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]>
 // CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["C"] at [0] -> ["C"] at [0]>] bounds = [32] -> [32]>
+
+// CHECK-LABEL: test1 transform_ex1
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>] bounds = [4] -> [1, 4]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "A"] at [0, 1] -> ["A", "B"] at [1, 0]>] bounds = [1, 4] -> [4, 1]>
+
+// CHECK-LABEL: test2 transform_ex1
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]>
+
 func.func @transform_ex1(%arg0: memref<4x1x32xf32>) -> memref<4x32xf32>
   attributes {
-    remove_dims_by_names = ["A"]
+    remove_dims_by_names = {
+      test0 = ["A"],
+      test1 = ["C"],
+      test2 = ["X"]}
   } {
   %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : memref<4x1x32xf32> to memref<1x4x32xf32>
   %1= rock.transform %0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
   return %1 : memref<4x32xf32>
 }
 
-// CHECK-LABEL: test transform_ex2
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>] bounds = [4] -> [1, 4]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["B", "A"] at [0, 1] -> ["A", "B"] at [0, 1]>] bounds = [1, 4] -> [4, 1]>
-func.func @transform_ex2(%arg0: memref<4x1x32xf32>) -> memref<4x32xf32>
+// CHECK-LABEL: test0 transform_ex2
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "C"] at [0, 2] -> ["A", "C"] at [0, 2]>, <Unmerge{256} ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 256, 64] -> [1, 256, 64]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 256, 64] -> [1, 64, 256]>
+
+// CHECK-LABEL: test1 transform_ex2
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "C"] at [0, 2] -> ["A", "C"] at [0, 2]>, <Unmerge{4} ["D"] at [1] -> ["B"] at [1]>] bounds = [1, 4, 64] -> [1, 4, 64]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 4, 64] -> [1, 64, 4]>
+
+// CHECK-LABEL: test2 transform_ex2
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A", "C"] at [0, 1] -> ["A", "C"] at [0, 1]>] bounds = [1, 64] -> [1, 64]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["C"] at [1] -> ["C"] at [1]>] bounds = [1, 64] -> [1, 64]>
+
+// CHECK-LABEL: test3 transform_ex2
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0 * 256 + d1)> by [<Unmerge{4, 256} ["D", "B"] at [0, 1] -> ["B"] at [0]>] bounds = [4, 256] -> [1024]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["B"] at [0] -> ["B"] at [0]>] bounds = [1024] -> [1024]>
+
+func.func @transform_ex2(%arg0: memref<1x64x1024xf32>) -> memref<1x4x256x64xf32>
   attributes {
-    remove_dims_by_names = ["B"]
+    remove_dims_by_names = {
+      test0 = ["D"],
+      test1 = ["B"],
+      test2 = ["B", "D"],
+      test3 = ["A", "C"]
+    }
   } {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : memref<4x1x32xf32> to memref<1x4x32xf32>
-  %1= rock.transform %0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["B"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
-  return %1 : memref<4x32xf32>
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
+  return %1 : memref<1x4x256x64xf32>
 }
 
-// CHECK-LABEL: test transform_ex3
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["B"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]>
-// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]>
-func.func @transform_ex3(%arg0: memref<4x1x32xf32>) -> memref<4x32xf32>
+// CHECK-LABEL: test0 transform_ex3
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [0, 1]>] bounds = [1024, 64] -> [1024, 64]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [1, 0]>] bounds = [1024, 64] -> [64, 1024]>
+
+// CHECK-LABEL: test1 transform_ex3
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0 mod 32, d1)> by [<Broadcast{32} ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [32, 1024] -> [1, 1024]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 1024] -> [1, 1024]>
+
+func.func @transform_ex3(%arg0: memref<1x64x1024xf32>) -> memref<32x1024x64xf32>
   attributes {
-    remove_dims_by_names = ["X"]
+    remove_dims_by_names = {
+      test0 = ["A"],
+      test1 = ["C"]
+    }
   } {
-  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1, d0, d2)> by [<PassThrough ["B", "A", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [1, 0, 2]>] bounds = [1, 4, 32] -> [4, 1, 32]> : memref<4x1x32xf32> to memref<1x4x32xf32>
-  %1= rock.transform %0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "B"] at [0, 1]>, <PassThrough ["B"] at [1] -> ["C"] at [2]>] bounds = [4, 32] -> [1, 4, 32]> : memref<1x4x32xf32> to memref<4x32xf32>
-  return %1 : memref<4x32xf32>
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  %1 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (0, d1, d2)> by [<Broadcast{32} ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [1, 2]>] bounds = [32, 1024, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<32x1024x64xf32>
+  return %1 : memref<32x1024x64xf32>
 }
 
-// CHECK-LABEL1: @test_transform_ex6
-//func.func @test_transform_ex6(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_indices = [0, 2]} {
-//  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-//  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
-//  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
-//  return %2 : memref<4x256x64xf32>
-//}
+// CHECK-LABEL: test0 transform_ex4
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<ConstDim{0, 1} [] at [] -> ["B"] at [0]>, <PassThrough ["C"] at [0] -> ["C"] at [1]>] bounds = [64] -> [1024, 64]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["B", "C"] at [0, 1] -> ["B", "C"] at [1, 0]>] bounds = [1024, 64] -> [64, 1024]>
 
-//// CHECK-LABEL1: @test_transform_ex7
-//func.func @test_transform_ex7(%arg0: memref<1x64x1024xf32>) -> memref<4x256x64xf32> attributes {remove_dims_by_names = ["A", "C"]} {
-//  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
-//  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d1 * 256 + d2, d3)> by [<PassThrough ["A", "C"] at [0, 3] -> ["A", "C"] at [0, 2]>, <Unmerge{4, 256} ["D", "B"] at [1, 2] -> ["B"] at [1]>] bounds = [1, 4, 256, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x4x256x64xf32>
-//  %2 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (0, d0, d1, d2)> by [<Merge{1, 4} ["A"] at [0] -> ["A", "D"] at [0, 1]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 3]>] bounds = [4, 256, 64] -> [1, 4, 256, 64]> : memref<1x4x256x64xf32> to memref<4x256x64xf32>
-//  return %2 : memref<4x256x64xf32>
-//}
+// CHECK-LABEL: test1 transform_ex4
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <ConstDim{0, 1} [] at [] -> ["B"] at [1]>] bounds = [1] -> [1, 1024]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1) -> (d0, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B"] at [1] -> ["B"] at [1]>] bounds = [1, 1024] -> [1, 1024]>
+
+// CHECK-LABEL: test2 transform_ex4
+// CHECK-NEXT: #rock.transform_map<affine_map<() -> (0)> by [<ConstDim{0, 1} [] at [] -> ["B"] at [0]>] bounds = [] -> [1024]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> (d0)> by [<PassThrough ["B"] at [0] -> ["B"] at [0]>] bounds = [1024] -> [1024]>
+
+func.func @transform_ex4(%arg0: memref<1x64x1024xf32>) -> memref<1x64xf32>
+  attributes {
+    remove_dims_by_names = {
+      test0 = ["A"],
+      test1 = ["C"],
+      test2 = ["A", "C"]
+    }
+  } {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  %1 = rock.transform %0 by <affine_map<(d0, d2) -> (d0, 0, d2)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <ConstDim{0, 1} [] at [] -> ["B"] at [1]>, <PassThrough ["C"] at [1] -> ["C"] at [2]>] bounds = [1, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x64xf32>
+  return %1 : memref<1x64xf32>
+}
+
+// CHECK-LABEL: test0 transform_ex5
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["A", "B", "C"] at [0, 1, 2] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 1024, 64] -> [1, 1024, 64]>
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]>
+
+// CHECK-LABEL: test1 transform_ex5
+// CHECK-NEXT: #rock.transform_map<affine_map<(d0) -> ()> by [<AddDim{8} ["X"] at [0] -> [] at []>] bounds = [8] -> []>
+
+func.func @transform_ex5(%arg0: memref<1x64x1024xf32>) -> memref<1x8x1024x64xf32>
+  attributes {
+    remove_dims_by_names = {
+      test0 = ["X"],
+      test1 = ["A", "B", "C"]
+    }
+  } {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["A"] at [0] -> ["A"] at [0]>, <PassThrough ["B", "C"] at [1, 2] -> ["B", "C"] at [2, 1]>] bounds = [1, 1024, 64] -> [1, 64, 1024]> : memref<1x64x1024xf32> to memref<1x1024x64xf32>
+  %1 = rock.transform %0 by <affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)> by [<AddDim{8} ["X"] at [1] -> [] at []>, <PassThrough ["A", "B", "C"] at [0, 2, 3] -> ["A", "B", "C"] at [0, 1, 2]>] bounds = [1, 8, 1024, 64] -> [1, 1024, 64]> : memref<1x1024x64xf32> to memref<1x8x1024x64xf32>
+  return %1 : memref<1x8x1024x64xf32>
+}

--- a/mlir/test/lib/Dialect/Rock/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Rock/CMakeLists.txt
@@ -4,6 +4,7 @@ add_rocmlir_test_library(MLIRRockTestPasses
   TestRockMultibuffer.cpp
   TestBufferDependencyAnalysis.cpp
   TestFunctionFusibility.cpp
+  TestTransformationMapsUtils.cpp
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC

--- a/mlir/test/lib/Dialect/Rock/TestTransformationMapsUtils.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestTransformationMapsUtils.cpp
@@ -89,7 +89,20 @@ static LogicalResult testSubDimensions(func::FuncOp f) {
       rock::untransform(builder, returnValue);
 
   auto removees = RequestProcessor::getRemovees(f);
-  rock::removeUpperDims(builder, transformAttrs, removees);
+  auto results = rock::removeUpperDims(builder, transformAttrs, removees);
+  if (failed(results)) {
+    return failure();
+  }
+
+  std::string outputString;
+  llvm::raw_string_ostream stream(outputString);
+  stream << "test " << f.getSymName() << '\n';
+  for (auto item : *results) {
+    item.print(stream);
+    stream << '\n';
+  }
+
+  llvm::outs() << stream.str();
   return success();
 }
 

--- a/mlir/test/lib/Dialect/Rock/TestTransformationMapsUtils.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestTransformationMapsUtils.cpp
@@ -1,0 +1,117 @@
+//===- TestVectorizationInference.cpp - test max vector length code -----===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------===//
+// test/lib/Dialect/Rock/testTransformationMapsUtilss.cpp
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Rock/IR/Rock.h"
+#include "mlir/Dialect/Rock/utility/transformMapUtils.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/Support/Casting.h"
+#include <tuple>
+
+using namespace mlir;
+using namespace mlir::rock;
+
+namespace {
+struct TransformMapsUtilsTestPass
+    : public PassWrapper<TransformMapsUtilsTestPass,
+                         OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TransformMapsUtilsTestPass)
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<RockDialect, func::FuncDialect>();
+  }
+
+  StringRef getArgument() const final {
+    return "rock-transform-maps-utils-test";
+  }
+  StringRef getDescription() const final {
+    return "Tests transformation map utils in Rock";
+  }
+
+  void runOnOperation() override;
+};
+} // end namespace
+
+namespace {
+struct ByIndices {
+  static SetVector<int64_t> getRemovees(func::FuncOp f) {
+    SetVector<int64_t> removeIndices;
+    auto attrArray = f->getAttr("remove_dims_by_indices");
+    for (auto &attr : attrArray.cast<ArrayAttr>()) {
+      removeIndices.insert(attr.cast<IntegerAttr>().getInt());
+    }
+    return removeIndices;
+  }
+};
+
+struct ByNames {
+  static SetVector<StringRef> getRemovees(func::FuncOp f) {
+    SetVector<StringRef> removeIndices;
+    auto attrArray = f->getAttr("remove_dims_by_names");
+    for (auto &attr : attrArray.cast<ArrayAttr>()) {
+      removeIndices.insert(attr.cast<StringAttr>().getValue());
+    }
+    return removeIndices;
+  }
+};
+} // namespace
+
+template <typename RequestProcessor>
+static LogicalResult testSubDimensions(func::FuncOp f) {
+  Value returnValue;
+  WalkResult walkResult = f.walk([&](func::ReturnOp op) -> WalkResult {
+    if (op.getNumOperands() == 1) {
+      returnValue = op->getOperand(0);
+      return WalkResult::advance();
+    }
+    return WalkResult::interrupt();
+  });
+  if (walkResult.wasInterrupted()) {
+    return failure();
+  }
+
+  OpBuilder builder(f.getContext());
+
+  ArrayAttr transformAttrs;
+  std::tie(std::ignore, transformAttrs, std::ignore) =
+      rock::untransform(builder, returnValue);
+
+  auto removees = RequestProcessor::getRemovees(f);
+  rock::removeUpperDims(builder, transformAttrs, removees);
+  return success();
+}
+
+void TransformMapsUtilsTestPass::runOnOperation() {
+  func::FuncOp f = getOperation();
+  if (f->getAttr("remove_dims_by_indices")) {
+    if (failed(testSubDimensions<ByIndices>(f))) {
+      emitError(UnknownLoc::get(f.getContext()), "Pass failure");
+      signalPassFailure();
+    }
+  } else if (f->getAttr("remove_dims_by_names")) {
+    if (failed(testSubDimensions<ByNames>(f))) {
+      emitError(UnknownLoc::get(f.getContext()), "Pass failure");
+      signalPassFailure();
+    }
+  }
+}
+
+namespace mlir {
+namespace rock {
+void registerTransformMapsUtilsTestPass() {
+  PassRegistration<TransformMapsUtilsTestPass>();
+}
+} // end namespace rock
+} // end namespace mlir

--- a/mlir/tools/rocmlir-opt/rocmlir-opt.cpp
+++ b/mlir/tools/rocmlir-opt/rocmlir-opt.cpp
@@ -25,6 +25,7 @@ void registerVectorizationInferenceTestPass();
 void registerMultiBufferingTestPass();
 void registerBufferDependencyAnalysisTestPass();
 void registerFusibilityTestPass();
+void registerTransformMapsUtilsTestPass();
 } // end namespace rock
 } // end namespace mlir
 
@@ -35,6 +36,7 @@ void registerRockTestPasses() {
   rock::registerMultiBufferingTestPass();
   rock::registerBufferDependencyAnalysisTestPass();
   rock::registerFusibilityTestPass();
+  rock::registerTransformMapsUtilsTestPass();
 }
 #endif
 


### PR DESCRIPTION
This PR adds `removeUpperDims` utility which can remove upper dimensions by indices or names and propagate the information through an entire `TransformMapAttr`. The implementation maybe not algorithmically-efficient but, based on the tests, it leads to correct solutions. Sometimes, it is difficult to decide whether the use of a vector, a map of a set is efficient or not. I would make a note that sizes of the involved containers are small in practice. Thus, the implementation is probably ok performance-wise.

Closes https://github.com/ROCm/rocMLIR-internal/issues/1303