### PR TITLE
Update MI300 quick-tuning list

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -72,55 +72,72 @@ static const InitParamsNonAccel initParametersConv[nInitParametersConv];
 
 // BEGIN_GEMM_XDL_f32_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersGemm[PopulateParamsXDL::nInitParametersGemm] = {
-    {64,64,8,16,16,4,1,1,2,true,true},
+    {64,64,8,64,16,4,1,1,2,true,true},
+    {128,128,8,32,16,4,1,1,2,true,true},
+    {64,128,8,32,16,4,1,1,2,true,true},
     {32,64,8,16,16,4,1,1,2,true,true},
     {32,32,8,16,16,8,1,1,2,true,true},
     {32,16,8,16,16,8,1,1,2,true,true},
     {16,32,8,16,16,8,1,1,2,true,true},
-    {64,64,8,64,16,8,1,1,2,true,true},
+    {32,64,8,32,16,8,1,1,2,true,true},
     {16,32,4,16,16,8,1,1,2,true,true},
-    {256,256,2,64,32,4,1,1,2,true,true}
+    {256,256,2,128,32,4,1,1,2,true,true},
+    {64,64,4,32,32,1,1,1,2,true,true}
 };
 // END_GEMM_XDL_f32_DEFS
 
 // BEGIN_CONV_XDL_f32_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersConv[PopulateParamsXDL::nInitParametersConv] = {
     {128,128,4,128,16,4,1,1,2,true,true},
+    {128,64,4,128,16,4,1,1,2,true,true},
+    {128,128,8,64,16,1,1,1,2,true,true},
+    {64,128,4,64,16,4,1,1,2,true,true},
     {64,64,8,32,16,4,1,1,2,true,true},
-    {64,64,4,32,32,8,1,1,2,true,true},
-    {64,128,2,32,32,8,1,1,2,true,true},
-    {64,64,4,64,16,4,1,1,2,true,true},
-    {64,128,8,64,32,1,1,1,2,true,true},
+    {64,64,8,32,32,4,1,1,2,true,true},
+    {64,64,4,16,16,4,1,1,2,true,true},
     {64,32,8,16,16,4,1,1,2,true,true},
-    {256,32,8,64,32,1,1,1,2,true,true},
-    {64,16,8,16,16,8,1,1,2,true,true},
-    {64,256,2,32,32,4,1,1,2,true,true},
-    {256,64,2,128,32,8,1,1,2,true,true},
+    {128,128,8,64,16,4,1,1,2,true,true},
+    {256,64,4,64,16,4,1,1,2,true,true},
+    {64,64,4,32,32,4,1,1,2,true,true},
     {64,256,4,64,16,4,1,1,2,true,true},
-    {64,64,8,16,16,8,1,1,2,true,true},
+    {128,256,8,64,16,1,1,1,2,true,true},
     {32,32,8,16,16,8,1,1,2,true,true},
+    {64,16,8,16,16,8,1,1,2,true,true},
+    {128,32,8,64,16,4,1,1,2,true,true},
+    {64,64,8,16,16,8,1,1,2,true,true},
+    {64,256,8,32,32,1,1,1,2,true,true},
+    {256,32,8,64,32,1,1,1,2,true,true},
+    {64,128,4,64,16,1,1,1,2,true,true},
+    {32,16,8,16,16,8,1,1,2,true,true},
     {256,128,4,64,32,4,1,1,2,true,true},
-    {128,64,4,128,16,8,1,1,2,true,true},
-    {32,16,4,16,16,8,1,1,2,true,true},
-    {16,16,8,16,16,8,1,1,2,true,true},
+    {256,128,2,128,32,4,1,1,2,true,true},
+    {16,32,8,16,16,8,1,1,2,true,true},
+    {32,16,8,16,16,4,1,1,2,true,true},
+    {32,128,4,32,16,4,1,1,2,true,true},
     {32,64,8,32,16,8,1,1,2,true,true},
