### PR TITLE
Fix tuning for split-k fusions

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
@@ -9,6 +9,7 @@
 #define ROCK_UTILITY_FUSION_H
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -22,11 +23,8 @@ class FuncOp;
 } // namespace func
 
 namespace rock {
-// Checks whether a function contains any `linalg::GenericOp` which
-// reads or writes to the output of any `Operation` implementing
-// `RockGemmWrapperInterface`. The result of this test can be ignored
-// if the Data Parallel GEMM scheme is used.
-LogicalResult testFusionLegality(func::FuncOp func);
+// Checks whether a function is valid for split-k.
+LogicalResult testFusionLegalitySplitK(func::FuncOp func);
 
 // Checks whether a function contains any `rock::ReduceOp` and
 // the atomic operation is supported by the hardware.
@@ -37,7 +35,7 @@ LogicalResult testFusionLegalityReduce(func::FuncOp func);
 // `func:FuncOp` and calls the implementation `testFusionLegality` (see above).
 // Note, this overloaded function assumes that `ModuleOp` contains
 // a single `func:FuncOp`
-LogicalResult testFusionLegality(ModuleOp mod);
+LogicalResult testFusionLegalitySplitK(ModuleOp mod);
 
 // Same as above, overload of `testFusionLegalityReduce` for `ModuleOp`.
 LogicalResult testFusionLegalityReduce(ModuleOp mod);
@@ -45,7 +43,7 @@ LogicalResult testFusionLegalityReduce(ModuleOp mod);
 // Checks whether the output fusion linalg::GenericOp is valid. Assuming a
 // split-k kernel.
 LogicalResult
-checkValidOutputFusion(linalg::GenericOp genericOp, Value gemmResult,
+checkValidOutputFusion(linalg::GenericOp genericOp, Value gemmResult, GemmFeatures features,
                        SmallVector<std::tuple<Operation *, int>> &adds);
 
 } // end namespace rock

--- a/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
@@ -30,9 +30,9 @@ LogicalResult testFusionLegalitySplitK(func::FuncOp func);
 // the atomic operation is supported by the hardware.
 LogicalResult testFusionLegalityReduce(func::FuncOp func);
 
-// This is an overload of the `testFusionLegality` which is more convenient
+// This is an overload of the `testFusionLegalitySplitK` which is more convenient
 // to use in CAPI. Given a `ModuleOp`, the function retrieve the embedded
-// `func:FuncOp` and calls the implementation `testFusionLegality` (see above).
+// `func:FuncOp` and calls the implementation `testFusionLegalitySplitK` (see above).
 // Note, this overloaded function assumes that `ModuleOp` contains
 // a single `func:FuncOp`
 LogicalResult testFusionLegalitySplitK(ModuleOp mod);

--- a/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
@@ -30,11 +30,11 @@ LogicalResult testFusionLegalitySplitK(func::FuncOp func);
 // the atomic operation is supported by the hardware.
 LogicalResult testFusionLegalityReduce(func::FuncOp func);
 
-// This is an overload of the `testFusionLegalitySplitK` which is more convenient
-// to use in CAPI. Given a `ModuleOp`, the function retrieve the embedded
-// `func:FuncOp` and calls the implementation `testFusionLegalitySplitK` (see above).
-// Note, this overloaded function assumes that `ModuleOp` contains
-// a single `func:FuncOp`
+// This is an overload of the `testFusionLegalitySplitK` which is more
+// convenient to use in CAPI. Given a `ModuleOp`, the function retrieve the
+// embedded `func:FuncOp` and calls the implementation
+// `testFusionLegalitySplitK` (see above). Note, this overloaded function
+// assumes that `ModuleOp` contains a single `func:FuncOp`
 LogicalResult testFusionLegalitySplitK(ModuleOp mod);
 
 // Same as above, overload of `testFusionLegalityReduce` for `ModuleOp`.
@@ -43,7 +43,8 @@ LogicalResult testFusionLegalityReduce(ModuleOp mod);
 // Checks whether the output fusion linalg::GenericOp is valid. Assuming a
 // split-k kernel.
 LogicalResult
-checkValidOutputFusion(linalg::GenericOp genericOp, Value gemmResult, GemmFeatures features,
+checkValidOutputFusion(linalg::GenericOp genericOp, Value gemmResult,
+                       GemmFeatures features,
                        SmallVector<std::tuple<Operation *, int>> &adds);
 
 } // end namespace rock

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -207,7 +207,7 @@ LogicalResult checkLDSSize(StringAttr arch, int64_t ldsBytes);
 
 // Trace gemm output back to its function arguments
 FailureOr<SmallVector<BlockArgument>>
-traceGemmOutputToArgs(Value matC, func::FuncOp func, OpBuilder &builder,
+traceGemmOutputToArgs(Value matC, func::FuncOp func,
                       const BufferDependencyAnalysis &deps);
 
 } // end namespace rock

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -83,7 +83,7 @@ void AffixTuningParameters::runOnOperation() {
         zero = b.getIntegerAttr(elementType, 0);
       }
       FailureOr<SmallVector<BlockArgument>> args =
-          traceGemmOutputToArgs(c, func, b, bufferDeps);
+          traceGemmOutputToArgs(c, func, bufferDeps);
       assert(succeeded(args) &&
              "can't trace the GEMM output to a kernel result");
       for (auto arg : args.value())

--- a/mlir/lib/Dialect/Rock/Transforms/GemmLinalgSplitkNormalizationPass.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmLinalgSplitkNormalizationPass.cpp
@@ -128,8 +128,8 @@ rewriteLinalgForSplitK(func::FuncOp &func,
       LLVM_DEBUG(llvm::dbgs()
                  << "Found linalg::GenericOp that reads GEMM output, let's "
                     "modify it if it has addf and/or subf\n");
-      if (failed(divideAddBySplitkFactor(op, gemmOut[0], splitKFactors[0], features[0],
-                                         rewriter)))
+      if (failed(divideAddBySplitkFactor(op, gemmOut[0], splitKFactors[0],
+                                         features[0], rewriter)))
         return failure();
     } else {
       LLVM_DEBUG(llvm::dbgs() << "We didn't find any linalg::GenericOp that "

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -185,11 +185,6 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
 
   const int64_t splitKFactor = op.getParams()->getSplitKFactor();
   if (splitKFactor > 1) {
-    if (!bitEnumContainsAll(op.getFeatures(), GemmFeatures::atomic_add)) {
-      return op.emitError(
-          "Split-K `GemmOp` requires support of `atomic_add` hardware feature");
-    }
-
     auto maybeSplitk =
         arrangeSplitKTransform(rw, op, loc, splitKFactor, a, b, c);
     if (failed(maybeSplitk))

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -278,7 +278,7 @@ GemmRewritePattern::arrangeSplitKTransform(OpBuilder &builder, GemmOp op,
   Value matC = op.getC();
   auto func = llvm::cast<func::FuncOp>(op->getParentOp());
   FailureOr<SmallVector<BlockArgument>> args =
-      traceGemmOutputToArgs(matC, func, builder, bufferDeps);
+      traceGemmOutputToArgs(matC, func, bufferDeps);
   if (failed(args)) {
     return op->emitError("can't trace gemm output to output argument");
   }

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -164,7 +164,8 @@ computeOptimalSplitKFactors(GemmSize origGemmSize, int32_t gemmMPerBlock,
 static SmallVector<int64_t>
 computeOptimalSplitKFactors(RockGemmWrapperInterface gemmOp,
                             int32_t gemmMPerBlock, int32_t gemmNPerBlock,
-                            int32_t gemmKPerBlock, int32_t kPack, bool isSplitKFusible) {
+                            int32_t gemmKPerBlock, int32_t kPack,
+                            bool isSplitKFusible) {
   auto info = PopulateParamsInfo::fromOp(gemmOp);
   SmallVector<int64_t> splitKValues = {1};
   GemmFeatures currentFeatures = gemmOp.getGemmFeatures();
@@ -199,8 +200,7 @@ computeOptimalSplitKFactors(RockGemmWrapperInterface gemmOp,
 // If `kind` is Full, also filters out unlikely-to-be-good configurations.
 void createGemmTuningRangeBF(TuningParamSet *newSpace,
                              RockGemmWrapperInterface gemmOp,
-                             bool isSplitKFusible,
-                             TuningParamSetKind kind) {
+                             bool isSplitKFusible, TuningParamSetKind kind) {
   auto info = PopulateParamsInfo::fromOp(gemmOp);
 
   // blockSize M/block N/block K/block M/thread N/thread
@@ -328,7 +328,8 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
           for (uint32_t gemmKPerBlock : validRangeGeneralGemmParams[3]) {
             for (uint32_t gemmMPerThread : validRangeGeneralGemmParams[4]) {
               auto optimalSplitKFactors = computeOptimalSplitKFactors(
-                  gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock, 1, isSplitKFusible);
+                  gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock, 1,
+                  isSplitKFusible);
               for (auto splitKFactor : optimalSplitKFactors) {
                 for (uint32_t gemmNPerThread : validRangeGeneralGemmParams[5]) {
                   InitParamsNonAccel gemmParams(

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -164,7 +164,7 @@ computeOptimalSplitKFactors(GemmSize origGemmSize, int32_t gemmMPerBlock,
 static SmallVector<int64_t>
 computeOptimalSplitKFactors(RockGemmWrapperInterface gemmOp,
                             int32_t gemmMPerBlock, int32_t gemmNPerBlock,
-                            int32_t gemmKPerBlock, int32_t kPack) {
+                            int32_t gemmKPerBlock, int32_t kPack, bool isSplitKFusible) {
   auto info = PopulateParamsInfo::fromOp(gemmOp);
   SmallVector<int64_t> splitKValues = {1};
   GemmFeatures currentFeatures = gemmOp.getGemmFeatures();
@@ -173,9 +173,8 @@ computeOptimalSplitKFactors(RockGemmWrapperInterface gemmOp,
   if (bitEnumContainsAll(currentFeatures, GemmFeatures::wmma)) {
     return splitKValues;
   }
-  const bool isAllowedTypeC =
-      gemmOp.getCType().isF32() || gemmOp.getCType().isF16();
-  if (!isAllowedTypeC) {
+
+  if (!isSplitKFusible) {
     return splitKValues;
   }
 
@@ -200,6 +199,7 @@ computeOptimalSplitKFactors(RockGemmWrapperInterface gemmOp,
 // If `kind` is Full, also filters out unlikely-to-be-good configurations.
 void createGemmTuningRangeBF(TuningParamSet *newSpace,
                              RockGemmWrapperInterface gemmOp,
+                             bool isSplitKFusible,
                              TuningParamSetKind kind) {
   auto info = PopulateParamsInfo::fromOp(gemmOp);
 
@@ -257,7 +257,7 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
               for (uint32_t gemmKPack : xdlopsParams[5]) {
                 auto optimalSplitKFactors = computeOptimalSplitKFactors(
                     gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock,
-                    gemmKPack);
+                    gemmKPack, isSplitKFusible);
                 for (int64_t splitKFactor : optimalSplitKFactors) {
                   for (uint32_t forceUnroll : xdlopsParams[6]) {
                     InitParamsAccel gemmParams(gemmMPerBlock, gemmNPerBlock,
@@ -296,7 +296,7 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
               for (uint32_t gemmKPack : wmmaParams[5]) {
                 auto optimalSplitKFactors = computeOptimalSplitKFactors(
                     gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock,
-                    gemmKPack);
+                    gemmKPack, isSplitKFusible);
                 for (auto splitKFactor : optimalSplitKFactors) {
                   for (uint32_t forceUnroll : wmmaParams[6]) {
                     InitParamsAccel gemmParams(gemmMPerBlock, gemmNPerBlock,
@@ -328,7 +328,7 @@ void createGemmTuningRangeBF(TuningParamSet *newSpace,
           for (uint32_t gemmKPerBlock : validRangeGeneralGemmParams[3]) {
             for (uint32_t gemmMPerThread : validRangeGeneralGemmParams[4]) {
               auto optimalSplitKFactors = computeOptimalSplitKFactors(
-                  gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock, 1);
+                  gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock, 1, isSplitKFusible);
               for (auto splitKFactor : optimalSplitKFactors) {
                 for (uint32_t gemmNPerThread : validRangeGeneralGemmParams[5]) {
                   InitParamsNonAccel gemmParams(
@@ -462,13 +462,15 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind) {
   struct TuningParamSet *newSpace;
   newSpace = new TuningParamSet();
 
+  bool isSplitKFusible = succeeded(rock::testFusionLegalitySplitK(mod));
+
   // create range and heuristic
   WalkResult findPrimary =
       mod->walk([&](rock::RockGemmWrapperInterface op) -> WalkResult {
         switch (kind) {
         case TuningParamSetKind::Full:
         case TuningParamSetKind::Exhaustive:
-          createGemmTuningRangeBF(newSpace, op, kind);
+          createGemmTuningRangeBF(newSpace, op, isSplitKFusible, kind);
           break;
         case TuningParamSetKind::Quick:
           createQuickTuningRange(newSpace, op);
@@ -1013,7 +1015,7 @@ bool isModuleFusible(ModuleOp module, StringRef perfConfig) {
   bool fusible = succeeded(rock::testFusionLegalityReduce(module));
   if (!rock::isSplitKRequested(module, perfConfig))
     return fusible;
-  return fusible && succeeded(rock::testFusionLegality(module));
+  return fusible && succeeded(rock::testFusionLegalitySplitK(module));
 }
 
 } // namespace rock

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -36,6 +36,22 @@ bool validOperationGemmOut(Operation &op) {
              ExtUIOp, ExtSIOp, ExtFOp, TruncFOp, TruncIOp>(op);
 }
 
+static LogicalResult validOutput(Type outType, GemmFeatures features) {
+  // Split-K currently supports only f32/f16 element types
+  if (!isa<Float32Type, Float16Type>(outType))
+    return failure();
+
+  if (isa<Float32Type>(outType) &&
+      !bitEnumContainsAll(features, GemmFeatures::atomic_add)) {
+    return failure();
+  }
+  if (isa<Float16Type>(outType) &&
+      !bitEnumContainsAll(features, GemmFeatures::atomic_add_f16)) {
+    return failure();
+  }
+  return success();
+}
+
 LogicalResult mlir::rock::checkValidOutputFusion(
     linalg::GenericOp genericOp, Value gemmResult, GemmFeatures features,
     SmallVector<std::tuple<Operation *, int>> &adds) {
@@ -50,20 +66,6 @@ LogicalResult mlir::rock::checkValidOutputFusion(
   */
   auto outputs = genericOp.getOutputs();
   assert(outputs.size() == 1);
-  auto outElementType = cast<ShapedType>(outputs[0].getType()).getElementType();
-  
-  // Split-K currently supports only f32/f16 element types
-  if(!isa<Float32Type, Float16Type>(outElementType))
-    return failure();
-  
-  if(isa<Float32Type>(outElementType) && !bitEnumContainsAll(features,
-                              GemmFeatures::atomic_add)) {
-    return failure();
-  }
-  if(isa<Float16Type>(outElementType) && !bitEnumContainsAll(features,
-                              GemmFeatures::atomic_add_f16)) {
-    return failure();
-  }
 
   // find tensor index
   int tensorIndex = -1;
@@ -132,6 +134,22 @@ LogicalResult mlir::rock::testFusionLegalitySplitK(func::FuncOp func) {
   WalkResult walkResult =
       func.walk([&](rock::RockGemmWrapperInterface gemmOp) -> WalkResult {
         auto gemmResult = gemmOp.getOutArgument()->get();
+
+        auto maybeBlockArgs = traceGemmOutputToArgs(gemmResult, func, analysis);
+        if (failed(maybeBlockArgs))
+          return WalkResult::interrupt();
+
+        // here we check that the kernel outputs are supported by hardware
+        // atomic_add features some kernels output might come directly from GEMM
+        // without passing through linalg::genericop or rock::reduceop
+        auto blockArgs = maybeBlockArgs.value();
+        for (auto blockArg : blockArgs) {
+          auto outElementType =
+              cast<ShapedType>(blockArg.getType()).getElementType();
+          if (failed(validOutput(outElementType, gemmOp.getGemmFeatures())))
+            return WalkResult::interrupt();
+        }
+
         auto maybeAlloc = findMemrefAlloc(gemmResult);
         if (failed(maybeAlloc)) {
           return WalkResult::advance();
@@ -160,8 +178,8 @@ LogicalResult mlir::rock::testFusionLegalitySplitK(func::FuncOp func) {
         // check if generic ops are valid fusions
         for (auto genericOp : genericOps) {
           SmallVector<std::tuple<Operation *, int>> adds;
-          if (failed(
-                  checkValidOutputFusion(genericOp, maybeAlloc.value(), gemmOp.getGemmFeatures(), adds)))
+          if (failed(checkValidOutputFusion(genericOp, maybeAlloc.value(),
+                                            gemmOp.getGemmFeatures(), adds)))
             return WalkResult::interrupt();
         }
 

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -145,7 +145,8 @@ LogicalResult mlir::rock::testFusionLegalitySplitK(func::FuncOp func) {
         for (auto blockArg : blockArgs) {
           auto outElementType =
               cast<ShapedType>(blockArg.getType()).getElementType();
-          if (failed(validOutputAtomicAdd(outElementType, gemmOp.getGemmFeatures())))
+          if (failed(validOutputAtomicAdd(outElementType,
+                                          gemmOp.getGemmFeatures())))
             return WalkResult::interrupt();
         }
 
@@ -207,7 +208,7 @@ LogicalResult mlir::rock::testFusionLegalityReduce(func::FuncOp func) {
                               GemmFeatures::atomic_fmax_f32))
         return WalkResult::interrupt();
     } else {
-      if(failed(validOutputAtomicAdd(outElemType, reduceOp.getFeatures())))
+      if (failed(validOutputAtomicAdd(outElemType, reduceOp.getFeatures())))
         return WalkResult::interrupt();
     }
     return WalkResult::advance();

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -139,9 +139,8 @@ LogicalResult mlir::rock::testFusionLegalitySplitK(func::FuncOp func) {
         if (failed(maybeBlockArgs))
           return WalkResult::interrupt();
 
-        // here we check that the kernel outputs are supported by hardware
-        // atomic_add features some kernels output might come directly from GEMM
-        // without passing through linalg::genericop or rock::reduceop
+        // Verify hardware compatibility (split-k) for kernel output.
+        // Checks if atomic_add operations are supported by the target hardware.
         auto blockArgs = maybeBlockArgs.value();
         for (auto blockArg : blockArgs) {
           auto outElementType =

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -834,7 +834,6 @@ static void traceGemmAllocToArgs(memref::AllocOp buffer,
 
 FailureOr<SmallVector<BlockArgument>>
 mlir::rock::traceGemmOutputToArgs(Value matC, func::FuncOp func,
-                                  OpBuilder &builder,
                                   const BufferDependencyAnalysis &deps) {
   if (func.getNumArguments() == 0)
     return failure();

--- a/mlir/test/fusion/fusability-dot-add-no-atomic-add-f16.mlir
+++ b/mlir/test/fusion/fusability-dot-add-no-atomic-add-f16.mlir
@@ -1,0 +1,22 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:0
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg0: memref<1x2x320xf32>, %arg1: memref<1x2x1280xf32>, %arg2: memref<1x1280x320xf32>, %arg3: memref<1x2x320xf16>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xf32>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xf32> = memref<1x2x1280xf32> * memref<1x1280x320xf32>
+    %0 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf32> to memref<2x320xf32>
+    %1 = rock.transform %arg0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf32> to memref<2x320xf32>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x320xf16>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xf32>, memref<2x320xf32>) outs(%alloc_0 : memref<2x320xf16>) {
+    ^bb0(%in: f32, %in_1: f32, %out: f16):
+      %3 = arith.addf %in, %in_1 : f32
+      %4 = arith.truncf %3 : f32 to f16
+      linalg.yield %4 : f16
+    }
+    %2 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 320] -> [2, 320]> : memref<2x320xf16> to memref<1x2x320xf16>
+    memref.copy %2, %arg3 : memref<1x2x320xf16> to memref<1x2x320xf16>
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-dot-add-no-atomic-add.mlir
+++ b/mlir/test/fusion/fusability-dot-add-no-atomic-add.mlir
@@ -1,0 +1,21 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:0
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg0: memref<1x2x320xf32>, %arg1: memref<1x2x1280xf32>, %arg2: memref<1x1280x320xf32>, %arg3: memref<1x2x320xf32>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xf32>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add_f16 storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xf32> = memref<1x2x1280xf32> * memref<1x1280x320xf32>
+    %0 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf32> to memref<2x320xf32>
+    %1 = rock.transform %arg0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf32> to memref<2x320xf32>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x320xf32>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xf32>, memref<2x320xf32>) outs(%alloc_0 : memref<2x320xf32>) {
+    ^bb0(%in: f32, %in_1: f32, %out: f32):
+      %3 = arith.addf %in, %in_1 : f32
+      linalg.yield %3 : f32
+    }
+    %2 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 320] -> [2, 320]> : memref<2x320xf32> to memref<1x2x320xf32>
+    memref.copy %2, %arg3 : memref<1x2x320xf32> to memref<1x2x320xf32>
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-i8-dot-add-convert.mlir
+++ b/mlir/test/fusion/fusability-i8-dot-add-convert.mlir
@@ -1,0 +1,22 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:1
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg0: memref<1x2x320xf16>, %arg1: memref<1x2x1280xi8>, %arg2: memref<1x1280x320xi8>, %arg3: memref<1x2x320xf16>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xi8>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add|atomic_add_f16 storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xi8> = memref<1x2x1280xi8> * memref<1x1280x320xi8>
+    %0 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xi8> to memref<2x320xi8>
+    %1 = rock.transform %arg0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf16> to memref<2x320xf16>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x320xf16>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xi8>, memref<2x320xf16>) outs(%alloc_0 : memref<2x320xf16>) {
+    ^bb0(%in: i8, %in_1: f16, %out: f16):
+      %3 = arith.sitofp %in : i8 to f16
+      %4 = arith.addf %3, %in_1 : f16
+      linalg.yield %4 : f16
+    }
+    %5 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 320] -> [2, 320]> : memref<2x320xf16> to memref<1x2x320xf16>
+    memref.copy %5, %arg3 : memref<1x2x320xf16> to memref<1x2x320xf16>
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-i8-dot-add-multiple-outs-no-splitk.mlir
+++ b/mlir/test/fusion/fusability-i8-dot-add-multiple-outs-no-splitk.mlir
@@ -1,0 +1,25 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:0
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg0: memref<1x2x320xf16>, %arg1: memref<1x2x1280xi8>, %arg2: memref<1x1280x320xi8>, %arg3: memref<1x2x320xi8>, %arg4: memref<1x2x1xf16>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xi8>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add|atomic_add_f16 storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xi8> = memref<1x2x1280xi8> * memref<1x1280x320xi8>
+    %0 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xi8> to memref<2x320xi8>
+    %1 = rock.transform %arg0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf16> to memref<2x320xf16>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x320xf16>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xi8>, memref<2x320xf16>) outs(%alloc_0 : memref<2x320xf16>) {
+    ^bb0(%in: i8, %in_1: f16, %out: f16):
+      %3 = arith.sitofp %in : i8 to f16
+      %4 = arith.addf %3, %in_1 : f16
+      linalg.yield %4 : f16
+    }
+    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x1xf16>
+    rock.reduce  sum %alloc_0 into %alloc_1 features =  mfma|dot|atomic_add|atomic_add_f16 {axis = 1 : index, blockSize = 256 : i32, gridSize = 2 : i32} : memref<2x320xf16> into memref<2x1xf16>
+    %5 = rock.transform %alloc_1 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 1] -> [2, 1]> : memref<2x1xf16> to memref<1x2x1xf16>
+    memref.copy %alloc, %arg3 : memref<1x2x320xi8> to memref<1x2x320xi8>
+    memref.copy %5, %arg4 : memref<1x2x1xf16> to memref<1x2x1xf16>
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-i8-dot-add-multiple-outs-no-splitk2.mlir
+++ b/mlir/test/fusion/fusability-i8-dot-add-multiple-outs-no-splitk2.mlir
@@ -1,0 +1,34 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:0
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg0: memref<1x2x320xf16>, %arg1: memref<1x2x1280xi8>, %arg2: memref<1x1280x320xi8>, %arg3: memref<1x2x320xf16>, %arg4: memref<1x2x1xf16>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xi8>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add|atomic_add_f16 storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xi8> = memref<1x2x1280xi8> * memref<1x1280x320xi8>
+    %0 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xi8> to memref<2x320xi8>
+    %1 = rock.transform %arg0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf16> to memref<2x320xf16>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x320xf16>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xi8>, memref<2x320xf16>) outs(%alloc_0 : memref<2x320xf16>) {
+    ^bb0(%in: i8, %in_1: f16, %out: f16):
+      %3 = arith.sitofp %in : i8 to f16
+      %4 = arith.addf %3, %in_1 : f16
+      linalg.yield %4 : f16
+    }
+    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x320xf16>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xi8>, memref<2x320xf16>) outs(%alloc_1 : memref<2x320xf16>) {
+    ^bb0(%in: i8, %in_1: f16, %out: f16):
+      %5 = arith.fptoui %in_1 : f16 to i8
+      %6 = arith.addi %5, %in : i8
+      %7 = arith.sitofp %6 : i8 to f16
+      linalg.yield %7 : f16
+    }
+    %8 = rock.transform %alloc_1 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 320] -> [2, 320]> : memref<2x320xf16> to memref<1x2x320xf16>
+    %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<2x1xf16>
+    rock.reduce  sum %alloc_0 into %alloc_2 features =  mfma|dot|atomic_add|atomic_add_f16 {axis = 1 : index, blockSize = 256 : i32, gridSize = 2 : i32} : memref<2x320xf16> into memref<2x1xf16>
+    %9 = rock.transform %alloc_2 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 1] -> [2, 1]> : memref<2x1xf16> to memref<1x2x1xf16>
+    memref.copy %8, %arg3 : memref<1x2x320xf16> to memref<1x2x320xf16>
+    memref.copy %9, %arg4 : memref<1x2x1xf16> to memref<1x2x1xf16>
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-i8-dot-add-multiple-outs.mlir
+++ b/mlir/test/fusion/fusability-i8-dot-add-multiple-outs.mlir
@@ -1,0 +1,26 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:1
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg0: memref<1x2x320xf16>, %arg1: memref<1x2x1280xi8>, %arg2: memref<1x1280x320xi8>, %arg3: memref<1x2x320xf16>, %arg4: memref<1x2x1xf16>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xi8>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add|atomic_add_f16 storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xi8> = memref<1x2x1280xi8> * memref<1x1280x320xi8>
+    %0 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xi8> to memref<2x320xi8>
+    %1 = rock.transform %arg0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xf16> to memref<2x320xf16>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x320xf16>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xi8>, memref<2x320xf16>) outs(%alloc_0 : memref<2x320xf16>) {
+    ^bb0(%in: i8, %in_1: f16, %out: f16):
+      %3 = arith.sitofp %in : i8 to f16
+      %4 = arith.addf %3, %in_1 : f16
+      linalg.yield %4 : f16
+    }
+    %5 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 320] -> [2, 320]> : memref<2x320xf16> to memref<1x2x320xf16>
+    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x1xf16>
+    rock.reduce  sum %alloc_0 into %alloc_1 features =  mfma|dot|atomic_add|atomic_add_f16 {axis = 1 : index, blockSize = 256 : i32, gridSize = 2 : i32} : memref<2x320xf16> into memref<2x1xf16>
+    %6 = rock.transform %alloc_1 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 1] -> [2, 1]> : memref<2x1xf16> to memref<1x2x1xf16>
+    memref.copy %5, %arg3 : memref<1x2x320xf16> to memref<1x2x320xf16>
+    memref.copy %6, %arg4 : memref<1x2x1xf16> to memref<1x2x1xf16>
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-i8-dot-add.mlir
+++ b/mlir/test/fusion/fusability-i8-dot-add.mlir
@@ -1,0 +1,21 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:0
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg0: memref<1x2x320xi8>, %arg1: memref<1x2x1280xi8>, %arg2: memref<1x1280x320xi8>, %arg3: memref<1x2x320xi8>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xi8>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add|atomic_add_f16 storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xi8> = memref<1x2x1280xi8> * memref<1x1280x320xi8>
+    %0 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xi8> to memref<2x320xi8>
+    %1 = rock.transform %arg0 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 2} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [2, 320] -> [1, 2, 320]> : memref<1x2x320xi8> to memref<2x320xi8>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x320xi8>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : memref<2x320xi8>, memref<2x320xi8>) outs(%alloc_0 : memref<2x320xi8>) {
+    ^bb0(%in: i8, %in_1: i8, %out: i8):
+      %3 = arith.addi %in, %in_1 : i8
+      linalg.yield %3 : i8
+    }
+    %4 = rock.transform %alloc_0 by <affine_map<(d0, d1, d2) -> (d0 * 2 + d1, d2)> by [<Unmerge{1, 2} ["exp0", "exp1"] at [0, 1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>] bounds = [1, 2, 320] -> [2, 320]> : memref<2x320xi8> to memref<1x2x320xi8>
+    memref.copy %4, %arg3 : memref<1x2x320xi8> to memref<1x2x320xi8>
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-i8-dot.mlir
+++ b/mlir/test/fusion/fusability-i8-dot.mlir
@@ -1,0 +1,12 @@
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,5,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-SPLITK
+// CHECK-SPLITK: fusible:0
+// RUN: rocmlir-gen -emit-module-fusibility-for=v2:16,16,4,16,16,1,1,1,1 - < %s | FileCheck %s --check-prefixes=CHECK-NONSPLITK
+// CHECK-NONSPLITK: fusible:1
+module {
+  func.func @mlir_dot_add(%arg1: memref<1x2x1280xi8>, %arg2: memref<1x1280x320xi8>, %arg3: memref<1x2x320xi8>) attributes {enable_splitk_for_tuning, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x2x320xi8>
+    rock.gemm %alloc = %arg1 * %arg2 features =  mfma|dot|atomic_add|atomic_add_f16 storeMethod =  set {arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} : memref<1x2x320xi8> = memref<1x2x1280xi8> * memref<1x1280x320xi8>
+    memref.copy %alloc, %arg3 : memref<1x2x320xi8> to memref<1x2x320xi8>
+    return
+  }
+}

--- a/mlir/test/lib/Dialect/Rock/TestFunctionFusibility.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestFunctionFusibility.cpp
@@ -43,7 +43,7 @@ struct FunctionFusibilityTestPass
 
 static LogicalResult analyse(func::FuncOp func) {
   OpBuilder builder(func.getContext());
-  if (succeeded(rock::testFusionLegality(func))) {
+  if (succeeded(rock::testFusionLegalitySplitK(func))) {
     func->setAttr("fusibile", builder.getStringAttr("yes"));
   } else {
     func->setAttr("fusibile", builder.getStringAttr("no"));


### PR DESCRIPTION
RockTuningImpl.cpp was checking the GEMM output to decide if split-k is enabled when doing exhaustive tuning. Now we can allow for example: i8 gemm and then type conversion to f16, then split-k would still be valid. I changed the code to use fusionUtils to decide if split-k should be enabled.

Additionally, changed the code to use GemmFeatures (atomic_add and atomic_add_f16) to decide if split-k should be enabled.