### PR TITLE
[External] Force the libModules datalayout to be equal to compiler

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -347,6 +347,10 @@ SerializeToHsacoPass::translateToLLVMIR(llvm::LLVMContext &llvmContext) {
     // referenced by the module or a previous library since there will be no
     // other source of references to those symbols in this compilation and since
     // we don't want to bloat the resulting code object.
+
+    // Override the libModules datalayout with the compiler's
+    // data layout should there be a discrepency.
+    libModule->setDataLayout(ret->getDataLayout());
     bool err = linker.linkInModule(
         std::move(libModule), llvm::Linker::Flags::LinkOnlyNeeded,
         [](llvm::Module &m, const StringSet<> &gvs) {

--- a/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
+++ b/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
@@ -143,6 +143,7 @@ MLIRMemRefTransforms
 MLIRMemRefUtils
 MLIRMemorySlotInterfaces
 MLIRMeshDialect
+MLIRMeshTransforms
 MLIRNVGPUDialect
 MLIRNVGPUToNVVM
 MLIRNVGPUTransformOps
@@ -194,6 +195,7 @@ MLIRTensorTransforms
 MLIRTensorUtils
 MLIRTilingInterface
 MLIRTosaDialect
+MLIRTosaShardingInterfaceImpl
 MLIRTosaToArith
 MLIRTosaToLinalg
 MLIRTosaToSCF
@@ -201,6 +203,7 @@ MLIRTosaToTensor
 MLIRTosaTransforms
 MLIRTransformDebugExtension
 MLIRTransformDialect
+MLIRTransformDialectInterfaces
 MLIRTransformDialectUtils
 MLIRTransformLoopExtension
 MLIRTransformPDLExtension


### PR DESCRIPTION
It turned out after seeing rocm 6.1 image, the bitcode lib s data layout was still different.
Im forcing it here to be the same as the module being compiled -- see if thats alright.