### PR TITLE
Fix multi-output fusion bugs by reworking regularization

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/Rock.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/Rock.h
@@ -40,6 +40,15 @@ class PatternRewriter;
 #include "mlir/Dialect/Rock/IR/ConvolutionDims.h"
 #include "mlir/Dialect/Rock/IR/GemmSize.h"
 
+namespace mlir {
+namespace OpTrait {
+namespace rock {
+template <typename ConcreteType>
+class FusionRoot : public TraitBase<ConcreteType, FusionRoot> {};
+} // namespace rock
+} // namespace OpTrait
+} // namespace mlir
+
 // Following ifdef could be used to change
 // the attention operator to be a fused gemm-gemm
 // kernel for debugging purposes. This will also

--- a/mlir/include/mlir/Dialect/Rock/IR/RockBase.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockBase.td
@@ -26,4 +26,8 @@ def Rock_Dialect : Dialect {
   }];
 }
 
+def RockFusionRoot : NativeOpTrait<"FusionRoot"> {
+  let cppNamespace = "mlir::OpTrait::rock";
+}
+
 #endif // ROCK_BASE

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -205,13 +205,13 @@ def Rock_ReduceOp :
 }
 
 def Rock_AttentionOp :
-  Rock_Op<"attention">,
+  Rock_Op<"attention", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]>,
   Arguments<(ins
-    Arg<TensorOrMemRefOf<[F32, F16, I8]>, "queries", [MemRead]>:$queries,
-    Arg<TensorOrMemRefOf<[F32, F16, I8]>, "keys", [MemRead]>:$keys,
-    Arg<TensorOrMemRefOf<[F32, F16]>, "values", [MemRead]>:$values,
+    TensorOrMemRefOf<[F32, F16, I8]>:$queries,
+    TensorOrMemRefOf<[F32, F16, I8]>:$keys,
+    TensorOrMemRefOf<[F32, F16]>:$values,
     Variadic<TensorOrMemRefOf<[F32, F16, I8]>>:$preSoftmaxElemWiseInputs,
-    Arg<TensorOrMemRefOf<[F32, F16]>, "output", [MemRead, MemWrite]>:$out,
+    TensorOrMemRefOf<[F32, F16]>:$out,
     UnitAttr:$qTransposed,
     UnitAttr:$kTransposed,
     UnitAttr:$vTransposed,
@@ -386,9 +386,9 @@ def Rock_TensorUntransformCastOp :
 
 def Rock_GridwiseGemmOp :
     Rock_Op<"gridwise_gemm">,
-    Arguments<(ins MemRefRankOf<GemmInputTypes, [3]>:$a,
-                   MemRefRankOf<GemmInputTypes, [3]>:$b,
-                   MemRefRankOf<GemmAccumulatorTypes, [3]>:$c,
+    Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix A view", [MemRead]>:$a,
+                   Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
+                   Arg<MemRefRankOf<GemmAccumulatorTypes, [3]>, "matrix C view", [MemRead, MemWrite]>:$c,
                    Rock_GemmFeaturesAttr:$features,
                    StoreMethodAttr:$storeMethod,
                    I32Attr:$numCU,
@@ -407,9 +407,9 @@ def Rock_GridwiseGemmOp :
 // gridwise_gemm_accel
 def Rock_GridwiseGemmAccelOp :
     Rock_Op<"gridwise_gemm_accel">,
-    Arguments<(ins MemRefRankOf<GemmInputTypes, [3]>:$a,
-                   MemRefRankOf<GemmInputTypes, [3]>:$b,
-                   MemRefRankOf<GemmAccumulatorTypes, [3]>:$c,
+    Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix A view", [MemRead]>:$a,
+                   Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
+                   Arg<MemRefRankOf<GemmAccumulatorTypes, [3]>, "matrix C view", [MemRead, MemWrite]>:$c,
                    StrAttr:$arch,
                    I32Attr:$numCU,
                    Rock_GemmFeaturesAttr:$features,
@@ -429,7 +429,7 @@ def Rock_GridwiseGemmAccelOp :
 
 // gridwise_attention_accel
 def Rock_GridwiseAttentionAccelOp :
-    Rock_Op<"gridwise_attention_accel">,
+    Rock_Op<"gridwise_attention_accel", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]>,
     Arguments<(ins MemRefRankOf<[F32, F16, I8], [3]>:$queries,
                    MemRefRankOf<[F32, F16, I8], [3]>:$keys,
                    MemRefRankOf<[F32, F16], [3]>:$values,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -63,7 +63,8 @@ class IndexArrayLength<int n> : ConfinedAttr<IndexArrayAttr, [ArrayMinCount<n>]>
 class Rock_ConvOpBase<string mnemonic, list<Type> inputTypes=[F32, F16, BF16], list<Type> outputTypes=[F32, F16, BF16]> :
     Rock_Op<mnemonic, [DeclareOpInterfaceMethods<RockGemmWrapperInterface>,
                        DeclareOpInterfaceMethods<RockConvInterface>,
-                       DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]>{
+                       DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                       RockFusionRoot]>{
     dag commonConvArgs = (ins TensorOrMemRefRankOf<inputTypes, [5,6]>:$filter,
                               TensorOrMemRefRankOf<inputTypes, [5,6]>:$input,
                               TensorOrMemRefRankOf<outputTypes, [5,6]>:$output,
@@ -133,7 +134,7 @@ def Rock_ConvBwdWeightOp : Rock_ConvOpBase<"conv_bwd_weight">
 }
 
 def Rock_GemmOp :
-    Rock_Op<"gemm", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>]>,
+    Rock_Op<"gemm", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>, RockFusionRoot]>,
     Arguments<(ins Arg<TensorOrMemRefRankOf<GemmInputTypes, [2, 3]>,
                        "matrix A", [MemRead]>:$a,
                    Arg<TensorOrMemRefRankOf<GemmInputTypes, [2, 3]>,
@@ -205,7 +206,7 @@ def Rock_ReduceOp :
 }
 
 def Rock_AttentionOp :
-  Rock_Op<"attention", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]>,
+  Rock_Op<"attention", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, RockFusionRoot]>,
   Arguments<(ins
     TensorOrMemRefOf<[F32, F16, I8]>:$queries,
     TensorOrMemRefOf<[F32, F16, I8]>:$keys,
@@ -385,7 +386,7 @@ def Rock_TensorUntransformCastOp :
 }
 
 def Rock_GridwiseGemmOp :
-    Rock_Op<"gridwise_gemm">,
+    Rock_Op<"gridwise_gemm", [RockFusionRoot]>,
     Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix A view", [MemRead]>:$a,
                    Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
                    Arg<MemRefRankOf<GemmAccumulatorTypes, [3]>, "matrix C view", [MemRead, MemWrite]>:$c,
@@ -406,7 +407,7 @@ def Rock_GridwiseGemmOp :
 
 // gridwise_gemm_accel
 def Rock_GridwiseGemmAccelOp :
-    Rock_Op<"gridwise_gemm_accel">,
+    Rock_Op<"gridwise_gemm_accel", [RockFusionRoot]>,
     Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix A view", [MemRead]>:$a,
                    Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
                    Arg<MemRefRankOf<GemmAccumulatorTypes, [3]>, "matrix C view", [MemRead, MemWrite]>:$c,
@@ -429,7 +430,7 @@ def Rock_GridwiseGemmAccelOp :
 
 // gridwise_attention_accel
 def Rock_GridwiseAttentionAccelOp :
