### PR TITLE
Collected small Jenkinsfile improvements

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -406,6 +406,12 @@ boolean isNotNavi3x(String chip) {
 
 void collectCoverageData(String profdata, String cov, String cpath) {
     sh """
+       rm -f *.profraw
+       # Arbitrarily 150 GB;  we typically see 125 GB of *.profraw.
+       if [ `df --output=avail -k . | tail -1l` -lt 153600000 ]; then
+          echo Not enough free disk space for profiling.
+          exit 1
+       fi
        ninja check-rocmlir
        # Profile processing.
        ${profdata} merge -sparse ./*.profraw -o ./coverage.profdata

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -404,6 +404,27 @@ boolean isNotNavi3x(String chip) {
     return "${CHIP}" != 'gfx1100' && "${CHIP}" != 'gfx1101'
 }
 
+void collectCoverageData(String profdata, String cov, String cpath) {
+    sh """
+       ninja check-rocmlir
+       # Profile processing.
+       ${profdata} merge -sparse ./*.profraw -o ./coverage.profdata
+       rm -f build/*.profraw
+       ${cov} report --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver      \
+          --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
+          --ignore-filename-regex=external/llvm-project > ./coverage_${cpath}.report
+       cat ./coverage_${cpath}.report
+       ${cov} export --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver      \
+          --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
+          --ignore-filename-regex=external/llvm-project --format=lcov              \
+          --compilation-dir ${WORKSPACE} > ./coverage_${cpath}.lcov
+       ${cov} show --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver        \
+          --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
+          --ignore-filename-regex=external/llvm-project -Xdemangler=llvm-cxxfilt   \
+          --format=html > ./coverage_${cpath}.html
+       """
+}
+
 
 pipeline {
     agent none
@@ -1127,46 +1148,33 @@ pipeline {
                     stage ("body") {
                         steps {
                             // Build with profiling on, and just code-generation tests.
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE',
-                                       message: 'Code coverage stage had an error or timeout.') {
-                                timeout(time: 60, activity: true, unit: 'MINUTES') {
-                                    sh 'rm -f build/CMakeCache.txt'
-                                    sh 'rm -f build/*.profraw'
-                                    buildProject('check-rocmlir-build-only',
-                                                 '-DBUILD_FAT_LIBROCKCOMPILER=ON -DCMAKE_BUILD_TYPE=debug -DLLVM_BUILD_INSTRUMENTED_COVERAGE=ON')
-                                    dir ('build') {
-                                        // Run tests.
-                                        sh """
-                                           ninja check-rocmlir
-                                           # Profile processing.
-                                           ${LLVM_PROFDATA} merge -sparse ./*.profraw -o ./coverage.profdata
-                                           rm -f build/*.profraw
-                                           ${LLVM_COV} report --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver \
-                                              --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
-                                              --ignore-filename-regex=external/llvm-project > ./coverage_${CPATH}.report
-                                           cat ./coverage_${CPATH}.report
-                                           ${LLVM_COV} export --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver \
-                                              --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
-                                              --ignore-filename-regex=external/llvm-project --format=lcov              \
-                                              --compilation-dir ${WORKSPACE} > ./coverage_${CPATH}.lcov
-                                           ${LLVM_COV} show --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver  \
-                                              --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata          \
-                                              --ignore-filename-regex=external/llvm-project -Xdemangler=llvm-cxxfilt  \
-                                              --format=html > ./coverage_${CPATH}.html
-                                           """
-                                        // Upload to codecov.
-                                        withCredentials([string(credentialsId: 'codecov-token-rocmlir', variable: 'CODECOV_TOKEN')]) {
-                                            sh '''
-                                               curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
-                                               proxy_opt=""
-                                               if [ -n "${http_proxy}" ]; then
-                                                   proxy_opt="-U ${http_proxy}"
-                                               fi
-                                               ./codecov -t ${CODECOV_TOKEN} --flags "${CPATH}" -f ./coverage_${CPATH}.lcov ${proxy_opt}
-                                               '''
+                            script {
+                                try {
+                                    timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                        sh 'rm -f build/CMakeCache.txt'
+                                        sh 'rm -f build/*.profraw'
+                                        buildProject('check-rocmlir-build-only',
+                                                     '-DBUILD_FAT_LIBROCKCOMPILER=ON -DCMAKE_BUILD_TYPE=debug -DLLVM_BUILD_INSTRUMENTED_COVERAGE=ON')
+                                        dir ('build') {
+                                            // Run tests.
+                                            collectCoverageData("${LLVM_PROFDATA}", "${LLVM_COV}", "${CPATH}")
+                                            // Upload to codecov.
+                                            withCredentials([string(credentialsId: 'codecov-token-rocmlir',
+                                                                    variable: 'CODECOV_TOKEN')]) {
+                                                sh '''
+                                                   curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
+                                                   proxy_opt=""
+                                                   if [ -n "${http_proxy}" ]; then
+                                                       proxy_opt="-U ${http_proxy}"
+                                                   fi
+                                                   ./codecov -t ${CODECOV_TOKEN} --flags "${CPATH}" -f ./coverage_${CPATH}.lcov ${proxy_opt}
+                                                   '''
+                                            }
                                         }
+                                        archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', onlyIfSuccessful: true
                                     }
-                                    archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', onlyIfSuccessful: true
+                                } catch (Exception e) {
+                                    echo "NOTE: Code coverage stage had an error or timeout:\n${e}"
                                 }
                             }
                         }


### PR DESCRIPTION
1.  catchError doesn't catch timeout exceptions, but try/catch does.  Use try/catch in the codecov stage.  This is a precursor to using "retry" to automatically catch and retry after infrastructure issues.
2.  check-rocmlir-build-only with profiling on does make some *.profraw files.  Delete them before check-rocmlir.
3.  Use df to check for enough disk space before running codecov, because it'll generate around 125 GB of *.profraw files.
4.  Abstract the bulk of the codecov shell script into a function.