### PR TITLE
Support for parsing options from ROCMLIR_DEBUG_FLAGS in library calls like MIGraphX

### DIFF
--- a/mlir/include/mlir-c/RegisterRocMLIR.h
+++ b/mlir/include/mlir-c/RegisterRocMLIR.h
@@ -25,6 +25,9 @@ mlirRegisterRocMLIRDialects(MlirDialectRegistry registry);
 /// Register all compiler passes of rocMLIR.
 MLIR_CAPI_EXPORTED void mlirRegisterRocMLIRPasses(void);
 
+/// Register command-line options read from ROCMLIR_DEBUG_FLAGS.
+MLIR_CAPI_EXPORTED void mlirRegisterRocMLIROptions(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mlir/include/mlir/InitRocMLIRCLOptions.h
+++ b/mlir/include/mlir/InitRocMLIRCLOptions.h
@@ -1,0 +1,30 @@
+//===- InitRocMLIRCLOptions.h - rocMLIR CL Options Registration -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file registers command-line options.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_INITROCMLIRCLOPTIONS_H_
+#define MLIR_INITROCMLIRCLOPTIONS_H_
+
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir {
+
+inline void registerMLIRCLOptions() {
+  mlir::registerAsmPrinterCLOptions();
+  mlir::registerMLIRContextCLOptions();
+  mlir::registerPassManagerCLOptions();
+}
+
+} // namespace mlir
+
+#endif // MLIR_INITROCMLIRCLOPTIONS_H_

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -134,7 +134,8 @@ MLIR_CAPI_EXPORTED bool mlirGetBinary(MlirModule module, size_t *size,
 MLIR_CAPI_EXPORTED
 void mlirMIGraphXAddHighLevelPipeline(MlirPassManager pm) {
   auto passMan = unwrap(pm);
-  applyPassManagerCLOptions(*passMan);
+  if (failed(applyPassManagerCLOptions(*passMan)))
+    llvm::errs() << "Failed to apply command-line options.\n";
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::migraphx::addHighLevelPipeline(*passMan);
   mlir::rock::buildBufferizePipeline(*passMan);
@@ -154,7 +155,8 @@ mlirMIGraphXAddApplicabilityPipeline(MlirPassManager pm) {
 MLIR_CAPI_EXPORTED bool mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
                                                        const char *arch) {
   auto *passMan = unwrap(pm);
-  applyPassManagerCLOptions(*passMan);
+  if (failed(applyPassManagerCLOptions(*passMan)))
+    return false;
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::rock::KernelOptions kOpts;
   kOpts.tuningFallback = false;

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -134,6 +134,7 @@ MLIR_CAPI_EXPORTED bool mlirGetBinary(MlirModule module, size_t *size,
 MLIR_CAPI_EXPORTED
 void mlirMIGraphXAddHighLevelPipeline(MlirPassManager pm) {
   auto passMan = unwrap(pm);
+  applyPassManagerCLOptions(*passMan);
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::migraphx::addHighLevelPipeline(*passMan);
   mlir::rock::buildBufferizePipeline(*passMan);
@@ -153,6 +154,7 @@ mlirMIGraphXAddApplicabilityPipeline(MlirPassManager pm) {
 MLIR_CAPI_EXPORTED bool mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
                                                        const char *arch) {
   auto *passMan = unwrap(pm);
+  applyPassManagerCLOptions(*passMan);
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::rock::KernelOptions kOpts;
   kOpts.tuningFallback = false;

--- a/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
+++ b/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
@@ -10,9 +10,9 @@
 #include "mlir-c/RegisterRocMLIR.h"
 
 #include "mlir/CAPI/IR.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/InitRocMLIRPasses.h"
+#include "mlir/Pass/PassManager.h"
 #include "llvm/Support/CommandLine.h"
 
 void mlirRegisterRocMLIRDialects(MlirDialectRegistry registry) {
@@ -27,7 +27,8 @@ void mlirRegisterRocMLIROptions() {
   mlir::registerAsmPrinterCLOptions();
   mlir::registerMLIRContextCLOptions();
   mlir::registerPassManagerCLOptions();
-  llvm::cl::ParseCommandLineOptions(sizeof(fakeArgv) / sizeof(const char*),
-    fakeArgv, "Fake 'command line' for MIGraphX library debugging",
-    nullptr, "ROCMLIR_DEBUG_FLAGS");
+  llvm::cl::ParseCommandLineOptions(
+      sizeof(fakeArgv) / sizeof(const char *), fakeArgv,
+      "Fake 'command line' for MIGraphX library debugging", nullptr,
+      "ROCMLIR_DEBUG_FLAGS");
 }

--- a/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
+++ b/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
@@ -10,11 +10,24 @@
 #include "mlir-c/RegisterRocMLIR.h"
 
 #include "mlir/CAPI/IR.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/InitRocMLIRPasses.h"
+#include "llvm/Support/CommandLine.h"
 
 void mlirRegisterRocMLIRDialects(MlirDialectRegistry registry) {
   mlir::registerRocMLIRDialects(*unwrap(registry));
 }
 
 void mlirRegisterRocMLIRPasses() { mlir::registerRocMLIRPasses(); }
+
+void mlirRegisterRocMLIROptions() {
+  const char *fakeArgv[] = {"rocMLIR-invoked-as-library",
+                            "--mlir-print-local-scope"};
+  mlir::registerAsmPrinterCLOptions();
+  mlir::registerMLIRContextCLOptions();
+  mlir::registerPassManagerCLOptions();
+  llvm::cl::ParseCommandLineOptions(sizeof(fakeArgv) / sizeof(const char*),
+    fakeArgv, "Fake 'command line' for MIGraphX library debugging",
+    nullptr, "ROCMLIR_DEBUG_FLAGS");
+}

--- a/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
+++ b/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
@@ -10,9 +10,9 @@
 #include "mlir-c/RegisterRocMLIR.h"
 
 #include "mlir/CAPI/IR.h"
+#include "mlir/InitRocMLIRCLOptions.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/InitRocMLIRPasses.h"
-#include "mlir/Pass/PassManager.h"
 #include "llvm/Support/CommandLine.h"
 
 void mlirRegisterRocMLIRDialects(MlirDialectRegistry registry) {
@@ -24,9 +24,7 @@ void mlirRegisterRocMLIRPasses() { mlir::registerRocMLIRPasses(); }
 void mlirRegisterRocMLIROptions() {
   const char *fakeArgv[] = {"rocMLIR-invoked-as-library",
                             "--mlir-print-local-scope"};
-  mlir::registerAsmPrinterCLOptions();
-  mlir::registerMLIRContextCLOptions();
-  mlir::registerPassManagerCLOptions();
+  mlir::registerMLIRCLOptions();
   llvm::cl::ParseCommandLineOptions(
       sizeof(fakeArgv) / sizeof(const char *), fakeArgv,
       "Fake 'command line' for MIGraphX library debugging", nullptr,

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -330,6 +330,7 @@ int main(void) {
   MlirDialectRegistry registry = mlirDialectRegistryCreate();
   mlirRegisterRocMLIRDialects(registry);
   mlirRegisterRocMLIRPasses();
+  mlirRegisterRocMLIROptions();
   mlirContextAppendDialectRegistry(ctx, registry);
   // TODO: this is a emulation of an old behavior, we should load only the
   // dialects we use

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
 #include "mlir/ExecutionEngine/RocmDeviceName.h"
 #include "mlir/IR/AsmState.h"
+#include "mlir/InitRocMLIRCLOptions.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/InitRocMLIRPasses.h"
 #include "mlir/Parser/Parser.h"
@@ -435,9 +436,7 @@ int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
 
   // Register any pass manager command line options.
-  mlir::registerPassManagerCLOptions();
-  mlir::registerMLIRContextCLOptions();
-  mlir::registerAsmPrinterCLOptions();
+  mlir::registerMLIRCLOptions();
   mlir::PassPipelineCLParser passPipeline("", "compiler passes to run");
 
   // Parse pass names in main to ensure static initialization completed.

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -48,6 +48,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/ValueRange.h"
+#include "mlir/InitRocMLIRCLOptions.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
@@ -3664,9 +3665,7 @@ int main(int argc, char **argv) {
   DialectRegistry registry;
   registerRocMLIRDialects(registry);
   // Parse pass names in main to ensure static initialization completed.
-  mlir::registerMLIRContextCLOptions();
-  mlir::registerAsmPrinterCLOptions();
-  mlir::registerPassManagerCLOptions();
+  mlir::registerMLIRCLOptions();
   MLIRContext context(registry, MLIRContext::Threading::DISABLED);
   // LLVM dialect is temporary for the freeze trick.
   context.loadDialect<rock::RockDialect, func::FuncDialect, scf::SCFDialect,

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -29,6 +29,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
+#include "mlir/InitRocMLIRCLOptions.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/InitRocMLIRPasses.h"
 #include "mlir/Parser/Parser.h"
@@ -396,9 +397,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
 int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
 
-  mlir::registerAsmPrinterCLOptions();
-  mlir::registerMLIRContextCLOptions();
-  mlir::registerPassManagerCLOptions();
+  mlir::registerMLIRCLOptions();
   llvm::cl::ParseCommandLineOptions(argc, argv, "rocMLIR tuning driver");
 
   DialectRegistry registry;

--- a/mlir/tools/xmir-runner/xmir-runner.cpp
+++ b/mlir/tools/xmir-runner/xmir-runner.cpp
@@ -21,6 +21,7 @@
 #include "mlir/ExecutionEngine/RocmDeviceName.h"
 #include "mlir/ExecutionEngine/RocmSystemDetect.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/InitRocMLIRCLOptions.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
@@ -95,8 +96,7 @@ static LogicalResult runMLIRPasses(Operation *m, JitRunnerOptions &options) {
 }
 
 int main(int argc, char **argv) {
-  registerPassManagerCLOptions();
-  registerMLIRContextCLOptions();
+  mlir::registerMLIRCLOptions();
   llvm::InitLLVM y(argc, argv);
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetInfos();


### PR DESCRIPTION
Call the necessary bits to initialise and parse command-line options from an environment variable, and do it from the MIGraphX interface functions.  Design decision request:  require a patch in MIGraphX that is slightly cleaner, or do it all in rocMLIR by being slightly unclean.