### PR TITLE
Add 3-D layouts to conv regression tests and fix the problems exposed

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -65,9 +65,9 @@ class Rock_ConvOpBase<string mnemonic, list<Type> inputTypes=[F32, F16, BF16], l
                        DeclareOpInterfaceMethods<RockConvInterface>,
                        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
                        RockFusionRoot]>{
-    dag commonConvArgs = (ins TensorOrMemRefRankOf<inputTypes, [5,6]>:$filter,
-                              TensorOrMemRefRankOf<inputTypes, [5,6]>:$input,
-                              TensorOrMemRefRankOf<outputTypes, [5,6]>:$output,
+    dag commonConvArgs = (ins TensorOrMemRefOf<inputTypes>:$filter,
+                              TensorOrMemRefOf<inputTypes>:$input,
+                              TensorOrMemRefOf<outputTypes>:$output,
                               StrAttr:$arch,
                               Rock_GemmFeaturesAttr:$features,
                               OptionalAttr<I32Attr>:$derivedBlockSize,
@@ -119,7 +119,7 @@ def Rock_ConvBwdDataOp : Rock_ConvOpBase<"conv_bwd_data">
 
 def Rock_ConvBwdWeightOp : Rock_ConvOpBase<"conv_bwd_weight">
 {
-  dag additionalArgs = (ins Optional<TensorOrMemRefRankOf<[F32], [5,6]>>:$workspace,
+  dag additionalArgs = (ins Optional<TensorOrMemRefOf<[F32]>>:$workspace,
                             OptionalAttr<IndexAttr>:$kBlocks, I32Attr:$numCU);
   let arguments = !con(commonConvArgs, additionalArgs);
   let summary = "N-D convolution backward weight";
@@ -135,11 +135,11 @@ def Rock_ConvBwdWeightOp : Rock_ConvOpBase<"conv_bwd_weight">
 
 def Rock_GemmOp :
     Rock_Op<"gemm", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>, RockFusionRoot]>,
-    Arguments<(ins Arg<TensorOrMemRefRankOf<GemmInputTypes, [2, 3]>,
+    Arguments<(ins Arg<TensorOrMemRefOf<GemmInputTypes>,
                        "matrix A", [MemRead]>:$a,
-                   Arg<TensorOrMemRefRankOf<GemmInputTypes, [2, 3]>,
+                   Arg<TensorOrMemRefOf<GemmInputTypes>,
                        "matrix B", [MemRead]>:$b,
-                   Arg<TensorOrMemRefRankOf<GemmOutputTypes, [2, 3]>,
+                   Arg<TensorOrMemRefOf<GemmOutputTypes>,
                        "matrix C", [MemRead, MemWrite]>:$c,
                    UnitAttr:$aTransposed,
                    UnitAttr:$bTransposed,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -119,7 +119,7 @@ def Rock_ConvBwdDataOp : Rock_ConvOpBase<"conv_bwd_data">
 
 def Rock_ConvBwdWeightOp : Rock_ConvOpBase<"conv_bwd_weight">
 {
-  dag additionalArgs = (ins Optional<TensorOrMemRefRankOf<[F32], [5]>>:$workspace,
+  dag additionalArgs = (ins Optional<TensorOrMemRefRankOf<[F32], [5,6]>>:$workspace,
                             OptionalAttr<IndexAttr>:$kBlocks, I32Attr:$numCU);
   let arguments = !con(commonConvArgs, additionalArgs);
   let summary = "N-D convolution backward weight";

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -465,11 +465,14 @@ ConvolutionDims ConvolutionDims::fromOp(Operation *op) {
   }
 
   SmallVector<int64_t> fil({y, x});
-  if (z > 0) fil.push_back(z);
+  if (z > 0)
+    fil.push_back(z);
   SmallVector<int64_t> out({ho, wo});
-  if (dout > 0) out.push_back(dout);
+  if (dout > 0)
+    out.push_back(dout);
   SmallVector<int64_t> in({hi, wi});
-  if (di > 0) in.push_back(di);
+  if (di > 0)
+    in.push_back(di);
   return ConvolutionDims(fil, out, in, k, c, n, g);
 }
 

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -295,7 +295,7 @@ void TransformMapBuilder::defineDim(StringRef name, uint32_t dim,
                     "fetching the attribute");
   bool nameInsertResult = endIndices.insert({name, dim}).second;
   assert(nameInsertResult &&
-         "Trying to redife a result name in a coordinate transformation");
+         "Trying to redefine a result name in a coordinate transform");
   SmallString<8> nameCopy = name;
   bool dimInsertResult = endNames.insert({dim, nameCopy}).second;
   assert(dimInsertResult &&

--- a/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
@@ -630,7 +630,7 @@ LogicalResult backwardWeightAtomicAdd(ConvBwdWeightOp op, PatternRewriter &b) {
     // is what's left
     llvm::StringMap<SmallVector<StringRef, 2>> expansions;
     expansions.insert({"ni", {"n0", "n1"}});
-    for (int i = 0; i < convDims.in.size(); i++) {
+    for (size_t i = 0; i < convDims.in.size(); i++) {
       StringAttr key = b.getStringAttr(Twine(i) + "i");
       StringAttr val = b.getStringAttr(Twine(i) + "ipad");
       expansions.insert({key, {val}});

--- a/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
@@ -630,7 +630,7 @@ LogicalResult backwardWeightAtomicAdd(ConvBwdWeightOp op, PatternRewriter &b) {
     // is what's left
     llvm::StringMap<SmallVector<StringRef, 2>> expansions;
     expansions.insert({"ni", {"n0", "n1"}});
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < convDims.in.size(); i++) {
       StringAttr key = b.getStringAttr(Twine(i) + "i");
       StringAttr val = b.getStringAttr(Twine(i) + "ipad");
       expansions.insert({key, {val}});
@@ -897,11 +897,13 @@ LogicalResult backwardData(ConvBwdDataOp op, PatternRewriter &b) {
     sliceTransform.passThrough({"g", "k", "c"});
     llvm::SmallVector<StringRef, 2> uppers;
     llvm::SmallVector<StringRef, 2> lowers;
+    llvm::SmallVector<int64_t, 2> begins;
     for (size_t i = 0; i < convDims.in.size(); i++) {
       uppers.push_back(b.getStringAttr(Twine(i) + "dotslice"));
       lowers.push_back(b.getStringAttr(Twine(i) + "dot"));
+      begins.push_back(0);
     }
-    sliceTransform.slice(uppers, lowers, {0, 0}, iDotSlice);
+    sliceTransform.slice(uppers, lowers, begins, iDotSlice);
     uppers.clear();
     lowers.clear();
     for (size_t i = 0; i < convDims.fil.size(); i++) {
@@ -1066,11 +1068,13 @@ LogicalResult backwardData(ConvBwdDataOp op, PatternRewriter &b) {
     sliceTransform.passThrough({"go", "no", "ko"});
     llvm::SmallVector<StringRef, 2> uppers;
     llvm::SmallVector<StringRef, 2> lowers;
+    llvm::SmallVector<int64_t, 2> begins;
     for (size_t i = 0; i < convDims.out.size(); i++) {
       uppers.push_back(b.getStringAttr(Twine(i) + "slice"));
       lowers.push_back(b.getStringAttr(Twine(i) + "dot"));
+      begins.push_back(0);
     }
-    sliceTransform.slice(uppers, lowers, {0, 0}, iDotSlice);
+    sliceTransform.slice(uppers, lowers, begins, iDotSlice);
     lowers.clear();
     uppers.clear();
     for (size_t i = 0; i < convDims.out.size(); i++) {

--- a/mlir/test/e2e/conv_regression_bwd.toml
+++ b/mlir/test/e2e/conv_regression_bwd.toml
@@ -9,7 +9,7 @@ prefix = "--operation "
 
 [[axis]]
 name = "layout"
-values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk"]
+values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk", "-fil_layout=kc012 -in_layout=nc012 -out_layout=nk012"]
 
 [[axis]]
 name = "data type"

--- a/mlir/test/e2e/conv_regression_fwd.toml
+++ b/mlir/test/e2e/conv_regression_fwd.toml
@@ -9,7 +9,7 @@ prefix = "--operation "
 
 [[axis]]
 name = "layout"
-values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk", "-fil_layout=yxck -in_layout=nhwc -out_layout=nhwk"]
+values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk", "-fil_layout=yxck -in_layout=nhwc -out_layout=nhwk", "-fil_layout=kc012 -in_layout=nc012 -out_layout=nk012"]
 
 [[axis]]
 name = "data type"
@@ -225,4 +225,3 @@ config = "-groupsize=1 -batchsize=64 -in_channels=4 -out_channels=64 -in_h=4 -in
 #############################################################################################
 [[suite.test]]
 config = "--reverse_grid -groupsize=1 -batchsize=128 -in_channels=8 -out_channels=128 -in_h=16 -in_w=16 -fil_h=5 -fil_w=5 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0"
-

--- a/mlir/test/e2e/conv_regression_fwd_nonNavi3x.toml
+++ b/mlir/test/e2e/conv_regression_fwd_nonNavi3x.toml
@@ -9,7 +9,7 @@ prefix = "--operation "
 
 [[axis]]
 name = "layout"
-values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk", "-fil_layout=yxck -in_layout=nhwc -out_layout=nhwk"]
+values = ["-fil_layout=kcyx -in_layout=nchw -out_layout=nkhw", "-fil_layout=kyxc -in_layout=nhwc -out_layout=nhwk", "-fil_layout=yxck -in_layout=nhwc -out_layout=nhwk", "-fil_layout=kc012 -in_layout=nc012 -out_layout=nk012"]
 
 [[axis]]
 name = "data type"

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1081,8 +1081,7 @@ static void populateDefaults() {
         paddingWidthLeft.getValue(), paddingWidthRight.getValue(),
         strideWidth.getValue(), dilationWidth.getValue());
   }
-  if (isConv && outputDepth.getNumOccurrences() == 0 &&
-      inputDepth.getNumOccurrences() > 0) {
+  if (isConv && outputDepth.getNumOccurrences() == 0) {
     outputDepth = rock::ConvGenerator::outputDim(
         inputDepth.getValue(), filterDepth.getValue(),
         paddingDepthLeft.getValue(), paddingDepthRight.getValue(),
@@ -3612,14 +3611,20 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
           outputLayout.getValue());
 
       SmallVector<int64_t> inDims{inputHeight, inputWidth};
-      if (nDims > 2)
+      if (nDims > 2) {
+        if (inputDepth < 1) inputDepth = 1;
         inDims.push_back(inputDepth);
+      }
       SmallVector<int64_t> outDims{outputHeight, outputWidth};
-      if (nDims > 2)
+      if (nDims > 2) {
+        if (outputDepth < 1) outputDepth = 1;
         outDims.push_back(outputDepth);
+      }
       SmallVector<int64_t> filDims{filterHeight, filterWidth};
-      if (nDims > 2)
+      if (nDims > 2) {
+        if (filterDepth < 1) filterDepth = 1;
         filDims.push_back(filterDepth);
+      }
 
       status =
           convGenerator.parseConvDims(batchSize, groupSize, inputChannel,

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3612,17 +3612,20 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
 
       SmallVector<int64_t> inDims{inputHeight, inputWidth};
       if (nDims > 2) {
-        if (inputDepth < 1) inputDepth = 1;
+        if (inputDepth < 1)
+          inputDepth = 1;
         inDims.push_back(inputDepth);
       }
       SmallVector<int64_t> outDims{outputHeight, outputWidth};
       if (nDims > 2) {
-        if (outputDepth < 1) outputDepth = 1;
+        if (outputDepth < 1)
+          outputDepth = 1;
         outDims.push_back(outputDepth);
       }
       SmallVector<int64_t> filDims{filterHeight, filterWidth};
       if (nDims > 2) {
-        if (filterDepth < 1) filterDepth = 1;
+        if (filterDepth < 1)
+          filterDepth = 1;
         filDims.push_back(filterDepth);
       }
 


### PR DESCRIPTION
Fix defaulting of output depth in rocmlir-gen.
Simple 3D tests added to conv_regression_fwd -- added one 3D layout.
Fix the defaults for depths, and add conv-fwd 3-D tests.
Add a 3-D case to the conv-bwd test, and fix several things to make it pass.