### PR TITLE
Fix tests where no GPU is present

### DIFF
--- a/mlir/test/Conversion/TosaToRock/no-mixed-layout.mlir
+++ b/mlir/test/Conversion/TosaToRock/no-mixed-layout.mlir
@@ -1,9 +1,9 @@
-// RUN: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | FileCheck %s
+// RUN: rocmlir-driver -host-pipeline partition,highlevel -targets amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack- %s | FileCheck %s
 
 // CHECK: rock.conv({{.*}}) {{.*}} {{{.*}}, filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], output_layout = ["no", "go", "ko", "ho", "wo"]{{.*}}}
 
 module {
-  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x384x28x28xf32>, %arg2: tensor<512x384x1x1xf32>) -> tensor<1x512x28x28xf32> {
+  func.func @test(%arg0: tensor<1x512x1x1xf32>, %arg1: tensor<1x384x28x28xf32>, %arg2: tensor<512x384x1x1xf32>) -> tensor<1x512x28x28xf32> attributes {kernel, mhal.arch = "amdgcn-amd-amdhsagfx90a:sramecc+:xnack-"} {
     %cst = arith.constant dense<[0, 2, 3, 1]> : tensor<4xi64>
     %0 = "tosa.transpose"(%arg1, %cst) : (tensor<1x384x28x28xf32>, tensor<4xi64>) -> tensor<1x28x28x384xf32>
     %1 = "tosa.transpose"(%arg2, %cst) : (tensor<512x384x1x1xf32>, tensor<4xi64>) -> tensor<512x1x1x384xf32>

--- a/mlir/test/Dialect/Rock/lowering_affix_params_negative.mlir
+++ b/mlir/test/Dialect/Rock/lowering_affix_params_negative.mlir
@@ -1,12 +1,12 @@
 // Negative test to deliberately pass incorrect tuning parameters.
 
-// RUN: rocmlir-gen --arch %arch -p -mfma=on -t f16 --perf_config "v2:128,128,2,64,64,2,1,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics
+// RUN: rocmlir-gen --arch gfx90a -p -mfma=on -t f16 --perf_config "v2:128,128,2,64,64,2,1,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics
 // expected-error{{Incorrect KPACK tuning parameter: 2}}
 
-// RUN: rocmlir-gen --arch %arch -p -mfma=on -t f16 --perf_config "v2:128,128,2,64,64,16,1,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics
+// RUN: rocmlir-gen --arch gfx90a -p -mfma=on -t f16 --perf_config "v2:128,128,2,64,64,16,1,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics
 // expected-error{{Incorrect KPACK tuning parameter: 16}}
 
-// RUN: rocmlir-gen --arch %arch -p -mfma=on -t f32 --perf_config "v2:128,128,8,64,64,8,1,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics
+// RUN: rocmlir-gen --arch gfx90a -p -mfma=on -t f32 --perf_config "v2:128,128,8,64,64,8,1,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics
 // expected-error{{Incorrect KPACK tuning parameter: 8}}
 
 // RUN: rocmlir-gen --operation gemm --arch gfx1100 -p -wmma=on -t f16 --perf_config "v2:256,128,8,64,128,1,1,1,1" | rocmlir-opt -rock-affix-params -verify-diagnostics

--- a/mlir/test/common_utils/common.py
+++ b/mlir/test/common_utils/common.py
@@ -52,7 +52,7 @@ def get_agents(rocm_path):
             q = subprocess.run([rocm_path + "/bin/rocm_agent_enumerator"],
                                check=True, stdout=subprocess.PIPE)
             agents = set(x.decode("utf-8") for x in q.stdout.split())
-        return set(a for a in agents if a != b"gfx000")
+        return set(a for a in agents if a != "gfx000")
     else:
         p = subprocess.run([rocm_path + "/bin/amdgpu_arch.exe"],
                            check=True, stdout=subprocess.PIPE, shell=True)

--- a/mlir/test/e2e/PrGemmSplitK.cfg
+++ b/mlir/test/e2e/PrGemmSplitK.cfg
@@ -1,3 +1,3 @@
 # Currently, split-k is only supported accel-gemm codepath.
-if (not config.arch_support_mfma) and (not config.arch_support_wmma) and (not 'atomic_add' in config.features):
+if config.no_AMD_GPU or ((not config.arch_support_mfma) and (not config.arch_support_wmma) and (not 'atomic_add' in config.features)):
   config.unsupported = True

--- a/mlir/test/fusion/pr-e2e/reductions/atomic_add/lit.local.cfg
+++ b/mlir/test/fusion/pr-e2e/reductions/atomic_add/lit.local.cfg
@@ -1,2 +1,2 @@
-if not 'atomic_add' in config.features:
+if not config.enable_rock_driver_pr_e2e_test or config.no_AMD_GPU or not 'atomic_add' in config.features:
   config.unsupported = True

--- a/mlir/test/fusion/tosa-to-rock-add.mlir
+++ b/mlir/test/fusion/tosa-to-rock-add.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-driver -host-pipeline highlevel -kernel-pipeline=gpu,rocdl -arch %arch %s -o -| FileCheck %s
+// RUN: rocmlir-driver -host-pipeline highlevel -kernel-pipeline=gpu,rocdl -arch amdgcn-amd-amdhsa:gfx1030 %s -o -| FileCheck %s
 
 // CHECK-LABEL: test_fusion
 

--- a/mlir/test/rocmlir-driver/populate.mlir
+++ b/mlir/test/rocmlir-driver/populate.mlir
@@ -1,7 +1,7 @@
-// RUN: rocmlir-gen --arch %arch -p -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s --enable-var-scope=false -D\$ITYPE=f32 -D\$OTYPE=f32
-// RUN: rocmlir-gen --arch %arch -p -t f16 -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s -D\$ITYPE=f16 -D\$OTYPE=f16
-// RUN: rocmlir-gen --arch %arch -p -t bf16 -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s -D\$ITYPE=bf16 -D\$OTYPE=bf16
-// RUN: rocmlir-gen --arch %arch -p -t i8 -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s -D\$ITYPE=i8 -D\$OTYPE=i32
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s --enable-var-scope=false -D\$ITYPE=f32 -D\$OTYPE=f32
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -t f16 -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s -D\$ITYPE=f16 -D\$OTYPE=f16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -t bf16 -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s -D\$ITYPE=bf16 -D\$OTYPE=bf16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -t i8 -mfma=off -wmma=off -atomic_add=off -atomic_fmax_f32=off -dot=on --mlir-print-local-scope | FileCheck %s -D\$ITYPE=i8 -D\$OTYPE=i32
 
 // CHECK-LABEL: module
 // CHECK-NEXT: func.func @rock_conv_gkc01_ngc01_ngk01_0

--- a/mlir/test/rocmlir-driver/populate_host.mlir
+++ b/mlir/test/rocmlir-driver/populate_host.mlir
@@ -1,6 +1,6 @@
-// RUN: rocmlir-gen --arch %arch -p -ph --apply-bufferization-pipeline=false | FileCheck %s
-// RUN: rocmlir-gen --arch %arch -p -ph -t f16 --apply-bufferization-pipeline=false | FileCheck %s
-// RUN: rocmlir-gen --arch %arch -p -ph -t i8 --apply-bufferization-pipeline=false | FileCheck %s
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph --apply-bufferization-pipeline=false | FileCheck %s
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -t f16 --apply-bufferization-pipeline=false | FileCheck %s
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -t i8 --apply-bufferization-pipeline=false | FileCheck %s
 
 // CHECK-LABEL: func.func @main()
 // CHECK-NEXT: %[[filter:.*]] = memref.alloc() : memref<[[GKCYX:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>

--- a/mlir/test/rocmlir-driver/populate_host_convert.mlir
+++ b/mlir/test/rocmlir-driver/populate_host_convert.mlir
@@ -1,7 +1,7 @@
-// RUN: rocmlir-gen --arch %arch -p -ph -pr --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=F32
-// RUN: rocmlir-gen --arch %arch -p -ph -pr -t f16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefixes=F16,CHECK
-// RUN: rocmlir-gen --arch %arch -p -ph -pr -t bf16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefixes=BF16,CHECK
-// RUN: rocmlir-gen --arch %arch -p -ph -pr -t i8 --apply-bufferization-pipeline=false | FileCheck %s --check-prefixes=I8
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=F32
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr -t f16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefixes=F16,CHECK
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr -t bf16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefixes=BF16,CHECK
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr -t i8 --apply-bufferization-pipeline=false | FileCheck %s --check-prefixes=I8
 
 // F32-NOT: func.func @_memcpy_
 // I8-NOT: func.func @_memcpy_

--- a/mlir/test/rocmlir-driver/populate_host_print.mlir
+++ b/mlir/test/rocmlir-driver/populate_host_print.mlir
@@ -1,7 +1,7 @@
-// RUN: rocmlir-gen --arch %arch -p -ph -pr --apply-bufferization-pipeline=false | FileCheck %s
-// RUN: rocmlir-gen --arch %arch -p -ph -pr -t f16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=F16
-// RUN: rocmlir-gen --arch %arch -p -ph -pr -t bf16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=BF16
-// RUN: rocmlir-gen --arch %arch -p -ph -pr -t i8 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=I8
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr --apply-bufferization-pipeline=false | FileCheck %s
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr -t f16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=F16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr -t bf16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=BF16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -ph -pr -t i8 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=I8
 
 // CHECK-LABEL: func.func @main()
 // CHECK-NEXT: %[[filter:.*]] = memref.alloc() : memref<[[GKCYX:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>

--- a/mlir/test/rocmlir-driver/populate_padding.mlir
+++ b/mlir/test/rocmlir-driver/populate_padding.mlir
@@ -1,5 +1,5 @@
-// RUN: rocmlir-gen --arch %arch -mfma=off -atomic_add=off -p=false --padding_h=0 -batchsize=32 -in_channels=32 -out_channels=256 -in_h=14 -in_w=14 -fil_h=1 -fil_w=1  --padding_w_l=1 --padding_w_r=2 --mlir-print-local-scope | FileCheck %s --check-prefix=Padding_One
-// RUN: rocmlir-gen --arch %arch -mfma=off -atomic_add=off -p=false --padding_h=3 -batchsize=32 -in_channels=32 -out_channels=256 -in_h=14 -in_w=14 -fil_h=1 -fil_w=1  --padding_w_l=1 --padding_w_r=2 --mlir-print-local-scope | FileCheck %s --check-prefix=Padding_Two
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -mfma=off -atomic_add=off -p=false --padding_h=0 -batchsize=32 -in_channels=32 -out_channels=256 -in_h=14 -in_w=14 -fil_h=1 -fil_w=1  --padding_w_l=1 --padding_w_r=2 --mlir-print-local-scope | FileCheck %s --check-prefix=Padding_One
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -mfma=off -atomic_add=off -p=false --padding_h=3 -batchsize=32 -in_channels=32 -out_channels=256 -in_h=14 -in_w=14 -fil_h=1 -fil_w=1  --padding_w_l=1 --padding_w_r=2 --mlir-print-local-scope | FileCheck %s --check-prefix=Padding_Two
 
 // Padding_One-LABEL: func.func @rock_conv_gkc01_ngc01_ngk01_0
 // Padding_One-SAME: ([[arg0:%.+]]: memref<8192xf32>, [[arg1:%.+]]: memref<200704xf32>, [[arg2:%.+]]: memref<1949696xf32>)

--- a/mlir/test/rocmlir-driver/populate_prc.mlir
+++ b/mlir/test/rocmlir-driver/populate_prc.mlir
@@ -1,11 +1,11 @@
-// RUN: rocmlir-gen --arch %arch -p -prc | FileCheck %s --check-prefix=F32
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -prc | FileCheck %s --check-prefix=F32
 
 // F32: func.func @main()
 // F32:  %[[RES:.*]] = memref.cast {{.*}} : memref<{{.*}}> to memref<*xf32>
 // F32-NEXT:    call @printMemrefF32(%[[RES]]) : (memref<*xf32>) -> ()
 
-// RUN: rocmlir-gen --arch %arch -p -prc -t f16 | FileCheck %s --check-prefixes=CHECK -D\$TYPE=f16
-// RUN: rocmlir-gen --arch %arch -p -prc -t bf16 | FileCheck %s --check-prefix=CHECK -D\$TYPE=bf16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -prc -t f16 | FileCheck %s --check-prefixes=CHECK -D\$TYPE=f16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -prc -t bf16 | FileCheck %s --check-prefix=CHECK -D\$TYPE=bf16
 
 // CHECK-LABEL: func.func @conv_cpu
 // CHECK-SAME: ([[arg0:%.+]]: memref<9216x[[$TYPE]]>, [[arg1:%.+]]: memref<1048576x[[$TYPE]]>, [[arg2:%.+]]: memref<14745600x[[$TYPE]]>)
@@ -22,7 +22,7 @@
 // CHECK:  %[[RES2:.*]] = memref.cast %[[RES1]] : memref<{{.*}}> to memref<*xf32>
 // CHECK:  call @printMemrefF32(%[[RES2]]) : (memref<*xf32>) -> ()
 
-// RUN: rocmlir-gen --arch %arch -p -prc -t i8 | FileCheck %s --check-prefix=INT8
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -prc -t i8 | FileCheck %s --check-prefix=INT8
 
 // INT8: func.func @main()
 // INT8:  [[RES:%.*]] = memref.cast {{.*}} : memref<{{.*}}> to memref<*xi32>

--- a/mlir/test/rocmlir-driver/populate_random_data.mlir
+++ b/mlir/test/rocmlir-driver/populate_random_data.mlir
@@ -1,14 +1,14 @@
-// RUN: rocmlir-gen --arch %arch -ph -p -rand=none | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=NONE
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand=none | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=NONE
 
 // NONE-NOT: call @seedRandomValues
 
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,RAND1,RAND2,RAND3
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_side filter | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,RAND1,FIXED2,FIXED3
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_side input | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,RAND2,FIXED3
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_side filter -operation conv_bwd_data | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,RAND1,FIXED2,FIXED3
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_side output  -operation conv_bwd_data | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,FIXED2,RAND3
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_side input -operation conv_bwd_weight | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,RAND2,FIXED3
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_side output  -operation conv_bwd_weight | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,FIXED2,RAND3
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,RAND1,RAND2,RAND3
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_side filter | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,RAND1,FIXED2,FIXED3
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_side input | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,RAND2,FIXED3
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_side filter -operation conv_bwd_data | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,RAND1,FIXED2,FIXED3
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_side output  -operation conv_bwd_data | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,FIXED2,RAND3
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_side input -operation conv_bwd_weight | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,RAND2,FIXED3
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_side output  -operation conv_bwd_weight | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,FIXED2,RAND3
 
 // CHECK-LABEL: @main
 // CHECK-DAG: %[[min:.*]] = arith.constant -5 : i16
@@ -33,11 +33,11 @@
 // FIXED3-NEXT: %[[val3:.*]] = func.call @randomIntegerValue(%[[one_i16]], %[[one_i16]])
 // CHECK-NEXT: memref.store %[[val1]]
 
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 2 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=SEED2
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 2 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=SEED2
 // SEED2: %[[two:.*]] = arith.constant 2 : i32
 // SEED2: call @seedRandomValues(%[[two]])
 
-// RUN: rocmlir-gen --arch %arch -ph -p -rand 1 -rand_type float -rand_min 1 -rand_max 3 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_FLOAT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_type float -rand_min 1 -rand_max 3 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_FLOAT
 
 // RAND_FLOAT-LABEL: @main
 // RAND_FLOAT-DAG: %[[min:.*]] = arith.constant 1 : i16

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -1,5 +1,5 @@
-// RUN: rocmlir-gen --arch %arch --operation attention -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 --with-attn-scale -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK_SCALE
-// RUN: rocmlir-gen --arch %arch --operation attention -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK_NO_SCALE
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 --with-attn-scale -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK_SCALE
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK_NO_SCALE
 
 // CHECK_SCALE: module attributes {mhal.arch = "[[$ARCH:.*]]"}
 
@@ -36,7 +36,7 @@
 
 // ----
 
-// RUN: rocmlir-gen --arch %arch --operation attention -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK_NO_SCALE
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK_NO_SCALE
 
 // CHECK_NO_SCALE: module attributes {mhal.arch = "[[$ARCH:.*]]"}
 

--- a/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
+++ b/mlir/test/rocmlir-gen/gemm-kernel-types.mlir
@@ -1,10 +1,10 @@
-// RUN: rocmlir-gen --arch %arch --operation gemm -t f16 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,F16,FLOAT
-// RUN: rocmlir-gen --arch %arch --operation gemm -t i8 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,I8,INT
-// RUN: rocmlir-gen --arch %arch --operation gemm -t i8 -c_dtype i8 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,I8-I8,INT
-// RUN: rocmlir-gen --arch %arch --operation gemm -ta fp8 -tb bf8 -tc f32 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,FP8-BF8,FLOAT
-// RUN: rocmlir-gen --arch %arch --operation gemm -t fp8_bf8 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,FP8-BF8,FLOAT
-// RUN: rocmlir-gen --arch %arch --operation gemm -ta fp8 -tb bf8 -tc f32 -g 3 -m 1024 -k 769 -n 512 -pv --force-f8-types=ocp | FileCheck %s --check-prefixes=CHECK,FP8-BF8-OCP,FLOAT
-// RUN: rocmlir-gen --arch %arch --operation gemm -t fp8_bf8 -g 3 -m 1024 -k 769 -n 512 -pv --force-f8-types=ocp | FileCheck %s --check-prefixes=CHECK,FP8-BF8-OCP,FLOAT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t f16 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,F16,FLOAT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t i8 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,I8,INT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t i8 -c_dtype i8 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,I8-I8,INT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -ta fp8 -tb bf8 -tc f32 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,FP8-BF8,FLOAT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t fp8_bf8 -g 3 -m 1024 -k 769 -n 512 -pv | FileCheck %s --check-prefixes=CHECK,FP8-BF8,FLOAT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -ta fp8 -tb bf8 -tc f32 -g 3 -m 1024 -k 769 -n 512 -pv --force-f8-types=ocp | FileCheck %s --check-prefixes=CHECK,FP8-BF8-OCP,FLOAT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t fp8_bf8 -g 3 -m 1024 -k 769 -n 512 -pv --force-f8-types=ocp | FileCheck %s --check-prefixes=CHECK,FP8-BF8-OCP,FLOAT
 
 // CHECK-LABEL: func @rock_gemm
 // F16-SAME: (%{{.*}}: memref<2362368xf16>, %{{.*}}: memref<1181184xf16>, %{{.*}}: memref<1572864xf16>)

--- a/mlir/test/rocmlir-gen/gemm-kernel.mlir
+++ b/mlir/test/rocmlir-gen/gemm-kernel.mlir
@@ -1,13 +1,13 @@
 // The extra rocmlir-opt calls check IR validity
 
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,NOTRB,NOTRC
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,NOTRB,TRC
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transB | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,TRB,NOTRC
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transB -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,TRB,TRC
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,NOTRB,NOTRC
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,NOTRB,TRC
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA -transB | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,TRB,NOTRC
-// RUN: rocmlir-gen --arch %arch --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA -transB -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,TRB,TRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,NOTRB,NOTRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,NOTRB,TRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transB | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,TRB,NOTRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transB -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,NOTRA,TRB,TRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,NOTRB,NOTRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,NOTRB,TRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA -transB | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,TRB,NOTRC
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -g 3 -m 1024 -k 769 -n 512 -pv -transA -transB -transC | rocmlir-opt | FileCheck %s --enable-var-scope --check-prefixes=CHECK,TRA,TRB,TRC
 
 // NOTRA-DAG: #[[mapAUnmerge:.*]] = affine_map<(d0, d1, d2) -> ((d0 * 1024 + d1) * 769 + d2)>
 // TRA-DAG:   #[[mapAUnmerge:.*]] = affine_map<(d0, d1, d2) -> ((d0 * 769 + d1) * 1024 + d2)>

--- a/mlir/test/rocmlir-gen/generate-clone-harness.mlir
+++ b/mlir/test/rocmlir-gen/generate-clone-harness.mlir
@@ -1,5 +1,5 @@
-// RUN: rocmlir-gen -fut mlir_reshape_convolution  --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx -host-pipeline=migraphx,highlevel |rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_reshape_convolution_wrapper --verifier clone - | FileCheck %s
-// RUN: rocmlir-gen -fut mlir_reshape_convolution  --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx -host-pipeline=migraphx,highlevel |rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_reshape_convolution_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full| FileCheck %s  --check-prefixes=CHECK_FULL
+// RUN: rocmlir-gen -fut mlir_reshape_convolution  --arch gfx90a:sramecc+:xnack- --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx -host-pipeline=migraphx,highlevel |rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_reshape_convolution_wrapper --verifier clone - | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_reshape_convolution  --arch gfx90a:sramecc+:xnack- --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx -host-pipeline=migraphx,highlevel |rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_reshape_convolution_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full| FileCheck %s  --check-prefixes=CHECK_FULL
 
 
 func.func private @mlir_reshape_convolution(%arg0: !migraphx.shaped<1x1x16x2x16x2xf32, 256x256x16x0x1x0>, %arg1: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>) -> (!migraphx.shaped<1x1x32x32xf32, 1024x1024x32x1>) {

--- a/mlir/test/rocmlir-gen/problem-key.mlir
+++ b/mlir/test/rocmlir-gen/problem-key.mlir
@@ -1,8 +1,8 @@
-// RUN: rocmlir-gen --arch %arch --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_1
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_1
 // CHECK_1: -t f32 -transQ false -transK false -transV false -transO false -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
-// RUN: rocmlir-gen --arch %arch --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -g 4 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_2
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -g 4 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_2
 // CHECK_2: -t f16 -transQ false -transK false -transV false -transO false -g 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
-// RUN: rocmlir-gen --arch %arch --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_3
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_3
 // CHECK_3: -t i8 -transQ false -transK false -transV false -transO false -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 
 // Checking numCU

--- a/mlir/test/xmir/resnet18.tosa.mlir
+++ b/mlir/test/xmir/resnet18.tosa.mlir
@@ -1,4 +1,4 @@
- // RUN: rocmlir-driver -host-pipeline partition,highlevel -targets %arch %s | rocmlir-gen -ph -print-results -verifier clone -fut forward - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | FileCheck %s
+ // RUN: rocmlir-driver -host-pipeline partition,highlevel -targets gfx90a:sramecc+:xnack- %s | rocmlir-gen -ph -print-results -verifier clone -fut forward - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | FileCheck %s
 
 // CHECK: mhal.launch @forward__part_19
 


### PR DESCRIPTION
When I built rocMLIR on a system that had its GPU
out (rocm_agent_enumerator just reports a gfx000) various tests didn't run because %arch was the empty string.

Also, the get_agents() function wasn't properly updated for the utf-8 decodes that are now done on subprocess output, so gfx000 wasn't necessarily being filtered out properly.