### PR TITLE
Fix MIGraphX CI docker image build issue

### DIFF
--- a/external/llvm-project/mlir/lib/Transforms/Utils/CMakeLists.txt
+++ b/external/llvm-project/mlir/lib/Transforms/Utils/CMakeLists.txt
@@ -15,6 +15,9 @@ add_mlir_library(MLIRTransformUtils
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Transforms
 
+  DEPENDS
+  MLIRTransformsPassIncGen
+
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRControlFlowInterfaces


### PR DESCRIPTION
This patch adds a dependency that fixes the MIGraphX Docker image build error on CI.