### PR TITLE
Pass config.rocmlir_gen_flags to get_arch_features to turn off support_mfma when '-mfma=off' is in the flags.

### DIFF
--- a/mlir/test/common_utils/common.py
+++ b/mlir/test/common_utils/common.py
@@ -2,7 +2,7 @@ import subprocess
 
 # Helper function to decode arch to its features
 # Keep this in sync with mlir/lib/Dialect/Rock/Generator/AmdArchDb.cpp:mlir::rock::lookupArchInfo
-def get_arch_features(arch: str):
+def get_arch_features(arch: str, flags=""):
     chip_name = arch.split(':')[0]
     if(len(chip_name) < 5):
         return
@@ -29,7 +29,7 @@ def get_arch_features(arch: str):
     elif major == 'gfx11':
         arch_features = 'dot|atomic_add|atomic_fmax_f32|wmma'
     if arch_features and 'mfma' in arch_features:
-        support_mfma = True
+        support_mfma = not '-mfma=off' in flags
         pass
     elif arch_features and 'wmma' in arch_features:
         support_wmma = True

--- a/mlir/test/e2e/lit.site.cfg.py.in
+++ b/mlir/test/e2e/lit.site.cfg.py.in
@@ -51,7 +51,7 @@ if config.rocm_path:
         agents = get_agents(config.rocm_path)
         config.arch = ','.join(agents)
         for x in agents:
-            config.features, config.arch_support_mfma, config.arch_support_wmma = get_arch_features(x)
+            config.features, config.arch_support_mfma, config.arch_support_wmma = get_arch_features(x, flags=config.rocmlir_gen_flags)
             config.substitutions.append(('%features', config.features))
 
         # Check other features here


### PR DESCRIPTION
Design check:  should we pass the flags in to get_arch_features to turn the flag off directly, or should we test for -mfma=off in flags in the various lit.local.cfg files that will care?  This is for issue #1495;  its purpose is to stop the failures in the public CI, ml-ci.amd.com:21096.