### PR TITLE
Move enableApplicability to allow ReuseLDSPass to fail if there is not enough LDS memory

### DIFF
--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -154,22 +154,22 @@ void rock::buildKernelPipeline(OpPassManager &pm,
   funcPm.addPass(rock::createRockGridwiseGemmToBlockwisePass());
   funcPm.addPass(rock::createRockBlockwiseGemmToThreadwisePass());
 
-  if (!options.enableApplicability) {
-    if (options.enableFusion) {
-      // align linalg tiling
-      /* rocmlir-opt --rock-linalg-align --canonicalize
-       * --convert-linalg-to-affine-loops
-       */
-      funcPm.addPass(rock::createRockLinalgAlignPass());
-      funcPm.addPass(rock::createRockPipelinePass());
-      funcPm.addPass(createCanonicalizerPass());
-      funcPm.addPass(createConvertLinalgToAffineLoopsPass());
-      funcPm.addPass(rock::createRockVectorizeFusionsPass());
-    }
-    funcPm.addPass(rock::createRockReuseLDSPass());
-    funcPm.addPass(rock::createRockOutputSwizzlePass());
-    funcPm.addPass(rock::createRockReuseLDSPass());
+  if (options.enableFusion) {
+    // align linalg tiling
+    /* rocmlir-opt --rock-linalg-align --canonicalize
+     * --convert-linalg-to-affine-loops
+     */
+    funcPm.addPass(rock::createRockLinalgAlignPass());
+    funcPm.addPass(rock::createRockPipelinePass());
+    funcPm.addPass(createCanonicalizerPass());
+    funcPm.addPass(createConvertLinalgToAffineLoopsPass());
+    funcPm.addPass(rock::createRockVectorizeFusionsPass());
+  }
+  funcPm.addPass(rock::createRockReuseLDSPass());
+  funcPm.addPass(rock::createRockOutputSwizzlePass());
+  funcPm.addPass(rock::createRockReuseLDSPass());
 
+  if (!options.enableApplicability) {
     // rock lowering for reductions
     /* rocmlir-opt --rock-lower-reduce
      */


### PR DESCRIPTION
When there is not enough LDS, the reuse LDS pass fails, therefore, enableApplicability=true should run the reuse LDS pass. Before this pass, the failure happened earlier. Simple fix where we move enableApplicability in Pipelines.cpp

Fixes: https://github.com/ROCm/rocMLIR/issues/1642