### PR TITLE
Mfma prune

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -269,7 +269,8 @@ public:
   // Succced if `params` should be included in a "full" tuning space that
   // excludes those known to not yeild good performance on the problem described
   // in `info`. This function uses hardcoded heuristics.
-  virtual LogicalResult couldBePerformant(const PopulateParamsInfo &info,
+  virtual LogicalResult couldBePerformant(OpBuilder &b,
+					  const PopulateParamsInfo &info,
                                           const InitParamType &params) = 0;
 
   // Convert the provided InitParamType into an MLIR `Attribute`.
@@ -316,7 +317,8 @@ public:
                                     const PopulateParamsInfo &info,
                                     const InitParamsNonAccel &params) override;
 
-  LogicalResult couldBePerformant(const PopulateParamsInfo &info,
+  LogicalResult couldBePerformant(OpBuilder &b,
+				  const PopulateParamsInfo &info,
                                   const InitParamsNonAccel &params) override;
 
   int64_t calculatePaddingAmount(const InitParamsNonAccel &params,
@@ -357,7 +359,8 @@ public:
                                     const PopulateParamsInfo &info,
                                     const InitParamsAccel &params) override;
 
-  LogicalResult couldBePerformant(const PopulateParamsInfo &info,
+  LogicalResult couldBePerformant(OpBuilder &b,
+				  const PopulateParamsInfo &info,
                                   const InitParamsAccel &params) override;
 
   virtual LogicalResult
@@ -376,9 +379,10 @@ protected:
   /// The actual implementation of couldBePerformant(), which shouldn't exist
   /// once we merge gridwise_gemm and gridwise_gemm_accel and thus flatten
   /// out the class heirachy in this file.
-  virtual LogicalResult specificCouldBePerformant(const InitParamsAccel &params,
-                                                  Type dataTypeA,
-                                                  Type dataTypeB) = 0;
+  virtual LogicalResult specificCouldBePerformant(OpBuilder &b,
+						  const PopulateParamsInfo &info,
+						  const InitParamsAccel &params) = 0;
+
 };
 
 //
@@ -413,9 +417,9 @@ public:
                        bool enableDPerWaveFiltering = true) override;
 
 protected:
-  LogicalResult specificCouldBePerformant(const InitParamsAccel &params,
-                                          Type dataTypeA,
-                                          Type dataTypeB) override;
+  LogicalResult specificCouldBePerformant(OpBuilder &b,
+					  const PopulateParamsInfo &info,
+					  const InitParamsAccel &params) override;
 };
 
 //
@@ -448,9 +452,9 @@ public:
                        bool enableDPerWaveFiltering = true) override;
 
 protected:
