### PR TITLE
Adjust Dockerfile for Separate hip-python Installation

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -79,6 +79,10 @@ ENV LC_ALL en_US.UTF-8
 ADD "https://raw.githubusercontent.com/google/llvm-premerge-checks/master/scripts/requirements.txt" llvm-requirements.txt
 RUN pip3 install -r llvm-requirements.txt
 
+# Install hip-python from Test PyPI.
+# Ideally, it should be in requirements.txt, but it doesn't work there currently.
+RUN pip3 install --index-url https://test.pypi.org/simple hip-python
+
 ADD "https://raw.githubusercontent.com/ROCm/rocMLIR/develop/requirements.txt" requirements.txt
 RUN pip3 install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ tomli==2.0.1
 numpy>=1.19.5, <=2.1.2
 ml_dtypes>=0.1.0, <=0.5.0   # provides several NumPy dtype extensions, including the bf16
 scipy
-hip-python --index-url https://test.pypi.org/simple


### PR DESCRIPTION
Moved the installation of hip-python from requirements.txt directly into the Dockerfile, it doesn't work there currently. Ideally, this package should be managed within requirements.txt, but current constraints necessitate separate handling to ensure successful installation.