### PR TITLE
[DO NOT SQUASH] Fix build warnings

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/GPU/Transforms/Passes.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/GPU/Transforms/Passes.h
@@ -151,14 +151,15 @@ protected:
 // Registration
 //===----------------------------------------------------------------------===//
 
+// Remove deprecation warnings because we're going to Get Around To This
 /// Register pass to serialize GPU kernel functions to a HSAco binary
 /// annotation.
-LLVM_DEPRECATED("use Target attributes instead", "")
+// LLVM_DEPRECATED("use Target attributes instead", "")
 void registerGpuSerializeToHsacoPass();
 
 /// Create an instance of the GPU kernel function to HSAco binary serialization
 /// pass.
-LLVM_DEPRECATED("use Target attributes instead", "")
+// LLVM_DEPRECATED("use Target attributes instead", "")
 std::unique_ptr<Pass> createGpuSerializeToHsacoPass(StringRef triple,
                                                     StringRef arch,
                                                     StringRef features,

--- a/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/Transforms/SerializeToHsaco.cpp
@@ -240,9 +240,9 @@ SerializeToHsacoPass::translateToLLVMIR(llvm::LLVMContext &llvmContext) {
       StringRef funcName = f.getName();
       if ("printf" == funcName)
         needOpenCl = true;
-      if (funcName.startswith("__ockl_"))
+      if (funcName.starts_with("__ockl_"))
         needOckl = true;
-      if (funcName.startswith("__ocml_"))
+      if (funcName.starts_with("__ocml_"))
         needOcml = true;
     }
   }

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -457,7 +457,7 @@ static LogicalResult checkUniqueReader(Operation *op, Operation *reader,
   for (Value result : op->getResults()) {
     // if its block arg, it can have uses beyond the unit of compilation
     // in scope here.
-    if (result.isa<BlockArgument>()) {
+    if (isa<BlockArgument>(result)) {
       isUnique = false;
     }
     for (auto &use : result.getUses()) {
@@ -541,7 +541,7 @@ traceToWriter(Value startVal,
 
 static Value makeRegs(LinalgAlignRewriter &b, MemRefType::Builder &mrb,
                       Location loc, Type srcType) {
-  auto srcMemType = srcType.cast<MemRefType>();
+  auto srcMemType = cast<MemRefType>(srcType);
   // 1. create a second allocation of the same type to hold loaded elements
   return b.create<GpuAllocOp>(loc, static_cast<MemRefType>(mrb.setElementType(
                                        srcMemType.getElementType())));

--- a/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
@@ -163,7 +163,7 @@ void AnnotateGenericOp(Operation *op, MLIRContext *ctx) {
                  dyn_cast_or_null<ViewLikeOpInterface>(inp.getDefiningOp()))
         inp = viewOp.getViewSource();
 
-      if (inp.isa<BlockArgument>()) {
+      if (isa<BlockArgument>(inp)) {
         auto arg = dyn_cast<BlockArgument>(inp);
         auto shape = inp.getType().cast<ShapedType>();
         int64_t argSize = shape.getNumElements();

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1143,7 +1143,7 @@ static void createPermutationForMinorIdentityWithBroadcast(
   for (const auto &idxAndValue : llvm::enumerate(originalMap.getResults())) {
     auto idx = idxAndValue.index();
     AffineExpr resultExpr = idxAndValue.value();
-    if (resultExpr.isa<AffineDimExpr>()) {
+    if (isa<AffineDimExpr>(resultExpr)) {
       foundInputDims.insert(originalMap.getDimPosition(idx));
     }
   }
@@ -1151,7 +1151,7 @@ static void createPermutationForMinorIdentityWithBroadcast(
   for (const auto &idxAndValue : llvm::enumerate(originalMap.getResults())) {
     auto idx = idxAndValue.index();
     AffineExpr resultExpr = idxAndValue.value();
-    if (resultExpr.isa<AffineDimExpr>()) {
+    if (isa<AffineDimExpr>(resultExpr)) {
       auto swap1 = originalMap.getDimPosition(idx);
       auto swap2 =
           originalMap.getNumInputs() - originalMap.getNumResults() + idx;
@@ -1200,7 +1200,7 @@ Value mlir::rock::insertTransposeAndBroadcastTransforms(
         newInpDimSize *= inpShape[idx];
         AffineExpr resultExpr = idxAndValue.value();
         mergeDims.push_back(idx);
-        if (diff != 0 && resultExpr.isa<AffineConstantExpr>() &&
+        if (diff != 0 && isa<AffineConstantExpr>(resultExpr) &&
             inpShape[idx] == 1) {
           diff++;
         } else {
@@ -1638,7 +1638,7 @@ ArrayAttr mlir::rock::invertTransforms(OpBuilder &b, Location loc,
                                        ArrayAttr transforms) {
   SmallVector<Attribute, 4> invertedTrs;
   for (Attribute tr : llvm::reverse(transforms)) {
-    TransformMapAttr trMap = tr.cast<TransformMapAttr>();
+    auto trMap = cast<TransformMapAttr>(tr);
     TransformMapAttr invertedTrMap = invertTransformMap(b, trMap, loc);
     if (!invertedTrMap)
       return {};


### PR DESCRIPTION
1. Fix deprecated uses of `.isa<>` on `Value`s and anything else that pattern-matched in those files
2. Comment out the deprecation of `SerializeToHsaco` so we stop getting yelled at about it.