### PR TITLE
Avoid collapsing a dimension multiple times

### DIFF
--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -360,7 +360,7 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
       uint32_t fastestDim = groupCandidate.back();
       size_t fastestDimPosInMerge = dimPosition.back();
       size_t slowestDimPosInMerge = dimPosition.front();
-      for (auto d : groupCandidate){
+      for (auto d : groupCandidate) {
         // Make sure that the dimension cannot be reused
         dimToMerge.erase(d);
         contiguousGroups[keyI.transformPair()].unionSets(fastestDim, d);
@@ -382,7 +382,7 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
                thisMergeParams.slice(slowestDimPosInMerge,
                                      fastestDimPosInMerge -
                                          slowestDimPosInMerge))) {
-        if (p == 1 && dimToMerge.contains(d) ){
+        if (p == 1 && dimToMerge.contains(d)) {
           // Make sure that the dimension cannot be reused
           dimToMerge.erase(d);
           contiguousGroups[keyI.transformPair()].unionSets(fastestDim, d);

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -360,8 +360,11 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
       uint32_t fastestDim = groupCandidate.back();
       size_t fastestDimPosInMerge = dimPosition.back();
       size_t slowestDimPosInMerge = dimPosition.front();
-      for (auto d : groupCandidate)
+      for (auto d : groupCandidate){
+        // Make sure that the dimension cannot be reused
+        dimToMerge.erase(d);
         contiguousGroups[keyI.transformPair()].unionSets(fastestDim, d);
+      }
 
       // We also want to add the singleton dimensions of the merge the
       // groupCandidate belongs to. In this way we cover for situations like
@@ -379,8 +382,11 @@ void findCountiguousGroupsUnmerge(const ArrayRef<uint32_t> upperDims,
                thisMergeParams.slice(slowestDimPosInMerge,
                                      fastestDimPosInMerge -
                                          slowestDimPosInMerge))) {
-        if (p == 1)
+        if (p == 1 && dimToMerge.contains(d) ){
+          // Make sure that the dimension cannot be reused
+          dimToMerge.erase(d);
           contiguousGroups[keyI.transformPair()].unionSets(fastestDim, d);
+        }
       }
     }
   }


### PR DESCRIPTION
It might happen that a singleton dimension can be reused multiple times generating larger groups and messing the collapse logic. 