### PR TITLE
Fix dependency graph creation in RockPipeline and not generate loops with negative iterations

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -668,10 +668,11 @@ void RockPipeline::runOnOperation() {
         rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
     assert(isConstantIntValue(forOp.getStep(), 1) &&
            "Step size other one is not permitted in rock-pipeline");
-    if (!maybeNumIterations.has_value())
+    if (!maybeNumIterations.has_value()) {
       emitError(loc,
                 "Number of iterations are unknown while doing rock-pipeline\n");
-
+      return signalPassFailure();
+    }
     adjustInitiationInterval(maybeNumIterations.value(), numStages, ii);
 
     // Insert the barriers as new stages

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -102,11 +102,11 @@ AddressSpace getAddressSpace(MemrefTypedValue val) {
 MemoryAccessType getOperandAccessType(Operation *op, Value operand) {
   if (hasEffect<MemoryEffects::Write>(op, operand)) {
     return MemoryAccessType::WRITE;
-  } else if (hasEffect<MemoryEffects::Read>(op, operand)) {
-    return MemoryAccessType::READ;
-  } else {
-    return MemoryAccessType::UNKNOWN;
   }
+  if (hasEffect<MemoryEffects::Read>(op, operand)) {
+    return MemoryAccessType::READ;
+  }
+  return MemoryAccessType::UNKNOWN;
 }
 
 // Simple rewrite pass to remove the stages and backward barriers in the
@@ -253,11 +253,13 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
   // Create the dependency graph
   DagType dag = createDependencyGraph(stages, resources);
 
-  // Start building the schedules
-  //
-  // Since we accept the stages from the user, we don't need to do any
-  // analysis to determine what goes in each stage. We only have to group things
-  // in set of stages of length II.
+  // Definition of initiation interval (II)
+  // Initiation interval is defind by number of cycles in each iteration of a
+  // loop. Only one cycle is counted for parallel stages. Assume each stage
+  // executes in one cycle. Start building the schedules Since we accept the
+  // stages from the user, we don't need to do any analysis to determine what
+  // goes in each stage. We only have to group things in set of stages of length
+  // II.
   //  For instance, consider the following unpipelined schedule. The column `t`
   //  represents
   // the time slot, and the subsequent columns represents the iterations.
@@ -282,7 +284,7 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
   //  +===+=========+
   // In this case, we reduced the time slots to 3, and we have 2 set of stages
   // runnning in parallel. Please note that conflicts can only happen between S0
-  // and S3. If we increase II, we generate the following pipeline:
+  // and S3. If we decrease II, we generate the following pipeline:
   //  +t\i+=== 0 ===++=== 1 ===+
   //  + 0 +== S0  ==++== S2  ==+
   //  +===+=========++=========+
@@ -385,7 +387,7 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
 
     // Add the parallel stages
     for (auto stage : parallelStages) {
-      schedule.push_back({stage, stageIter[stage]});
+      schedule.emplace_back(stage, stageIter[stage]);
     }
   }
 }
@@ -393,15 +395,15 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
 // Prune a dependency graph taking into account multi-buffers. Since
 // multi-buffers are logically different for each iteration, if the dependency
 // on a multi-buffer spans multiple iteration then it can be pruned
