### PR TITLE
GridwiseGemmParams: fix compile error with LLVM libc++ due to missing const

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -209,7 +209,7 @@ private:
     size_t original_pos;
     int64_t padding_amount;
 
-    bool operator<(const InitParamData &rhs) {
+    bool operator<(const InitParamData &rhs) const {
       if (this->padding_amount < rhs.padding_amount) {
         return true;
       } else if (this->padding_amount == rhs.padding_amount) {


### PR DESCRIPTION
LLVM's C++ stdlib is more picky and requires this to be marked const to avoid compile errors when sorting.