### PR TITLE
Rocmlir tuning driver datatype fix

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -114,8 +114,8 @@ static benchmark::DataType getDataType(Type inputType) {
     return benchmark::DataType::BF16;
   } else if (inputType.isInteger(8)) {
     return benchmark::DataType::I8;
-  } else if (inputType.isFloat8E4M3FNUZ() || inputType.isFloat8E4M3FN() ||
-             inputType.isFloat8E5M2() || inputType.isFloat8E5M2FNUZ()) {
+  } else if (isa<Float8E4M3FNUZType, Float8E4M3FNType, Float8E5M2Type,
+                 Float8E5M2FNUZType>(inputType)) {
     return benchmark::DataType::F8;
   } else {
     llvm_unreachable("Kernels only accept ints or floats");

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -114,7 +114,8 @@ static benchmark::DataType getDataType(Type inputType) {
     return benchmark::DataType::BF16;
   } else if (inputType.isInteger(8)) {
     return benchmark::DataType::I8;
-  } else if (inputType.isFloat8E4M3FNUZ() || inputType.isFloat8E4M3FN()) {
+  } else if (inputType.isFloat8E4M3FNUZ() || inputType.isFloat8E4M3FN() ||
+             inputType.isFloat8E5M2() || inputType.isFloat8E5M2FNUZ()) {
     return benchmark::DataType::F8;
   } else {
     llvm_unreachable("Kernels only accept ints or floats");


### PR DESCRIPTION
Fix getDataType() in rocmlir-tuning-driver.cpp to consider all F8 datatypes.

Resolves [ROCm/rocMLIR-internal#1752](https://github.com/ROCm/rocMLIR-internal/issues/1752)
