### PR TITLE
Prune attention tuning space for Navi3x

### DIFF
--- a/mlir/utils/jenkins/ci-configs/selected-attention-configs
+++ b/mlir/utils/jenkins/ci-configs/selected-attention-configs
@@ -1,1 +1,1 @@
--transO false -transV false -transK true -transQ false -t f16 -g 256 -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 128 -head_dim_v 128
+-transO false -transV false -transK true -transQ false -t f16 -g 256 -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale=False


### PR DESCRIPTION
This commit prunes down the tuning space
for attentions in Navi3x without hurting
performance to improve CI performance.

It turned out *some* single wave configs take
more time to compile in the backend.

Also, when numWaves are less than numEUPerCU
there were not performant. Therefore skipping
them for now.

closes : https://github.com/ROCm/rocMLIR-internal/issues/1538