### PR TITLE
Bumping Navi3 CI execution to use 4 threads

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -249,7 +249,7 @@ void checkRocmlirOnNavi3x(boolean fixed, String testSuite) {
              -DROCK_E2E_TEST_SUITES=${testSuite}
              -DROCMLIR_DRIVER_RANDOM_DATA_SEED=${fixed ? 'none' : '1'}
              -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=${fixed ? 1 : 0}
-             -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 1'
+             -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 4'
              -DCMAKE_EXPORT_COMPILE_COMMANDS=1
      """)
 }
@@ -264,7 +264,7 @@ void check_RockE2ETests_Navi3x(boolean fixed) {
                  -DROCMLIR_DRIVER_E2E_TEST_ENABLED=0
                  -DROCK_E2E_TEST_ENABLED=0
                  -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=1
-                 -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 1'
+                 -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 4'
                  -DCMAKE_EXPORT_COMPILE_COMMANDS=1
          """)
          echo "Static Test step skipped"
@@ -279,7 +279,7 @@ void check_RockE2ETests_Navi3x(boolean fixed) {
              -DROCK_E2E_TEST_SUITES='part1'
              -DROCMLIR_DRIVER_RANDOM_DATA_SEED=${fixed ? 'none' : '1'}
              -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=${fixed ? 1 : 0}
-             -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 1'
+             -DLLVM_LIT_ARGS='-v --time-tests --filter-out=dense_output_bf16.mlir -j 4'
              -DCMAKE_EXPORT_COMPILE_COMMANDS=1
         """)
         checkRocmlirOnNavi3x(fixed, 'part2')


### PR DESCRIPTION
In retrospect, bumping the Navi3 CI to use 1 thread is making the test running excruciating long. I'm attempt to bump the thread count back up again. I'm hoping this can move cost of time in CI back to reasonable range.