### PR TITLE
Use early-increment range for loop through uses that may erase an operation.

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -457,7 +457,7 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
                                              Value tOutput,
                                              ArrayRef<int32_t> dims,
                                              Value tInput) const {
-    for (auto &use : tOutput.getUses()) {
+    for (auto &use : llvm::make_early_inc_range(tOutput.getUses())) {
       if (auto op = dyn_cast<tensor::CollapseShapeOp>(use.getOwner())) {
         SmallVector<ReassociationIndices, 4> reassocIndices =
             op.getReassociationIndices();


### PR DESCRIPTION
Observed a use-after-free error when building with -DLLVM_USE_SANITIZER=Address.  Looks like a node is being erased and its uses erased with it, before the loop has advanced to the next use.  The early-increment range exists to avoid that problem.