### PR TITLE
Rearrange alloc_tensor creation and CSE to fix input fusion crash

### DIFF
--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -93,7 +93,7 @@ void rock::buildBufferizePipeline(OpPassManager &pm,
   funcPm2.addPass(rock::createRockFoldBroadcastPass());
 
   // bufferization
-  /* rocmlir-opt --canonicalize --cse -convert-tensor-to-linalg
+  /* rocmlir-opt --canonicalize -convert-tensor-to-linalg --cse
         --one-shot-bufferize="allow-return-allocs=1
      create-deallocs=0 bufferize-function-boundaries=1
      unknown-type-conversion=identity-layout-map
@@ -101,6 +101,18 @@ void rock::buildBufferizePipeline(OpPassManager &pm,
         --buffer-results-to-out-params
    */
   funcPm2.addPass(createCanonicalizerPass());
+  // Note: this is a workaround for an impedance mismatch between bufferization
+  // and our fusion code. Specifically, if there are two identical
+  // tensor.empty's
+  //, they can be CSE'd together, and then, if the bufferizer notices that the
+  // allocation that that empty tensor has two independent uses (that is,
+  // if op1 and op2 both have the "initial output" %x, and the values produces
+  // by op1 are dead by the time op2 rolls around), it'll reuse the buffer.
+  // This breaks rocMLIR's fusion code, which assumes allocations aren't reused
+  // like this. So, until we move bufferization after rock.regularize (so that
+  // we can do the alloc_tensor introductions ourselves), we have to do it up
+  // here before CSE.
+  funcPm2.addPass(bufferization::createEmptyTensorToAllocTensorPass());
   funcPm2.addPass(createCSEPass());
 
   pm.addPass(createConvertTensorToLinalgPass());

--- a/mlir/test/fusion/bug-1520-input-fusion-regression.mlir
+++ b/mlir/test/fusion/bug-1520-input-fusion-regression.mlir
@@ -1,0 +1,27 @@
+// RUN: rocmlir-driver --kernel-pipeline=migraphx,highlevel %s | FileCheck %s
+// Note: if we move bufferization, this should be a check for three emptys or
+// alloc_tensors unless there's a wider refactoring.
+// CHECK-COUNT-3: memref.alloc
+// CHECK-NOT: memref.alloc
+module {
+  func.func @mlir_add_sigmoid_mul_slice_reshape_transpose_slice_dot_add_sigmoid_mul_add_add_tanh_sub_mul_add(%arg0: !migraphx.shaped<2x5xf32, 5x1>, %arg1: !migraphx.shaped<2x5xf32, 5x1>, %arg2: !migraphx.shaped<2x5xf32, 5x1>, %arg3: !migraphx.shaped<2x5xf32, 5x1>, %arg4: !migraphx.shaped<2x5xf32, 5x1>, %arg5: !migraphx.shaped<2x5xf32, 5x1>, %arg6: !migraphx.shaped<2x5xf32, 5x1>, %arg7: !migraphx.shaped<2x5xf32, 5x1>, %arg8: !migraphx.shaped<2x15x5xf32, 75x5x1>) -> !migraphx.shaped<2x5xf32, 5x1> attributes {arch = "gfx908:sramecc+:xnack-", enable_splitk_for_tuning = true, kernel = "mixr", num_cu = 120 : i64} {
+    %0 = migraphx.add %arg0, %arg1 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %1 = migraphx.sigmoid %0 : <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %2 = migraphx.mul %1, %arg2 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %3 = migraphx.slice %arg8 {axes = [0], ends = [1], starts = [0]} : <2x15x5xf32, 75x5x1> -> <1x15x5xf32, 75x5x1>
+    %4 = migraphx.reshape %3 {dims = [15, 5]} : <1x15x5xf32, 75x5x1> -> <15x5xf32, 5x1>
+    %5 = migraphx.transpose %4 {permutation = [1, 0]} : <15x5xf32, 5x1> -> <5x15xf32, 1x5>
+    %6 = migraphx.slice %5 {axes = [1], ends = [15], starts = [10]} : <5x15xf32, 1x5> -> <5x5xf32, 15x1>
+    %7 = migraphx.dot %2, %6 : <2x5xf32, 5x1>, <5x5xf32, 15x1> -> <2x5xf32, 5x1>
+    %8 = migraphx.add %arg3, %arg4 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %9 = migraphx.sigmoid %8 : <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %10 = migraphx.mul %9, %arg2 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %11 = migraphx.add %7, %arg5 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %12 = migraphx.add %arg6, %11 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %13 = migraphx.tanh %12 : <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %14 = migraphx.sub %arg7, %9 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %15 = migraphx.mul %14, %13 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    %16 = migraphx.add %15, %10 : <2x5xf32, 5x1>, <2x5xf32, 5x1> -> <2x5xf32, 5x1>
+    return %16 : !migraphx.shaped<2x5xf32, 5x1>
+  }
+}

--- a/mlir/test/fusion/tosa-tp-highlevel.mlir
+++ b/mlir/test/fusion/tosa-tp-highlevel.mlir
@@ -1,5 +1,5 @@
 // RUN: rocmlir-driver --host-pipeline highlevel %s | FileCheck %s
-// CHECK-COUNT-2: linalg.generic
+// CHECK-COUNT-3: linalg.generic
 // CHECK-NOT: linalg.generic
 // This is only to detect any changes in tosa transpose optimization, nothing wrong it differs
 // Just test needs to be amended once any change is detected.

--- a/mlir/test/rocmlir-driver/pipelines.mlir
+++ b/mlir/test/rocmlir-driver/pipelines.mlir
@@ -105,6 +105,7 @@
 // HIGHLEVEL-NEXT:rock-view-to-transform,
 // HIGHLEVEL-NEXT:rock-fold-broadcast,
 // HIGHLEVEL-NEXT:canonicalize{  max-iterations=10 max-num-rewrites=-1 region-simplify=true test-convergence=false top-down=true},
+// HIGHLEVEL-NEXT:empty-tensor-to-alloc-tensor,
 // HIGHLEVEL-NEXT:cse),
 // HIGHLEVEL-NEXT:convert-tensor-to-linalg,
 // HIGHLEVEL-NEXT:func.func(empty-tensor-to-alloc-tensor,


### PR DESCRIPTION
Fixes https://github.com/ROCm/rocMLIR-internal/issues/1520

As mentioned in the comments in the code below, this PR fixes an issue that areses because `tensor.empty` operations were combined in a way that caused the regularization pass to trip an assert.

To put it another way, the rocMLIR fusion code relies on never needing to try to "fuse"

%a = alloc()
f(reads ..., writes %a)
%b = alloc()
g(reads ... + %a, writes %b)
// No other uses of %a until
h(reads ... + %b, writes %a)

This can happen if you combine two tensor.empty ops and the buferization analysis notices that you don't actually need two buffers for the two different empty tensors.

Therefore, to fix the assert, as a workaround, copy the translation from tensor.empty to bufferization.alloc_tensor before the call to CSE. We leave the existing call to that pass in place just to be safe.

This has a side effect of increasing the number of generics in the tosa transpsoe optimiization test.