### PR TITLE
Add lookup for more layouts in PerfRunner and Add an option for verifying each perfConfig with tuningRunner

### DIFF
--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -376,10 +376,10 @@ class ConvConfiguration(PerfConfiguration):
 
     MLIR_FILTER_LAYOUTS = {"NCHW": "kcyx", "NCHWG": "kcyxg", "NHWC": "kyxc", "NHWCG": "kyxcg",
                            "NC01": "kc01", "NC01G": "kc01g", "N01C": "k01c", "N01CG": "k01cg",
-                           "GNC01":"gkc01"}
+                           "GNC01":"gkc01", "GN01C":"gk01c"}
     MLIR_OUTPUT_LAYOUTS = {"NCHW": "nkhw", "NCHWG": "nkhwg", "NHWC": "nhwk", "NHWCG": "nhwkg",
                            "NC01": "nk01", "NC01G": "nk01g", "N01C": "n01k", "N01CG": "n01kg",
-                           "NGC01":"ngk01"}
+                           "NGC01":"ngk01", "N01GC": "n01gk"}
     filterLayoutMap = {'N':'k', 'C':'c', 'H':'0', 'W':'1', 'G':'g'}
     inputLayoutMap = {'N':'n', 'C':'c', 'H':'0', 'W':'1', 'G':'g'}
     outputLayoutMap = {'N':'n', 'C':'k', 'H':'0', 'W':'1', 'G':'g'}

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -119,7 +119,7 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
         theseTFlops = entry['TFlops']
         # verify that each perfConfig passes accuracy verification
         if options.verifyPerfConfigs:
-            if options.verifyMode == "None":
+            if options.verifyMode == "none":
                 print(f"Use of `--verify-perf-configs` should happen in conjuction with `--verify-mode`. Please pass `--verify-mode=cpu` or `--verify-mode=gpu` flag")
                 sys.exit()
             else:

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -116,7 +116,7 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
         entry = config.tableEntry(nanoSeconds)
         allData.append(entry)
         theseTFlops = entry['TFlops']
-        ## verify that each perfConfig passes accuracy verification
+        # verify that each perfConfig passes accuracy verification
         if options.verifyPerfConfigs:
             if options.verifyMode == "None":
                 print(f"Use of `--verify-perf-configs` should happen in conjuction with `--verify-mode`. Please pass `--verify-mode=cpu` or `--verify-mode=gpu` flag")

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -121,13 +121,13 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
         if options.verifyPerfConfigs:
             if options.verifyMode == "none":
                 print("Use of `--verify-perf-configs` should happen in conjuction with `--verify-mode`. Please pass `--verify-mode=cpu` or `--verify-mode=gpu` flag")
-                return None, None 
+                sys.exit(1) 
             else:
                 verifyNs = verifyKernelWithPerfConfig(perfConfig, config, paths, options)
                 if np.isnan(verifyNs):
                     # Verification failed, abort the loop
                     print(f"verification failed on : {testVector} : {perfConfig}", file=sys.stderr)
-                    return None, None
+                    sys.exit(1)
 
         if not np.isnan(theseTFlops) and theseTFlops > maxTFlops:
             maxTFlops = theseTFlops

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -134,7 +134,7 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
             minNs = nanoSeconds
             winningConfig = perfConfig
             if options.compact_print and not options.quiet:
-                conditional_print(options.compact_print and not options.quiet, f"Tested {i} configs, best perf {maxTFlops} TFlops {minNs} ns on perf_config {winningConfig}", file=sys.stderr)
+                print(f"Tested {i} configs, best perf {maxTFlops} TFlops {minNs} ns on perf_config {winningConfig}", file=sys.stderr)
 
     return winningConfig, maxTFlops
 

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -120,7 +120,7 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
         # verify that each perfConfig passes accuracy verification
         if options.verifyPerfConfigs:
             if options.verifyMode == "none":
-                print(f"Use of `--verify-perf-configs` should happen in conjuction with `--verify-mode`. Please pass `--verify-mode=cpu` or `--verify-mode=gpu` flag")
+                print("Use of `--verify-perf-configs` should happen in conjuction with `--verify-mode`. Please pass `--verify-mode=cpu` or `--verify-mode=gpu` flag")
                 return None, None 
             else:
                 verifyNs = verifyKernelWithPerfConfig(perfConfig, config, paths, options)

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -36,6 +36,7 @@ class Options:
     numCU: int
     rocmlir_gen_flags: str
     verifyMode: str
