### PR TITLE
Add support for `pad` + removeSubDims in `removeUpperDims`

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -247,9 +247,23 @@ Value addPassThroughIndices(OpBuilder &b, Value transformed,
 
 ArrayRef<int64_t> getLowerShape(ArrayAttr transformStack);
 
+// Given a sequence of transform maps, this will remove the specified upper
+// dimensions. This is usually used to obtain intra-tile indexing in the
+// resultant tile where the remaining upper dims correspond to.
+// NOTE: if there is padding involved in a dimension that is partially
+// being removed, that padding will be ignored in the sub tile indexing
+// maps because the sub tile is assumed to fully materialized filled
+// padded data.
 FailureOr<ArrayAttr> removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
                                      SetVector<int64_t> removeIndicesSet);
 
+// Given a sequence of transform maps, this will remove the specified upper
+// dimensions. This is usually used to obtain intra-tile indexing in the
+// resultant tile where the remaining upper dims correspond to.
+// NOTE: if there is padding involved in a dimension that is partially
+// being removed, that padding will be ignored in the sub tile indexing
+// maps because the sub tile is assumed to fully materialized filled
+// padded data.
 FailureOr<ArrayAttr> removeUpperDims(OpBuilder &b, ArrayAttr transformAttrs,
                                      const StringSet<> &removeDimNamesSet);
 } // end namespace rock

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -2118,12 +2118,30 @@ static FailureOr<rock::TransformMapAttr> removeUpperDimsFromMap(
       case TransformType::Pad: {
         for (auto [idx, upperDim] : llvm::enumerate(tr.getUpperDims())) {
           LLVM_DEBUG(llvm::dbgs() << "pad upper dim = " << upperDim << "\n");
-          assert(!removedSubDims.contains(upperDim));
+          if(removedSubDims.contains(upperDim)){
+            // If the padded dimension is being sub-tiled, then the padding is meaningless
+            // because it happens at the either boundary and only some tiles will have the effect.
+            // For all GPU usecases, we would materialize the padded region in sub tiles.
+            // Thus, we ignore the padding in sub-tile views.
+            LLVM_DEBUG(llvm::dbgs() << "Some parts of the padded dimension is to be removed.\n");
+            const auto lowerDim = tr.getLowerDims()[idx];
+            origLowerBounds[lowerDim] = origUpperBounds[upperDim];
+            args.params.append({0, 0});
+          }
+          else{
+            args.params.append({tr.getParams()[idx * 2], tr.getParams()[idx * 2 + 1]});
+          }
         }
+        break;
+      }
+      case TransformType::Broadcast:
+      case TransformType::AddDim:
+      case TransformType::ConstDim: {
         llvm::copy(tr.getParams(), std::back_inserter(args.params));
         break;
       }
       default: {
+        LLVM_DEBUG(llvm::dbgs() << "Unsupported coordinate transform:" << tr << "\n");
         return failure();
       }
       }

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -2108,8 +2108,8 @@ static FailureOr<rock::TransformMapAttr> removeUpperDimsFromMap(
           origLowerBounds[lowerDim] = origUpperBounds[upperDim];
         }
         for (auto [dim, subDimInfo] : removedSubDims) {
-          LLVM_DEBUG(llvm::dbgs()
-            << "copying removedSubDimInfo from:" << dim << " to:" << upperToLower[dim] << "\n");
+          LLVM_DEBUG(llvm::dbgs() << "copying removedSubDimInfo from:" << dim
+                                  << " to:" << upperToLower[dim] << "\n");
           newRemovedSubDims[upperToLower[dim]] = subDimInfo;
         }
         llvm::copy(tr.getParams(), std::back_inserter(args.params));
@@ -2118,18 +2118,21 @@ static FailureOr<rock::TransformMapAttr> removeUpperDimsFromMap(
       case TransformType::Pad: {
         for (auto [idx, upperDim] : llvm::enumerate(tr.getUpperDims())) {
           LLVM_DEBUG(llvm::dbgs() << "pad upper dim = " << upperDim << "\n");
-          if(removedSubDims.contains(upperDim)){
-            // If the padded dimension is being sub-tiled, then the padding is meaningless
-            // because it happens at the either boundary and only some tiles will have the effect.
-            // For all GPU usecases, we would materialize the padded region in sub tiles.
-            // Thus, we ignore the padding in sub-tile views.
-            LLVM_DEBUG(llvm::dbgs() << "Some parts of the padded dimension is to be removed.\n");
+          if (removedSubDims.contains(upperDim)) {
+            // If the padded dimension is being sub-tiled, then the padding is
+            // meaningless because it happens at the either boundary and only
+            // some tiles will have the effect. For all GPU usecases, we would
+            // materialize the padded region in sub tiles. Thus, we ignore the
+            // padding in sub-tile views.
+            LLVM_DEBUG(
+                llvm::dbgs()
+                << "Some parts of the padded dimension is to be removed.\n");
             const auto lowerDim = tr.getLowerDims()[idx];
             origLowerBounds[lowerDim] = origUpperBounds[upperDim];
             args.params.append({0, 0});
-          }
-          else{
-            args.params.append({tr.getParams()[idx * 2], tr.getParams()[idx * 2 + 1]});
+          } else {
+            args.params.append(
+                {tr.getParams()[idx * 2], tr.getParams()[idx * 2 + 1]});
           }
         }
         break;
@@ -2141,7 +2144,8 @@ static FailureOr<rock::TransformMapAttr> removeUpperDimsFromMap(
         break;
       }
       default: {
-        LLVM_DEBUG(llvm::dbgs() << "Unsupported coordinate transform:" << tr << "\n");
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Unsupported coordinate transform:" << tr << "\n");
         return failure();
       }
       }


### PR DESCRIPTION
Currently, the `pad` is not properly handled when removing upper dims,
especially in presense of dimensions collapse and expansion happenning.

This PR adds support for that in terms of the two cases that be there:
1) If a part of the dimension that is being removed does not involve a padded region : 
this means we can do the padding as usual as the padding is contained within the subtile.
2) If a part of the dimension that is being removed does involve a padded region : 
From the subtile's perspective, this means we are taking a tile out of a dimension where edges are padded. Therefore, as long as the subtile is considered the padding does not affect coordinates within the subtile because they would be materialized with the padded (zero most of the time) value. Thus, we ll ignore the padding.

closes : https://github.com/ROCm/rocMLIR-internal/issues/1590