### PR TITLE
Fix hardcoded arguments and results ids for prefill

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -9,6 +9,7 @@
 #ifndef ROCK_UTILITY_LOWERINGUTILS_H
 #define ROCK_UTILITY_LOWERINGUTILS_H
 
+#include "mlir/Analysis/BufferDependencyAnalysis.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
@@ -203,6 +204,11 @@ Value gpuAlloc(OpBuilder &b, Location loc, int64_t bufferDim, Type elementType,
 
 // helper to verify a lds allocation fits in the GPU
 LogicalResult checkLDSSize(StringAttr arch, int64_t ldsBytes);
+
+// Trace gemm output back to its function arguments
+FailureOr<SmallVector<BlockArgument>>
+traceGemmOutputToArgs(Value matC, func::FuncOp func, OpBuilder &builder,
+                      const BufferDependencyAnalysis &deps);
 
 } // end namespace rock
 } // end namespace mlir

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -222,9 +222,8 @@ static bool isTosaReduction(Operation *op) {
 
 static Value traceToRes(Value tensor, DenseMap<Value, Value> &cache,
                         Value expectedTensor) {
-  auto cached = cache.find(tensor);
-  if (cached != cache.end())
-    return cached->second;
+  if (cache.contains(tensor))
+    return cache.find(tensor)->second;
 
   Value res = nullptr;
   if (tensor.getDefiningOp()) {

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -237,12 +237,11 @@ static Value traceToRes(Value tensor, DenseMap<Value, Value> &cache,
       res = traceToRes(collapse.getSrc(), cache, expectedTensor);
     } else if (auto tosaOp = tensor.getDefiningOp<tosa::TosaOp>()) {
       for (auto operand : tosaOp->getOperands()) {
-        if (!operand.getDefiningOp())
-          if (llvm::isa<TensorType>(operand.getType())) {
-            res = traceToRes(operand, cache, expectedTensor);
-            if (res)
-              break;
-          }
+        if (llvm::isa<TensorType>(operand.getType())) {
+          res = traceToRes(operand, cache, expectedTensor);
+          if (res)
+            break;
+        }
       }
     }
   }

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -223,7 +223,7 @@ static bool isTosaReduction(Operation *op) {
 static Value traceToRes(Value tensor, DenseMap<Value, Value> &cache,
                         Value expectedTensor) {
   if (cache.contains(tensor))
-    return cache.find(tensor)->second;
+    return cache.at(tensor);
 
   Value res = nullptr;
   if (tensor.getDefiningOp()) {

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -172,9 +172,7 @@ setPrefillForSplitK(func::FuncOp &func,
     }
     return WalkResult::advance();
   });
-  if (walkRes.wasInterrupted())
-    return failure();
-  return success();
+  return walkRes.wasInterrupted() ? failure() : success();
 }
 } // end namespace
 

--- a/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce.mlir
+++ b/mlir/test/Conversion/TosaToRock/reductions/tosa-to-rock-reduce.mlir
@@ -28,4 +28,30 @@ func.func @test_reduce_max(%arg0: tensor<2x10x100xf32>) -> tensor<2x10x1xf32> at
   return %1 : tensor<2x10x1xf32>
 }
 