+    verifyPerfConfigs: bool
     tflops: bool
     compact_print: bool
 
@@ -94,7 +95,7 @@ Errors = {errs.decode('utf-8')}""", file=sys.stderr)
             os.chdir(prevdir)
     return nanoSeconds
 
-def getWinningConfig(tuningOutput, config, allData, options: Options):
+def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, options: Options):
     maxTFlops = -np.inf
     minNs = np.inf
     winningConfig = "None"
@@ -115,6 +116,14 @@ def getWinningConfig(tuningOutput, config, allData, options: Options):
         entry = config.tableEntry(nanoSeconds)
         allData.append(entry)
         theseTFlops = entry['TFlops']
+        ## verify that each perfConfig passes accuracy verification
+        if options.verifyMode != "none" and options.verifyPerfConfigs:
+            verifyNs = verifyKernelWithPerfConfig(perfConfig, config, paths, options)
+            if np.isnan(verifyNs):
+                # Verification failed, abort the loop
+                print(f"verification failed on : {testVector} : {perfConfig}", file=sys.stderr)
+                return None, None
+
         if not np.isnan(theseTFlops) and theseTFlops > maxTFlops:
             maxTFlops = theseTFlops
             minNs = nanoSeconds
@@ -159,7 +168,7 @@ def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         # Tune, printing progress as we go to avoid CI timeouts
-        winningConfig, maxTFlops = getWinningConfig(tuningLoop.stdout, config, allData, options)
+        winningConfig, maxTFlops = getWinningConfig(tuningLoop.stdout, testVector, config, allData, paths, options)
 
         if options.verifyMode != "none":
             verifyNs = verifyKernelWithPerfConfig(winningConfig, config, paths, options)
@@ -302,6 +311,11 @@ def main(args=None):
         choices=["none", "cpu", "gpu"],
         help="How to verify the winning tuned kernel")
 
+    parser.add_argument("--verify-perf-configs",
+        action='store_true',
+        default=False,
+        help="Compile and verify given problem with all applicable perf configs")
+
     parser.add_argument("--test_dir",
         default="../mlir/test/fusion/resnet50-e2e",
         type=str,
@@ -348,6 +362,7 @@ def main(args=None):
         tuningSpaceKind=parsed_args.tuning_space,
         rocmlir_gen_flags=rocmlir_gen_flags,
         verifyMode=parsed_args.verify_mode,
+        verifyPerfConfigs = parsed_args.verify_perf_configs,
         tflops=parsed_args.tflops,
         compact_print=parsed_args.compact_print)
 

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -309,7 +309,7 @@ def main(args=None):
     parser.add_argument("--verify-mode",
         default="gpu",
         choices=["none", "cpu", "gpu"],
-        help="How to verify the winning tuned kernel")
+        help="Flag to specify if verification of compiled kernel with selected PerfConfig should use CPU based implementation or GPU based implementation")
 
     parser.add_argument("--verify-perf-configs",
         action='store_true',

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -121,13 +121,13 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
         if options.verifyPerfConfigs:
             if options.verifyMode == "none":
                 print(f"Use of `--verify-perf-configs` should happen in conjuction with `--verify-mode`. Please pass `--verify-mode=cpu` or `--verify-mode=gpu` flag")
-                sys.exit()
+                return None, None 
             else:
                 verifyNs = verifyKernelWithPerfConfig(perfConfig, config, paths, options)
                 if np.isnan(verifyNs):
                     # Verification failed, abort the loop
                     print(f"verification failed on : {testVector} : {perfConfig}", file=sys.stderr)
-                return None, None
+                    return None, None
 
         if not np.isnan(theseTFlops) and theseTFlops > maxTFlops:
             maxTFlops = theseTFlops

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -117,11 +117,15 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
         allData.append(entry)
         theseTFlops = entry['TFlops']
         ## verify that each perfConfig passes accuracy verification
-        if options.verifyMode != "none" and options.verifyPerfConfigs:
-            verifyNs = verifyKernelWithPerfConfig(perfConfig, config, paths, options)
-            if np.isnan(verifyNs):
-                # Verification failed, abort the loop
-                print(f"verification failed on : {testVector} : {perfConfig}", file=sys.stderr)
+        if options.verifyPerfConfigs:
+            if options.verifyMode == "None":
+                print(f"Use of `--verify-perf-configs` should happen in conjuction with `--verify-mode`. Please pass `--verify-mode=cpu` or `--verify-mode=gpu` flag")
+                sys.exit()
+            else:
+                verifyNs = verifyKernelWithPerfConfig(perfConfig, config, paths, options)
+                if np.isnan(verifyNs):
+                    # Verification failed, abort the loop
+                    print(f"verification failed on : {testVector} : {perfConfig}", file=sys.stderr)
                 return None, None
 
         if not np.isnan(theseTFlops) and theseTFlops > maxTFlops:
@@ -314,7 +318,7 @@ def main(args=None):
     parser.add_argument("--verify-perf-configs",
         action='store_true',
         default=False,
-        help="Compile and verify given problem with all applicable perf configs")
+        help="Compile and verify given problem with all applicable perf configs. Whether it would use CPU or GPU based verification is controlled by `--verify-mode`. Should be used in conjunction with `--verify-mode`")
 
     parser.add_argument("--test_dir",
         default="../mlir/test/fusion/resnet50-e2e",

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -51,7 +51,8 @@ def verifyModeFlags(verifyMode: str) -> str:
 
 #Run a gemm or conv config and verify it
 def verifyKernelWithPerfConfig(perfConfig, config, paths: Paths, options: Options) -> float:
-    print(f"Verifying with perfConfig = {perfConfig}", file=sys.stderr)
+    if not options.compact_print:
+        print(f"Verifying with perfConfig = {perfConfig}", file=sys.stderr)
     config.setPerfConfig(perfConfig.strip())
     rocmlirGenCommand = paths.mlir_paths.rocmlir_gen_path + \
         verifyModeFlags(options.verifyMode) + \
@@ -133,7 +134,7 @@ def getWinningConfig(tuningOutput, testVector, config, allData, paths: Path, opt
             minNs = nanoSeconds
             winningConfig = perfConfig
             if options.compact_print and not options.quiet:
-                print(f"Tested {i} configs, best perf {maxTFlops} TFlops {minNs} ns on perf_config {winningConfig}", file=sys.stderr)
+                conditional_print(options.compact_print and not options.quiet, f"Tested {i} configs, best perf {maxTFlops} TFlops {minNs} ns on perf_config {winningConfig}", file=sys.stderr)
 
     return winningConfig, maxTFlops
 


### PR DESCRIPTION
Example : 


```
python3 ../mlir/utils/performance/tuningRunner.py --op conv --data-type f16 -c $(pwd)/configs.txt --verify-mode=cpu --verify-perf-configs
```

Prints following log : 

```
Tuning: convfp16 -F 1 -f GNC01 -I N01GC -O NGC01 -n 1 -c 128 -H 40 -W 40 -k 80 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1
Verifying with perfConfig = v2:16,16,4,16,16,4,1,1,1
Verifying with perfConfig = v2:16,16,4,16,16,8,1,1,1
Verifying with perfConfig = v2:16,16,8,16,16,4,1,1,1
Verifying with perfConfig = v2:16,16,8,16,16,8,1,1,1
Verifying with perfConfig = v2:16,32,4,16,16,4,1,1,1
Verifying with perfConfig = v2:16,32,4,16,16,8,1,1,1
Verifying with perfConfig = v2:16,32,8,16,16,4,1,1,1
Verifying with perfConfig = v2:16,32,8,16,16,8,1,1,1
Verifying with perfConfig = v2:16,64,4,16,16,4,1,1,1
Verifying with perfConfig = v2:16,64,4,16,16,4,3,1,1
Verifying with perfConfig = v2:16,64,4,16,16,4,4,1,1
Verifying with perfConfig = v2:16,64,4,16,16,8,1,1,1
Verifying with perfConfig = v2:16,64,4,16,16,8,3,1,1
Verifying with perfConfig = v2:16,64,4,16,16,8,4,1,1
.
.
.
.
.
.
.
Tested 400 configs, best perf 22.740750379527213 TFlops 4611.0 ns on perf_config v2:32,64,2,32,32,8,1,1,1,1

```