### PR TITLE
Remove -DROCMLIR_GEN_FLAGS from Jenkinsfile.downstream.

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -83,7 +83,6 @@ pipeline {
                             steps {
                                 buildProject('check-mlir check-rocmlir', """
                                   -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=1
-                                  -DROCMLIR_GEN_FLAGS="-mfma=off -atomic_add=off"
                                   -DROCMLIR_DRIVER_E2E_TEST_ENABLED=0
                                   -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=1
                                   -DLLVM_LIT_ARGS=-v


### PR DESCRIPTION
We were using ROCMLIR_GEN_FLAGS to set -mfma=off.  Recent changes to the lit code (common.py) don't look at the flags when determining if mfma was available, and the combination led to running mfma tests on mfma-capable machines with mfma disabled, which caused failures in the public-CI side of pull-request CI.  Let's remove the flag, as the simplest solution to the failures.