### PR TITLE
Remove unnecessary pass from a test

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/ShuffleGemmForReductions.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ShuffleGemmForReductions.cpp
@@ -161,7 +161,6 @@ ArrayAttr reorderReductionDims(BottomUpTMBuilder &toReductionSplit,
                                  ArrayRef<unsigned>{0, 1});
     SmallVector<int64_t> splitSizes;
     SmallVector<SmallString<8>> splitNames;
-    splitNames.reserve(reductionSubDimsVec.size());
     SmallVector<unsigned> splitDims;
     int64_t dimInsertionPoint = 2;
     int64_t currSize = dLen;

--- a/mlir/lib/Dialect/Rock/Transforms/ShuffleGemmForReductions.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ShuffleGemmForReductions.cpp
@@ -161,7 +161,7 @@ ArrayAttr reorderReductionDims(BottomUpTMBuilder &toReductionSplit,
                                  ArrayRef<unsigned>{0, 1});
     SmallVector<int64_t> splitSizes;
     SmallVector<SmallString<8>> splitNames;
-    SmallVector<StringRef> splitNamesRefs;
+    splitNames.reserve(reductionSubDimsVec.size());
     SmallVector<unsigned> splitDims;
     int64_t dimInsertionPoint = 2;
     int64_t currSize = dLen;
@@ -171,7 +171,6 @@ ArrayAttr reorderReductionDims(BottomUpTMBuilder &toReductionSplit,
         SmallString<8> dimName(Twine("d_nr" + Twine(idx)).str());
         splitNames.push_back(dimName);
       }
-      splitNamesRefs.push_back(splitNames.back());
       splitDims.push_back(dimInsertionPoint++);
       LLVM_DEBUG(llvm::dbgs()
                  << "\tsplitSize = " << currSize / (sdInfo.size * sdInfo.stride)
@@ -181,7 +180,6 @@ ArrayAttr reorderReductionDims(BottomUpTMBuilder &toReductionSplit,
         SmallString<8> dimName(Twine("d_r" + Twine(idx)).str());
         splitNames.push_back(dimName);
       }
-      splitNamesRefs.push_back(splitNames.back());
       reductionDims[dimInsertionPoint] = sdInfo.size;
       splitDims.push_back(dimInsertionPoint++);
       LLVM_DEBUG(llvm::dbgs() << "\tsplitSize = " << sdInfo.size << "\n");
@@ -193,11 +191,15 @@ ArrayAttr reorderReductionDims(BottomUpTMBuilder &toReductionSplit,
         SmallString<8> dimName(Twine("d_nr_end").str());
         splitNames.push_back(dimName);
       }
-      splitNamesRefs.push_back(splitNames.back());
       splitDims.push_back(dimInsertionPoint++);
       LLVM_DEBUG(llvm::dbgs() << "\tsplitSize = " << currSize << "\n");
       splitSizes.push_back(currSize);
     }
+    SmallVector<StringRef> splitNamesRefs;
+    splitNamesRefs.reserve(splitNames.size());
+    for (auto &str : splitNames)
+      splitNamesRefs.push_back(str);
+
     toReductionSplit.unmerge(splitNamesRefs, splitDims, dName, splitSizes);
     reduceSplit = toReductionSplit.get();
   }
