### PR TITLE
Fix crash with invalid !migraphx.shaped types

### DIFF
--- a/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
+++ b/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
@@ -251,6 +251,8 @@ RankedTensorType MIXRShapedType::asMemoryLayoutTensor() const {
 
 RankedTensorType MIXRShapedType::asFlatMemoryTensor() const {
   RankedTensorType memoryTensorType = asMemoryLayoutTensor();
+  if (!memoryTensorType)
+    return nullptr;
   return memoryTensorType.clone(memoryTensorType.getNumElements());
 }
 


### PR DESCRIPTION
asFlatMemoryTensor() was being invoked in the MIGraphX type conversions without checking if the underlynig call to asMemoryLayoutTensor() succeeded. This caused crashes when trying to check the rank of a null pointer.

This commit restores us to merely failing the pass.

Fixes https://github.com/ROCm/rocMLIR-internal/issues/1640