-    Rock_Op<"gridwise_attention_accel", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]>,
+    Rock_Op<"gridwise_attention_accel", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, RockFusionRoot]>,
     Arguments<(ins MemRefRankOf<[F32, F16, I8], [3]>:$queries,
                    MemRefRankOf<[F32, F16, I8], [3]>:$keys,
                    MemRefRankOf<[F32, F16], [3]>:$values,

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1796,6 +1796,20 @@ LogicalResult GridwiseAttentionAccelOp::verify() {
   return success();
 }
 
+void GridwiseAttentionAccelOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  auto *read = MemoryEffects::Read::get();
+  auto *write = MemoryEffects::Write::get();
+  effects.emplace_back(read, &getOutMutable());
+  effects.emplace_back(write, &getOutMutable());
+
+  effects.emplace_back(read, &getQueriesMutable());
+  effects.emplace_back(read, &getKeysMutable());
+  effects.emplace_back(read, &getValuesMutable());
+  for (auto &regionArg : getPreSoftmaxElemWiseInputsMutable())
+    effects.emplace_back(read, &regionArg);
+}
+
 //===----------------------------------------------------------------------===//
 // WorkgroupIdOp and WorkitemIdOp
 //===----------------------------------------------------------------------===//
@@ -2000,6 +2014,20 @@ LogicalResult AttentionOp::verify() {
     return emitError("reduction dimensions of second gemm do not match");
   }
   return success();
+}
+
+void AttentionOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  auto *read = MemoryEffects::Read::get();
+  auto *write = MemoryEffects::Write::get();
+  effects.emplace_back(read, &getOutMutable());
+  effects.emplace_back(write, &getOutMutable());
+
+  effects.emplace_back(read, &getQueriesMutable());
+  effects.emplace_back(read, &getKeysMutable());
+  effects.emplace_back(read, &getValuesMutable());
+  for (auto &regionArg : getPreSoftmaxElemWiseInputsMutable())
+    effects.emplace_back(read, &regionArg);
 }
 
 //===-----------------------------------------------------===//

--- a/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
@@ -14,23 +14,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ============================================================
+#include "mlir/Analysis/BufferDependencyAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
-#include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.h"
-#include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/Passes.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
 namespace mlir {
@@ -147,187 +146,452 @@ struct RegularizeGenericRewritePattern
   }
 };
 
