### PR TITLE
Enable e2e fusion bf16 tests on gfx11.

### DIFF
--- a/mlir/test/fusion/e2e/generate-fusion-tests.py
+++ b/mlir/test/fusion/e2e/generate-fusion-tests.py
@@ -40,8 +40,6 @@ def generate_option_list(table, key1, key2):
 def generate_op_variants_test(indir, outdir, type, file, opspec):
     archNames = getArch()
     arch = ','.join(archNames)
-    if "bf16" in type and "gfx11" in arch:
-        return
     opname,op = opspec
     with open(f"{indir}/{file}.e2e.template") as f:
         template = f.read()
@@ -69,8 +67,6 @@ def generate_type_only_test(indir, outdir, type, file):
         gen_type = 'i32'
     else:
         raise Exception("Unsupported type '{type}'")
-    if "bf16" in type and "gfx11" in arch:
-        return
     with open(f"{indir}/{file}.e2e.template") as f:
         template = f.read()
     outfile = f"{outdir}/{file}-{type}.e2e.mlir"


### PR DESCRIPTION
This commit removes the conditional logic that skipped generating fusion e2e tests for bf16 on the gfx11 architecture (https://github.com/ROCm/rocMLIR-internal/issues/1080). This allows bf16 tests to run on Navi3x, ensuring that the architecture is fully supported. Tests passing on ctr-smc-s39-007 machine.
