### PR TITLE
Collected improvements to CI performance testing

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -400,6 +400,10 @@ boolean shouldRunBuildAndTest(String codepath) {
     }
 }
 
+boolean isNotNavi3x(String chip) {
+    return "${CHIP}" != 'gfx1100' && "${CHIP}" != 'gfx1101'
+}
+
 
 pipeline {
     agent none
@@ -914,6 +918,11 @@ pipeline {
                         }
                     }
                     stage("Test Attention") {
+                        when {
+                            beforeAgent true;
+                            // gfx110x lacks mfma/wmma necessary for attention.
+                            expression { return isNotNavi3x("${CHIP}") }
+                        }
                         steps {
                             dir('build') {
                                 // Run attention benchmarks
@@ -927,6 +936,9 @@ pipeline {
                         when {
                             beforeAgent true;
                             equals expected: true, actual: params.checkCK;
+                            // ck-benchmark-driver requires CK xdl functions, which are
+                            // only built for gfx9xx.
+                            expression { return isNotNavi3x("${CHIP}") }
                         }
                         steps {
                             catchError (buildResult: null) { // This is an optional stage

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -70,7 +70,7 @@ def setCommonStyles(styler: 'pd.io.formats.style.Styler', speedupCols: list, col
         {'selector': 'tbody tr:nth-child(even)', 'props': [('background-color', '#eeeeee')]},
         {'selector': 'table', 'props': [('background-color', '#dddddd'), ('border-collapse', 'collapse')]},
         {'selector': 'th, td', 'props': [('padding', '0.5em'), ('text-align', 'center'), ('max-width', '150px')]}])
-    styler.format(precision=ROUND_DIGITS, na_rep="FAILED")
+    styler.format(precision=ROUND_DIGITS, na_rep="---")
     for col in speedupCols:
         if col in styler.columns:
             styler.applymap(colorizer, subset=[col])


### PR DESCRIPTION
These changes fix problems that either caused silent failures or produced unnecessary FAILED entries in performance reports.

perfRunner.py:
 - Force split-k-factor to 1 in tuningDb inside benchmarkFusionKernels.
 - Abstract process-pipeline creation and exception-handling into runPipeline.
 - Copy solution to "rocm_agent_enumerator -name" from pull request #1604.
 - Use toCommandLine to index into tuningDb for fusion tests.
 - Use same column order in the config-not-found case as in the run-config case.

reportUtils.py
 - Simple output tweak for perfRunner.py reports.

Jenkinsfile:
 - Don't do attention perfRunner.py on gfx110x.
 - Don't run the CK benchmarking for gfx110x, because ck-benchmark-driver won't compile.