### PR TITLE
Enable bf16 atomic add for gfx950

### DIFF
--- a/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AmdArchDb.cpp
@@ -130,6 +130,8 @@ AmdArchInfo mlir::rock::lookupArchInfo(StringRef arch) {
     AmdArchInfo gfx950Info(cdna3Info);
     gfx950Info.hasFp8ConversionInstrs = false;
     gfx950Info.hasOcpFp8ConversionInstrs = true;
+    gfx950Info.defaultFeatures =
+        bitEnumSet(gfx950Info.defaultFeatures, GemmFeatures::atomic_add_bf16);
     return gfx950Info;
   }
   llvm::errs() << "Warning: unknown architecture, falling back to defaults: "

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -73,7 +73,6 @@ Value createConstantFloatOp(OpBuilder &b, Location loc, Type type,
       createAPFloat(elemType, value);
   APFloat apValue = floatRes.first;
   auto status = floatRes.second;
-
   assert(status == expectedStatus);
   Value retValue;
 

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -69,10 +69,11 @@ std::pair<APFloat, llvm::detail::opStatus> createAPFloat(Type elemType,
 Value createConstantFloatOp(OpBuilder &b, Location loc, Type type,
                             Type elemType, float value,
                             APFloat::opStatus expectedStatus) {
-  std::pair<APFloat, llvm::detail::opStatus> floatRes =
-      createAPFloat(elemType, value);
-  APFloat apValue = floatRes.first;
-  auto status = floatRes.second;
+                              std::pair<APFloat, llvm::detail::opStatus> floatRes =
+                              createAPFloat(elemType, value);
+                          APFloat apValue = floatRes.first;
+                          auto status = floatRes.second;
+
   assert(status == expectedStatus);
   Value retValue;
 

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -69,10 +69,10 @@ std::pair<APFloat, llvm::detail::opStatus> createAPFloat(Type elemType,
 Value createConstantFloatOp(OpBuilder &b, Location loc, Type type,
                             Type elemType, float value,
                             APFloat::opStatus expectedStatus) {
-                              std::pair<APFloat, llvm::detail::opStatus> floatRes =
-                              createAPFloat(elemType, value);
-                          APFloat apValue = floatRes.first;
-                          auto status = floatRes.second;
+  std::pair<APFloat, llvm::detail::opStatus> floatRes =
+      createAPFloat(elemType, value);
+  APFloat apValue = floatRes.first;
+  auto status = floatRes.second;
 
   assert(status == expectedStatus);
   Value retValue;

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -404,7 +404,7 @@ func.func @rock_gemm_xdlops_fp8_bf8_ocp(%a : memref<1x72x128xf8E4M3FN>, %b : mem
   // CHECK-SAME: derivedBlockSize = 256
   // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 128, kpack = 8, mPerWave = 16, nPerWave = 128, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 900
+  // GRID-SAME: gridSize = 1800
   rock.gemm %c = tr %a * %b features = mfma|dot|atomic_add|atomic_add_f16|atomic_add_bf16 storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx950",
     numCU = 120 : i32

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -404,8 +404,8 @@ func.func @rock_gemm_xdlops_fp8_bf8_ocp(%a : memref<1x72x128xf8E4M3FN>, %b : mem
   // CHECK-SAME: derivedBlockSize = 256
   // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 128, kpack = 8, mPerWave = 16, nPerWave = 128, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 1800
-  rock.gemm %c = tr %a * %b features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set {
+  // GRID-SAME: gridSize = 900
+  rock.gemm %c = tr %a * %b features = mfma|dot|atomic_add|atomic_add_f16|atomic_add_bf16 storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx950",
     numCU = 120 : i32
   } : memref<1x128x115200xf32> = memref<1x72x128xf8E4M3FN> * memref<1x72x115200xf8E5M2>

--- a/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
@@ -72,7 +72,7 @@ func.func @fp8_bf8_xdlops_ocp(%arg0: memref<1x128x128xf8E4M3FN>, %arg1: memref<1
   // CHECK: rock.blockwise_gemm_accel
   // CHECK-SAME: %[[viewAGemmMB]]
   // CHECK-SAME: %[[viewBGemmMB]]
-  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) features =  mfma|dot|atomic_add|atomic_add_f16 {arch = "amdgcn-amd-amdhsa:gfx950", blockSize = 256 : i32, gridSize = 900 : i32, numCU = 228 : i32, params = #xdlops_gemm_params1a} : memref<1x128x128xf8E4M3FN>, memref<1x128x115200xf8E5M2>, memref<1x128x115200xf32>
+  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) features =  mfma|dot|atomic_add|atomic_add_f16|atomic_add_bf16 {arch = "amdgcn-amd-amdhsa:gfx950", blockSize = 256 : i32, gridSize = 900 : i32, numCU = 228 : i32, params = #xdlops_gemm_params1a} : memref<1x128x128xf8E4M3FN>, memref<1x128x115200xf8E5M2>, memref<1x128x115200xf32>
   return
 }
 

--- a/mlir/test/common_utils/common.py
+++ b/mlir/test/common_utils/common.py
@@ -15,8 +15,10 @@ def get_arch_features(arch: str):
     major = chip_name[:-2]
     minor = chip_name[-2:]
     if major == 'gfx9':
-        if minor in ['08', '0a', '40', '41', '42', '50']:
+        if minor in ['08', '0a', '40', '41', '42']:
             arch_features = 'mfma|dot|atomic_add|atomic_add_f16'
+        elif minor == '50':
+            arch_features = 'mfma|dot|atomic_add|atomic_add_f16|atomic_add_bf16'
         elif minor == '06':
             arch_features = 'dot'
         else:

--- a/mlir/test/rocmlir-driver/atomic_add_assembly.mlir
+++ b/mlir/test/rocmlir-driver/atomic_add_assembly.mlir
@@ -6,6 +6,10 @@
 // RUN: rocmlir-gen --arch gfx942 --store-method atomic_add --operation gemm -t bf16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=BUFFER_ATOMIC_CMPSWAP
 // RUN: rocmlir-gen --arch gfx942 --store-method atomic_add --operation gemm -t f32 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GLOBAL_ATOMIC_ADD_F32
 
+// RUN: rocmlir-gen --arch gfx950 --store-method atomic_add --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=BUFFER_ATOMIC_ADD_F16
+// RUN: rocmlir-gen --arch gfx950 --store-method atomic_add --operation gemm -t bf16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=BUFFER_ATOMIC_ADD_BF16
+// RUN: rocmlir-gen --arch gfx950 --store-method atomic_add --operation gemm -t f32 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GLOBAL_ATOMIC_ADD_F32
+
 // RUN: rocmlir-gen --arch gfx1100 --store-method atomic_add --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=BUFFER_ATOMIC_CMPSWAP
 // RUN: rocmlir-gen --arch gfx1100 --store-method atomic_add --operation gemm -t bf16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=BUFFER_ATOMIC_CMPSWAP
 // RUN: rocmlir-gen --arch gfx1100 --store-method atomic_add --operation gemm -t f32 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GLOBAL_ATOMIC_ADD_F32

--- a/mlir/test/rocmlir-driver/atomic_add_ops.mlir
+++ b/mlir/test/rocmlir-driver/atomic_add_ops.mlir
@@ -6,6 +6,10 @@
 // RUN: rocmlir-gen --arch gfx942 --store-method atomic_add --operation gemm -t bf16 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=BUFFER_ATOMIC_COMPSWAP
 // RUN: rocmlir-gen --arch gfx942 --store-method atomic_add --operation gemm -t f32 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=ATOMICRMW
 
+// RUN: rocmlir-gen --arch gfx950 --store-method atomic_add --operation gemm -t f16 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=BUFFER_ATOMIC_ADD
+// RUN: rocmlir-gen --arch gfx950 --store-method atomic_add --operation gemm -t bf16 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=BUFFER_ATOMIC_ADD
+// RUN: rocmlir-gen --arch gfx950 --store-method atomic_add --operation gemm -t f32 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=ATOMICRMW
+
 // RUN: rocmlir-gen --arch gfx1100 --store-method atomic_add --operation gemm -t f16 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=BUFFER_ATOMIC_COMPSWAP
 // RUN: rocmlir-gen --arch gfx1100 --store-method atomic_add --operation gemm -t bf16 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=BUFFER_ATOMIC_COMPSWAP
 // RUN: rocmlir-gen --arch gfx1100 --store-method atomic_add --operation gemm -t f32 -p | rocmlir-driver --kernel-pipeline=gpu,rocdl | FileCheck %s --check-prefix=ATOMICRMW

--- a/mlir/test/rocmlir-gen/atomic-add-bf16-enablement.mlir
+++ b/mlir/test/rocmlir-gen/atomic-add-bf16-enablement.mlir
@@ -1,6 +1,7 @@
-// RUN: rocmlir-gen --arch gfx1201 --operation gemm --store-method=atomic_add -t f16 -p | grep '|atomic_add_bf16' | count 1
-// RUN: rocmlir-gen --arch gfx1100 --operation gemm --store-method=atomic_add -t f16 -p | not grep '|atomic_add_bf16'
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm --store-method=atomic_add -t bf16 -p | grep '|atomic_add_bf16' | count 1
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm --store-method=atomic_add -t bf16 -p | not grep '|atomic_add_bf16'
 
+// RUN: rocmlir-gen --arch gfx950 --operation gemm --store-method=atomic_add -t bf16 -p | grep '|atomic_add_bf16' | count 1
 // RUN: rocmlir-gen --arch gfx942 --operation gemm --store-method=atomic_add -t bf16 -p | not grep '|atomic_add_bf16'
 
 // YES: rock.gemm

--- a/mlir/test/rocmlir-gen/atomic-add-f16-enablement.mlir
+++ b/mlir/test/rocmlir-gen/atomic-add-f16-enablement.mlir
@@ -1,6 +1,9 @@
 // RUN: rocmlir-gen --arch gfx1201 --operation gemm --store-method=atomic_add -t f16 -p | grep '|atomic_add_f16' | count 1
 // RUN: rocmlir-gen --arch gfx1100 --operation gemm --store-method=atomic_add -t f16 -p | not grep '|atomic_add_f16'
 
+// RUN: rocmlir-gen --arch gfx950 --operation gemm --store-method=atomic_add -t f16 -p | grep '|atomic_add_f16' | count 1
+// RUN: rocmlir-gen --arch gfx942 --operation gemm --store-method=atomic_add -t f16 -p | grep '|atomic_add_f16' | count 1
+
 // YES: rock.gemm
 // YES-SAME: features = {{[^ ]*}}atomic_add_f16
 // NO: rock.gemm

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -457,9 +457,12 @@ def main() -> bool:
     codepath = args.codepath
     rocmlir_gen_flags = []
     if codepath not in supported_codepath:
-        if 'gfx908' in arch or 'gfx90a' in arch or 'gfx94' in arch or 'gfx95' in arch:
+        if 'gfx908' in arch or 'gfx90a' in arch or 'gfx94' in arch:
             codepath = 'mfma'
             rocmlir_gen_flags = ['-mfma=on', '-dot=on', '-atomic_add=on', '-atomic_add_f16=on']
+        elif 'gfx95' in arch:
+            codepath = 'mfma'
+            rocmlir_gen_flags = ['-mfma=on', '-dot=on', '-atomic_add=on', '-atomic_add_f16=on', '-atomic_add_bf16=on']
         elif 'gfx906' in arch:
             codepath = 'vanilla'
             rocmlir_gen_flags = ['-mfma=off', '-dot=on', '-atomic_add=off']


### PR DESCRIPTION
In this PR we enable bf16 atomic add for gfx950. That means bf16 split-k and bf16 reductions.

Note that https://github.com/ROCm/rocMLIR/pull/1732 needs to be merged first. Then, I'll point this PR to develop branch.