### PR TITLE
Do the ROCMLIR_DEBUG_FLAGS registration entirely in rocMLIR.

### DIFF
--- a/mlir/include/mlir/InitRocMLIRCLOptions.h
+++ b/mlir/include/mlir/InitRocMLIRCLOptions.h
@@ -16,6 +16,7 @@
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Pass/PassManager.h"
+#include "llvm/Support/CommandLine.h"
 
 namespace mlir {
 
@@ -23,6 +24,16 @@ inline void registerMLIRCLOptions() {
   mlir::registerAsmPrinterCLOptions();
   mlir::registerMLIRContextCLOptions();
   mlir::registerPassManagerCLOptions();
+}
+
+inline void registerRocMLIROptions() {
+  const char *fakeArgv[] = {"rocMLIR-invoked-as-library",
+                            "--mlir-print-local-scope"};
+  mlir::registerMLIRCLOptions();
+  llvm::cl::ParseCommandLineOptions(
+      sizeof(fakeArgv) / sizeof(const char *), fakeArgv,
+      "Fake 'command line' for MIGraphX library debugging", nullptr,
+      "ROCMLIR_DEBUG_FLAGS");
 }
 
 } // namespace mlir

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Rock/Pipelines/Pipelines.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/ExecutionEngine/RocmDeviceName.h"
+#include "mlir/InitRocMLIRCLOptions.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/TargetSelect.h"
 #include <mutex>
@@ -136,6 +137,7 @@ MLIR_CAPI_EXPORTED bool mlirGetBinary(MlirModule module, size_t *size,
 MLIR_CAPI_EXPORTED
 void mlirMIGraphXAddHighLevelPipeline(MlirPassManager pm) {
   auto passMan = unwrap(pm);
+  mlir::registerRocMLIROptions();
   if (failed(applyPassManagerCLOptions(*passMan)))
     llvm::errs() << "Failed to apply command-line options.\n";
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
@@ -157,6 +159,7 @@ mlirMIGraphXAddApplicabilityPipeline(MlirPassManager pm) {
 MLIR_CAPI_EXPORTED bool mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
                                                        const char *arch) {
   auto *passMan = unwrap(pm);
+  mlir::registerRocMLIROptions();
   if (failed(applyPassManagerCLOptions(*passMan)))
     return false;
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);

--- a/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
+++ b/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
@@ -13,25 +13,11 @@
 #include "mlir/InitRocMLIRCLOptions.h"
 #include "mlir/InitRocMLIRDialects.h"
 #include "mlir/InitRocMLIRPasses.h"
-#include "llvm/Support/CommandLine.h"
 
 void mlirRegisterRocMLIRDialects(MlirDialectRegistry registry) {
   mlir::registerRocMLIRDialects(*unwrap(registry));
 }
 
-void mlirRegisterRocMLIRPasses() {
-  mlir::registerRocMLIRPasses();
-  // TODO: remove this call once we call mlirRegisterRocMLIROptions()
-  // in MIGraphX/src/targets/gpu/mlir.cpp.
-  mlir::registerMLIRCLOptions();
-}
+void mlirRegisterRocMLIRPasses() { mlir::registerRocMLIRPasses(); }
 
-void mlirRegisterRocMLIROptions() {
-  const char *fakeArgv[] = {"rocMLIR-invoked-as-library",
-                            "--mlir-print-local-scope"};
-  mlir::registerMLIRCLOptions();
-  llvm::cl::ParseCommandLineOptions(
-      sizeof(fakeArgv) / sizeof(const char *), fakeArgv,
-      "Fake 'command line' for MIGraphX library debugging", nullptr,
-      "ROCMLIR_DEBUG_FLAGS");
-}
+void mlirRegisterRocMLIROptions() { mlir::registerRocMLIROptions(); }


### PR DESCRIPTION
Paul Fultz pointed out that I could do the registration on the rocMLIR side.  That's easier, let's do it that way.