### PR TITLE
quick atomic_add fp16 fix when a shape contains only 1s

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -961,7 +961,7 @@ static void atomicFp16AddAligned(OpBuilder &b, Location loc, Value data,
 
   // Compute the last non-unit dim
   int64_t lastNonUnitDim = shape.size() - 1;
-  while (shape[lastNonUnitDim] == 1 && lastNonUnitDim >= 0)
+  while (shape[lastNonUnitDim] == 1 && lastNonUnitDim > 0)
     lastNonUnitDim--;
 
   // Get the flattened size


### PR DESCRIPTION
This PR tries to fix the following problem which came from MIGraphX

```bash
module {
  func.func @mlir_reshape_dot(%arg0: !migraphx.shaped<1x8xf16, 8x1>, %arg1: !migraphx.shaped<8xf16, 1>) -> !migraphx.shaped<1x1xf16, 1x1> attributes {arch = "gfx942:sramecc+:xnack-", kernel = "mixr", num_cu = 304 : i64, enable_splik_for_tuning} {
    %0 = migraphx.reshape %arg1 {dims = [8, 1]} : <8xf16, 1> -> <8x1xf16, 1x1>
    %1 = migraphx.dot %arg0, %0 : <1x8xf16, 8x1>, <8x1xf16, 1x1> -> <1x1xf16, 1x1>
    return %1 : !migraphx.shaped<1x1xf16, 1x1>
  }
}
```

The problem occurs during tuning - i.e.,

```bash
rocmlir-gen -fut mlir_reshape_dot --arch gfx908 --clone-harness ./test.mlir | rocmlir-driver -kernel-pipeline=migraphx  | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-tuning-driver --tuning-space=exhaustive 
```

In particular, the failure occurs at `--perf_config=v2:16,16,4,16,16,4,2,1,1`.

`rocMLIR` hits the following assertion:

```bash
/home/umayadav/repo/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/ArrayRef.h:255: const T &llvm::ArrayRef<long>::operator[](size_t) const [T = long]: Assertion `Index < Length && "Invalid index!"' failed.
```

The debugger shows that it happens https://github.com/ROCm/rocMLIR/blob/72bb6fc2cb20e459f999d3d0fbee4fe403d2eb06/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp#L963-L965

because `lastNonUnitDim == -1`. The analysis shows that it happens when `shape == <1,1>`