-    {16,16,8,16,16,4,1,1,2,true,true}
+    {256,64,8,64,32,4,1,1,2,true,true},
+    {16,16,8,16,16,4,1,1,2,true,true},
+    {64,256,4,32,32,8,1,1,2,true,true}
 };
 // END_CONV_XDL_f32_DEFS
 
 // BEGIN_GEMM_XDL_f16_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersFp16Gemm[PopulateParamsXDL::nInitParametersFp16Gemm] = {
-    {64,128,4,32,32,8,1,1,2,true,true},
     {64,64,8,32,32,8,1,1,2,true,true},
+    {64,128,4,32,32,8,1,1,2,true,true},
     {128,128,4,128,16,8,1,1,2,true,true},
     {32,64,8,16,16,8,1,1,2,true,true},
     {16,64,8,16,16,8,1,1,2,true,true},
     {64,16,8,16,16,8,1,1,2,true,true},
+    {128,128,8,32,32,8,1,1,2,true,true},
     {128,256,2,128,32,8,1,1,2,true,true},
-    {128,128,8,64,16,8,1,1,2,true,true},
+    {128,256,4,64,16,8,1,1,2,true,true},
     {64,128,8,32,32,8,1,1,2,true,true},
     {16,16,8,16,16,8,1,1,2,true,true},
-    {128,256,4,64,16,8,1,1,2,true,true},
+    {128,256,4,32,16,8,1,1,2,true,true},
+    {256,128,8,128,16,8,1,1,2,true,true},
+    {128,256,8,32,32,8,1,1,2,true,true},
+    {128,128,2,128,32,8,1,1,2,true,true},
     {256,256,8,128,16,4,1,1,2,true,true}
 };
 // END_GEMM_XDL_f16_DEFS
@@ -128,34 +145,44 @@ const InitParamsAccel PopulateParamsXDL::initParametersFp16Gemm[PopulateParamsXD
 // BEGIN_CONV_XDL_f16_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersFp16Conv[PopulateParamsXDL::nInitParametersFp16Conv] = {
     {64,64,8,32,32,8,1,1,2,true,true},
-    {128,128,4,64,32,8,1,1,2,true,true},
     {128,128,4,64,16,8,1,1,2,true,true},
     {128,128,8,128,32,8,1,1,2,true,true},
+    {128,128,4,64,32,8,1,1,2,true,true},
+    {256,128,8,64,16,4,1,1,2,true,true},
+    {128,256,4,128,16,8,1,1,2,true,true},
+    {128,128,4,128,16,4,1,1,2,true,true},
+    {256,128,4,128,16,8,1,1,2,true,true},
+    {256,128,4,128,16,4,1,1,2,true,true},
     {128,32,8,32,32,8,1,1,2,true,true},
-    {256,128,4,128,32,4,1,1,2,true,true},
-    {128,128,4,32,32,4,1,1,2,true,true},
+    {128,128,8,128,32,4,1,1,2,true,true},
+    {128,256,4,64,32,4,1,1,2,true,true},
+    {128,64,8,64,16,8,1,1,2,true,true},
+    {64,128,8,64,16,8,1,1,2,true,true},
     {64,16,8,16,16,8,1,1,2,true,true},
-    {128,64,8,64,32,8,1,1,2,true,true},
     {256,128,2,128,32,4,1,1,2,true,true},
-    {64,32,8,32,32,8,1,1,2,true,true},
-    {256,128,4,128,32,8,1,1,2,true,true},
-    {64,128,8,32,16,8,1,1,2,true,true},
+    {128,64,4,32,32,8,1,1,2,true,true},
     {256,64,8,64,16,4,1,1,2,true,true},
-    {128,256,4,64,32,8,1,1,2,true,true},
-    {128,256,4,64,16,4,1,1,2,true,true},
-    {64,128,4,16,16,8,1,1,2,true,true},
-    {128,64,4,64,16,8,1,1,2,true,true},
-    {128,256,2,128,32,4,1,1,2,true,true},
+    {64,64,8,16,16,8,1,1,2,true,true},
+    {64,32,8,32,32,8,1,1,2,true,true},
+    {256,128,2,64,32,8,1,1,2,true,true},
     {32,32,8,16,16,8,1,1,2,true,true},
-    {64,32,8,16,16,8,1,1,2,true,true},
-    {256,128,8,128,16,4,1,1,2,true,true},
-    {64,64,4,32,32,8,1,1,2,true,true},
-    {32,64,8,32,16,4,1,1,2,true,true},
-    {256,64,4,64,32,8,1,1,2,true,true},
+    {128,64,4,128,16,8,1,1,2,true,true},
+    {64,256,4,64,16,4,1,1,2,true,true},
+    {64,128,4,32,16,8,1,1,2,true,true},
     {32,16,8,16,16,8,1,1,2,true,true},
-    {16,16,8,16,16,8,1,1,2,true,true},
-    {64,64,8,32,32,1,1,1,2,true,true},
-    {16,256,4,16,16,8,1,1,2,true,true}
+    {64,256,4,32,32,4,1,1,2,true,true},
+    {128,16,8,32,16,8,1,1,2,true,true},
+    {64,32,8,16,16,8,1,1,2,true,true},
+    {16,32,8,16,16,8,1,1,2,true,true},
+    {64,256,2,32,32,4,1,1,2,true,true},
+    {64,64,4,64,16,8,1,1,2,true,true},
+    {32,64,8,32,16,4,1,1,2,true,true},
+    {32,16,8,32,16,8,1,1,2,true,true},
+    {64,64,2,32,32,4,1,1,2,true,true},
+    {256,32,4,128,32,8,1,1,2,true,true},
+    {64,64,4,64,32,4,1,1,2,true,true},
+    {256,256,8,64,32,8,1,1,2,true,true},
+    {256,256,4,128,16,4,1,1,2,true,true}
 };
 // END_CONV_XDL_f16_DEFS
 
