### PR TITLE
Wrap the codecov stage in a timeout, and a catchError to make it innocuous.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1086,32 +1086,37 @@ pipeline {
                     stage ("body") {
                         steps {
                             // Build with profiling on, and just code-generation tests.
-                            sh 'rm -f build/CMakeCache.txt'
-                            sh 'rm -f build/*.profraw'
-                            buildProject('check-rocmlir-build-only',
-                                         '-DBUILD_FAT_LIBROCKCOMPILER=ON -DCMAKE_BUILD_TYPE=debug -DLLVM_BUILD_INSTRUMENTED_COVERAGE=ON')
-                            dir ('build') {
-                                // Run tests.
-                                sh 'ninja check-rocmlir'
-                                // Profile processing.
-                                sh '/opt/rocm/llvm/bin/llvm-profdata merge -sparse ./*.profraw -o ./coverage.profdata'
-                                sh "/opt/rocm/llvm/bin/llvm-cov report --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata --ignore-filename-regex=external/llvm-project > ./coverage_${CPATH}.report"
-                                sh "cat ./coverage_${CPATH}.report"
-                                sh "/opt/rocm/llvm/bin/llvm-cov export --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata --ignore-filename-regex=external/llvm-project --format=lcov --compilation-dir ${WORKSPACE} > ./coverage_${CPATH}.lcov"
-                                sh "/opt/rocm/llvm/bin/llvm-cov show --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata --ignore-filename-regex=external/llvm-project -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt --format=html > ./coverage_${CPATH}.html"
-                                // Upload to codecov.
-                                withCredentials([string(credentialsId: 'codecov-token-rocmlir', variable: 'CODECOV_TOKEN')]) {
-                                    sh '''
-                                       curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
-                                       proxy_opt=""
-                                       if [ -n "${http_proxy}" ]; then
-                                           proxy_opt="-U ${http_proxy}"
-                                       fi
-                                       ./codecov -t ${CODECOV_TOKEN} --flags "${CPATH}" -f ./coverage_${CPATH}.lcov ${proxy_opt}
-                                       '''
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE',
+                                       message: 'Code coverage stage had an error or timeout.') {
+                                timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                    sh 'rm -f build/CMakeCache.txt'
+                                    sh 'rm -f build/*.profraw'
+                                    buildProject('check-rocmlir-build-only',
+                                                 '-DBUILD_FAT_LIBROCKCOMPILER=ON -DCMAKE_BUILD_TYPE=debug -DLLVM_BUILD_INSTRUMENTED_COVERAGE=ON')
+                                    dir ('build') {
+                                        // Run tests.
+                                        sh 'ninja check-rocmlir'
+                                        // Profile processing.
+                                        sh '/opt/rocm/llvm/bin/llvm-profdata merge -sparse ./*.profraw -o ./coverage.profdata'
+                                        sh "/opt/rocm/llvm/bin/llvm-cov report --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata --ignore-filename-regex=external/llvm-project > ./coverage_${CPATH}.report"
+                                        sh "cat ./coverage_${CPATH}.report"
+                                        sh "/opt/rocm/llvm/bin/llvm-cov export --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata --ignore-filename-regex=external/llvm-project --format=lcov --compilation-dir ${WORKSPACE} > ./coverage_${CPATH}.lcov"
+                                        sh "/opt/rocm/llvm/bin/llvm-cov show --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata --ignore-filename-regex=external/llvm-project -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt --format=html > ./coverage_${CPATH}.html"
+                                        // Upload to codecov.
+                                        withCredentials([string(credentialsId: 'codecov-token-rocmlir', variable: 'CODECOV_TOKEN')]) {
+                                            sh '''
+                                               curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
+                                               proxy_opt=""
+                                               if [ -n "${http_proxy}" ]; then
+                                                   proxy_opt="-U ${http_proxy}"
+                                               fi
+                                               ./codecov -t ${CODECOV_TOKEN} --flags "${CPATH}" -f ./coverage_${CPATH}.lcov ${proxy_opt}
+                                               '''
+                                        }
+                                    }
+                                    archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', onlyIfSuccessful: true
                                 }
                             }
-                            archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', onlyIfSuccessful: true
                         }
                     }
                 }


### PR DESCRIPTION
For now, 60-minute timeout, but 30-minute may be feasible.