### PR TITLE
use 'type' command instead of 'touch' on Windows

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/CMakeLists.txt
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/CMakeLists.txt
@@ -19,12 +19,21 @@ function(add_linalg_ods_yaml_gen yaml_ast_file output_file)
     DEPENDS
     ${MLIR_LINALG_ODS_YAML_GEN_EXE}
     ${MLIR_LINALG_ODS_YAML_GEN_TARGET})
+if(WIN32)
+  add_custom_command(
+    OUTPUT ${DUMMY_FILE}
+    COMMAND type nul > ${DUMMY_FILE}
+    DEPENDS
+    ${GEN_ODS_FILE} ${GEN_CPP_FILE}
+  )
+else()
   add_custom_command(
     OUTPUT ${DUMMY_FILE}
     COMMAND touch ${DUMMY_FILE}
     DEPENDS
     ${GEN_ODS_FILE} ${GEN_CPP_FILE}
     )
+endif()
   add_custom_target(
     MLIR${output_file}YamlIncGen
     DEPENDS


### PR DESCRIPTION
This PR changes to use the `type` command on Windows to achieve the same result as the `touch` command on Linux.

There is no `touch` command on Windows, and having that command requires installing GNU tools alongside Windows tools. Unfortunately, that kind of installation pollutes the Windows build with POSIX libraries (we need a native Windows build for performance reasons).