### PR TITLE
[DO NOT SQUASH] Remove mhal.prefill attr's tight coupling to `rock` dialect

### DIFF
--- a/external/mlir-hal/include/mlir/Dialect/MHAL/Utility/Utils.h
+++ b/external/mlir-hal/include/mlir/Dialect/MHAL/Utility/Utils.h
@@ -1,0 +1,29 @@
+//=== Utils.h - functions that often come up during lowering
+//---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef MHAL_UTILITY_UTILS_H
+#define MHAL_UTILITY_UTILS_H
+
+#include "mlir/Dialect/MHAL/IR/MHAL.h"
+
+namespace mlir {
+
+namespace LLVM {
+class LLVMFuncOp;
+}
+
+namespace mhal {
+
+class PrefillAttr;
+
+// Return `mhal::PrefillAttr` attributes for a given function
+SmallVector<PrefillAttr> getStoredPrefillAttributes(LLVM::LLVMFuncOp func);
+
+} // namespace mhal
+} // end namespace mlir
+#endif

--- a/external/mlir-hal/lib/Dialect/MHAL/CMakeLists.txt
+++ b/external/mlir-hal/lib/Dialect/MHAL/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(IR)
+add_subdirectory(Utility)
 
 if(MHAL_ENABLE_TRANSFORMS)
 add_subdirectory(Transforms)

--- a/external/mlir-hal/lib/Dialect/MHAL/Utility/CMakeLists.txt
+++ b/external/mlir-hal/lib/Dialect/MHAL/Utility/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_mlir_dialect_library(MLIRMHALUtility
+  Utils.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRDialect
+  MLIRArithDialect
+  MLIRFuncDialect
+  MLIRIR
+  MLIRMemRefDialect
+  MLIRSupport
+  MLIRMHAL
+  MLIRGPUDialect
+)

--- a/external/mlir-hal/lib/Dialect/MHAL/Utility/Utils.cpp
+++ b/external/mlir-hal/lib/Dialect/MHAL/Utility/Utils.cpp
@@ -1,0 +1,32 @@
+//=== Utils.cpp - functions that often come up during lowering
+//---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include "mlir/Dialect/MHAL/Utility/Utils.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+using namespace llvm;
+
+SmallVector<mlir::mhal::PrefillAttr>
+mlir::mhal::getStoredPrefillAttributes(mlir::LLVM::LLVMFuncOp func) {
+  SmallVector<mhal::PrefillAttr> storedAttrs;
+  auto gpuModule = cast<gpu::GPUModuleOp>(func->getParentOp());
+  if (auto moduleAttr = gpuModule->getAttr(func.getSymName())) {
+    if (auto arrayAttr = dyn_cast<ArrayAttr>(moduleAttr)) {
+      for (auto attr : arrayAttr) {
+        if (auto prefillAttr = dyn_cast<mhal::PrefillAttr>(attr)) {
+          storedAttrs.push_back(prefillAttr);
+        }
+      }
+    }
+  }
+  return storedAttrs;
+}

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -477,4 +477,24 @@ def Rock_EnableSplitKForTuning : Rock_Attr<"EnableSplitKForTuning"> {
 def Rock_ExpandedFrom1D : Rock_Attr<"ExpandedFrom1D"> {
   let mnemonic = "expanded_from_1d";
 }
+
+def Rock_PrefillAttr : Rock_Attr<"Prefill"> {
+  let mnemonic = "rock.prefill";
+
+  let description = [{
+      A user interface parameter for initializing specific memory buffers
+
+      The attribute is a way to describe which specific kernel parameter
+      (typically memref) must be initialized with specific value before
+      a kernel invocation.
+
+  }];
+
+  let parameters = (ins
+    "uint32_t":$argIndex,
+    "TypedAttr":$initValue
+  );
+  let assemblyFormat = "`<` params `>`";
+}
+
 #endif

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -10,7 +10,6 @@
 #define ROCK_UTILITY_LOWERINGUTILS_H
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/MHAL/IR/MHAL.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
@@ -187,10 +186,6 @@ AffineMap getIdxReversalMap(OpBuilder &b);
 
 // helper to create ReassociationIndices for flattening
 ReassociationIndices getReassociationForFlattening(ShapedType srcTp);
-
-// Return `mhal::PrefillAttr` attributes for a given function
-SmallVector<mhal::PrefillAttr>
-getStoredPrefillAttributes(mlir::LLVM::LLVMFuncOp func);
 
 } // end namespace rock
 } // end namespace mlir

