### PR TITLE
Exit gracefully if no support for wmma/mfma for attention tuning

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -55,6 +55,9 @@ void createAttnTuningRangeBF(TuningParamSet *newSpace, AttentionOp attnOp,
   } else if (bitEnumContainsAny(features, GemmFeatures::wmma)) {
     isWMMA = true;
     validRangeAttnParams = validRangeAttnParamsWMMA;
+  } else {
+    // We only support GPUs with matrix accelerator extentions
+    return;
   }
   OpBuilder b(attnOp.getContext());
   for (uint32_t gemm0MPerBlock : validRangeAttnParams[0]) {


### PR DESCRIPTION
If I run this command on navi3, it fails "Aborted (core dumped)". This is due to wmma not having f32 input support. In createAttnTuningRangeBF, validRangeAttnParams is empty if there's no mfma or wmma. Then, we access validRangeAttnParams[0] which is out of bounds.

```bash
./bin/rocmlir-gen -operation attention -t f32 --arch gfx1100 --num_cu 70 -g 1 -seq_len_q 16384 -seq_len_k 16384 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale=False -transQ=False -transK=True -transQ=False -transK=False --kernel-repeats 1 --perf_config= | ./bin/rocmlir-tuning-driver --tuning-space=exhaustive
```

This PR fixes this by exiting gracefully if there are no matrix accelerator extensions for attention tuning.
Closes: https://github.com/ROCm/rocMLIR-internal/issues/1634