### PR TITLE
Add support for tuning split-k with convolutions

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Generator/ConvGenerator.h
+++ b/mlir/include/mlir/Dialect/Rock/Generator/ConvGenerator.h
@@ -32,6 +32,8 @@ public:
     std::string arch;
     // TODO: drop these
     std::string chip;
+    // TODO[split-K]: remove after integrating split-K into MIGraphX
+    bool disableSplitKForTuning;
     std::string triple;
     std::string chipFeatures;
     std::string perfConfig;
@@ -63,8 +65,8 @@ public:
 
   ConvGenerator(
       const std::string &arch = "", const std::string &chip = "",
-      const std::string &triple = "", const std::string &chipFeatures = "",
-      const std::string &perfConfig = "",
+      bool disableSplitKForTuning = false, const std::string &triple = "",
+      const std::string &chipFeatures = "", const std::string &perfConfig = "",
       std::optional<int> num_cu = std::nullopt, bool reverseGrid = false,
       GemmFeatures features = GemmFeatures::none,
       const std::optional<rock::ConvOpType> operation = std::nullopt,

--- a/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
@@ -506,7 +506,6 @@ LogicalResult ConvGenerator::parseConvConfig(OpBuilder &builder,
     }
     return (argMap["fil_layout"].length() == argMap["in_layout"].length()) &&
            (argMap["in_layout"].length() == argMap["out_layout"].length());
-
   };
 
   // Proceed only if we have a valid argMap. Otherwise leave the handle to be
