### PR TITLE
[TOSA] Fix accType for the Quant Convolutions as well

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -356,8 +356,7 @@ LogicalResult ConvConverter<ConvType>::matchAndRewrite(
 
   // Determine the accumulation type based on the output type.
   Type accType;
-  if (isa<FloatType>(outElementTy) &&
-      outElementTy.getIntOrFloatBitWidth() >= 16) {
+  if (isa<FloatType>(elementTy) && elementTy.getIntOrFloatBitWidth() >= 16) {
     accType = rewriter.getF32Type();
     // accType is not used by rocMLIR when converting tosa to rock.
     // accType for Float8 type is required to be Float16 as per TOSA v1.0 spec
@@ -365,10 +364,10 @@ LogicalResult ConvConverter<ConvType>::matchAndRewrite(
     // lowering using rocMLIR. [Risk]: CPU may generate different results
     // compared to GPU if accType gets used on CPU lowering path. Currently it
     // seems none of the TosaToXYZ converter uses this attribute.
-  } else if (isa<FloatType>(outElementTy) &&
-             outElementTy.getIntOrFloatBitWidth() <= 8) {
+  } else if (isa<FloatType>(elementTy) &&
+             elementTy.getIntOrFloatBitWidth() <= 8) {
     accType = rewriter.getF16Type();
-  } else if (isa<IntegerType>(outElementTy)) {
+  } else if (isa<IntegerType>(elementTy)) {
     accType = rewriter.getI32Type();
   }
   // convolution config attributes

--- a/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa.mlir
@@ -199,3 +199,13 @@ func.func @conv2d_float8(%arg0: !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>, %
   %0 = migraphx.convolution %arg0, %arg1 {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : <1x16x4x4xf8E5M2, 256x16x4x1>, <16x16x1x1xf8E5M2, 16x1x1x1> -> <1x16x4x4xf8E5M2, 256x16x4x1>
   return %0 : !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>
 }
+
+// CHECK-LABEL: @quant_conv2d_float8
+// CHECK-SAME: (%{{.*}}: tensor<256xf8E5M2>, %{{.*}}: tensor<256xf8E5M2>) -> tensor<256xf32>
+func.func @quant_conv2d_float8(%arg0: !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>, %arg1: !migraphx.shaped<16x16x1x1xf8E5M2, 16x1x1x1>) -> !migraphx.shaped<1x16x4x4xf32, 256x16x4x1> {
+  // CHECK-COUNT-2: tosa.transpose
+  // CHECK: tosa.conv2d
+  // CHECK-SAME: {acc_type = f16, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x16xf8E5M2>, tensor<16x1x1x16xf8E5M2>, tensor<16xf32>) -> tensor<1x4x4x16xf32>
+  %0 = migraphx.quant_convolution %arg0, %arg1 {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : <1x16x4x4xf8E5M2, 256x16x4x1>, <16x16x1x1xf8E5M2, 16x1x1x1> -> <1x16x4x4xf32, 256x16x4x1>
+  return %0 : !migraphx.shaped<1x16x4x4xf32, 256x16x4x1>
+}


### PR DESCRIPTION
Use elementType instead of OutElemenTy to support QuantConvolution 