### PR TITLE
Also link ctest when installing cmake, since MIGraphX testing uses it.

### DIFF
--- a/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/Dockerfile
@@ -15,10 +15,7 @@
 FROM rocm/mlir:rocm6.1-latest
 
 RUN apt-get update; \
-    apt-get install -y dumb-init; \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 ;\
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100 ;\
-    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-10 100
+    apt-get install -y dumb-init;
 
 # LTS releases often bundle obsolete pip versions that cannot access newest
 # Linux binary wheels.

--- a/mlir/utils/buildbot/mlir-rocm-mi200/run.sh
+++ b/mlir/utils/buildbot/mlir-rocm-mi200/run.sh
@@ -26,7 +26,7 @@ echo "dl.mlse.buildbot@amd.com" > "${WORKER_NAME}/info/admin"
   rocm-smi --showdriverversion --showid --showmeminfo all ;\
   lsb_release -d | cut -f 2- ; \
   clang --version | head -n1 ; \
-  ld.lld-10 --version ; \
+  ld.lld --version ; \
   cmake --version | head -n1 ; \
 ) > ${WORKER_NAME}/info/host
 

--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -39,6 +39,7 @@ RUN wget --no-verbose -O /cmake.sh https://github.com/Kitware/CMake/releases/dow
     mkdir -p /etc/cmake; \
     /cmake.sh --prefix=/etc/cmake --skip-license; \
     ln -s /etc/cmake/bin/cmake /usr/bin/cmake; \
+    ln -s /etc/cmake/bin/ctest /usr/bin/ctest; \
     cmake --version; \
     rm /cmake.sh
 

--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -64,6 +64,7 @@ RUN echo 'install llvm ${LLVM_VERSION}' && \
     ln -s /usr/bin/llvm-profdata-${LLVM_VERSION} /usr/bin/llvm-profdata && \
     ln -s /usr/bin/llvm-cov-${LLVM_VERSION} /usr/bin/llvm-cov && \
     ln -s /usr/bin/llvm-symbolizer-${LLVM_VERSION} /usr/bin/llvm-symbolizer && \
+    ln -s /usr/bin/llvm-cxxfilt-${LLVM_VERSION} /usr/bin/llvm-cxxfilt && \
     clang --version
 
 RUN echo 'configure locale' && \


### PR DESCRIPTION
The cmake build that I copied from llvm-premerge-checks installs into /etc/cmake/bin and then links to /usr/bin.  However, it doesn't like ctest, and verify-cmake-with-mlir barfed in the nightly.

Added the link, as the simplest change.  Could also use the ubuntu repo (cmake version 3.22.1) or the kitware repo with the necessary key, if one of those is preferred.