### PR TITLE
[EXTERNAL] Add amdgpu.sched_barrier

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -489,6 +489,46 @@ def AMDGPU_LDSBarrierOp : AMDGPU_Op<"lds_barrier"> {
   let assemblyFormat = "attr-dict";
 }
 
+def AMDGPU_SchedBarrierOpOpt : I32EnumAttr<"sched_barrier_opt_enum",
+    "The possible options for scheduling barriers",
+    [
+      I32EnumAttrCase<"allow_none",            0x0000>,
+      I32EnumAttrCase<"allow_non_mem_non_sideffect",  0x0001>,
+      I32EnumAttrCase<"allow_valu", 0x0002>,
+      I32EnumAttrCase<"allow_salu", 0x0004>,
+      I32EnumAttrCase<"allow_mfma_wmma",  0x0008>,
+      I32EnumAttrCase<"allow_all_vmem",  0x0010>,
+      I32EnumAttrCase<"allow_vmem_read",  0x0020>,
+      I32EnumAttrCase<"allow_vmem_write", 0x0040>,
+      I32EnumAttrCase<"allow_all_ds", 0x0080>,
+      I32EnumAttrCase<"allow_ds_read", 0x0100>,
+      I32EnumAttrCase<"allow_ds_write", 0x0200>,
+      I32EnumAttrCase<"allow_transcendental", 0x0400>
+    ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::amdgpu";
+}
+
+def AMDGPU_SchedBarrierOpOptAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_SchedBarrierOpOpt,
+  "sched_barrier_opt">;
+
+def AMDGPU_SchedBarrierOpOptArrayAttr : TypedArrayAttrBase<AMDGPU_SchedBarrierOpOptAttr,
+                                        "sched_barrier_opt array attribute">;
+
+def AMDGPU_SchedBarrierOp :
+  AMDGPU_Op<"sched_barrier">,
+  Arguments<(ins  AMDGPU_SchedBarrierOpOptArrayAttr:$opts)>
+  {
+  let summary = "Barrier that includes a wait for LDS memory operations.";
+  let description = [{
+    `amdgpu.sched_barrier` is just a scheduling barrier for backend
+    scheduler.
+  }];
+  let assemblyFormat = [{
+    $opts attr-dict
+  }];
+}
+
 def AMDGPU_MFMAPermB : I32EnumAttr<"MFMAPermB",
     "The possible permutations of the lanes storing B available in an MFMA",
     [

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/amdgpu-to-rocdl.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/amdgpu-to-rocdl.mlir
@@ -226,3 +226,34 @@ func.func @lds_barrier() {
   amdgpu.lds_barrier
   func.return
 }
+
+// CHECK-LABEL: func @sched_barrier
+func.func @sched_barrier() {
+  // rocdl.sched.barrier 0
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_none>]
+  // rocdl.sched.barrier 1
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_non_mem_non_sideffect>]
+  // rocdl.sched.barrier 2
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_valu>]
+  // rocdl.sched.barrier 4
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_salu>]
+  // rocdl.sched.barrier 8
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_mfma_wmma>]
+  // rocdl.sched.barrier 16
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_all_vmem>]
+  // rocdl.sched.barrier 32
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_vmem_read>]
+  // rocdl.sched.barrier 64
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_vmem_write>]
+  // rocdl.sched.barrier 128
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_all_ds>]
+  // rocdl.sched.barrier 256
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_ds_read>]
+  // rocdl.sched.barrier 512
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_ds_write>]
+  // rocdl.sched.barrier 1024
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_transcendental>]
+  // rocdl.sched.barrier 18
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_valu>, #amdgpu<sched_barrier_opt allow_all_vmem>]
+  func.return
+}

--- a/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
@@ -109,6 +109,15 @@ func.func @lds_barrier() {
   func.return
 }
 
+// CHECK-LABEL: func @sched_barrier
+func.func @sched_barrier() {
+  // CHECK: amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_none>]
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_none>]
+  // CHECK: amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_valu>, #amdgpu<sched_barrier_opt allow_all_vmem>]
+  amdgpu.sched_barrier [#amdgpu<sched_barrier_opt allow_valu>, #amdgpu<sched_barrier_opt allow_all_vmem>]
+  func.return
+}
+
 // CHECK-LABEL: func @mfma
 func.func @mfma(%arg0 : f32, %arg1 : vector<32xf32>) -> vector<32xf32> {
   // CHECK: amdgpu.mfma


### PR DESCRIPTION
This commit adds sched_barrier operator
to AMDGPU dialect that lowers to rocdl.sched.barrier.

closes : https://github.com/ROCm/rocMLIR-internal/issues/1527