### PR TITLE
Fix excess devectorizaiton in buffer ops

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1043,7 +1043,7 @@ static void perHardwareOp(Type realType,
   int64_t numElems = 1;
   if (auto vecTy = dyn_cast<VectorType>(realType))
     numElems = vecTy.getNumElements();
-  int64_t maxElemsPerOp = (4 * elemType.getIntOrFloatBitWidth()) / 32;
+  int64_t maxElemsPerOp = 128 / elemType.getIntOrFloatBitWidth();
   int64_t offset = 0;
   while (offset < numElems) {
     int64_t thisOpNumElems = std::min(numElems - offset, maxElemsPerOp);


### PR DESCRIPTION
The code that computed how many buffer ops were needed had the wrong definition of "how many elements can go in one buffer load/store", which led to, for example, loads of f16s only being vectorized to a maximum of 2 elements.

The compiler conveniently patched this up for us in a lot of cases, but while I was working on flat memrefs, I found instances where the compiler didn't manage to be smart, causing performance regressions.

This commit fixes this issue.