### PR TITLE
Handle non-zero-preserving input fusions, make read_into track validity

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -856,7 +856,7 @@ def Rock_IndexDiffUpdateOp :
   let hasVerifier = 1;
 }
 
-defvar SupportedMemoryElems = [F32, F16, BF16, I<4>, I8, I16, I32,
+defvar SupportedMemoryElems = [F32, F16, BF16, I1, I<4>, I8, I16, I32,
                                F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN];
 defvar NativeMemoryOpTypes = [F32, F16, BF16, I<4>, I8, I16, I32,
                            F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN,
@@ -987,19 +987,34 @@ def Rock_GlobalStoreOp :
   let hasVerifier = 1;
 }
 
+defvar SameShapeVectorOfI1 = [{
+  ::mlir::VectorType::get(::llvm::cast<::mlir::ShapedType>($_self).getShape(), ::mlir::IntegerType::get($_ctxt, 1))
+}];
 // threadwise_read_into
 def Rock_ThreadwiseReadIntoOp :
     Rock_Op<"threadwise_read_into",
     [DeclareOpInterfaceMethods<RockAcceptingViewOpInterface>,
-     DeclareOpInterfaceMethods<RockWriterOpInterface>]>,
-    AllElementTypesMatch<["source", "dest"]>,
+     DeclareOpInterfaceMethods<RockWriterOpInterface>, AttrSizedOperandSegments,
+     // This wasn't being enforced and broke buffers of vectors.
+     //AllElementTypesMatch<["source", "dest"]>,
+     OptionalTypesMatchWith<"validity record is a vector of one boolean per dest entry",
+      "dest", "validityRecord", SameShapeVectorOfI1>,
+     TypesMatchWith<"all dynamic validities are a vector of one boolean per dest entry",
+      "dest", "dynamicValidities", SameShapeVectorOfI1,
+      [{
+        [](::mlir::Type lhs, ::mlir::TypeRange rhs) -> bool {
+          return llvm::all_of(rhs, [lhs](::mlir::Type t) { return t == lhs; });
+        }
+      }]>]>,
     Arguments<(ins Arg<MemRefOf<NativeMemoryOpTypes>, "source view", [MemRead]>:$source,
       Arg<MemRefOf<NativeMemoryOpTypes>, "destination registers", [MemWrite]>:$dest,
+      Variadic<VectorOf<[I1]>>:$dynamicValidities,
       TransformMapArrayAttr:$extraViews,
       Variadic<Index>:$extraIndices,
       UnitAttr:$forceUnroll,
       UnitAttr:$useIndexDiffs
-    )> {
+    )>,
+    Results<(outs Optional<VectorOf<[I1]>>:$validityRecord)> {
   let summary = "Read values from transformed source into destination";
 
   let description = [{
@@ -1040,13 +1055,37 @@ def Rock_ThreadwiseReadIntoOp :
     If extraIndices are used, the [extraViews]source must have the form
     (extraIdx0, ... , extraIdxN, iteration_number).
 
-    This is used during fusion to represent loads from addition arguments like
-    bias tensors.
+    If any `dynamicValidities` are passed in, they must have the same shape
+    as the output registers, and the booleans in each of these validities will be
+    ANDed together with the validity implied by the coordinate transformations
+    to determine whether the read is to actually be performed.
+
+    Note that using dynamic validities forces the vectorization width to 1.
+
+    If `validityRecord` is specified, it will be filled with a boolean indicating
+    whether each of the values in `dest` was actually read from memory or if it
+    fell into some padded or otherwise invalid (ex. a coordinate went negative)
+    region. This is used to allow manually applying re-applying padding after
+    an input fusion that could cause the padded region to be non-zero.
+
+    This operation is also used during fusion to represent loads from additional
+    arguments like bias tensors.
   }];
+
+  let builders = [
+    // Alias for the common case where we aren't filling a buffer of validity checks
+    OpBuilder<(ins "Value":$source, "Value":$dest,
+                   "ArrayAttr":$extraViews, "ValueRange":$extraIndices,
+                   "bool":$forceUnroll, "bool":$useIndexDiffs),
+      [{
+        build($_builder, $_state, TypeRange{}, source, dest, ValueRange{}, extraViews, extraIndices, forceUnroll, useIndexDiffs);
+      }]>
+  ];
 
   let assemblyFormat = [{
     attr-dict $extraViews `(` $source `)` (`[` $extraIndices^ `]`)? `->` $dest
-    `:` type($source) `->` type($dest)
+    (`if` ` ` `[` $dynamicValidities^ `]`)?
+    `:` type($source) `->` type($dest) (`,` type($validityRecord)^)?
   }];
   let hasVerifier = 1;
 }

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1060,7 +1060,10 @@ def Rock_ThreadwiseReadIntoOp :
     ANDed together with the validity implied by the coordinate transformations
     to determine whether the read is to actually be performed.
 
-    Note that using dynamic validities forces the vectorization width to 1.
+    Note that using dynamic validities forces the vectorization width to 1 (but
+    that merely requesting a validity vector does not). There isn't any inherent
+    reason for this limitation other than that support for post-vectorization
+    masking wasn't needed in the initial usecase for this feature.
 
     If `validityRecord` is specified, it will be filled with a boolean indicating
     whether each of the values in `dest` was actually read from memory or if it

--- a/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
@@ -41,7 +41,7 @@ Value getAsTensor(OpBuilder &builder, Location loc, mlir::Value value,
 
 // Return the type of a boolean vector whose shape is the same as the shape of
 // `v` except that its elements are booleans.
-Type validityVectorShapedLike(Value v);
+Type vectorOfBoolShapedLike(Value v);
 
 } // namespace rock
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
@@ -39,6 +39,10 @@ Type getFlattenedType(Type type);
 Value getAsTensor(OpBuilder &builder, Location loc, mlir::Value value,
                   bool isWritable = false);
 
+// Return the type of a boolean vector whose shape is the same as the shape of
+// `v` except that its elements are booleans.
+Type validityVectorShapedLike(Value v);
+
 } // namespace rock
 } // namespace mlir
 

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1667,15 +1667,22 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
           "Vector buffers vector's lengths need to be evenly divisible");
   }
 