-DagType pruneGraph(DagType dag) {
+DagType pruneGraph(const DagType& dag) {
   DagType prunedGraph;
   // Multibuffers have the logical property of being unique for each iteration
   // of the loop Hence, if we know we are dealing with a multi-buffer and the
   // dependency concerns two different iteration. In other words, if stageA
   // accesses LDS in iteration i and stageB accesses LDS in iteration j stageA
   // and stageB have no dependencies as long as i!=j
-  for (auto [sink, edges] : dag) {
-    for (auto [source, deps] : edges) {
+  for (auto [source, edges] : dag) {
+    for (auto [sink, deps] : edges) {
       DenseSet<std::pair<rock::GpuAllocOp, DependencyType>> newDeps;
       for (auto [alloc, type] : deps) {
         if (getAddressSpace(alloc) != gpu::AddressSpace::Workgroup)
@@ -409,7 +411,7 @@ DagType pruneGraph(DagType dag) {
         newDeps.insert({alloc, type});
       }
       if (!newDeps.empty())
-        prunedGraph[sink][source] = newDeps;
+        prunedGraph[source][sink] = newDeps;
     }
   }
   return prunedGraph;
@@ -461,7 +463,7 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
     timeSlot++;
   }
 
-  // Algorithm for barrier placment:
+  // Algorithm for barrier placement:
   // a. Add forward barriers to address the dependency in the basic block
   // b. Add backward barriers to account for loop carried dependency
   // c. Add empty stages to make the pipeline balanced, so that we can double up
@@ -577,6 +579,9 @@ void RockPipeline::runOnOperation() {
 
   // Always (try to) multi-buffer by one and store the new
   // allocs in a set
+  // multiBuffering is only happening on LDS Buffers as "multiBuffer" checks for
+  // "i8" dtype store multibuffers in "multiAllocs" store all buffers including
+  // private and global in "resources"
   llvm::SetVector<rock::GpuAllocOp> multiAllocs;
   llvm::SetVector<rock::GpuAllocOp> resources;
   for (auto alloc : singleAllocs) {
@@ -643,6 +648,8 @@ void RockPipeline::runOnOperation() {
 
     // Insert the barriers as new stages
     SmallVector<rock::StageOp> extendedStages;
+    // use "multiAllocs" to place LDS barriers, no need to explicitly place
+    // barriers for registers or globals
     placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages,
                   ii);
     auto maybeNumIterations =
@@ -657,6 +664,7 @@ void RockPipeline::runOnOperation() {
     }
 
     ScheduleType schedule;
+    // use all "resources" to generate dependency graph and generate schedule
     createSchedule(extendedStages, resources, ii, schedule, multiBufferFactors);
 
     RewritePatternSet patterns(&getContext());

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -710,8 +710,8 @@ void RockPipeline::runOnOperation() {
   {
     if (removeStages) {
       RewritePatternSet patterns(&getContext());
-      patterns.add<RemoveStagesRewritePattern, PushBarrierDownRewritePattern>(
-          &getContext());
+      patterns.add<RemoveStagesRewritePattern, PushBarrierDownRewritePattern,
+                   RemoveBackToBackBarriersRewritePattern>(&getContext());
       (void)applyPatternsGreedily(getOperation(), std::move(patterns));
     }
   }

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -469,8 +469,8 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
   // a. Add forward barriers to address the dependency in the basic block
   // b. Add backward barriers to account for loop carried dependency
   // c. Add empty stages to make the pipeline balanced, so that we can double up
-  //    the initiation interval and let the pipeline transformation automaticall
-  //    do the work for us
+  //    the initiation interval and let the pipeline transformation
+  //    automatically do the work for us
   DenseSet<rock::StageOp> forwardStages;
 
   // a. Place forward barriers
@@ -601,8 +601,7 @@ void RockPipeline::runOnOperation() {
 
   // Always (try to) multi-buffer by one and store the new
   // allocs in a set
-  // multiBuffering is only happening on LDS Buffers as "multiBuffer" checks for
-  // "i8" dtype. Store multibuffers in "multiAllocs" and store all buffers
+  // Store multibuffers in "multiAllocs" and store all buffers
   // including private and global in "resources"
   llvm::SetVector<rock::GpuAllocOp> multiAllocs;
   llvm::SetVector<rock::GpuAllocOp> resources;

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -396,7 +396,7 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
 // Prune a dependency graph taking into account multi-buffers. Since
 // multi-buffers are logically different for each iteration, if the dependency
 // on a multi-buffer spans multiple iteration then it can be pruned
-DagType pruneGraph(const DagType& dag) {
+DagType pruneGraph(const DagType &dag) {
   DagType prunedGraph;
   // Multibuffers have the logical property of being unique for each iteration
   // of the loop Hence, if we know we are dealing with a multi-buffer and the

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -255,13 +255,13 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
   DagType dag = createDependencyGraph(stages, resources);
 
   // Definition of initiation interval (II)
-  // Initiation interval is defind by number of cycles in each iteration of a
+  // Initiation interval is defined by number of cycles in each iteration of a
   // loop. Only one cycle is counted for parallel stages. Assume each stage
   // executes in one cycle.
-  // Start building the schedules. Since we accept the
-  // stages from the user, we don't need to do any analysis to determine what
-  // goes in each stage. We only have to group things in set of stages of length
-  // II.
+  // Start building the schedules. Since we accept the stages from the user, we
+  // don't need to do any analysis to determine what goes in each stage. Each
+  // `II` number of stages will execute in sequence. All groups of `II`
+  // stages execute in parallel.
   //  For instance, consider the following unpipelined schedule. The column `t`
   //  represents
   // the time slot, and the subsequent columns represents the iterations.
@@ -445,18 +445,13 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
                    ArrayRef<rock::StageOp> stages,
                    SetVector<rock::GpuAllocOp> &allocs,
                    SmallVector<rock::StageOp> &extendedStages,
-                   int64_t &initiationInterval) {
+                   int64_t &initiationInterval, int64_t numIterations) {
   DagType dag = createDependencyGraph(stages, allocs);
   dag = pruneGraph(dag);
 
-  auto maybeNumIterations =
-      rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
-
   // If there is a loop, we probably need a backward barrier, i.e.,
   // an LDS barrier that takes the loop dependency into account
-  const bool addBackwardBarrier =
-      (!maybeNumIterations.has_value() ||
-       (maybeNumIterations.has_value() && maybeNumIterations.value() > 1));
+  const bool addBackwardBarrier = numIterations > 1;
 
   DenseMap<rock::StageOp, int> timeSlotMap;
   int timeSlot = 0;
@@ -569,7 +564,7 @@ void adjustInitiationInterval(int64_t numIterations, size_t numStages,
   int64_t numPrologues = numParallelStages - 1;
   // if number of iterations are less than number of prologues that are going
   // to be emitted, it will not result in correct output therefore increase II
-  // untill that condition becomes false. This can help achieve maximum loop
+  // until that condition becomes false. This can help achieve maximum loop
   // pipelining
   while (numIterations < numPrologues) {
     ii++;
@@ -580,6 +575,8 @@ void adjustInitiationInterval(int64_t numIterations, size_t numStages,
   LLVM_DEBUG(DBGS() << "Number of parallel stages: " << numParallelStages
                     << "\n");
   LLVM_DEBUG(DBGS() << "Number of Prologues: " << numPrologues << "\n");
+  // num of prologues == number of epilogues
+  LLVM_DEBUG(DBGS() << "Number of Epilogues: " << numPrologues << "\n");
 }
 
 struct RockPipeline : public rock::impl::RockPipelinePassBase<RockPipeline> {
@@ -672,7 +669,8 @@ void RockPipeline::runOnOperation() {
     assert(isConstantIntValue(forOp.getStep(), 1) &&
            "Step size other one is not permitted in rock-pipeline");
     if (!maybeNumIterations.has_value())
-      continue;
+      emitError(loc,
+                "Number of iterations are unknown while doing rock-pipeline\n");
 
     adjustInitiationInterval(maybeNumIterations.value(), numStages, ii);
 
@@ -680,8 +678,8 @@ void RockPipeline::runOnOperation() {
     SmallVector<rock::StageOp> extendedStages;
     // use "multiAllocs" to place LDS barriers, no need to explicitly place
     // barriers for registers or globals
-    placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages,
-                  ii);
+    placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages, ii,
+                  maybeNumIterations.value());
 
     ScheduleType schedule;
     // use all "resources" to generate dependency graph and generate schedule

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -473,8 +473,8 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
   DenseSet<rock::StageOp> forwardStages;
 
   // a. Place forward barriers
-  for (auto [source, edges] : dag) {
-    for (auto [sink, deps] : edges) {
+  for (const auto &[source, edges] : dag) {
+    for (const auto &[sink, deps] : edges) {
       if (!forwardStages.contains(sink)) {
         forwardStages.insert(sink);
       }

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -368,7 +368,7 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
 
     // Whatever resource is shared, we need to select among multiple buffers.
     for (size_t i = 0; i < parallelStages.size(); i++) {
-      // The only resource that can conflict btween different stages is memory
+      // The only resource that can conflict between different stages is memory
       // If there are memory conflicts we can sort them via multibuffers. I.e.,
       // we can (logically) provide a different buffer for different cycles
       for (size_t j = i + 1; j < parallelStages.size(); j++) {

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -578,10 +578,15 @@ void RockPipeline::runOnOperation() {
   // Always (try to) multi-buffer by one and store the new
   // allocs in a set
   llvm::SetVector<rock::GpuAllocOp> multiAllocs;
+  llvm::SetVector<rock::GpuAllocOp> resources;
   for (auto alloc : singleAllocs) {
     SmallVector<rock::GpuAllocOp> newAllocs;
-    if (succeeded(rock::multiBuffer(rewriter, alloc, newAllocs, 1, true)))
+    if (succeeded(rock::multiBuffer(rewriter, alloc, newAllocs, 1, true))) {
       multiAllocs.insert(newAllocs.back());
+      resources.insert(newAllocs.back());
+    } else {
+      resources.insert(alloc);
+    }
   }
 
   // Collect the global resources (i.e., the memory allocations)
@@ -640,10 +645,19 @@ void RockPipeline::runOnOperation() {
     SmallVector<rock::StageOp> extendedStages;
     placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages,
                   ii);
+    auto maybeNumIterations =
+        rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
+    if (!maybeNumIterations.has_value()) {
+      continue;
+    }
+    // if number of iterations are less than numStages, skip doing loop
+    // pipelining
+    if (size_t(maybeNumIterations.value()) < stages.size()) {
+      continue;
+    }
 
     ScheduleType schedule;
-    createSchedule(extendedStages, multiAllocs, ii, schedule,
-                   multiBufferFactors);
+    createSchedule(extendedStages, resources, ii, schedule, multiBufferFactors);
 
     RewritePatternSet patterns(&getContext());
     mlir::scf::PipeliningOption options;

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -257,7 +257,8 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
   // Definition of initiation interval (II)
   // Initiation interval is defind by number of cycles in each iteration of a
   // loop. Only one cycle is counted for parallel stages. Assume each stage
-  // executes in one cycle. Start building the schedules Since we accept the
+  // executes in one cycle.
+  // Start building the schedules. Since we accept the
   // stages from the user, we don't need to do any analysis to determine what
   // goes in each stage. We only have to group things in set of stages of length
   // II.
@@ -601,8 +602,8 @@ void RockPipeline::runOnOperation() {
   // Always (try to) multi-buffer by one and store the new
   // allocs in a set
   // multiBuffering is only happening on LDS Buffers as "multiBuffer" checks for
-  // "i8" dtype store multibuffers in "multiAllocs" store all buffers including
-  // private and global in "resources"
+  // "i8" dtype. Store multibuffers in "multiAllocs" and store all buffers
+  // including private and global in "resources"
   llvm::SetVector<rock::GpuAllocOp> multiAllocs;
   llvm::SetVector<rock::GpuAllocOp> resources;
   for (auto alloc : singleAllocs) {
@@ -671,9 +672,9 @@ void RockPipeline::runOnOperation() {
         rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
     assert(isConstantIntValue(forOp.getStep(), 1) &&
            "Step size other one is not permitted in rock-pipeline");
-    if (!maybeNumIterations.has_value()) {
+    if (!maybeNumIterations.has_value())
       continue;
-    }
+
     adjustInitiationInterval(maybeNumIterations.value(), numStages, ii);
 
     // Insert the barriers as new stages

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -589,7 +589,6 @@ void RockPipeline::runOnOperation() {
   // - Registers
   // - LDS
   DenseMap<rock::GpuAllocOp, int> multiBufferFactors;
-  llvm::MapVector<scf::ForOp, ScheduleType> scheduleMap;
   for (auto res : multiAllocs)
     multiBufferFactors[res] = 1;
 
@@ -632,7 +631,7 @@ void RockPipeline::runOnOperation() {
     });
 
     if (stages.empty())
-      WalkResult::advance();
+      continue;
 
     LLVM_DEBUG(DBGS() << "Number of stages: " << stages.size() << "\n");
     LLVM_DEBUG(DBGS() << "Initiation Interval: " << ii << "\n");

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -646,13 +646,13 @@ void RockPipeline::runOnOperation() {
 
     LLVM_DEBUG(DBGS() << "Number of stages: " << stages.size() << "\n");
     LLVM_DEBUG(DBGS() << "Initiation Interval: " << ii << "\n");
-
-    // Insert the barriers as new stages
-    SmallVector<rock::StageOp> extendedStages;
-    // use "multiAllocs" to place LDS barriers, no need to explicitly place
-    // barriers for registers or globals
-    placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages,
-                  ii);
+    size_t numStages = stages.size();
+    size_t numParallelStages = llvm::divideCeil(numStages, ii);
+    // calculate number of prologue executions
+    size_t numPrologues = numParallelStages - 1;
+    LLVM_DEBUG(DBGS() << "Number of parallel stages: " << numParallelStages
+                      << "\n");
+    LLVM_DEBUG(DBGS() << "Number of Prologues: " << numPrologues << "\n");
     auto maybeNumIterations =
         rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
     assert(isConstantIntValue(forOp.getStep(), 1) &&
@@ -660,19 +660,20 @@ void RockPipeline::runOnOperation() {
     if (!maybeNumIterations.has_value()) {
       continue;
     }
-    size_t numParallelStages = llvm::divideCeil(extendedStages.size(), ii);
-    // calculate number of prologue executions
-    size_t numPrologues = numParallelStages - 1;
-    LLVM_DEBUG(DBGS() << "Number of parallel stages: " << numParallelStages
-                      << "\n");
-    LLVM_DEBUG(DBGS() << "Number of Prologues: " << numPrologues << "\n");
-
     // if number of iterations are less than number of prologues that are going
-    // to be emitted, it will not result in correct output therefore abort
-    // pipelining in such cases.
+    // to be emitted, it will not result in correct output therefore do not do
+    // any loop pipelining this is achieved by setting II=numStages as we still
+    // want to correctly place forward and backward barriers
     if (size_t(maybeNumIterations.value()) < numPrologues) {
-      continue;
+      ii = numStages;
     }
+
+    // Insert the barriers as new stages
+    SmallVector<rock::StageOp> extendedStages;
+    // use "multiAllocs" to place LDS barriers, no need to explicitly place
+    // barriers for registers or globals
+    placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages,
+                  ii);
 
     ScheduleType schedule;
     // use all "resources" to generate dependency graph and generate schedule

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -561,6 +561,26 @@ SmallVector<scf::ForOp> collectLoopLevels(mlir::func::FuncOp func) {
   return loops;
 }
 
+void adjustInitiationInterval(int64_t numIterations, size_t numStages,
+                              int64_t &ii) {
+  int64_t numParallelStages = llvm::divideCeil(numStages, ii);
+  // calculate number of prologue executions
+  int64_t numPrologues = numParallelStages - 1;
+  // if number of iterations are less than number of prologues that are going
+  // to be emitted, it will not result in correct output therefore increase II
+  // untill that condition becomes false. This can help achieve maximum loop
+  // pipelining
+  while (numIterations < numPrologues) {
+    ii++;
+    LLVM_DEBUG(DBGS() << "Adjusted II to  " << ii << "\n");
+    numParallelStages = llvm::divideCeil(numStages, ii);
+    numPrologues = numParallelStages - 1;
+  }
+  LLVM_DEBUG(DBGS() << "Number of parallel stages: " << numParallelStages
+                    << "\n");
+  LLVM_DEBUG(DBGS() << "Number of Prologues: " << numPrologues << "\n");
+}
+
 struct RockPipeline : public rock::impl::RockPipelinePassBase<RockPipeline> {
   using rock::impl::RockPipelinePassBase<RockPipeline>::RockPipelinePassBase;
   void runOnOperation() override;
@@ -647,12 +667,6 @@ void RockPipeline::runOnOperation() {
     LLVM_DEBUG(DBGS() << "Number of stages: " << stages.size() << "\n");
     LLVM_DEBUG(DBGS() << "Initiation Interval: " << ii << "\n");
     size_t numStages = stages.size();
-    size_t numParallelStages = llvm::divideCeil(numStages, ii);
-    // calculate number of prologue executions
-    size_t numPrologues = numParallelStages - 1;
-    LLVM_DEBUG(DBGS() << "Number of parallel stages: " << numParallelStages
-                      << "\n");
-    LLVM_DEBUG(DBGS() << "Number of Prologues: " << numPrologues << "\n");
     auto maybeNumIterations =
         rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
     assert(isConstantIntValue(forOp.getStep(), 1) &&
@@ -660,13 +674,7 @@ void RockPipeline::runOnOperation() {
     if (!maybeNumIterations.has_value()) {
       continue;
     }
-    // if number of iterations are less than number of prologues that are going
-    // to be emitted, it will not result in correct output therefore do not do
-    // any loop pipelining this is achieved by setting II=numStages as we still
-    // want to correctly place forward and backward barriers
-    if (size_t(maybeNumIterations.value()) < numPrologues) {
-      ii = numStages;
-    }
+    adjustInitiationInterval(maybeNumIterations.value(), numStages, ii);
 
     // Insert the barriers as new stages
     SmallVector<rock::StageOp> extendedStages;

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -26,11 +26,14 @@
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/ADT/DynamicAPInt.h"
 #include "llvm/ADT/SetOperations.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <map>
@@ -654,12 +657,22 @@ void RockPipeline::runOnOperation() {
                   ii);
     auto maybeNumIterations =
         rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
+    assert(isConstantIntValue(forOp.getStep(), 1) &&
+           "Step size other one is not permitted in rock-pipeline");
     if (!maybeNumIterations.has_value()) {
       continue;
     }
-    // if number of iterations are less than numStages, skip doing loop
-    // pipelining
-    if (size_t(maybeNumIterations.value()) < stages.size()) {
+    size_t numParallelStages = llvm::divideCeil(extendedStages.size(), ii);
+    // calculate number of prologue executions
+    size_t numPrologues = numParallelStages - 1;
+    LLVM_DEBUG(DBGS() << "Number of parallel stages: " << numParallelStages
+                      << "\n");
+    LLVM_DEBUG(DBGS() << "Number of Prologues: " << numPrologues << "\n");
+
+    // if number of iterations are less than number of prologues that are going
+    // to be emitted, it will not result in correct output therefore abort
+    // pipelining in such cases.
+    if (size_t(maybeNumIterations.value()) < numPrologues) {
       continue;
     }
 

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -26,12 +26,10 @@
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Patterns.h"
-#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
-#include "llvm/ADT/DynamicAPInt.h"
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/Support/MathExtras.h"
 

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -462,7 +462,7 @@ func.func @rock_pipeline_4_stages_ii_1_f16(%input : memref<16xf16, #gpu.address_
     return
 }
 
-// This test shouldn't pipeline the loop but it should add barriers and multibuffer by factor 1
+// This test should adjust II to 2 to enable loop pipelining
 // CHECK-LABEL: rock_pipeline_4_stages_ii_1_f16_less_iterations
 func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index
@@ -476,6 +476,8 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
 
     %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[C0:.*]] = arith.constant 0 : index
+    // CHECK: %[[C1:.*]] = arith.constant 1 : index
     // CHECK: %[[rawLds:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
     // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
     // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
@@ -485,6 +487,7 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     // CHECK: name = "__bwd_barrier__"
     // CHECK: name = "S1"
     // CHECK: scf.for
+    // CHECK-SAME: %[[C0]] to %[[C1]]
       // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "S0"
       // CHECK: rock.extract_multibuffer(%[[ldsView]])
@@ -497,6 +500,88 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     // CHECK: name = "S2"
     // CHECK: name = "S3"
     scf.for %arg3 = %c0 to %c2_0 step %c1 {
+      rock.stage {
+        %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+        memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S0"}
+      rock.stage {
+        %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        rock.yield
+      }{name="S1"}
+      rock.stage {
+        %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        %comp = arith.addf %tmp, %c2 : f16
+        memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S2"}
+      rock.stage {
+        %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        %comp = arith.addf %tmp, %c2 : f16
+        memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S3"}
+    }{pipeline = #rock.pipeline<1>}
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// This test should adjust II to 2 to enable loop pipelining
+// CHECK-LABEL: rock_pipeline_4_stages_ii_1_f16_less_iterations_2
+func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations_2(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+    // CHECK: name = "S0" 
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S2"
+    // CHECK: scf.for 
+    // CHECK-SAME: %[[c0]] to %[[c0]]
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S1"
+    // CHECK: name = "S3"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S3"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S2"
+    // CHECK: name = "S3" 
+    scf.for %arg3 = %c0 to %c3 step %c1 {
       rock.stage {
         %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
         memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -276,6 +276,7 @@ func.func @rock_pipeline_no_stages_ii_1(%input : memref<16xi8, #gpu.address_spac
     memref.store %out, %output[%c0] : memref<16xi8, #gpu.address_space<global>>
     return
 }
+
 // CHECK-LABEL: rock_pipeline_4_stages_ii_2
 func.func @rock_pipeline_4_stages_ii_2(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -1,6 +1,5 @@
 // RUN: rocmlir-opt %s --rock-pipeline="rock-pipeline-remove-stages=false" | FileCheck %s
 
-
 // CHECK-LABEL: rock_pipeline_3_stages_ii_1
 func.func @rock_pipeline_3_stages_ii_1(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index
@@ -295,16 +294,18 @@ func.func @rock_pipeline_4_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     // CHECK: %[[lds0View:.*]] = memref.view %[[rawLds0]]
     // CHECK: %[[lds1View:.*]] = memref.view %[[rawLds1]]
     // CHECK: memref.view %[[rawReg]]
-
+    // CHECK: name = "__bwd_barrier__"
     // CHECK: name = "S0"
     // CHECK: name = "__fwd_barrier__"
     // CHECK: name = "S1"
     // CHECK: scf.for
+      // CHECK: name = "__bwd_barrier__"
       // CHECK: name = "__fwd_barrier__"
       // CHECK:  rock.extract_multibuffer(%[[lds0View]], %[[lds1View]])
       // CHECK: name = "S0"
       // CHECK:  rock.extract_multibuffer(%[[lds0View]], %[[lds1View]])
       // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "S1"
       // CHECK:  rock.extract_multibuffer(%[[lds0View]], %[[lds1View]])

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -125,6 +125,61 @@ func.func @rock_pipeline_3_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     return
 }
 
+// this test shouldn't pipeline loop but it would should add barriers and multibuffer by 1
+// CHECK-LABEL: rock_pipeline_3_stages_ii_2_less_iterations
+func.func @rock_pipeline_3_stages_ii_2_less_iterations(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : i8
+    %c1_0 = arith.constant 1 : index
+
+    %rawLds  = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
+    %rawRegA = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    %rawRegB = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<16xi8, #gpu.address_space<workgroup>> to memref<16xi8, #gpu.address_space<workgroup>>
+    %regA = memref.view %rawRegA[%c0][] : memref<16xi8, #gpu.address_space<private>> to memref<16xi8, #gpu.address_space<private>>
+    %regB = memref.view %rawRegB[%c0][] : memref<16xi8, #gpu.address_space<private>> to memref<16xi8, #gpu.address_space<private>>
+
+    // CHECK: %[[rawLds:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawRegA:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[rawRegB:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[ldsView:.*]] = memref.view %[[rawLds]]
+    // CHECK: %[[regAView:.*]] = memref.view %[[rawRegA]]
+    // CHECK: %[[regBView:.*]] = memref.view %[[rawRegB]]
+    // scf.for 
+    // CHECK: rock.extract_multibuffer(%[[regAView]])
+    // CHECK: name = "S0"
+    // CHECK: rock.extract_multibuffer(%[[regAView]])
+    // CHECK: rock.extract_multibuffer(%[[ldsView]])
+    // CHECK: name = "S1"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: rock.extract_multibuffer(%[[ldsView]])
+    // CHECK: name = "S2"
+    scf.for %arg3 = %c0 to %c1_0 step %c1 {
+      rock.stage {
+        %a = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>
+        memref.store %a, %regA[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        rock.yield
+      }{name="S0"}
+      rock.stage {
+        %a = memref.load %regA[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        memref.store %a, %lds[%arg3] : memref<16xi8, #gpu.address_space<workgroup>>
+        rock.yield
+      }{name="S1"}
+      rock.stage {
+        %a = memref.load %lds[%arg3] : memref<16xi8, #gpu.address_space<workgroup>>
+        %b = arith.addi %a, %c2 : i8
+        memref.store %b, %regB[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        rock.yield
+      }{name="S2"}
+    }{pipeline = #rock.pipeline<2>}
+
+    %out = memref.load %regB[%c0] : memref<16xi8, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xi8, #gpu.address_space<global>>
+    return
+}
+
 // CHECK-LABEL: rock_pipeline_3_stages_ii_3
 func.func @rock_pipeline_3_stages_ii_3(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index
@@ -247,8 +302,8 @@ func.func @rock_pipeline_4_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     return
 }
 
-// CHECK-LABEL: rock_pipeline_4_stages_ii_1
-func.func @rock_pipeline_4_stages_ii_1(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
+// CHECK-LABEL: rock_pipeline_4_stages_ii_1_i8
+func.func @rock_pipeline_4_stages_ii_1_i8(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : i8

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -340,26 +340,20 @@ func.func @rock_pipeline_4_stages_ii_1_f16(%input : memref<16xf16, #gpu.address_
     %c16 = arith.constant 16 : index
 
     %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
-    %rawReg0 = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
-    %rawReg1 = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
-    %rawReg2 = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
 
     %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
-    %reg0 = memref.view %rawReg0[%c0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
-    %reg1 = memref.view %rawReg1[%c0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
-    %reg2 = memref.view %rawReg2[%c0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
     // CHECK: %[[rawLds0:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
     // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
-    // CHECK: %[[rawReg0:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
-    // CHECK: %[[rawReg1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
-    // CHECK: %[[rawReg2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
     // CHECK: %[[ldsView0:.*]] = memref.view %[[rawLds0]]
     // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
-    // CHECK: %[[regView0:.*]] = memref.view %[[rawReg0]]
-    // CHECK: %[[regView1:.*]] = memref.view %[[rawReg1]]
-    // CHECK: %[[regView2:.*]] = memref.view %[[rawReg2]]
-
-    // Please note how we swap S0/S1 and S2/S3 to avoid private multi-buffers
+    
+    // No multibuffering on Private buffers
     // CHECK: name = "S0"
     // CHECK: name = "S1"
     // CHECK: name = "S0"
@@ -369,15 +363,11 @@ func.func @rock_pipeline_4_stages_ii_1_f16(%input : memref<16xf16, #gpu.address_
     // CHECK: name = "S2"
     // CHECK: scf.for
       // CHECK: name = "__fwd_barrier__"
-      // CHECK: rock.extract_multibuffer(%[[regView0]])
       // CHECK: rock.extract_multibuffer(%[[ldsView0]], %[[ldsView1]])
       // CHECK: name = "S1"
-      // CHECK: rock.extract_multibuffer(%[[regView0]])
       // CHECK: name = "S0"
-      // CHECK: rock.extract_multibuffer(%[[regView1]])
       // CHECK: name = "S3"
       // CHECK: rock.extract_multibuffer(%[[ldsView0]], %[[ldsView1]])
-      // CHECK: rock.extract_multibuffer(%[[regView1]])
       // CHECK: name = "S2"
     // CHECK: name = "__fwd_barrier__"
     // CHECK: name = "S1"

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -92,15 +92,15 @@ func.func @rock_pipeline_3_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     // CHECK: scf.for
       // CHECK: name = "__fwd_barrier__"
       // CHECK: rock.extract_multibuffer(%[[regAView]])
-      // CHECK name = "S0"
+      // CHECK: name = "S0"
       // CHECK: rock.extract_multibuffer(%[[ldsView]])
-      // CHECK name = "S2"
+      // CHECK: name = "S2"
       // CHECK: name = "__bwd_barrier__"
       // CHECK: rock.extract_multibuffer(%[[regAView]])
       // CHECK: rock.extract_multibuffer(%[[ldsView]])
       // CHECK: name = "S1"
     // CHECK: name = "__fwd_barrier__"
-    // CHECK name = "S2"
+    // CHECK: name = "S2"
     scf.for %arg3 = %c0 to %c16 step %c1 {
       rock.stage {
         %a = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>
@@ -147,7 +147,6 @@ func.func @rock_pipeline_3_stages_ii_2_less_iterations(%input : memref<16xi8, #g
     // CHECK: %[[ldsView:.*]] = memref.view %[[rawLds]]
     // CHECK: %[[regAView:.*]] = memref.view %[[rawRegA]]
     // CHECK: %[[regBView:.*]] = memref.view %[[rawRegB]]
-    // scf.for 
     // CHECK: rock.extract_multibuffer(%[[regAView]])
     // CHECK: name = "S0"
     // CHECK: rock.extract_multibuffer(%[[regAView]])
@@ -300,20 +299,20 @@ func.func @rock_pipeline_4_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     // CHECK: name = "S0"
     // CHECK: name = "__fwd_barrier__"
     // CHECK: name = "S1"
-    // CHECK scf.for
+    // CHECK: scf.for
       // CHECK: name = "__fwd_barrier__"
       // CHECK:  rock.extract_multibuffer(%[[lds0View]], %[[lds1View]])
       // CHECK: name = "S0"
       // CHECK:  rock.extract_multibuffer(%[[lds0View]], %[[lds1View]])
       // CHECK: name = "S2"
       // CHECK: name = "__fwd_barrier__"
-      // CHECK name = "S1"
+      // CHECK: name = "S1"
       // CHECK:  rock.extract_multibuffer(%[[lds0View]], %[[lds1View]])
-      // CHECK name = "S3"
+      // CHECK: name = "S3"
     // CHECK: name = "__fwd_barrier__"
-    // CHECK name = "S2"
+    // CHECK: name = "S2"
     // CHECK: name = "__fwd_barrier__"
-    // CHECK name = "S3"
+    // CHECK: name = "S3"
     scf.for %arg3 = %c0 to %c16 step %c1 {
       rock.stage {
         %tmp = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -246,3 +246,173 @@ func.func @rock_pipeline_4_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     memref.store %out, %output[%c0] : memref<16xi8, #gpu.address_space<global>>
     return
 }
+
+// CHECK-LABEL: rock_pipeline_4_stages_ii_1
+func.func @rock_pipeline_4_stages_ii_1(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : i8
+    %c16 = arith.constant 16 : index
+
+    %rawLds  = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
+    %rawReg0 = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    %rawReg1 = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    %rawReg2 = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<16xi8, #gpu.address_space<workgroup>> to memref<16xi8, #gpu.address_space<workgroup>>
+    %reg0 = memref.view %rawReg0[%c0][] : memref<16xi8, #gpu.address_space<private>> to memref<16xi8, #gpu.address_space<private>>
+    %reg1 = memref.view %rawReg1[%c0][] : memref<16xi8, #gpu.address_space<private>> to memref<16xi8, #gpu.address_space<private>>
+    %reg2 = memref.view %rawReg2[%c0][] : memref<16xi8, #gpu.address_space<private>> to memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[rawLds0:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawReg0:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[rawReg1:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[rawReg2:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[ldsView0:.*]] = memref.view %[[rawLds0]]
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[regView0:.*]] = memref.view %[[rawReg0]]
+    // CHECK: %[[regView1:.*]] = memref.view %[[rawReg1]]
+    // CHECK: %[[regView2:.*]] = memref.view %[[rawReg2]]
+
+    // Please note how we swap S0/S1 and S2/S3 to avoid private multi-buffers
+    // CHECK: name = "S0"
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: name = "S2"
+    // CHECK: scf.for
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[regView0]])
+      // CHECK: rock.extract_multibuffer(%[[ldsView0]], %[[ldsView1]])
+      // CHECK: name = "S1"
+      // CHECK: rock.extract_multibuffer(%[[regView0]])
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[regView1]])
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView0]], %[[ldsView1]])
+      // CHECK: rock.extract_multibuffer(%[[regView1]])
+      // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S1"
+    // CHECK: name = "S3"
+    // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S3"
+    // CHECK: name = "S2"
+    // CHECK: name = "S3"
+    scf.for %arg3 = %c0 to %c16 step %c1 {
+      rock.stage {
+        %tmp = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>
+        memref.store %tmp, %reg0[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        rock.yield
+      }{name="S0"}
+      rock.stage {
+        %tmp = memref.load %reg0[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        memref.store %tmp, %lds[%arg3] : memref<16xi8, #gpu.address_space<workgroup>>
+        rock.yield
+      }{name="S1"}
+      rock.stage {
+        %tmp = memref.load %lds[%arg3] : memref<16xi8, #gpu.address_space<workgroup>>
+        %comp = arith.addi %tmp, %c2 : i8
+        memref.store %tmp, %reg1[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        rock.yield
+      }{name="S2"}
+      rock.stage {
+        %tmp = memref.load %reg1[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        %comp = arith.addi %tmp, %c2 : i8
+        memref.store %comp, %reg2[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        rock.yield
+      }{name="S3"}
+    }{pipeline = #rock.pipeline<1>}
+
+    %out = memref.load %reg2[%c0] : memref<16xi8, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xi8, #gpu.address_space<global>>
+    return
+}
+
+// CHECK-LABEL: rock_pipeline_4_stages_ii_1_f16
+func.func @rock_pipeline_4_stages_ii_1_f16(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c16 = arith.constant 16 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawReg0 = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    %rawReg1 = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    %rawReg2 = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %reg0 = memref.view %rawReg0[%c0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
+    %reg1 = memref.view %rawReg1[%c0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
+    %reg2 = memref.view %rawReg2[%c0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[rawLds0:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawReg0:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    // CHECK: %[[rawReg1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    // CHECK: %[[rawReg2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    // CHECK: %[[ldsView0:.*]] = memref.view %[[rawLds0]]
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[regView0:.*]] = memref.view %[[rawReg0]]
+    // CHECK: %[[regView1:.*]] = memref.view %[[rawReg1]]
+    // CHECK: %[[regView2:.*]] = memref.view %[[rawReg2]]
+
+    // Please note how we swap S0/S1 and S2/S3 to avoid private multi-buffers
+    // CHECK: name = "S0"
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: name = "S2"
+    // CHECK: scf.for
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[regView0]])
+      // CHECK: rock.extract_multibuffer(%[[ldsView0]], %[[ldsView1]])
+      // CHECK: name = "S1"
+      // CHECK: rock.extract_multibuffer(%[[regView0]])
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[regView1]])
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView0]], %[[ldsView1]])
+      // CHECK: rock.extract_multibuffer(%[[regView1]])
+      // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S1"
+    // CHECK: name = "S3"
+    // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S3"
+    // CHECK: name = "S2"
+    // CHECK: name = "S3"
+    scf.for %arg3 = %c0 to %c16 step %c1 {
+      rock.stage {
+        %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+        memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S0"}
+      rock.stage {
+        %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        rock.yield
+      }{name="S1"}
+      rock.stage {
+        %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        %comp = arith.addf %tmp, %c2 : f16
+        memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S2"}
+      rock.stage {
+        %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        %comp = arith.addf %tmp, %c2 : f16
+        memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S3"}
+    }{pipeline = #rock.pipeline<1>}
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -125,7 +125,7 @@ func.func @rock_pipeline_3_stages_ii_2(%input : memref<16xi8, #gpu.address_space
     return
 }
 
-// this test shouldn't pipeline loop but it would should add barriers and multibuffer by 1
+// this test shouldn't pipeline loop but it would add barriers and multibuffer by 1
 // CHECK-LABEL: rock_pipeline_3_stages_ii_2_less_iterations
 func.func @rock_pipeline_3_stages_ii_2_less_iterations(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index
@@ -476,8 +476,8 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
 
     %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
-    // CHECK: %[[C0:.*]] = arith.constant 0 : index
-    // CHECK: %[[C1:.*]] = arith.constant 1 : index
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[c1:.*]] = arith.constant 1 : index
     // CHECK: %[[rawLds:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
     // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
     // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
@@ -487,7 +487,7 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     // CHECK: name = "__bwd_barrier__"
     // CHECK: name = "S1"
     // CHECK: scf.for
-    // CHECK-SAME: %[[C0]] to %[[C1]]
+    // CHECK-SAME: %[[c0]] to %[[c1]]
       // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "S0"
       // CHECK: rock.extract_multibuffer(%[[ldsView]])
@@ -529,7 +529,7 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     return
 }
 
-// This test should adjust II to 2 to enable loop pipelining
+// this test should do loop pipelining without adjust II but notice that it emits scf.for loop with zero iterations. 
 // CHECK-LABEL: rock_pipeline_4_stages_ii_1_f16_less_iterations_2
 func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations_2(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -235,6 +235,49 @@ func.func @rock_pipeline_3_stages_ii_3(%input : memref<16xi8, #gpu.address_space
     return
 }
 
+// This test shouldn't do any pipelining as it doesn't have any stages but it should still multibuffer by 1
+// CHECK-LABEL: rock_pipeline_no_stages_ii_1
+func.func @rock_pipeline_no_stages_ii_1(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : i8
+    %c16 = arith.constant 16 : index
+
+    %rawLds  = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
+    %rawRegA = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    %rawRegB = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<16xi8, #gpu.address_space<workgroup>> to memref<16xi8, #gpu.address_space<workgroup>>
+    %regA = memref.view %rawRegA[%c0][] : memref<16xi8, #gpu.address_space<private>> to memref<16xi8, #gpu.address_space<private>>
+    %regB = memref.view %rawRegB[%c0][] : memref<16xi8, #gpu.address_space<private>> to memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[c16:.*]] = arith.constant 16 : index
+    // CHECK: %[[lds0:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawRegA:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+    // CHECK: %[[rawRegB:.*]] = rock.alloc() : memref<16xi8, #gpu.address_space<private>>
+
+    // CHECK: %[[lds0View:.*]] = memref.view {{.*}}
+    // CHECK: %[[rawRegAView:.*]] = memref.view {{.*}}
+    // CHECK: %[[rawRegBView:.*]] = memref.view {{.*}}
+
+    // CHECK: scf.for
+    // CHECK-SAME: %[[c0]] to %[[c16]]
+      // CHECK-NOT: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[lds0View]])
+      // CHECK: rock.extract_multibuffer(%[[lds0View]])
+    scf.for %arg3 = %c0 to %c16 step %c1 {
+        %a = memref.load %input[%arg3] : memref<16xi8, #gpu.address_space<global>>
+        memref.store %a, %regA[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        %b = memref.load %regA[%arg3] : memref<16xi8, #gpu.address_space<private>>
+        memref.store %b, %lds[%arg3] : memref<16xi8, #gpu.address_space<workgroup>>
+        %c = memref.load %lds[%arg3] : memref<16xi8, #gpu.address_space<workgroup>>
+        %d = arith.addi %c, %c2 : i8
+        memref.store %d, %regB[%arg3] : memref<16xi8, #gpu.address_space<private>>
+    }{pipeline = #rock.pipeline<1>}
+    %out = memref.load %regB[%c0] : memref<16xi8, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xi8, #gpu.address_space<global>>
+    return
+}
 // CHECK-LABEL: rock_pipeline_4_stages_ii_2
 func.func @rock_pipeline_4_stages_ii_2(%input : memref<16xi8, #gpu.address_space<global>>, %output : memref<16xi8, #gpu.address_space<global>>){
     %c0 = arith.constant 0 : index

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -406,3 +406,61 @@ func.func @rock_pipeline_4_stages_ii_1_f16(%input : memref<16xf16, #gpu.address_
     memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
     return
 }
+
+// This test shouldn't pipeline the loop but it should add barriers and multibuffer by factor 1
+// CHECK-LABEL: rock_pipeline_4_stages_ii_1_f16_less_iterations
+func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c2_0 = arith.constant 2 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView:.*]] = memref.view %[[rawLds]]
+    
+    // CHECK: scf.for
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView]])
+      // CHECK: name = "S1"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3"
+    scf.for %arg3 = %c0 to %c2_0 step %c1 {
+      rock.stage {
+        %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+        memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S0"}
+      rock.stage {
+        %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        rock.yield
+      }{name="S1"}
+      rock.stage {
+        %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        %comp = arith.addf %tmp, %c2 : f16
+        memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S2"}
+      rock.stage {
+        %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        %comp = arith.addf %tmp, %c2 : f16
+        memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.yield
+      }{name="S3"}
+    }{pipeline = #rock.pipeline<1>}
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -483,6 +483,7 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     // CHECK: %[[ldsView:.*]] = memref.view %[[rawLds]]
     
     // CHECK: scf.for
+      // CHECK: name = "__bwd_barrier__"
       // CHECK: name = "S0"
       // CHECK: rock.extract_multibuffer(%[[ldsView]])
       // CHECK: name = "S1"

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -481,16 +481,21 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations(%input : memref<16xf1
     // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
     // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
     // CHECK: %[[ldsView:.*]] = memref.view %[[rawLds]]
-    
+    // CHECK: name = "S0" 
+    // CHECK: name = "__bwd_barrier__"
+    // CHECK: name = "S1"
     // CHECK: scf.for
-      // CHECK: name = "__bwd_barrier__"
+      // CHECK: name = "__fwd_barrier__"
       // CHECK: name = "S0"
       // CHECK: rock.extract_multibuffer(%[[ldsView]])
-      // CHECK: name = "S1"
-      // CHECK: name = "__fwd_barrier__"
-      // CHECK: rock.extract_multibuffer(%[[ldsView]])
       // CHECK: name = "S2"
+      // CHECK: name = "__bwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView]])
+      // CHECK: name = "S1"
       // CHECK: name = "S3"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S2"
+    // CHECK: name = "S3"
     scf.for %arg3 = %c0 to %c2_0 step %c1 {
       rock.stage {
         %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>


### PR DESCRIPTION
This fixes two bugs in RockPipeline. 

1. It wasn't creating correct dependency graph while generating Schedule. It was only using "MultiBuffers" while creating dependency graph for generating schedule which was generating incorrect IR. 
2. For certain cases it was generating Loops with negative iterations. This PR adds some checks to avoid pipelining in such cases.