-void AnnotateGenericOp(Operation *op, MLIRContext *ctx) {
-  if (auto lgop = dyn_cast<linalg::GenericOp>(op)) {
-    int64_t majorTensorSize = 0;
-    size_t majorTensorIdx;
-    size_t inputIdx = 0;
-    size_t argIdx = -1;
-    if (lgop.getInputs().size() == 1) {
-      lgop->setAttr("rock.majorTensorNumber",
-                    IntegerAttr::get(IndexType::get(ctx), 1));
-      return;
-    }
-    for (auto inp : lgop.getInputs()) {
-      while (auto viewOp =
-                 dyn_cast_or_null<ViewLikeOpInterface>(inp.getDefiningOp()))
-        inp = viewOp.getViewSource();
-
-      if (isa<BlockArgument>(inp)) {
-        auto arg = dyn_cast<BlockArgument>(inp);
-        auto shape = cast<ShapedType>(inp.getType());
-        int64_t argSize = shape.getNumElements();
-        if (inputIdx == 0 || argSize > majorTensorSize ||
-            (argSize == majorTensorSize && argIdx > arg.getArgNumber())) {
-          majorTensorIdx = inputIdx;
-          majorTensorSize = argSize;
-          argIdx = arg.getArgNumber();
-        }
-      }
-      inputIdx++;
-    }
-    if (majorTensorIdx >= 0)
-      lgop->setAttr("rock.majorTensorNumber",
-                    IntegerAttr::get(IndexType::get(ctx), majorTensorIdx));
+static void annotateGenericOp(linalg::GenericOp lgop) {
+  MLIRContext *ctx = lgop.getContext();
+  int64_t majorTensorSize = 0;
+  size_t majorTensorIdx;
+  size_t argIdx = -1;
+  if (lgop.getInputs().size() == 1) {
+    lgop->setAttr("rock.majorTensorNumber",
+                  IntegerAttr::get(IndexType::get(ctx), 1));
+    return;
   }
-  return;
+  for (auto [inputIdx, inp] : llvm::enumerate(lgop.getInputs())) {
+    while (auto viewOp =
+               dyn_cast_or_null<ViewLikeOpInterface>(inp.getDefiningOp()))
+      inp = viewOp.getViewSource();
+
+    if (isa<BlockArgument>(inp)) {
+      auto arg = dyn_cast<BlockArgument>(inp);
+      auto shape = cast<ShapedType>(inp.getType());
+      int64_t argSize = shape.getNumElements();
+      if (inputIdx == 0 || argSize > majorTensorSize ||
+          (argSize == majorTensorSize && argIdx > arg.getArgNumber())) {
+        majorTensorIdx = inputIdx;
+        majorTensorSize = argSize;
+        argIdx = arg.getArgNumber();
+      }
+    }
+  }
+  if (majorTensorIdx >= 0)
+    lgop->setAttr("rock.majorTensorNumber",
+                  IntegerAttr::get(IndexType::get(ctx), majorTensorIdx));
 }
 
 ////////////////////////////////////////////////////////////////////////
-////  Push Transforms Over alloc to writer
+////  Classify buffer writes into input and output fusion chains
 ////////////////////////////////////////////////////////////////////////
-struct PushTransformsUpRewritePattern
-    : public OpRewritePattern<memref::AllocOp> {
-  using OpRewritePattern<memref::AllocOp>::OpRewritePattern;
 
-  /////////////////////////////////////////////////////////////////////
-  static bool isFusorOp(Operation *useOp, Value viewedBuffer) {
-    if (auto reduceOp = dyn_cast<rock::ReduceOp>(useOp))
-      return reduceOp.getOut() == viewedBuffer;
-    return isa<rock::GridwiseGemmOp, rock::GridwiseGemmAccelOp,
-               rock::GridwiseAttentionAccelOp, rock::ThreadwiseWriteAllOp>(
-        useOp);
-  }
-
-  static bool collectChain(Value result, Operation *forwOp,
-                           SmallVector<Operation *> &chain) {
-    while (auto top = dyn_cast<rock::TransformOp>(forwOp)) {
-      result = top.getResult();
-      if (!result.hasOneUse()) {
-        // currently restricted to 1 reader
-        LLVM_DEBUG(llvm::dbgs() << "multiple readers on transform\n");
-        return false; // TODO: fix when encountered
-      }
-      chain.push_back(forwOp);
-      forwOp = (*result.getUses().begin()).getOwner();
-    }
-    chain.push_back(forwOp);
-    if (auto lgop = dyn_cast<linalg::GenericOp>(forwOp)) {
-      return llvm::is_contained(lgop.getOutputs(), result);
-    } else if (auto mcop = dyn_cast<memref::CopyOp>(forwOp)) {
-      // should never be output of memcpy?
-      assert(mcop.getTarget() != result);
-      return mcop.getTarget() == result;
-    } else if (auto rgop = dyn_cast<rock::GridwiseGemmOp>(forwOp)) {
-      return rgop.getC() == result;
-    } else if (auto rgop = dyn_cast<rock::GridwiseGemmAccelOp>(forwOp)) {
-      return rgop.getC() == result;
-    } else if (auto rgop = dyn_cast<rock::GridwiseAttentionAccelOp>(forwOp)) {
-      return rgop.getOut() == result;
-    } else if (auto reduceOp = dyn_cast<rock::ReduceOp>(forwOp)) {
-      return reduceOp.getOut() == result;
-    } else if (auto rgop = dyn_cast<rock::ThreadwiseWriteAllOp>(forwOp)) {
-      return rgop.getDest() == result;
-    }
-    LLVM_DEBUG(llvm::dbgs() << "unsupported op\n" << *forwOp);
-    return false;
-  }
-
-  LogicalResult matchAndRewrite(memref::AllocOp alloc,
-                                PatternRewriter &rw) const override {
-    LogicalResult lres = failure();
-    Value buffer = alloc.getResult();
-
-    bool hasTransforms = false;
-    Operation *writer = nullptr;
-    Operation *fusor = nullptr;
-    SmallVector<SmallVector<Operation *>> readChains;
-
-    // find the fusor
-    for (auto &use : buffer.getUses()) {
-      Operation *useOp = use.getOwner();
-      Value result = buffer;
-      while (auto top = dyn_cast<rock::TransformOp>(useOp)) {
-        result = top.getResult();
-        useOp = (*result.getUses().begin()).getOwner();
-      }
-      if (isFusorOp(useOp, result)) {
-        fusor = useOp;
-      } else if (auto lgop = dyn_cast<linalg::GenericOp>(useOp)) {
-        if (!fusor && llvm::is_contained(lgop.getOutputs(), result))
-          fusor = useOp;
-      }
-    }
-
-    // find fusee's transform chains
-    for (auto &use : buffer.getUses()) {
-      Operation *useOp = use.getOwner();
-      SmallVector<Operation *> chain;
-      bool isWriter = collectChain(buffer, useOp, chain);
-      if (isWriter) {
-        assert(writer == nullptr);
-        writer = useOp;
-      }
-      if (!chain.empty() && chain.back() != fusor) {
-        hasTransforms |= chain.size() > 1;
-        readChains.push_back(chain);
-      }
-    }
-
-    // push transforms from fusee to fusor
-    if (fusor && hasTransforms) {
-      PatternRewriter::InsertionGuard guard(rw);
-      rw.setInsertionPoint(alloc);
-      Location loc = alloc.getLoc();
-      for (auto readChain : readChains) {
-        if (readChain.size() > 1) {
-          Operation *readOp = readChain.back();
-          readChain.pop_back();
-          assert(!isa<rock::TransformOp>(readOp));
-          Operation *lastTOp = readChain.back();
-          Value readInp = lastTOp->getResult(0);
-
-          // Collect inverses of transforms now so we can bail without modifying
-          // IR.
-          SmallVector<TransformMapAttr> inverses;
-          inverses.reserve(readChain.size());
-          for (Operation *op : llvm::reverse(readChain)) {
-            auto txOp = dyn_cast<rock::TransformOp>(op);
-            if (!txOp)
-              return rw.notifyMatchFailure(op->getLoc(),
-                                           "non-transform op in read chain");
-            auto itx = rock::invertTransformMap(rw, txOp.getTransform(), loc);
-            if (!itx)
-              return rw.notifyMatchFailure(
-                  txOp.getLoc(), [&txOp](Diagnostic &diag) {
-                    diag << "unable to invert transform" << txOp.getTransform();
-                  });
-            inverses.push_back(itx);
-          }
-
-          // create new buffer (substitue in fusee)
-          MemRefType nbufferType = cast<MemRefType>(readInp.getType());
-          Value nbuffer =
-              rw.create<memref::AllocOp>(loc, nbufferType).getResult();
-          // update fusee with new buffer input
-          readOp->replaceUsesOfWith(readInp, nbuffer);
-
-          // insert inverse transforms after new buffer to fusor chain
-          Value val = nbuffer;
-          for (auto [itx, op] : llvm::zip(inverses, llvm::reverse(readChain))) {
-            auto top = rw.create<rock::TransformOp>(loc, val, itx);
-            val = top.getResult();
-            rw.eraseOp(op);
-          }
-          rw.replaceOp(alloc, val);
-
-          lres = success();
-        }
-      }
-    }
-    return lres;
-  }
+namespace {
+struct TransformPushState {
+  llvm::SmallVector<memref::AllocOp> worklist;
+  llvm::SmallPtrSet<OpOperand *, 8> inputFusionWrites;
+  llvm::SmallPtrSet<OpOperand *, 8> outputFusionWrites;
 };
+} // end namespace
+
+/// Given an operand that reads a buffer, collect the writer of thet buffer and,
+/// recursively, all the writers of the buffers that writer reads, and so on.
+/// This is meant to collect all the buffer writes involved in an input fusion.
+static void collectInputFusionWrites(OpOperand *reader,
+                                     const BufferDependencyAnalysis &bufferDeps,
+                                     TransformPushState &state) {
+  std::optional<memref::AllocOp> maybeBuffer = bufferDeps.getReadBuffer(reader);
+  // This reads an argument or some such thing
+  if (!maybeBuffer)
+    return;
+  std::optional<SmallVector<OpOperand *>> writers =
+      bufferDeps.getWriters(*maybeBuffer);
+  if (!writers)
+    return;
+  for (OpOperand *writer : *writers) {
+    if (!state.inputFusionWrites.insert(writer).second) {
+      continue; // No infinite recursion
+    }
+    auto writeOp = dyn_cast<MemoryEffectOpInterface>(writer->getOwner());
+    if (!writeOp)
+      continue;
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    writeOp.getEffects(effects);
+    for (const auto &effect : effects) {
+      OpOperand *maybeRecursiveReader = effect.getEffectValue<OpOperand *>();
+      // Test against `writer` to guard against [MemRead, MemWrite]
+      if (maybeRecursiveReader && maybeRecursiveReader != writer &&
+          isa<MemoryEffects::Read>(effect.getEffect())) {
+        collectInputFusionWrites(maybeRecursiveReader, bufferDeps, state);
+      }
+    }
+  }
+}
+
+/// Given the operand that writes to a buffer, collect the writes of its reader,
+/// and the writes of that reader, and so on until you're no longer writing to a
+/// buffer. If any auxiliary inputs come from buffers themselves, collect
+/// their writes as input fusions, because, in a fusion context, those other
+/// writers will be tiled by a threadwise_read_into, not a threadwise_write_all.
+static void
+collectOutputFusionWrites(OpOperand *writer,
+                          const BufferDependencyAnalysis &bufferDeps,
+                          TransformPushState &state) {
+  std::optional<memref::AllocOp> maybeBuffer =
+      bufferDeps.getWrittenBuffer(writer);
+  // This reads an argument or some such thing
+  if (!maybeBuffer)
+    return;
+  if (!state.outputFusionWrites.insert(writer).second)
+    return; // Prevent recursion
+  std::optional<SmallVector<OpOperand *>> readers =
+      bufferDeps.getReaders(*maybeBuffer);
+  if (!readers)
+    return;
+  SmallPtrSet<OpOperand *, 4> elementwiseArgs, onwardWrites;
+  for (OpOperand *reader : *readers) {
+    auto readOp = dyn_cast<MemoryEffectOpInterface>(reader->getOwner());
+    if (!readOp)
+      continue;
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    readOp.getEffects(effects);
+    for (const auto &effect : effects) {
+      OpOperand *operand = effect.getEffectValue<OpOperand *>();
+      if (!operand || operand == reader)
+        continue;
+      if (isa<MemoryEffects::Write>(effect.getEffect())) {
+        onwardWrites.insert(operand);
+        elementwiseArgs.erase(operand);
+      }
+      if (isa<MemoryEffects::Read>(effect.getEffect()) &&
+          !onwardWrites.contains(operand)) {
+        elementwiseArgs.insert(operand);
+      }
+    }
+  }
+  for (OpOperand *arg : elementwiseArgs)
+    collectInputFusionWrites(arg, bufferDeps, state);
+  for (OpOperand *localWrite : onwardWrites) {
+    LLVM_DEBUG(llvm::dbgs() << "Traversing via onward writer: "
+                            << *localWrite->getOwner() << "\n");
+    collectOutputFusionWrites(localWrite, bufferDeps, state);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////
+////  Push Transforms Over alloc to fusor
+////////////////////////////////////////////////////////////////////////
+
+/// In the below, a fusor is the operation that will have some computation fused
+/// into it. This is usually a gemm (either its output or inputs) but can be,
+/// for example, another linalg.generic. The operation that will be fused into
+/// the fusor is the fusee.
+///
+/// A fusor writes to or reads from a memref.alloc() and a fusee does the
+/// opposite of what the fusor does. Before this pass runs, both the fusor and
+/// the fusee may access that intermediate buffer (which will be rewritten away
+/// by fusion) through some sequence of view operations.
+///
+/// After these rewrites, we have the following invariants, which make the
+/// fusion code itself (it's down in AlignTiling.cpp) much simpler and enables
+/// analysis of vectorization within the parts of the pipeline between this pass
+/// and AlignTiling (which can be important for key performance queries).
+///
+/// - The fusee always has a direct reference to the buffer
+///
+/// Furthermore, if multiple fusees have such a non-direct reference, the
+/// intermediate buffer will be duplicated so that each transform stack can be
+/// inverted in isolation.
+
+/// Invert the transform stack between `operand` and `oldAlloc`, replacing all
+/// users but that transform stack with a new allocation whose type is the type
+/// of the front of the transform stack. If the original transforms (and
+/// allocation) then have no other uses, erase them after doing this. This also
+/// updates worklists with the new allocation and reanalyzes the buffer
+/// dependencies.
+static LogicalResult
+regularizeTransformStack(memref::AllocOp oldAlloc, OpOperand *transformedUse,
+                         BufferDependencyAnalysis &bufferDeps,
+                         TransformPushState &state, IRRewriter &rw) {
+  SmallVector<TransformOp> transforms;
+  Value transformed = transformedUse->get();
+  Value buffer;
+  std::tie(buffer, std::ignore) = untransform(transformed, transforms);
+  if (buffer != oldAlloc.getResult()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "While processing " << transformed << " wanted to reach "
+               << oldAlloc.getResult() << " but reached " << buffer << "\n");
+    return oldAlloc->emitError(
+        "mismatch between expected buffer and result of untransform() while "
+        "inverting fusion transforms");
+  }
+
+  SmallVector<std::pair<TransformMapAttr, Location>> inverses;
+  inverses.reserve(transforms.size());
+  for (TransformOp transform : llvm::reverse(transforms)) {
+    Location loc = transform.getLoc();
+    TransformMapAttr inverse =
+        invertTransformMap(rw, transform.getTransform(), loc);
+    if (!inverse)
+      return transform.emitOpError("could not invert fusee transform while "
+                                   "regularizing fusions. Map = ")
+             << transform.getTransform();
+    inverses.emplace_back(inverse, loc);
+  }
+
+  rw.setInsertionPointAfter(oldAlloc);
+  auto newAlloc = rw.create<memref::AllocOp>(
+      oldAlloc.getLoc(), cast<MemRefType>(transformed.getType()));
+  Value newBuffer = newAlloc.getResult();
+  rw.modifyOpInPlace(transformedUse->getOwner(),
+                     [&]() { transformedUse->set(newBuffer); });
+  Value viewed = newBuffer;
+  for (auto [inverse, loc] : llvm::reverse(inverses))
+    viewed = rw.create<rock::TransformOp>(loc, viewed, inverse);
+  // Don't replace the use that kicked all this off, we're probably about to
+  // erase it.
+  rw.replaceAllUsesExcept(buffer, viewed, transforms.back());
+
+  for (TransformOp transform : transforms)
+    if (transform.use_empty())
+      rw.eraseOp(transform);
+  if (oldAlloc.use_empty())
+    rw.eraseOp(oldAlloc);
+  else
+    bufferDeps.analyze(oldAlloc);
+  // If the inversions are being processed correctly, this should hit the early
+  // exit case.
+  bufferDeps.analyze(newAlloc);
+  state.worklist.push_back(newAlloc);
+  return success();
+}
+
+/// If the writer of the buffer that'll be input-fused views that buffer through
+/// a series of transforms, invert those transforms and add them to the readers'
+/// (fusors) transform stacks, allocating a new buffer whose type is the type of
+/// that transformed view. This means that we don't need to compute inverses
+/// during, say, vectorization queries in GridwiseGemmToBlockwise.
+static LogicalResult pushTransformsToInputFusionReaders(
+    memref::AllocOp allocOp, BufferDependencyAnalysis &bufferDeps,
+    OpOperand *writer, TransformPushState &state, IRRewriter &rw) {
+  Value maybeTransformedBuffer = writer->get();
+  // If the input fusion writes directly to its buffer, there's nothing to do
+  // here, we've met the invariant.
+  if (maybeTransformedBuffer == allocOp.getResult())
+    return success();
+  LLVM_DEBUG(
+      llvm::dbgs() << "Processing input fusion write of " << writer->get()
+                   << " (argument " << writer->getOperandNumber() << " of "
+                   << *writer->getOwner() << ") via " << allocOp << "\n");
+  return regularizeTransformStack(allocOp, writer, bufferDeps, state, rw);
+}
+
+/// Isolate multiple readers that use transforms to view a buffer from each
+/// other so that we can regularize. This function will create a copy of
+/// `allocOp` for each of its readers that applies coordinate transformations
+/// while it reads from `allocOp` as a fusion input. This will allow register
+/// tiles to be reused in multiple contexts with multiple indexing schemes. Note
+/// that the extra copies implied by this operation will be elided - in the
+/// worst case, mem2reg will get through them, assuming we don't delete them.
+/// (An example of such multiple uses is returning both the gemm and the sum of
+/// each row within the gemm).
+static LogicalResult
+isolateMultipleTransformingReaders(memref::AllocOp allocOp, Operation *writer,
+                                   BufferDependencyAnalysis &bufferDeps,
+                                   ArrayRef<OpOperand *> readers,
+                                   TransformPushState &state, IRRewriter &rw) {
+  TypedValue<MemRefType> buffer = allocOp.getResult();
+  Location loc = allocOp.getLoc();
+
+  LLVM_DEBUG(llvm::dbgs() << "Fixing multiple transformed readers of "
+                          << allocOp << "\n");
+  for (OpOperand *reader : llvm::make_early_inc_range(readers)) {
+    LLVM_DEBUG(llvm::dbgs() << "Reading op is " << *reader->getOwner() << "\n");
+    Value transformed = reader->get();
+    rw.setInsertionPointAfter(allocOp);
+    // If there are partially-merged transform chains, isolate the transform
+    // chain and update the reader.
+    Value isolated = isolateTransforms(rw, transformed);
+    if (isolated != transformed) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Isolated " << transformed << " to " << isolated << "\n");
+      rw.modifyOpInPlace(reader->getOwner(), [&]() { reader->set(isolated); });
+    }
+
+    Value probablyBuffer;
+    SmallVector<TransformOp> transforms;
+    std::tie(probablyBuffer, std::ignore) = untransform(isolated, transforms);
+    if (probablyBuffer != buffer)
+      return allocOp.emitOpError("expected transformed reader ")
+             << *(reader->getOwner()) << " to trace value to " << buffer
+             << " but it reached " << probablyBuffer;
+    auto newBuffer = rw.create<memref::AllocOp>(loc, buffer.getType());
+    if (!transforms.empty()) {
+      TransformOp viewRoot = transforms.back();
+      rw.modifyOpInPlace(viewRoot, [&]() {
+        viewRoot.getInputMutable().set(newBuffer.getResult());
+      });
+    } else {
+      rw.modifyOpInPlace(reader->getOwner(),
+                         [&]() { reader->set(newBuffer.getResult()); });
+    }
+    rw.setInsertionPointAfter(writer);
+    auto copy = rw.create<memref::CopyOp>(loc, allocOp, newBuffer);
+    state.worklist.push_back(newBuffer);
+    state.outputFusionWrites.insert(&copy.getTargetMutable());
+    bufferDeps.analyze(newBuffer);
+  }
+
+  // Prevent analysis of original allocation from going stale.
+  // If this function isn't correctly dispatching all the
+  // multiple-transforming-readers cases, the worklist emplacement will cause
+  // infinite recursion.
+  bufferDeps.analyze(allocOp);
+  state.worklist.push_back(allocOp);
+  return success();
+}
+
+/// Push transforms up from fusees to fusors.
+///
+/// This function handles the setup and the output fusion case. In this case,
+/// if any of the readers of an intermediate buffer take a transformed view of
+/// that buffer, we invert that view and put those inverse views on the writer
+/// so that we don't need to, for example, compute inverses during vectorization
+/// queries or -rock-align-tiling. After the inverses are computed, we swap in a
+/// new allocation whose type is the type that the reader/fusee expects.
+///
+/// When there are multiple competing transform chains to invert, we introduce
+/// copy operations that preserve the original buffer type so that we can invert
+/// each chain onto the write of the copy and then process that.
+static LogicalResult pushTransformsUp(memref::AllocOp allocOp,
+                                      BufferDependencyAnalysis &bufferDeps,
+                                      TransformPushState &state,
+                                      IRRewriter &rw) {
+  auto maybeBufferWriters = bufferDeps.getWriters(allocOp);
+  auto maybeBufferReaders = bufferDeps.getReaders(allocOp);
+  if (!maybeBufferWriters)
+    return allocOp.emitOpError(
+        "couldn't find an operation that writes this buffer");
+  if (!maybeBufferReaders)
+    return allocOp.emitError(
+        "couldn't find an operation that reads this buffer");
+  SmallVector<OpOperand *> bufferWriters = std::move(*maybeBufferWriters);
+  SmallVector<OpOperand *> bufferReaders = std::move(*maybeBufferReaders);
+  if (bufferWriters.size() != 1) {
+    allocOp->getParentOp()->dump();
+    return allocOp.emitError(
+               "expected one operation to write this buffer, but there are ")
+           << bufferWriters.size();
+  }
+
+  OpOperand *writer = bufferWriters[0];
+  bool isInputFusion = state.inputFusionWrites.contains(writer);
+  if (isInputFusion)
+    return pushTransformsToInputFusionReaders(allocOp, bufferDeps, writer,
+                                              state, rw);
+  if (!state.outputFusionWrites.contains(writer)) {
+    return allocOp.emitOpError("couldn't find the writer of a buffer in the "
+                               "set of analyzed fusable writes. See ")
+           << bufferWriters.front()->get();
+  }
+
+  OpOperand *transformingReader = nullptr;
+  for (OpOperand *reader : bufferReaders) {
+    Value readArg = reader->get();
+    if (!readArg.getDefiningOp<rock::TransformOp>()) {
+      continue;
+    }
+    if (transformingReader && transformingReader != reader)
+      return isolateMultipleTransformingReaders(
+          allocOp, writer->getOwner(), bufferDeps, bufferReaders, state, rw);
+    transformingReader = reader;
+  }
+  // It's the simple case, do nothing
+  if (!transformingReader)
+    return success();
+
+  if (transformingReader && bufferReaders.size() > 1) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Adding copies to partially intercept a transform stack\n");
+    return isolateMultipleTransformingReaders(
+        allocOp, writer->getOwner(), bufferDeps, bufferReaders, state, rw);
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "Processing output fusion read via "
+                          << transformingReader->get() << " (argument "
+                          << transformingReader->getOperandNumber() << " of "
+                          << *transformingReader->getOwner() << ") via "
+                          << allocOp << "\n");
+
+  return regularizeTransformStack(allocOp, transformingReader, bufferDeps,
+                                  state, rw);
+}
+
+LogicalResult findFusionRoots(func::FuncOp kernel,
+                              const BufferDependencyAnalysis &bufferDeps,
+                              TransformPushState &state) {
+  bool foundFusionRoot = false;
+  kernel.walk([&](Operation *op) {
+    llvm::TypeSwitch<Operation *>(op)
+        .Case(
+            [&](memref::AllocOp allocOp) { state.worklist.push_back(allocOp); })
+        .Case([&](GridwiseGemmOp gemmOp) {
+          foundFusionRoot = true;
+          collectOutputFusionWrites(&gemmOp.getCMutable(), bufferDeps, state);
+          collectInputFusionWrites(&gemmOp.getAMutable(), bufferDeps, state);
+          collectInputFusionWrites(&gemmOp.getBMutable(), bufferDeps, state);
+        })
+        .Case([&](GridwiseGemmAccelOp gemmOp) {
+          foundFusionRoot = true;
+          collectOutputFusionWrites(&gemmOp.getCMutable(), bufferDeps, state);
+          collectInputFusionWrites(&gemmOp.getAMutable(), bufferDeps, state);
+          collectInputFusionWrites(&gemmOp.getBMutable(), bufferDeps, state);
+        })
+        .Case([&](GridwiseAttentionAccelOp attenOp) {
+          foundFusionRoot = true;
+          collectOutputFusionWrites(&attenOp.getOutMutable(), bufferDeps,
+                                    state);
+          collectInputFusionWrites(&attenOp.getQueriesMutable(), bufferDeps,
+                                   state);
+          collectInputFusionWrites(&attenOp.getKeysMutable(), bufferDeps,
+                                   state);
+          collectInputFusionWrites(&attenOp.getValuesMutable(), bufferDeps,
+                                   state);
+
+          // The linalg.generic inside the attention's body will be expected to
+          // write out a global tensor as if it were an output fusion, so its
+          // write should be added to the set of output fusion writes lest we
+          // get complaints that there's an alloc that doesn't participatie in
+          // fusion.
+          for (auto lgop :
+               attenOp.getPreSoftmaxBody().getOps<linalg::GenericOp>()) {
+            collectOutputFusionWrites(&lgop.getOutputsMutable()[0], bufferDeps,
+                                      state);
+          }
+        });
+  });
+  // Make the traversal top-down just to be safe.
+  std::reverse(state.worklist.begin(), state.worklist.end());
+
+  return success(foundFusionRoot);
+}
+
+static LogicalResult runPushTransformsUp(func::FuncOp op,
+                                         BufferDependencyAnalysis &bufferDeps) {
+  TransformPushState state;
+  if (failed(findFusionRoots(op, bufferDeps, state))) {
+    // This pass is being run post gridwise-gemm-to-blockwise or otherwise out
+    // of its context, and so should do nothing. Usually this is because the
+    // early-pipeline applicability passes are being re-run as part of the
+    // lowering pipeline.
+    return success();
+  }
+  IRRewriter rw(op.getContext());
+  while (!state.worklist.empty()) {
+    memref::AllocOp allocOp = state.worklist.pop_back_val();
+    LLVM_DEBUG(llvm::dbgs() << "Regularizing: " << allocOp << "\n");
+    if (failed(pushTransformsUp(allocOp, bufferDeps, state, rw)))
+      return failure();
+    LLVM_DEBUG(llvm::dbgs() << "// --- //\n");
+  }
+  return success();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -357,16 +621,15 @@ void RockRegularizePass::runOnOperation() {
     patterns.add<CollapseRewritePattern, ExpandRewritePattern,
                  RegularizeGenericRewritePattern>(ctx);
     if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
-      signalPassFailure();
+      return signalPassFailure();
     }
   }
 
   {
-    RewritePatternSet patterns(ctx);
-    patterns.add<PushTransformsUpRewritePattern>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns))))
-      signalPassFailure();
+    auto &bufferDeps = getAnalysis<BufferDependencyAnalysis>();
+    if (failed(runPushTransformsUp(func, bufferDeps)))
+      return signalPassFailure();
   }
 
