### PR TITLE
Fix crash arising from insufficient guards in WMMA instruction selector

### DIFF
--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -64,9 +64,9 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
     inputVectorLen = 16;
   }
 
-  if (mPerWave % inputVectorLen != 0)
+  if (mPerWave % inputVectorLen != 0 || mPerWave % dPerAccel != 0)
     return failure();
-  if (nPerWave % inputVectorLen != 0)
+  if (nPerWave % inputVectorLen != 0 || nPerWave % dPerAccel != 0)
     return failure();
 
   int64_t mRepeats = mPerWave / dPerAccel;

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -843,7 +843,7 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
   // and we want to do a(16x16) * b(16x16), 16 threads are loading a vector
   // of 16 Ks and the other 16 threads are replicating those values.
   int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
-  if (arch.contains("gfx12")) {
+  if (!isGfx11) {
     // Post-gfx12 each thread is loading a partial set of values
     // to reduce. For instance, with the previous example, each
     // thread is loading a vector of 8 Ks. The first 16 threads are

--- a/mlir/test/Dialect/Rock/affix_tuning_params_mperblock_too_small_gfx12.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params_mperblock_too_small_gfx12.mlir
@@ -1,0 +1,6 @@
+// RUN: not rocmlir-opt -rock-affix-params %s >/dev/null
+
+func.func @mlir_dot_add(%arg0: memref<1x2x1024xf16>, %arg1: memref<1x1024x320xf16>, %arg2: memref<1x2x320xf16> ) attributes {arch = "gfx1201", kernel = "mixr", num_cu = 32 : i64} {
+  rock.gemm %arg2 = %arg0 * %arg1 features =  dot|atomic_add|atomic_fmax_f32|wmma storeMethod =  set {arch = "gfx1201", perf_config = "v2:16,128,8,8,128,4,1,1,1"} : memref<1x2x320xf16> = memref<1x2x1024xf16> * memref<1x1024x320xf16>
+  return
+}


### PR DESCRIPTION
When serecting WMMA instructions, we get the number of repeats by dividing by dPerAccel. We used to guard this against division by 0 by checking that mPerWave and nPerWave were divisible by inputVectorLen, which was equal to dPerAccel ... until gfx12, where dPerAccel becase double the length of inputVectorLen (because WMMA changed to re-use both halves of the wave). This caused 0 coefficients in transform maps, which led to a bunch of weird crashes.

Fixes https://github.com/ROCm/rocMLIR-internal/issues/1582 (by making the input problem invalid) but doesn't actually fix the assertion crash we saw in that ticket because I got a different crash on develop.