### PR TITLE
Use hip-python API instead of rocm_agent_enumerator

### DIFF
--- a/mlir/test/common_utils/common.py
+++ b/mlir/test/common_utils/common.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-
+from hip import hip
 
 # Helper function to decode arch to its features
 # Keep this in sync with mlir/lib/Dialect/Rock/Generator/AmdArchDb.cpp:mlir::rock::lookupArchInfo
@@ -42,21 +42,27 @@ def get_arch_features(arch: str):
         pass
     return arch_features, support_mfma, support_wmma
 
+def hip_check(call_result):
+    err = call_result[0]
+    result = call_result[1:]
+    if len(result) == 1:
+        result = result[0]
+    if isinstance(err, hip.hipError_t) and err != hip.hipError_t.hipSuccess:
+        raise RuntimeError(str(err))
+    return result
 
-def get_agents(rocm_path):
-    if os.name != 'nt':
-        p = subprocess.run([rocm_path + "/bin/rocm_agent_enumerator", "-name"],
-                           check=True, stdout=subprocess.PIPE)
-        agents = set(x.decode("utf-8") for x in p.stdout.split())
-        if not agents or not all(agent.startswith("gfx") for agent in agents):
-            # TODO: Remove this workaround for a bug in rocm_agent_enumerator -name
-            # Once https://github.com/RadeonOpenCompute/rocminfo/pull/59 lands
-            q = subprocess.run([rocm_path + "/bin/rocm_agent_enumerator"],
-                               check=True, stdout=subprocess.PIPE)
-            agents = set(x.decode("utf-8") for x in q.stdout.split())
-        return set(a for a in agents if a != "gfx000")
-    else:
-        p = subprocess.run([rocm_path + "/bin/amdgpu_arch.exe"],
-                           check=True, stdout=subprocess.PIPE, shell=True)
-        return set(p.stdout.decode("utf-8").split())
+def get_agents():
+    agents = set()
+    device_count = hip_check(hip.hipGetDeviceCount())
+    for device in range(device_count):
+        props = hip.hipDeviceProp_t()
+        hip_check(hip.hipGetDeviceProperties(props,device))
+        agent = props.gcnArchName.decode('utf-8')
+        agents.add(agent)
 
+    return agents
+
+
+def is_xdlops_present() -> bool:
+    """This function checks whether a GPU with xdlops support is present"""
+    return any([agent.startswith("gfx9") for agent in get_agents()])

--- a/mlir/test/e2e/generateE2ETest.py
+++ b/mlir/test/e2e/generateE2ETest.py
@@ -35,18 +35,26 @@ import os
 import sys
 import getopt
 import glob
-import subprocess
+from hip import hip
+
+def hip_check(call_result):
+    err = call_result[0]
+    result = call_result[1:]
+    if len(result) == 1:
+        result = result[0]
+    if isinstance(err, hip.hipError_t) and err != hip.hipError_t.hipSuccess:
+        raise RuntimeError(str(err))
+    return result
 
 def getArch():
-    p = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator", "-name"], check=True,
-                       stdout=subprocess.PIPE)
-    agents = set(x.decode("utf-8") for x in p.stdout.split())
-    if not agents:
-        # TODO: Remove this workaround for a bug in rocm_agent_enumerator -name
-        # Once https://github.com/RadeonOpenCompute/rocminfo/pull/59 lands
-        q = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator"],
-                              check=True, stdout=subprocess.PIPE)
-        agents = set(x.decode("utf-8") for x in q.stdout.split() if x != b"gfx000")
+    agents = set()
+    device_count = hip_check(hip.hipGetDeviceCount())
+    for device in range(device_count):
+        props = hip.hipDeviceProp_t()
+        hip_check(hip.hipGetDeviceProperties(props,device))
+        agent = props.gcnArchName.decode('utf-8')
+        agents.add(agent)
+
     return agents
 
 def generate_option_list(prefixes: dict, table: list, key1: str, key2: str):

--- a/mlir/test/e2e/lit.site.cfg.py.in
+++ b/mlir/test/e2e/lit.site.cfg.py.in
@@ -48,7 +48,7 @@ config.arch_support_mfma = False
 config.arch_support_wmma = False
 if config.rocm_path:
     try:
-        agents = get_agents(config.rocm_path)
+        agents = get_agents()
         config.arch = ','.join(agents)
         for x in agents:
             config.features, config.arch_support_mfma, config.arch_support_wmma = get_arch_features(x)

--- a/mlir/test/fusion/e2e/generate-fusion-tests.py
+++ b/mlir/test/fusion/e2e/generate-fusion-tests.py
@@ -6,23 +6,32 @@ import shutil
 import glob
 import itertools
 import tomli
-import subprocess
+from hip import hip
 
 RANDTYPE = {'f32' : 'float',
             'f16' : 'float',
             'bf16' : 'float',
             'i32' : 'int',
             'i8' : 'int'}
+            
+def hip_check(call_result):
+    err = call_result[0]
+    result = call_result[1:]
+    if len(result) == 1:
+        result = result[0]
+    if isinstance(err, hip.hipError_t) and err != hip.hipError_t.hipSuccess:
+        raise RuntimeError(str(err))
+    return result
+
 def getArch():
