### PR TITLE
Clean up intermediate loop code, fix excess loop iterations

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -148,9 +148,13 @@ def Rock_TransformAttr : Rock_Attr<"Transform"> {
           This has the effect of concatentating the dimensions if they are consecutive
         - AddDim{size} - Adds one upper dimension of the given size that does not
           correspond to any lower dimension.
-        - Broadcast{c1, c2, ..., cN} - Broadcast lower dimensions of size 1 to
-          upper dimensions.
-        - ConstDim{c1, l1, c2, l2, .. cN, lN} a
+        - Broadcast{c1, c2, ..., cN} - Broadcast lower dimensions of size
+          c1, c2, ... cN to upper dimensions whose size isn't (currently) recorded
+          in the parameters. Note that the upper dimension's length doesn't have to
+          evenly divide into the lower one.
+        - ConstDim{c1, l1, c2, l2, .. cN, lN} an operator that sets the lower
+          dimensions of length l1, ... lN to the values c1, ..., cN. It takes no
+          input arguments.
     }];
 
     let parameters = (ins
@@ -334,8 +338,8 @@ def Rock_XdlopsGemmDerivedParamsAttr : Rock_Attr<"XdlopsGemmDerivedParams", [Roc
       return $_get(
         params.getContext(),
         params.getKpackPerBlock(),
-        mPerBlock, 
-        nPerBlock, 
+        mPerBlock,
+        nPerBlock,
         params.getKpack(),
         mPerWave,
         nPerWave,

--- a/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
@@ -171,6 +171,7 @@ public:
   // This is implemented as a `Broadcast{length}` operation. The input dimension
   // doesn't need to evenly divide the `length`.
   void takeRemainder(StringRef name, int64_t length);
+
 protected:
   void addTransform(TransformType type, ArrayRef<int64_t> params,
                     ArrayRef<StringRef> startNames,

--- a/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
@@ -167,6 +167,10 @@ public:
   void merge(ArrayRef<StringRef> lowerNames, ArrayRef<uint32_t> lowerDims,
              StringRef upperName, ArrayRef<int64_t> sizes);
 
+  // Map `name` to `name` % `length`.
+  // This is implemented as a `Broadcast{length}` operation. The input dimension
+  // doesn't need to evenly divide the `length`.
+  void takeRemainder(StringRef name, int64_t length);
 protected:
   void addTransform(TransformType type, ArrayRef<int64_t> params,
                     ArrayRef<StringRef> startNames,

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -592,6 +592,16 @@ void TopDownTMBuilder::merge(ArrayRef<StringRef> lowerNames,
                lowerDims);
 }
 
+void TopDownTMBuilder::takeRemainder(StringRef name, int64_t length) {
+  assert(length > 0 && "Remainder can't be zero");
+  uint32_t dim = startIndex(name);
+  // WE're not recording this, but we should be.
+  //int64_t size = startSize(dim);
+  defineDim(name, dim, length);
+  // The semantics of Broadcast are x -> x % l so we might as well use it.
+  addTransform(TransformType::Broadcast, {length}, {name}, {dim}, {name}, {dim});
+}
+
 llvm::SmallVector<uint32_t>
 TopDownTMBottomDimsWrapper::toBottomDims(ArrayRef<StringRef> names) {
   llvm::SmallVector<uint32_t> ret;

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -596,10 +596,11 @@ void TopDownTMBuilder::takeRemainder(StringRef name, int64_t length) {
   assert(length > 0 && "Remainder can't be zero");
   uint32_t dim = startIndex(name);
   // WE're not recording this, but we should be.
-  //int64_t size = startSize(dim);
+  // int64_t size = startSize(dim);
   defineDim(name, dim, length);
   // The semantics of Broadcast are x -> x % l so we might as well use it.
-  addTransform(TransformType::Broadcast, {length}, {name}, {dim}, {name}, {dim});
+  addTransform(TransformType::Broadcast, {length}, {name}, {dim}, {name},
+               {dim});
 }
 
 llvm::SmallVector<uint32_t>

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -476,9 +476,9 @@ struct BlockwiseGemmAccelRewritePattern
       Value i = mLoop.getInductionVar();
 
       // regsA = read A from LDS
-      b.create<ThreadwiseReadIntoOp>(loc, wrappedLDSBufferForLoadA,
-                                     op.getBufferA(), b.getArrayAttr({}),
-                                     ValueRange{tid, i}, true, true);
+      b.create<ThreadwiseReadIntoOp>(
+          loc, wrappedLDSBufferForLoadA, op.getBufferA(), b.getArrayAttr({}),
+          ValueRange{tid, i}, /*forceUnroll=*/true, /*useIndexDiffs=*/true);
 
       auto nLoop = b.create<affine::AffineForOp>(loc, 0, nRepeats);
       {
@@ -487,9 +487,9 @@ struct BlockwiseGemmAccelRewritePattern
         Value j = nLoop.getInductionVar();
 
         // regsB = read B from LDS
-        b.create<ThreadwiseReadIntoOp>(loc, wrappedLDSBufferForLoadB,
-                                       op.getBufferB(), b.getArrayAttr({}),
-                                       ValueRange{tid, j}, true, true);
+        b.create<ThreadwiseReadIntoOp>(
+            loc, wrappedLDSBufferForLoadB, op.getBufferB(), b.getArrayAttr({}),
+            ValueRange{tid, j}, /*forceUnroll=*/true, /*useIndexDiffs=*/true);
 
         // regsC += regsA * regsB
         auto kLoop = b.create<affine::AffineForOp>(loc, 0, kBasePerThread);

--- a/mlir/lib/Dialect/Rock/Transforms/CleanMath.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/CleanMath.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Rock/Passes.h"
@@ -44,7 +45,62 @@ struct RockCleanMathPass
     : public rock::impl::RockCleanMathPassBase<RockCleanMathPass> {
   void runOnOperation() override;
 };
+
+/// This is a rewrite for a specific and irritating pattern that shows up in our
+/// code a bunch on account of the whole index diff thing.
+/// Specifically:
+///    %prev = arith.remui %blah, %c1
+///    %cur = arith.addi %prev, %c(M < N, usually 1)
+///    %curModulus = arith.remui %cur, %cN
+///    %checkWrap = arith.subi %curWrapped, %prev
+///    %val = arith.addi %checkWrap, %cN
+///
+/// If %prev + 1 is still less than N, this is (%prev + 1) mod N - %prev + N
+struct SimplifyCheckingSmallConstantOverflow
+    : public OpRewritePattern<arith::RemUIOp> {
+  using OpRewritePattern<arith::RemUIOp>::OpRewritePattern;
+};
 } // end namespace
+
+/// This function hasn't come from anywhere and is relying on the overall
+/// tests of the integer range inference implementation for its correctness.
+static LogicalResult deleteTrivialRemainder(DataFlowSolver &solver,
+                                            Operation &op) {
+  if (!isa<arith::RemSIOp, arith::RemUIOp>(op))
+    return failure();
+  Value result = op.getResult(0);
+  Value lhs = op.getOperand(0);
+  Value rhs = op.getOperand(1);
+  auto rhsConstVal = rhs.getDefiningOp<arith::ConstantOp>();
+  if (!rhsConstVal)
+    return failure();
+  APInt modulus = cast<IntegerAttr>(rhsConstVal.getValue()).getValue();
+  if (!modulus.isStrictlyPositive())
+    return failure();
+  auto *maybeLhsRange = solver.lookupState<IntegerValueRangeLattice>(lhs);
+  if (!maybeLhsRange || maybeLhsRange->getValue().isUninitialized())
+    return failure();
+  const ConstantIntRanges &lhsRange = maybeLhsRange->getValue().getValue();
+  const APInt &min =
+      llvm::isa<arith::RemUIOp>(op) ? lhsRange.umin() : lhsRange.smin();
+  const APInt &max =
+      llvm::isa<arith::RemUIOp>(op) ? lhsRange.umax() : lhsRange.smax();
+  // The minima and maxima here are given as closed ranges, we must be strictly
+  // less than the modulus.
+  if (min.isNegative() || min.uge(modulus))
+    return failure();
+  if (max.isNegative() || max.uge(modulus))
+    return failure();
+  if (!min.ule(max))
+    return failure();
+
+  // With all those conditions out of the way, we know thas this invocation of
+  // a remainder is a noop because the input is strictly within the range
+  // [0, modulus), so get rid of it.
+  result.replaceAllUsesWith(lhs);
+  op.erase();
+  return success();
+}
 
 /// From
 /// external/llvm-project/mlir/test/lib/Transforms/TestIntRangeInference.cpp
@@ -96,6 +152,8 @@ static void rewrite(DataFlowSolver &solver, MLIRContext *context,
     for (Operation &op : llvm::make_early_inc_range(*block)) {
       builder.setInsertionPoint(&op);
 
+      if (succeeded(deleteTrivialRemainder(solver, op)))
+        continue;
       // Replace any result with constants.
       bool replacedAll = op.getNumResults() != 0;
       for (Value res : op.getResults())

--- a/mlir/lib/Dialect/Rock/Transforms/CleanMath.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/CleanMath.cpp
@@ -45,21 +45,6 @@ struct RockCleanMathPass
     : public rock::impl::RockCleanMathPassBase<RockCleanMathPass> {
   void runOnOperation() override;
 };
-
-/// This is a rewrite for a specific and irritating pattern that shows up in our
-/// code a bunch on account of the whole index diff thing.
-/// Specifically:
-///    %prev = arith.remui %blah, %c1
-///    %cur = arith.addi %prev, %c(M < N, usually 1)
-///    %curModulus = arith.remui %cur, %cN
-///    %checkWrap = arith.subi %curWrapped, %prev
-///    %val = arith.addi %checkWrap, %cN
-///
-/// If %prev + 1 is still less than N, this is (%prev + 1) mod N - %prev + N
-struct SimplifyCheckingSmallConstantOverflow
-    : public OpRewritePattern<arith::RemUIOp> {
-  using OpRewritePattern<arith::RemUIOp>::OpRewritePattern;
-};
 } // end namespace
 
 /// This function hasn't come from anywhere and is relying on the overall

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -167,6 +167,12 @@ struct TransformingForRewritePattern
     for (const auto &pair : llvm::zip(bounds, strides)) {
       int64_t bound, stride;
       std::tie(bound, stride) = pair;
+      // This is a one-iteration loop, so don't actually emit a loop so as to
+      // enable constant folding.
+      if (bound == stride && bound > 0) {
+        ivs.push_back(b.createOrFold<arith::ConstantIndexOp>(loc, 0));
+        continue;
+      }
       llvm::SmallVector<Value, 3> iterInits;
       if (loops.empty())
         llvm::copy(op.getIterInits(), std::back_inserter(iterInits));
@@ -241,7 +247,24 @@ struct TransformingForRewritePattern
         cloneMap.map(validities[i], isValid);
       }
     }
-
+    // One-iteration loops should be inlined, do so here.
+    if (loops.empty()) {
+      auto yieldOp = cast<rock::YieldOp>(op.getBody()->getTerminator());
+      b.replaceAllUsesWith(op.getResults(), yieldOp.getOperands());
+      SmallVector<Value> blockArgValues;
+      for (auto [blockArg, initValue] :
+           llvm::zip(op.getIterArgs(), op.getIterInits())) {
+        cloneMap.map(blockArg, initValue);
+      }
+      blockArgValues.reserve(op.getBody()->getNumArguments());
+      for (auto blockArg : op.getBody()->getArguments())
+        blockArgValues.push_back(cloneMap.lookup(blockArg));
+      b.inlineBlockBefore(op.getBody(), op.getOperation()->getBlock(),
+                          op.getOperation()->getIterator(), blockArgValues);
+      b.eraseOp(yieldOp);
+      b.eraseOp(op);
+      return success();
+    }
     // Map loop arguments, clone operations in body
     affine::AffineForOp il = loops[loops.size() - 1];
     for (auto p : llvm::zip(op.getIterArgs(), il.getRegionIterArgs())) {
@@ -1676,13 +1699,21 @@ void RockSugarToLoopsPass::runOnOperation() {
   if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
     signalPassFailure();
 
-  // Apply loop invariant code motion to all loops before unrolling
-  WalkResult licmResult =
-      op.walk<WalkOrder::PostOrder>([](LoopLikeOpInterface loop) -> WalkResult {
+  IRRewriter b(op.getContext());
+  // Apply loop invariant code motion to all loops before unrolling.
+  WalkResult loopMinimizationResult = op.walk<WalkOrder::PostOrder>(
+      [&b](LoopLikeOpInterface loop) -> WalkResult {
+        (void)loop.promoteIfSingleIteration(b);
+        // Affine loops don't implement the iteration promoter interface and
+        // need their own method.
+        if (auto affineLoop =
+                dyn_cast<affine::AffineForOp>(loop.getOperation())) {
+          (void)affine::promoteIfSingleIteration(affineLoop);
+        }
         moveLoopInvariantCode(loop);
         return WalkResult::advance();
       });
-  if (licmResult.wasInterrupted())
+  if (loopMinimizationResult.wasInterrupted())
     return signalPassFailure();
 
   // Note that the reason unrolling is a separate call here is that

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -510,7 +510,11 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
     loadType = elementType;
     vectorSrcLen = elementType.dyn_cast<VectorType>().getNumElements();
     elementType = elementType.dyn_cast<VectorType>().getElementType();
+    collapseContiguousMerges(sourceView);
     srcStride = 1;
+    if (!isDstVectorBuffer) {
+      numValues = numValues / vectorSrcLen;
+    }
   } else {
     VectorizationResult vectorSrcRes = getMaxVectorization(
         sourceView, extraIdxCount, /*inputDimLen=*/numValues);

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -257,8 +257,8 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getLoadRegsAsTileViews(
                           {0, 1}, isKContigousDim);
     TransformMapAttr splitIdAttr = threadwiseSplitId.get();
     auto toGlobalIdx = TopDownTMBuilder::below(threadwiseSplitId, splitIdAttr);
-    toGlobalIdx.unmerge("k", 0, {"k_iter"}, {kPerThread});
-    toGlobalIdx.unmerge(dName, 1, {dIterName}, {dPerThread});
+    toGlobalIdx.passThrough({"k"}, 0, {"k_iter"});
+    toGlobalIdx.passThrough({dName}, 1, {dIterName});
     TransformMapAttr toGlobalIdxAttr = toGlobalIdx.get();
     gpuViews.threadSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
   }
@@ -358,7 +358,7 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
     auto toGlobalIdx = TopDownTMBuilder::below(threadwiseSplitId, splitIdAttr);
     toGlobalIdx.unmerge("k", 0, {"kouterPerThread", "kpackPerThread"},
                         {kOuterPerThread, kpackPerThread});
-    toGlobalIdx.unmerge(dName, 1, {dIterName}, {dPerThread});
+    toGlobalIdx.passThrough({dName}, 1, {dIterName});
     TransformMapAttr toGlobalIdxAttr = toGlobalIdx.get();
     gpuViews.threadSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
   }

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1572,7 +1572,7 @@ TopDownTMBuilder mlir::rock::rotateIf(bool condition, TopDownTMBuilder &builder,
                                       ArrayRef<StringRef> afterDims,
                                       SmallVector<Attribute> &transformAttrs) {
   if (condition) {
-    // d = (d+k_outer)
+    // d = (d+stride*k_outer)
     TopDownTMBuilder rotateD0 = TopDownTMBuilder::below(builder, attr);
     if (!beforeDims.empty())
       rotateD0.passThrough(beforeDims);
@@ -1582,7 +1582,7 @@ TopDownTMBuilder mlir::rock::rotateIf(bool condition, TopDownTMBuilder &builder,
     TransformMapAttr rotateD0Attr = rotateD0.get();
     transformAttrs.push_back(rotateD0Attr);
 
-    // d = (d+k_outer) % d
+    // d = (d+stride*k_outer) % d
     TopDownTMBuilder rotateD1 = TopDownTMBuilder::below(rotateD0, rotateD0Attr);
     if (!beforeDims.empty())
       rotateD1.passThrough(beforeDims);

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1583,30 +1583,15 @@ TopDownTMBuilder mlir::rock::rotateIf(bool condition, TopDownTMBuilder &builder,
     transformAttrs.push_back(rotateD0Attr);
 
     // d = (d+k_outer) % d
-    unsigned int numBeforeDims = beforeDims.size();
-    unsigned int idx = numBeforeDims;
     TopDownTMBuilder rotateD1 = TopDownTMBuilder::below(rotateD0, rotateD0Attr);
     if (!beforeDims.empty())
       rotateD1.passThrough(beforeDims);
-    rotateD1.merge({"to_discard", dName}, {idx, ++idx}, dName, {kOuter, d});
-    for (auto dim : afterDims)
-      rotateD1.passThrough({dim}, ++idx, {dim});
+    rotateD1.takeRemainder(dName, d);
+    if (!afterDims.empty())
+      rotateD1.passThrough(afterDims);
     TransformMapAttr rotateD1Attr = rotateD1.get();
     transformAttrs.push_back(rotateD1Attr);
-
-    // discard the additional dimension
-    TopDownTMBuilder rotateD2 = TopDownTMBuilder::below(rotateD1, rotateD1Attr);
-    idx = numBeforeDims;
-    if (!beforeDims.empty())
-      rotateD2.passThrough(beforeDims);
-    rotateD2.ignore("to_discard");
-    rotateD2.passThrough({dName}, {idx++}, {dName});
-    for (auto dim : afterDims)
-      rotateD2.passThrough({dim}, idx++, {dim});
-    TransformMapAttr rotateD2Attr = rotateD2.get();
-    transformAttrs.push_back(rotateD2Attr);
-
-    TopDownTMBuilder rotated = TopDownTMBuilder::below(rotateD2, rotateD2Attr);
+    TopDownTMBuilder rotated = TopDownTMBuilder::below(rotateD1, rotateD1Attr);
     return rotated;
   } else {
     TopDownTMBuilder unrotated = TopDownTMBuilder::below(builder, attr);

--- a/mlir/unittests/Dialect/Rock/TransformMapBuilderTests.cpp
+++ b/mlir/unittests/Dialect/Rock/TransformMapBuilderTests.cpp
@@ -243,7 +243,6 @@ TEST_F(TMBuilderTest, LongBroadcast) {
   EXPECT_EQ(resUp.getMap().getAffineMap(),
             AffineMap::get(2, 0, {affD(0) % affC(2), affD(1)}, &context));
   EXPECT_EQ(resUp, resDown);
-
 }
 
 TEST_F(TMBuilderTest, GemmOut) {

--- a/mlir/unittests/Dialect/Rock/TransformMapBuilderTests.cpp
+++ b/mlir/unittests/Dialect/Rock/TransformMapBuilderTests.cpp
@@ -211,14 +211,39 @@ TEST_F(TMBuilderTest, ConstDim) {
 
 TEST_F(TMBuilderTest, Broadcast) {
   auto buildUp = makeBottomUp({"a", "b"}, {1, 3});
+  auto buildDown = makeTopDown({"a", "b"}, {3, 3});
 
   buildUp.passThrough({1}, {1});
-  buildUp.broadcast({0}, {1});
+  buildUp.broadcast({0}, {3});
+
+  buildDown.passThrough({1}, {1});
+  buildDown.takeRemainder("a", 1);
 
   TransformMapAttr resUp = buildUp.get();
+  TransformMapAttr resDown = buildDown.get();
 
   EXPECT_EQ(resUp.getMap().getAffineMap(),
             AffineMap::get(2, 0, {affC(0), affD(1)}, &context));
+  EXPECT_EQ(resUp, resDown);
+}
+
+TEST_F(TMBuilderTest, LongBroadcast) {
+  auto buildUp = makeBottomUp({"a", "b"}, {2, 3});
+  auto buildDown = makeTopDown({"a", "b"}, {3, 3});
+
+  buildUp.passThrough({1}, {1});
+  buildUp.broadcast({0}, {3});
+
+  buildDown.passThrough({1}, {1});
+  buildDown.takeRemainder("a", 2);
+
+  TransformMapAttr resUp = buildUp.get();
+  TransformMapAttr resDown = buildDown.get();
+
+  EXPECT_EQ(resUp.getMap().getAffineMap(),
+            AffineMap::get(2, 0, {affD(0) % affC(2), affD(1)}, &context));
+  EXPECT_EQ(resUp, resDown);
+
 }
 
 TEST_F(TMBuilderTest, GemmOut) {


### PR DESCRIPTION
1. Some of our transforms had single-argument Merge{} or Unmerge{} calls, which could've thrown off some analyses (looks like they didn't but they could've)
2. When a source buffer was made of vectors but the destination wasn't, the threadwise_read_into loop ran for too many iterations. I *think* this didn't cause a bug because the out of bounds stores were, after unrolling, trivially removable, but it probably didn't help our codegen.
3. Allow for eliminating single-iteration loops during SugarToLoops.

From what I can tell, these things don't affect our codegen any, but they were bugging me so.