### PR TITLE
Add check for block size being 1024 or less

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/Rock.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/Rock.h
@@ -64,6 +64,10 @@ ArrayAttr getIndexArrayAttr(Builder &b, ArrayRef<int64_t> values);
 // limit the maxWaves per workgroup to be 4.
 constexpr int64_t maxWavesPerWG = 4;
 
+// The largest workgroup size ("block size") that LLVM and the runtime
+// support.
+constexpr int64_t maxHardwareWorkgroupSize = 1024;
+
 } // end namespace rock
 } // end namespace mlir
 

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -536,6 +536,8 @@ LogicalResult PopulateParamsXDL::isValidBlockwiseGemm(
 
   const int64_t waveSize = mlir::rock::lookupArchInfo(arch).waveSize;
   int64_t blockSize = obtainBlockSize(waveSize, param);
+  if (blockSize > maxHardwareWorkgroupSize)
+    return failure();
   // TBD: support fp16/bf16
 
   // clang-format off
@@ -790,6 +792,8 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
 
   const int64_t waveSize = mlir::rock::lookupArchInfo(arch).waveSize;
   int64_t blockSize = obtainBlockSize(waveSize, param);
+  if (blockSize > maxHardwareWorkgroupSize)
+    return failure();
 
   // clang-format off
   std::vector<std::tuple<int, int, int>> validWaveGemmSize =

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -257,9 +257,9 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
                                                splitKFactor, forceUnroll, true);
                     if (gemmMPerBlock >= gemmMPerWave &&
                         gemmNPerBlock >= gemmMnPerXdl) {
-                      if (kind == TuningParamSetKind::Exhaustive ||
-                          (succeeded(tuningInfo.paramsProbablyValid(
-                               b, info, gemmParams)) &&
+                      if (succeeded(tuningInfo.paramsProbablyValid(
+                              b, info, gemmParams)) &&
+                          (kind == TuningParamSetKind::Exhaustive ||
                            succeeded(
                                tuningInfo.couldBePerformant(info, gemmParams))))
                         newSpace->tuningRange.push_back(


### PR DESCRIPTION
We were, in some cases, generating blocksize = 2048 because we got too aggressive with removing some limits on the blocksize.

This fixes the issue.

Also, fix a weird thing where attention perf configs could be invalid and get in to the tuning set.

Fixes https://github.com/ROCm/rocMLIR-internal/issues/1491

Must backport