### PR TITLE
Minor infrastructure fixes factored out from flat memrefs

### DIFF
--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/Rock/Pipelines/Pipelines.h"
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
 #include "mlir/ExecutionEngine/RocmDeviceName.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/InitRocMLIRPasses.h"
 #include "mlir/Parser/Parser.h"
@@ -436,6 +437,7 @@ int main(int argc, char **argv) {
   // Register any pass manager command line options.
   mlir::registerPassManagerCLOptions();
   mlir::registerMLIRContextCLOptions();
+  mlir::registerAsmPrinterCLOptions();
   mlir::PassPipelineCLParser passPipeline("", "compiler passes to run");
 
   // Parse pass names in main to ensure static initialization completed.

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/ExecutionEngine/RocmDeviceName.h"
 #include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Builders.h"
@@ -3887,6 +3888,7 @@ int main(int argc, char **argv) {
   registerRocMLIRDialects(registry);
   // Parse pass names in main to ensure static initialization completed.
   mlir::registerMLIRContextCLOptions();
+  mlir::registerAsmPrinterCLOptions();
   mlir::registerPassManagerCLOptions();
   MLIRContext context(registry, MLIRContext::Threading::DISABLED);
   // LLVM dialect is temporary for the freeze trick.

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -131,6 +131,7 @@ def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
             commandLine = testVector.split(sep=' ')
             config = confClass.fromCommandLine(commandLine, options.arch, options.numCU)
             config.MLIR_N_REPEATS=1
+            testVector = config.toCommandLine()
             print("Tuning:", testVector, file=sys.stderr)
             commandLineOptions = config.generateMlirDriverCommandLine(options.rocmlir_gen_flags)
             # Note, we don't need the -ph, this goes to the tuning driver


### PR DESCRIPTION
- Make the tuning runner take problem configs to their canonical form to prevent suprious matches
- Add the printing options to rocmlir-gen and rocmlir-driver, enabling --mlir-print-local-scope to be used in more of our tools.