### PR TITLE
Fix storeMethod in non-accel gemm for split-k

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -390,6 +390,7 @@ def Rock_GridwiseGemmOp :
                    MemRefRankOf<GemmInputTypes, [3]>:$b,
                    MemRefRankOf<GemmAccumulatorTypes, [3]>:$c,
                    Rock_GemmFeaturesAttr:$features,
+                   StoreMethodAttr:$storeMethod,
                    I32Attr:$numCU,
                    I32Attr:$gridSize,
                    Rock_GeneralGemmParamsAttr:$params)> {
@@ -398,7 +399,7 @@ def Rock_GridwiseGemmOp :
     The `rock.gridwise_gemm` op computes gridwise GEMM.
   }];
   let assemblyFormat = [{
-    $c `=` $a `*` $b `features` `=` $features attr-dict `:` type($c) `=` type($a) `*` type($b)
+    $c `=` $a `*` $b `storeMethod` `(` $storeMethod `)` `features` `=` $features attr-dict `:` type($c) `=` type($a) `*` type($b)
   }];
   let hasVerifier = 1;
 }

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -231,8 +231,8 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
         op.getFeaturesAttr(), op.getStoreMethodAttr(), blockSize, gridSize,
         cast<RockAccelTuningParamAttrInterface>(params));
   } else {
-    rw.create<GridwiseGemmOp>(loc, a, b, accumulator, op.getFeaturesAttr(), op.getStoreMethodAttr(),
-                              numCUAttr, gridSize,
+    rw.create<GridwiseGemmOp>(loc, a, b, accumulator, op.getFeaturesAttr(),
+                              op.getStoreMethodAttr(), numCUAttr, gridSize,
                               cast<GeneralGemmParamsAttr>(params));
   }
 

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -231,7 +231,7 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
         op.getFeaturesAttr(), op.getStoreMethodAttr(), blockSize, gridSize,
         cast<RockAccelTuningParamAttrInterface>(params));
   } else {
-    rw.create<GridwiseGemmOp>(loc, a, b, accumulator, op.getFeaturesAttr(),
+    rw.create<GridwiseGemmOp>(loc, a, b, accumulator, op.getFeaturesAttr(), op.getStoreMethodAttr(),
                               numCUAttr, gridSize,
                               cast<GeneralGemmParamsAttr>(params));
   }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -751,7 +751,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
                                    ValueRange{gridCoords.g_block,
                                               gridCoords.m_block,
                                               gridCoords.n_block, tid},
-                                   op.getFeatures(), StoreMethod::Set,
+                                   op.getFeatures(), op.getStoreMethod(),
                                    /*forceUnroll=*/true, useIndexDiffs);
     b.eraseOp(op);
 

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -4,6 +4,7 @@
 // RUN: rocmlir-opt -rock-gemm-to-gridwise %s | FileCheck %s
 
 #general_gemm_params0 = #rock.general_gemm_params<blockSize = 64, kPerBlock = 8, mPerBlock = 128, nPerBlock = 128, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1, splitKFactor = 1>
+#general_gemm_params_splitk = #rock.general_gemm_params<blockSize = 64, kPerBlock = 8, mPerBlock = 128, nPerBlock = 128, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1, splitKFactor = 2>
 #general_gemm_params1 = #rock.general_gemm_params<blockSize = 64, kPerBlock = 16, mPerBlock = 64, nPerBlock = 64, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1, splitKFactor = 1>
 #xdlops_gemm_params0 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, forceUnroll = true, splitKFactor = 1>
 #xdlops_gemm_params1 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 64, nPerWave = 64, mnPerXdl = 32, forceUnroll = true, splitKFactor = 1>
@@ -19,6 +20,18 @@ func.func @gemm_easy_case_from_conv(%a: memref<1x72x128xf32>, %b: memref<1x72x51
     arch = "amdgcn-amd-amdhsa:gfx906",
     gridSize = 4 : i32,
     params = #general_gemm_params0
+  } : memref<1x128x512xf32> = memref<1x72x128xf32> * memref<1x72x512xf32>
+  func.return
+}
+
+// CHECK-LABEL: func.func @gemm_splitk
+func.func @gemm_splitk(%a: memref<1x72x128xf32>, %b: memref<1x72x512xf32>, %c: memref<1x128x512xf32>) {
+  // CHECK: rock.gridwise_gemm
+  // CHECK-SAME: storeMethod( atomic_add)
+  rock.gemm %c = tr %a * %b features = atomic_add storeMethod = set {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    gridSize = 4 : i32,
+    params = #general_gemm_params_splitk
   } : memref<1x128x512xf32> = memref<1x72x128xf32> * memref<1x72x512xf32>
   func.return
 }