-  if (!getDynamicValidities().empty() &&
-      srcType.getElementType() != destType.getElementType()) {
-    return emitOpError("dynamic validities applied where the "
-                       "source and destination have different types are "
-                       "currently unimplemented");
-  }
-  if (!getDynamicValidities().empty() && srcVectorType) {
-    return emitOpError(
-        "dynamic validities with vector buffers are unimplemented");
+  if (!getDynamicValidities().empty()) {
+    if (srcType.getElementType() != destType.getElementType()) {
+      return emitOpError("dynamic validities applied where the "
+                         "source and destination have different types are "
+                         "currently unimplemented");
+    }
+    if (srcVectorType) {
+      return emitOpError(
+          "dynamic validities with vector buffers are unimplemented");
+    }
+    if (!gpuSrcMemSpaceAttr ||
+        gpuSrcMemSpaceAttr.getValue() != gpu::AddressSpace::Private) {
+      return emitOpError(
+          "it's currently expeccted that dynamic validities will only be used "
+          "in register-to-register reads produced by input fusion");
+    }
   }
   return success();
 }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1669,8 +1669,9 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
 
   if (!getDynamicValidities().empty() &&
       srcType.getElementType() != destType.getElementType()) {
-    return emitOpError("dynamic validities are incompatible with making the "
-                       "source and destination have different types");
+    return emitOpError("dynamic validities applied where the "
+                       "source and destination have different types are "
+                       "currently unimplemented");
   }
   if (!getDynamicValidities().empty() && srcVectorType) {
     return emitOpError(

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1006,21 +1006,21 @@ LogicalResult InsertSliceOp::verify() {
 // GpuAllocOp
 //===-----------------------------------------------------===//
 
-static int64_t getSize(MemRefType memref) {
-  int64_t elementSize;
+static int64_t getByteSize(MemRefType memref) {
+  int64_t elementBitWidth = 0;
   Type type = memref.getElementType();
   if (auto vecType = dyn_cast<VectorType>(type)) {
-    elementSize =
-        (vecType.getElementTypeBitWidth() * vecType.getNumElements()) / 8;
+    elementBitWidth =
+        (vecType.getElementTypeBitWidth() * vecType.getNumElements());
   } else {
-    elementSize = type.getIntOrFloatBitWidth() / 8;
+    elementBitWidth = type.getIntOrFloatBitWidth();
   }
-  return memref.getNumElements() * elementSize;
+  return (memref.getNumElements() * elementBitWidth) / 8;
 }
 
 LogicalResult GpuAllocOp::verify() {
   // Make sure the size is bigger than 0
-  if (getSize(getOutput().getType()) > 0) {
+  if (getByteSize(getOutput().getType()) > 0) {
     return success();
   }
   return emitError("The size of rock.alloc should be greather than zero.");
@@ -1034,7 +1034,7 @@ LogicalResult GpuDeallocOp::verify() {
   // Make sure the input memref defining operation is a GpuAllocOp
   if (auto gpuAlloc = dyn_cast<GpuAllocOp>(getMemref().getDefiningOp())) {
     // Make sure the size is bigger than 0
-    if (getSize(getMemref().getType()) > 0) {
+    if (getByteSize(getMemref().getType()) > 0) {
       return success();
     }
     return emitError("The size of rock.dealloc should be greather than zero.");
@@ -1667,6 +1667,15 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
           "Vector buffers vector's lengths need to be evenly divisible");
   }
 
+  if (!getDynamicValidities().empty() &&
+      srcType.getElementType() != destType.getElementType()) {
+    return emitOpError("dynamic validities are incompatible with making the "
+                       "source and destination have different types");
+  }
+  if (!getDynamicValidities().empty() && srcVectorType) {
+    return emitOpError(
+        "dynamic validities with vector buffers are unimplemented");
+  }
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -857,7 +857,7 @@ static LogicalResult knownToPreserveZero(linalg::GenericOp laGeneric,
 /// - Clone the output tile
 /// - Set up a register->register threadwise_read_into between this cloned tile
 ///   and the original output tile, with dynamic validities drawn from the
-///   validity validity results of each read.
+///   validity results of each read.
 /// The extra threadwise_read_into we create here will cause elements that
 /// didn't actually get fetched from memory to become 0s again thanks to an if
 /// statement in what would otherwise be a memcpy().

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -24,30 +24,36 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/Passes.h"
+#include "mlir/Dialect/Rock/utility/builderUtils.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Rewrite/FrozenRewritePatternSet.h"
 #include "mlir/Rewrite/PatternApplicator.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/FoldUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ScopedPrinter.h"
@@ -542,11 +548,10 @@ traceToWriter(Value startVal,
 }
 
 static Value makeRegs(LinalgAlignRewriter &b, MemRefType::Builder &mrb,
-                      Location loc, Type srcType) {
-  auto srcMemType = cast<MemRefType>(srcType);
+                      Location loc, Type newElementType) {
   // 1. create a second allocation of the same type to hold loaded elements
-  return b.create<GpuAllocOp>(loc, static_cast<MemRefType>(mrb.setElementType(
-                                       srcMemType.getElementType())));
+  return b.create<GpuAllocOp>(
+      loc, static_cast<MemRefType>(mrb.setElementType(newElementType)));
 }
 
 static void markGenericWritersToRevisit(LinalgAlignRewriter &b, Value rawSrc) {
@@ -580,12 +585,18 @@ Value getRegisterValue<ThreadwiseWriteAllOp>(ThreadwiseWriteAllOp op) {
 /// While doing this, also mark any linalg.generic that write to this input as
 /// needing revisiting because we now know their tile size.
 ///
+/// If `validityRecord` is a non-null pointer, create a value to record
+/// whether each element of the tile was read from valid coordinates and
+/// put that buffer into `validityRecord`.
+///
 /// Returns the new register tile.
 template <typename TiledOp>
 static Value
 makeExtraInputTile(LinalgAlignRewriter &b, TiledOp tiledOp, Value src,
                    ArrayRef<TransformMapAttr> globalCoordsToGenericViews,
-                   linalg::GenericOp laGeneric) {
+                   linalg::GenericOp laGeneric,
+                   ValueRange dynamicValidities = {},
+                   Value *validityRecord = nullptr) {
   // 0. capture the memref containing the outputs being written or
   // (in the case of propagating tiling informatinon up to gemm-independent
   // code) where the values will be written.
@@ -612,7 +623,7 @@ makeExtraInputTile(LinalgAlignRewriter &b, TiledOp tiledOp, Value src,
   b.setInsertionPoint(laGeneric);
   auto mrbBuilder = cast<MemRefType>(tile.getType());
   MemRefType::Builder mrb(mrbBuilder);
-  Value alloc = makeRegs(b, mrb, loc, src.getType());
+  Value alloc = makeRegs(b, mrb, loc, getElementTypeOrSelf(src.getType()));
 
   // 1.1. Find out if the source is a scalar so we don't unroll a memset()
   Value rawSrc = std::get<0>(untransform(b, src));
@@ -641,9 +652,15 @@ makeExtraInputTile(LinalgAlignRewriter &b, TiledOp tiledOp, Value src,
   src = applyViewsOnDest(b, loc, src, globalCoordsToGenericViews);
 
   // 2.1. load into registers
+  Type validityRecordResultType = validityVectorShapedLike(alloc);
   ThreadwiseReadIntoOp threadwiseReadIntoOp = b.create<ThreadwiseReadIntoOp>(
-      loc, src, alloc, tiledOp.getExtraViews(),
+      loc,
+      validityRecord != nullptr ? TypeRange{validityRecordResultType}
+                                : TypeRange{},
+      src, alloc, dynamicValidities, tiledOp.getExtraViews(),
       /*extraIndices=*/tiledOp.getExtraIndices(), forceUnroll, useIndexDiffs);
+  if (validityRecord != nullptr)
+    *validityRecord = threadwiseReadIntoOp.getValidityRecord();
 
   // 3. Mark linalg.generic operations that populate this source buffer as
   // operations that need to be re-checekd for fusion now that we know their
@@ -726,17 +743,26 @@ static void addRegisterReadsForTiledInput(
   }
 }
 
-/// As above, but applying
+/// As above, but applying the tiling from a `threadwise_read_into`.
+/// `validityRecords` is only populated if the tiling source accesses a
+/// `validityRecords` parameter.
 static void
 addRegisterReadsForTiledOutput(LinalgAlignRewriter &b,
                                linalg::GenericOp laGeneric,
                                ThreadwiseReadIntoOp twReadOp,
                                ArrayRef<TransformMapAttr> relativeViewsOnResult,
-                               SmallVectorImpl<Value> &newInputs) {
+                               SmallVectorImpl<Value> &newInputs,
+                               SmallVectorImpl<Value> &validityRecords) {
+  bool hasValidityRecord = twReadOp.getValidityRecord() != Value{};
   for (auto inp : laGeneric.getInputs()) {
+    Value validityRecord = nullptr;
     Value newInput =
-        makeExtraInputTile(b, twReadOp, inp, relativeViewsOnResult, laGeneric);
+        makeExtraInputTile(b, twReadOp, inp, relativeViewsOnResult, laGeneric,
+                           twReadOp.getDynamicValidities(),
+                           hasValidityRecord ? &validityRecord : nullptr);
     newInputs.push_back(newInput);
+    if (hasValidityRecord)
+      validityRecords.push_back(validityRecord);
   }
 
   // move linalg.generic into the same block with threadwiseReadIntoOp
@@ -772,29 +798,100 @@ static void reconfigureLAGeneric(LinalgAlignRewriter &b,
 
 static LogicalResult canFuseAcrossAtomic(LinalgAlignRewriter &b,
                                          linalg::GenericOp laGeneric) {
-  bool isLegal = true;
-  for (auto &region : laGeneric->getRegions()) {
-    for (auto &block : region) {
-      for (auto &op : block) {
-        if (llvm::isa<arith::TruncFOp>(op)) {
-          Type resultType = op.getResult(0).getType();
-          isLegal = resultType == b.getF32Type();
-          isLegal |= resultType == b.getF16Type();
-        } else if (llvm::isa<arith::TruncIOp>(op)) {
-          Type resultType = op.getResult(0).getType();
-          isLegal = resultType == b.getI32Type();
-        } else if (llvm::isa<linalg::YieldOp>(op)) {
-          isLegal = true;
-        } else {
-          isLegal = false;
-        }
+  auto opCanSwapWithAtomic = [](Operation &op) -> bool {
+    return llvm::TypeSwitch<Operation &, bool>(op)
+        .Case<linalg::YieldOp>([](linalg::YieldOp ignored) { return true; })
+        .Case<arith::TruncFOp>([](arith::TruncFOp truncOp) {
+          Type resultType = truncOp.getOut().getType();
+          return isa<Float32Type, Float16Type>(resultType);
+        })
+        .Case<arith::TruncIOp>([](arith::TruncIOp truncOp) {
+          return truncOp.getOut().getType().isInteger(32);
+        })
+        .Default([](Operation &ignored) { return false; });
+  };
+  return success(
+      llvm::all_of(laGeneric.getRegion().getOps(), opCanSwapWithAtomic));
+}
 
-        if (!isLegal)
-          break;
-      }
-    }
+/// Return true if all the operations inside a given `linalg.generic` are known
+/// to preserve 0 - that is, they return zero if all their non-constant inputs
+/// are zero. This property allows us to not need to re-apply any padding that's
+/// being moved from the outputs of the generic to the inputs because we know
+/// that if the inputs all fall into the padding, the result of the elementwise
+/// function will also be the expected zero.
+static LogicalResult knownToPreserveZero(linalg::GenericOp laGeneric,
+                                         LinalgAlignRewriter &b) {
+  // Brute-force test: clone the generic, replace all the arguments with 0s,
+  // and constant-fold.
+  LLVM_DEBUG(llvm::dbgs() << "* Cloning generic to test if it allows 0s\n");
+  auto clonedOp = cast<linalg::GenericOp>(b.clone(*laGeneric));
+  Location loc = clonedOp.getLoc();
+  LinalgAlignRewriter::InsertionGuard guard(b);
+  b.setInsertionPointToStart(&clonedOp.getRegion().front());
+  OperationFolder folder(clonedOp.getContext(), b.getListener());
+  for (BlockArgument &arg : clonedOp.getRegion().getArguments()) {
+    Value zero = createZeroConstantOp(b, loc, arg.getType());
+    arg.replaceAllUsesWith(zero);
   }
-  return success(isLegal);
+  for (Operation &op :
+       llvm::make_early_inc_range(clonedOp.getRegion().getOps())) {
+    bool ignored = false;
+    (void)folder.tryToFold(&op, &ignored);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "* Folded input fusion region to " << clonedOp
+                          << "\n");
+  auto yieldOp =
+      cast<linalg::YieldOp>(clonedOp.getRegion().front().getTerminator());
+  bool foldedToZero = llvm::all_of(yieldOp.getValues(), [&](Value v) {
+    return matchPattern(v, m_AnyZeroFloat()) || matchPattern(v, m_Zero());
+  });
+  LLVM_DEBUG(llvm::dbgs() << "* Cloning generic to test if it allows 0s\n");
+  b.eraseOp(clonedOp);
+  return success(foldedToZero);
+}
+
+/// If this generic doesn't preserve zero (ex, it's x => x + 1) and if the
+/// validity of the tiling operation was being tracked (this indicates input
+/// fusion), then:
+/// - Clone the output tile
+/// - Set up a register->register threadwise_read_into between this cloned tile
+///   and the original output tile, with dynamic validities drawn from the
+///   validity validity results of each read.
+/// The extra threadwise_read_into we create here will cause elements that
+/// didn't actually get fetched from memory to become 0s again thanks to an if
+/// statement in what would otherwise be a memcpy().
+///
+/// Returns the validity record from the padding read if there is one.
+static Value reapplyPaddingIfNeeded(linalg::GenericOp reconfiguredGeneric,
+                                    ValueRange validityRecords,
+                                    ThreadwiseReadIntoOp oldTwRead,
+                                    LinalgAlignRewriter &b) {
+  // If the old read isn't recording its validity anywhere, or if we're not
+  // using that record, we don't need to propagate the validity records from the
+  // inputs.
+  if (!oldTwRead.getValidityRecord() ||
+      oldTwRead.getValidityRecord().use_empty()) {
+    if (validityRecords.empty())
+      return Value{};
+    if (succeeded(knownToPreserveZero(reconfiguredGeneric, b)))
+      return Value{};
+  }
+  Value originalTile = reconfiguredGeneric.getOutputs()[0];
+  LinalgAlignRewriter::InsertionGuard guard(b);
+  b.setInsertionPoint(reconfiguredGeneric);
+  Value unmaskedTile = b.clone(*originalTile.getDefiningOp())->getResult(0);
+  b.modifyOpInPlace(reconfiguredGeneric, [&]() {
+    reconfiguredGeneric.getOutputsMutable()[0].assign(unmaskedTile);
+  });
+  b.setInsertionPointAfter(reconfiguredGeneric);
+  auto maskingRead = b.create<rock::ThreadwiseReadIntoOp>(
+      reconfiguredGeneric.getLoc(), validityVectorShapedLike(unmaskedTile),
+      unmaskedTile, originalTile,
+      /*dynamicValidities=*/validityRecords,
+      /*extraViews=*/b.getArrayAttr({}), /*extraIndices=*/ValueRange{},
+      /*forceUnroll=*/false, /*useIndexDiffs=*/false);
+  return maskingRead.getValidityRecord();
 }
 
 LogicalResult
@@ -875,15 +972,25 @@ LAGenericRewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
     }
     Value newOutput = tileReadOp.getDest();
     SmallVector<Value> newInputs;
+    // Only populated if this threadwise_read_into is tracking its validity -
+    // that is, if this is part of an input fusion (where we're worried about
+    // re-applying padding in cases where the generic doesn't preserve 0).
+    SmallVector<Value> newValidityRecords;
     addRegisterReadsForTiledOutput(b, laGeneric, tileReadOp,
-                                   globalCoordsToGenericViews, newInputs);
+                                   globalCoordsToGenericViews, newInputs,
+                                   newValidityRecords);
     // Prevent SSA weirdness from register allocations introduced too late.
     // addRegisterReadsForTiledOutput() may have moved laGeneric into a
     // different block. In this case, SSA is already in good shape.
     if (newOutput.getDefiningOp()->getBlock() == laGeneric->getBlock())
       b.moveBeforeIfNeeded(newOutput.getDefiningOp(), laGeneric);
     reconfigureLAGeneric(b, laGeneric, newInputs, newOutput);
-    b.eraseOp(tileReadOp);
+    Value newValidityRecord =
+        reapplyPaddingIfNeeded(laGeneric, newValidityRecords, tileReadOp, b);
+    if (!newValidityRecord)
+      b.eraseOp(tileReadOp);
+    else
+      b.replaceOp(tileReadOp, newValidityRecord);
     return success();
   }
   auto outType = cast<ShapedType>(out.getType());
@@ -910,7 +1017,7 @@ LAGenericRewritePattern::matchAndRewrite(linalg::GenericOp laGeneric,
   // 3.1. Make an allocation that matches the tile but has the type of the
   // linalg.generic output.
   MemRefType::Builder mrb(gemmOutType);
-  Value laOutRegs = makeRegs(b, mrb, loc, out.getType());
+  Value laOutRegs = makeRegs(b, mrb, loc, getElementTypeOrSelf(out.getType()));
 
   // 3.2. Tile linalg.generic with vgpr as input, return output vgprs
   SmallVector<Value> newInputs;

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -610,7 +610,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         b.setInsertionPointToStart(&stage0.getRegion().emplaceBlock());
 
         b.create<ThreadwiseReadIntoOp>(
-            loc, validityVectorShapedLike(loadBufferA), wrappedA, loadBufferA,
+            loc, vectorOfBoolShapedLike(loadBufferA), wrappedA, loadBufferA,
             /*dynamicValidities=*/ValueRange{},
             /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/
@@ -618,7 +618,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
                        gridCoords.n_block, tid},
             true, true);
         b.create<ThreadwiseReadIntoOp>(
-            loc, validityVectorShapedLike(loadBufferB), wrappedB, loadBufferB,
+            loc, vectorOfBoolShapedLike(loadBufferB), wrappedB, loadBufferB,
             /*dynamicValidities=*/ValueRange{},
             /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/
@@ -832,7 +832,7 @@ struct GridwiseAttentionAccelRewritePattern
     Value viewIn = transform(rewriter, in, maybeInBufferViews->gridSubTile);
     auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
     rewriter.create<ThreadwiseReadIntoOp>(
-        loc, validityVectorShapedLike(fromGlobalRegBuffer), viewIn,
+        loc, vectorOfBoolShapedLike(fromGlobalRegBuffer), viewIn,
         fromGlobalRegBuffer,
         /*dynamicValidities=*/ValueRange{},
         /*extraViews=*/rewriter.getArrayAttr({}),
@@ -2712,7 +2712,7 @@ struct GridwiseGemmAccelRewritePattern
               loc, reverseMap, ValueRange{iv, nIterations});
         }
         b.create<ThreadwiseReadIntoOp>(
-            loc, validityVectorShapedLike(loadBufferA), wrappedA, loadBufferA,
+            loc, vectorOfBoolShapedLike(loadBufferA), wrappedA, loadBufferA,
             /*dynamicValidities=*/ValueRange{},
             /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/
@@ -2720,7 +2720,7 @@ struct GridwiseGemmAccelRewritePattern
                        gridCoords.n_block, tid},
             true, true);
         b.create<ThreadwiseReadIntoOp>(
-            loc, validityVectorShapedLike(loadBufferB), wrappedB, loadBufferB,
+            loc, vectorOfBoolShapedLike(loadBufferB), wrappedB, loadBufferB,
             /*dynamicValidities=*/ValueRange{},
             /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -489,14 +489,13 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     }
     Value wrappedB = transform(b, op.getB(), maybeBBufferViews->gridSubTile);
 
-    Type loadBufferAType, loadBufferBType;
-    loadBufferAType = MemRefType::get({aCopyPerThread}, elementTypeA,
-                                      AffineMap{}, privateMemoryAddressSpace);
-    loadBufferBType = MemRefType::get({bCopyPerThread}, elementTypeB,
-                                      AffineMap{}, privateMemoryAddressSpace);
-
-    auto loadBufferA = b.create<GpuAllocOp>(loc, loadBufferAType);
-    auto loadBufferB = b.create<GpuAllocOp>(loc, loadBufferBType);
+    auto makeRegs = [&](int64_t len, Type elementType) -> GpuAllocOp {
+      Type allocType = MemRefType::get({len}, elementType, AffineMap{},
+                                       privateMemoryAddressSpace);
+      return b.create<GpuAllocOp>(loc, allocType);
+    };
+    GpuAllocOp loadBufferA = makeRegs(aCopyPerThread, elementTypeA);
+    GpuAllocOp loadBufferB = makeRegs(bCopyPerThread, elementTypeB);
 
     // Compute grid coordinates
     FailureOr<mlir::StringAttr> maybeArch = getArch(op);
@@ -507,18 +506,6 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         b, loc, bid,
         {G, mBlocks, nBlocks, op.getNumCU(), elementTypeA, destType},
         maybeArch->getValue());
-    b.create<ThreadwiseReadIntoOp>(
-        loc, wrappedA, loadBufferA, /*extraViews=*/b.getArrayAttr({}),
-        /*extraIndices=*/
-        ValueRange{/*kIter=*/zeroConstantOp, gridCoords.g_block,
-                   gridCoords.m_block, gridCoords.n_block, tid},
-        true, true);
-    b.create<ThreadwiseReadIntoOp>(
-        loc, wrappedB, loadBufferB, /*extraViews=*/b.getArrayAttr({}),
-        /*extraIndices=*/
-        ValueRange{/*kIter=*/zeroConstantOp, gridCoords.g_block,
-                   gridCoords.m_block, gridCoords.n_block, tid},
-        true, true);
 
     Value storeBufferA = b.create<GpuAllocOp>(loc, loadBufferA.getType());
     Value storeBufferB = b.create<GpuAllocOp>(loc, loadBufferB.getType());
@@ -623,13 +610,17 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         b.setInsertionPointToStart(&stage0.getRegion().emplaceBlock());
 
         b.create<ThreadwiseReadIntoOp>(
-            loc, wrappedA, loadBufferA, /*extraViews=*/b.getArrayAttr({}),
+            loc, validityVectorShapedLike(loadBufferA), wrappedA, loadBufferA,
+            /*dynamicValidities=*/ValueRange{},
+            /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/
             ValueRange{/*kIter=*/iv, gridCoords.g_block, gridCoords.m_block,
                        gridCoords.n_block, tid},
             true, true);
         b.create<ThreadwiseReadIntoOp>(
-            loc, wrappedB, loadBufferB, /*extraViews=*/b.getArrayAttr({}),
+            loc, validityVectorShapedLike(loadBufferB), wrappedB, loadBufferB,
+            /*dynamicValidities=*/ValueRange{},
+            /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/
             ValueRange{/*kIter=*/iv, gridCoords.g_block, gridCoords.m_block,
                        gridCoords.n_block, tid},
@@ -841,7 +832,9 @@ struct GridwiseAttentionAccelRewritePattern
     Value viewIn = transform(rewriter, in, maybeInBufferViews->gridSubTile);
     auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
     rewriter.create<ThreadwiseReadIntoOp>(
-        loc, viewIn, fromGlobalRegBuffer,
+        loc, validityVectorShapedLike(fromGlobalRegBuffer), viewIn,
+        fromGlobalRegBuffer,
+        /*dynamicValidities=*/ValueRange{},
         /*extraViews=*/rewriter.getArrayAttr({}),
         ValueRange{kIter, gridCoords.g_block, gridCoords.m_block,
                    gridCoords.n_block, tid},
@@ -915,8 +908,50 @@ struct GridwiseAttentionAccelRewritePattern
     return ldsByteBuffer;
   }
 
-  // This function will create fromGlobalRegsBuffer, toLDSRegBuffer and
-  // ldsTileBuffer for a gemm input
+  std::tuple<SmallVector<Value>, int64_t>
+  createSharedLDSByteBufferRefs(PatternRewriter &rewriter, Location loc,
+                                ArrayRef<int64_t> numElementsArr,
+                                ArrayRef<Type> elemTypeArr) const {
+    auto workgroupMemoryAddressSpace = rewriter.getAttr<gpu::AddressSpaceAttr>(
+        gpu::GPUDialect::getWorkgroupAddressSpace());
+    int64_t maxSizeBytes = 0;
+    SmallVector<int64_t, 4> byteSizes;
+    for (auto [numElements, elemType] :
+         llvm::zip(numElementsArr, elemTypeArr)) {
+      int64_t sizeBytes = numElements * getByteWidth(elemType);
+      if (sizeBytes > maxSizeBytes) {
+        maxSizeBytes = sizeBytes;
+      }
+      byteSizes.push_back(sizeBytes);
+    }
+    auto ldsMemRefType =
+        MemRefType::get({maxSizeBytes}, rewriter.getI8Type(), AffineMap{},
+                        workgroupMemoryAddressSpace);
+    Value ldsByteBuffer = rewriter.create<GpuAllocOp>(loc, ldsMemRefType);
+
+    SmallVector<Value> ret;
+    for (int64_t byteSize : byteSizes) {
+      if (byteSize == 0) {
+        ret.push_back(Value());
+        continue;
+      }
+      if (byteSize == maxSizeBytes) {
+        ret.push_back(ldsByteBuffer);
+        continue;
+      }
+      auto byteBufferType =
+          MemRefType::get({byteSize}, rewriter.getI8Type(), AffineMap{},
+                          workgroupMemoryAddressSpace);
+      Value ldsByteBufferSubView = rewriter.create<memref::SubViewOp>(
+          loc, byteBufferType, ldsByteBuffer, ArrayRef<int64_t>{0},
+          ArrayRef<int64_t>{byteSize}, ArrayRef<int64_t>{1});
+      ret.push_back(ldsByteBufferSubView);
+    }
+    return {ret, maxSizeBytes};
+  }
+
+  // This function will create fromGlobalRegsBuffer and toLDSRegBuffer for a
+  // gemm input
   std::tuple<Value, Value>
   createRegBuffersForGemmIn(Location loc, int64_t kPerBlock, int64_t blockSize,
                             Type elemType, int64_t dPerBlock,
@@ -1750,7 +1785,7 @@ struct GridwiseAttentionAccelRewritePattern
     Value fromGlobalRegBufferQ;
     Value toLDSRegBufferQ;
     if (doBypassLDSForQ) {
-      Type loadBufferType =
+      auto loadBufferType =
           MemRefType::get({accelParamsGemm0.nRepeats *
                            accelParamsGemm0.kpackPerThread * gemm0kpack},
                           elemTypeQ, AffineMap{}, privateMemoryAddressSpace);
@@ -2527,9 +2562,9 @@ struct GridwiseGemmAccelRewritePattern
     // Get current workitem ID.
     auto tid = b.create<WorkitemIdOp>(loc, b.getIndexType());
 
-    auto loadBufferA =
+    Value loadBufferA =
         gpuAlloc(b, loc, aCopyPerThread, elementTypeA, AddressSpace::Private);
-    auto loadBufferB =
+    Value loadBufferB =
         gpuAlloc(b, loc, bCopyPerThread, elementTypeB, AddressSpace::Private);
 
     auto zeroConstantOp = b.create<ConstantIndexOp>(loc, 0);
@@ -2719,13 +2754,17 @@ struct GridwiseGemmAccelRewritePattern
               loc, reverseMap, ValueRange{iv, nIterations});
         }
         b.create<ThreadwiseReadIntoOp>(
-            loc, wrappedA, loadBufferA, /*extraViews=*/b.getArrayAttr({}),
+            loc, validityVectorShapedLike(loadBufferA), wrappedA, loadBufferA,
+            /*dynamicValidities=*/ValueRange{},
+            /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/
             ValueRange{/*kIter=*/iv, gridCoords.g_block, gridCoords.m_block,
                        gridCoords.n_block, tid},
             true, true);
         b.create<ThreadwiseReadIntoOp>(
-            loc, wrappedB, loadBufferB, /*extraViews=*/b.getArrayAttr({}),
+            loc, validityVectorShapedLike(loadBufferB), wrappedB, loadBufferB,
+            /*dynamicValidities=*/ValueRange{},
+            /*extraViews=*/b.getArrayAttr({}),
             /*extraIndices=*/
             ValueRange{/*kIter=*/iv, gridCoords.g_block, gridCoords.m_block,
                        gridCoords.n_block, tid},

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -525,7 +525,7 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
     loadType = vectorTypeOrSelf(elementType, vectorSrcLen);
   }
 
-  // Force the dynamic validity case down to a vectorizaiton of 1
+  // Force the dynamic validity case down to a vectorization of 1
   if (!adaptor.getDynamicValidities().empty()) {
     vectorSrcLen = 1;
     srcStride = 1;

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -202,5 +202,10 @@ Value getAsTensor(OpBuilder &builder, Location loc, mlir::Value value,
   return origTensor;
 }
 
+Type validityVectorShapedLike(Value v) {
+  return VectorType::get(cast<ShapedType>(v.getType()).getShape(),
+                         IntegerType::get(v.getContext(), 1));
+}
+
 } // namespace rock
 } // namespace mlir

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -202,7 +202,7 @@ Value getAsTensor(OpBuilder &builder, Location loc, mlir::Value value,
   return origTensor;
 }
 
-Type validityVectorShapedLike(Value v) {
+Type vectorOfBoolShapedLike(Value v) {
   return VectorType::get(cast<ShapedType>(v.getType()).getShape(),
                          IntegerType::get(v.getContext(), 1));
 }

--- a/mlir/test/fusion/e2e/rock-add-to-input.e2e.template
+++ b/mlir/test/fusion/e2e/rock-add-to-input.e2e.template
@@ -1,0 +1,19 @@
+// RUN: sed -e 's/##ARCH##/%arch/g' %s | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext --entry-point-result=void --mattr=-avx512bf16 | FileCheck %s
+// ALLOW_RETRIES: 2
+
+// CHECK:  [5]
+!unit = memref<1x1x1x{type}>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+module attributes {{mhal.arch = "##ARCH##"}} {{
+  func.func @test_fusion(%arg0: !unit, %arg1: !unit, %arg2: !unit) attributes {{kernel}} {{
+    %cst = arith.constant 4.0 : {type}
+    %0 = memref.alloc() : !unit
+    linalg.generic {{indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel", "parallel"]}} ins(%arg0 : !unit) outs(%0 : !unit) {{
+    ^bb0(%arg3: {type}, %arg4: {type}):
+      %1 = arith.addf %arg3, %cst : {type}
+      linalg.yield %1 : {type}
+    }}
+    rock.gemm %arg2 = %0 * %arg1 features = none storeMethod = set {{arch = "##ARCH##"}} : !unit = !unit * !unit
+    return
+  }}
+}}

--- a/mlir/test/fusion/e2e/tests.toml
+++ b/mlir/test/fusion/e2e/tests.toml
@@ -9,6 +9,7 @@ values = ["f32", "f16", "bf16"]
 [[suite.axis]]
 name = "test files"
 values = ["mixr-bcast-add",
+          "rock-add-to-input",
           "rock-bcast",
           "rock-bcast-exp",
           "rock-bcast-idxmap",

--- a/mlir/test/fusion/linalg-generic-biased-inputs.mlir
+++ b/mlir/test/fusion/linalg-generic-biased-inputs.mlir
@@ -1,0 +1,54 @@
+// RUN: rocmlir-opt -rock-linalg-align -canonicalize %s | FileCheck %s
+
+!tile = memref<16xf16, #gpu.address_space<private>>
+!in_global = memref<4xf16>
+!out_global = memref<16xf16>
+#map = affine_map<(d0) -> (d0)>
+#transform_map = #rock.transform_map<#map by [<Pad{0, 12} ["xPad"] at [0] -> ["x"] at [0]>] bounds = [16] -> [4]>
+
+// CHECK-LABEL: @must_reapply_padding
+// CHECK-SAME: (%[[arg0:.+]]: memref<4xf16>, %[[arg1:.+]]: memref<16xf16>)
+// CHECK: %[[padded:.+]] = rock.transform %[[arg0]]
+// CHECK: %[[validity:.+]] = rock.threadwise_read_into [](%[[padded]]) -> %[[globalIn:.+]] :
+// CHECK: linalg.generic
+// CHECK-SAME: ins(%[[globalIn]] : memref<{{[^>]+}}>>)
+// CHECK-SAME: outs(%[[unmaskedOut:.+]] : memref<{{[^>]+}}>>)
+// CHECK: rock.threadwise_read_into [](%[[unmaskedOut]]) -> %[[maskedOut:.+]] if [%[[validity]]]
+// CHECK: rock.threadwise_write_all features = none %[[maskedOut]]
+func.func @must_reapply_padding(%arg0: !in_global, %arg1: !out_global) attributes {kernel} {
+  %cst = arith.constant 4.0 : f16
+  %alloc = memref.alloc() : !in_global
+  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : !in_global) outs (%alloc : !in_global) {
+  ^bb0(%arg2: f16, %arg3: f16):
+    %0 = arith.addf %arg2, %cst : f16
+    linalg.yield %0 : f16
+  }
+  %1 = rock.transform %alloc by #transform_map : !in_global to !out_global
+  %buf = rock.alloc() : !tile
+  %2 = rock.threadwise_read_into [](%1) -> %buf : !out_global -> !tile, vector<16xi1>
+  rock.threadwise_write_all features = none %buf -> [](%arg1) by set : !tile -> !out_global
+  return
+}
+
+// CHECK-LABEL: @doesnt_reapply_padding
+// CHECK-SAME: (%[[arg0:.+]]: memref<4xf16>, %[[arg1:.+]]: memref<16xf16>)
+// CHECK: %[[padded:.+]] = rock.transform %[[arg0]]
+// CHECK: rock.threadwise_read_into [](%[[padded]]) -> %[[globalIn:.+]] :
+// CHECK: linalg.generic
+// CHECK-SAME: ins(%[[globalIn]] : memref<{{[^>]+}}>>)
+// CHECK-SAME: outs(%[[unmaskedOut:.+]] : memref<{{[^>]+}}>>)
+// CHECK: rock.threadwise_write_all features = none %[[unmaskedOut]]
+func.func @doesnt_reapply_padding(%arg0: !in_global, %arg1: !out_global) attributes {kernel} {
+  %cst = arith.constant 4.0 : f16
+  %alloc = memref.alloc() : !in_global
+  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : !in_global) outs (%alloc : !in_global) {
+  ^bb0(%arg2: f16, %arg3: f16):
+    %0 = arith.mulf %arg2, %cst : f16
+    linalg.yield %0 : f16
+  }
+  %1 = rock.transform %alloc by #transform_map : !in_global to !out_global
+  %buf = rock.alloc() : !tile
+  %2 = rock.threadwise_read_into [](%1) -> %buf : !out_global -> !tile, vector<16xi1>
+  rock.threadwise_write_all features = none %buf -> [](%arg1) by set : !tile -> !out_global
+  return
+}

--- a/mlir/test/fusion/pr-e2e/mixr-bcast-add-align-tiling.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-bcast-add-align-tiling.mlir
@@ -2,7 +2,7 @@
 // ALLOW_RETRIES: 2
 
 module {
-    // CHECK-COUNT-4: rock.threadwise_read_into {{.*}}
+    // CHECK-COUNT-2: rock.threadwise_read_into {{.*}}
     // CHECK: rock.threadwise_read_into
     // CHECK: linalg.generic
     // CHECK: rock.threadwise_write_all

--- a/mlir/test/fusion/pr-e2e/mixr-mbcast-add-align-tiling.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-mbcast-add-align-tiling.mlir
@@ -2,7 +2,7 @@
 // ALLOW_RETRIES: 2
 
 module {
-    // CHECK-COUNT-4: rock.threadwise_read_into {{.*}}
+    // CHECK-COUNT-2: rock.threadwise_read_into {{.*}}
     // CHECK: rock.threadwise_read_into
     // CHECK: linalg.generic
     // CHECK: rock.threadwise_write_all

--- a/mlir/test/fusion/tosa-to-rock-gemm-reshape-add.mlir
+++ b/mlir/test/fusion/tosa-to-rock-gemm-reshape-add.mlir
@@ -5,7 +5,7 @@
 // CHECK_LINALG_ALIGN-DAG: #[[MAP1:.*]] = #rock.transform_map<#[[AMAP]] by [<Unmerge{1, 1} ["col0", "col1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 1, 1000] -> [1, 1000]>
 // CHECK_LINALG_ALIGN-DAG: #[[MAP2:.*]] = #rock.transform_map<#[[AMAP1]] by [<Unmerge{1, 1000} ["col0", "col1"] at [0, 1] -> ["dim0"] at [0]>] bounds = [1, 1000] -> [1000]>
 
-// CHECK_LINALG_ALIGN-COUNT-4: rock.threadwise_read_into {{.*}}
+// CHECK_LINALG_ALIGN-COUNT-2: rock.threadwise_read_into {{.*}}
 // CHECK_LINALG_ALIGN: rock.threadwise_read_into {{.*}} -> [[lain:%.*]] :
 // CHECK_LINALG_ALIGN: linalg.generic{{.*}} ins({{.*}}, [[lain]] :{{.*}}) outs(%[[outBuf:.*]] : memref<16xf32, #gpu.address_space<private>>)
 // CHECK_LINALG_ALIGN: rock.threadwise_write_all {{.*}} %[[outBuf]] ->

--- a/mlir/test/fusion/tosa-to-rock-tp-add-tp.mlir
+++ b/mlir/test/fusion/tosa-to-rock-tp-add-tp.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-driver --host-pipeline highlevel %s | rocmlir-opt --rock-affix-params --rock-conv-to-gemm --rock-gemm-to-gridwise -rock-regularize --rock-gridwise-gemm-to-blockwise --rock-linalg-align | FileCheck %s
 
 // CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<{{.*}} by [<PassThrough ["dim0", "dim2", "dim3", "dim1"] at [0, 1, 2, 3] -> ["dim0", "dim2", "dim3", "dim1"] at [0, 2, 3, 1]>] bounds = [256, 28, 28, 64] -> [256, 64, 28, 28]>
-// CHECK-COUNT-4: rock.threadwise_read_into {{.*}}
+// CHECK-COUNT-2: rock.threadwise_read_into {{.*}}
 // CHECK: rock.threadwise_read_into {{.*}} -> [[lain:%.*]] :
 // CHECK: linalg.generic{{.*}} ins({{.*}}, [[lain]] :{{.*}}) outs(%[[outBuf:.*]] : memref<16xf32, #gpu.address_space<private>>)
 // CHECK: rock.threadwise_write_all {{.*}} %[[outBuf]] ->

--- a/mlir/test/fusion/tosa-to-rock-tp-add.mlir
+++ b/mlir/test/fusion/tosa-to-rock-tp-add.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-driver --host-pipeline highlevel %s | rocmlir-opt --rock-affix-params --rock-conv-to-gemm --rock-gemm-to-gridwise -rock-regularize --rock-gridwise-gemm-to-blockwise --rock-linalg-align | FileCheck %s
 
 // CHECK-DAG: #[[MAP2:.*]] = #rock.transform_map<#map{{.*}} by [<PassThrough ["{{.*}}", "{{.*}}", "{{.*}}", "{{.*}}"] at [0, 1, 2, 3] -> ["{{.*}}", "{{.*}}", "{{.*}}", "{{.*}}"] at [0, 2, 3, 1]>] bounds = [256, 28, 28, 64] -> [256, 64, 28, 28]>
-// CHECK-COUNT-4: rock.threadwise_read_into {{.*}}
+// CHECK-COUNT-2: rock.threadwise_read_into {{.*}}
 // CHECK: rock.threadwise_read_into {{.*}} -> [[lain:%.*]] :
 // CHECK: linalg.generic{{.*}} ins({{.*}}, [[lain]] :{{.*}}) outs(%[[outBuf:.*]] : memref<16xf32, #gpu.address_space<private>>)
 // CHECK: rock.threadwise_write_all {{.*}} %[[outBuf]] ->


### PR DESCRIPTION
Apologies for the mega-commit. (this one also includes a cherry-pick from upstream)

Previously, if you input-fused an elementwise funciton like
(x) => (x + 4), this would cause issues, because the 4 would be added
both to elements of the input value but also to padding values
introduces during tiling, which would cause incorrect results.

To fix this, we:
1. Make threadwise_read_into optionally return a boolean vector of
validities, recording whether or not an element in the register tile
actually came from memory or not
2. Give threadwise_read_into a dynamic validities argument, where the
validity data from the coordinate transforms is ANDed with the
validity vectors from those arguments to allow applying validitiies
that don't come from coordinate transforms.
3. Update all the threadwise_read_into operations that can have input
fusions on them to generate a validity record.
4. It a linalg.generic is being tiled by a threadwise_read_into and
that read records validity (that is, it came from an input
fusion) *and* the result of the elementwise function on all-zero
inputs isn't zero, we propagate the validities.

That is, we make the threadwise_read_into ops that read each input to
the generic record their validities, and then do a register ->
register threadwise_read_into (which would ordinarily be a memcpy())
with dynamic validities taken from those reads to re-apply the 0 mask
after the generic runs.

**Note:** While I was here, I noticed that non-xdlops gemms were producing two sets of theradwise_read_into ops, so I fixed that, which broke a few tests

Also, fix up the validator on `rock.alloc` so it doesn't reject int4 buffers ( @dhernandez0 )