### PR TITLE
Just register the options once.

### DIFF
--- a/mlir/include/mlir-c/RegisterRocMLIR.h
+++ b/mlir/include/mlir-c/RegisterRocMLIR.h
@@ -26,7 +26,7 @@ mlirRegisterRocMLIRDialects(MlirDialectRegistry registry);
 MLIR_CAPI_EXPORTED void mlirRegisterRocMLIRPasses(void);
 
 /// Register command-line options read from ROCMLIR_DEBUG_FLAGS.
-MLIR_CAPI_EXPORTED void mlirRegisterRocMLIROptions(void);
+MLIR_CAPI_EXPORTED void mlirRegisterRocMLIRLibCLOptions(void);
 
 #ifdef __cplusplus
 }

--- a/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
+++ b/mlir/lib/CAPI/RegisterRocMLIR/RegisterRocMLIR.cpp
@@ -21,12 +21,12 @@ void mlirRegisterRocMLIRDialects(MlirDialectRegistry registry) {
 
 void mlirRegisterRocMLIRPasses() {
   mlir::registerRocMLIRPasses();
-  // TODO: remove this call once we call mlirRegisterRocMLIROptions()
+  // TODO: remove this call once we call mlirRegisterRocMLIRLibCLOptions()
   // in MIGraphX/src/targets/gpu/mlir.cpp.
-  mlir::registerMLIRCLOptions();
+  mlirRegisterRocMLIRLibCLOptions();
 }
 
-void mlirRegisterRocMLIROptions() {
+void mlirRegisterRocMLIRLibCLOptions() {
   const char *fakeArgv[] = {"rocMLIR-invoked-as-library",
                             "--mlir-print-local-scope"};
   mlir::registerMLIRCLOptions();

--- a/mlir/test/CAPI/mixr_full.c
+++ b/mlir/test/CAPI/mixr_full.c
@@ -330,7 +330,7 @@ int main(void) {
   MlirDialectRegistry registry = mlirDialectRegistryCreate();
   mlirRegisterRocMLIRDialects(registry);
   mlirRegisterRocMLIRPasses();
-  mlirRegisterRocMLIROptions();
+  mlirRegisterRocMLIRLibCLOptions();
   mlirContextAppendDialectRegistry(ctx, registry);
   // TODO: this is a emulation of an old behavior, we should load only the
   // dialects we use


### PR DESCRIPTION
[Could swear I did this already, but I can't find it.]
Supersedes pull request #1655.  Register the options relevant to ROCMLIR_DEBUG_FLAGS in one place, which is called once in MIGraphX mlir.cpp.  I put the call in a rocMLIR function because I'm still suspicious of the trouble I had a while back, and want to see it work for other people in other situations before I commit to adding a call to MIGraphX.  Also changed the function name as suggested.