### PR TITLE
Prevent calling LICM on removed loops

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Conversion/ArithToAMDGPU/ArithToAMDGPU.h
+++ b/external/llvm-project/mlir/include/mlir/Conversion/ArithToAMDGPU/ArithToAMDGPU.h
@@ -10,6 +10,7 @@
 #define MLIR_CONVERSION_ARITHTOAMDGPU_ARITHTOAMDGPU_H
 
 #include <memory>
+#include <string>
 
 namespace mlir {
 


### PR DESCRIPTION
Hopefully fix the crashes-after-a-while issues that hit CI.

Also add a missing #include to ArithToAMDGPU