### PR TITLE
[DO NOT MERGE][TEST BRANCH] Use old kernarg mechanism

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/AnalyzeMemoryUse.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AnalyzeMemoryUse.cpp
@@ -115,7 +115,7 @@ void RockAnalyzeMemoryUsePass::runOnOperation() {
     func.setArgAttr(idx, LLVM::LLVMDialect::getNoUndefAttrName(), unit);
 
     // `inreg` enables SGPR preloading in new calling conventions.
-    func.setArgAttr(idx, LLVM::LLVMDialect::getInRegAttrName(), unit);
+    //func.setArgAttr(idx, LLVM::LLVMDialect::getInRegAttrName(), unit);
     // As near as we can tell, there's no universe in which global pointers
     // aren't aligned to 16 bytes.
     func.setArgAttr(idx, LLVM::LLVMDialect::getAlignAttrName(),

--- a/mlir/test/Dialect/Rock/analyze_memory_use.mlir
+++ b/mlir/test/Dialect/Rock/analyze_memory_use.mlir
@@ -3,7 +3,7 @@
 // Note: the 64-bit index support is tested in large_tensor_detection
 
 // CHECK-LABEL: @base_case
-// CHECK-SAME: (%{{.*}}: memref<16xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.inreg, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.readonly}, %{{.*}}: memref<16xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.inreg, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.writeonly}, %{{.*}}: index)
+// CHECK-SAME: (%{{.*}}: memref<16xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.readonly}, %{{.*}}: memref<16xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.writeonly}, %{{.*}}: index)
 func.func @base_case(%arg0: memref<16xf32>, %arg1: memref<16xf32>, %arg2: index) attributes {kernel} {
   %c0 = arith.constant 0 : index
   %true = arith.constant true
@@ -28,7 +28,7 @@ func.func @atomic_case(%arg0: memref<16xf32>, %arg1: memref<16xf32>, %arg2: inde
 }
 
 // CHECK-LABEL: @collapse_case
-// CHECK-SAME: (%{{.*}}: memref<4x4xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.inreg, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.readonly}, %{{.*}}: memref<16xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.inreg, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.writeonly}, %{{.*}}: index)
+// CHECK-SAME: (%{{.*}}: memref<4x4xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.readonly}, %{{.*}}: memref<16xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 64 : i64, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.writeonly}, %{{.*}}: index)
 func.func @collapse_case(%arg0: memref<4x4xf32>, %arg1: memref<16xf32>, %arg2: index) attributes {kernel} {
   %c0 = arith.constant 0 : index
   %true = arith.constant true


### PR DESCRIPTION
Remove inreg from function arguments to see if those traps we're seeing in the MLIR-generated binaries happen to be a function of old card firmware.