### PR TITLE
Add Fp8 to quick-tuning

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -159,6 +159,60 @@ const InitParamsAccel PopulateParamsXDL::initParametersFp16Conv[PopulateParamsXD
 };
 // END_CONV_XDL_f16_DEFS
 
+// BEGIN_GEMM_XDL_fp8_DEFS
+const InitParamsAccel PopulateParamsXDL::initParametersFp8Gemm[PopulateParamsXDL::nInitParametersFp8Gemm] = {
+    {128,128,8,32,16,16,1,true,true},
+    {128,256,4,32,16,16,1,true,true},
+    {128,64,8,32,32,16,1,true,true},
+    {32,32,16,16,16,16,1,true,true},
+    {128,256,4,64,32,16,1,true,true},
+    {64,128,4,32,32,16,1,true,true},
+    {32,32,32,16,16,16,1,true,true},
+    {64,128,4,32,16,16,1,true,true},
+    {64,64,8,32,32,8,1,true,true},
+    {32,64,16,32,16,16,1,true,true},
+    {256,128,4,128,64,16,1,true,true},
+    {64,16,32,16,16,16,1,true,true},
+    {64,64,16,32,32,16,1,true,true},
+    {64,16,16,16,16,16,1,true,true},
+    {64,128,4,16,16,8,1,true,true},
+    {128,32,16,32,16,16,1,true,true},
+    {16,16,8,16,16,16,1,true,true},
+    {64,32,32,32,16,16,1,true,true},
+    {16,16,32,16,16,8,1,true,true},
+    {32,16,4,16,16,16,1,true,true},
+    {16,256,8,16,16,16,1,true,true}
+};
+// END_GEMM_XDL_fp8_DEFS
+
+// BEGIN_CONV_XDL_fp8_DEFS
+const InitParamsAccel PopulateParamsXDL::initParametersForwardFp8Conv[PopulateParamsXDL::nInitParametersForwardFp8Conv] = {
+    {128,128,8,64,16,16,1,true,true},
+    {128,128,8,32,16,8,1,true,true},
+    {32,16,8,16,16,16,1,true,true},
+    {32,32,16,16,16,8,1,true,true},
+    {64,64,16,32,32,16,1,true,true},
+    {32,16,16,16,16,16,1,true,true},
+    {256,128,4,64,16,16,1,true,true},
+    {128,256,4,64,64,16,1,true,true},
+    {32,16,32,16,16,16,1,true,true},
+    {256,64,4,128,64,16,1,true,true},
+    {64,64,8,64,16,8,1,true,true},
+    {64,128,8,32,16,8,1,true,true},
+    {256,32,4,64,32,16,1,true,true},
+    {128,64,8,32,32,16,1,true,true},
+    {128,32,8,32,32,8,1,true,true},
+    {32,32,8,16,16,16,1,true,true},
+    {32,64,8,16,16,16,1,true,true},
+    {128,16,8,32,16,16,1,true,true},
+    {64,256,4,16,16,8,1,true,true},
+    {128,16,8,64,16,16,1,true,true},
+    {64,16,32,16,16,8,1,true,true},
+    {32,32,32,32,16,16,1,true,true},
+    {128,64,4,32,32,16,1,true,true}
+};
+// END_CONV_XDL_fp8_DEFS
+
 // BEGIN_GEMM_XDL_i8_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersI8Gemm[PopulateParamsXDL::nInitParametersI8Gemm] = {
     {64,128,16,64,16,4,1,true,true},
