### PR TITLE
[DO NOT SQUASH] Fix vector conversion (ExtendToSupportedTypes)

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/Math/Transforms/ExtendToSupportedTypes.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Math/Transforms/ExtendToSupportedTypes.cpp
@@ -66,7 +66,7 @@ void mlir::math::populateExtendToSupportedTypesTypeConverter(
   typeConverter.addConversion(
       [&sourceTypes, targetType](ShapedType type) -> std::optional<Type> {
         if (auto elemTy = dyn_cast<FloatType>(type.getElementType()))
-          if (!sourceTypes.contains(type))
+          if (!sourceTypes.contains(elemTy))
             return type.clone(targetType);
 
         return std::nullopt;

--- a/external/llvm-project/mlir/test/Dialect/Math/extend-to-supported-types-f16.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Math/extend-to-supported-types-f16.mlir
@@ -89,6 +89,15 @@ func.func @sin_vector(%arg0: vector<2xbf16>) -> vector<2xbf16> {
   return %0 : vector<2xbf16>
 }
 
+// CHECK-LABEL: @sin_vector_f16
+// CHECK-SAME: ([[ARG0:%.+]]: vector<2xf16>)
+// CHECK: [[SIN:%.+]] = math.sin [[ARG0]]
+// CHECK: return [[SIN]] : vector<2xf16>
+func.func @sin_vector_f16(%arg0: vector<2xf16>) -> vector<2xf16> {
+  %0 = math.sin %arg0 : vector<2xf16>
+  return %0 : vector<2xf16>
+}
+
 // CHECK-LABEL: @fastmath
 // CHECK: math.sin %{{.+}} fastmath<nsz>
 func.func @fastmath(%arg0: f16) -> f16 {

--- a/mlir/test/fusion/pr-e2e/mixr-gemm/mixr-gemm-erf_f16.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm/mixr-gemm-erf_f16.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-driver -kernel-pipeline migraphx,highlevel %s | rocmlir-gen -ph -print-results -rand 3 - | rocmlir-driver -arch %arch -c  | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 module {
-  // CHECK:  [-1, 1, 1, -1, 0.99{{[0-9]*}}, -1, -1, 1, -1, 0, -1, -0.99{{[0-9]*}}, 0, -1, -1]
+  // CHECK:  [-1, 1, 1, -1, 1, -1, -1, 1, -1, 0, -1, -1, 0, -1, -1]
   func.func @dot_add(%arg0: !migraphx.shaped<1x5x4xf16, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf16, 12x3x1>) -> !migraphx.shaped<1x5x3xf16, 15x3x1> attributes{kernel, arch = ""} {
     %0 = migraphx.dot %arg0, %arg1 : <1x5x4xf16, 20x4x1>, <1x4x3xf16, 12x3x1> -> <1x5x3xf16, 15x3x1>
     %2 = migraphx.erf %0 : <1x5x3xf16, 15x3x1> -> <1x5x3xf16, 15x3x1>


### PR DESCRIPTION
Fix a bug I recently introduced for vector conversion. Due to actually using __ocml_erf_f16, a test changes slightly from 0.999 to 1 and -0.999 to -1.