### PR TITLE
Improve performance of quantizelinear for int4

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -210,6 +210,9 @@ FailureOr<SmallVector<BlockArgument>>
 traceGemmOutputToArgs(Value matC, func::FuncOp func,
                       const BufferDependencyAnalysis &deps);
 
+// Trace value to a block argument, going through view-like operations
+FailureOr<BlockArgument> findBlockArgument(Value value);
+
 } // end namespace rock
 } // end namespace mlir
 #endif

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -288,6 +288,9 @@ getLowerSubDimensions(OpBuilder &b, ArrayAttr transformAttrs,
 SmallVector<SmallString<8>> createDimNames(int64_t len, StringRef prefix);
 SmallVector<StringRef> getStringRefsFor(ArrayRef<SmallString<8>> strings);
 
+// Find input type of gemm before input fusion is applied
+FailureOr<Type> getGemmInputElementType(Value transformed);
+
 } // end namespace rock
 } // end namespace mlir
 #endif

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -2557,7 +2557,16 @@ struct GridwiseGemmAccelRewritePattern
 
     // Obtain data types of inputs.
     auto elementTypeA = op.getA().getType().getElementType();
+    auto maybeElementTypeALoad = getGemmInputElementType(op.getA());
+    auto elementTypeALoad = failed(maybeElementTypeALoad)
+                                ? elementTypeA
+                                : maybeElementTypeALoad.value();
+
     auto elementTypeB = op.getB().getType().getElementType();
+    auto maybeElementTypeBLoad = getGemmInputElementType(op.getB());
+    auto elementTypeBLoad = failed(maybeElementTypeBLoad)
+                                ? elementTypeB
+                                : maybeElementTypeBLoad.value();
     auto destType = op.getC().getType().getElementType();
 
     // Prepare some useful constants.
