### PR TITLE
Manually set overflow flags when expanding indexing maps

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -28,11 +28,11 @@
 #include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/AffineExprVisitor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
@@ -67,6 +67,100 @@ struct RockSugarToLoopsPass
     : public rock::impl::RockSugarToLoopsPassBase<RockSugarToLoopsPass> {
   void runOnOperation() override;
 };
+
+static constexpr IntegerOverflowFlags noWrap =
+    IntegerOverflowFlags::nuw | IntegerOverflowFlags::nsw;
+/// Visitor for AffineExpr's where we assume all the inputs are non-negative
+/// becaues we're doing the speculative execution/validity thing and there's no
+/// good way to hint this after the fact. Visit affine expressions recursively
+/// and build the sequence of operations that correspond to it.  Visitation
+/// functions return an Value of the expression subtree they visited along with
+/// whether the subexpression is still known to be nonnegative. Unlike the
+/// version over in the affine map utilities, doesn't bother to track errors
+/// like zero divisors.
+class NonNegativeInsAffineExprExpander
+    : public AffineExprVisitor<NonNegativeInsAffineExprExpander,
+                               std::pair<Value, bool>> {
+public:
+  /// This internal class expects arguments to be non-null, checks must be
+  /// performed at the call site.
+  NonNegativeInsAffineExprExpander(OpBuilder &builder, ValueRange dimValues,
+                                   ValueRange symbolValues, Location loc)
+      : builder(builder), dimValues(dimValues), symbolValues(symbolValues),
+        loc(loc) {}
+
+  template <typename OpTy>
+  std::pair<Value, bool> buildBinaryExpr(AffineBinaryOpExpr expr) {
+    auto [lhs, lhsNneg] = visit(expr.getLHS());
+    auto [rhs, rhsNneg] = visit(expr.getRHS());
+    auto op = builder.create<OpTy>(loc, lhs, rhs);
+    return std::make_pair(op.getResult(), lhsNneg && rhsNneg);
+  }
+
+  std::pair<Value, bool> visitAddExpr(AffineBinaryOpExpr expr) {
+    auto [result, isNneg] = buildBinaryExpr<AddIOp>(expr);
+    result.getDefiningOp<AddIOp>().setOverflowFlags(
+        isNneg ? noWrap : IntegerOverflowFlags::none);
+    return std::make_pair(result, isNneg);
+  }
+
+  std::pair<Value, bool> visitMulExpr(AffineBinaryOpExpr expr) {
+    auto [result, isNneg] = buildBinaryExpr<MulIOp>(expr);
+    result.getDefiningOp<MulIOp>().setOverflowFlags(
+        isNneg ? noWrap : IntegerOverflowFlags::none);
+    return std::make_pair(result, isNneg);
+  }
+
+  std::pair<Value, bool> visitModExpr(AffineBinaryOpExpr expr) {
+    return buildBinaryExpr<RemUIOp>(expr);
+  }
+  std::pair<Value, bool> visitFloorDivExpr(AffineBinaryOpExpr expr) {
+    return buildBinaryExpr<DivUIOp>(expr);
+  }
+  std::pair<Value, bool> visitCeilDivExpr(AffineBinaryOpExpr expr) {
+    return buildBinaryExpr<CeilDivUIOp>(expr);
+  }
+
+  std::pair<Value, bool> visitConstantExpr(AffineConstantExpr expr) {
+    int64_t value = expr.getValue();
+    auto op = builder.create<arith::ConstantIndexOp>(loc, value);
+    // The one source of potentially negative numbers in here.
+    return std::make_pair(op.getResult(), value >= 0);
+  }
+
+  std::pair<Value, bool> visitDimExpr(AffineDimExpr expr) {
+    assert(expr.getPosition() < dimValues.size() &&
+           "affine dim position out of range");
+    return std::make_pair(dimValues[expr.getPosition()], true);
+  }
+
+  std::pair<Value, bool> visitSymbolExpr(AffineSymbolExpr expr) {
+    assert(expr.getPosition() < symbolValues.size() &&
+           "symbol dim position out of range");
+    return std::make_pair(symbolValues[expr.getPosition()], true);
+  }
+
+private:
+  OpBuilder &builder;
+  ValueRange dimValues;
+  ValueRange symbolValues;
+
+  Location loc;
+};
+
+SmallVector<Value, 8> expandNonNegativeAffineMap(OpBuilder &builder,
+                                                 Location loc,
+                                                 AffineMap affineMap,
+                                                 ValueRange operands) {
+  auto numDims = affineMap.getNumDims();
+  NonNegativeInsAffineExprExpander expander(
+      builder, operands.take_front(numDims), operands.drop_front(numDims), loc);
+  auto expanded = llvm::to_vector<8>(
+      llvm::map_range(affineMap.getResults(), [&expander](AffineExpr expr) {
+        return std::get<0>(expander.visit(expr));
+      }));
+  return expanded;
+}
 
 //===----------------------------------------------------------------------===//
 // TransformingFor lowering.
