### PR TITLE
Handle process exception from calling rocminfo, to see why it sometimes fails.

### DIFF
--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -1327,7 +1327,15 @@ def getChip():
     return chip
 
 def getNumCU(chip):
-    rocminfo = subprocess.check_output("/opt/rocm/bin/rocminfo")
+    try:
+        rocminfo = subprocess.check_output("/opt/rocm/bin/rocminfo",
+                                           stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        print(e.stderr.decode('utf-8'))
+        raise
+    except Exception as e:
+        print(f"Exception: {e}")
+        raise
     rocminfoLines = rocminfo.decode("utf-8").split("\n")
     foundChip = False
     for line in rocminfoLines:


### PR DESCRIPTION
Sometimes we see rocminfo CalledProcessErrors in the log file, but it doesn't capture stderr and it's not apparent why it failed.  This patch attempts to catch the error and print stderr so hopefully we'll see it and maybe can do something about it.