@@ -2606,18 +2615,20 @@ struct GridwiseGemmAccelRewritePattern
 
     // Get the vector copy layout for A and B
     FailureOr<VectorDimInfo> maybeVecDimInfoA = getVectorDim(
-        b, loc, matA, elementTypeA, blockSize, kPerBlock, mPerBlock, kpack);
+        b, loc, matA, elementTypeALoad, blockSize, kPerBlock, mPerBlock, kpack);
     if (failed(maybeVecDimInfoA)) {
       return failure();
     }
     FailureOr<VectorDimInfo> maybeVecDimInfoB = getVectorDim(
-        b, loc, matB, elementTypeB, blockSize, kPerBlock, nPerBlock, kpack);
+        b, loc, matB, elementTypeBLoad, blockSize, kPerBlock, nPerBlock, kpack);
     if (failed(maybeVecDimInfoB)) {
       return failure();
     }
     LLVM_DEBUG(llvm::dbgs()
                << "gridSize: " << gridSize << "\n"
                << "blockSize: " << blockSize << "\n"
+               << "elementTypeALoad: " << elementTypeALoad << "\n"
+               << "elementTypeBLoad: " << elementTypeBLoad << "\n"
                << "aCopyPerThread: " << aCopyPerThread << "\n"
                << "bCopyPerThread: " << bCopyPerThread << "\n"
                << "aCopyKpacksPerThread: " << aCopyKpacksPerThread << "\n"

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
@@ -163,7 +164,7 @@ struct PushBarrierDownRewritePattern
       return failure();
 
     // We assume that operations that have a body may modify LDS
-    if (nextOp->getNumRegions() > 0)
+    if (nextOp->getNumRegions() > 0 && !dyn_cast<linalg::GenericOp>(nextOp))
       return failure();
 
     bool moveDown = true;

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -575,7 +575,7 @@ FailureOr<memref::AllocOp> mlir::rock::findMemrefAlloc(Value value) {
   return findAlloc<memref::AllocOp>(value);
 }
 
-FailureOr<BlockArgument> findBlockArgument(Value value) {
+FailureOr<BlockArgument> mlir::rock::findBlockArgument(Value value) {
   auto maybeBlockArg = dyn_cast_or_null<BlockArgument>(value);
   while (!maybeBlockArg) {
     // Keep going until the operation that defines the value is a

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -2612,3 +2612,59 @@ mlir::rock::getStringRefsFor(ArrayRef<SmallString<8>> strings) {
   }
   return nameRefs;
 }
+
+FailureOr<Type> mlir::rock::getGemmInputElementType(Value transformed) {
+  FailureOr<memref::AllocOp> maybeAlloc = findMemrefAlloc(transformed);
+  if (failed(maybeAlloc))
+    return failure();
+  auto memref = maybeAlloc.value().getMemref();
+
+  // find input fusion
+  Value newTransformed = nullptr;
+  for (Operation *user : memref.getUsers()) {
+    Value candidate = nullptr;
+    if (auto genericOp = dyn_cast<linalg::GenericOp>(user)) {
+      if (genericOp.getOutputs().size() != 1) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Can't process linalg.generic with multiple outputs\n");
+        return failure();
+      }
+      Value genericOut = genericOp.getOutputs().front();
+      if (genericOut == memref) {
+        if (auto index = genericOp->getAttrOfType<IntegerAttr>(
+                "rock.majorTensorNumber")) {
+          candidate = genericOp.getInputs()[index.getInt()];
+        } else {
+          LLVM_DEBUG(llvm::dbgs() << "can't analyze linalg.generic "
+                                     "without rock.majorTensorNumber\n");
+          return failure();
+        }
+      } else {
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "Found a linalg.generic that takes as input the gemm A or B\n");
+        return failure();
+      }
+    } else {
+      continue;
+    }
+
+    if (newTransformed) {
+      LLVM_DEBUG(llvm::dbgs() << "Found multiple linalg.generic that "
+                                 "could be the next one\n");
+      return failure();
+    }
+    newTransformed = candidate;
+  }
+  newTransformed = newTransformed ? newTransformed : memref;
+
+  auto blockArg = findBlockArgument(newTransformed);
+  if (failed(blockArg))
+    return failure();
+
+  auto shapedTy = dyn_cast<ShapedType>(blockArg.value().getType());
+  if (!shapedTy)
+    return failure();
+
+  return shapedTy.getElementType();
+}

--- a/mlir/test/Dialect/Rock/migraphx_to_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/migraphx_to_blockwise_gemm_accel.mlir
@@ -1,0 +1,24 @@
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-driver -kernel-pipeline migraphx,highlevel -targets %arch |  rocmlir-driver -arch %arch -c --mlir-print-ir-after=rock-gridwise-gemm-to-blockwise -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  // CHECK: %[[TRANS0:.*]] = rock.transform %{{.*}} <Unmerge{32, 4, 32} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>
+  // CHECK: %[[TRANS1:.*]] = rock.transform %[[TRANS0]]
+  // CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%[[TRANS1]])
+  func.func @mlir_transpose_reshape_unpack_int4_unsqueeze_reshape_slice_slice_squeeze_squeeze_dequantizelinear_unsqueeze_transpose_dot(%arg0: !migraphx.shaped<1x1x4096xf16, 4096x4096x1>, %arg1: !migraphx.shaped<12288x2048xui8, 2048x1>, %arg2: !migraphx.shaped<384x32x32x2xf16, 2048x64x2x1>) -> !migraphx.shaped<1x1x12288xf16, 12288x12288x1> attributes {arch = "##TOKEN_ARCH##", kernel = "mixr"} {
+    %0 = migraphx.transpose %arg2 {permutation = [0, 2, 1, 3]} : <384x32x32x2xf16, 2048x64x2x1> -> <384x32x32x2xf16, 2048x2x64x1>
+    %1 = migraphx.reshape %0 {dims = [12288, 32, 2]} : <384x32x32x2xf16, 2048x2x64x1> -> <12288x32x2xf16, 64x2x1>
+    %2 = migraphx.unpack %arg1 {axis = 1 : i64} : <12288x2048xui8, 2048x1> -> <12288x4096xui8, 4096x1>
+    %3 = migraphx.reshape %1 {dims = [12288, 32, 1, 2]} : <12288x32x2xf16, 64x2x1> -> <12288x32x1x2xf16, 64x2x2x1>
+    %4 = migraphx.multibroadcast %3 {out_dyn_dims = [], out_lens = [12288, 32, 128, 2]} : <12288x32x1x2xf16, 64x2x2x1> -> <12288x32x128x2xf16, 64x2x0x1>
+    %5 = migraphx.reshape %4 {dims = [12288, 4096, 2]} : <12288x32x128x2xf16, 64x2x0x1> -> <12288x4096x2xf16, 8192x2x1>
+    %6 = migraphx.slice %5 {axes = [2], ends = [1], starts = [0]} : <12288x4096x2xf16, 8192x2x1> -> <12288x4096x1xf16, 8192x2x1>
+    %7 = migraphx.slice %5 {axes = [2], ends = [2], starts = [1]} : <12288x4096x2xf16, 8192x2x1> -> <12288x4096x1xf16, 8192x2x1>
+    %8 = migraphx.reshape %6 {dims = [12288, 4096]} : <12288x4096x1xf16, 8192x2x1> -> <12288x4096xf16, 8192x2>
+    %9 = migraphx.reshape %7 {dims = [12288, 4096]} : <12288x4096x1xf16, 8192x2x1> -> <12288x4096xf16, 8192x2>
+    %10 = migraphx.dequantizelinear %2, %8, %9 : <12288x4096xui8, 4096x1>, <12288x4096xf16, 8192x2>, !migraphx.shaped<12288x4096xf16, 8192x2> -> <12288x4096xf16, 4096x1>
+    %11 = migraphx.reshape %10 {dims = [1, 12288, 4096]} : <12288x4096xf16, 4096x1> -> <1x12288x4096xf16, 50331648x4096x1>
+    %12 = migraphx.transpose %11 {permutation = [0, 2, 1]} : <1x12288x4096xf16, 50331648x4096x1> -> <1x4096x12288xf16, 50331648x1x4096>
+    %13 = migraphx.dot %arg0, %12 {perf_config="v2:16,32,8,16,16,16,1,1,1"} : <1x1x4096xf16, 4096x4096x1>, <1x4096x12288xf16, 50331648x1x4096> -> <1x1x12288xf16, 12288x12288x1>
+    return %13 : !migraphx.shaped<1x1x12288xf16, 12288x12288x1>
+  }
+}