@@ -123,15 +217,13 @@ struct TransformingForRewritePattern
         }
         for (auto t : transforms.getAsRange<TransformMapAttr>()) {
           AffineMap map = t.getMap().getAffineMap();
-          std::optional<AffineResults> init;
+          AffineResults init;
           if (lowerInit.empty())
-            init = affine::expandAffineMap(b, loc, map, op.getUpperInits(i));
+            init = expandNonNegativeAffineMap(b, loc, map, op.getUpperInits(i));
           else
-            init = affine::expandAffineMap(b, loc, map,
-                                           lowerInit[lowerInit.size() - 1]);
-          if (!init)
-            return failure();
-          lowerInit.push_back(*init);
+            init = expandNonNegativeAffineMap(b, loc, map,
+                                              lowerInit[lowerInit.size() - 1]);
+          lowerInit.push_back(init);
         }
       }
     } else { // !useDiffs
@@ -202,16 +294,14 @@ struct TransformingForRewritePattern
         // Start by offsetting the upper inputs.
         for (auto p : llvm::zip(op.getUpperInits(i), ivs)) {
           computed.push_back(
-              b.create<AddIOp>(loc, std::get<0>(p), std::get<1>(p)));
+              b.create<AddIOp>(loc, std::get<0>(p), std::get<1>(p), noWrap));
         }
         for (const auto &[composedMap, transform] : allComposedMaps[i]) {
           if (!composedMap) // empty transformations
             continue;
-          std::optional<AffineResults> transformed =
-              affine::expandAffineMap(b, loc, composedMap, computed);
-          if (!transformed)
-            return failure();
-          computed.assign(*transformed);
+          AffineResults transformed =
+              expandNonNegativeAffineMap(b, loc, composedMap, computed);
+          computed.assign(transformed);
           if (transform) { // Time for bounds checks or other validity updates
             Value validityUpdate =
                 updateValidityAfter(b, loc, transform, computed);
@@ -496,7 +586,8 @@ struct IndexDiffUpdateRewritePattern
     // value : lower level updated coordinate on that dimension.
     DenseMap<uint32_t, Value> lowerIndicesUpdatedMap;
 
-    auto addToOriginal = [&b, loc](Value original, Value diff) -> Value {
+    auto addToOriginal = [&b, loc](Value original, Value diff,
+                                   bool canBeInvalid = false) -> Value {
       auto mbDiffConst = isConstantValue(diff);
       if (mbDiffConst.has_value()) {
         int64_t diff = mbDiffConst.value();
@@ -508,7 +599,15 @@ struct IndexDiffUpdateRewritePattern
           return b.create<ConstantIndexOp>(loc, diff + mbOriginalConst.value());
         }
       }
-      return b.create<AddIOp>(loc, original, diff);
+      // If the operation is something like Embed{} or Pad{} that can produce
+      // negative results (but thereby cancel validity - that is, if a negative
+      // result means all the further operations are being speculatively
+      // executed), we conservatively don't say anything. However, in other
+      // cases, the original value must be non-negative and the index diff can't
+      // make it go below zero, so we can declare nuw.
+      return b.create<AddIOp>(loc, original, diff,
+                              canBeInvalid ? IntegerOverflowFlags::none
+                                           : (IntegerOverflowFlags::nuw));
     };
 
     LLVM_DEBUG(llvm::dbgs()
@@ -546,8 +645,8 @@ struct IndexDiffUpdateRewritePattern
 
         uint32_t lowerDim = q[0];
         lowerIndicesDiffMap[lowerDim] = lowerDiff;
-        lowerIndicesUpdatedMap[lowerDim] =
-            addToOriginal(lowerIndicesOriginal[lowerDim], lowerDiff);
+        lowerIndicesUpdatedMap[lowerDim] = addToOriginal(
+            lowerIndicesOriginal[lowerDim], lowerDiff, /*canBeInvalid=*/true);
       } else if (transformation == TransformType::Unmerge) {
         assert(e.size() == p.size());
         assert(q.size() == 1);
@@ -562,11 +661,13 @@ struct IndexDiffUpdateRewritePattern
             lowerDiff = b.create<ConstantIndexOp>(
                 loc, mbUpperDiff.value() + coefficient * mbLowerDiff.value());
           } else {
+            // nuw as per the affine map expander above, but not nsw for adds
+            // because these can be vegative
             lowerDiff = b.create<AddIOp>(
                 loc, upperIndicesDiff[upperDim],
                 b.create<MulIOp>(loc,
                                  b.create<ConstantIndexOp>(loc, coefficient),
-                                 lowerDiff));
+                                 lowerDiff, IntegerOverflowFlags::nuw));
           }
         }
         uint32_t lowerDim = q[0];
