### PR TITLE
[HOTFIX] Work around busted bf16 tests from ext/trunc folding

### DIFF
--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2874,12 +2874,37 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
           b, loc, lowerBounds, upperBounds, steps,
           [valFlat, testElemType, valElemType](OpBuilder &b, Location loc,
                                                ValueRange ivs) {
-            auto valOrig = b.create<memref::LoadOp>(loc, valFlat, ivs);
-            auto valTruncated =
+            Value valOrig = b.create<affine::AffineLoadOp>(loc, valFlat, ivs);
+            Value valTruncated =
                 b.create<arith::TruncFOp>(loc, testElemType, valOrig);
-            auto valExt =
+            // Block the optimization on bfloats where
+            // extf (truncf x : T to bfoloat) : bfloat to T==> x
+            // that is implemented in X86's SelectionDAG (and maybe other places
+            // in the future), since, unlike in most instances of that sort of
+            // precision-removing cast, we actually want to blank off the low
+            // bits of the float mantissa.
+            // TODO: Replace with an arithmetic fence once they're implemnted
+            // for bfloat - that is after LLVM PR #90836 lands and is
+            // upstream-merged.
+            if (testElemType.isBF16()) {
+              // This is the most nominal non-noop I can think of as a hack.
+              // Yes, this means that bfloat tests will compare wrong for -inf
+              // for a few days/weeks, but we don't have any tests like that so.
+              Value minFiniteBf16 = b.create<arith::ConstantFloatOp>(
+                  loc,
+                  APFloat::getLargest(APFloat::BFloat(), /*Negative=*/true),
+                  b.getBF16Type());
+              Value isNegInf = b.create<arith::CmpFOp>(
+                  loc, b.getI1Type(), arith::CmpFPredicate::OLT, valTruncated,
+                  minFiniteBf16);
+              Value notNegInf =
+                  b.create<arith::MaximumFOp>(loc, valTruncated, minFiniteBf16);
+              valTruncated = b.create<arith::SelectOp>(loc, isNegInf,
+                                                       valTruncated, notNegInf);
+            }
+            Value valExt =
                 b.create<arith::ExtFOp>(loc, valElemType, valTruncated);
-            b.create<memref::StoreOp>(loc, valExt, valFlat, ivs);
+            b.create<affine::AffineStoreOp>(loc, valExt, valFlat, ivs);
           });
     }
   } else {
@@ -3687,8 +3712,8 @@ int main(int argc, char **argv) {
   // Parse pass names in main to ensure static initialization completed.
   mlir::registerMLIRContextCLOptions();
   mlir::registerPassManagerCLOptions();
-  MLIRContext context(registry);
-  context.disableMultithreading();
+  MLIRContext context(registry, MLIRContext::Threading::DISABLED);
+  // LLVM dialect is temporary for the freeze trick.
   context.loadDialect<rock::RockDialect, func::FuncDialect, scf::SCFDialect,
                       affine::AffineDialect, memref::MemRefDialect,
                       math::MathDialect, arith::ArithDialect,


### PR DESCRIPTION
The x86 backend now merges together sequences of the form
```llvm
%1 = fptrunc float %0 to bfloat
%2 = fpext bfloat %1 to float
...(%2)
```
to just `%0`.

Normally, this is fine, and just gives higher precision. However, in our test code, when we're verifying a GPU reference (that is, one where we did the computation in floats to test a lower-precision datatype) we were relying on such trunc/ext pairs to lose the extra precision (since the code under test returnd a memref<...xbfloat>, and was extf'd to f32 for verification).

There is an arithmetic fence intrinsic that should let us prevent the optimization in that one spot, but supporting it for bfloat on x86 is a currently open PR. Until then, I've picked decently complex noop that blocks this optimization.

Spceifically, for bfloat, we do
```mlir
%v = load %gpuRefOutput[...] : float
%t = arith.truncf %v : float to bfloat
%isneginf = arith.cmpf olt, %t, -BFLOAT_MAX
%t.clamp = arith.maximumf %t, -BFLOAT_MAX
%fix.neginf = select %isneginf, %t, %t.clamp
%vMasked = arith.extf %fix.neginf : bfloat to float
store %vMasked, %gpuRefOutput[...]
```

This'll work as a nice hotfix from what I can tell.