### PR TITLE
Make tuning-driver get arch from func or mod

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/Rock/Pipelines/Pipelines.h"
 #include "mlir/Dialect/Rock/Tuning/RockTuning.h"
 #include "mlir/Dialect/Rock/utility/fusionUtils.h"
+#include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/ExecutionEngine/RocmDeviceName.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -414,16 +415,18 @@ int main(int argc, char **argv) {
   }
 
   ModuleOp module;
-  WalkResult findModule = source->walk([&](ModuleOp op) -> WalkResult {
-    if (op->hasAttr("mhal.arch")) {
-      module = op;
+  WalkResult findModule = source->walk([&](func::FuncOp op) -> WalkResult {
+    FailureOr<StringAttr> mayBeArch = rock::getArch(op);
+    if (succeeded(mayBeArch)) {
+      module = op->getParentOfType<ModuleOp>();
+      module->setAttr("mhal.arch", mayBeArch.value());
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
   });
   if (!findModule.wasInterrupted()) {
     source->emitOpError(
-        "no architecture set, set mhal.arch on the input module");
+        "no architecture set, set mhal.arch on the input module or func");
     llvm::errs() << "Tuning loop failed\n";
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Currently, the tuning-driver has a requirement
that the module needs to have the arch.
However, our clients may only set the arch
in the func.

This commit adds support to get get arch from
func or mod before failing the tuning-driver.