### PR TITLE
Use cmake -E touch for cross-platform compatibility

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/CMakeLists.txt
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/CMakeLists.txt
@@ -19,21 +19,12 @@ function(add_linalg_ods_yaml_gen yaml_ast_file output_file)
     DEPENDS
     ${MLIR_LINALG_ODS_YAML_GEN_EXE}
     ${MLIR_LINALG_ODS_YAML_GEN_TARGET})
-if(WIN32)
   add_custom_command(
     OUTPUT ${DUMMY_FILE}
-    COMMAND type nul > ${DUMMY_FILE}
+    COMMAND ${CMAKE_COMMAND} -E touch ${DUMMY_FILE}
     DEPENDS
     ${GEN_ODS_FILE} ${GEN_CPP_FILE}
   )
-else()
-  add_custom_command(
-    OUTPUT ${DUMMY_FILE}
-    COMMAND touch ${DUMMY_FILE}
-    DEPENDS
-    ${GEN_ODS_FILE} ${GEN_CPP_FILE}
-    )
-endif()
   add_custom_target(
     MLIR${output_file}YamlIncGen
     DEPENDS


### PR DESCRIPTION
This PR replaces the platform-specific touch command with cmake -E touch to ensure compatibility across different operating systems. The cmake -E touch command works on both Windows and Linux, eliminating the need for conditional branches in the CMake script.