### PR TITLE
Use separate call to check for `gfx11`

### DIFF
--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -843,7 +843,7 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
   // and we want to do a(16x16) * b(16x16), 16 threads are loading a vector
   // of 16 Ks and the other 16 threads are replicating those values.
   int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
-  if (!isGfx11) {
+  if (!arch.contains("gfx11")) {
     // Post-gfx12 each thread is loading a partial set of values
     // to reduce. For instance, with the previous example, each
     // thread is loading a vector of 8 Ks. The first 16 threads are

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -843,6 +843,8 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
   // and we want to do a(16x16) * b(16x16), 16 threads are loading a vector
   // of 16 Ks and the other 16 threads are replicating those values.
   int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
+  // isGfx11 flag is set after call to this function. Therefore can not use
+  // isGfx11 flag yet from inside this function.
   if (!arch.contains("gfx11")) {
     // Post-gfx12 each thread is loading a partial set of values
     // to reduce. For instance, with the previous example, each


### PR DESCRIPTION
Earlier it was using `isGfx11` flag which gets initialized after call to base class constructor `AccelEmitter`

Therefore it can't be used inside the constructor of the base class. 

Fixes GemmVariants tests on Navi3x