### PR TITLE
[CI] Revert multi-step execution in Navi3x nightly E2E tests

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -185,7 +185,7 @@ String getLabelFromCodepath(String codepath) {
     } else if (codepath == "vanilla"){
         label = 'mlir'
     } else if (codepath == "navi3x") {
-        label = 'mlir && gfx1101'
+        label = 'mlir && ( gfx1100 || gfx1101 )'
     } else if (codepath == "navi4x") {
         label = 'mlir && ( gfx1200 || gfx1201 )'
     } else {
@@ -249,24 +249,9 @@ void build_fixedE2ETests(String codepath) {
              """)
 }
 
-void checkRocmlirOnNavi3x(boolean fixed, String testSuite) {
-    // print verbose logs for all the tests on Navi3x for the debugging purposes
-    sh '[ ! -d build ] || rm -rf build'
-    buildProject('check-rocmlir', """
-             -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=0
-             -DROCMLIR_DRIVER_E2E_TEST_ENABLED=0
-             -DROCK_E2E_TEST_ENABLED=1
-             -DROCK_E2E_TEST_SUITES=${testSuite}
-             -DROCMLIR_DRIVER_RANDOM_DATA_SEED=${fixed ? 'none' : '1'}
-             -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=${fixed ? 1 : 0}
-             -DLLVM_LIT_ARGS='-va --time-tests --filter-out=dense_output_bf16.mlir -j 4'
-             -DCMAKE_EXPORT_COMPILE_COMMANDS=1
-     """)
-}
-
 void check_RockE2ETests_Navi3x(boolean fixed) {
 
-    // Run PR CI tests; Skip Static Test on Novi3x
+    // Run PR CI tests; Skip Static Test on Navi3x
     if ( params.nightly == false ) {
         buildProject('check-mlir check-rocmlir', """
                  -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=1
@@ -278,7 +263,6 @@ void check_RockE2ETests_Navi3x(boolean fixed) {
          """)
          echo "Static Test step skipped"
     }
-    // Run nightly E2E tests in multiple smaller batches to increase the chance of successful completion
     else {
         // print verbose logs for all the tests on Navi3x for debugging purposes
         sh '[ ! -d build ] || rm -rf build'
@@ -292,10 +276,6 @@ void check_RockE2ETests_Navi3x(boolean fixed) {
              -DLLVM_LIT_ARGS='-va --time-tests --filter-out=dense_output_bf16.mlir -j 4'
              -DCMAKE_EXPORT_COMPILE_COMMANDS=1
         """)
-        checkRocmlirOnNavi3x(fixed, 'part2')
-        checkRocmlirOnNavi3x(fixed, 'part3')
-        checkRocmlirOnNavi3x(fixed, 'part4')
-        checkRocmlirOnNavi3x(fixed, 'part5')
     }
 }
 

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -270,7 +270,6 @@ void check_RockE2ETests_Navi3x(boolean fixed) {
              -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=0
              -DROCMLIR_DRIVER_E2E_TEST_ENABLED=1
              -DROCK_E2E_TEST_ENABLED=1
-             -DROCK_E2E_TEST_SUITES='part1'
              -DROCMLIR_DRIVER_RANDOM_DATA_SEED=${fixed ? 'none' : '1'}
              -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=${fixed ? 1 : 0}
              -DLLVM_LIT_ARGS='-va --time-tests --filter-out=dense_output_bf16.mlir -j 4'


### PR DESCRIPTION
Fixes: https://github.com/ROCm/rocMLIR-internal/issues/1148