### PR TITLE
[MERGE COMMIT OR REBASE] Mass release backport to 6.3

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -14,6 +14,7 @@ trigger:
   branches:
     include:
     - develop
+    - mainline
   paths:
     exclude:
     - .github

--- a/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
@@ -196,6 +196,7 @@ struct TopDownTMBottomDimsWrapper {
       : b(b), bottomDims(bottomDims) {}
   void passThrough(StringRef name);
   void passThrough(ArrayRef<StringRef> names);
+  void passThrough(StringRef outName, StringRef inName);
 
   void pad(ArrayRef<StringRef> outNames, ArrayRef<StringRef> inNames,
            ArrayRef<int64_t> params);
@@ -293,6 +294,7 @@ struct BottomUpTMTopDimsWrapper {
       : b(b), topDims(topDims) {}
   void passThrough(StringRef name);
   void passThrough(ArrayRef<StringRef> names);
+  void passThrough(StringRef outName, StringRef inName);
 
   void pad(ArrayRef<StringRef> outNames, ArrayRef<StringRef> inNames,
            ArrayRef<int64_t> params);

--- a/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
+++ b/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
@@ -251,6 +251,8 @@ RankedTensorType MIXRShapedType::asMemoryLayoutTensor() const {
 
 RankedTensorType MIXRShapedType::asFlatMemoryTensor() const {
   RankedTensorType memoryTensorType = asMemoryLayoutTensor();
+  if (!memoryTensorType)
+    return nullptr;
   return memoryTensorType.clone(memoryTensorType.getNumElements());
 }
 

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -624,6 +624,11 @@ void TopDownTMBottomDimsWrapper::passThrough(ArrayRef<StringRef> names) {
   b.passThrough(names, toBottomDims(names), names);
 }
 
+void TopDownTMBottomDimsWrapper::passThrough(StringRef outName,
+                                             StringRef inName) {
+  b.passThrough(outName, toBottomDims(outName), inName);
+}
+
 void TopDownTMBottomDimsWrapper::pad(ArrayRef<StringRef> outNames,
                                      ArrayRef<StringRef> inNames,
                                      ArrayRef<int64_t> params) {
@@ -840,6 +845,11 @@ void BottomUpTMTopDimsWrapper::passThrough(StringRef name) {
 
 void BottomUpTMTopDimsWrapper::passThrough(ArrayRef<StringRef> names) {
   b.passThrough(names, toTopDims(names), names);
+}
+
+void BottomUpTMTopDimsWrapper::passThrough(StringRef outName,
+                                           StringRef inName) {
+  b.passThrough(outName, toTopDims(outName), inName);
 }
 
 void BottomUpTMTopDimsWrapper::pad(ArrayRef<StringRef> outNames,

--- a/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
@@ -111,8 +111,10 @@ GemmFeatures mlir::rock::AmdArchInfo::getDefaultFeatures(Type dataType) {
   bool isWmma = bitEnumContainsAll(theseFeatures, GemmFeatures::wmma);
   Type elementType = getElementTypeOrSelf(dataType);
   if (isWmma) {
-    if (!elementType.isF16() && !elementType.isBF16() &&
-        !elementType.isInteger(8)) {
+    if (!(isa<Float16Type, BFloat16Type>(elementType) ||
+          elementType.isInteger(8) ||
+          (hasFp8ConversionInstrs &&
+           isa<Float8E5M2Type, Float8E4M3FNType>(elementType)))) {
       theseFeatures = bitEnumClear(theseFeatures, GemmFeatures::wmma);
     }
   }

--- a/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
@@ -58,7 +58,7 @@ static constexpr AmdArchInfo
                   GemmFeatures::atomic_fmax_f32 | GemmFeatures::wmma,
               /*waveSize=*/32, /*maxWavesPerEU*/ 20, /*totalSGPRPerEU*/ 512,
               /*totalVGPRPerEU*/ 1536, /*totalSharedMemPerCU*/ 131072,
-              /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/48,
+              /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/12,
               /*hasFp8ConversionInstrs=*/false, /*maxNumXCC=*/1);
 
 AmdArchInfo mlir::rock::lookupArchInfo(StringRef arch) {

--- a/mlir/test/Dialect/Rock/conv_to_gemm.mlir
+++ b/mlir/test/Dialect/Rock/conv_to_gemm.mlir
@@ -1,0 +1,32 @@
+// RUN: rocmlir-opt --rock-conv-to-gemm --mlir-print-local-scope --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @nhwc_1x1
+// CHECK: <AddDim{1} ["0"] at [1] -> [] at []>, <PassThrough ["0o"] at [2] -> ["0ipad"] at [1]>, <AddDim{1} ["1"] at [3] -> [] at []>, <PassThrough ["1o"] at [4] -> ["1ipad"] at [2]>
+// CHECK-NOT: Embed
+func.func @nhwc_1x1(%arg0: memref<16384xf16>, %arg1: memref<802816xf16>, %arg2: memref<3211264xf16>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3, d4) -> ((d0 * 256 + d1 + d2 + d3) * 64 + d4)> by [<Unmerge{1, 256, 1, 1, 64} ["g", "k", "0", "1", "c"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [1, 256, 1, 1, 64] -> [16384]> : memref<16384xf16> to memref<1x256x1x1x64xf16>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2 + d3) * 64 + d4)> by [<Unmerge{64, 14, 14, 1, 64} ["ni", "0i", "1i", "gi", "ci"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 14, 14, 1, 64] -> [802816]> : memref<802816xf16> to memref<64x14x14x1x64xf16>
+  %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2 + d3) * 256 + d4)> by [<Unmerge{64, 14, 14, 1, 256} ["no", "0o", "1o", "go", "ko"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 14, 14, 1, 256] -> [3211264]> : memref<3211264xf16> to memref<64x14x14x1x256xf16>
+  rock.conv(%0, %1, %2) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", derivedBlockSize = 128 : i32, dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "0", "1", "c"], input_layout = ["ni", "0i", "1i", "gi", "ci"], numCU = 96 : i32, output_layout = ["no", "0o", "1o", "go", "ko"], padding = [0 : index, 0 : index, 0 : index, 0 : index], params = #rock.wmma_gemm_params<kpackPerBlock = 4, mPerBlock = 256, nPerBlock = 64, kpack = 8, mPerWave = 64, nPerWave = 64, splitKFactor = 1, forceUnroll = true>, strides = [1 : index, 1 : index]} : memref<1x256x1x1x64xf16>, memref<64x14x14x1x64xf16>, memref<64x14x14x1x256xf16>
+  return
+}
+
+// CHECK-LABEL: @nhwc_1x1_stride_2
+// CHECK: <AddDim{1} ["0"] at [1] -> [] at []>, <Embed{2} ["0o"] at [2] -> ["0ipad"] at [1]>, <AddDim{1} ["1"] at [3] -> [] at []>, <Embed{2} ["1o"] at [4] -> ["1ipad"] at [2]>
+func.func @nhwc_1x1_stride_2(%arg0: memref<16384xf16>, %arg1: memref<802816xf16>, %arg2: memref<802816xf16>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3, d4) -> ((d0 * 256 + d1 + d2 + d3) * 64 + d4)> by [<Unmerge{1, 256, 1, 1, 64} ["g", "k", "0", "1", "c"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [1, 256, 1, 1, 64] -> [16384]> : memref<16384xf16> to memref<1x256x1x1x64xf16>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2 + d3) * 64 + d4)> by [<Unmerge{64, 14, 14, 1, 64} ["ni", "0i", "1i", "gi", "ci"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 14, 14, 1, 64] -> [802816]> : memref<802816xf16> to memref<64x14x14x1x64xf16>
+  %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 7 + d1) * 7 + d2 + d3) * 256 + d4)> by [<Unmerge{64, 7, 7, 1, 256} ["no", "0o", "1o", "go", "ko"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 7, 7, 1, 256] -> [802816]> : memref<802816xf16> to memref<64x7x7x1x256xf16>
+  rock.conv(%0, %1, %2) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", derivedBlockSize = 128 : i32, dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "0", "1", "c"], input_layout = ["ni", "0i", "1i", "gi", "ci"], numCU = 96 : i32, output_layout = ["no", "0o", "1o", "go", "ko"], padding = [0 : index, 0 : index, 0 : index, 0 : index], params = #rock.wmma_gemm_params<kpackPerBlock = 4, mPerBlock = 256, nPerBlock = 64, kpack = 8, mPerWave = 64, nPerWave = 64, splitKFactor = 1, forceUnroll = true>, strides = [2 : index, 2 : index]} : memref<1x256x1x1x64xf16>, memref<64x14x14x1x64xf16>, memref<64x7x7x1x256xf16>
+  return
+}
+
+// CHECK-LABEL: @nhwc_3x3
+// CHECK: <Embed{1, 1} ["0", "0o"] at [1, 2] -> ["0ipad"] at [1]>, <Embed{1, 1} ["1", "1o"] at [3, 4] -> ["1ipad"] at [2]>
+func.func @nhwc_3x3(%arg0: memref<147456xf16>, %arg1: memref<802816xf16>, %arg2: memref<2359296xf16>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3, d4) -> ((((d0 * 256 + d1) * 3 + d2) * 3 + d3) * 64 + d4)> by [<Unmerge{1, 256, 3, 3, 64} ["g", "k", "0", "1", "c"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [1, 256, 3, 3, 64] -> [147456]> : memref<147456xf16> to memref<1x256x3x3x64xf16>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2 + d3) * 64 + d4)> by [<Unmerge{64, 14, 14, 1, 64} ["ni", "0i", "1i", "gi", "ci"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 14, 14, 1, 64] -> [802816]> : memref<802816xf16> to memref<64x14x14x1x64xf16>
+  %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 12 + d1) * 12 + d2 + d3) * 256 + d4)> by [<Unmerge{64, 12, 12, 1, 256} ["no", "0o", "1o", "go", "ko"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 12, 12, 1, 256] -> [2359296]> : memref<2359296xf16> to memref<64x12x12x1x256xf16>
+  rock.conv(%0, %1, %2) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", derivedBlockSize = 128 : i32, dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "0", "1", "c"], input_layout = ["ni", "0i", "1i", "gi", "ci"], numCU = 96 : i32, output_layout = ["no", "0o", "1o", "go", "ko"], padding = [0 : index, 0 : index, 0 : index, 0 : index], params = #rock.wmma_gemm_params<kpackPerBlock = 4, mPerBlock = 256, nPerBlock = 64, kpack = 8, mPerWave = 64, nPerWave = 64, splitKFactor = 1, forceUnroll = true>, strides = [1 : index, 1 : index]} : memref<1x256x3x3x64xf16>, memref<64x14x14x1x64xf16>, memref<64x12x12x1x256xf16>
+  return
+}

--- a/mlir/test/rocmlir-gen/wmma-enablement.mlir
+++ b/mlir/test/rocmlir-gen/wmma-enablement.mlir
@@ -1,0 +1,12 @@
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm --operation gemm -wmma infer -t f16 -p | grep '|wmma' | count 1
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t fp8_fp8 -p | grep '|wmma' | count 1
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t bf8_bf8 -p | grep '|wmma' | count 1
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t fp8_fp8 -force-f8-types=fnuz -p | not grep '|wmma'
+
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -wmma infer -t f16 -p | grep '|wmma' | count 1
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -wmma infer -t fp8_fp8 -p | not grep '|wmma'
+
+// YES: rock.gemm
+// YES-SAME: features = {{[^ ]*}}wmma
+// NO: rock.gemm
+// NO-NOT: wmma

--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 MAINTAINER Zhuoran Yin <zhuoran.yin@amd.com>
 
 ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/6.2/
-ARG ROCM_BUILD_NAME=focal
+ARG ROCM_BUILD_NAME=jammy
 ARG ROCM_BUILD_NUM=main
 ARG ROCM_PATH=/opt/rocm-6.2
 
@@ -23,7 +23,7 @@ RUN echo 'install build dependencies'; \
         libelf-dev libffi-dev gcc-multilib libmpfr-dev libpfm4-dev \
         python3 python3-psutil python3-pip python3-setuptools \
         lsb-release software-properties-common \
-        swig python3-dev libedit-dev libncurses5-dev libxml2-dev liblzma-dev golang rsync jq \
+        swig python3-dev libedit-dev libncurses5-dev libxml2-dev libxslt-dev liblzma-dev golang rsync jq \
         # for libc++ tests that use the timezone database of the chrono header
         tzdata \
         # for llvm installation script
@@ -100,6 +100,9 @@ RUN groupadd -g 109 render
 # Add ROCm build distribution
 RUN wget --no-check-certificate -qO - http://repo.radeon.com/rocm/rocm.gpg.key 2>/dev/null | apt-key add -
 RUN echo "deb [arch=amd64] $ROCM_DEB_REPO $ROCM_BUILD_NAME $ROCM_BUILD_NUM" > /etc/apt/sources.list.d/rocm.list
+RUN echo 'Package: *' > /etc/apt/preferences.d/repo-radeon-pin-600 && \
+    echo 'Pin: release o=repo.radeon.com' >> /etc/apt/preferences.d/repo-radeon-pin-600 && \
+    echo 'Pin-Priority: 600' >> /etc/apt/preferences.d/repo-radeon-pin-600
 
 # Note instead of installing the latest, we should always manually bump cmake version when necessary.
 # This make sure that we don't accidentally use newer cmake features incompatible with our client.

--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -4,7 +4,7 @@ ARG ROCM_PATH=/opt/rocm-6.2
 # --------------------- Section 4: MIGraphX dependencies ---------------
 WORKDIR /MIGraphXDeps
 RUN pip3 install setuptools wheel
-RUN pip3 install onnxruntime==1.10.0
+RUN pip3 install onnx==1.14.1 onnxruntime
 RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz
 ENV MIGRAPHX_REF=develop
 RUN wget https://raw.githubusercontent.com/ROCm/AMDMIGraphX/${MIGRAPHX_REF}/requirements.txt \


### PR DESCRIPTION
Whereas ROCm hasn't branched for 6.3 yet

Whereas, since we cut the release branch, we have only landed bugfixes and internal CI improvements

Whereas MIGraphX needs to pick up the new commits, and

Whereas bulldozing through branch protection to land all these changes would be unreasonable, 

Therefore, this PR backports the current state of `develop` to the 6.3 release branch.