@@ -355,12 +357,10 @@ ArrayAttr generateShuffledGemmOutputViews(
       SmallVector<unsigned> mReductionSubDims;
       SmallVector<int64_t> mReductionSubDimSizes;
       SmallVector<SmallString<8>> mReductionSubDimNames;
-      SmallVector<StringRef> mReductionSubDimNameRefs;
 
       SmallVector<unsigned> mNonReductionSubDims;
       SmallVector<int64_t> mNonReductionSubDimSizes;
       SmallVector<SmallString<8>> mNonReductionSubDimNames;
-      SmallVector<StringRef> mNonReductionSubDimNameRefs;
       int64_t currSize = m;
       for (const auto &[idx, sdInfo] : enumerate(mReductionSubDimInfo)) {
         mNonReductionSubDimSizes.push_back(currSize /
@@ -369,7 +369,6 @@ ArrayAttr generateShuffledGemmOutputViews(
           SmallString<8> dimName(Twine("m_nr" + Twine(idx)).str());
           mNonReductionSubDimNames.push_back(dimName);
         }
-        mNonReductionSubDimNameRefs.push_back(mNonReductionSubDimNames.back());
         mNonReductionSubDims.push_back(dimInsertionPoint++);
 
         mReductionSubDimSizes.push_back(sdInfo.size);
@@ -377,7 +376,6 @@ ArrayAttr generateShuffledGemmOutputViews(
           SmallString<8> dimName(Twine("m_r" + Twine(idx)).str());
           mReductionSubDimNames.push_back(dimName);
         }
-        mReductionSubDimNameRefs.push_back(mReductionSubDimNames.back());
         mReductionSubDims.push_back(dimInsertionPoint++);
 
         currSize = sdInfo.stride;
@@ -388,13 +386,23 @@ ArrayAttr generateShuffledGemmOutputViews(
           SmallString<8> dimName("m_nr_last");
           mNonReductionSubDimNames.push_back(dimName);
         }
-        mNonReductionSubDimNameRefs.push_back(mNonReductionSubDimNames.back());
         mNonReductionSubDims.push_back(dimInsertionPoint++);
       }
+
+      SmallVector<StringRef> mNonReductionSubDimNameRefs;
+      mNonReductionSubDimNameRefs.reserve(mNonReductionSubDimNames.size());
+      for (auto &str : mNonReductionSubDimNames)
+        mNonReductionSubDimNameRefs.push_back(str);
+
       toSplitOriginalSubDims.unmerge(mNonReductionSubDimNameRefs,
                                      mNonReductionSubDims, "m_nr",
                                      mNonReductionSubDimSizes);
       if (!mReductionSubDimSizes.empty()) {
+        SmallVector<StringRef> mReductionSubDimNameRefs;
+        mReductionSubDimNameRefs.reserve(mReductionSubDimNames.size());
+        for (auto &str : mReductionSubDimNames)
+          mReductionSubDimNameRefs.push_back(str);
+
         toSplitOriginalSubDims.unmerge(mReductionSubDimNameRefs,
                                        mReductionSubDims, "m_r",
                                        mReductionSubDimSizes);
@@ -409,12 +417,10 @@ ArrayAttr generateShuffledGemmOutputViews(
       SmallVector<unsigned> nReductionSubDims;
       SmallVector<int64_t> nReductionSubDimSizes;
       SmallVector<SmallString<8>> nReductionSubDimNames;
-      SmallVector<StringRef> nReductionSubDimNameRefs;
 
       SmallVector<unsigned> nNonReductionSubDims;
       SmallVector<int64_t> nNonReductionSubDimSizes;
       SmallVector<SmallString<8>> nNonReductionSubDimNames;
-      SmallVector<StringRef> nNonReductionSubDimNameRefs;
       int64_t currSize = n;
       for (const auto &[idx, sdInfo] : enumerate(nReductionSubDimInfo)) {
         nNonReductionSubDimSizes.push_back(currSize /
@@ -423,7 +429,6 @@ ArrayAttr generateShuffledGemmOutputViews(
           SmallString<8> dimName(Twine("n_nr" + Twine(idx)).str());
           nNonReductionSubDimNames.push_back(dimName);
         }
-        nNonReductionSubDimNameRefs.push_back(nNonReductionSubDimNames.back());
         nNonReductionSubDims.push_back(dimInsertionPoint++);
 
         nReductionSubDimSizes.push_back(sdInfo.size);
@@ -431,7 +436,6 @@ ArrayAttr generateShuffledGemmOutputViews(
           SmallString<8> dimName(Twine("n_r" + Twine(idx)).str());
           nReductionSubDimNames.push_back(dimName);
         }
-        nReductionSubDimNameRefs.push_back(nReductionSubDimNames.back());
         nReductionSubDims.push_back(dimInsertionPoint++);
 
         currSize = sdInfo.stride;
@@ -442,13 +446,23 @@ ArrayAttr generateShuffledGemmOutputViews(
           SmallString<8> dimName("n_nr_last");
           nNonReductionSubDimNames.push_back(dimName);
         }
-        nNonReductionSubDimNameRefs.push_back(nNonReductionSubDimNames.back());
         nNonReductionSubDims.push_back(dimInsertionPoint++);
       }
+      SmallVector<StringRef> nNonReductionSubDimNameRefs;
+      nNonReductionSubDimNameRefs.reserve(nNonReductionSubDimNames.size());
+
+      for (auto &str : nNonReductionSubDimNames)
+        nNonReductionSubDimNameRefs.push_back(str);
+
       toSplitOriginalSubDims.unmerge(nNonReductionSubDimNameRefs,
                                      nNonReductionSubDims, "n_nr",
                                      nNonReductionSubDimSizes);
       if (!nReductionSubDimSizes.empty()) {
+
+        SmallVector<StringRef> nReductionSubDimNameRefs;
+        nReductionSubDimNameRefs.reserve(nReductionSubDimNames.size());
+        for (auto &str : nReductionSubDimNames)
+          nReductionSubDimNameRefs.push_back(str);
         toSplitOriginalSubDims.unmerge(nReductionSubDimNameRefs,
                                        nReductionSubDims, "n_r",
                                        nReductionSubDimSizes);

--- a/mlir/lib/Dialect/Rock/Transforms/ShuffleGemmForReductions.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ShuffleGemmForReductions.cpp
@@ -194,11 +194,7 @@ ArrayAttr reorderReductionDims(BottomUpTMBuilder &toReductionSplit,
       LLVM_DEBUG(llvm::dbgs() << "\tsplitSize = " << currSize << "\n");
       splitSizes.push_back(currSize);
     }
-    SmallVector<StringRef> splitNamesRefs;
-    splitNamesRefs.reserve(splitNames.size());
-    for (auto &str : splitNames)
-      splitNamesRefs.push_back(str);
-
+    SmallVector<StringRef> splitNamesRefs = getStringRefsFor(splitNames);
     toReductionSplit.unmerge(splitNamesRefs, splitDims, dName, splitSizes);
     reduceSplit = toReductionSplit.get();
   }
@@ -388,20 +384,14 @@ ArrayAttr generateShuffledGemmOutputViews(
         mNonReductionSubDims.push_back(dimInsertionPoint++);
       }
 
-      SmallVector<StringRef> mNonReductionSubDimNameRefs;
-      mNonReductionSubDimNameRefs.reserve(mNonReductionSubDimNames.size());
-      for (auto &str : mNonReductionSubDimNames)
-        mNonReductionSubDimNameRefs.push_back(str);
-
+      SmallVector<StringRef> mNonReductionSubDimNameRefs =
+          getStringRefsFor(mNonReductionSubDimNames);
       toSplitOriginalSubDims.unmerge(mNonReductionSubDimNameRefs,
                                      mNonReductionSubDims, "m_nr",
                                      mNonReductionSubDimSizes);
       if (!mReductionSubDimSizes.empty()) {
-        SmallVector<StringRef> mReductionSubDimNameRefs;
-        mReductionSubDimNameRefs.reserve(mReductionSubDimNames.size());
-        for (auto &str : mReductionSubDimNames)
-          mReductionSubDimNameRefs.push_back(str);
-
+        SmallVector<StringRef> mReductionSubDimNameRefs =
+            getStringRefsFor(mReductionSubDimNames);
         toSplitOriginalSubDims.unmerge(mReductionSubDimNameRefs,
                                        mReductionSubDims, "m_r",
                                        mReductionSubDimSizes);
@@ -447,21 +437,15 @@ ArrayAttr generateShuffledGemmOutputViews(
         }
         nNonReductionSubDims.push_back(dimInsertionPoint++);
       }
-      SmallVector<StringRef> nNonReductionSubDimNameRefs;
-      nNonReductionSubDimNameRefs.reserve(nNonReductionSubDimNames.size());
-
-      for (auto &str : nNonReductionSubDimNames)
-        nNonReductionSubDimNameRefs.push_back(str);
-
+      SmallVector<StringRef> nNonReductionSubDimNameRefs =
+          getStringRefsFor(nNonReductionSubDimNames);
       toSplitOriginalSubDims.unmerge(nNonReductionSubDimNameRefs,
                                      nNonReductionSubDims, "n_nr",
                                      nNonReductionSubDimSizes);
       if (!nReductionSubDimSizes.empty()) {
 
-        SmallVector<StringRef> nReductionSubDimNameRefs;
-        nReductionSubDimNameRefs.reserve(nReductionSubDimNames.size());
-        for (auto &str : nReductionSubDimNames)
-          nReductionSubDimNameRefs.push_back(str);
+        SmallVector<StringRef> nReductionSubDimNameRefs =
+            getStringRefsFor(nReductionSubDimNames);
         toSplitOriginalSubDims.unmerge(nReductionSubDimNameRefs,
                                        nReductionSubDims, "n_r",
                                        nReductionSubDimSizes);

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -2536,6 +2536,7 @@ SmallVector<SmallString<8>> mlir::rock::createDimNames(int64_t len,
 SmallVector<StringRef>
 mlir::rock::getStringRefsFor(ArrayRef<SmallString<8>> strings) {
   SmallVector<StringRef> nameRefs;
+  nameRefs.reserve(strings.size());
   for (const SmallString<8> &str : strings) {
     nameRefs.push_back(str);
   }

--- a/mlir/test/Dialect/Rock/rock-shuffle-gemm-for-reductions.mlir
+++ b/mlir/test/Dialect/Rock/rock-shuffle-gemm-for-reductions.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-opt -rock-shuffle-gemm-for-reductions -mlir-print-local-scope -rock-gemm-to-gridwise %s | FileCheck %s
+// RUN: rocmlir-opt -rock-shuffle-gemm-for-reductions -mlir-print-local-scope %s | FileCheck %s
 
 // CHECK-LABEL: @mlir_convolution_multi_reduce
 func.func @mlir_convolution_multi_reduce(%arg0: memref<320xf32>, %arg1: memref<32768xf32>, %arg2: memref<11520xf32>, %arg3: memref<64xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32}, %arg4: memref<64xf32>, %arg5: memref<2621440xf32>) attributes {arch = "gfx942:sramecc+:xnack-", block_size = 256 : i32, grid_size = 320 : i32, kernel = "mixr"} {


### PR DESCRIPTION
A one-liner to remove running -rock-gemm-to-gridwise on a test that only needed -rock-shuffle-gemm-for-reductions