### PR TITLE
Fix convolution verifier having the wrong loop dimensions

### DIFF
--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1808,7 +1808,7 @@ createCPUConvWithMLIR(ModuleOp module, func::FuncOp func,
   switch (genConfig.operation.value()) {
   case rock::ConvOpType::Fwd:
     upperBounds.append(genConfig.outputDimension);
-    upperBounds.push_back(filterInfo.nonImg1Len); // output channels 'k'
+    upperBounds.push_back(filterInfo.nonImg2Len); // input channels 'c'
     upperBounds.append(filterInfo.imageLens);
     break;
   case rock::ConvOpType::BwdData:


### PR DESCRIPTION
So ... the verification loops for forward convolutions were, just like I commented [output dimensions], K, Y, X instead of the correct [output dimensions], C, Y, X, causing verification failures in nightly.

These missed PR testing since most of that gets done with -pv_with_gpu and the parts that don't are in ignorable branches (IIRC).