-    p = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator", "-name"], check=True,
-                       stdout=subprocess.PIPE)
-    agents = set(x.decode("utf-8") for x in p.stdout.split())
-    if not agents:
-        # TODO: Remove this workaround for a bug in rocm_agent_enumerator -name
-        # Once https://github.com/RadeonOpenCompute/rocminfo/pull/59 lands
-        q = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator"],
-                              check=True, stdout=subprocess.PIPE)
-        agents = set(x.decode("utf-8") for x in q.stdout.split() if x != b"gfx000")
+    agents = set()
+    device_count = hip_check(hip.hipGetDeviceCount())
+    for device in range(device_count):
+        props = hip.hipDeviceProp_t()
+        hip_check(hip.hipGetDeviceProperties(props,device))
+        agent = props.gcnArchName.decode('utf-8')
+        agents.add(agent)
+
     return agents
 
 def generate_option_list(table, key1, key2):

--- a/mlir/test/fusion/e2e/lit.site.cfg.py.in
+++ b/mlir/test/fusion/e2e/lit.site.cfg.py.in
@@ -55,7 +55,7 @@ config.arch_support_mfma = False
 config.arch_support_wmma = False
 if config.rocm_path:
     try:
-        agents = get_agents(config.rocm_path)
+        agents = get_agents()
         config.arch = ','.join(agents)
         for x in agents:
             if any([arch in x for arch in ["gfx908", "gfx90a", "gfx942", "gfx950"]]):

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -79,7 +79,7 @@ config.arch_support_wmma = False
 config.features = None
 if config.rocm_path:
     try:
-        agents = get_agents(config.rocm_path)
+        agents = get_agents()
         config.arch = ','.join(agents)
         for x in agents:
             if not config.features:

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -23,6 +23,7 @@ from typing import Callable, Iterable, List, Sequence, Optional, Tuple, TypeVar,
 import perfRunner
 from perfRunner import ConvConfiguration
 from perfRunner import Paths
+from perfRunner import getArch
 from perfCommonUtils import CORRECT_RESULT_RE
 
 @dataclass(frozen=True)
@@ -405,17 +406,6 @@ async def runConfig(paramIter: Iterable[IterType],
     print(f"Passed: {n_passes}, Invalid: {n_invalids}, Failed: {len(failures)}")
     return len(failures) == 0
 
-def getArch():
-    p = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator", "-name"], check=True,
-                       stdout=subprocess.PIPE)
-    agents = set(x.decode("utf-8") for x in p.stdout.split())
-    if not agents:
-        # TODO: Remove this workaround for a bug in rocm_agent_enumerator -name
-        # Once https://github.com/RadeonOpenCompute/rocminfo/pull/59 lands
-        q = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator"],
-                              check=True, stdout=subprocess.PIPE)
-        agents = set(x.decode("utf-8") for x in q.stdout.split() if x != b"gfx000")
-    return agents
 
 def main() -> bool:
     parser = argparse.ArgumentParser(

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict, Tuple
 import numpy as np
 import pandas as pd
+from hip import hip
 
 import reportUtils
 from perfCommonUtils import Operation, GEMMLibrary
@@ -1252,27 +1253,24 @@ def tuneMLIRKernels(configs, arch, numCU):
                 print("MIOpen tuning timed out")
                 _, errs = p1.communicate()
 
-def is_xdlops_present() -> bool:
-    """This function checks whether a GPU with xdlops support is present"""
-    xdlop_supported_gpus = ['gfx908', 'gfx90a', 'gfx942', 'gfx950']
-    xdlop_supported_gpus_str = xdlop_supported_gpus[0]
-    for gpu in xdlop_supported_gpus[1:]:
-        xdlop_supported_gpus_str += '|' + gpu
-    r = subprocess.run(f"/opt/rocm/bin/rocm_agent_enumerator -t GPU | grep -q -E '{xdlop_supported_gpus_str}'",
-                       check=True, shell=True)
-    if r.returncode == 0:
-        return True
-    return False
+def hip_check(call_result):
+    err = call_result[0]
+    result = call_result[1:]
+    if len(result) == 1:
+        result = result[0]
+    if isinstance(err, hip.hipError_t) and err != hip.hipError_t.hipSuccess:
+        raise RuntimeError(str(err))
+    return result
 
 def getArch():
-    p = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator", "-name"], check=True,
-                       stdout=subprocess.PIPE)
-    agents = set(x.decode("utf-8") for x in p.stdout.split())
-    if not agents or not all(agent.startswith("gfx") for agent in agents):
-        # "rocm_agent_enumerator -name" may time out or fail.
-        q = subprocess.run(["/opt/rocm/bin/rocm_agent_enumerator"],
-                              check=True, stdout=subprocess.PIPE)
-        agents = set(x.decode("utf-8") for x in q.stdout.split() if x != b"gfx000")
+    agents = set()
+    device_count = hip_check(hip.hipGetDeviceCount())
+    for device in range(device_count):
+        props = hip.hipDeviceProp_t()
+        hip_check(hip.hipGetDeviceProperties(props,device))
+        agent = props.gcnArchName.decode('utf-8')
+        agents.add(agent)
+
     return agents
 
 def parseDataTypes(data_types):


### PR DESCRIPTION
Handle agent detection correctly by using hip-python API instead of rocm_agent_enumerator.
Add requirements.txt for external python libraries.

Resolves [#1760](https://github.com/ROCm/rocMLIR-internal/issues/1760)