### PR TITLE
Fixes for group conv emit-key

### DIFF
--- a/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
@@ -673,6 +673,10 @@ LogicalResult ConvGenerator::parseConvDims(int64_t batchSize, int64_t groupSize,
                                            int64_t outputChannel,
                                            ArrayRef<int64_t> outputDims,
                                            ArrayRef<int64_t> filterDims) {
+
+  if (outputChannel % groupSize != 0 || inputChannel % groupSize != 0)
+    return failure();
+
   config.filterDims.clear();
   for (auto dim : filterDims)
     config.filterDims.push_back(dim);

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -785,13 +785,13 @@ LogicalResult getTuningProblemStr(rock::RockGemmWrapperInterface gemmIF,
     // N
     problemOS << "-n " << inShape[iLayoutMap["ni"]] << sep;
     // C
-    problemOS << "-c " << inShape[iLayoutMap["ci"]] << sep;
+    problemOS << "-c " << inShape[iLayoutMap["ci"]]*inShape[iLayoutMap["gi"]] << sep;
     // H
     problemOS << "-H " << inShape[iLayoutMap["0i"]] << sep;
     // W
     problemOS << "-W " << inShape[iLayoutMap["1i"]] << sep;
     // K
-    problemOS << "-k " << filShape[fLayoutMap["k"]] << sep;
+    problemOS << "-k " << filShape[fLayoutMap["k"]]*filShape[fLayoutMap["g"]] << sep;
     // Y
     problemOS << "-y " << filShape[fLayoutMap["0"]] << sep;
     // X

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -785,13 +785,15 @@ LogicalResult getTuningProblemStr(rock::RockGemmWrapperInterface gemmIF,
     // N
     problemOS << "-n " << inShape[iLayoutMap["ni"]] << sep;
     // C
-    problemOS << "-c " << inShape[iLayoutMap["ci"]]*inShape[iLayoutMap["gi"]] << sep;
+    problemOS << "-c " << inShape[iLayoutMap["ci"]] * inShape[iLayoutMap["gi"]]
+              << sep;
     // H
     problemOS << "-H " << inShape[iLayoutMap["0i"]] << sep;
     // W
     problemOS << "-W " << inShape[iLayoutMap["1i"]] << sep;
     // K
-    problemOS << "-k " << filShape[fLayoutMap["k"]]*filShape[fLayoutMap["g"]] << sep;
+    problemOS << "-k " << filShape[fLayoutMap["k"]] * filShape[fLayoutMap["g"]]
+              << sep;
     // Y
     problemOS << "-y " << filShape[fLayoutMap["0"]] << sep;
     // X

--- a/mlir/test/rocmlir-gen/problem-key.mlir
+++ b/mlir/test/rocmlir-gen/problem-key.mlir
@@ -19,6 +19,9 @@
 // RUN: rocmlir-gen --arch gfx942 --operation conv -t f16 --fil_layout gkc01 --in_layout ngc01 --out_layout ngk01 --batchsize 64 --in_channels 256 --in_h 20 --in_w 20 --out_channels 256 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 3 --padding_w 3 --groupsize 128 --kernel-repeats 1 --perf_config=v2:32,256,2,32,32,4,1,1,1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_GROUP_CONV
 // CHECK_GROUP_CONV: convfp16 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 64 -c 256 -H 20 -W 20 -k 256 -y 7 -x 7 -p 3 -q 3 -u 1 -v 1 -l 1 -j 1 -g 128
 
+// RUN: rocmlir-gen --arch gfx942 --operation conv -t f16 --fil_layout gkc01 --in_layout ngc01 --out_layout ngk01 --batchsize 64 --in_channels 256 --in_h 20 --in_w 20 --out_channels 512 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 3 --padding_w 3 --groupsize 128 --kernel-repeats 1 --perf_config=v2:32,256,2,32,32,4,1,1,1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_GROUP_CONV2
+// CHECK_GROUP_CONV2: convfp16 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 64 -c 256 -H 20 -W 20 -k 512 -y 7 -x 7 -p 3 -q 3 -u 1 -v 1 -l 1 -j 1 -g 128
+
 // Checking numCU
 
 // RUN: rocmlir-gen --arch gfx942 --num_cu 304 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -g 4 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_NUMCU

--- a/mlir/test/rocmlir-gen/problem-key.mlir
+++ b/mlir/test/rocmlir-gen/problem-key.mlir
@@ -13,6 +13,12 @@
 // RUN: rocmlir-gen --arch gfx942 --operation attention -current_seq_len=16,16,17,1,30,40,38,12 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_7
 // CHECK_7: -t i8 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 
+// RUN: rocmlir-gen --arch gfx942 --operation conv -t f16 --fil_layout gkc01 --in_layout ngc01 --out_layout ngk01 --batchsize 64 --in_channels 256 --in_h 20 --in_w 20 --out_channels 256 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 3 --padding_w 3 --groupsize 256 --kernel-repeats 1 --perf_config=v2:32,256,2,32,32,4,1,1,1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_DEPTHWISE_CONV
+// CHECK_DEPTHWISE_CONV: convfp16 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 64 -c 256 -H 20 -W 20 -k 256 -y 7 -x 7 -p 3 -q 3 -u 1 -v 1 -l 1 -j 1 -g 256
+
+// RUN: rocmlir-gen --arch gfx942 --operation conv -t f16 --fil_layout gkc01 --in_layout ngc01 --out_layout ngk01 --batchsize 64 --in_channels 256 --in_h 20 --in_w 20 --out_channels 256 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 3 --padding_w 3 --groupsize 128 --kernel-repeats 1 --perf_config=v2:32,256,2,32,32,4,1,1,1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_GROUP_CONV
+// CHECK_GROUP_CONV: convfp16 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 64 -c 256 -H 20 -W 20 -k 256 -y 7 -x 7 -p 3 -q 3 -u 1 -v 1 -l 1 -j 1 -g 128
+
 // Checking numCU
 
 // RUN: rocmlir-gen --arch gfx942 --num_cu 304 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -g 4 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_NUMCU

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -314,7 +314,8 @@ class ConvConfiguration(PerfConfiguration):
     def computeTFlops(self, ns):
         # NaN will propagate as expected
         # Repeats are handled by the fact that we're using avarageNs
-        return (2.0 * self.n * self.c * self.k * self.ho * self.wo * self.y * self.x) / (float(ns) * 1e-9) / 1e12
+        assert(self.c % self.group == 0)
+        return (2.0 * self.n * (self.c//self.group) * self.k * self.ho * self.wo * self.y * self.x) / (float(ns) * 1e-9) / 1e12
 
     def tableEntry(self, nanoSeconds):
         # Future(kdrewnia): This can just be a dict literal on Python 3.7+
@@ -364,6 +365,7 @@ class ConvConfiguration(PerfConfiguration):
                            '--conv_stride_w', str(self.convStrideW),
                            '--padding_h', str(self.paddingH),
                            '--padding_w', str(self.paddingW),
+                           '--groupsize', str(self.group),
                            '--kernel-repeats', str(self.MLIR_N_REPEATS),
                            f"--perf_config={self.perfConfig}"])
         result += ' '

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -314,6 +314,7 @@ class ConvConfiguration(PerfConfiguration):
     def computeTFlops(self, ns):
         # NaN will propagate as expected
         # Repeats are handled by the fact that we're using avarageNs
+        assert(self.k % self.group == 0)
         assert(self.c % self.group == 0)
         return (2.0 * self.n * (self.c//self.group) * self.k * self.ho * self.wo * self.y * self.x) / (float(ns) * 1e-9) / 1e12
 


### PR DESCRIPTION
rocmlir-gen --emit-tuning-key is returning the wrong problem key for group convs.

See the result of: 
```bash
bin/rocmlir-gen --operation conv -t f16 --arch gfx90a:sramecc+:xnack- --num_cu 104 --fil_layout gkc01 --in_layout ngc01 --out_layout ngk01 --batchsize 64 --in_channels 256 --in_h 20 --in_w 20 --out_channels 256 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 3 --padding_w 3 --groupsize 256 --kernel-repeats 1 --perf_config=v2:32,256,2,32,32,4,1,1,1 | bin/rocmlir-gen --emit-tuning-key -
```

is:
```
convfp16 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 64 -c 1 -H 20 -W 20 -k 1 -y 7 -x 7 -p 3 -q 3 -u 1 -v 1 -l 1 -j 1 -g 256
```

And c and k must be 256. So, we are tuning for the wrong convs.