### PR TITLE
navi4x tests fail with mixed types bf8_fp8

### DIFF
--- a/mlir/test/e2e/PrGemm.toml
+++ b/mlir/test/e2e/PrGemm.toml
@@ -21,7 +21,7 @@ prefix = "--transA="
 # Note: only one fp8 variant is tested as that's enough for a sanity check
 [[axis]]
 name = "data type"
-values = ["f32", "f16", "i8", "fp8_bf8"]
+values = ["f32", "f16", "i8", "fp8_fp8"]
 prefix = "-t "
 
 ## Gemm variants
@@ -38,7 +38,7 @@ config = "-g 3 -m 1024 -k 769 -n 1024 --reverse_grid"
 # Don't re-test f16 and i8 with transposes: it won't give us much new
 [[suite.test.exclude]]
 name = "data type"
-values = ["f16", "i8", "fp8_bf8"]
+values = ["f16", "i8", "fp8_fp8"]
 [[suite.test.exclude]]
 name = "transA"
 values = ["true"]
@@ -49,4 +49,4 @@ config = "-g 1 -m 32768 -k 1 -n 32769"
 # Only test f32 here
 [[suite.test.exclude]]
 name = "data type"
-values = ["f16", "i8", "fp8_bf8"]
+values = ["f16", "i8", "fp8_fp8"]

--- a/mlir/test/fusion/e2e/lit.site.cfg.py.in
+++ b/mlir/test/fusion/e2e/lit.site.cfg.py.in
@@ -60,7 +60,7 @@ if config.rocm_path:
         for x in agents:
             if any([arch in x for arch in ["gfx908", "gfx90a", "gfx940", "gfx941", "gfx942"]]):
                 config.arch_support_mfma = True
-            elif "gfx11" in x:
+            elif "gfx11" in x or "gfx12" in x:
                 config.arch_support_wmma = True
             # Check other features here
         if not config.arch:

--- a/mlir/test/rocmlir-gen/wmma-enablement.mlir
+++ b/mlir/test/rocmlir-gen/wmma-enablement.mlir
@@ -2,9 +2,13 @@
 // RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t fp8_fp8 -p | grep '|wmma' | count 1
 // RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t bf8_bf8 -p | grep '|wmma' | count 1
 // RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t fp8_fp8 -force-f8-types=fnuz -p | not grep '|wmma'
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t bf8_fp8 -p | not grep '|wmma'
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm -wmma infer -t fp8_bf8 -p | not grep '|wmma'
 
 // RUN: rocmlir-gen --arch gfx1100 --operation gemm -wmma infer -t f16 -p | grep '|wmma' | count 1
 // RUN: rocmlir-gen --arch gfx1100 --operation gemm -wmma infer -t fp8_fp8 -p | not grep '|wmma'
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -wmma infer -t bf8_fp8 -p | not grep '|wmma'
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -wmma infer -t fp8_bf8 -p | not grep '|wmma'
 
 // YES: rock.gemm
 // YES-SAME: features = {{[^ ]*}}wmma

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3473,8 +3473,7 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
 
     if (wmmaFeature == FeatureToggle::infer) {
       // Disable acceleration for mixed types
-      if (filterElemType.getIntOrFloatBitWidth() !=
-          inputElemType.getIntOrFloatBitWidth()) {
+      if (filterElemType != inputElemType) {
         enabledFeatures =
             bitEnumClear(enabledFeatures, rock::GemmFeatures::wmma);
       }


### PR DESCRIPTION
Fix when wmma is enabled by rocmlir-gen (and ConvGenerator) for mixed types.