### PR TITLE
[CI] Add a option define the target branch

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -88,10 +88,10 @@ void preMergeCheck(String codepath) {
         fi
         '''
         if (params.ignoreExternalLinting == true) {
-            sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --ignore-external'
+            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${params.rocMLIRTargetBranch} --ignore-external"
         }
         else {
-            sh 'python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py'
+            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${params.rocMLIRTargetBranch}"
         }
     } else {
         echo "Static Test step skipped"
@@ -397,6 +397,8 @@ pipeline {
                description: 'The MIGraphX branch/commit to verify against.')
         string(name: 'CKBranch', defaultValue: 'develop',
             description: 'The Composable Kernel branch to be used with the job')
+        string(name: 'rocMLIRTargetBranch', defaultValue: 'origin/develop',
+            description: 'The target branch the PR is intended to merge with')
 
 
         // Each below control whether to run a individual stage from parallel run


### PR DESCRIPTION
This commit adds the option for CI to define the target branch
it is merging with. This is useful for backport where the clang-format
(and friends) should be compared with the target branch and not origin/develop.