### PR TITLE
fix compilation on Windows with AMDDeviceLibs

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Dialect/GPU/CMakeLists.txt
@@ -137,9 +137,11 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
     # printf(), which we use the hip version of anyway.
     list(REMOVE_ITEM device_lib_targets "opencl")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Transforms)
-    add_custom_command(OUTPUT Transforms/AmdDeviceLibs.cpp.inc
-      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/AmdDeviceLibsIncGen.py
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Transforms/AmdDeviceLibs.cpp.inc
+      COMMAND ${Python3_EXECUTABLE}
       ARGS
+        ${CMAKE_CURRENT_SOURCE_DIR}/AmdDeviceLibsIncGen.py
         ${CMAKE_CURRENT_BINARY_DIR}/Transforms/AmdDeviceLibs.cpp.inc
         ${AMD_DEVICE_LIBS_PREFIX}
         ${device_lib_targets}
@@ -148,8 +150,8 @@ if(MLIR_ENABLE_ROCM_CONVERSIONS)
         ${AMD_DEVICE_LIBS_TARGETS}
       COMMENT "Generating device libraries include package"
     )
-    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES Transforms/AmdDeviceLibs.cpp.inc)
-    add_custom_target(AmdDeviceLibsIncGen DEPENDS Transforms/AmdDeviceLibs.cpp.inc)
+    set_property(DIRECTORY APPEND PROPERTY MAKE_CLEAN_FILES ${CMAKE_CURRENT_BINARY_DIR}/Transforms/AmdDeviceLibs.cpp.inc)
+    add_custom_target(AmdDeviceLibsIncGen DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Transforms/AmdDeviceLibs.cpp.inc)
     set_property(SOURCE Transforms/SerializeToHsaco.cpp APPEND
       PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Transforms/AmdDeviceLibs.cpp.inc)
     add_dependencies(obj.MLIRGPUTransforms AmdDeviceLibsIncGen)


### PR DESCRIPTION
The PR fixes building the rocMLIR librockCompiler library with AMDDeviceLibs on Windows.