### PR TITLE
[TOSA] Set `accType` to Float16 for the Fp8 types 

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -361,7 +361,10 @@ LogicalResult ConvConverter<ConvType>::matchAndRewrite(
     accType = rewriter.getF32Type();
     // accType is not used by rocMLIR when converting tosa to rock.
     // accType for Float8 type is required to be Float16 as per TOSA v1.0 spec
-    // therefore just set it as required, it is being ignored anyways.
+    // therefore just set it as required, it is being ignored anyways for GPU
+    // lowering using rocMLIR. [Risk]: CPU may generate different results
+    // compared to GPU if accType gets used on CPU lowering path. Currently it
+    // seems none of the TosaToXYZ converter uses this attribute.
   } else if (isa<FloatType>(outElementTy) &&
              outElementTy.getIntOrFloatBitWidth() <= 8) {
     accType = rewriter.getF16Type();

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/Dialect/Tosa/Utils/QuantUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -355,12 +356,18 @@ LogicalResult ConvConverter<ConvType>::matchAndRewrite(
 
   // Determine the accumulation type based on the output type.
   Type accType;
-  if (isa<FloatType>(outElementTy)) {
+  if (isa<FloatType>(outElementTy) &&
+      outElementTy.getIntOrFloatBitWidth() >= 16) {
     accType = rewriter.getF32Type();
+    // accType is not used by rocMLIR when converting tosa to rock.
+    // accType for Float8 type is required to be Float16 as per TOSA v1.0 spec
+    // therefore just set it as required, it is being ignored anyways.
+  } else if (isa<FloatType>(outElementTy) &&
+             outElementTy.getIntOrFloatBitWidth() <= 8) {
+    accType = rewriter.getF16Type();
   } else if (isa<IntegerType>(outElementTy)) {
     accType = rewriter.getI32Type();
   }
-
   // convolution config attributes
   if (dims == 1) {
     if ((dilations.size() != 1) || (strides.size() != 1) ||

--- a/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa.mlir
@@ -189,3 +189,13 @@ func.func @conv1d_add(%arg0: !migraphx.shaped<1x64x224xf32, 0x1x0>, %arg1: !migr
   %1 = migraphx.add %0, %arg0 : <1x64x224xf32, 14336x224x1>, <1x64x224xf32, 0x1x0> -> <1x64x224xf32, 14336x224x1>
   return %1 : !migraphx.shaped<1x64x224xf32, 14336x224x1>
 }
+
+// CHECK-LABEL: @conv2d_float8
+// CHECK-SAME: (%{{.*}}: tensor<256xf8E5M2>, %{{.*}}: tensor<256xf8E5M2>) -> tensor<256xf8E5M2>
+func.func @conv2d_float8(%arg0: !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>, %arg1: !migraphx.shaped<16x16x1x1xf8E5M2, 16x1x1x1>) -> !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1> {
+  // CHECK-COUNT-2: tosa.transpose
+  // CHECK: tosa.conv2d
+  // CHECK-SAME: {acc_type = f16, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x16xf8E5M2>, tensor<16x1x1x16xf8E5M2>, tensor<16xf8E5M2>) -> tensor<1x4x4x16xf8E5M2>
+  %0 = migraphx.convolution %arg0, %arg1 {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : <1x16x4x4xf8E5M2, 256x16x4x1>, <16x16x1x1xf8E5M2, 16x1x1x1> -> <1x16x4x4xf8E5M2, 256x16x4x1>
+  return %0 : !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>
+}


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/121466/files 

Tosa v1.0 spec introduced `accType` for a few TOSA ops. It requires accType for the float8 convolution to be fp16, otherwise verifier complains about. 

Fp16 accumulator may not be the right choice for fp8 dtypes. It can overflow. 

rocMLIR is not using accType attribute therefore, just set it and ignore it. 