### PR TITLE
Fix too-strict test in fp8 emulation chenks

### DIFF
--- a/external/llvm-project/mlir/lib/Conversion/ArithToAMDGPU/ArithToAMDGPU.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/ArithToAMDGPU/ArithToAMDGPU.cpp
@@ -39,7 +39,9 @@ struct ArithToAMDGPUConversionPass final
 };
 
 struct ExtFOnFloat8RewritePattern final : OpRewritePattern<arith::ExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  Chipset chipset;
+  ExtFOnFloat8RewritePattern(MLIRContext *ctx, Chipset chipset)
+      : OpRewritePattern::OpRewritePattern(ctx), chipset(chipset) {}
 
   LogicalResult match(arith::ExtFOp op) const override;
   void rewrite(arith::ExtFOp op, PatternRewriter &rewriter) const override;
@@ -68,6 +70,15 @@ struct TruncfToFloat16RewritePattern final
 
 } // end namespace
 
+static LogicalResult isSupportedFp8(Type elementType, Chipset chipset) {
+  if (chipset.isGfx940())
+    return success(elementType.isFloat8E5M2FNUZ() ||
+                   elementType.isFloat8E4M3FNUZ());
+  if (chipset.hasOcpFp8())
+    return success(elementType.isFloat8E5M2() || elementType.isFloat8E4M3FN());
+  return failure();
+}
+
 static Value castF32To(Type elementType, Value f32, Location loc,
                        PatternRewriter &rewriter) {
   if (elementType.isF32())
@@ -86,8 +97,7 @@ LogicalResult ExtFOnFloat8RewritePattern::match(arith::ExtFOp op) const {
       return failure();
     inType = inVecType.getElementType();
   }
-  return success(inType.isFloat8E5M2FNUZ() || inType.isFloat8E4M3FNUZ() ||
-                 inType.isFloat8E5M2() || inType.isFloat8E4M3FN());
+  return isSupportedFp8(inType, chipset);
 }
 
 void ExtFOnFloat8RewritePattern::rewrite(arith::ExtFOp op,
@@ -218,10 +228,7 @@ LogicalResult TruncFToFloat8RewritePattern::match(arith::TruncFOp op) const {
     // Conversion between 8-bit floats is not supported with truncation enabled.
     return failure();
 
-  return success((((outType.isFloat8E5M2FNUZ() || outType.isFloat8E4M3FNUZ()) &&
-                   chipset.isGfx940()) ||
-                  ((outType.isFloat8E5M2() || outType.isFloat8E4M3FN()) &&
-                   chipset.hasOcpFp8())));
+  return isSupportedFp8(outType, chipset);
 }
 
 void TruncFToFloat8RewritePattern::rewrite(arith::TruncFOp op,
@@ -361,7 +368,7 @@ void mlir::arith::populateArithToAMDGPUConversionPatterns(
     bool saturateFP8Truncf, bool allowPackedF16Rtz, Chipset chipset) {
 
   if (convertFP8Arithmetic) {
-    patterns.add<ExtFOnFloat8RewritePattern>(patterns.getContext());
+    patterns.add<ExtFOnFloat8RewritePattern>(patterns.getContext(), chipset);
     patterns.add<TruncFToFloat8RewritePattern>(patterns.getContext(),
                                                saturateFP8Truncf, chipset);
   }
@@ -380,7 +387,7 @@ void ArithToAMDGPUConversionPass::runOnOperation() {
   }
 
   bool convertFP8Arithmetic =
-      (*maybeChipset).majorVersion == 9 && (*maybeChipset).minorVersion >= 0x40;
+      maybeChipset->isGfx940() || maybeChipset->hasOcpFp8();
   arith::populateArithToAMDGPUConversionPatterns(
       patterns, convertFP8Arithmetic, saturateFP8Truncf, allowPackedF16Rtz,
       *maybeChipset);


### PR DESCRIPTION
--convert-arith-to-amdgpu was, despite having fp8 patterns that support gfx12, still checking for gfx9[>= 40] in order to enable any fp8 conversions at all. This PR fixes that check and refactors the test for pattern applicability.

Fixes https://github.com/ROCm/rocMLIR-internal/issues/1583