-  func->walk([&ctx](Operation *op) { AnnotateGenericOp(op, ctx); });
+  func->walk(annotateGenericOp);
 }

--- a/mlir/test/fusion/bug-1546-compile-failure.mlir
+++ b/mlir/test/fusion/bug-1546-compile-failure.mlir
@@ -1,0 +1,32 @@
+// RUN: rocmlir-opt --rock-regularize --mlir-print-local-scope %s | FileCheck %s
+// RUN: rocmlir-driver --kernel-pipeline=gpu --arch "gfx908:sramecc+:xnack-"
+
+// -----// IR Dump After RockGemmToGridwisePass (rock-gemm-to-gridwise) //----- //
+// CHECK-LABEL: @mlir_dot_mul
+// CHECK-COUNT-4: memref.copy
+// CHECK-NOT: memref.copy
+// CHECK: return
+func.func @mlir_dot_mul(%arg0: memref<6xf32>, %arg1: memref<12xf32>, %arg2: memref<8xf32>, %arg3: memref<8xf32>) attributes {arch = "gfx908:sramecc+:xnack-", block_size = 64 : i32, grid_size = 1 : i32, kernel = "mixr", num_cu = 120 : i64} {
+  %cst = arith.constant 2.500000e-01 : f32
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> ((d0 * 2 + d1) * 3 + d2)> by [<Unmerge{1, 2, 3} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [1, 2, 3] -> [6]> : memref<6xf32> to memref<1x2x3xf32>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> ((d0 * 3 + d1) * 4 + d2)> by [<Unmerge{1, 3, 4} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [1, 3, 4] -> [12]> : memref<12xf32> to memref<1x3x4xf32>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x4xf32>
+  %2 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemmK", "gemmM"] at [1, 2] -> ["gemmK", "gemmM"] at [2, 1]>] bounds = [1, 3, 2] -> [1, 2, 3]> : memref<1x2x3xf32> to memref<1x3x2xf32>
+  %3 = rock.transform %2 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 13} ["gemmKPad"] at [1] -> ["gemmK"] at [1]>, <Pad{0, 14} ["gemmMPad"] at [2] -> ["gemmM"] at [2]>] bounds = [1, 16, 16] -> [1, 3, 2]> : memref<1x3x2xf32> to memref<1x16x16xf32>
+  %4 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 13} ["gemmKPad"] at [1] -> ["gemmK"] at [1]>, <Pad{0, 12} ["gemmNPad"] at [2] -> ["gemmN"] at [2]>] bounds = [1, 16, 16] -> [1, 3, 4]> : memref<1x3x4xf32> to memref<1x16x16xf32>
+  %5 = rock.transform %alloc by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 14} ["gemmMPad"] at [1] -> ["gemmM"] at [1]>, <Pad{0, 12} ["gemmNPad"] at [2] -> ["gemmN"] at [2]>] bounds = [1, 16, 16] -> [1, 2, 4]> : memref<1x2x4xf32> to memref<1x16x16xf32>
+  rock.gridwise_gemm_accel(%3, %4, %5) storeMethod( set) features =  mfma|dot|atomic_add {arch = "gfx908:sramecc+:xnack-", blockSize = 64 : i32, gridSize = 1 : i32, numCU = 120 : i32, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 16, nPerBlock = 16, kpack = 4, mPerWave = 16, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>} : memref<1x16x16xf32>, memref<1x16x16xf32>, memref<1x16x16xf32>
+  %6 = rock.transform %alloc by <affine_map<(d0) -> (0, d0 floordiv 4, d0 mod 4)> by [<Merge{1, 2, 4} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [8] -> [1, 2, 4]> : memref<1x2x4xf32> to memref<8xf32>
+  %7 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 4] -> [1, 2, 4]> : memref<1x2x4xf32> to memref<2x4xf32>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4xf32>
+  linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%7 : memref<2x4xf32>) outs(%alloc_0 : memref<2x4xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %10 = arith.mulf %in, %cst : f32
+    linalg.yield %10 : f32
+  }
+  %8 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 4] -> [2, 4]> : memref<2x4xf32> to memref<1x2x4xf32>
+  %9 = rock.transform %8 by <affine_map<(d0) -> (0, d0 floordiv 4, d0 mod 4)> by [<Merge{1, 2, 4} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [8] -> [1, 2, 4]> : memref<1x2x4xf32> to memref<8xf32>
+  memref.copy %6, %arg2 : memref<8xf32> to memref<8xf32>
+  memref.copy %9, %arg3 : memref<8xf32> to memref<8xf32>
+  return
+}