+// CHECK-LABEL: @test_reduce_max_two_outputs
+// CHECK-SAME: -> (tensor<2x10x1xf32> {mhal.read_access, rock.prefill = 0xFF800000 : f32}
+// CHECK-SAME: , tensor<2x1x100xf32> {mhal.read_access, rock.prefill = 0xFF800000 : f32})
+func.func @test_reduce_max_two_outputs(%arg0: tensor<2x10x100xf32>, %arg1: tensor<2x100x100xf32>) -> (tensor<2x10x1xf32>, tensor<2x1x100xf32>) attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x10x1xf32>
+  // CHECK: rock.reduce  max %arg0 into %[[outBuf]] {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 8 : i32} : tensor<2x10x100xf32> into tensor<2x10x1xf32> -> tensor<2x10x1xf32>
+  %1 = "tosa.reduce_max"(%arg0) {axis = 2 : i32} : (tensor<2x10x100xf32>) -> tensor<2x10x1xf32>
+  // CHECK: %[[outBuf2:.*]] = bufferization.alloc_tensor() : tensor<2x1x100xf32>
+  // CHECK: rock.reduce  max %arg1 into %[[outBuf2]] {{.*}} {axis = 1 : index, blockSize = 256 : i32, gridSize = 79 : i32} : tensor<2x100x100xf32> into tensor<2x1x100xf32> -> tensor<2x1x100xf32>
+  %2 = "tosa.reduce_max"(%arg1) {axis = 1 : i32} : (tensor<2x100x100xf32>) -> tensor<2x1x100xf32>
+  return %1, %2 : tensor<2x10x1xf32>, tensor<2x1x100xf32>
+}
+
+// CHECK-LABEL: @test_reduce_sum_two_outputs
+// CHECK-SAME: -> (tensor<2x10x1xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32}
+// CHECK-SAME: , tensor<2x1x100xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_reduce_sum_two_outputs(%arg0: tensor<2x10x100xf32>, %arg1: tensor<2x100x100xf32>) -> (tensor<2x10x1xf32>, tensor<2x1x100xf32>) attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x10x1xf32>
+  // CHECK: rock.reduce  sum %arg0 into %[[outBuf]] {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 8 : i32} : tensor<2x10x100xf32> into tensor<2x10x1xf32> -> tensor<2x10x1xf32>
+  %1 = "tosa.reduce_sum"(%arg0) {axis = 2 : i32} : (tensor<2x10x100xf32>) -> tensor<2x10x1xf32>
+  // CHECK: %[[outBuf2:.*]] = bufferization.alloc_tensor() : tensor<2x1x100xf32>
+  // CHECK: rock.reduce  sum %arg1 into %[[outBuf2]] {{.*}} {axis = 1 : index, blockSize = 256 : i32, gridSize = 79 : i32} : tensor<2x100x100xf32> into tensor<2x1x100xf32> -> tensor<2x1x100xf32>
+  %2 = "tosa.reduce_sum"(%arg1) {axis = 1 : i32} : (tensor<2x100x100xf32>) -> tensor<2x1x100xf32>
+  return %1, %2 : tensor<2x10x1xf32>, tensor<2x1x100xf32>
+}
+
 }

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -28,11 +28,13 @@ func.func @gemm_easy_case_from_conv(%a: memref<1x72x128xf32>, %b: memref<1x72x51
 func.func @gemm_splitk(%a: memref<1x72x128xf32>, %b: memref<1x72x512xf32>, %c: memref<1x128x512xf32>) {
   // CHECK: rock.gridwise_gemm
   // CHECK-SAME: storeMethod( atomic_add)
-  rock.gemm %c = tr %a * %b features = atomic_add storeMethod = set {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x128x512xf32>
+  rock.gemm %alloc = tr %a * %b features = atomic_add storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx1100",
     gridSize = 4 : i32,
     params = #general_gemm_params_splitk
   } : memref<1x128x512xf32> = memref<1x72x128xf32> * memref<1x72x512xf32>
+  memref.copy %alloc, %c : memref<1x128x512xf32> to memref<1x128x512xf32>
   func.return
 }
 
@@ -102,12 +104,37 @@ func.func @gemm_pad_for_split_k(%a: memref<1x128x238xf32>, %b: memref<1x238x512x
   // CHECK-DAG: %[[normalizeB:.*]] = rock.transform %[[b]] by {{.*}} : memref<1x238x512xf32> to memref<1x240x512xf32{{.*}}>
   // CHECK-DAG: %[[splitA:.*]] = rock.transform %[[normalizeA]] by {{.*}} : memref<1x240x128xf32> to memref<1x3x80x128xf32{{.*}}>
   // CHECK-DAG: %[[splitB:.*]] = rock.transform %[[normalizeB]] by {{.*}} : memref<1x240x512xf32> to memref<1x3x80x512xf32{{.*}}>
-  rock.gemm %c = %a * %b features = mfma|dot|atomic_add storeMethod = set {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x128x512xf32>
+  rock.gemm %alloc = %a * %b features = mfma|dot|atomic_add storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx906",
     derivedBlockSize = 256 : i32,
     gridSize = 4 : i32,
     params = #xdlops_gemm_params3
   } : memref<1x128x512xf32> = memref<1x128x238xf32> * memref<1x238x512xf32>
+  memref.copy %alloc, %c : memref<1x128x512xf32> to memref<1x128x512xf32>
+  func.return
+}
+
+// CHECK-LABEL: func.func @gemm_reduce_and_split_k
+// CHECK-SAME: (%[[a:.*]]: memref<1x128x238xf32>, %[[b:.*]]: memref<1x238x512xf32>, %[[c:.*]]: memref<1x128x1xf32> {rock.prefill = {{.*}} : f32}, %[[d:.*]]: memref<1x128x512xf32> {rock.prefill = {{.*}} : f32})
+func.func @gemm_reduce_and_split_k(%a: memref<1x128x238xf32>, %b: memref<1x238x512xf32>, %c: memref<1x128x1xf32>, %d: memref<1x128x512xf32>) {
+  // CHECK-DAG: %[[transA:.*]] = rock.transform %[[a]] by {{.*}} : memref<1x128x238xf32> to memref<1x238x128xf32{{.*}}>
+  // CHECK-DAG: %[[normalizeA:.*]] = rock.transform %[[transA]] by {{.*}} : memref<1x238x128xf32> to memref<1x240x128xf32{{.*}}>
+  // CHECK-DAG: %[[normalizeB:.*]] = rock.transform %[[b]] by {{.*}} : memref<1x238x512xf32> to memref<1x240x512xf32{{.*}}>
+  // CHECK-DAG: %[[splitA:.*]] = rock.transform %[[normalizeA]] by {{.*}} : memref<1x240x128xf32> to memref<1x3x80x128xf32{{.*}}>
+  // CHECK-DAG: %[[splitB:.*]] = rock.transform %[[normalizeB]] by {{.*}} : memref<1x240x512xf32> to memref<1x3x80x512xf32{{.*}}>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x128x512xf32>
+  %alloc2 = memref.alloc() {alignment = 64 : i64} : memref<1x128x1xf32>
+  rock.gemm %alloc = %a * %b features = mfma|dot|atomic_add storeMethod = set {
+    arch = "amdgcn-amd-amdhsa:gfx906",
+    derivedBlockSize = 256 : i32,
+    gridSize = 4 : i32,
+    params = #xdlops_gemm_params3
+  } : memref<1x128x512xf32> = memref<1x128x238xf32> * memref<1x238x512xf32>
+  rock.reduce sum %alloc into %alloc2 features = mfma|dot|atomic_add {axis = 2 : index, blockSize = 256 : i32, gridSize = 2 : i32} : memref<1x128x512xf32> into memref<1x128x1xf32>
+  memref.copy %alloc, %d : memref<1x128x512xf32> to memref<1x128x512xf32>
+  memref.copy %alloc2, %c : memref<1x128x1xf32> to memref<1x128x1xf32>
+
   func.return
 }
 

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case1.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case1.mlir
@@ -7,11 +7,6 @@
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 module {
-  func.func private @init_output(%arg0: memref<1x4x3xf32> {mhal.write_access}) {
-    %cst = arith.constant 0xff800000 : f32 
-    linalg.fill ins(%cst : f32) outs(%arg0 : memref<1x4x3xf32>)
-    return
-  }
   func.func private @test_reduce__part_1(%arg0: memref<5x4x3xf32> {mhal.read_access}, %arg1: memref<1x4x3xf32> {mhal.read_access, mhal.write_access}) {
     %0 = memref.collapse_shape %arg1 [[0, 1], [2]] : memref<1x4x3xf32> into memref<4x3xf32>
     linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["reduction", "parallel", "parallel"]} ins(%arg0 : memref<5x4x3xf32>) outs(%0 : memref<4x3xf32>) {
@@ -21,14 +16,13 @@ module {
     }
     return
   }
-  func.func @test_reduce(%arg0: memref<5x4x3xf32>, %arg1: memref<1x4x3xf32>) attributes {arch = ""} {
-    call @init_output (%arg1) : (memref<1x4x3xf32>) -> ()
+  func.func @test_reduce(%arg0: memref<5x4x3xf32>, %arg1: memref<1x4x3xf32> {mhal.read_access, mhal.write_access}) attributes {arch = ""} {
     %token1 = mhal.launch @test_reduce__part_1 (%arg0, %arg1) : (memref<5x4x3xf32>, memref<1x4x3xf32>)
     mhal.await %token1 : !mhal.token
     return
   }
   module @__xmodule_ attributes {mhal.arch = "##TOKEN_ARCH##", mhal.module} {
-    func.func private @test_reduce__part_1(%arg0: memref<5x4x3xf32> {mhal.read_access}, %arg1: memref<1x4x3xf32> {mhal.read_access, mhal.write_access}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 16, block_size = 1024} {
+    func.func private @test_reduce__part_1(%arg0: memref<5x4x3xf32> {mhal.read_access}, %arg1: memref<1x4x3xf32> {mhal.read_access, mhal.write_access, rock.prefill = 0xFF800000 : f32}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 16, block_size = 1024} {
       rock.reduce max %arg0 into %arg1 features = ##TOKEN_FEATURES## {axis = 0 : index, blockSize = 1024 : i32, gridSize = 16 : i32} : memref<5x4x3xf32> into memref<1x4x3xf32>
       return
     }

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case1.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case1.mlir
@@ -7,6 +7,11 @@
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 module {
+  func.func private @init_output(%arg0: memref<1x4x3xf32> {mhal.write_access}) {
+    %cst = arith.constant 0xff800000 : f32
+    linalg.fill ins(%cst : f32) outs(%arg0 : memref<1x4x3xf32>)
+    return
+  }
   func.func private @test_reduce__part_1(%arg0: memref<5x4x3xf32> {mhal.read_access}, %arg1: memref<1x4x3xf32> {mhal.read_access, mhal.write_access}) {
     %0 = memref.collapse_shape %arg1 [[0, 1], [2]] : memref<1x4x3xf32> into memref<4x3xf32>
     linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["reduction", "parallel", "parallel"]} ins(%arg0 : memref<5x4x3xf32>) outs(%0 : memref<4x3xf32>) {
@@ -17,6 +22,7 @@ module {
     return
   }
   func.func @test_reduce(%arg0: memref<5x4x3xf32>, %arg1: memref<1x4x3xf32> {mhal.read_access, mhal.write_access}) attributes {arch = ""} {
+    call @init_output (%arg1) : (memref<1x4x3xf32>) -> ()
     %token1 = mhal.launch @test_reduce__part_1 (%arg0, %arg1) : (memref<5x4x3xf32>, memref<1x4x3xf32>)
     mhal.await %token1 : !mhal.token
     return

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case2.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case2.mlir
@@ -21,14 +21,14 @@ module {
     }
     return
   }
-  func.func @test_reduce(%arg0: memref<10x30x20xf32>, %arg1: memref<10x1x20xf32>) attributes {arch = ""} {
+  func.func @test_reduce(%arg0: memref<10x30x20xf32>, %arg1: memref<10x1x20xf32> {mhal.read_access, mhal.write_access}) attributes {arch = ""} {
     call @init_output (%arg1) : (memref<10x1x20xf32>) -> ()
     %token1 = mhal.launch @test_reduce__part_1 (%arg0, %arg1) : (memref<10x30x20xf32>, memref<10x1x20xf32>)
     mhal.await %token1 : !mhal.token
     return
   }
   module @__xmodule_ attributes {mhal.arch = "##TOKEN_ARCH##",mhal.module} {
-    func.func private @test_reduce__part_1(%arg0: memref<10x30x20xf32> {mhal.read_access}, %arg1: memref<10x1x20xf32> {mhal.read_access, mhal.write_access}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 1, block_size = 256} {
+    func.func private @test_reduce__part_1(%arg0: memref<10x30x20xf32> {mhal.read_access}, %arg1: memref<10x1x20xf32> {mhal.read_access, mhal.write_access, rock.prefill = 0xFF800000 : f32}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 1, block_size = 256} {
       rock.reduce max %arg0 into %arg1 features = ##TOKEN_FEATURES## {axis = 1 : index, blockSize = 256 : i32, gridSize = 1 : i32} : memref<10x30x20xf32> into memref<10x1x20xf32>
       return
     }

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case3.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case3.mlir
@@ -7,11 +7,6 @@
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 module {
-  func.func private @init_output(%arg0: memref<1x30x10xf32> {mhal.write_access}) {
-    %cst = arith.constant 0xff800000 : f32 
-    linalg.fill ins(%cst : f32) outs(%arg0 : memref<1x30x10xf32>)
-    return
-  }
   func.func private @test_reduce__part_1(%arg0: memref<20x30x10xf32> {mhal.read_access}, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access}) {
     %0 = memref.collapse_shape %arg1 [[0, 1], [2]] : memref<1x30x10xf32> into memref<30x10xf32>
     linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["reduction", "parallel", "parallel"]} ins(%arg0 : memref<20x30x10xf32>) outs(%0 : memref<30x10xf32>) {
@@ -21,14 +16,13 @@ module {
     }
     return
   }
-  func.func @test_reduce(%arg0: memref<20x30x10xf32>, %arg1: memref<1x30x10xf32>) attributes {arch = ""} {
-    call @init_output (%arg1) : (memref<1x30x10xf32>) -> ()
+  func.func @test_reduce(%arg0: memref<20x30x10xf32>, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access}) attributes {arch = ""} {
     %token1 = mhal.launch @test_reduce__part_1 (%arg0, %arg1) : (memref<20x30x10xf32>, memref<1x30x10xf32>)
     mhal.await %token1 : !mhal.token
     return
   }
   module @__xmodule_ attributes {mhal.arch = "##TOKEN_ARCH##", mhal.module} {
-    func.func private @test_reduce__part_1(%arg0: memref<20x30x10xf32> {mhal.read_access}, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 2, block_size = 256} {
+    func.func private @test_reduce__part_1(%arg0: memref<20x30x10xf32> {mhal.read_access}, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access, rock.prefill = 0xFF800000 : f32}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 2, block_size = 256} {
       rock.reduce max %arg0 into %arg1 features = ##TOKEN_FEATURES## {axis = 0 : index, blockSize = 256 : i32, gridSize = 2 : i32} : memref<20x30x10xf32> into memref<1x30x10xf32>
       return
     }

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case3.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_max/rock-reduce-max-case3.mlir
@@ -7,6 +7,11 @@
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 module {
+  func.func private @init_output(%arg0: memref<1x30x10xf32> {mhal.write_access}) {
+    %cst = arith.constant 0xff800000 : f32
+    linalg.fill ins(%cst : f32) outs(%arg0 : memref<1x30x10xf32>)
+    return
+  }
   func.func private @test_reduce__part_1(%arg0: memref<20x30x10xf32> {mhal.read_access}, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access}) {
     %0 = memref.collapse_shape %arg1 [[0, 1], [2]] : memref<1x30x10xf32> into memref<30x10xf32>
     linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["reduction", "parallel", "parallel"]} ins(%arg0 : memref<20x30x10xf32>) outs(%0 : memref<30x10xf32>) {
@@ -17,6 +22,7 @@ module {
     return
   }
   func.func @test_reduce(%arg0: memref<20x30x10xf32>, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access}) attributes {arch = ""} {
+    call @init_output (%arg1) : (memref<1x30x10xf32>) -> ()
     %token1 = mhal.launch @test_reduce__part_1 (%arg0, %arg1) : (memref<20x30x10xf32>, memref<1x30x10xf32>)
     mhal.await %token1 : !mhal.token
     return

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case1.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case1.mlir
@@ -42,7 +42,7 @@ module {
   }
 
   module @__xmodule_gfx90a attributes {mhal.arch = "gfx90a", mhal.module} {
-    func.func private @test_reduce__part_1(%arg0: memref<2x3x40xf32> {mhal.read_access}, %arg1: memref<2x3x1xf32> {mhal.read_access, mhal.write_access}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 1, block_size = 256} {
+    func.func private @test_reduce__part_1(%arg0: memref<2x3x40xf32> {mhal.read_access}, %arg1: memref<2x3x1xf32> {mhal.read_access, mhal.write_access, rock.prefill = 0.000000e+00 : f32}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 1, block_size = 256} {
       rock.reduce sum %arg0 into %arg1 features = mfma|dot|atomic_add {axis = 2 : index, blockSize = 256 : i32, gridSize = 1 : i32} : memref<2x3x40xf32> into memref<2x3x1xf32>
       return
     }

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case2.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case2.mlir
@@ -28,7 +28,7 @@ module {
     return
   }
   module @__xmodule_gfx90a attributes {mhal.arch = "gfx90a",mhal.module} {
-    func.func private @test_reduce__part_1(%arg0: memref<10x30x20xf32> {mhal.read_access}, %arg1: memref<10x1x20xf32> {mhal.read_access, mhal.write_access}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 1, block_size = 256} {
+    func.func private @test_reduce__part_1(%arg0: memref<10x30x20xf32> {mhal.read_access}, %arg1: memref<10x1x20xf32> {mhal.read_access, mhal.write_access, rock.prefill = 0.000000e+00 : f32}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 1, block_size = 256} {
       rock.reduce sum %arg0 into %arg1 features = mfma|dot|atomic_add {axis = 1 : index, blockSize = 256 : i32, gridSize = 1 : i32} : memref<10x30x20xf32> into memref<10x1x20xf32>
       return
     }

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case3.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case3.mlir
@@ -28,7 +28,7 @@ module {
     return
   }
   module @__xmodule_gfx90a attributes {mhal.arch = "gfx90a", mhal.module} {
-    func.func private @test_reduce__part_1(%arg0: memref<20x30x10xf32> {mhal.read_access}, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 2, block_size = 256} {
+    func.func private @test_reduce__part_1(%arg0: memref<20x30x10xf32> {mhal.read_access}, %arg1: memref<1x30x10xf32> {mhal.read_access, mhal.write_access, rock.prefill = 0.000000e+00 : f32}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 2, block_size = 256} {
       rock.reduce sum %arg0 into %arg1 features = mfma|dot|atomic_add {axis = 0 : index, blockSize = 256 : i32, gridSize = 2 : i32} : memref<20x30x10xf32> into memref<1x30x10xf32>
       return
     }

--- a/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case4.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/reduce_sum/gfx90a/rock-reduce-case4.mlir
@@ -28,7 +28,7 @@ module {
     return
   }
   module @__xmodule_gfx90a attributes {mhal.arch = "gfx90a", mhal.module} {
-    func.func private @test_reduce__part_1(%arg0: memref<1000x250x100xf32> {mhal.read_access}, %arg1: memref<1x250x100xf32> {mhal.read_access, mhal.write_access}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 16, block_size = 1024} {
+    func.func private @test_reduce__part_1(%arg0: memref<1000x250x100xf32> {mhal.read_access}, %arg1: memref<1x250x100xf32> {mhal.read_access, mhal.write_access, rock.prefill = 0.000000e+00 : f32}) attributes {kernel, original_func = @test_reduce__part_1, grid_size = 16, block_size = 1024} {
       rock.reduce sum %arg0 into %arg1 features = mfma|dot|atomic_add {axis = 0 : index, blockSize = 1024 : i32, gridSize = 16 : i32} : memref<1000x250x100xf32> into memref<1x250x100xf32>
       return
     }

--- a/mlir/test/fusion/linalg-generic-with-atomic-store.mlir
+++ b/mlir/test/fusion/linalg-generic-with-atomic-store.mlir
@@ -1,19 +1,19 @@
-// RUN: rocmlir-opt --rock-view-to-transform -rock-affix-params -rock-conv-to-gemm -rock-gemm-to-gridwise --rock-regularize --rock-gridwise-gemm-to-blockwise --rock-linalg-align %s -verify-diagnostics
+// RUN: rocmlir-opt -rock-conv-to-gemm -rock-gemm-to-gridwise --rock-regularize --rock-gridwise-gemm-to-blockwise --rock-linalg-align %s -verify-diagnostics
 
-#map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 
 module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
 
-  func.func @rock_gemm(%arg0: memref<1x1024x1024xf32>, %arg1: memref<1x1024x512xf32>, %arg2: memref<1x1024x512xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
-    %0 = memref.alloc() : memref<1x1024x512xf32>
-    rock.gemm %0 = %arg0 * %arg1 features =  mfma|dot|atomic_add storeMethod = atomic_add {arch = "amdgcn-amd-amdhsa:gfx90a"} : memref<1x1024x512xf32> = memref<1x1024x1024xf32> * memref<1x1024x512xf32>
-
+  func.func @rock_gemm(%arg0: memref<1x1024x1024xf32>, %arg1: memref<1x1024x512xf32>, %arg2: memref<1x1024x512xf32> {rock.prefill = 0.000000e+00 : f32}) attributes {block_size = 256 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
+    %alloc = memref.alloc() : memref<1x1024x512xf32>
+    rock.gemm %alloc = %arg0 * %arg1 features =  mfma|dot|atomic_add storeMethod =  atomic_add {arch = "amdgcn-amd-amdhsa:gfx90a", derivedBlockSize = 256 : i32, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 2, mPerBlock = 256, nPerBlock = 256, kpack = 4, mPerWave = 128, nPerWave = 128, mnPerXdl = 32, splitKFactor = 1, forceUnroll = true>} : memref<1x1024x512xf32> = memref<1x1024x1024xf32> * memref<1x1024x512xf32>
+    
     // expected-error @+1 {{'linalg.generic' op is infusible with non-`Set` store method}}
-    linalg.generic {indexing_maps = [#map0, #map0], iterator_types=["parallel", "parallel", "parallel"]} ins(%0 : memref<1x1024x512xf32>) outs(%arg2 : memref<1x1024x512xf32>) {
-    ^bb0(%i: f32, %o: f32):
-        %c0 = arith.constant 2.0 : f32
-        %r = arith.addf %i, %c0 : f32
-        linalg.yield %r : f32
+    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%alloc : memref<1x1024x512xf32>) outs(%arg2 : memref<1x1024x512xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %cst = arith.constant 2.000000e+00 : f32
+      %0 = arith.addf %in, %cst : f32
+      linalg.yield %0 : f32
     }
     return
   }


### PR DESCRIPTION
In this PR we trace back the kernel argument (or return result) instead of using hardcoded indices for the prefill flag. This is modified in TosaToRock for reduce ops and in GemmToGridwise for splitk.

Additionally, rocmlir-gen will fill output tensors without "prefill" flag to 100 for the kernel launcher. This is to make sure non-prefill outputs are init to different values for the gpu vs cpu. Therefore, if an output is incorrectly not set to prefill we would fail.