@@ -215,40 +242,56 @@ const InitParamsAccel PopulateParamsXDL::initParametersForwardFp8Conv[PopulatePa
 
 // BEGIN_GEMM_XDL_i8_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersI8Gemm[PopulateParamsXDL::nInitParametersI8Gemm] = {
-    {64,128,16,64,16,4,1,1,2,true,true},
-    {64,256,4,64,16,16,1,1,2,true,true},
+    {64,128,8,64,16,8,1,1,2,true,true},
+    {64,128,4,32,16,16,1,1,2,true,true},
+    {128,256,4,64,16,16,1,1,2,true,true},
+    {64,64,8,32,16,16,1,1,2,true,true},
     {64,64,16,32,16,4,1,1,2,true,true},
-    {64,128,32,64,32,4,1,1,2,true,true},
-    {32,64,8,16,16,16,1,1,2,true,true},
+    {128,128,8,32,16,16,1,1,2,true,true},
+    {64,128,8,16,16,16,1,1,2,true,true},
+    {64,16,16,16,16,16,1,1,2,true,true},
+    {32,64,16,16,16,4,1,1,2,true,true},
+    {32,64,8,32,16,16,1,1,2,true,true},
+    {32,32,16,16,16,16,1,1,2,true,true},
+    {32,256,4,16,16,16,1,1,2,true,true},
     {16,64,8,16,16,8,1,1,2,true,true},
-    {32,256,4,32,16,16,1,1,2,true,true},
-    {64,64,8,64,16,4,1,1,2,true,true},
     {64,16,8,16,16,16,1,1,2,true,true},
-    {32,32,32,16,16,8,1,1,2,true,true},
-    {32,16,16,16,16,16,1,1,2,true,true},
-    {16,32,32,16,16,4,1,1,2,true,true},
+    {64,32,16,32,16,16,1,1,2,true,true},
+    {128,64,4,32,32,8,1,1,2,true,true},
+    {16,32,32,16,16,8,1,1,2,true,true},
     {256,256,8,128,64,1,1,1,2,true,true},
-    {16,32,8,16,16,8,1,1,2,true,true}
+    {64,16,16,32,16,16,1,1,2,true,true},
+    {16,32,8,16,16,8,1,1,2,true,true},
+    {32,64,32,32,16,16,1,1,2,true,true}
 };
 // END_GEMM_XDL_i8_DEFS
 
 // BEGIN_CONV_XDL_i8_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersForwardI8Conv[PopulateParamsXDL::nInitParametersForwardI8Conv] = {