--- a/mlir/lib/CAPI/Dialect/CMakeLists.txt
+++ b/mlir/lib/CAPI/Dialect/CMakeLists.txt
@@ -19,5 +19,6 @@ add_rocmlir_public_c_api_library(MLIRCAPIRock
   MLIRRockOps
   MLIRRockTuning
   MLIRMHAL
+  MLIRMHALUtility
   MLIRRockUtility
 )

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -12,7 +12,7 @@
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Wrap.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/MHAL/IR/MHAL.h"
+#include "mlir/Dialect/MHAL/Utility/Utils.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/Tuning/ConvContext.h"
 #include "mlir/Dialect/Rock/Tuning/RockTuning.h"
@@ -174,7 +174,7 @@ size_t mlirGetNumPrefillArgs(MlirModule module) {
 
   if (!func.has_value())
     return 0;
-  auto attrs = rock::getStoredPrefillAttributes(func.value());
+  auto attrs = mhal::getStoredPrefillAttributes(func.value());
   return attrs.size();
 }
 
@@ -190,7 +190,7 @@ void mlirGetPrefillArgsInfo(MlirModule module, size_t *indices,
 
   if (!func.has_value())
     return;
-  auto attrs = rock::getStoredPrefillAttributes(func.value());
+  auto attrs = mhal::getStoredPrefillAttributes(func.value());
 
   assert(attrs.size() >= length && "length cannot exceed the attr size");
   for (size_t i = 0; i < length; ++i) {

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -222,7 +222,7 @@ void LowerRockOpsToGPUPass::runOnOperation() {
     llvm::SmallVector<Attribute, 4> prefillAttrs;
     for (uint32_t argIdx = 0; argIdx < theFunc.getNumArguments(); ++argIdx) {
       if (auto attr =
-              theFunc.getArgAttr(argIdx, mhal::PrefillAttr::getMnemonic())) {
+              theFunc.getArgAttr(argIdx, rock::PrefillAttr::getMnemonic())) {
         auto prefillAttr =
             b.getAttr<mhal::PrefillAttr>(argIdx, cast<TypedAttr>(attr));
         prefillAttrs.push_back(prefillAttr);

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -14,7 +14,6 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/MHAL/IR/MHAL.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
@@ -1067,7 +1066,7 @@ typename std::enable_if_t<
       /*useDPP=*/nullptr);
 
   func::FuncOp func = op->template getParentOfType<func::FuncOp>();
-  func.setResultAttr(0, mhal::PrefillAttr::getMnemonic(), outputInitVal);
+  func.setResultAttr(0, rock::PrefillAttr::getMnemonic(), outputInitVal);
   func.setResultAttr(0, func::FuncOp::getReadAccessAttrName(),
                      rw.getUnitAttr());
   // The original function also need the read access attr for the output.

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -1,5 +1,4 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/MHAL/IR/MHAL.h"
 #include "mlir/Dialect/Rock/IR/GemmSize.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.h"
@@ -72,7 +71,7 @@ void AffixTuningParameters::runOnOperation() {
       OpBuilder b(op.getContext());
       auto func = llvm::cast<func::FuncOp>(op->getParentOp());
       auto c = op.getC();
-      auto attrName = mhal::PrefillAttr::getMnemonic();
+      auto attrName = rock::PrefillAttr::getMnemonic();
       auto elementType = cast<MemRefType>(c.getType()).getElementType();
       Attribute zero;
       if (llvm::isa<FloatType>(elementType)) {

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -20,7 +20,6 @@
 //
 //===-----------------------------------------------------===//
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/MHAL/IR/MHAL.h"
 #include "mlir/Dialect/Rock/IR/GemmSize.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
@@ -275,7 +274,7 @@ GemmRewritePattern::arrangeSplitKTransform(OpBuilder &builder, GemmOp op,
 
   // set the prefill attribute
   auto func = llvm::cast<func::FuncOp>(op->getParentOp());
-  auto attrName = mhal::PrefillAttr::getMnemonic();
+  auto attrName = rock::PrefillAttr::getMnemonic();
   auto elementType = cast<MemRefType>(c.getType()).getElementType();
   Attribute zero;
   if (llvm::isa<FloatType>(elementType)) {
@@ -535,9 +534,6 @@ AttentionRewritePattern::computeGridSize(ConversionPatternRewriter &rw,
 
   RockAccelTuningParamAttrInterface accelParams0 =
       cast<RockAccelTuningParamAttrInterface>(op.getParams0Attr());
-
-  RockAccelTuningParamAttrInterface accelParams1 =
-      cast<RockAccelTuningParamAttrInterface>(op.getParams1Attr());
 
   SmallVector<int64_t, 3> queriesShape =
       llvm::to_vector<3>(cast<MemRefType>(queries.getType()).getShape());

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -745,19 +745,3 @@ mlir::rock::getReassociationForFlattening(ShapedType srcTp) {
     reassociation.push_back(i);
   return reassociation;
 }
-
-SmallVector<mhal::PrefillAttr>
-mlir::rock::getStoredPrefillAttributes(mlir::LLVM::LLVMFuncOp func) {
-  SmallVector<mhal::PrefillAttr> storedAttrs;
-  auto gpuModule = cast<gpu::GPUModuleOp>(func->getParentOp());
-  if (auto moduleAttr = gpuModule->getAttr(func.getSymName())) {
-    if (auto arrayAttr = dyn_cast<ArrayAttr>(moduleAttr)) {
-      for (auto attr : arrayAttr) {
-        if (auto prefillAttr = dyn_cast<mhal::PrefillAttr>(attr)) {
-          storedAttrs.push_back(prefillAttr);
-        }
-      }
-    }
-  }
-  return storedAttrs;
-}

--- a/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce.mlir
+++ b/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce.mlir
@@ -2,7 +2,7 @@
 
 module attributes {kernel.module, mhal.arch = "amdgcn-amd-amdhsa:gfx906"} {
 // CHECK-LABEL: @test_basic
-// CHECK-SAME: -> (tensor<2x10x1xf32> {func.read_access, mhal.prefill = 0.000000e+00 : f32})
+// CHECK-SAME: -> (tensor<2x10x1xf32> {func.read_access, rock.prefill = 0.000000e+00 : f32})
 func.func @test_basic(%arg0: tensor<2x10x100xf32>) -> tensor<2x10x1xf32> attributes {kernel} {
   // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x10x1xf32>
   // CHECK: rock.reduce  sum %arg0 into %[[outBuf]] {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 8 : i32} : tensor<2x10x100xf32> into tensor<2x10x1xf32> -> tensor<2x10x1xf32>
@@ -11,7 +11,7 @@ func.func @test_basic(%arg0: tensor<2x10x100xf32>) -> tensor<2x10x1xf32> attribu
 }
 
 // CHECK-LABEL: @test_middle_axis_reduction
-// CHECK-SAME: -> (tensor<4x1x20xf32> {func.read_access, mhal.prefill = 0.000000e+00 : f32})
+// CHECK-SAME: -> (tensor<4x1x20xf32> {func.read_access, rock.prefill = 0.000000e+00 : f32})
 func.func @test_middle_axis_reduction(%arg0: tensor<4x300x20xf32>) -> tensor<4x1x20xf32> attributes {kernel} {
   // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<4x1x20xf32>
   // CHECK: rock.reduce  sum %arg0 into %[[outBuf]] {{.*}} {axis = 1 : index, blockSize = 256 : i32, gridSize = 94 : i32} : tensor<4x300x20xf32> into tensor<4x1x20xf32> -> tensor<4x1x20xf32>
@@ -20,7 +20,7 @@ func.func @test_middle_axis_reduction(%arg0: tensor<4x300x20xf32>) -> tensor<4x1
 }
 
 // CHECK-LABEL: @test_reduce_max
-// CHECK-SAME: -> (tensor<2x10x1xf32> {func.read_access, mhal.prefill = 0xFF800000 : f32})
+// CHECK-SAME: -> (tensor<2x10x1xf32> {func.read_access, rock.prefill = 0xFF800000 : f32})
 func.func @test_reduce_max(%arg0: tensor<2x10x100xf32>) -> tensor<2x10x1xf32> attributes {kernel} {
   // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x10x1xf32>
   // CHECK: rock.reduce  max %arg0 into %[[outBuf]] {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 8 : i32} : tensor<2x10x100xf32> into tensor<2x10x1xf32> -> tensor<2x10x1xf32>

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -82,7 +82,7 @@ func.func @gemm_transposed_from_gridwise(%a: memref<1x128x72xf32>, %b: memref<1x
 }
 
 // CHECK-LABEL: func.func @gemm_pad_for_split_k
-// CHECK-SAME: (%[[a:.*]]: memref<1x128x238xf32>, %[[b:.*]]: memref<1x238x512xf32>, %[[c:.*]]: memref<1x128x512xf32> {mhal.prefill = {{.*}} : f32})
+// CHECK-SAME: (%[[a:.*]]: memref<1x128x238xf32>, %[[b:.*]]: memref<1x238x512xf32>, %[[c:.*]]: memref<1x128x512xf32> {rock.prefill = {{.*}} : f32})
 func.func @gemm_pad_for_split_k(%a: memref<1x128x238xf32>, %b: memref<1x238x512xf32>, %c: memref<1x128x512xf32>) {
   // CHECK-DAG: %[[transA:.*]] = rock.transform %[[a]] by {{.*}} : memref<1x128x238xf32> to memref<1x238x128xf32{{.*}}>
   // CHECK-DAG: %[[normalizeA:.*]] = rock.transform %[[transA]] by {{.*}} : memref<1x238x128xf32> to memref<1x240x128xf32{{.*}}>

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2895,7 +2895,7 @@ void insertPrefills(func::FuncOp fut) {
         size_t argCount = calleeFunc.getArguments().size();
         for (size_t i = 0; i < argCount; i++) {
           if (Attribute initAttr =
-                  calleeFunc.getArgAttr(i, mhal::PrefillAttr::getMnemonic())) {
+                  calleeFunc.getArgAttr(i, rock::PrefillAttr::getMnemonic())) {
             argInitValues[i] = initAttr;
           }
         }

--- a/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
+++ b/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
@@ -216,6 +216,7 @@ MLIRMHAL
 MLIRMHALPipeline
 MLIRMHALSupport
 MLIRMHALTransforms
+MLIRMHALUtility
 MLIRMIGraphXDialect
 MLIRMIGraphXPipeline
 MLIRMIGraphXToTosa


### PR DESCRIPTION
Currently, our lowering has a tight coupling with `rock` and `mhal` dialect
only via *prefill* attr. Now, this prohibits pulling in just the `rock` dialect
to third party projects without requiring pulling `mhal` dependency, especially
where the third part project has it own hal. Idea is we should be able to 
pull `rock` dialect to lower to upstream dialects.

This PR introduces a same concept of *prefill* attr in `rock` dialect and moves
the creation of `mhal` prefill attr to a conversion.