### PR TITLE
Fix weekly Jenkins stalls by removing "any" machine selection

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -771,7 +771,7 @@ pipeline {
                 equals expected: true, actual: params.weekly;
                 equals expected: true, actual: params.staticLib;
             }
-            agent any
+            agent { label 'build-only' }
             options {
                 skipDefaultCheckout()
             }


### PR DESCRIPTION
According to @okakarpa, the "any" machine would translate to a jenkins server that doesn't have any label. Since @okakarpa has made sure every machine will have a label, this will stall the weekly test pipeline forever. The workaround is to add a `build-only` label so the result can be archived and pipeline proceed.