### PR TITLE
Fix `mhal::PrefillAttr` data retrieval after switching to target attributes

### DIFF
--- a/external/mlir-hal/include/mlir/Dialect/MHAL/Utility/Utils.h
+++ b/external/mlir-hal/include/mlir/Dialect/MHAL/Utility/Utils.h
@@ -13,16 +13,16 @@
 
 namespace mlir {
 
-namespace LLVM {
-class LLVMFuncOp;
+namespace gpu {
+class BinaryOp;
 }
 
 namespace mhal {
 
 class PrefillAttr;
 
-// Return `mhal::PrefillAttr` attributes for a given function
-SmallVector<PrefillAttr> getStoredPrefillAttributes(LLVM::LLVMFuncOp func);
+// Return `mhal::PrefillAttr` attributes for a given binary
+SmallVector<PrefillAttr> getStoredPrefillAttributes(gpu::BinaryOp binary);
 
 } // namespace mhal
 } // end namespace mlir

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -11,6 +11,7 @@
 #include "mlir/CAPI/Pass.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Wrap.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MHAL/Utility/Utils.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
@@ -168,13 +169,11 @@ size_t mlirGetNumPrefillArgs(MlirModule module) {
   auto mod = unwrap(module);
   assert(mod.getRegion().getBlocks().size() == 1 &&
          "expected a single block/function in a module");
-
-  std::optional<LLVM::LLVMFuncOp> func = std::nullopt;
-  mod.walk([&](LLVM::LLVMFuncOp op) { func = op; });
-
-  if (!func.has_value())
+  std::optional<gpu::BinaryOp> binary = std::nullopt;
+  mod.walk([&](gpu::BinaryOp op) { binary = op; });
+  if (!binary.has_value())
     return 0;
-  auto attrs = mhal::getStoredPrefillAttributes(func.value());
+  auto attrs = mhal::getStoredPrefillAttributes(binary.value());
   return attrs.size();
 }
 
@@ -185,12 +184,11 @@ void mlirGetPrefillArgsInfo(MlirModule module, size_t *indices,
   assert(mod.getRegion().getBlocks().size() == 1 &&
          "expected a single block/function in a module");
 
-  std::optional<LLVM::LLVMFuncOp> func = std::nullopt;
-  mod.walk([&](LLVM::LLVMFuncOp op) { func = op; });
-
-  if (!func.has_value())
+  std::optional<gpu::BinaryOp> binary = std::nullopt;
+  mod.walk([&](gpu::BinaryOp op) { binary = op; });
+  if (!binary.has_value())
     return;
-  auto attrs = mhal::getStoredPrefillAttributes(func.value());
+  auto attrs = mhal::getStoredPrefillAttributes(binary.value());
 
   assert(attrs.size() >= length && "length cannot exceed the attr size");
   for (size_t i = 0; i < length; ++i) {


### PR DESCRIPTION
This patch updates `mhal::getStoredPrefillAttributes`, `mlirGetNumPrefillArgs`, and `mlirGetPrefillArgsInfo` to work on GPU binaries.

Previously `mhal::PrefillAttr` attributes were stored on the GPU module discardable attributes. However, now they are stored in the property dictionary of `#gpu.object` attributes.

This patch fixes: https://github.com/ROCm/rocMLIR-internal/issues/1543
However, the tests remain de-activated.