### PR TITLE
[CI] Fix navi3x thresholds

### DIFF
--- a/mlir/test/e2e/conv_regression_fwd_navi3x.toml
+++ b/mlir/test/e2e/conv_regression_fwd_navi3x.toml
@@ -1,6 +1,6 @@
 directory = "conv_regression_fwd_navi3x"
 prefix = "rocmlir-gen"
-suffix = "-rand_type float --absDiff_threshold 1 -RMS_threshold 0.0001 -relDiff_threshold 0.00001 -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "-rand_type float -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -249,7 +249,7 @@ void checkRocmlirOnNavi3x(boolean fixed, String testSuite) {
              -DROCK_E2E_TEST_SUITES=${testSuite}
              -DROCMLIR_DRIVER_RANDOM_DATA_SEED=${fixed ? 'none' : '1'}
              -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=${fixed ? 1 : 0}
-             -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 8'
+             -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 1'
              -DCMAKE_EXPORT_COMPILE_COMMANDS=1
      """)
 }
@@ -494,13 +494,8 @@ pipeline {
                         steps {
                             script {
                                 if ( "${CODEPATH}" == 'navi3x' ) {
-                                    try {
+                                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                         check_RockE2ETests_Navi3x(true)
-                                    } catch (Exception e) {
-                                        if (params.nightly)
-                                            currentBuild.result = 'SUCCESS'
-                                        else
-                                            currentBuild.result = 'FAILURE'
                                     }
                                 }
                                 else {
@@ -524,10 +519,8 @@ pipeline {
                         steps {
                             script {
                                 if ( "${CODEPATH}" == 'navi3x') {
-                                    try {
+                                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                         check_RockE2ETests_Navi3x(false)
-                                    } catch (Exception e) {
-                                        currentBuild.result = 'SUCCESS'
                                     }
                                 }
                                 else


### PR DESCRIPTION
After, packed fp16 math changes (PR1484)
the thresholds for fp16 kernels were changed
to be 0.001. However, there were nghtly tests
in our CI that had stricter thresholds set but
were failing silently in our nightly tests due
to navi3x stage was not required to pass.

This commit fixes all that.