### PR TITLE
[CI] Update Dockerfile to set ONNX version to 1.14.1

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -4,7 +4,7 @@ ARG ROCM_PATH=/opt/rocm-6.2
 # --------------------- Section 4: MIGraphX dependencies ---------------
 WORKDIR /MIGraphXDeps
 RUN pip3 install setuptools wheel
-RUN pip3 install onnxruntime==1.10.0
+RUN pip3 install onnx==1.14.1 onnxruntime
 RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz
 ENV MIGRAPHX_REF=develop
 RUN wget https://raw.githubusercontent.com/ROCm/AMDMIGraphX/${MIGRAPHX_REF}/requirements.txt \


### PR DESCRIPTION
Update Dockerfile to set ONNX version to 1.14.1 and install the latest ONNX Runtime for Python 3.10.