### PR TITLE
Fix memory leaks in rocmlir-tuning-dirver, rocmlir-gen

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
@@ -48,7 +48,7 @@ struct TuningParamSet {
   KernelType primaryOpType;
 };
 
-TuningParamSet *createTunableParamSpace(ModuleOp &mod, TuningParamSetKind kind);
+TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind);
 // Get a parameters from the set of tunable parameters.
 bool tuningGetParam(TuningParamSet *tuningSpace, unsigned pos,
                     ParamEntry *paramEntry);
@@ -66,7 +66,7 @@ struct TuningTable {
 
 TuningTable *tuningTableCreate();
 size_t getTuningHash(ModuleOp &mod);
-LogicalResult getTuningProblemStr(ModuleOp &mod, SmallVectorImpl<char> &out);
+LogicalResult getTuningProblemStr(ModuleOp mod, SmallVectorImpl<char> &out);
 bool tuningTableUpdate(TuningTable *perfTable, StringRef problem,
                        StringRef perfConfig, float time);
 LogicalResult tuningTableLookup(TuningTable *perfTable, ModuleOp &mod,

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -445,8 +445,7 @@ void createTuningRange(TuningParamSet *newSpace, AttentionOp attnOp) {
   // We only support GPUs with matrix accelerator extentions
 }
 
-TuningParamSet *createTunableParamSpace(ModuleOp &mod,
-                                        TuningParamSetKind kind) {
+TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind) {
   struct TuningParamSet *newSpace;
   newSpace = new TuningParamSet();
 
@@ -846,7 +845,7 @@ LogicalResult getTuningProblemStr(rock::RockGemmWrapperInterface gemmIF,
 // operation. String format of the problem will not be required by the DB,
 // since it can store each field separately.
 // Currently serialize the problem in MIOpenDriver command friendly format
-LogicalResult getTuningProblemStr(ModuleOp &mod, SmallVectorImpl<char> &out) {
+LogicalResult getTuningProblemStr(ModuleOp mod, SmallVectorImpl<char> &out) {
   {
     rock::RockGemmWrapperInterface gemmIF;
     WalkResult findPrimary =


### PR DESCRIPTION
1. Move to OwningOpRef<ModuleOp> in rocmlir-tuning-driver and rocmlir-gen to prevent missed delete calls that cause memory leaks
2. When we create a tunig space, wrap it an a unique_ptr to ensure it doesn't leak.
3. Update certain tuning APIs to not take ModuleOp by reference
4. Update some functions that populate existing modules in rocmilr-gen to return void.