@@ -844,9 +843,12 @@ LogicalResult ConvGenerator::genConvModule(ModuleOp &module, int rawKernelId,
   func = func::FuncOp::create(builder.getUnknownLoc(), kernelName, funcType,
                               ArrayRef<NamedAttribute>(kernelAttrs));
   // TODO[split-K]: remove after integrating split-K into MIGraphX
-  if (!config.disableSplitKForTuning)
+  // TODO[split-K]: split-K does not work with BwdWeight
+  if (!config.disableSplitKForTuning &&
+      config.operation.value() != ConvOpType::BwdWeight) {
     func->setAttr(rock::EnableSplitKForTuningAttr::getMnemonic(),
                   builder.getUnitAttr());
+  }
   if (config.reverseGrid) {
     func->setAttr(rock::ReverseGridAttrAttr::getMnemonic(),
                   builder.getUnitAttr());

--- a/mlir/test/Dialect/Rock/lowering_affix_params.mlir
+++ b/mlir/test/Dialect/Rock/lowering_affix_params.mlir
@@ -2,4 +2,4 @@
 // RUN: rocmlir-gen --arch gfx908 -p --operation=conv | rocmlir-driver -rock-affix-params -rock-conv-to-gemm | FileCheck %s
 
 // CHECK: module {{.*}}
-// CHECK-NEXT: func.func @{{.*}}(%{{.*}}: memref<{{.*}}>, %{{.*}}: memref<{{.*}}>, %arg2: memref<{{.*}}>) attributes {block_size = {{.*}} : i32, kernel = 0 : i32, mhal.arch = "{{.*}}"}
+// CHECK-NEXT: func.func @{{.*}}(%{{.*}}: memref<{{.*}}>, %{{.*}}: memref<{{.*}}>, %arg2: memref<{{.*}}>) attributes {block_size = {{.*}} : i32, enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "{{.*}}"}

--- a/mlir/test/rocmlir-driver/populate.mlir
+++ b/mlir/test/rocmlir-driver/populate.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL: module
 // CHECK-NEXT: func.func @rock_conv_gkc01_ngc01_ngk01_0
 // CHECK-SAME: ([[arg0:%.+]]: memref<9216x[[$ITYPE]]>, [[arg1:%.+]]: memref<1048576x[[$ITYPE]]>, [[arg2:%.+]]: memref<14745600x[[$OTYPE]]>)
-// CHECK-SAME: attributes {kernel = 0 : i32, mhal.arch = "{{.*}}"}
+// CHECK-SAME: attributes {enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "{{.*}}"}
 // CHECK-NEXT: [[fil:%.+]] = rock.transform [[arg0]]
 // CHECK-SAME: ["g", "k", "c", "0", "1"]
 // CHECK-NEXT: [[$In:%.+]] = rock.transform [[arg1]]

--- a/mlir/test/rocmlir-driver/populate_padding.mlir
+++ b/mlir/test/rocmlir-driver/populate_padding.mlir
@@ -3,7 +3,7 @@
 
 // Padding_One-LABEL: func.func @rock_conv_gkc01_ngc01_ngk01_0
 // Padding_One-SAME: ([[arg0:%.+]]: memref<8192xf32>, [[arg1:%.+]]: memref<200704xf32>, [[arg2:%.+]]: memref<1949696xf32>)
-// Padding_One-SAME: attributes {kernel = 0 : i32, mhal.arch = "{{.*}}"}
+// Padding_One-SAME: attributes {enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "{{.*}}"}
 // Padding_One-NEXT: [[exp0:%.+]] = rock.transform [[arg0]] by
 // Padding_One-SAME: Unmerge{1, 256, 32, 1, 1}
 // Padding_One-NEXT: [[exp1:%.+]] = rock.transform [[arg1]] by
@@ -14,7 +14,7 @@
 
 // Padding_Two-LABEL: func.func @rock_conv_gkc01_ngc01_ngk01_0
 // Padding_Two-SAME: ([[arg0:%.+]]: memref<8192xf32>, [[arg1:%.+]]: memref<200704xf32>, [[arg2:%.+]]: memref<2785280xf32>)
-// Padding_Two-SAME: attributes {kernel = 0 : i32, mhal.arch = "{{.*}}"}
+// Padding_Two-SAME: attributes {enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "{{.*}}"}
 // Padding_Two-NEXT: [[exp0:%.+]] = rock.transform [[arg0]] by
 // Padding_Two-SAME: Unmerge{1, 256, 32, 1, 1}
 // Padding_Two-NEXT: [[exp1:%.+]] = rock.transform [[arg1]] by

--- a/mlir/test/rocmlir-driver/populate_subkernels.mlir
+++ b/mlir/test/rocmlir-driver/populate_subkernels.mlir
@@ -4,28 +4,28 @@
 // RUN: rocmlir-gen -conv-config "--operation conv --arch amdgcn-amd-amdhsa:gfx906 --num_cu 64 --fil_layout GNCHW --in_type fp32 --fil_type fp32 --out_type fp32 --in_layout NGCHW --out_layout NGCHW --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name conv_fwd --groupsize 1 --kernel_id 3" | FileCheck %s --check-prefix=KERNEL3
 
 // KERNEL0-LABEL: module
-// KERNEL0-NEXT:  func.func @conv_fwd_0(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {kernel = 0 : i32, mhal.arch = "{{.*}}"} {
+// KERNEL0-NEXT:  func.func @conv_fwd_0(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "{{.*}}"} {
 // KERNEL0-NEXT: %[[exp0:.*]] = rock.transform %arg0 {{.*}} : memref<1048576xf32> to memref<1x1024x1024x1x1xf32>
 // KERNEL0-NEXT: %[[exp1:.*]] = rock.transform %arg1 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>
 // KERNEL0-NEXT: %[[exp2:.*]] = rock.transform %arg2 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>
 // KERNEL0-NEXT: rock.conv(%[[exp0]], %[[exp1]], %[[exp2]]) features = dot {arch = "amdgcn-amd-amdhsa:gfx906", dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], numCU = 64 : i32, output_layout = ["no", "go", "ko", "0o", "1o"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 
 // KERNEL1-LABEL: module
-// KERNEL1-NEXT:  func.func @conv_fwd_1(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {kernel = 1 : i32, mhal.arch = "{{.*}}"} {
+// KERNEL1-NEXT:  func.func @conv_fwd_1(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {enable_splitk_for_tuning, kernel = 1 : i32, mhal.arch = "{{.*}}"} {
 // KERNEL1-NEXT: %[[exp0:.*]] = rock.transform %arg0 {{.*}} : memref<1048576xf32> to memref<1x1024x1024x1x1xf32>
 // KERNEL1-NEXT: %[[exp1:.*]] = rock.transform %arg1 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>
 // KERNEL1-NEXT: %[[exp2:.*]] = rock.transform %arg2 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>
 // KERNEL1-NEXT: rock.conv(%[[exp0]], %[[exp1]], %[[exp2]]) features = dot {arch = "amdgcn-amd-amdhsa:gfx906", dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], numCU = 64 : i32, output_layout = ["no", "go", "ko", "0o", "1o"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 
 // KERNEL2-LABEL: module
-// KERNEL2-NEXT:  func.func @conv_fwd_2(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {kernel = 2 : i32, mhal.arch = "{{.*}}"} {
+// KERNEL2-NEXT:  func.func @conv_fwd_2(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {enable_splitk_for_tuning, kernel = 2 : i32, mhal.arch = "{{.*}}"} {
 // KERNEL2-NEXT: %[[exp0:.*]] = rock.transform %arg0 {{.*}} : memref<1048576xf32> to memref<1x1024x1024x1x1xf32>
 // KERNEL2-NEXT: %[[exp1:.*]] = rock.transform %arg1 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>
 // KERNEL2-NEXT: %[[exp2:.*]] = rock.transform %arg2 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>
 // KERNEL2-NEXT: rock.conv(%[[exp0]], %[[exp1]], %[[exp2]]) features = dot {arch = "amdgcn-amd-amdhsa:gfx906", dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], numCU = 64 : i32, output_layout = ["no", "go", "ko", "0o", "1o"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]} : memref<1x1024x1024x1x1xf32>, memref<64x1x1024x14x14xf32>, memref<64x1x1024x14x14xf32>
 
 // KERNEL3-LABEL: module
-// KERNEL3-NEXT:  func.func @conv_fwd_3(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {kernel = 3 : i32, mhal.arch = "{{.*}}"} {
+// KERNEL3-NEXT:  func.func @conv_fwd_3(%arg0: memref<1048576xf32>, %arg1: memref<12845056xf32>, %arg2: memref<12845056xf32>) attributes {enable_splitk_for_tuning, kernel = 3 : i32, mhal.arch = "{{.*}}"} {
 // KERNEL3-NEXT: %[[exp0:.*]] = rock.transform %arg0 {{.*}} : memref<1048576xf32> to memref<1x1024x1024x1x1xf32>
 // KERNEL3-NEXT: %[[exp1:.*]] = rock.transform %arg1 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>
 // KERNEL3-NEXT: %[[exp2:.*]] = rock.transform %arg2 {{.*}} : memref<12845056xf32> to memref<64x1x1024x14x14xf32>

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3601,7 +3601,8 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
       }
 
       convGenerator = rock::ConvGenerator(
-          arch, chip, triple, chipFeatures, perfConfig.getValue(),
+          arch, chip, disableSplitKForTuning, triple, chipFeatures,
+          perfConfig.getValue(),
           num_cu.getNumOccurrences() ? std::optional<int>(num_cu.getValue())
                                      : std::nullopt,
           reverse_grid, enabledFeatures,


### PR DESCRIPTION
Added the **enable_splitk_for_tuning** attribute to the convolution func to enable tuning of various split-k values.