--- a/mlir/test/Dialect/Rock/invalid.mlir
+++ b/mlir/test/Dialect/Rock/invalid.mlir
@@ -7,7 +7,7 @@ func.func @gridwise_gemm_i32_wants_i8(%a: memref<1x16x16xf32>,
                         %b: memref<1x16x16xf32>,
                         %c: memref<1x16x16xi32>) {
   // expected-error@+1 {{'rock.gridwise_gemm' op floating-point input type 'f32' requires a floating-point output type, but the output type is 'i32'}}
-  rock.gridwise_gemm %c = %a * %b features = dot {
+  rock.gridwise_gemm %c = %a * %b storeMethod(set) features = dot {
     gridSize = 1 : i32,
     numCU = 64 : i32,
     params = #general_gemm_params0}
@@ -22,7 +22,7 @@ func.func @gridwise_gemm_i8_wants_i32(%a: memref<1x16x16xi8>,
                         %b: memref<1x16x16xi8>,
                         %c: memref<1x16x16xf32>) {
   // expected-error@+1 {{'rock.gridwise_gemm' op integer input type 'i8' requires an integer output type, but the output type is 'f32'}}
-  rock.gridwise_gemm %c = %a * %b features = dot {
+  rock.gridwise_gemm %c = %a * %b storeMethod(set) features = dot {
     gridSize = 1 : i32,
     numCU = 64 : i32,
     params = #general_gemm_params0}
@@ -37,7 +37,7 @@ func.func @gridwise_gemm_m_too_big(%a: memref<1x1x2147483648xf32>,
                         %b: memref<1x1x1xf32>,
                         %c: memref<1x2147483648x1xf32>) {
   // expected-error@+1 {{'rock.gridwise_gemm' op M dimmension 2147483648 cannot be greater than int32_max 2147483647}}
-  rock.gridwise_gemm %c = %a * %b features = dot {
+  rock.gridwise_gemm %c = %a * %b storeMethod(set) features = dot {
     gridSize = 1 : i32,
     numCU = 64 : i32,
     params = #general_gemm_params0}
@@ -52,7 +52,7 @@ func.func @gridwise_gemm_k_too_big(%a: memref<1x2147483648x1xf32>,
                         %b: memref<1x2147483648x1xf32>,
                         %c: memref<1x1x1xf32>) {
   // expected-error@+1 {{'rock.gridwise_gemm' op K dimmension 2147483648 cannot be greater than int32_max 2147483647}}
-  rock.gridwise_gemm %c = %a * %b features = dot {
+  rock.gridwise_gemm %c = %a * %b storeMethod(set) features = dot {
     gridSize = 1 : i32,
     numCU = 64 : i32,
     params = #general_gemm_params0}
@@ -66,7 +66,7 @@ func.func @gridwise_gemm_m_too_big(%a: memref<1x1x1xf32>,
                         %b: memref<1x1x2147483648xf32>,
                         %c: memref<1x1x2147483648xf32>) {
   // expected-error@+1 {{'rock.gridwise_gemm' op N dimmension 2147483648 cannot be greater than int32_max 2147483647}}
-  rock.gridwise_gemm %c = %a * %b features = dot {
+  rock.gridwise_gemm %c = %a * %b storeMethod(set) features = dot {
     gridSize = 1 : i32,
     numCU = 64 : i32,
     params = #general_gemm_params0}

--- a/mlir/test/Dialect/Rock/ops.mlir
+++ b/mlir/test/Dialect/Rock/ops.mlir
@@ -177,7 +177,7 @@ func.func @rock_transform_1_to_n(%memref : memref<?x?x?x?x?xf32>) {
 //  CHECK-NEXT: rock.transform
 
 func.func @rock_gridwise_gemm(%A : memref<2x72x128xf32>, %B : memref<2x72x256xf32>, %C : memref<2x128x256xf32>) {
-  rock.gridwise_gemm %C = %A * %B features = none {
+  rock.gridwise_gemm %C = %A * %B storeMethod(set) features = none {
     blockSize = 256 : i32,
     gridSize = 1 : i32,
     numCU = 64 : i32,

--- a/mlir/test/fusion/input-fusion-regularize-generic-chain.mlir
+++ b/mlir/test/fusion/input-fusion-regularize-generic-chain.mlir
@@ -29,7 +29,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
     // CHECK: %[[IN:.+]] = rock.transform %alloc_0 by #[[MAP]]
     %0 = rock.transform %alloc_0 by #transform_map : memref<1x32x16xf32> to memref<1x16x32xf32>
     // CHECK-NEXT: rock.gridwise_gemm %{{.*}} = %[[IN]] * %{{.*}}
-    rock.gridwise_gemm %arg2 = %0 * %arg1 features =  dot|atomic_add {gridSize = 1 : i32, numCU = 104 : i32, params = #general_gemm_params} : memref<1x32x32xf32> = memref<1x16x32xf32> * memref<1x16x32xf32>
+    rock.gridwise_gemm %arg2 = %0 * %arg1 storeMethod(set) features =  dot|atomic_add {gridSize = 1 : i32, numCU = 104 : i32, params = #general_gemm_params} : memref<1x32x32xf32> = memref<1x16x32xf32> * memref<1x16x32xf32>
     return
   }
 
@@ -60,7 +60,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
       linalg.yield %3 : f32
     }
     // CHECK: rock.gridwise_gemm %{{.+}} = %[[gemmIn]] * %{{.+}}
-    rock.gridwise_gemm %arg2 = %alloc_0 * %arg1 features =  dot|atomic_add {gridSize = 1 : i32, numCU = 104 : i32, params = #general_gemm_params} : memref<1x32x32xf32> = memref<1x16x32xf32> * memref<1x16x32xf32>
+    rock.gridwise_gemm %arg2 = %alloc_0 * %arg1 storeMethod(set) features =  dot|atomic_add {gridSize = 1 : i32, numCU = 104 : i32, params = #general_gemm_params} : memref<1x32x32xf32> = memref<1x16x32xf32> * memref<1x16x32xf32>
     return
   }
 }

--- a/mlir/test/fusion/input-output-fusion-regularize.mlir
+++ b/mlir/test/fusion/input-output-fusion-regularize.mlir
@@ -27,7 +27,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
     // CHECK-NEXT: %[[ALLOC_0:.*]] = memref.alloc() : memref<1x32x32xf32>
     %gemmOut = memref.alloc() : memref<1x32x32xf32>
     // CHECK-NEXT: rock.gridwise_gemm %[[ALLOC_0]] = %[[IN]] * %{{.*}}
-    rock.gridwise_gemm %gemmOut = %1 * %arg1 features =  dot|atomic_add {gridSize = 1 : i32, numCU = 104 : i32, params = #general_gemm_params} : memref<1x32x32xf32> = memref<1x16x32xf32> * memref<1x16x32xf32>
+    rock.gridwise_gemm %gemmOut = %1 * %arg1 storeMethod(set) features =  dot|atomic_add {gridSize = 1 : i32, numCU = 104 : i32, params = #general_gemm_params} : memref<1x32x32xf32> = memref<1x16x32xf32> * memref<1x16x32xf32>
     // CHECK-NEXT: %[[ALLOC_1:.*]] = memref.alloc() : memref<1x32x32xf32>
     // CHECK-NEXT: %[[OUTS:.*]] = rock.transform %alloc_1 by #[[MAP2]]
     %alloc_1 = memref.alloc() : memref<1x32x32xf32>

--- a/mlir/test/fusion/rock-gemm-align-tiling-multiple-args.mlir
+++ b/mlir/test/fusion/rock-gemm-align-tiling-multiple-args.mlir
@@ -11,7 +11,7 @@ func.func @rock_gemm(%arg0: memref<64x64x64xf16>, %arg1: memref<64x64x64xf32>, %
     linalg.yield %2 : f32
   }
   %0 = rock.transform %alloc by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemmK", "gemmM"] at [1, 2] -> ["gemmK", "gemmM"] at [2, 1]>] bounds = [64, 64, 64] -> [64, 64, 64]> : memref<64x64x64xf32> to memref<64x64x64xf32>
-  rock.gridwise_gemm %arg2 = %0 * %arg1 features =  dot|atomic_add|atomic_fmax_f32 {gridSize = 64 : i32, numCU = 48 : i32, params = #rock.general_gemm_params<blockSize = 256, kPerBlock = 16, mPerBlock = 64, nPerBlock = 64, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1, splitKFactor = 1>} : memref<64x64x64xf32> = memref<64x64x64xf32> * memref<64x64x64xf32>
+  rock.gridwise_gemm %arg2 = %0 * %arg1 storeMethod(set) features =  dot|atomic_add|atomic_fmax_f32 {gridSize = 64 : i32, numCU = 48 : i32, params = #rock.general_gemm_params<blockSize = 256, kPerBlock = 16, mPerBlock = 64, nPerBlock = 64, kPerThread = 1, mPerThread = 4, nPerThread = 4, kpack = 1, splitKFactor = 1>} : memref<64x64x64xf32> = memref<64x64x64xf32> * memref<64x64x64xf32>
   return
 }
 


### PR DESCRIPTION
Currently, non-accel gemm is hard coded to use storeMethod always as `set`.
However, our tuning ranges (and tuning parameter rejection) does not stop a client from using split-k on non-accel gemm.

This commit fixes that by introducing the storeMethod to non-accel gemm and
ensuring the plumbing is intact.
closes : https://github.com/ROCm/rocMLIR-internal/issues/1522