-  LogicalResult specificCouldBePerformant(const InitParamsAccel &params,
-                                          Type dataTypeA,
-                                          Type dataTypeB) override;
+  LogicalResult specificCouldBePerformant(OpBuilder &b,
+					  const PopulateParamsInfo &info,
+					  const InitParamsAccel &params) override;
 };
 
 } // namespace rock

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -341,14 +341,6 @@ PopulateParamsAccel::paramsProbablyValid(OpBuilder &b,
 LogicalResult
 PopulateParamsAccel::couldBePerformant(OpBuilder &b, const PopulateParamsInfo &info,
                                        const InitParamsAccel &params) {
-  //int64_t mRepeats = ;
-  //int64_t nRepeats = ;e
-  // look ABBEgg
-  // OpBuilder b
-  // info.gemmAType, info.gemmBtype
-  // info.arch
-  // tuningParams = op.getParams()
-  // 
   return specificCouldBePerformant(b, info, params);
 }
 
@@ -707,8 +699,6 @@ LogicalResult
 PopulateParamsXDL::specificCouldBePerformant(OpBuilder &b,
 					     const PopulateParamsInfo &info,
 					     const InitParamsAccel &params) {
-  // Implement this if needed.
-  /*
   Attribute params0 = getGemmParamsAttr(b, params);
   RockAccelTuningParamAttrInterface accelParams0;
   if (auto xdlopsParams0 = dyn_cast<XdlopsGemmParamsAttr>(params0)) {
@@ -718,23 +708,20 @@ PopulateParamsXDL::specificCouldBePerformant(OpBuilder &b,
     accelParams0 = cast<RockAccelTuningParamAttrInterface>(params0);
   }
   auto accelEmitterPtr = accel::AccelEmitter::select(
-						     info.gemmFeatures, info.gemmAType, info.gemmBType, info.arch.StringRef(), accelParams0);
+						     info.gemmFeatures, info.gemmAType, info.gemmBType, StringRef(info.arch), accelParams0);
 
   if (!accelEmitterPtr)
     return failure();
 
-  rock::accel::AccelEmitterParams params = accelEmitterPtr->getParams();
+  rock::accel::AccelEmitterParams accelParams = accelEmitterPtr->getParams();
 
-  int64_t numOutputVectorElements = params.numOutputVectorElements();
+  int64_t numOutputVectorElements = accelParams.numOutputVectorElements();
 
   // would be best to have register count be a part of arch, is not necessarily totalVGPRPerEu
   if(numOutputVectorElements > 256) {
     return failure();
   }
        
-     check output size
-    int64_t nOutputVectors = nResultVectors * mRepeats * nRepeats;
-   */
   
   return success();
 }

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/Dialect/Rock/utility/math.h"
+#include "mlir/Dialect/Rock/IR/AccelEmitter.h"
 #include "mlir/Support/LogicalResult.h"
 
 #include "llvm/Support/Debug.h"
@@ -212,9 +213,11 @@ PopulateParams::paramsProbablyValid(OpBuilder &b,
 }
 
 LogicalResult
-PopulateParams::couldBePerformant(const PopulateParamsInfo &info,
+PopulateParams::couldBePerformant(OpBuilder &b,
+				  const PopulateParamsInfo &info,
                                   const InitParamsNonAccel &params) {
   // Implement this if needed.
+  (void)b;
   (void)info;
   (void)params;
   return success();
@@ -336,9 +339,17 @@ PopulateParamsAccel::paramsProbablyValid(OpBuilder &b,
 }
 
 LogicalResult
-PopulateParamsAccel::couldBePerformant(const PopulateParamsInfo &info,
+PopulateParamsAccel::couldBePerformant(OpBuilder &b, const PopulateParamsInfo &info,
                                        const InitParamsAccel &params) {
-  return specificCouldBePerformant(params, info.gemmAType, info.gemmBType);
+  //int64_t mRepeats = ;
+  //int64_t nRepeats = ;e
+  // look ABBEgg
+  // OpBuilder b
+  // info.gemmAType, info.gemmBtype
+  // info.arch
+  // tuningParams = op.getParams()
+  // 
+  return specificCouldBePerformant(b, info, params);
 }
 
 LogicalResult PopulateParamsAccel::obtainTuningParameters(
@@ -693,12 +704,38 @@ PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataTypeA,
 }
 
 LogicalResult
-PopulateParamsXDL::specificCouldBePerformant(const InitParamsAccel &params,
-                                             Type dataTypeA, Type dataTypeB) {
+PopulateParamsXDL::specificCouldBePerformant(OpBuilder &b,
+					     const PopulateParamsInfo &info,
+					     const InitParamsAccel &params) {
   // Implement this if needed.
-  (void)params;
-  (void)dataTypeA;
-  (void)dataTypeB;
+  /*
+  Attribute params0 = getGemmParamsAttr(b, params);
+  RockAccelTuningParamAttrInterface accelParams0;
+  if (auto xdlopsParams0 = dyn_cast<XdlopsGemmParamsAttr>(params0)) {
+    auto xdlopsDerivedParams0 = XdlopsGemmDerivedParamsAttr::get(xdlopsParams0);
+    accelParams0 = xdlopsDerivedParams0;
+  } else {
+    accelParams0 = cast<RockAccelTuningParamAttrInterface>(params0);
+  }
+  auto accelEmitterPtr = accel::AccelEmitter::select(
+						     info.gemmFeatures, info.gemmAType, info.gemmBType, info.arch.StringRef(), accelParams0);
+
+  if (!accelEmitterPtr)
+    return failure();
+
+  rock::accel::AccelEmitterParams params = accelEmitterPtr->getParams();
+
+  int64_t numOutputVectorElements = params.numOutputVectorElements();
+
+  // would be best to have register count be a part of arch, is not necessarily totalVGPRPerEu
+  if(numOutputVectorElements > 256) {
+    return failure();
+  }
+       
+     check output size
+    int64_t nOutputVectors = nResultVectors * mRepeats * nRepeats;
+   */
+  
   return success();
 }
 
@@ -913,12 +950,13 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
 }
 
 LogicalResult
-PopulateParamsWmma::specificCouldBePerformant(const InitParamsAccel &params,
-                                              Type dataTypeA, Type dataTypeB) {
+PopulateParamsWmma::specificCouldBePerformant(OpBuilder &b,
+					     const PopulateParamsInfo &info,
+					     const InitParamsAccel &params) {
   // Implement this if needed.
+  (void)b;
+  (void)info;
   (void)params;
-  (void)dataTypeA;
-  (void)dataTypeB;
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -272,7 +272,7 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
                               b, info, gemmParams)) &&
                           (kind == TuningParamSetKind::Exhaustive ||
                            succeeded(
-                               tuningInfo.couldBePerformant(info, gemmParams))))
+				     tuningInfo.couldBePerformant(b, info, gemmParams))))
                         newSpace->tuningRange.push_back(
                             cast<RockTuningParamAttrInterface>(
                                 tuningInfo.getGemmParamsAttr(b, gemmParams)));
@@ -309,7 +309,7 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
                                                                  gemmParams)) &&
                         (kind == TuningParamSetKind::Exhaustive ||
                          succeeded(
-                             tuningInfo.couldBePerformant(info, gemmParams))))
+                             tuningInfo.couldBePerformant(b, info, gemmParams))))
                       newSpace->tuningRange.push_back(
                           cast<RockTuningParamAttrInterface>(
                               tuningInfo.getGemmParamsAttr(b, gemmParams)));
@@ -340,7 +340,7 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
                                                                gemmParams)) &&
                       (kind == TuningParamSetKind::Exhaustive ||
                        succeeded(
-                           tuningInfo.couldBePerformant(info, gemmParams))))
+                           tuningInfo.couldBePerformant(b, info, gemmParams))))
                     newSpace->tuningRange.push_back(
                         cast<RockTuningParamAttrInterface>(
                             tuningInfo.getGemmParamsAttr(b, gemmParams)));


### PR DESCRIPTION
Try pruning configs that take too many registers as likely non-performant. This adds a tentative check in the XDLOPs `specificCouldBePerformant()` function to see if the output size (`numOutputVectorElements`) is greater than the number of available registers.