### PR TITLE
Fix test for input vectorization traversal, use types correctly, add …

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
@@ -153,7 +153,7 @@ static void annotateGenericOp(linalg::GenericOp lgop) {
   size_t argIdx = -1;
   if (lgop.getInputs().size() == 1) {
     lgop->setAttr("rock.majorTensorNumber",
-                  IntegerAttr::get(IndexType::get(ctx), 1));
+                  IntegerAttr::get(IndexType::get(ctx), 0));
     return;
   }
   for (auto [inputIdx, inp] : llvm::enumerate(lgop.getInputs())) {

--- a/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/Regularize.cpp
@@ -149,8 +149,12 @@ struct RegularizeGenericRewritePattern
 static void annotateGenericOp(linalg::GenericOp lgop) {
   MLIRContext *ctx = lgop.getContext();
   int64_t majorTensorSize = 0;
-  size_t majorTensorIdx;
+  size_t majorTensorIdx = -1;
   size_t argIdx = -1;
+  if (lgop.getInputs().empty()) {
+    // Weird constant iniializer or something.
+    return;
+  }
   if (lgop.getInputs().size() == 1) {
     lgop->setAttr("rock.majorTensorNumber",
                   IntegerAttr::get(IndexType::get(ctx), 0));

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -828,14 +828,16 @@ findPostFusionTransforms(Value buffer, Operation *currentUser) {
       if (genericOut == buffer) {
         if (auto index = genericOp->getAttrOfType<IntegerAttr>(
                 "rock.majorTensorNumber")) {
+          candidate = genericOp.getInputs()[index.getInt()];
+        } else {
           LLVM_DEBUG(llvm::dbgs()
                      << "[vectorization] can't analyze linalg.generic "
                         "without rock.majorTensorNumber\n");
           return failure();
-        } else
-          candidate = genericOp.getInputs()[index.getInt()];
-      } else
+        }
+      } else {
         candidate = genericOut;
+      }
     } else {
       LLVM_DEBUG(llvm::dbgs()
                  << "[vectorization] Unexpected user of temporary buffer: "
@@ -960,7 +962,7 @@ VectorizationResult mlir::rock::getMaxVectorization(
   // warp will issue, if possible, a global_load_dwordx4 instruction
   if (!ignoreDataType) {
     constexpr int64_t maxVectorLenBits = 128;
-    int64_t bwidth = upperType.getElementTypeBitWidth();
+    int64_t bwidth = outputType.getElementTypeBitWidth();
     result = math_util::gcd(maxVectorLenBits / bwidth, result);
   }
   // bufferVectorSize will become non-trivial once scalarization comes in


### PR DESCRIPTION
…tests

1. The test for input vectorization traversal was backwards
2. The majorTensorNumber was being set incorrectly on single-arugment linalg.generic operations
3. Now, the vectorizer looks at the ultimate type of the buffer and not the type of the intermeditae allocation when deciding the maximum possible vectorization.