### PR TITLE
[CI] Make our PR CI use a fixed layout for conv

### DIFF
--- a/mlir/utils/jenkins/ci-configs/selected-conv-configs
+++ b/mlir/utils/jenkins/ci-configs/selected-conv-configs
@@ -1,1 +1,1 @@
--n 64 -c 1024 -H 14 -W 14 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1
+-n 64 -c 1024 -H 14 -W 14 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1 -f NHWC -I NHWC -O NHWC


### PR DESCRIPTION
The reason we have a tuning of a single conv in PR CI to make sure the tuner is functional.

To that effect, I think we dont have to tune for all layouts because we have that coverage in e2e tests.

This commit is to fix the layout that we tune in PR CI so it would be not painful on slower HW (Navi3x).