### PR TITLE
Change BufferDependencyAnalysis to use OpOperand* in its internals

### DIFF
--- a/mlir/include/mlir/Analysis/BufferDependencyAnalysis.h
+++ b/mlir/include/mlir/Analysis/BufferDependencyAnalysis.h
@@ -27,16 +27,16 @@ namespace mlir {
 struct BufferDependencyAnalysis {
   BufferDependencyAnalysis(Operation *op);
 
-  std::optional<llvm::SmallVector<Operation *>>
+  std::optional<llvm::SmallVector<OpOperand *>>
   getReaders(memref::AllocOp allocOp);
-  std::optional<llvm::SmallVector<Operation *>>
+  std::optional<llvm::SmallVector<OpOperand *>>
   getWriters(memref::AllocOp allocOp);
 
-  const llvm::DenseMap<memref::AllocOp, llvm::SmallVector<Operation *>> &
+  const llvm::DenseMap<memref::AllocOp, llvm::SmallVector<OpOperand *>> &
   getReadersTable() {
     return readersTable;
   }
-  const llvm::DenseMap<memref::AllocOp, llvm::SmallVector<Operation *>> &
+  const llvm::DenseMap<memref::AllocOp, llvm::SmallVector<OpOperand *>> &
   getWritersTable() {
     return writersTable;
   }
@@ -44,10 +44,14 @@ struct BufferDependencyAnalysis {
   // Returns the operation this analysis was constructed from.
   Operation *getOperation() const { return op; }
 
+  // Compute the analysis on `op`, overwriting existing analysis if necessary.
+  // This is to be used after updating the graph.
+  void analyze(memref::AllocOp allocOp);
+
 private:
   Operation *op;
-  llvm::DenseMap<memref::AllocOp, llvm::SmallVector<Operation *>> readersTable;
-  llvm::DenseMap<memref::AllocOp, llvm::SmallVector<Operation *>> writersTable;
+  llvm::DenseMap<memref::AllocOp, llvm::SmallVector<OpOperand *>> readersTable;
+  llvm::DenseMap<memref::AllocOp, llvm::SmallVector<OpOperand *>> writersTable;
 };
 } // namespace mlir
 

--- a/mlir/test/lib/Dialect/Rock/TestBufferDependencyAnalysis.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestBufferDependencyAnalysis.cpp
@@ -94,8 +94,9 @@ static LogicalResult analyse(func::FuncOp func) {
     // test readers
     auto testReaders = analysis.getReaders(allocOp);
     if (testReaders.has_value()) {
-      for (auto *testReaderOp : testReaders.value()) {
-        auto testReaderOpName = testReaderOp->getName().getStringRef();
+      for (auto *testReaderOperand : testReaders.value()) {
+        auto testReaderOpName =
+            testReaderOperand->getOwner()->getName().getStringRef();
         if (!expectedOpNames.readers.contains(testReaderOpName)) {
           std::lock_guard<std::mutex> guard(mutex);
           llvm::errs() << "failed to find `" << testReaderOpName
@@ -108,8 +109,9 @@ static LogicalResult analyse(func::FuncOp func) {
     // test writers
     auto testWriters = analysis.getWriters(allocOp);
     if (testWriters.has_value()) {
-      for (auto *testWriterOp : testWriters.value()) {
-        auto testWriterOpName = testWriterOp->getName().getStringRef();
+      for (auto *testWriterOperand : testWriters.value()) {
+        auto testWriterOpName =
+            testWriterOperand->getOwner()->getName().getStringRef();
         if (!expectedOpNames.writers.contains(testWriterOpName)) {
           std::lock_guard<std::mutex> guard(mutex);
           llvm::errs() << "failed to find `" << testWriterOpName


### PR DESCRIPTION
I'm refactoring the regularization pass to correctly handle multiple readers from a fusor's buffer. As part of this, I realized I should go ahead and migrate that pass to BufferDependencyAnalysis as planned.

While thinking about that, I realized that the reader and writer lists should actually consist of OpOperand*'s (that is, effectively, an operation and a position within that operation's operands - or, equivalently, a Value and a way to identify a specific use of that value). This allows users of the analysis to, for example, pick out the (probably transformed) value that a reader or writer is operating on, which'd allow for, for example, calls to isolateTransforms() on that value.

This commit also adds the analyze() method so that when new buffers are added or existing buffers have their use lists modified, the results of the analysis can be recomputed.

This commit doesn't directly fix any bugs but does pave the way to fixes for our reduction fusion issues.