### PR TITLE
Use the same MITuna branch in Dockerfile that we use in Jenkinsfile.

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -115,7 +115,7 @@ RUN apt-get update && \
   rocprofiler-dev \
   rocblas \
   rocblas-dev \
-  hipblas-dev \  
+  hipblas-dev \
   hipblaslt-dev \
   miopen-hip \
   miopen-hip-dev \
@@ -138,7 +138,7 @@ RUN wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.34-linux-glibc2
 
 # python setup for tuna
 # --ignore-installed because of problems upgrading PyYAML.  See also -U.
-ADD "https://raw.githubusercontent.com/ROCm/MITuna/develop/requirements.txt" tuna-requirements.txt
+ADD "https://raw.githubusercontent.com/ROCm/MITuna/pf-tuna-rocmlir-3/requirements.txt" tuna-requirements.txt
 RUN python3 -m venv /tuna-venv && . /tuna-venv/bin/activate && \
     python3 -m pip install -r tuna-requirements.txt --ignore-installed && \
     python3 -m pip install scipy pandas


### PR DESCRIPTION
We could also change Dockerfile to install python3.10, or to start with Ubuntu 22.04 which uses python3.10, but they don't solve the real problem of synchronising the installed Tuna requirements with the MITuna branch that we use.  This patch is also lots simpler.