--- a/mlir/test/fusion/bug-1550-reduction-fusion-compile-failure.mlir
+++ b/mlir/test/fusion/bug-1550-reduction-fusion-compile-failure.mlir
@@ -1,0 +1,51 @@
+// RUN: rocmlir-opt --rock-regularize --mlir-print-local-scope %s | FileCheck %s
+// RUN: rocmlir-driver --kernel-pipeline=gpu --arch "gfx908:sramecc+:xnack-"
+
+// -----// IR Dump After RockGemmToGridwisePass (rock-gemm-to-gridwise) //----- //
+// CHECK-LABEL: @mlir_convolution_reshape_mul_reshape_reduce_sum_reshape_mul_mul_reshape_reduce_sum_reshape
+func.func @mlir_convolution_reshape_mul_reshape_reduce_sum_reshape_mul_mul_reshape_reduce_sum_reshape(%arg0: memref<320xf32>, %arg1: memref<32768xf32>, %arg2: memref<11520xf32>, %arg3: memref<64xf32> {func.read_access, rock.prefill = 0.000000e+00 : f32}, %arg4: memref<64xf32>, %arg5: memref<2621440xf32>) attributes {arch = "gfx908:sramecc+:xnack-", block_size = 256 : i32, grid_size = 1536 : i32, kernel = "mixr", num_cu = 120 : i64} {
+  %cst = arith.constant 2.44140629E-5 : f32
+  %0 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3) -> (((d0 * 4 + d1) * 64 + d2) * 64 + d3)> by [<Unmerge{2, 4, 64, 64} ["exp0", "exp1", "exp2", "exp3"] at [0, 1, 2, 3] -> ["dim0"] at [0]>] bounds = [2, 4, 64, 64] -> [32768]> : memref<32768xf32> to memref<2x4x64x64xf32>
+  %1 = rock.transform %arg2 by <affine_map<(d0, d1, d2, d3) -> (((d0 * 4 + d1) * 3 + d2) * 3 + d3)> by [<Unmerge{320, 4, 3, 3} ["exp0", "exp1", "exp2", "exp3"] at [0, 1, 2, 3] -> ["dim0"] at [0]>] bounds = [320, 4, 3, 3] -> [11520]> : memref<11520xf32> to memref<320x4x3x3xf32>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x320x64x64xf32>
+  %2 = rock.transform %0 by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 4 + d2, d3, d4)> by [<PassThrough ["n", "h", "w"] at [0, 3, 4] -> ["n", "h", "w"] at [0, 2, 3]>, <Unmerge{1, 4} ["g", "c"] at [1, 2] -> ["c"] at [1]>] bounds = [2, 1, 4, 64, 64] -> [2, 4, 64, 64]> : memref<2x4x64x64xf32> to memref<2x1x4x64x64xf32>
+  %3 = rock.transform %1 by <affine_map<(d0, d1, d2, d3, d4) -> (d0 * 320 + d1, d2, d3, d4)> by [<PassThrough ["c", "y", "x"] at [2, 3, 4] -> ["c", "y", "x"] at [1, 2, 3]>, <Unmerge{1, 320} ["g", "k"] at [0, 1] -> ["k"] at [0]>] bounds = [1, 320, 4, 3, 3] -> [320, 4, 3, 3]> : memref<320x4x3x3xf32> to memref<1x320x4x3x3xf32>
+  %4 = rock.transform %alloc by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 320 + d2, d3, d4)> by [<PassThrough ["n", "h", "w"] at [0, 3, 4] -> ["n", "h", "w"] at [0, 2, 3]>, <Unmerge{1, 320} ["g", "k"] at [1, 2] -> ["k"] at [1]>] bounds = [2, 1, 320, 64, 64] -> [2, 320, 64, 64]> : memref<2x320x64x64xf32> to memref<2x1x320x64x64xf32>
+  %5 = rock.transform %3 by <affine_map<(d0, d1, d2) -> (d0, d2, d1 floordiv 9, (d1 mod 9) floordiv 3, d1 mod 3)> by [<PassThrough ["gemmG"] at [0] -> ["g"] at [0]>, <Merge{4, 3, 3} ["gemmK"] at [1] -> ["c", "0", "1"] at [2, 3, 4]>, <PassThrough ["gemmM"] at [2] -> ["k"] at [1]>] bounds = [1, 36, 320] -> [1, 320, 4, 3, 3]> : memref<1x320x4x3x3xf32> to memref<1x36x320xf32>
+  %6 = rock.transform %2 by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 - 1, d4 - 1)> by [<PassThrough ["ni"] at [0] -> ["ni"] at [0]>, <PassThrough ["gi"] at [1] -> ["gi"] at [1]>, <PassThrough ["ci"] at [2] -> ["ci"] at [2]>, <Pad{1, 1, 1, 1} ["0ipad", "1ipad"] at [3, 4] -> ["0i", "1i"] at [3, 4]>] bounds = [2, 1, 4, 66, 66] -> [2, 1, 4, 64, 64]> : memref<2x1x4x64x64xf32> to memref<2x1x4x66x66xf32>
+  %7 = rock.transform %6 by <affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3 + d4, d5 + d6)> by [<PassThrough ["ni", "gi", "ci"] at [0, 1, 2] -> ["ni", "gi", "ci"] at [0, 1, 2]>, <Embed{1, 1} ["0", "0o"] at [3, 4] -> ["0ipad"] at [3]>, <Embed{1, 1} ["1", "1o"] at [5, 6] -> ["1ipad"] at [4]>] bounds = [2, 1, 4, 3, 64, 3, 64] -> [2, 1, 4, 66, 66]> : memref<2x1x4x66x66xf32> to memref<2x1x4x3x64x3x64xf32>
+  %8 = rock.transform %7 by <affine_map<(d0, d1, d2) -> (d2 floordiv 4096, d0, d1 floordiv 9, (d1 mod 9) floordiv 3, (d2 mod 4096) floordiv 64, d1 mod 3, d2 mod 64)> by [<PassThrough ["gemmG"] at [0] -> ["gi"] at [1]>, <Merge{4, 3, 3} ["gemmK"] at [1] -> ["ci", "0", "1"] at [2, 3, 5]>, <Merge{2, 64, 64} ["gemmN"] at [2] -> ["ni", "0o", "1o"] at [0, 4, 6]>] bounds = [1, 36, 8192] -> [2, 1, 4, 3, 64, 3, 64]> : memref<2x1x4x3x64x3x64xf32> to memref<1x36x8192xf32>
+  %9 = rock.transform %4 by <affine_map<(d0, d1, d2) -> (d2 floordiv 4096, d0, d1, (d2 mod 4096) floordiv 64, d2 mod 64)> by [<PassThrough ["gemmG"] at [0] -> ["go"] at [1]>, <PassThrough ["gemmM"] at [1] -> ["ko"] at [2]>, <Merge{2, 64, 64} ["gemmN"] at [2] -> ["no", "0o", "1o"] at [0, 3, 4]>] bounds = [1, 320, 8192] -> [2, 1, 320, 64, 64]> : memref<2x1x320x64x64xf32> to memref<1x320x8192xf32>
+  %10 = rock.transform %5 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 28} ["gemmKPad"] at [1] -> ["gemmK"] at [1]>, <Pad{0, 64} ["gemmMPad"] at [2] -> ["gemmM"] at [2]>] bounds = [1, 64, 384] -> [1, 36, 320]> : memref<1x36x320xf32> to memref<1x64x384xf32>
+  %11 = rock.transform %8 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 28} ["gemmKPad"] at [1] -> ["gemmK"] at [1]>, <PassThrough ["gemmN"] at [2] -> ["gemmN"] at [2]>] bounds = [1, 64, 8192] -> [1, 36, 8192]> : memref<1x36x8192xf32> to memref<1x64x8192xf32>
+  %12 = rock.transform %9 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 64} ["gemmMPad"] at [1] -> ["gemmM"] at [1]>, <PassThrough ["gemmN"] at [2] -> ["gemmN"] at [2]>] bounds = [1, 384, 8192] -> [1, 320, 8192]> : memref<1x320x8192xf32> to memref<1x384x8192xf32>
+  rock.gridwise_gemm_accel(%10, %11, %12) storeMethod( set) features =  mfma|dot|atomic_add {arch = "gfx908:sramecc+:xnack-", blockSize = 256 : i32, gridSize = 1536 : i32, numCU = 120 : i32, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 128, nPerBlock = 16, kpack = 8, mPerWave = 32, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>} : memref<1x64x384xf32>, memref<1x64x8192xf32>, memref<1x384x8192xf32>
+  %13 = rock.transform %alloc by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 10 + d2, d3, d4)> by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <Unmerge{32, 10} ["exp1", "exp2"] at [1, 2] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [3] -> ["dim2"] at [2]>, <PassThrough ["dim3"] at [4] -> ["dim3"] at [3]>] bounds = [2, 32, 10, 64, 64] -> [2, 320, 64, 64]> : memref<2x320x64x64xf32> to memref<2x32x10x64x64xf32>
+  %14 = rock.transform %alloc by <affine_map<(d0) -> (d0 floordiv 1310720, (d0 mod 1310720) floordiv 4096, (d0 mod 4096) floordiv 64, d0 mod 64)> by [<Merge{2, 320, 64, 64} ["dim0"] at [0] -> ["col0", "col1", "col2", "col3"] at [0, 1, 2, 3]>] bounds = [2621440] -> [2, 320, 64, 64]> : memref<2x320x64x64xf32> to memref<2621440xf32>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x32x10x64x64xf32>
+  linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%13 : memref<2x32x10x64x64xf32>) outs(%alloc_0 : memref<2x32x10x64x64xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %19 = arith.mulf %in, %cst : f32
+    linalg.yield %19 : f32
+  }
+  %15 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 4096, (d2 mod 4096) floordiv 64, d2 mod 64)> by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Merge{10, 64, 64} ["dim2"] at [2] -> ["col2", "col3", "col4"] at [2, 3, 4]>] bounds = [2, 32, 40960] -> [2, 32, 10, 64, 64]> : memref<2x32x10x64x64xf32> to memref<2x32x40960xf32>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x32x1xf32>
+  rock.reduce  sum %15 into %alloc_1 features =  mfma|dot|atomic_add {axis = 2 : index, blockSize = 256 : i32, gridSize = 2400 : i32} : memref<2x32x40960xf32> into memref<2x32x1xf32>
+  %16 = rock.transform %alloc_1 by <affine_map<(d0) -> (d0 floordiv 32, d0 mod 32, 0)> by [<Merge{2, 32, 1} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [64] -> [2, 32, 1]> : memref<2x32x1xf32> to memref<64xf32>
+  %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<2x32x10x64x64xf32>
+  linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%13 : memref<2x32x10x64x64xf32>) outs(%alloc_2 : memref<2x32x10x64x64xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %19 = arith.mulf %in, %in : f32
+    %20 = arith.mulf %19, %cst : f32
+    linalg.yield %20 : f32
+  }
+  %17 = rock.transform %alloc_2 by <affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 4096, (d2 mod 4096) floordiv 64, d2 mod 64)> by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Merge{10, 64, 64} ["dim2"] at [2] -> ["col2", "col3", "col4"] at [2, 3, 4]>] bounds = [2, 32, 40960] -> [2, 32, 10, 64, 64]> : memref<2x32x10x64x64xf32> to memref<2x32x40960xf32>
+  %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<2x32x1xf32>
+  rock.reduce  sum %17 into %alloc_3 features =  mfma|dot|atomic_add {axis = 2 : index, blockSize = 256 : i32, gridSize = 2400 : i32} : memref<2x32x40960xf32> into memref<2x32x1xf32>
+  %18 = rock.transform %alloc_3 by <affine_map<(d0) -> (d0 floordiv 32, d0 mod 32, 0)> by [<Merge{2, 32, 1} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [64] -> [2, 32, 1]> : memref<2x32x1xf32> to memref<64xf32>
+  memref.copy %16, %arg3 : memref<64xf32> to memref<64xf32>
+  memref.copy %18, %arg4 : memref<64xf32> to memref<64xf32>
+  memref.copy %14, %arg5 : memref<2621440xf32> to memref<2621440xf32>
+  return
+}
+

