### PR TITLE
Add back relDiff and absDiff thresholds for navi3x nightly

### DIFF
--- a/mlir/test/e2e/conv_regression_fwd_navi3x.toml
+++ b/mlir/test/e2e/conv_regression_fwd_navi3x.toml
@@ -1,6 +1,6 @@
 directory = "conv_regression_fwd_navi3x"
 prefix = "rocmlir-gen"
-suffix = "-rand_type float -arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "-rand_type float -arch %arch %pv %random_data %rocmlir_gen_flags --absDiff_threshold 1 -relDiff_threshold 0.00001 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"


### PR DESCRIPTION
I shouldve not changed relDiff and absDiff thresholds rather only should ve changed RMS which was the one affected by packed fp16 changes (https://github.com/ROCm/rocMLIR/pull/1484).

This commit re-instates the manual relDiff and absDiff thresholds for conv_regression_fwd_navi3x.