### PR TITLE
Add cleanWs call in the codecov stage's post section.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1120,6 +1120,11 @@ pipeline {
                         }
                     }
                 }
+                post {
+                    always {
+                        cleanWs()
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The codecov stage was leaving 100+ GB of *.profraw files behind in the workspace, and they weren't necessary.  Clean them up with a cleanWs call in a post section of the codecov stage.