@@ -179,7 +233,7 @@ const InitParamsAccel PopulateParamsXDL::initParametersI8Gemm[PopulateParamsXDL:
 // END_GEMM_XDL_i8_DEFS
 
 // BEGIN_CONV_XDL_i8_DEFS
-const InitParamsAccel PopulateParamsXDL::initParametersForward8BitConv[PopulateParamsXDL::nInitParametersForward8BitConv] = {
+const InitParamsAccel PopulateParamsXDL::initParametersForwardI8Conv[PopulateParamsXDL::nInitParametersForwardI8Conv] = {
     {64,128,4,64,16,16,1,true,true},
     {128,128,4,128,16,16,1,true,true},
     {64,64,8,32,32,16,1,true,true},
@@ -222,14 +276,24 @@ static constexpr size_t nInitParametersFp16Conv = 29;
 static const InitParamsAccel initParametersFp16Conv[nInitParametersFp16Conv];
 // END_CONV_XDL_f16_DECS
 
+// BEGIN_GEMM_XDL_fp8_DECS
+static constexpr size_t nInitParametersFp8Gemm = 21;
+static const InitParamsAccel initParametersFp8Gemm[nInitParametersFp8Gemm];
+// END_GEMM_XDL_fp8_DECS
+
+// BEGIN_CONV_XDL_fp8_DECS
+static constexpr size_t nInitParametersForwardFp8Conv = 23;
+static const InitParamsAccel initParametersForwardFp8Conv[nInitParametersForwardFp8Conv];
+// END_CONV_XDL_fp8_DECS
+
 // BEGIN_GEMM_XDL_i8_DECS
 static constexpr size_t nInitParametersI8Gemm = 14;
 static const InitParamsAccel initParametersI8Gemm[nInitParametersI8Gemm];
 // END_GEMM_XDL_i8_DECS
 
 // BEGIN_CONV_XDL_i8_DECS
-static constexpr size_t nInitParametersForward8BitConv = 15;
-static const InitParamsAccel initParametersForward8BitConv[nInitParametersForward8BitConv];
+static constexpr size_t nInitParametersForwardI8Conv = 15;
+static const InitParamsAccel initParametersForwardI8Conv[nInitParametersForwardI8Conv];
 // END_CONV_XDL_i8_DECS
 
 #endif
@@ -289,6 +353,55 @@ const InitParamsAccel PopulateParamsWmma::initParametersFp16Conv[PopulateParamsW
 };
 // END_CONV_Wmma_f16_DEFS
 
+// BEGIN_GEMM_Wmma_fp8_DEFS
+const InitParamsAccel PopulateParamsWmma::initParametersFp8Gemm[PopulateParamsWmma::nInitParametersFp8Gemm] = {
+    {128,128,4,32,64,16,1,true,true},
+    {128,64,4,32,64,16,1,true,true},
+    {128,128,8,32,64,16,1,true,true},
+    {64,128,4,32,32,16,1,true,true},
+    {256,64,8,64,32,16,1,true,true},
+    {128,256,8,128,32,8,1,true,true},
+    {64,32,4,32,16,16,1,true,true},
+    {32,32,8,16,16,16,1,true,true},
+    {16,64,4,16,32,8,1,true,true},
+    {256,128,4,64,64,16,1,true,true},
+    {16,64,8,16,16,16,1,true,true},
+    {64,256,4,32,128,16,1,true,true},
+    {32,32,8,16,16,8,1,true,true},
+    {64,32,8,32,16,16,1,true,true},
+    {256,64,4,64,32,16,1,true,true},
+    {64,128,4,32,128,16,1,true,true},
+    {64,16,8,16,16,16,1,true,true},
+    {128,128,4,32,16,8,1,true,true}
+};
+// END_GEMM_Wmma_fp8_DEFS
+
+// BEGIN_CONV_Wmma_fp8_DEFS
+const InitParamsAccel PopulateParamsWmma::initParametersForwardFp8Conv[PopulateParamsWmma::nInitParametersForwardFp8Conv] = {
+    {128,64,8,64,32,16,1,true,true},
+    {128,128,4,32,64,16,1,true,true},
+    {128,128,8,32,64,8,1,true,true},
+    {64,128,8,32,64,16,1,true,true},
+    {256,64,8,64,32,16,1,true,true},
+    {64,128,8,64,32,16,1,true,true},
+    {256,128,8,64,32,16,1,true,true},
+    {256,64,4,64,32,16,1,true,true},
+    {128,64,8,32,32,16,1,true,true},
+    {128,32,8,32,32,16,1,true,true},
+    {128,16,8,32,16,16,1,true,true},
+    {128,128,2,64,32,16,1,true,true},
+    {64,32,8,32,16,16,1,true,true},
+    {64,128,8,64,32,8,1,true,true},
+    {256,64,4,32,64,8,1,true,true},
+    {64,32,8,16,16,16,1,true,true},
+    {64,16,8,16,16,16,1,true,true},
+    {32,64,4,16,32,16,1,true,true},
+    {32,64,2,32,32,8,1,true,true},
+    {16,32,4,16,32,16,1,true,true},
+    {16,64,8,16,64,16,1,true,true}
+};
+// END_CONV_Wmma_fp8_DEFS
+
 // BEGIN_GEMM_Wmma_i8_DEFS
 const InitParamsAccel PopulateParamsWmma::initParametersI8Gemm[PopulateParamsWmma::nInitParametersI8Gemm] = {
     {128,128,4,64,64,16,1,true,true},
@@ -310,7 +423,7 @@ const InitParamsAccel PopulateParamsWmma::initParametersI8Gemm[PopulateParamsWmm
 // END_GEMM_Wmma_i8_DEFS
 
 // BEGIN_CONV_Wmma_i8_DEFS
-const InitParamsAccel PopulateParamsWmma::initParametersForward8BitConv[PopulateParamsWmma::nInitParametersForward8BitConv] = {
+const InitParamsAccel PopulateParamsWmma::initParametersForwardI8Conv[PopulateParamsWmma::nInitParametersForwardI8Conv] = {
     {128,64,8,32,64,16,1,true,true},
     {256,64,8,32,64,16,1,true,true},
     {128,32,4,64,16,16,1,true,true},
@@ -339,14 +452,25 @@ static constexpr size_t nInitParametersFp16Conv = 26;
 static const InitParamsAccel initParametersFp16Conv[nInitParametersFp16Conv];
 // END_CONV_Wmma_f16_DECS
 
+// BEGIN_GEMM_Wmma_fp8_DECS
+static constexpr size_t nInitParametersFp8Gemm = 18;
+static const InitParamsAccel initParametersFp8Gemm[nInitParametersFp8Gemm];
+// END_GEMM_Wmma_fp8_DECS
+
+// BEGIN_CONV_Wmma_fp8_DECS
+static constexpr size_t nInitParametersForwardFp8Conv = 21;
+static const InitParamsAccel initParametersForwardFp8Conv[nInitParametersForwardFp8Conv];
+// END_CONV_Wmma_fp8_DECS
+
 // BEGIN_GEMM_Wmma_i8_DECS
 static constexpr size_t nInitParametersI8Gemm = 15;
 static const InitParamsAccel initParametersI8Gemm[nInitParametersI8Gemm];
 // END_GEMM_Wmma_i8_DECS
 
 // BEGIN_CONV_Wmma_i8_DECS
-static constexpr size_t nInitParametersForward8BitConv = 11;
-static const InitParamsAccel initParametersForward8BitConv[nInitParametersForward8BitConv];
+static constexpr size_t nInitParametersForwardI8Conv = 11;
+static const InitParamsAccel initParametersForwardI8Conv[nInitParametersForwardI8Conv];
 // END_CONV_Wmma_i8_DECS
 
 #endif
+

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -547,8 +547,9 @@ PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataTypeA,
   if (opType == KernelType::Gemm) {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      dataTypeA.isInteger() ?  params = {initParametersI8Gemm, nInitParametersI8Gemm} :
-        params = {initParametersFp8Gemm, nInitParametersFp8Gemm};
+      dataTypeA.isInteger()
+          ? params = {initParametersI8Gemm, nInitParametersI8Gemm}
+          : params = {initParametersFp8Gemm, nInitParametersFp8Gemm};
       break;
     case 16:
       params = {initParametersFp16Gemm, nInitParametersFp16Gemm};
@@ -559,8 +560,10 @@ PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataTypeA,
   } else {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      dataTypeA.isInteger() ? params = {initParametersForwardI8Conv, nInitParametersForwardI8Conv} :
-        params = {initParametersForwardFp8Conv, nInitParametersForwardFp8Conv};
+      dataTypeA.isInteger()
+          ? params = {initParametersForwardI8Conv, nInitParametersForwardI8Conv}
+          : params = {initParametersForwardFp8Conv,
+                      nInitParametersForwardFp8Conv};
       break;
     case 16:
       params = {initParametersFp16Conv, nInitParametersFp16Conv};
@@ -717,8 +720,9 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
   if (opType == KernelType::Gemm) {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      dataTypeA.isInteger() ?  params = {initParametersI8Gemm, nInitParametersI8Gemm} :
-        params = {initParametersFp8Gemm, nInitParametersFp8Gemm};
+      dataTypeA.isInteger()
+          ? params = {initParametersI8Gemm, nInitParametersI8Gemm}
+          : params = {initParametersFp8Gemm, nInitParametersFp8Gemm};
       break;
     case 16:
       params = {initParametersFp16Gemm, nInitParametersFp16Gemm};
@@ -729,8 +733,10 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
   } else {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      dataTypeA.isInteger() ? params = {initParametersForwardI8Conv, nInitParametersForwardI8Conv} :
-        params = {initParametersForwardFp8Conv, nInitParametersForwardFp8Conv};
+      dataTypeA.isInteger()
+          ? params = {initParametersForwardI8Conv, nInitParametersForwardI8Conv}
+          : params = {initParametersForwardFp8Conv,
+                      nInitParametersForwardFp8Conv};
       break;
     case 16:
       params = {initParametersFp16Conv, nInitParametersFp16Conv};

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -547,7 +547,8 @@ PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataTypeA,
   if (opType == KernelType::Gemm) {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      params = {initParametersI8Gemm, nInitParametersI8Gemm};
+      dataTypeA.isInteger() ?  params = {initParametersI8Gemm, nInitParametersI8Gemm} :
+        params = {initParametersFp8Gemm, nInitParametersFp8Gemm};
       break;
     case 16:
       params = {initParametersFp16Gemm, nInitParametersFp16Gemm};
@@ -558,7 +559,8 @@ PopulateParamsXDL::getTuningParameters(KernelType opType, Type dataTypeA,
   } else {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      params = {initParametersForward8BitConv, nInitParametersForward8BitConv};
+      dataTypeA.isInteger() ? params = {initParametersForwardI8Conv, nInitParametersForwardI8Conv} :
+        params = {initParametersForwardFp8Conv, nInitParametersForwardFp8Conv};
       break;
     case 16:
       params = {initParametersFp16Conv, nInitParametersFp16Conv};
@@ -715,7 +717,8 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
   if (opType == KernelType::Gemm) {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      params = {initParametersI8Gemm, nInitParametersI8Gemm};
+      dataTypeA.isInteger() ?  params = {initParametersI8Gemm, nInitParametersI8Gemm} :
+        params = {initParametersFp8Gemm, nInitParametersFp8Gemm};
       break;
     case 16:
       params = {initParametersFp16Gemm, nInitParametersFp16Gemm};
@@ -726,7 +729,8 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
   } else {
     switch (dataTypeA.getIntOrFloatBitWidth()) {
     case 8:
-      params = {initParametersForward8BitConv, nInitParametersForward8BitConv};
+      dataTypeA.isInteger() ? params = {initParametersForwardI8Conv, nInitParametersForwardI8Conv} :
+        params = {initParametersForwardFp8Conv, nInitParametersForwardFp8Conv};
       break;
     case 16:
       params = {initParametersFp16Conv, nInitParametersFp16Conv};

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -386,9 +386,9 @@ func.func @rock_gemm_from_i8_conv_gfx940(%a : memref<1x72x128xi8>, %b : memref<1
 func.func @rock_gemm_xdlops_fp8_bf8(%a : memref<1x72x128xf8E4M3FNUZ>, %b : memref<1x72x115200xf8E5M2FNUZ>, %c : memref<1x128x115200xf32>) {
   // CHECK: rock.gemm
   // CHECK-SAME: derivedBlockSize = 256
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 256, kpack = 16, mPerWave = 64, nPerWave = 64, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 128, kpack = 8, mPerWave = 16, nPerWave = 128, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 900
+  // GRID-SAME: gridSize = 1800
   rock.gemm %c = tr %a * %b features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx940",
     numCU = 120 : i32
@@ -402,9 +402,9 @@ func.func @rock_gemm_xdlops_fp8_bf8(%a : memref<1x72x128xf8E4M3FNUZ>, %b : memre
 func.func @rock_gemm_xdlops_fp8_bf8_ocp(%a : memref<1x72x128xf8E4M3FN>, %b : memref<1x72x115200xf8E5M2>, %c : memref<1x128x115200xf32>) {
   // CHECK: rock.gemm
   // CHECK-SAME: derivedBlockSize = 256
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 256, kpack = 16, mPerWave = 64, nPerWave = 64, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 128, kpack = 8, mPerWave = 16, nPerWave = 128, mnPerXdl = 16, splitKFactor = 1, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 900
+  // GRID-SAME: gridSize = 1800
   rock.gemm %c = tr %a * %b features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx950",
     numCU = 120 : i32

--- a/mlir/utils/performance/analysis/quickTuningGen.py
+++ b/mlir/utils/performance/analysis/quickTuningGen.py
@@ -7,7 +7,6 @@ import numpy as np
 import re
 import glob
 import pandas as pd
-from sklearn.preprocessing import MinMaxScaler
 from collections import defaultdict
 
 
@@ -83,8 +82,8 @@ class FileWriter():
         """
         instruction_types_to_datatypes = {
             "NonAccel": ["f32"],
-            "XDL": ["f32", "f16", "i8"],
-            "Wmma": ["f16", "i8"]
+            "XDL": ["f32", "f16", "fp8", "i8"],
+            "Wmma": ["f16", "fp8", "i8"]
         }
         markers = [
             "// BEGIN_GEMM",
@@ -128,9 +127,15 @@ class FileWriter():
         elif dtype == 'f16':
             init_params = f"initParametersFp16{op_cap}"
             n_init_params = f"nInitParametersFp16{op_cap}"
+        elif dtype == 'fp8' and op == 'conv':
+            init_params = f"initParametersForwardFp8{op_cap}"
+            n_init_params = f"nInitParametersForwardFp8{op_cap}"
+        elif dtype == 'fp8' and op == 'gemm':
+            init_params = f"initParametersFp8{op_cap}"
+            n_init_params = f"nInitParametersFp8{op_cap}"
         elif dtype == 'i8' and op == 'conv':
-            init_params = f"initParametersForward8Bit{op_cap}"
-            n_init_params = f"nInitParametersForward8Bit{op_cap}"
+            init_params = f"initParametersForwardI8{op_cap}"
+            n_init_params = f"nInitParametersForwardI8{op_cap}"
         elif dtype == 'i8' and op == 'gemm':
             init_params = f"initParametersI8{op_cap}"
             n_init_params = f"nInitParametersI8{op_cap}"
@@ -152,9 +157,15 @@ class FileWriter():
         elif dtype == 'f16':
             init_params = f"initParametersFp16{op_cap}"
             n_init_params = f"nInitParametersFp16{op_cap}"
+        elif dtype == 'fp8' and op == 'conv':
+            init_params = f"initParametersForwardFp8{op_cap}"
+            n_init_params = f"nInitParametersForwardFp8{op_cap}"
+        elif dtype == 'fp8' and op == 'gemm':
+            init_params = f"initParametersFp8{op_cap}"
+            n_init_params = f"nInitParametersFp8{op_cap}"
         elif dtype == 'i8' and op == 'conv':
-            init_params = f"initParametersForward8Bit{op_cap}"
-            n_init_params = f"nInitParametersForward8Bit{op_cap}"
+            init_params = f"initParametersForwardI8{op_cap}"
+            n_init_params = f"nInitParametersForwardI8{op_cap}"
         elif dtype == 'i8' and op == 'gemm':
             init_params = f"initParametersI8{op_cap}"
             n_init_params = f"nInitParametersI8{op_cap}"
@@ -176,6 +187,7 @@ class FileWriter():
         datatype_names_defs= {
             'f32': self.get_init_params_definitions(self.arch, 'f32', self.op),
             'f16': self.get_init_params_definitions(self.arch, 'f16', self.op),
+            'fp8': self.get_init_params_definitions(self.arch, 'fp8', self.op),
             'i8': self.get_init_params_definitions(self.arch, 'i8', self.op)
         }
 
@@ -201,7 +213,7 @@ class FileWriter():
         datatype_names_decs = {}
         datatype_n_decs = {}
 
-        for dtype in ['f32', 'f16', 'i8']:
+        for dtype in ['f32', 'f16', 'fp8', 'i8']:
             init_params_dec, n_params_dec = self.get_init_params_declaration(self.arch, dtype, self.op)
             datatype_names_decs[dtype] = init_params_dec
             datatype_n_decs[dtype] = n_params_dec
@@ -374,7 +386,7 @@ def print_results(result):
 def main(args=None):
     """
     usage: quickTunerGen.py [-h] --input-dir INPUT_DIR --op {gemm,conv} [--th TH] --arch ARCH [--update] [--no-splitK]
-    usage exsample: python3 quickTunerGen.py --input-dir tunedData --op conv --arch gfx90a --update --no-splitK
+    usage exsample: python3 quickTuningGen.py --input-dir tunedData --op conv --arch gfx90a --update --no-splitK
     """
     if args is None:
         args = sys.argv[1:]


### PR DESCRIPTION
This PR adds Fp8 perfconfigs to the quick tuning list and updates quickTuningGen.py to support Fp8.
Close: [#1675](https://github.com/ROCm/rocMLIR-internal/issues/1675)