### PR TITLE
disable occupancy warnings

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -1083,7 +1083,7 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
   ProgInfo.Occupancy = AMDGPUMCExpr::createOccupancy(
       STM.computeOccupancy(F, ProgInfo.LDSSize), ProgInfo.NumSGPRsForWavesPerEU,
       ProgInfo.NumVGPRsForWavesPerEU, STM, Ctx);
-
+  /*
   const auto [MinWEU, MaxWEU] =
       AMDGPU::getIntegerPairAttribute(F, "amdgpu-waves-per-eu", {0, 0}, true);
   uint64_t Occupancy;
@@ -1096,6 +1096,7 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
             ", final occupancy is " + Twine(Occupancy));
     F.getContext().diagnose(Diag);
   }
+  */
 }
 
 static unsigned getRsrcReg(CallingConv::ID CallConv) {

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -1083,6 +1083,11 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
   ProgInfo.Occupancy = AMDGPUMCExpr::createOccupancy(
       STM.computeOccupancy(F, ProgInfo.LDSSize), ProgInfo.NumSGPRsForWavesPerEU,
       ProgInfo.NumVGPRsForWavesPerEU, STM, Ctx);
+  /*
+  // Following lines are commented out as they print unnecessary occupancy unmet warnings for the rocMLIR.
+  // rocDL sets minWavesPerEU in as a guide for AMD GPU Codegen, which is not guranteed to be met always.
+  // DiagnosticInfoOptimizationFailure is always enabled as its severity is "DS_Warning".
+  // Therefore commneting following lines.
   const auto [MinWEU, MaxWEU] =
       AMDGPU::getIntegerPairAttribute(F, "amdgpu-waves-per-eu", {0, 0}, true);
   uint64_t Occupancy;
@@ -1095,6 +1100,7 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
             ", final occupancy is " + Twine(Occupancy));
     F.getContext().diagnose(Diag);
   }
+  */
 }
 
 static unsigned getRsrcReg(CallingConv::ID CallConv) {

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -1083,7 +1083,6 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
   ProgInfo.Occupancy = AMDGPUMCExpr::createOccupancy(
       STM.computeOccupancy(F, ProgInfo.LDSSize), ProgInfo.NumSGPRsForWavesPerEU,
       ProgInfo.NumVGPRsForWavesPerEU, STM, Ctx);
-  /*
   const auto [MinWEU, MaxWEU] =
       AMDGPU::getIntegerPairAttribute(F, "amdgpu-waves-per-eu", {0, 0}, true);
   uint64_t Occupancy;
@@ -1096,7 +1095,6 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
             ", final occupancy is " + Twine(Occupancy));
     F.getContext().diagnose(Diag);
   }
-  */
 }
 
 static unsigned getRsrcReg(CallingConv::ID CallConv) {

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -1084,9 +1084,12 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
       STM.computeOccupancy(F, ProgInfo.LDSSize), ProgInfo.NumSGPRsForWavesPerEU,
       ProgInfo.NumVGPRsForWavesPerEU, STM, Ctx);
   /*
-  // Following lines are commented out as they print unnecessary occupancy unmet warnings for the rocMLIR.
-  // rocDL sets minWavesPerEU in as a guide for AMD GPU Codegen, which is not guranteed to be met always.
-  // DiagnosticInfoOptimizationFailure is always enabled as its severity is "DS_Warning".
+  // Following lines are commented out as they print unnecessary occupancy unmet
+  warnings for the rocMLIR.
+  // rocDL sets minWavesPerEU in as a guide for AMD GPU Codegen, which is not
+  guranteed to be met always.
+  // DiagnosticInfoOptimizationFailure is always enabled as its severity is
+  "DS_Warning".
   // Therefore commneting following lines.
   const auto [MinWEU, MaxWEU] =
       AMDGPU::getIntegerPairAttribute(F, "amdgpu-waves-per-eu", {0, 0}, true);


### PR DESCRIPTION
While lowering to ROCDL, rocmlir sets `amdgpu-waves-per-eu` attribute to guide backend code generation. 
When it sets this attribute, it may not be possible to always accurately determine range of `waves-per-eu` in advance and therefore backend code generation may not be able to meet constraints set by `waves-per-eu`

Suppressing warnings as they are unnecessary for consumers for rocMLIR.

Fixes https://github.com/ROCm/rocMLIR-internal/issues/1584