### PR DESCRIPTION
In this PR we improve the performance of quantizelinear for int4, these are the changes:
- Get the right element type for the getVectorDim() call, when there are input fusions the type can change and we should get the original type to decide how many k/d to copy per thread.
- Move genericops before lds barrier if possible
- ~~Pack scale and bias together in the same tensor (quantizelinear)~~

There's a PR in migraphx to also change the layout of the scale+bias tensor: https://github.com/ROCm/AMDMIGraphX/pull/3718

This is the migraphx program of the layout change (int32 packing scale and bias together):
```python3
p = migraphx.program()
m = p.get_main_module()
x_1 = m.add_parameter("x1", migraphx.shape(type="half_type", lens=[384, 32, 32, 2]))
x_2 = m.add_literal(migraphx.generate_argument(migraphx.shape(type="uint8_type", lens=[12288, 2048]), 2))
p_x4 = m.add_parameter("x4", migraphx.shape(type="half_type", lens=[1, 1, 4096]))
x_1_transposed = m.add_instruction(migraphx.op("transpose", permutation=[0,2,1,3]), [x_1])
x_1_new = m.add_instruction(migraphx.op("reshape", dims=[12288,32,2]), [x_1_transposed])
x_4 = m.add_instruction(migraphx.op("unpack_int4", axis=1), [x_2]) # migraphx.shape(type="uint8_type", lens=[12288, 4096])
x_6 = m.add_instruction(migraphx.op("unsqueeze", axes=[2]), [x_1_new]) # migraphx.shape(type="half_type", lens=[12288, 32, 1, 1, 1, 1, 1])
x_7 = m.add_instruction(migraphx.op("multibroadcast", out_lens=[12288,32,128,2]), [x_6]) # migraphx.shape(type="half_type", lens=[12288, 32, 1, 1, 1, 1, 128], strides=[32, 1, 1, 1, 1, 1, 0])
x_8 = m.add_instruction(migraphx.op("reshape", dims=[12288,4096,2]), [x_7]) # migraphx.shape(type="half_type", lens=[12288, 4096])
scale = m.add_instruction(migraphx.op("slice", axes=[2], starts=[0], ends=[1]), [x_8])
bias = m.add_instruction(migraphx.op("slice", axes=[2], starts=[1], ends=[2]), [x_8])
scale_squeeze = m.add_instruction(migraphx.op("squeeze", axes=2), [scale])
bias_squeeze = m.add_instruction(migraphx.op("squeeze", axes=2), [bias])
x_12 = m.add_instruction(migraphx.op("dequantizelinear"), [x_4, scale_squeeze, bias_squeeze]) # migraphx.shape(type="half_type", lens=[12288, 4096])
x_13 = m.add_instruction(migraphx.op("unsqueeze", axes=[0]), [x_12]) # migraphx.shape(type="half_type", lens=[1, 12288, 4096])
x_14 = m.add_instruction(migraphx.op("transpose", permutation=[0,2,1]), [x_13]) # migraphx.shape(type="half_type", lens=[1, 4096, 12288], strides=[50331648, 1, 4096])
x_15 = m.add_instruction(migraphx.op("dot"), [p_x4, x_14]) # migraphx.shape(type="half_type", lens=[1, 1, 12288])
m.add_return([x_15])
```

|         | develop branch | this PR (+new layout) | speed up  |
| ------- | -------------- | --------------------- | --------- |
| gfx1101 | 0.1248ms | 0.0897ms             | 1.39x |
| gfx1150 (strix)   |  0.5302ms              |  0.4071ms |   1.30x        |

@pfultz2 pointed out we can use slice operations instead of changing quantizelinear to use one param. This simplifies this PR a lot.

TODO: 
- add tests
closes: https://github.com/ROCm/rocMLIR-internal/issues/1665