@@ -583,8 +684,9 @@ struct IndexDiffUpdateRewritePattern
           Value upperDiff = upperIndicesDiff[upperDim];
           Value lowerDiff = upperDiff;
           lowerIndicesDiffMap[lowerDim] = lowerDiff;
-          lowerIndicesUpdatedMap[lowerDim] =
-              addToOriginal(lowerIndicesOriginal[lowerDim], lowerDiff);
+          lowerIndicesUpdatedMap[lowerDim] = addToOriginal(
+              lowerIndicesOriginal[lowerDim], lowerDiff,
+              /*canBeInvalid=*/transformation == TransformType::Pad);
         }
       } else if (transformation == TransformType::Merge) {
         assert(p.size() == 1);
@@ -750,7 +852,7 @@ struct IndexDiffUpdateRewritePattern
           // transformations this computation should get hit by the dead code
           // eleminator
           Value newDiff = b.create<SubIOp>(
-              loc, diff, b.create<MulIOp>(loc, carry, upperBoundOp));
+              loc, diff, b.create<MulIOp>(loc, carry, upperBoundOp, noWrap));
 
           overflowOp = carry;
           lowerDiffsCarryChecked[lowerDim] = newDiff;

--- a/mlir/test/Dialect/Rock/lowering_transforming_for.mlir
+++ b/mlir/test/Dialect/Rock/lowering_transforming_for.mlir
@@ -108,13 +108,14 @@ func.func @no_transform_unrolled_strided() {
 // CHECK-LABEL: func.func @one_transform
 // CHECK-SAME:(%[[arg0:.*]]: index, %[[arg1:.*]]: index)
 func.func @one_transform(%arg0: index, %arg1: index) {
-    // CHECK: %[[true:.*]] = arith.constant true
+    // CHECK-DAG: %[[c4:.*]] = arith.constant 4
+    // CHECK-DAG: %[[true:.*]] = arith.constant true
     // CHECK: affine.for %[[d0:.*]] = 0 to 2
-    // CHECK: %[[u0:.*]] = arith.addi %[[arg0]], %[[d0]]
-    // CHECK: %[[cmp0:.*]] = arith.muli %[[u0]]
+    // CHECK: %[[u0:.*]] = arith.addi %[[arg0]], %[[d0]] overflow<nsw, nuw>
+    // CHECK: %[[cmp0:.*]] = arith.muli %[[u0]], %[[c4]] overflow<nsw, nuw>
     // CHECK: affine.for %[[d1:.*]] = 0 to 3
-    // CHECK: %[[u1:.*]] = arith.addi %[[arg1]], %[[d1]]
-    // CHECK-NEXT: %[[l0:.*]] = arith.addi %[[u1]], %[[cmp0]]
+    // CHECK: %[[u1:.*]] = arith.addi %[[arg1]], %[[d1]] overflow<nsw, nuw>
+    // CHECK-NEXT: %[[l0:.*]] = arith.addi %[[u1]], %[[cmp0]] overflow<nsw, nuw>
     // CHECK-NEXT: gpu.printf "%d, %d" %[[l0]], %[[true]]
     rock.transforming_for (%arg2) = [#transform_map0](%arg0, %arg1) (%arg3) = validity bounds [2, 3] strides [1, 1] {
         gpu.printf "%d, %d" %arg2, %arg3 : index, i1
@@ -125,14 +126,15 @@ func.func @one_transform(%arg0: index, %arg1: index) {
 // CHECK-LABEL: func.func @one_transform_index_diff
 // CHECK-SAME:(%[[arg0:.*]]: index, %[[arg1:.*]]: index)
 func.func @one_transform_index_diff(%arg0: index, %arg1: index) {
-    // CHECK: %[[true:.*]] = arith.constant true
-    // CHECK: %[[linit_cmp:.*]] = arith.muli %[[arg0]]
-    // CHECK: %[[linit:.*]] = arith.addi %[[arg1]], %[[linit_cmp]]
+    // CHECK-DAG: %[[c4:.*]] = arith.constant 4
+    // CHECK-DAG: %[[true:.*]] = arith.constant true
+    // CHECK: %[[linit_cmp:.*]] = arith.muli %[[arg0]], %[[c4]] overflow<nsw, nuw>
+    // CHECK: %[[linit:.*]] = arith.addi %[[arg1]], %[[linit_cmp]] overflow<nsw, nuw>
     // CHECK: affine.for %[[d0:.*]] = 0 to 2
     // CHECK-NEXT: affine.for %[[d1:.*]] = 0 to 3
-    // CHECK-NEXT: %[[c0:.*]] = arith.muli %[[d0]]
+    // CHECK-NEXT: %[[c0:.*]] = arith.muli %[[d0]], %[[c4]] overflow<nuw>
     // CHECK-NEXT: %[[c1:.*]] = arith.addi %[[d1]], %[[c0]]
-    // CHECK-NEXT: %[[l0:.*]] = arith.addi %[[linit]], %[[c1]]
+    // CHECK-NEXT: %[[l0:.*]] = arith.addi %[[linit]], %[[c1]] overflow<nuw>
     // CHECK-NEXT: gpu.printf "%d, %d" %[[l0]], %[[true]]
     rock.transforming_for {useIndexDiffs} (%arg2) = [#transform_map0](%arg0, %arg1) (%arg3) = validity bounds [2, 3] strides [1, 1] {
         gpu.printf "%d, %d" %arg2, %arg3 : index, i1


### PR DESCRIPTION
When we work with transform maps in the context of rocMLIR, we know the following properties that are not true of a general affine map:

1. We may assume that the inputs to the map are non-negative. If a previous computation (like subtracting off padding) would cause the inputs to potentially be negative, the validity bit will cause us to not use the final computation result, so we can have all the undefined behavior/unjustified optimizations/... in the rest of the address calculation - it won't matter.

To put it another way, we speculatively execute all the index calculatinos for the valid case, and then discard the result in the invalid case.

LLVM can't know that's what we meant, so we have to do that annocation ourselves.

2. During the index diffs mechanism, the individual diffs can be negative (ex. if our map is "x -> x / 3, x % 3" and we have the inital coordinates (0, 2), then moving to x + 1 gets us coordinates (1, 0) and diffs (1, -2)). We also can therefore see a diff becoming negative in general. However, we know that, unless we're in an operator that can impact validity (Pad{}, mainly, but also some Embed{}), the sum of the original index and the diff is always non-negative.

That non-negative-ness allows us to sprinkle `nuw` on most index diff updates, which is also a property that might be hard to infer in general.

--

This entire setup is implemented with a custom affine map expanded, which has the side benefit of letting us skip emitting all that super noise code for `mod`. That visitor looks for potentially negative expressions (that is, those with negative constants somewhere in their subtrees) and annotates all the adds and multiplies with nuw/nsw as appropriate for the non-negativity of the inputs.

(Note, because of the analysis up in AnalyzeMemoryUse, we have the invariant that signed overflow can't occur - if you ever need x int32_t_max as a map output, we go to 64-bit `index` instead).