### PR TITLE
Setup CMAKE_MODULE_PATH when LLVM_LIBDIR_SUFFIX is used

### DIFF
--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -45,10 +45,10 @@ list(APPEND CMAKE_MODULE_PATH
   "${ROCM_PATH}/hip/cmake"
 )
 list(APPEND CMAKE_MODULE_PATH
-  "${CMAKE_BINARY_DIR}/lib/cmake/mlir"
+  "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir"
 )
 list(APPEND CMAKE_MODULE_PATH
-  "${LLVM_BINARY_DIR}/llvm/lib/cmake/llvm/"
+  "${LLVM_BINARY_DIR}/llvm/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm/"
 )
 
 # Include dirs for MLIR and LLVM


### PR DESCRIPTION
LLVM_LIBDIR_SUFFIX is used control the install location of 64 bit arches on Fedora and is typlically used by adding the cmd line
  -DLLVM_LIBDIR_SUFFIX=64

The effect is to change the install location for lib/ to lib64/

When this option is used, the intermediate build locations for llvm and mlir cmake module also need to change.

So append ${LLVM_LIBDIR_SUFFIX} to the setup of the CMAKE_MODULE_PATH

**Note to reviewers:** This PR is already approved and just needs to be sent through a post-rebase CI