### PR TITLE
[DO NOT SQUASH][EXTERNAL] fix plumbing of rocdl attrs: waves_per_eu & unsafe_atomics

### DIFF
--- a/external/llvm-project/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
+++ b/external/llvm-project/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
@@ -128,6 +128,23 @@ public:
       attrValueStream << "1," << value.getInt();
       llvmFunc->addFnAttr("amdgpu-flat-work-group-size", llvmAttrValue);
     }
+    if (dialect->getWavesPerEuAttrHelper().getName() == attribute.getName()) {
+      auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
+      if (!func)
+        return op->emitOpError(Twine(attribute.getName()) +
+                               " is only supported on `llvm.func` operations");
+      auto value = dyn_cast<IntegerAttr>(attribute.getValue());
+      if (!value)
+        return op->emitOpError(Twine(attribute.getName()) +
+                               " must be an integer");
+
+      llvm::Function *llvmFunc =
+          moduleTranslation.lookupFunction(func.getName());
+      llvm::SmallString<8> llvmAttrValue;
+      llvm::raw_svector_ostream attrValueStream(llvmAttrValue);
+      attrValueStream << value.getInt();
+      llvmFunc->addFnAttr("amdgpu-waves-per-eu", llvmAttrValue);
+    }
     if (dialect->getFlatWorkGroupSizeAttrHelper().getName() ==
         attribute.getName()) {
       auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
@@ -158,6 +175,21 @@ public:
       llvm::Function *llvmFunc =
           moduleTranslation.lookupFunction(func.getName());
       llvmFunc->addFnAttr("uniform-work-group-size",
+                          value.getValue() ? "true" : "false");
+    }
+    if (dialect->getUnsafeFpAtomicsAttrHelper().getName() ==
+        attribute.getName()) {
+      auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
+      if (!func)
+        return op->emitOpError(Twine(attribute.getName()) +
+                               " is only supported on `llvm.func` operations");
+      auto value = dyn_cast<BoolAttr>(attribute.getValue());
+      if (!value)
+        return op->emitOpError(Twine(attribute.getName()) +
+                               " must be a boolean");
+      llvm::Function *llvmFunc =
+          moduleTranslation.lookupFunction(func.getName());
+      llvmFunc->addFnAttr("amdgpu-unsafe-fp-atomics",
                           value.getValue() ? "true" : "false");
     }
     // Set reqd_work_group_size metadata

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -62,6 +62,20 @@ llvm.func @kernel_func_no_uniform_work_groups() attributes {rocdl.kernel, rocdl.
   llvm.return
 }
 
+llvm.func @kernel_func_waves_per_eu()
+    attributes {rocdl.kernel, rocdl.waves_per_eu = 2 : i32} {
+  // CHECK-LABEL: amdgpu_kernel void @kernel_func_waves_per_eu()
+  // CHECK: #[[$KERNEL_WAVES_PER_EU_ATTR:[0-9]+]]
+  llvm.return
+}
+
+llvm.func @kernel_func_unsafe_fp_atomics()
+    attributes {rocdl.kernel, rocdl.unsafe_fp_atomics = true} {
+  // CHECK-LABEL: amdgpu_kernel void @kernel_func_unsafe_fp_atomics()
+  // CHECK: #[[$KERNEL_UNSAFE_FP_ATOMICS_ATTR:[0-9]+]]
+  llvm.return
+}
+
 llvm.func @rocdl.lane_id() -> i32 {
   // CHECK: [[mbcntlo:%.+]] = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   // CHECK-NEXT: call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 [[mbcntlo]])
@@ -527,3 +541,5 @@ llvm.func @rocdl_16bit_packed_floats(%sourceA: f32, %sourceB: f32) -> vector<2xf
 // CHECK-DAG: attributes #[[$KNOWN_BLOCK_SIZE_ATTRS]] = { "amdgpu-flat-work-group-size"="128,128"
 // CHECK-DAG: attributes #[[$KERNEL_NO_UNIFORM_WORK_GROUPS_ATTRS]] = { "amdgpu-flat-work-group-size"="1,256" "uniform-work-group-size"="false" }
 // CHECK-DAG: ![[$REQD_WORK_GROUP_SIZE]] = !{i32 16, i32 4, i32 2}
+// CHECK-DAG: attributes #[[$KERNEL_WAVES_PER_EU_ATTR]] = { "amdgpu-flat-work-group-size"="1,256" "amdgpu-waves-per-eu"="2" "uniform-work-group-size"="true" }
+// CHECK-DAG: attributes #[[$KERNEL_UNSAFE_FP_ATOMICS_ATTR]] = { "amdgpu-flat-work-group-size"="1,256" "amdgpu-unsafe-fp-atomics"="true" "uniform-work-group-size"="true" }

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -211,6 +211,10 @@ void LowerRockOpsToGPUPass::runOnOperation() {
     if (auto isReverse = rock::getReverseGrid(theFunc).value_or(nullptr)) {
       gpuFunc->setAttr(rock::ReverseGridAttrAttr::getMnemonic(), isReverse);
     }
+    FailureOr<StringAttr> maybeArch = rock::getArch(theFunc);
+    if (succeeded(maybeArch)) {
+      gpuFunc->setAttr("arch", maybeArch.value());
+    }
 
     int32_t indexWidth = 32;
     if (theFunc->hasAttr("rock.64bitindex"))
@@ -429,6 +433,8 @@ void LowerRockOpsToGPUPass::runOnOperation() {
         LLVM_DEBUG(llvm::dbgs() << "waves_per_eu not set"
                                 << "\n");
       }
+    } else {
+      LLVM_DEBUG(llvm::dbgs() << "arch not found.\n");
     }
   });
 

--- a/mlir/test/Conversion/RockToGPU/emptykernel.mlir
+++ b/mlir/test/Conversion/RockToGPU/emptykernel.mlir
@@ -1,11 +1,22 @@
-// RUN: rocmlir-opt -convert-rock-to-gpu %s | FileCheck %s
+// RUN: rocmlir-opt -convert-rock-to-gpu --split-input-file %s | FileCheck %s
 
 // CHECK: module attributes {gpu.container_module}
 // CHECK-NEXT: gpu.module @emptykernel_module
 // CHECK-NEXT: gpu.func @emptykernel(%{{.*}}: memref<?x?x?x?xf32> {llvm.noalias}) kernel
-
 module {
   func.func @emptykernel(%arg0: memref<?x?x?x?xf32> {llvm.noalias}) attributes {kernel = 0 : i32} {
+    return
+  }
+}
+
+// -----
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-NEXT: gpu.module @emptykernel_module
+// CHECK-NEXT: gpu.func @emptykernel(%{{.*}}: memref<?x?x?x?xf32> {llvm.noalias}) kernel
+// CHECK-SAME: arch = "gfx90a"
+module {
+  func.func @emptykernel(%arg0: memref<?x?x?x?xf32> {llvm.noalias}) attributes {kernel = 0 : i32, arch = "gfx90a"} {
     return
   }
 }


### PR DESCRIPTION
Currently, the rocdl attrs: waves_per_eu & unsafe_atomics are not plumbed to LLVM.
Not sure how that happened and therefore this results in selecting `cmpswap` instructions
instead of `atomic_fadd` in the backend -- leading to perf degradation in cases where `raw_buffer_*` ops are not used.

closes : https://github.com/ROCm/rocMLIR-internal/issues/1558