### PR TITLE
Fixing sporadic assertion

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/CleanMath.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/CleanMath.cpp
@@ -56,11 +56,11 @@ static LogicalResult deleteTrivialRemainder(DataFlowSolver &solver,
   Value result = op.getResult(0);
   Value lhs = op.getOperand(0);
   Value rhs = op.getOperand(1);
-  auto rhsConstVal = rhs.getDefiningOp<arith::ConstantOp>();
+  auto rhsConstVal = rhs.getDefiningOp<arith::ConstantIntOp>();
   if (!rhsConstVal)
     return failure();
-  APInt modulus = cast<IntegerAttr>(rhsConstVal.getValue()).getValue();
-  if (!modulus.isStrictlyPositive())
+  int64_t modulus = rhsConstVal.value();
+  if (modulus <= 0)
     return failure();
   auto *maybeLhsRange = solver.lookupState<IntegerValueRangeLattice>(lhs);
   if (!maybeLhsRange || maybeLhsRange->getValue().isUninitialized())

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -124,7 +124,7 @@ computeOptimalSplitKFactors(GemmSize origGemmSize, int32_t gemmMPerBlock,
     return a.workImbalance < b.workImbalance;
   });
 
-  const size_t maxVariants = std::min(static_cast<size_t>(4), factors.size());
+  const size_t maxVariants = std::min(static_cast<size_t>(6), factors.size());
   llvm::ArrayRef<LocalData> view(factors.data(), maxVariants);
   llvm::for_each(view, [&](const LocalData &item) {
     splitKValues.push_back(item.splitKValue);


### PR DESCRIPTION
This is an attempt to fix the sporadic assertion:
```
$ rocmlir-gen -operation gemm -t f16 -out_datatype f16 --arch gfx90a:sramecc+:xnack- --num_cu 110 -g 1 -m 1 -k 768 -n 768 -transA=False -transB=False --kernel-repeats 1 --perf_config= | rocmlir-tuning-driver --tuning-space=exhaustive

rocMLIR/external/llvm-project/llvm/lib/Support/APInt.cpp:283: int llvm::APInt::compare(const APInt &) const: Assertion `BitWidth == RHS.BitWidth && "Bit widths must be same for comparison"' failed.
```
After adding a bit of printfs, it looks like these lines:
```
auto rhsConstVal = rhs.getDefiningOp<arith::ConstantOp>();
APInt modulus = cast<IntegerAttr>(rhsConstVal.getValue()).getValue();
```
Were sporadically returning an `APInt modulus` whose bitwidth is different from `rhsConstVal`. I am not sure if this is  our fault, or if there is a subtle bug within the infra. However, if we convert to a `ConstantIntOp` and get the `int64_t` value, the assert seems to go away (note that `APInt::ule/APIInt::uge` work with `int64_t` as well). 

@ravil-mobile @umangyadav  could you try this out and verify that it is actually fixing the issue (I ran the tuning -for the offending config- 3 times an didn't see a problem)?

@krzysz00 does it look a reasonable fix to you?