--- a/mlir/test/fusion/input-fusion-regularize-generic-chain.mlir
+++ b/mlir/test/fusion/input-fusion-regularize-generic-chain.mlir
@@ -1,13 +1,12 @@
-// RUN: rocmlir-driver --rock-regularize %s | FileCheck %s
+// RUN: rocmlir-opt --rock-regularize --mlir-print-local-scope %s | FileCheck %s
 
 #general_gemm_params = #rock.general_gemm_params<blockSize = 128, kPerBlock = 16, mPerBlock = 32, nPerBlock = 32, kPerThread = 1, mPerThread = 2, nPerThread = 2, kpack = 1, splitKFactor = 1>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2, d1)>
-// CHECK-DAG: #[[MAP:.*]] = #rock.transform_map<#map{{.*}} by [<PassThrough ["gemmG", "gemmK", "gemmM"] at [0, 1, 2] -> ["gemmG", "gemmK", "gemmM"] at [0, 2, 1]>] bounds = [1, 32, 16] -> [1, 16, 32]>
 #transform_map = #rock.transform_map<#map1 by [<PassThrough ["gemmG", "gemmK", "gemmM"] at [0, 1, 2] -> ["gemmG", "gemmK", "gemmM"] at [0, 2, 1]>] bounds = [1, 32, 16] -> [1, 16, 32]>