+    {128,128,8,64,16,16,1,1,2,true,true},
+    {128,128,4,64,16,16,1,1,2,true,true},
     {64,128,4,64,16,16,1,1,2,true,true},
-    {128,128,4,128,16,16,1,1,2,true,true},
     {64,64,8,32,32,16,1,1,2,true,true},
-    {128,64,4,32,32,16,1,1,2,true,true},
-    {128,32,4,32,32,16,1,1,2,true,true},
+    {64,64,16,32,32,16,1,1,2,true,true},
     {256,64,4,128,32,16,1,1,2,true,true},
-    {64,32,8,32,16,16,1,1,2,true,true},
-    {64,64,16,32,32,4,1,1,2,true,true},
-    {64,64,16,16,16,16,1,1,2,true,true},
-    {128,128,16,128,16,8,1,1,2,true,true},
+    {32,64,8,32,16,16,1,1,2,true,true},
+    {256,64,4,64,64,16,1,1,2,true,true},
+    {64,256,4,64,16,16,1,1,2,true,true},
+    {128,64,4,32,32,16,1,1,2,true,true},
+    {128,32,4,32,16,16,1,1,2,true,true},
+    {64,64,16,64,16,16,1,1,2,true,true},
+    {64,64,8,32,16,8,1,1,2,true,true},
+    {256,64,4,128,64,16,1,1,2,true,true},
+    {128,16,8,128,16,16,1,1,2,true,true},
+    {128,16,8,64,16,16,1,1,2,true,true},
+    {128,16,8,32,16,16,1,1,2,true,true},
+    {128,64,16,128,16,8,1,1,2,true,true},
     {64,32,4,64,16,16,1,1,2,true,true},
-    {64,256,4,32,16,4,1,1,2,true,true},
-    {32,32,16,32,16,16,1,1,2,true,true},
-    {64,128,32,64,16,4,1,1,2,true,true},
-    {64,16,8,32,16,8,1,1,2,true,true}
+    {32,16,8,16,16,16,1,1,2,true,true},
+    {64,256,4,32,32,8,1,1,2,true,true},
+    {256,32,4,64,16,16,1,1,2,true,true},
+    {32,32,32,32,16,16,1,1,2,true,true},
+    {16,32,16,16,16,16,1,1,2,true,true}
 };
 // END_CONV_XDL_i8_DEFS
 
