### PR TITLE
use removeUpperDims if possible

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
@@ -112,7 +112,7 @@ struct AccelEmitter {
   /// 3) threadSubTileView :
   /// iter --> ... --> [KPerThread, DPerThread]
   /// for each operand tile to be used with gemm accelerators.
-  virtual RegsAsMatrixSubTiles createAccelGemmOperandTransforms(
+  virtual FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
       OpBuilder &b, Location loc, int64_t kIters,
       ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
       int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
@@ -123,7 +123,7 @@ struct AccelEmitter {
 
   /// Compute the output transform map to be used to store the result of the
   /// matrix multiplication tile.
-  virtual RegsAsMatrixSubTiles computeOutputTransforms(
+  virtual FailureOr<RegsAsMatrixSubTiles> computeOutputTransforms(
       OpBuilder &b, Location loc, int64_t mLen, int64_t nLen, int64_t blockSize,
       ArrayRef<int64_t> bidGridLengths, int64_t inMPerThread,
       int64_t inNPerThread, bool doSwapThreadIterSubDimsForM = false,
@@ -182,14 +182,14 @@ struct MfmaEmitter : public AccelEmitter {
                        StringRef dName, bool rotateDWithK,
                        bool doSplitKAcrossThreadsFirst = false) const override;
 
-  virtual RegsAsMatrixSubTiles createAccelGemmOperandTransforms(
+  virtual FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
       OpBuilder &b, Location loc, int64_t kIters,
       ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
       int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
       bool rotateDWithK,
       bool doSplitKAcrossThreadsFirst = false) const override;
 
-  RegsAsMatrixSubTiles computeOutputTransforms(
+  FailureOr<RegsAsMatrixSubTiles> computeOutputTransforms(
       OpBuilder &b, Location loc, int64_t mLen, int64_t nLen, int64_t blockSize,
       ArrayRef<int64_t> bidGridLengths, int64_t inMPerThread,
       int64_t inNPerThread, bool doSwapThreadIterSubDimsForM = false,
@@ -229,14 +229,14 @@ struct WmmaEmitter : public AccelEmitter {
                        StringRef dName, bool rotateDWithK,
                        bool doSplitKAcrossThreadsFirst = false) const override;
 
-  virtual RegsAsMatrixSubTiles createAccelGemmOperandTransforms(
+  virtual FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
       OpBuilder &b, Location loc, int64_t kIters,
       ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
       int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
       bool rotateDWithK,
       bool doSplitKAcrossThreadsFirst = false) const override;
 
-  RegsAsMatrixSubTiles computeOutputTransforms(
+  FailureOr<RegsAsMatrixSubTiles> computeOutputTransforms(
       OpBuilder &b, Location loc, int64_t mLen, int64_t nLen, int64_t blockSize,
       ArrayRef<int64_t> bidGridLengths, int64_t inMPerThread,
       int64_t inNPerThread, bool doSwapThreadIterSubDimsForM = false,

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -1051,9 +1051,8 @@ WmmaEmitter::createAccelGemmOperandTransforms(
   }
   // compute thread sub tile transforms
   {
-    // we can't use removeUpperDims because when isKContigousDim
-    // is false it merges "iter" as {"k_iter", "kpack", "d_iter"}
-    // while gridSubTile views merge it as {"k_iter", "d_iter", "kpack"}
+    // TODO: we can't use "removeUpperDims" because of bug #1562
+    // (https://github.com/ROCm/rocMLIR-internal/issues/1562)
     SmallVector<Attribute> transformAttrs;
     // First coordinate transform
     TopDownTMBuilder splitIter(b, {"iter"}, {dRepeats * kpackPerThread * kPack},
@@ -1063,8 +1062,8 @@ WmmaEmitter::createAccelGemmOperandTransforms(
         splitIter.merge({"d_iter", "k_iter", "kpack"}, {0, 1, 2}, "iter",
                         {dRepeats, kpackPerThread, kPack});
       } else {
-        splitIter.merge({"k_iter", "kpack", "d_iter"}, {0, 1, 2}, "iter",
-                        {kpackPerThread, kPack, dRepeats});
+        splitIter.merge({"k_iter", "d_iter", "kpack"}, {0, 1, 2}, "iter",
+                        {kpackPerThread, dRepeats, kPack});
       }
     }
     TransformMapAttr splitIterAttr = splitIter.get();

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -264,30 +264,33 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getLoadRegsAsTileViews(
     gpuViews.gridSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
   }
   {
-    TopDownTMBuilder blockwiseSplitId(b, {"tid", "iter"},
-                                      {blockSize, dataPerThread}, loc);
-    makeLoadRegsTidMerge(blockwiseSplitId, dThreadName, dThreads, kThreads,
-                         {0, 1}, isKContigousDim);
-    makeLoadRegsIterMerge(blockwiseSplitId, dIterName, dPerThread, kPerThread,
-                          {2, 3}, isKContigousDim);
-    TransformMapAttr splitIdAttr = blockwiseSplitId.get();
-    auto toGlobalIdx = TopDownTMBuilder::below(blockwiseSplitId, splitIdAttr);
-    toGlobalIdx.unmerge("k", 0, {"k_thread", "k_iter"}, {kThreads, kPerThread});
-    toGlobalIdx.unmerge(dName, 1, {dThreadName, dIterName},
-                        {dThreads, dPerThread});
-    TransformMapAttr toGlobalIdxAttr = toGlobalIdx.get();
-    gpuViews.blockSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
+    SetVector<StringRef> dimensionsToRemove;
+    dimensionsToRemove.insert("k_loop");
+    dimensionsToRemove.insert(bidGridOrder[0]);
+    dimensionsToRemove.insert(bidGridOrder[1]);
+    dimensionsToRemove.insert(bidGridOrder[2]);
+    FailureOr<ArrayAttr> maybeBlockSubTile =
+        removeUpperDims(b, gpuViews.gridSubTile, dimensionsToRemove);
+
+    if (failed(maybeBlockSubTile)) {
+      return failure();
+    }
+    gpuViews.blockSubTile = maybeBlockSubTile.value();
   }
   {
-    TopDownTMBuilder threadwiseSplitId(b, {"iter"}, {dataPerThread}, loc);
-    makeLoadRegsIterMerge(threadwiseSplitId, dIterName, dPerThread, kPerThread,
-                          {0, 1}, isKContigousDim);
-    TransformMapAttr splitIdAttr = threadwiseSplitId.get();
-    auto toGlobalIdx = TopDownTMBuilder::below(threadwiseSplitId, splitIdAttr);
-    toGlobalIdx.passThrough({"k"}, 0, {"k_iter"});
-    toGlobalIdx.passThrough({dName}, 1, {dIterName});
-    TransformMapAttr toGlobalIdxAttr = toGlobalIdx.get();
-    gpuViews.threadSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
+    SetVector<StringRef> dimensionsToRemove;
+    dimensionsToRemove.insert("k_loop");
+    dimensionsToRemove.insert(bidGridOrder[0]);
+    dimensionsToRemove.insert(bidGridOrder[1]);
+    dimensionsToRemove.insert(bidGridOrder[2]);
+    dimensionsToRemove.insert("tid");
+    FailureOr<ArrayAttr> maybeThreadSubTile =
+        removeUpperDims(b, gpuViews.gridSubTile, dimensionsToRemove);
+
+    if (failed(maybeThreadSubTile)) {
+      return failure();
+    }
+    gpuViews.threadSubTile = maybeThreadSubTile.value();
   }
   return gpuViews;
 }
@@ -352,6 +355,8 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
     gpuViews.gridSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
   }
   {
+    // Note: we can't use removeUpperDims because of
+    // "doSwapThreadIterSubDimsForD". This is not done for gpuViews.gridSubTile
     TopDownTMBuilder blockwiseSplitId(b, {"tid", "iter"},
                                       {blockSize, dataPerThread}, loc);
     makeLoadRegsTidMerge(blockwiseSplitId, dThreadName, dThreads, kThreads,
@@ -377,17 +382,19 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
     gpuViews.blockSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
   }
   {
-    TopDownTMBuilder threadwiseSplitId(b, {"iter"}, {dataPerThread}, loc);
-    threadwiseSplitId.merge({"kouterPerThread", dIterName, "kpackPerThread"},
-                            {0, 1, 2}, "iter",
-                            {kOuterPerThread, dPerThread, kpackPerThread});
-    TransformMapAttr splitIdAttr = threadwiseSplitId.get();
-    auto toGlobalIdx = TopDownTMBuilder::below(threadwiseSplitId, splitIdAttr);
-    toGlobalIdx.unmerge("k", 0, {"kouterPerThread", "kpackPerThread"},
-                        {kOuterPerThread, kpackPerThread});
-    toGlobalIdx.passThrough({dName}, 1, {dIterName});
-    TransformMapAttr toGlobalIdxAttr = toGlobalIdx.get();
-    gpuViews.threadSubTile = b.getArrayAttr({splitIdAttr, toGlobalIdxAttr});
+    SetVector<StringRef> dimensionsToRemove;
+    dimensionsToRemove.insert("k_loop");
+    dimensionsToRemove.insert(bidGridOrder[0]);
+    dimensionsToRemove.insert(bidGridOrder[1]);
+    dimensionsToRemove.insert(bidGridOrder[2]);
+    dimensionsToRemove.insert("tid");
+    FailureOr<ArrayAttr> maybeThreadSubTile =
+        removeUpperDims(b, gpuViews.gridSubTile, dimensionsToRemove);
+
+    if (failed(maybeThreadSubTile)) {
+      return failure();
+    }
+    gpuViews.threadSubTile = maybeThreadSubTile.value();
   }
   return gpuViews;
 }

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -144,19 +144,13 @@
   // CHECK-DAG: %[[gemm0NormExpTr0:.+]] = rock.transform %[[gemm0NormExp]]
   // CHECK-DAG: %[[gemm0NormExpTr1:.+]] = rock.transform %[[gemm0NormExpTr0]]
   // CHECK-DAG: %[[gemm0NormExpTr2:.+]] = rock.transform %[[gemm0NormExpTr1]]
-  // CHECK-DAG: %[[gemm0NormExpTr3:.+]] = rock.transform %[[gemm0NormExpTr2]]
-  // CHECK-DAG: %[[gemm0NormExpTr4:.+]] = rock.transform %[[gemm0NormExpTr3]]
-  // CHECK-DAG: %[[gemm0NormExpTr5:.+]] = rock.transform %[[gemm0NormExpTr4]]
 
   // Viewing another set of register with kPack packing
   // CHECK: %[[G1AregsKpackTr0:.+]] = rock.transform %[[G1AregsKpack:.+]] by
   // CHECK-DAG: %[[G1AregsKpackTr1:.+]] = rock.transform %[[G1AregsKpackTr0]] by
   // CHECK-DAG: %[[G1AregsKpackTr2:.+]] = rock.transform %[[G1AregsKpackTr1]] by
-  // CHECK-DAG: %[[G1AregsKpackTr3:.+]] = rock.transform %[[G1AregsKpackTr2]] by
-  // CHECK-DAG: %[[G1AregsKpackTr4:.+]] = rock.transform %[[G1AregsKpackTr3]] by
-  // CHECK-DAG: %[[G1AregsKpackTr5:.+]] = rock.transform %[[G1AregsKpackTr4]] by
 
-  // CHECK-DAG: rock.threadwise_copy %[[gemm0NormExpTr5]] -> %[[G1AregsKpackTr5]]
+  // CHECK-DAG: rock.threadwise_copy %[[gemm0NormExpTr2]] -> %[[G1AregsKpackTr2]]
 
   // Viewing G1 LDS A tile buffer
   // CHECK-DAG: %[[viewG1AStore:.+]] = memref.view %[[ldsG0A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>
@@ -276,5 +270,3 @@ func.func @gridwise_attn_grid_reversed(%arg0: memref<1x384x64xf32>, %arg1: memre
   } : memref<1x64x384xf32>, memref<1x64x384xf32>, memref<1x384x64xf32>, memref<1x384x64xf32>
   return
 }
-
-

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -144,13 +144,19 @@
   // CHECK-DAG: %[[gemm0NormExpTr0:.+]] = rock.transform %[[gemm0NormExp]]
   // CHECK-DAG: %[[gemm0NormExpTr1:.+]] = rock.transform %[[gemm0NormExpTr0]]
   // CHECK-DAG: %[[gemm0NormExpTr2:.+]] = rock.transform %[[gemm0NormExpTr1]]
+  // CHECK-DAG: %[[gemm0NormExpTr3:.+]] = rock.transform %[[gemm0NormExpTr2]]
+  // CHECK-DAG: %[[gemm0NormExpTr4:.+]] = rock.transform %[[gemm0NormExpTr3]]
+  // CHECK-DAG: %[[gemm0NormExpTr5:.+]] = rock.transform %[[gemm0NormExpTr4]]
 
   // Viewing another set of register with kPack packing
   // CHECK: %[[G1AregsKpackTr0:.+]] = rock.transform %[[G1AregsKpack:.+]] by
   // CHECK-DAG: %[[G1AregsKpackTr1:.+]] = rock.transform %[[G1AregsKpackTr0]] by
   // CHECK-DAG: %[[G1AregsKpackTr2:.+]] = rock.transform %[[G1AregsKpackTr1]] by
+  // CHECK-DAG: %[[G1AregsKpackTr3:.+]] = rock.transform %[[G1AregsKpackTr2]] by
+  // CHECK-DAG: %[[G1AregsKpackTr4:.+]] = rock.transform %[[G1AregsKpackTr3]] by
+  // CHECK-DAG: %[[G1AregsKpackTr5:.+]] = rock.transform %[[G1AregsKpackTr4]] by
 
-  // CHECK-DAG: rock.threadwise_copy %[[gemm0NormExpTr2]] -> %[[G1AregsKpackTr2]]
+  // CHECK-DAG: rock.threadwise_copy %[[gemm0NormExpTr5]] -> %[[G1AregsKpackTr5]]
 
   // Viewing G1 LDS A tile buffer
   // CHECK-DAG: %[[viewG1AStore:.+]] = memref.view %[[ldsG0A]][{{.*}}][] : memref<4096xi8, #gpu.address_space<workgroup>> to memref<1024xf32, #gpu.address_space<workgroup>>


### PR DESCRIPTION
In this PR we use "removeUpperDims" utility function wherever possible to clean up thread layout view creation functions.

There are some cases where it's not possible due to this bug: https://github.com/ROCm/rocMLIR-internal/issues/1562

ticket: https://github.com/ROCm/rocMLIR-internal/issues/1529