-// CHECK-DAG: #[[MAP1:.*]] = #rock.transform_map<#map{{.*}} by [<PassThrough ["gemmG", "gemmK", "gemmM"] at [0, 2, 1] -> ["gemmG", "gemmK", "gemmM"] at [0, 1, 2]>] bounds = [1, 16, 32] -> [1, 32, 16]>
 
 module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
+  // CHECK-LABEL: @rock_gemm
   func.func @rock_gemm(%arg0: memref<1x32x16xf16>, %arg1: memref<1x16x32xf32>, %arg2: memref<1x32x32xf32>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, grid_size = 1 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
     // CHECK: %[[ALLOC:.+]] = memref.alloc() : memref<1x32x16xf32>
     %alloc = memref.alloc() : memref<1x32x16xf32>
@@ -26,7 +25,8 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
       %1 = arith.addf %in, %cst : f32
       linalg.yield %1 : f32
     }
-    // CHECK: %[[IN:.+]] = rock.transform %alloc_0 by #[[MAP]]
+    // CHECK: %[[IN:.+]] = rock.transform %[[ALLOC_0]]
+    // CHECK-SAME: [<PassThrough ["gemmG", "gemmK", "gemmM"] at [0, 1, 2] -> ["gemmG", "gemmK", "gemmM"] at [0, 2, 1]>]
     %0 = rock.transform %alloc_0 by #transform_map : memref<1x32x16xf32> to memref<1x16x32xf32>
     // CHECK-NEXT: rock.gridwise_gemm %{{.*}} = %[[IN]] * %{{.*}}
     rock.gridwise_gemm %arg2 = %0 * %arg1 storeMethod(set) features =  dot|atomic_add {gridSize = 1 : i32, numCU = 104 : i32, params = #general_gemm_params} : memref<1x32x32xf32> = memref<1x16x32xf32> * memref<1x16x32xf32>
@@ -34,25 +34,29 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
   }
 
 
