### PR TITLE
Update comment regarding barrier gfx908 hack

### DIFF
--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -288,9 +288,8 @@ struct LDSBarrierOpLowering : public ConvertOpToLLVMPattern<LDSBarrierOp> {
       auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
                                                       LLVM::AsmDialect::AD_ATT);
       Location loc = op->getLoc();
-      // Ensure the inlineAsm is guarded with a scheduling region
-      // So it will not interfere with backend compilation more than
-      // it needs.
+      // TODO: Revert scheduling region when
+      // https://github.com/llvm/llvm-project/issues/109294 is fixed
       rewriter.create<amdgpu::SchedBarrierOp>(
           loc, amdgpu::sched_barrier_opt_enum::none);
       const char *asmStr =


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/109678 we learned this is caused by a backend bug: https://github.com/llvm/llvm-project/issues/109294 
Therefore, we can remove the scheduling barrier when that bug is fixed. Here I'm updating the comment with a TODO.