### PR TITLE
Temporarily call registerMLIRCLOptions() from mlirRegisterRocMLIRPasses(), until we can call it from MIGraphX.

### DIFF
--- a/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
+++ b/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
@@ -19,7 +19,12 @@ void mlirRegisterRocMLIRDialects(MlirDialectRegistry registry) {
   mlir::registerRocMLIRDialects(*unwrap(registry));
 }
 
-void mlirRegisterRocMLIRPasses() { mlir::registerRocMLIRPasses(); }
+void mlirRegisterRocMLIRPasses() {
+  mlir::registerRocMLIRPasses();
+  // TODO: remove this call once we call mlirRegisterRocMLIROptions()
+  // in MIGraphX/src/targets/gpu/mlir.cpp.
+  mlir::registerMLIRCLOptions();
+}
 
 void mlirRegisterRocMLIROptions() {
   const char *fakeArgv[] = {"rocMLIR-invoked-as-library",


### PR DESCRIPTION
Short-term measure to get nightlies passing again.  test_gpu_mlir and the rest of "make check" all pass.