+  // CHECK-LABEL: @rock_gemm_tr
   func.func @rock_gemm_tr(%arg0: memref<1x32x16xf16>, %arg1: memref<1x16x32xf32>, %arg2: memref<1x32x32xf32>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, grid_size = 1 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
     // CHECK: %[[alloc:.+]] = memref.alloc() : memref<1x32x16xf32>
-    // CHECK-NEXT: %[[tr:.*]] = rock.transform %[[alloc]] by #[[MAP1]]
+    // CHECK-NEXT: %[[trAlloc:.*]] = rock.transform %[[alloc]] by
+    // CHECK-SAME: [<PassThrough ["gemmG", "gemmK", "gemmM"] at [0, 2, 1] -> ["gemmG", "gemmK", "gemmM"] at [0, 1, 2]>]
     %alloc = memref.alloc() : memref<1x16x32xf32>
-    // CHECK-NEXT: %[[out:.+]] =  rock.transform %[[tr]] by #[[MAP]]
     %0 = rock.transform %alloc by #transform_map : memref<1x16x32xf32> to memref<1x32x16xf32>
-    // CHECK-NEXT: linalg.generic {{.*}} outs(%[[out]]
+    // CHECK-NEXT: linalg.generic {{.*}} outs(%[[alloc]]
     linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : memref<1x32x16xf16>) outs(%0 : memref<1x32x16xf32>) {
     ^bb0(%in: f16, %out: f32):
       %3 = arith.extf %in : f16 to f32
       linalg.yield %3 : f32
     }
     // CHECK: %[[alloc_0:.+]] = memref.alloc() : memref<1x32x16xf32>
-    // CHECK-NEXT: %[[gemmIn:.+]] = rock.transform %[[alloc_0]] by #[[MAP1]]
+    // CHECK-NEXT: %[[gemmIn:.+]] = rock.transform %[[alloc_0]]
+    // CHECK-SAME: [<PassThrough ["gemmG", "gemmK", "gemmM"] at [0, 2, 1] -> ["gemmG", "gemmK", "gemmM"] at [0, 1, 2]>]
+    // CHECK-NEXT: %[[reTrAlloc:.+]] = rock.transform %[[trAlloc]]
+    // CHECK-SAME: [<PassThrough ["gemmG", "gemmK", "gemmM"] at [0, 1, 2] -> ["gemmG", "gemmK", "gemmM"] at [0, 2, 1]>]
     %alloc_0 = memref.alloc() : memref<1x16x32xf32>
     %1 = rock.transform %alloc_0 by #transform_map : memref<1x16x32xf32> to memref<1x32x16xf32>
     %2 = rock.transform %alloc by #transform_map : memref<1x16x32xf32> to memref<1x32x16xf32>
     // CHECK-NEXT: linalg.generic
-    // CHECK-SAME: ins(%[[alloc]] : memref<1x32x16xf32>) outs(%[[alloc_0]]
+    // CHECK-SAME: ins(%[[reTrAlloc]] : memref<1x32x16xf32>) outs(%[[alloc_0]]
     linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%2 : memref<1x32x16xf32>) outs(%1 : memref<1x32x16xf32>) {
     ^bb0(%in: f32, %out: f32):
       %cst = arith.constant 2.000000e+00 : f32


### PR DESCRIPTION
Fixes https://github.com/ROCm/rocMLIR-internal/issues/1550

fixes https://github.com/ROCm/rocMLIR-internal/issues/1546

Depends on https://github.com/ROCm/rocMLIR/pull/1586

This commit rewrites --rock-regularize to have it handle more cases. Now, the regularizer directly uses the new buffer dependency analysis and looks through that information in order to not have to grow its own idea fo when to fuse things.

Secondly, the regularizer now fully collects which linalg.generic opesaritos are input fusions and which ones are output fusions, so that we can correctly move transforms from the generic to its readers when we're in an input fusion and move transforms from the readers to the writing generic in an output fusion. The old ad-hoc fusor detector wasn't really working.

Third, we extend the buffer dependency analysis to allow for updates and to allow the inverse lookup (given an OpOperand, determine which buffer it reads or writes).

We also now correctly handle the case where we have

```
%buf = alloc()
%c = f(%buf)
%d = g(%buf)
%e = h(%buf)
rock.gridwise_gemm_* %c = ...
linalg.generic ins(%d, ...)
linalg.generic ins(%e, ...)
```

by inserting memref.copy operations as nedede to isolate the two transform chains. These copies will be eliminated during AlignTiling if possible (sometimes they are legitimate copies, like, for exaple, "write out the GEMM results (with regular writes)" and "write a copy of those results through this reduction view and atomic_add") - those'll get cleaned up by mem2reg.

Overall, by not trying to rely on the pattern rewriter and doring the IR transformations we care about in place, we've cleaned up the regularizer.