### PR TITLE
[DRAFT]Add support for bf16 attention

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -208,12 +208,12 @@ def Rock_ReduceOp :
 def Rock_AttentionOp :
   Rock_Op<"attention", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, RockFusionRoot, AttrSizedOperandSegments]>,
   Arguments<(ins
-    TensorOrMemRefOf<[F32, F16, I8]>:$queries,
-    TensorOrMemRefOf<[F32, F16, I8]>:$keys,
-    TensorOrMemRefOf<[F32, F16]>:$values,
-    Variadic<TensorOrMemRefOf<[F32, F16, I8]>>:$preSoftmaxElemWiseInputs,
+    TensorOrMemRefOf<[F32, F16, BF16, I8]>:$queries,
+    TensorOrMemRefOf<[F32, F16, BF16, I8]>:$keys,
+    TensorOrMemRefOf<[F32, F16, BF16]>:$values,
+    Variadic<TensorOrMemRefOf<[F32, F16, BF16, I8]>>:$preSoftmaxElemWiseInputs,
     Optional<TensorOrMemRefOf<[I32]>>:$currentSeqLen,
-    TensorOrMemRefOf<[F32, F16]>:$out,
+    TensorOrMemRefOf<[F32, BF16, F16]>:$out,
     UnitAttr:$qTransposed,
     UnitAttr:$kTransposed,
     UnitAttr:$vTransposed,
@@ -225,7 +225,7 @@ def Rock_AttentionOp :
     OptionalAttr<RockTuningParamAttrInterface>:$params1,
     I32Attr:$firstGemmIdx
   )>,
-  Results<(outs Optional<TensorOf<[F32, F16]>>:$result)> {
+  Results<(outs Optional<TensorOf<[F32, F16, BF16]>>:$result)> {
   let summary = "Attention operation of transformer models";
   let description = [{
     Performs the operation out = SOFTMAX((queries * keys) .* scale) * values.
@@ -434,12 +434,12 @@ def Rock_GridwiseGemmAccelOp :
 // gridwise_attention_accel
 def Rock_GridwiseAttentionAccelOp :
     Rock_Op<"gridwise_attention_accel", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, RockFusionRoot, AttrSizedOperandSegments]>,
-    Arguments<(ins MemRefRankOf<[F32, F16, I8], [3]>:$queries,
-                   MemRefRankOf<[F32, F16, I8], [3]>:$keys,
-                   MemRefRankOf<[F32, F16], [3]>:$values,
-                   Variadic<TensorOrMemRefOf<[F32, F16, I8]>>:$preSoftmaxElemWiseInputs,
+    Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [3]>:$queries,
+                   MemRefRankOf<[F32, F16, BF16, I8], [3]>:$keys,
+                   MemRefRankOf<[F32, F16, BF16,], [3]>:$values,
+                   Variadic<TensorOrMemRefOf<[F32, F16, BF16, I8]>>:$preSoftmaxElemWiseInputs,
                    Optional<MemRefRankOf<[I32], [1]>>:$currentSeqLen,
-                   MemRefRankOf<[F32, F16], [3]>:$out,
+                   MemRefRankOf<[F32, F16, BF16], [3]>:$out,
                    StrAttr:$arch,
                    Rock_GemmFeaturesAttr:$features,
                    I32Attr:$blockSize,

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -579,6 +579,8 @@ LogicalResult getTuningProblemStr(rock::AttentionOp attnOp,
     problemOS << "f32" << sep;
   } else if (elemTypeQ.isF16()) {
     problemOS << "f16" << sep;
+  } else if (elemTypeQ.isBF16()) {
+    problemOS << "bf16" << sep;
   } else if (elemTypeQ.isInteger(8)) {
     problemOS << "i8" << sep;
   } else {

--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -30,6 +30,7 @@ if (ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED)
     PrResnet50
     PrAttentionF32
     PrAttentionF16
+    PrAttentionBF16
     PrAttentionI8
     PrGemmSplitK
   )

--- a/mlir/test/e2e/PrAttentionBF16.cfg
+++ b/mlir/test/e2e/PrAttentionBF16.cfg
@@ -1,0 +1,2 @@
+if (not config.arch_support_mfma) and (not config.arch_support_wmma):
+  config.unsupported = True

--- a/mlir/test/e2e/PrAttentionBF16.toml
+++ b/mlir/test/e2e/PrAttentionBF16.toml
@@ -1,0 +1,83 @@
+directory = "PrAttentionBF16"
+prefix = "rocmlir-gen"
+suffix = "--operation attention -t bf16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-cpu-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "operation"
+values = ["attention"]
+prefix = "--operation "
+
+[[axis]]
+name = "transK"
+values = ["true", "false"]
+prefix = "--transK="
+
+## attention variant
+[[suite]]
+name = "pr_attention_bf16"
+
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64"
+
+# reverse grid test
+[[suite.test]]
+config = "--reverse_grid -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -perf_config attn:v1:32,32,64,32,32,32,4,1"
+
+## This one test kPerBlock (16 x 4) == head_dim case
+## Also it has drepeats > 1 to check correct fetching
+[[suite.test]]
+config = "-seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128 -perf_config attn:v1:128,128,128,32,64,64,4,1"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64"
+
+# Check a padding config
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -perf_config attn:v1:64,64,256,4,64,64,8,1"
+
+# Check lds bypass config
+[[suite.test]]
+config = "-seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128 -perf_config attn:v1:128,128,128,32,128,32,4,1"
+
+# check a case where MPerBlock != gemm1M
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -perf_config attn:v1:32,32,64,8,32,32,8,1"
+
+# check a case where MPerBlock != gemm1M && MPerWave < 32
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -perf_config attn:v1:32,32,64,8,16,16,8,1"
+
+# check scale
+#[[suite.test]]
+#config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale"
+
+# check bias
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-bias"
+
+# check scale and bias together
+#[[suite.test]]
+#config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# cross attention
+[[suite.test]]
+config = "-seq_len_q 128 -seq_len_k 27 -head_dim_qk 64 -head_dim_v 32 --with-attn-scale --with-attn-bias"
+
+# issue 1661
+#[[suite.test]]
+#config = "-seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA
+#[[suite.test]]
+#config = "-num_heads_q 4 -num_heads_kv 2 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + KV Cache
+#[[suite.test]]
+#config = "-rand 1 -current_seq_len=17 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + KV Cache batch=3
+#[[suite.test]]
+#config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"


### PR DESCRIPTION
This commit adds bf16 type for attention op, resolving the issue mentioned in ticket https://github.com/ROCm/rocMLIR-internal/issues/1666 . I tried adding the tests based on f16 attention, and after extending the diff thresholds, there are still tests that fail. The failing tests are within the comments. 
I am uncertain about the acceptable diff threshold for bf16, as the failing tests show a maxRelDiff reaching 2.8e+00