@@ -257,22 +300,22 @@ const InitParamsAccel PopulateParamsXDL::initParametersForwardI8Conv[PopulatePar
 #ifdef XDL_DECLARATIONS_GEN
 
 // BEGIN_GEMM_XDL_f32_DECS
-static constexpr size_t nInitParametersGemm = 8;
+static constexpr size_t nInitParametersGemm = 11;
 static const InitParamsAccel initParametersGemm[nInitParametersGemm];
 // END_GEMM_XDL_f32_DECS
 
 // BEGIN_CONV_XDL_f32_DECS
-static constexpr size_t nInitParametersConv = 20;
+static constexpr size_t nInitParametersConv = 30;
 static const InitParamsAccel initParametersConv[nInitParametersConv];
 // END_CONV_XDL_f32_DECS
 
 // BEGIN_GEMM_XDL_f16_DECS
-static constexpr size_t nInitParametersFp16Gemm = 12;
+static constexpr size_t nInitParametersFp16Gemm = 16;
 static const InitParamsAccel initParametersFp16Gemm[nInitParametersFp16Gemm];
 // END_GEMM_XDL_f16_DECS
 
 // BEGIN_CONV_XDL_f16_DECS
-static constexpr size_t nInitParametersFp16Conv = 29;
+static constexpr size_t nInitParametersFp16Conv = 39;
 static const InitParamsAccel initParametersFp16Conv[nInitParametersFp16Conv];
 // END_CONV_XDL_f16_DECS
 
@@ -287,12 +330,12 @@ static const InitParamsAccel initParametersForwardFp8Conv[nInitParametersForward
 // END_CONV_XDL_fp8_DECS
 
 // BEGIN_GEMM_XDL_i8_DECS
-static constexpr size_t nInitParametersI8Gemm = 14;
+static constexpr size_t nInitParametersI8Gemm = 21;
 static const InitParamsAccel initParametersI8Gemm[nInitParametersI8Gemm];
 // END_GEMM_XDL_i8_DECS
 
 // BEGIN_CONV_XDL_i8_DECS
-static constexpr size_t nInitParametersForwardI8Conv = 15;
+static constexpr size_t nInitParametersForwardI8Conv = 24;
 static const InitParamsAccel initParametersForwardI8Conv[nInitParametersForwardI8Conv];
 // END_CONV_XDL_i8_DECS
 

--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -89,7 +89,6 @@ const InitParamsAccel PopulateParamsXDL::initParametersGemm[PopulateParamsXDL::n
 // BEGIN_CONV_XDL_f32_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersConv[PopulateParamsXDL::nInitParametersConv] = {
     {128,128,4,128,16,4,1,1,2,true,true},
-    {128,64,4,128,16,4,1,1,2,true,true},
     {128,128,8,64,16,1,1,1,2,true,true},
     {64,128,4,64,16,4,1,1,2,true,true},
     {64,64,8,32,16,4,1,1,2,true,true},
@@ -305,7 +304,7 @@ static const InitParamsAccel initParametersGemm[nInitParametersGemm];
 // END_GEMM_XDL_f32_DECS
 
 // BEGIN_CONV_XDL_f32_DECS
-static constexpr size_t nInitParametersConv = 30;
+static constexpr size_t nInitParametersConv = 29;
 static const InitParamsAccel initParametersConv[nInitParametersConv];
 // END_CONV_XDL_f32_DECS
 

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -49,7 +49,7 @@ func.func @rock_conv_f16(%filter : memref<1x128x8x3x3xf16>, %input : memref<128x
 func.func @rock_conv_i8(%filter : memref<1x128x8x3x3xi8>, %input : memref<128x1x8x32x32xi8>, %output : memref<128x1x128x30x30xi32>) {
   // CHECK: rock.conv
   // CHECK-SAME: derivedBlockSize = 256
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 256, kpack = 4, mPerWave = 32, nPerWave = 128, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 256, kpack = 8, mPerWave = 32, nPerWave = 128, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
   // GRID: rock.gridwise_gemm
   // GRID-SAME: gridSize = 900
   rock.conv(%filter, %input, %output) features = mfma|dot|atomic_add|atomic_add_f16 {
@@ -254,7 +254,7 @@ func.func @rock_conv_7x7_tuning(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256
 func.func @rock_conv_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x230x230xf32>, %arg2: memref<256x1x64x112x112xf32>) {
   // CHECK: rock.conv
   // CHECK-SAME: derivedBlockSize = 256
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 64, nPerBlock = 128, kpack = 1, mPerWave = 64, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 128, kpack = 1, mPerWave = 64, nPerWave = 32, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
   // GRID: rock.gridwise_gemm
   // GRID-SAME: gridSize = 25088
   rock.conv(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add|atomic_add_f16 {
@@ -316,10 +316,10 @@ func.func @rock_conv_bwd_data_7x7_tuning(%arg0: memref<1x64x3x7x7xf32>, %arg1: m
 // GRID-LABEL: @rock_conv_bwd_data_7x7
 func.func @rock_conv_bwd_data_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x230x230xf32>, %arg2: memref<256x1x64x112x112xf32>) attributes {kernel = 1 : i32} {
   // CHECK: rock.conv_bwd_data
-  // CHECK-SAME: derivedBlockSize = 64
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 16, nPerBlock = 16, kpack = 8, mPerWave = 16, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK-SAME: derivedBlockSize = 128
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 16, nPerBlock = 32, kpack = 8, mPerWave = 16, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 211600
+  // GRID-SAME: gridSize = 105800
   rock.conv_bwd_data(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add|atomic_add_f16 {
     arch = "amdgcn-amd-amdhsa:gfx908",
     dilations = [1 : index, 1 : index],
@@ -352,9 +352,9 @@ func.func @rock_gemm_from_conv(%a : memref<1x72x128xf32>, %b : memref<1x72x11520
 func.func @rock_gemm_from_i8_conv(%a : memref<1x72x128xi8>, %b : memref<1x72x115200xi8>, %c : memref<1x128x115200xi32>) {
   // CHECK: rock.gemm
   // CHECK-SAME: derivedBlockSize = 256
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 64, nPerBlock = 64, kpack = 4, mPerWave = 64, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 128, nPerBlock = 64, kpack = 8, mPerWave = 32, nPerWave = 64, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 3600
+  // GRID-SAME: gridSize = 1800
   rock.gemm %c = tr %a * %b features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx908",
     numCU = 120 : i32
@@ -370,9 +370,9 @@ func.func @rock_gemm_from_i8_conv(%a : memref<1x72x128xi8>, %b : memref<1x72x115
 func.func @rock_gemm_from_i8_conv_gfx942(%a : memref<1x72x128xi8>, %b : memref<1x72x115200xi8>, %c : memref<1x128x115200xi32>) {
   // CHECK: rock.gemm
   // CHECK-SAME: derivedBlockSize = 256
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 256, kpack = 16, mPerWave = 64, nPerWave = 64, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 128, nPerBlock = 64, kpack = 8, mPerWave = 32, nPerWave = 64, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 900
+  // GRID-SAME: gridSize = 1800
   rock.gemm %c = tr %a * %b features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set {
     arch = "amdgcn-amd-amdhsa:gfx942",
     numCU = 120 : i32

--- a/mlir/test/xmir/pr-e2e/resnet18/resnet18_part5.mlir
+++ b/mlir/test/xmir/pr-e2e/resnet18/resnet18_part5.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-gen -fut forward__part_5 --arch %arch --clone-harness %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -fut forward__part_5_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 
 // ALLOW_RETRIES: 2
-// CHECK: [1 1 0]
+// CHECK: [1 1 1]
 
 module {
   func.func private @forward__part_5(%arg0: tensor<1x256x14x14xf32> {mhal.read_access}, %arg1: tensor<512x1x1xf32> {mhal.read_access}) -> (tensor<1x512x7x7xf32> {mhal.write_access}) {

--- a/mlir/test/xmir/pr-e2e/resnet18/resnet18_part5.mlir
+++ b/mlir/test/xmir/pr-e2e/resnet18/resnet18_part5.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-gen -fut forward__part_5 --arch %arch --clone-harness %s | rocmlir-driver -host-pipeline highlevel | rocmlir-gen -ph -fut forward__part_5_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 
 // ALLOW_RETRIES: 2
-// CHECK: [1 1 1]
+// CHECK: [1 1 0]
 
 module {
   func.func private @forward__part_5(%arg0: tensor<1x256x14x14xf32> {mhal.read_access}, %arg1: tensor<512x1x1xf32> {mhal.read_access}) -> (tensor<1x512x7x7xf32> {mhal.write_access}) {

--- a/mlir/utils/performance/analysis/quickTuningGen.py
+++ b/mlir/utils/performance/analysis/quickTuningGen.py
@@ -279,9 +279,10 @@ class PerfConfigsFinder():
 
         targetColumns = []
         if self.op == "gemm":
-            targetColumns = ['TransA', 'TransB', 'G', 'M', 'K', 'N']
+            targetColumns = ['Chip', 'TransA', 'TransB', 'G', 'M', 'K', 'N']
         else:
             targetColumns = [
+                'Chip',
                 'Direction',
                 'InputLayout',
                 'N',


### PR DESCRIPTION
- Update the XDL quick-tuning list based on both newly gathered MI300 and previously gathered MI200 tuning data.
- Resolves https://github.com/ROCm/rocMLIR-internal/issues/1668