### PR TITLE
Fix rocmlir-gen attention i8 verification bug

### DIFF
--- a/mlir/test/e2e/PrAttentionI8.toml
+++ b/mlir/test/e2e/PrAttentionI8.toml
@@ -1,6 +1,6 @@
 directory = "PrAttentionI8"
 prefix = "rocmlir-gen"
-suffix = "--operation attention -t i8 --arch %arch -pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention -t i8 --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.01 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "operation"

--- a/mlir/test/rocmlir-gen/attention-verify-i8.mlir
+++ b/mlir/test/rocmlir-gen/attention-verify-i8.mlir
@@ -1,0 +1,24 @@
+// RUN: rocmlir-gen -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias --operation attention --transK=true  --operation attention -t i8 --arch gfx90a:sramecc+:xnack- -pv   -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_FULL
+// RUN: rocmlir-gen -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-bias --operation attention --transK=true  --operation attention -t i8 --arch gfx90a:sramecc+:xnack- -pv   -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_NOSCALE
+// RUN: rocmlir-gen -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --operation attention --transK=true  --operation attention -t i8 --arch gfx90a:sramecc+:xnack- -pv   -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_NOBIAS
+// RUN: rocmlir-gen -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --operation attention --transK=true  --operation attention -t i8 --arch gfx90a:sramecc+:xnack- -pv   -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_SIMPLE
+
+// CHECK_I8_FULL-LABEL: @main
+// CHECK_I8_FULL: call @rock_attention_gpu(%[[alloc0:.+]], %[[alloc1:.+]], %[[alloc2:.+]], %[[alloc3:.+]], %[[alloc4:.+]], %[[alloc5:.+]], %[[alloc6:.+]], %[[gpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<147456xf16>, memref<147456xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_FULL: call @host_naive_attention(%[[alloc7:.+]], %[[alloc8:.+]], %[[alloc9:.+]], %[[alloc10:.+]], %[[alloc11:.+]], %[[alloc12:.+]], %[[alloc13:.+]], %[[cpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<147456xf16>, memref<147456xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_FULL: call @rock_attention_verify7(%[[gpu_out]], %[[cpu_out]]) : (memref<24576xf16>, memref<24576xf16>) -> ()
+
+// CHECK_I8_NOSCALE-LABEL: @main
+// CHECK_I8_NOSCALE: call @rock_attention_gpu(%[[alloc0:.+]], %[[alloc1:.+]], %[[alloc2:.+]], %[[alloc3:.+]], %[[alloc4:.+]], %[[alloc5:.+]], %[[gpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<147456xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_NOSCALE: call @host_naive_attention(%[[alloc7:.+]], %[[alloc8:.+]], %[[alloc9:.+]], %[[alloc10:.+]], %[[alloc11:.+]], %[[alloc12:.+]], %[[cpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<147456xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_NOSCALE: call @rock_attention_verify6(%[[gpu_out]], %[[cpu_out]]) : (memref<24576xf16>, memref<24576xf16>) -> ()
+
+// CHECK_I8_NOBIAS-LABEL: @main
+// CHECK_I8_NOBIAS: call @rock_attention_gpu(%[[alloc0:.+]], %[[alloc1:.+]], %[[alloc2:.+]], %[[alloc3:.+]], %[[alloc4:.+]], %[[alloc5:.+]], %[[gpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<147456xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_NOBIAS: call @host_naive_attention(%[[alloc7:.+]], %[[alloc8:.+]], %[[alloc9:.+]], %[[alloc10:.+]], %[[alloc11:.+]], %[[alloc12:.+]], %[[cpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<147456xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_NOBIAS: call @rock_attention_verify6(%[[gpu_out]], %[[cpu_out]]) : (memref<24576xf16>, memref<24576xf16>) -> ()
+
+// CHECK_I8_SIMPLE-LABEL: @main
+// CHECK_I8_SIMPLE: call @rock_attention_gpu(%[[alloc0:.+]], %[[alloc1:.+]], %[[alloc2:.+]], %[[alloc3:.+]], %[[alloc4:.+]], %[[gpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_SIMPLE: call @host_naive_attention(%[[alloc7:.+]], %[[alloc8:.+]], %[[alloc9:.+]], %[[alloc10:.+]], %[[alloc11:.+]], %[[cpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<24576xf16>) -> ()
+// CHECK_I8_SIMPLE: call @rock_attention_verify5(%[[gpu_out]], %[[cpu_out]]) : (memref<24576xf16>, memref<24576xf16>) -> ()


### PR DESCRIPTION
rocmlir-gen was verifying the wrong tensors for i8 attention.