### PR TITLE
Handle the new F8 types in RockTuningImpl.cpp too.  Oops.

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/CMakeLists.txt
+++ b/mlir/lib/Conversion/TosaToRock/CMakeLists.txt
@@ -12,7 +12,7 @@ add_rocmlir_conversion_library(MLIRTosaToRock
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRLinalgDialect
-  MLIRRockConv2dGenerator
+  MLIRRockConvGenerator
   MLIRRockTransforms
   MLIRLinalgUtils
   MLIRPass

--- a/mlir/lib/Dialect/Rock/Generator/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Generator/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_rocmlir_dialect_library(MLIRRockConv2dGenerator
+add_rocmlir_dialect_library(MLIRRockConvGenerator
   ConvGenerator.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -12,8 +12,9 @@ add_rocmlir_dialect_library(MLIRRockConv2dGenerator
   MLIRSupport
 )
 
-target_link_libraries(MLIRRockConv2dGenerator
+target_link_libraries(MLIRRockConvGenerator
   PRIVATE
   MLIRRockTransforms
   MLIRRockOps
+  MLIRAMDGPUUtils
 )

--- a/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
@@ -350,8 +350,10 @@ static Type strToType(StringRef dataTypeStr, OpBuilder &builder) {
           .Case("bf16", builder.getBF16Type())
           .Case("i32", builder.getI32Type())
           .Case("i8", builder.getI8Type())
-          .Cases("f8E5M2FNUZ", "bf8", builder.getFloat8E5M2FNUZType())
-          .Cases("f8E4M3FNUZ", "fp8", builder.getFloat8E4M3FNUZType())
+          .Case("f8E5M2", builder.getFloat8E5M2Type())
+          .Case("f8E4M3FN", builder.getFloat8E4M3FNType())
+          .Case("f8E5M2FNUZ", builder.getFloat8E5M2FNUZType())
+          .Case("f8E4M3FNUZ", builder.getFloat8E4M3FNUZType())
           .Default(std::nullopt);
   if (!type) {
     llvm::errs() << "Unknown data type: " << dataTypeStr << "\n";

--- a/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
@@ -1,5 +1,5 @@
-#include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/Rock/Generator/ConvGenerator.h"
+#include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Rock/IR/GemmSize.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"

--- a/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
@@ -562,10 +562,7 @@ LogicalResult ConvGenerator::parseConvConfig(OpBuilder &builder,
       return std::string("f32");
     if (type == "fp16")
       return std::string("f16");
-    if (type == "f8E5M2FNUZ")
-      return std::string("bf8");
-    if (type == "f8E4M3FNUZ")
-      return std::string("fp8");
+    // +++pf: chipset-based expansion of fp8/bf8 here?
     return type;
   };
   config.operation = op.value();

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -532,6 +532,10 @@ GemmSize GemmSize::fromConvolution(ConvOpType type,
   return GemmSize(gemmGSize, gemmMSize, gemmKSize, gemmNSize);
 }
 
+static bool isFloat8Type(Type type) {
+  return isa<FloatType>(type) && type.getIntOrFloatBitWidth() == 8;
+}
+
 static LogicalResult verifyGemmTypes(Operation *op, GemmFeatures features,
                                      StringRef arch, Type elemTypeA,
                                      Type elemTypeB, Type elemTypeC) {
@@ -541,7 +545,7 @@ static LogicalResult verifyGemmTypes(Operation *op, GemmFeatures features,
       if (isGfx11)
         return op->emitOpError(
             "Wmma gridwise supports only F16/BF16/int8 data types");
-      if (!elemTypeA.isFloat8E4M3FN() || elemTypeA.isFloat8E5M2())
+      if (!isFloat8Type(elemTypeA))
         return op->emitOpError(
             "Wmma gridwise supports only F16/BF16/int8/E4M3/E5M2 data types");
     }
@@ -901,7 +905,7 @@ static LogicalResult verifyGridwiseGemm(GridOp op) {
     return failure();
   if (aElem.isInteger(8) && !(cElem.isInteger(32) || cElem.isInteger(8)))
     return op.emitOpError("i8 input requires i32 or i8 output");
-  if ((aElem.isFloat8E4M3FNUZ() || aElem.isFloat8E5M2FNUZ()) && !cElem.isF32())
+  if (isFloat8Type(aElem) && !cElem.isF32())
     return op.emitOpError("8-bit float input requires f32 output");
 
   ArrayRef<int64_t> aShape = aType.getShape(), bShape = bType.getShape(),

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -566,9 +566,7 @@ LogicalResult PopulateParamsXDL::isValidBlockwiseGemm(
   }
 
   // Add broadcasts for non 8-bit types.
-  bool is8BitReduceOnly = dataTypeA.isInteger(8) ||
-                          dataTypeA.isFloat8E4M3FNUZ() ||
-                          dataTypeA.isFloat8E5M2FNUZ();
+  bool is8BitReduceOnly = dataTypeA.getIntOrFloatBitWidth() == 8;
   if (!is8BitReduceOnly) {
     validWaveGemmSize.emplace_back(8, 64, 1);
     validWaveGemmSize.emplace_back(4, 64, 1);

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -248,8 +248,8 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
     // XDLOPS
     Type inTypeA = gemmOp.getAType();
     bool is8BitReduction = inTypeA.isInteger(8) || inTypeA.isFloat8E5M2FNUZ() ||
-                           inTypeA.isFloat8E4M3FNUZ() || inTypeA.isFloat8E5M2() ||
-                           inTypeA.isFloat8E4M3FN();
+                           inTypeA.isFloat8E4M3FNUZ() ||
+                           inTypeA.isFloat8E5M2() || inTypeA.isFloat8E4M3FN();
     const std::vector<std::vector<uint32_t>> &xdlopsParams =
         is8BitReduction ? validRangeAccelGemmParams8BitReduction
                         : validRangeAccelGemmParams;

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -17,11 +17,10 @@
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
 #include "mlir/Dialect/Rock/utility/fusionUtils.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
-#include "mlir/Dialect/Rock/utility/math.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <algorithm>
 
@@ -645,11 +644,11 @@ LogicalResult getTuningProblemStr(rock::RockGemmWrapperInterface gemmIF,
   KernelType opType = gemmIF.getKernelType();
   Operation *gemmOp = gemmIF.getOperation();
 
-  auto f8TypeStr = [](const Type &type) -> std::optional<StringRef> {
+  auto f8TypeStr = [](const Type &type) -> std::optional<StringLiteral> {
     if (type.isFloat8E4M3FNUZ() || type.isFloat8E4M3FN())
-      return "fp8";
+      return StringLiteral("fp8");
     if (type.isFloat8E5M2FNUZ() || type.isFloat8E5M2())
-      return "bf8";
+      return StringLiteral("bf8");
     return std::nullopt;
   };
 

--- a/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
@@ -118,7 +118,7 @@ GemmFeatures mlir::rock::AmdArchInfo::getDefaultFeatures(Type dataType) {
   }
   bool isMfma = bitEnumContainsAll(theseFeatures, GemmFeatures::mfma);
   if (isMfma && !hasFp8ConversionInstrs) {
-    if (dataType.isFloat8E4M3FNUZ() || dataType.isFloat8E5M2FNUZ())
+    if (isa<FloatType>(dataType) && dataType.getIntOrFloatBitWidth() == 8)
       theseFeatures = bitEnumClear(theseFeatures, GemmFeatures::mfma);
   }
   return theseFeatures;

--- a/mlir/test/rocmlir-gen/gemm-misc-options.mlir
+++ b/mlir/test/rocmlir-gen/gemm-misc-options.mlir
@@ -6,5 +6,7 @@
 // CONV: amdgcn-amd-amdhsa:gfx900   {{.*}}     conv -F 1 -f GNC01 -I NGC01 -O NGC01 -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
 // RUN: rocmlir-gen --emit-tuning-key -p -t fp8_fp8 --arch gfx900 | FileCheck %s --check-prefix=CONVFP8
 // CONVFP8: amdgcn-amd-amdhsa:gfx900   {{.*}}     convfp8_fp8 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
+// RUN: rocmlir-gen --emit-tuning-key -p -t fp8_fp8 --arch gfx1201 | FileCheck %s --check-prefix=CONVOCPFP8
+// CONVOCPFP8: amdgcn-amd-amdhsa:gfx1201   {{.*}}     convfp8_fp8 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
 // RUN: rocmlir-gen --arch gfx908 --operation gemm -p --emit-tuning-key | FileCheck %s --check-prefix=GEMM
 // GEMM: amdgcn-amd-amdhsa:gfx908   {{.*}}     -t f32 -out_datatype f32 -transA false -transB false -g 1 -m 1024 -n 512 -k 769

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3750,22 +3750,22 @@ int main(int argc, char **argv) {
 
   if (!arch.getValue().empty()) {
     bool archPrefersOCP = (archChip().substr(0, 5) == "gfx12");
-    std::map<F8TypesChoice,std::string>f8e4m3TypeNames{
+    std::map<F8TypesChoice, std::string> f8e4m3TypeNames{
         {F8TypesChoice::Arch, archPrefersOCP ? "f8E4M3FN" : "f8E4M3FNUZ"},
         {F8TypesChoice::Nanoo, "f8E4M3FNUZ"},
         {F8TypesChoice::OCP, "f8E4M3FN"}};
-    std::map<F8TypesChoice,std::string>f8e5m2TypeNames{
+    std::map<F8TypesChoice, std::string> f8e5m2TypeNames{
         {F8TypesChoice::Arch, archPrefersOCP ? "f8E5M2" : "f8E5M2FNUZ"},
         {F8TypesChoice::Nanoo, "f8E5M2FNUZ"},
         {F8TypesChoice::OCP, "f8E5M2"}};
 
     auto canonicaliseF8Type = [&](std::string name) {
-                                if (name == "fp8")
-                                  return f8e4m3TypeNames[forceF8Types.getValue()];
-                                if (name == "bf8")
-                                  return f8e5m2TypeNames[forceF8Types.getValue()];
-                                return std::string(name);
-                              };
+      if (name == "fp8")
+        return f8e4m3TypeNames[forceF8Types.getValue()];
+      if (name == "bf8")
+        return f8e5m2TypeNames[forceF8Types.getValue()];
+      return std::string(name);
+    };
 
     filterDataType = canonicaliseF8Type(filterDataType);
     inputDataType = canonicaliseF8Type(inputDataType);

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3749,22 +3749,21 @@ int main(int argc, char **argv) {
                                     "MLIR Rock Dialect host generation\n");
 
   if (!arch.getValue().empty()) {
-    SmallVector<std::string>f8e4m3TypeNames{"", "f8E4M3FNUZ", "f8E4M3FN"};
-    SmallVector<std::string>f8e5m2TypeNames{"", "f8E5M2FNUZ", "f8E5M2"};
-    int archIndex = llvm::to_underlying(F8TypesChoice::Arch);
-    if (archChip().substr(0, 5) == "gfx12") {
-      f8e4m3TypeNames[archIndex] = "f8E4M3FN";
-      f8e5m2TypeNames[archIndex] = "f8E5M2";
-    } else {
-      f8e4m3TypeNames[archIndex] = "f8E4M3FNUZ";
-      f8e5m2TypeNames[archIndex] = "f8E5M2FNUZ";
-    }
+    bool archPrefersOCP = (archChip().substr(0, 5) == "gfx12");
+    std::map<F8TypesChoice,std::string>f8e4m3TypeNames{
+        {F8TypesChoice::Arch, archPrefersOCP ? "f8E4M3FN" : "f8E4M3FNUZ"},
+        {F8TypesChoice::Nanoo, "f8E4M3FNUZ"},
+        {F8TypesChoice::OCP, "f8E4M3FN"}};
+    std::map<F8TypesChoice,std::string>f8e5m2TypeNames{
+        {F8TypesChoice::Arch, archPrefersOCP ? "f8E5M2" : "f8E5M2FNUZ"},
+        {F8TypesChoice::Nanoo, "f8E5M2FNUZ"},
+        {F8TypesChoice::OCP, "f8E5M2"}};
 
-    auto canonicaliseF8Type = [&](StringRef name) -> std::string {
+    auto canonicaliseF8Type = [&](std::string name) {
                                 if (name == "fp8")
-                                  return f8e4m3TypeNames[llvm::to_underlying(forceF8Types.getValue())];
+                                  return f8e4m3TypeNames[forceF8Types.getValue()];
                                 if (name == "bf8")
-                                  return f8e5m2TypeNames[llvm::to_underlying(forceF8Types.getValue())];
+                                  return f8e5m2TypeNames[forceF8Types.getValue()];
                                 return std::string(name);
                               };
 

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3718,9 +3718,11 @@ int main(int argc, char **argv) {
 
   amdgpu::Chipset chipset;
   if (!arch.getValue().empty()) {
-    FailureOr<amdgpu::Chipset> maybeChipset = amdgpu::Chipset::parse(archChip());
+    FailureOr<amdgpu::Chipset> maybeChipset =
+        amdgpu::Chipset::parse(archChip());
     if (failed(maybeChipset)) {
-      emitError(UnknownLoc::get(&context), "Invalid chipset name: " + archChip());
+      emitError(UnknownLoc::get(&context),
+                "Invalid chipset name: " + archChip());
       exit(1);
     }
     chipset = *maybeChipset;

--- a/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
+++ b/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
@@ -223,7 +223,7 @@ MLIRMIGraphXToTosa
 MLIRMIGraphXTransforms
 MLIRRocTarget
 MLIRRockAnalysis
-MLIRRockConv2dGenerator
+MLIRRockConvGenerator
 MLIRRockOps
 MLIRRockPipeline
 MLIRRockThin

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -114,7 +114,7 @@ static benchmark::DataType getDataType(Type inputType) {
     return benchmark::DataType::BF16;
   } else if (inputType.isInteger(8)) {
     return benchmark::DataType::I8;
-  } else if (inputType.isFloat8E4M3FNUZ()) {
+  } else if (inputType.isFloat8E4M3FNUZ() || inputType.isFloat8E4M3FN()) {
     return benchmark::DataType::F8;
   } else {
     llvm_unreachable("Kernels only accept ints or floats");


### PR DESCRIPTION
Handle the new F8 types in RockTuningImpl.cpp too.
Add an F8-types emit-tuning-key test to an existing test.
Canonicalise F8 types from fp8/bf8 to full type names early in rocmlir-gen.
Restrict the F8 type canonicalisation to runs when --arch is specified.

Aside from  forgetting to handle the OCP types in the tuning code, it turns out that both rocmlir-gen.cpp and ConvGenerator.cpp have code to convert "fp8" and "bf8" to types.  We should merge that code at some point, but the rocmlir-gen one has access to architecture and the --force-f8-types flag and the ConvGenerator one doesn't, and it runs second.

Rather than try the merging, I made rocmlir-gen.cpp convert the type strings "fp8" and "bf8" to the strings naming the correct type for the chip and flag, eg, "f8M4E3FN".  ConvGenerator then won't have to figure it out.

One minor quirk is that it's possible to run rocmlir-gen without specifying --arch in some circumstances, and that's used in several tests (which usually insert it in the next stage with rocmlir-driver).  I don't try to convert the type strings if there's no --arch, because then I can't really tell the chip.