### PR TITLE
Fix initialization for split-k

### DIFF
--- a/external/mlir-hal/lib/Conversion/MHALToGPU/MHALToGPU.cpp
+++ b/external/mlir-hal/lib/Conversion/MHALToGPU/MHALToGPU.cpp
@@ -102,7 +102,7 @@ struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
   }
 
   Value moveMemory(OpBuilder b, mhal::LaunchOp launchOp, Value opr,
-                   uint32_t fidx, bool readAccess, bool writeAccess,
+                   uint32_t fidx, bool writeAccess,
                    llvm::SmallVector<Value> &copyBackOprs,
                    llvm::SmallVector<Value, 8> &asyncDeps) const {
     if (auto gpuAllocOp = opr.getDefiningOp<gpu::AllocOp>()) {
@@ -128,12 +128,11 @@ struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
     Value dstToken = dst.getResult(1);
 
     auto makeCopy = [&]() {
-      if (readAccess) {
-        // copy to device
-        auto memcpyToken = b.create<gpu::MemcpyOp>(
-            loc, tokenType, ValueRange{dstToken}, dstMem, opr);
-        dstToken = memcpyToken.getResult(0);
-      }
+      // always copy to device, even if it's read_access only
+      // this way we initialize with whatever was provided by the user
+      auto memcpyToken = b.create<gpu::MemcpyOp>(
+          loc, tokenType, ValueRange{dstToken}, dstMem, opr);
+      dstToken = memcpyToken.getResult(0);
       if (writeAccess) {
         // copy from device
         copyBackOprs[fidx] = oprAllocOp ? opr : dstMem;
@@ -187,12 +186,12 @@ struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
 
     FunctionOpInterface funcIF(func);
     auto funcName = funcIF.getName();
-    auto binaryName = funcName + "_module";
+    std::string binaryName = (funcName + "_module").str();
 
-    auto binaryOp = module.lookupSymbol<gpu::BinaryOp>(binaryName.str());
+    auto binaryOp = module.lookupSymbol<gpu::BinaryOp>(binaryName);
     if (!binaryOp) {
       OpBuilder b(ctx);
-      binaryOp = b.create<gpu::BinaryOp>(floc, binaryName.str(), nullptr,
+      binaryOp = b.create<gpu::BinaryOp>(floc, binaryName, nullptr,
                                          ArrayRef<Attribute>({binary}));
 
       SymbolTable symbolTable(module);
@@ -232,18 +231,16 @@ struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
       Value opr = operands[i];
       // move input memories to GPU
       if (isa<MemRefType>(opr.getType())) {
-        bool readAccess{
-            func.getArgAttr(fidx, mhal::MHALDialect::getReadAccessAttrName())};
         bool writeAccess{
             func.getArgAttr(fidx, mhal::MHALDialect::getWriteAccessAttrName())};
-        opr = moveMemory(rw, op, opr, fidx, readAccess, writeAccess,
-                         copyBackOprs, asyncDeps);
+        opr =
+            moveMemory(rw, op, opr, fidx, writeAccess, copyBackOprs, asyncDeps);
       }
       gpuOperands.push_back(opr);
     }
 
     // The gpu.launch_func requires 1 and only 1 token
-    if (asyncDeps.size() == 0)
+    if (asyncDeps.empty())
       // There must be at least 1 token
       asyncDeps.push_back(makeWait(rw, loc));
     else if (asyncDeps.size() > 1) {
@@ -255,7 +252,7 @@ struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
     // Make gpu.launch_func
     auto gpuLaunchOp = rw.create<gpu::LaunchFuncOp>(
         loc,
-        SymbolRefAttr::get(getContext(), binaryName.str(),
+        SymbolRefAttr::get(getContext(), binaryName,
                            {FlatSymbolRefAttr::get(getContext(), funcName)}),
         gpu::KernelDim3{gridSizeIdx, oneIdx, oneIdx},
         gpu::KernelDim3{blockSizeIdx, oneIdx, oneIdx}, dynamicSharedMemorySize,

--- a/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
@@ -16,6 +16,7 @@
 #include "mlir-c/Dialect/RockEnums.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockTuningParamAttrInterface.h"
+#include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/Support/RWMutex.h"
 
@@ -75,6 +76,7 @@ LogicalResult tuningTableLookupByKey(TuningTable *perfTable,
                                      SmallVectorImpl<char> &out);
 
 bool isSplitKRequested(ModuleOp mod, StringRef perfConfig);
+bool isSplitKRequested(rock::GemmFeatures features, StringRef perfConfig);
 
 // This method checks a given fused module is actually fusible
 // for the given perfConfig

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
+#include "mlir/Dialect/Rock/Tuning/RockTuning.h"
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
 #include "mlir/Dialect/Rock/utility/builderUtils.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
@@ -30,11 +31,13 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/bit.h"
+#include "llvm/Support/LogicalResult.h"
 #include <utility>
 
 #define DEBUG_TYPE "convert-tosa-to-rock"
@@ -233,7 +236,8 @@ static FailureOr<rock::ConvOp>
 makeRockConv(ConversionPatternRewriter &rw, Operation *op, Value input,
              Value filter, Value output, DenseI64ArrayAttr pad,
              DenseI64ArrayAttr stride, DenseI64ArrayAttr dilation,
-             int64_t group) {
+             int64_t group, StringAttr arch, std::optional<uint32_t> numCU,
+             rock::GemmFeatures features) {
   Location loc = op->getLoc();
 
   SmallString<8> filterLayout("kyxc");
@@ -258,13 +262,8 @@ makeRockConv(ConversionPatternRewriter &rw, Operation *op, Value input,
   auto filterExp = expandTensor(rw, op, filter, filterLayout, "k", group);
   auto outputExp = expandTensor(rw, op, output, outputLayout, "k", group);
 
-  StringAttr arch;
-  std::optional<uint32_t> num_cu;
-  rock::GemmFeatures features;
-  std::tie(arch, num_cu, features) = getArchAttributes(op, input.getType());
-
   IntegerAttr numCUAttr =
-      num_cu.has_value() ? rw.getI32IntegerAttr(num_cu.value()) : nullptr;
+      numCU.has_value() ? rw.getI32IntegerAttr(numCU.value()) : nullptr;
   auto cop = rw.create<rock::ConvOp>(
       loc, outputExp.getType(), filterExp, inputExp, outputExp, arch,
       rw.getAttr<rock::GemmFeaturesAttr>(features),
@@ -301,11 +300,6 @@ makeRockConv(ConversionPatternRewriter &rw, Operation *op, Value input,
   return cop;
 }
 
-static bool isTosaReduction(Operation *op) {
-  return isa<tosa::ReduceMaxOp, tosa::ReduceSumOp, tosa::ReduceMinOp,
-             tosa::ReduceProductOp, tosa::ReduceAllOp, tosa::ReduceAnyOp>(op);
-}
-
 static Value traceToRes(Value tensor, DenseMap<Value, Value> &cache,
                         Value expectedTensor) {
   if (cache.contains(tensor))
@@ -313,13 +307,19 @@ static Value traceToRes(Value tensor, DenseMap<Value, Value> &cache,
 
   Value res = nullptr;
   if (tensor.getDefiningOp()) {
-    if (isTosaReduction(tensor.getDefiningOp()) && expectedTensor == tensor) {
+    if (expectedTensor == tensor) {
       res = tensor;
     } else if (auto view = tensor.getDefiningOp<ViewLikeOpInterface>()) {
       res = traceToRes(view.getViewSource(), cache, expectedTensor);
+    } else if (auto expand = tensor.getDefiningOp<tensor::ExpandShapeOp>()) {
+      res = traceToRes(expand.getSrc(), cache, expectedTensor);
     } else if (auto collapse =
                    tensor.getDefiningOp<tensor::CollapseShapeOp>()) {
       res = traceToRes(collapse.getSrc(), cache, expectedTensor);
+    } else if (auto untransform =
+                   tensor.getDefiningOp<rock::TensorUntransformCastOp>()) {
+      res =
+          traceToRes(untransform.getTransformedResult(), cache, expectedTensor);
     } else if (auto tosaOp = tensor.getDefiningOp<tosa::TosaOp>()) {
       for (auto operand : tosaOp->getOperands()) {
         if (llvm::isa<TensorType>(operand.getType())) {
@@ -335,7 +335,7 @@ static Value traceToRes(Value tensor, DenseMap<Value, Value> &cache,
   return res;
 }
 
-static FailureOr<int64_t> traceToRes(Value expectedTensor, func::FuncOp func) {
+static SetVector<int64_t> traceToRes(Value expectedTensor, func::FuncOp func) {
   llvm::DenseMap<Value, Value> cache;
 
   SmallVector<func::ReturnOp> returns;
@@ -343,13 +343,57 @@ static FailureOr<int64_t> traceToRes(Value expectedTensor, func::FuncOp func) {
   assert(returns.size() == 1 && "Number of returns is not one");
   func::ReturnOp returnOp = returns[0];
 
+  SetVector<int64_t> resIndices;
   for (auto [i, res] : llvm::enumerate(returnOp->getOperands())) {
     Value out = traceToRes(res, cache, expectedTensor);
-    if (out == expectedTensor) {
-      return i;
+    if (out == expectedTensor)
+      resIndices.insert(i);
+  }
+  return resIndices;
+}
+
+template <typename OpT>
+static LogicalResult setSplitKAttrs(OpT op, rock::GemmFeatures features,
+                                    ConversionPatternRewriter &rw) {
+  auto perfConfig = op->template getAttrOfType<StringAttr>("perf_config");
+  if (perfConfig && rock::isSplitKRequested(features, perfConfig)) {
+    func::FuncOp func = op->template getParentOfType<func::FuncOp>();
+    SetVector<int64_t> resIndices = traceToRes(op->getResult(0), func);
+    if (resIndices.empty())
+      return op.emitOpError(
+          "can't trace the operation output to a kernel result");
+
+    func::ReturnOp returnOp;
+    func.walk([&](func::ReturnOp op) { returnOp = op; });
+    for (int64_t resNumber : resIndices) {
+      Type elementType =
+          cast<ShapedType>(returnOp->getOperand(resNumber).getType())
+              .getElementType();
+      if (!isa<Float32Type, Float16Type, BFloat16Type>(elementType)) {
+        return rw.notifyMatchFailure(
+            op, "We only support F32, F16 and BF16 split-k, yet.");
+      }
+      Attribute outputInitVal = rw.getFloatAttr(elementType, 0.0);
+      func.setResultAttr(resNumber, rock::PrefillAttr::getMnemonic(),
+                         outputInitVal);
+      func.setResultAttr(resNumber, "mhal.read_access", rw.getUnitAttr());
+      // The original function also need the read access attr for the output.
+      if (func->hasAttr("original_func")) {
+        if (ModuleOp rootMod = func->getParentOfType<ModuleOp>()
+                                   ->getParentOfType<ModuleOp>()) {
+          SymbolTable symTable(rootMod);
+          SymbolRefAttr originalFuncAttr =
+              func->getAttrOfType<SymbolRefAttr>("original_func");
+          if (func::FuncOp originalFunc = dyn_cast<func::FuncOp>(
+                  symTable.lookupSymbolIn(rootMod, originalFuncAttr))) {
+            originalFunc.setResultAttr(resNumber, "mhal.read_access",
+                                       rw.getUnitAttr());
+          }
+        }
+      }
     }
   }
-  return failure();
+  return success();
 }
 
 template <typename OpT>
@@ -367,15 +411,23 @@ public:
     auto bias = operands[2];
     auto outputType = cast<RankedTensorType>(op.getType());
 
+    StringAttr arch;
+    std::optional<uint32_t> numCU;
+    rock::GemmFeatures features;
+    std::tie(arch, numCU, features) = getArchAttributes(op, input.getType());
+
+    if (failed(setSplitKAttrs(op, features, rw)))
+      return failure();
+
     Value output =
         rw.create<bufferization::AllocTensorOp>(loc, outputType, ValueRange{});
 
     int64_t group = 1;
     if (auto attr = op->template getAttrOfType<IntegerAttr>("group"))
       group = attr.getInt(); // Use op.getGroup() when all OpT have it.
-    FailureOr<rock::ConvOp> rockConv =
-        makeRockConv(rw, op, input, filter, output, op.getPadAttr(),
-                     op.getStrideAttr(), op.getDilationAttr(), group);
+    FailureOr<rock::ConvOp> rockConv = makeRockConv(
+        rw, op, input, filter, output, op.getPadAttr(), op.getStrideAttr(),
+        op.getDilationAttr(), group, arch, numCU, features);
     if (failed(rockConv))
       return failure();
 
@@ -477,15 +529,18 @@ public:
     Value output =
         rw.create<bufferization::AllocTensorOp>(loc, outputType, ValueRange{});
 
+    StringAttr arch;
+    std::optional<uint32_t> numCU;
+    rock::GemmFeatures features;
+    std::tie(arch, numCU, features) =
+        getArchAttributes(op, op.getA().getType());
+
+    if (failed(setSplitKAttrs(op, features, rw)))
+      return failure();
+
     UnitAttr transposeA = getTranspose(op, "transpose_a"),
              transposeB = getTranspose(op, "transpose_b"),
              transposeC = getTranspose(op, "transpose_c");
-
-    StringAttr arch;
-    std::optional<uint32_t> num_cu;
-    rock::GemmFeatures features;
-    std::tie(arch, num_cu, features) =
-        getArchAttributes(op, op.getA().getType());
 
     auto [mDim, nDim] = getLastDims(transposeC, outputType);
 
@@ -508,7 +563,7 @@ public:
     Value brB = insertBroadcast(adaptor.getB(), bShape, loc, rw);
 
     IntegerAttr numCUAttr =
-        num_cu.has_value() ? rw.getI32IntegerAttr(num_cu.value()) : nullptr;
+        numCU.has_value() ? rw.getI32IntegerAttr(numCU.value()) : nullptr;
     auto rockGemm = rw.create<rock::GemmOp>(
         loc, outputType, brA, brB, output, transposeA, transposeB, transposeC,
         arch, numCUAttr, rw.getAttr<rock::GemmFeaturesAttr>(features),
@@ -1382,26 +1437,27 @@ typename std::enable_if_t<
       /*useDPP=*/nullptr);
 
   func::FuncOp func = op->template getParentOfType<func::FuncOp>();
-  FailureOr<int64_t> maybeRes = traceToRes(op.getOutput(), func);
-  if (failed(maybeRes))
+  SetVector<int64_t> resIndices = traceToRes(op.getOutput(), func);
+  if (resIndices.empty())
     return op.emitOpError(
         "can't trace the reduction output to a kernel result");
-  int64_t resNumber = maybeRes.value();
 
-  func.setResultAttr(resNumber, rock::PrefillAttr::getMnemonic(),
-                     outputInitVal);
-  func.setResultAttr(resNumber, "mhal.read_access", rw.getUnitAttr());
-  // The original function also need the read access attr for the output.
-  if (func->hasAttr("original_func")) {
-    if (ModuleOp rootMod =
-            func->getParentOfType<ModuleOp>()->getParentOfType<ModuleOp>()) {
-      SymbolTable symTable(rootMod);
-      SymbolRefAttr originalFuncAttr =
-          func->getAttrOfType<SymbolRefAttr>("original_func");
-      if (func::FuncOp originalFunc = dyn_cast<func::FuncOp>(
-              symTable.lookupSymbolIn(rootMod, originalFuncAttr))) {
-        originalFunc.setResultAttr(resNumber, "mhal.read_access",
-                                   rw.getUnitAttr());
+  for (int64_t resNumber : resIndices) {
+    func.setResultAttr(resNumber, rock::PrefillAttr::getMnemonic(),
+                       outputInitVal);
+    func.setResultAttr(resNumber, "mhal.read_access", rw.getUnitAttr());
+    // The original function also need the read access attr for the output.
+    if (func->hasAttr("original_func")) {
+      if (ModuleOp rootMod =
+              func->getParentOfType<ModuleOp>()->getParentOfType<ModuleOp>()) {
+        SymbolTable symTable(rootMod);
+        SymbolRefAttr originalFuncAttr =
+            func->getAttrOfType<SymbolRefAttr>("original_func");
+        if (func::FuncOp originalFunc = dyn_cast<func::FuncOp>(
+                symTable.lookupSymbolIn(rootMod, originalFuncAttr))) {
+          originalFunc.setResultAttr(resNumber, "mhal.read_access",
+                                     rw.getUnitAttr());
+        }
       }
     }
   }

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -946,22 +946,24 @@ static int64_t retrieveSplitKValueImpl(StringRef perfConfig) {
   return params.splitKFactor;
 }
 
-static int64_t retrieveSplitKValue(rock::RockGemmWrapperInterface op,
+static int64_t retrieveSplitKValue(rock::GemmFeatures features,
                                    StringRef perfConfig) {
-  rock::GemmFeatures features = op.getGemmFeatures();
   if (isAccel(features)) {
     return retrieveSplitKValueImpl<rock::InitParamsAccel>(perfConfig);
   }
   return retrieveSplitKValueImpl<rock::InitParamsNonAccel>(perfConfig);
 }
 
+bool isSplitKRequested(rock::GemmFeatures features, StringRef perfConfig) {
+  return retrieveSplitKValue(features, perfConfig) > 1;
+}
+
 bool isSplitKRequested(ModuleOp mod, StringRef perfConfig) {
   WalkResult gemmWalkResult =
       mod.walk([&](rock::RockGemmWrapperInterface op) -> WalkResult {
-        int64_t splitKFactor = retrieveSplitKValue(op, perfConfig);
-        if (splitKFactor > 1) {
+        if (isSplitKRequested(op.getGemmFeatures(), perfConfig))
           return WalkResult::interrupt();
-        }
+
         return WalkResult::advance();
       });
 

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-splitk.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-splitk.mlir
@@ -1,0 +1,124 @@
+// RUN: rocmlir-opt --tosa-to-rock %s -o -| FileCheck %s
+
+module attributes {kernel.module, mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
+// CHECK-LABEL: @test_basic
+// CHECK-SAME: -> (tensor<2x128x256xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_basic(%a: tensor<2x128x64xf32>, %b: tensor<2x64x256xf32>) -> tensor<2x128x256xf32> attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x128x256xf32>
+  %c = "tosa.matmul"(%a, %b) {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : (tensor<2x128x64xf32>, tensor<2x64x256xf32>) -> tensor<2x128x256xf32>
+  // CHECK: rock.gemm %[[outBuf]] = %arg0 * %arg1 {{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1"} : tensor<2x128x256xf32> = tensor<2x128x64xf32> * tensor<2x64x256xf32> -> tensor<2x128x256xf32>
+  return %c : tensor<2x128x256xf32>
+}
+
+// CHECK-LABEL: @test_basic_f16
+// CHECK-SAME: -> (tensor<2x128x256xf16> {mhal.read_access, rock.prefill = 0.000000e+00 : f16})
+func.func @test_basic_f16(%a: tensor<2x128x64xf16>, %b: tensor<2x64x256xf16>) -> tensor<2x128x256xf16> attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x128x256xf16>
+  // CHECK: rock.gemm %[[outBuf]] = %arg0 * %arg1 {{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1"} : tensor<2x128x256xf16> = tensor<2x128x64xf16> * tensor<2x64x256xf16> -> tensor<2x128x256xf16>
+  %c = "tosa.matmul"(%a, %b) {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : (tensor<2x128x64xf16>, tensor<2x64x256xf16>) -> tensor<2x128x256xf16>
+  return %c : tensor<2x128x256xf16>
+}
+
+// CHECK-LABEL: @test_basic_bf16
+// CHECK-SAME: -> (tensor<2x128x256xbf16> {mhal.read_access, rock.prefill = 0.000000e+00 : bf16})
+func.func @test_basic_bf16(%a: tensor<2x128x64xbf16>, %b: tensor<2x64x256xbf16>) -> tensor<2x128x256xbf16> attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x128x256xbf16>
+  // CHECK: rock.gemm %[[outBuf]] = %arg0 * %arg1 {{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1"} : tensor<2x128x256xbf16> = tensor<2x128x64xbf16> * tensor<2x64x256xbf16> -> tensor<2x128x256xbf16>
+  %c = "tosa.matmul"(%a, %b) {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : (tensor<2x128x64xbf16>, tensor<2x64x256xbf16>) -> tensor<2x128x256xbf16>
+  return %c : tensor<2x128x256xbf16>
+}
+
+// CHECK-LABEL: @test_reduce
+// CHECK-SAME: -> (tensor<2x128x1xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_reduce(%a: tensor<2x128x64xf32>, %b: tensor<2x64x256xf32>) -> tensor<2x128x1xf32> attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x128x256xf32>
+  // CHECK: %[[gemmOut:.*]] = rock.gemm %[[outBuf]] = %arg0 * %arg1 {{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1"} : tensor<2x128x256xf32> = tensor<2x128x64xf32> * tensor<2x64x256xf32> -> tensor<2x128x256xf32>
+  // CHECK: %[[outBuf2:.*]] = bufferization.alloc_tensor() : tensor<2x128x1xf32>
+  // CHECK: rock.reduce  sum %[[gemmOut]] into %[[outBuf2]] {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 256 : i32} : tensor<2x128x256xf32> into tensor<2x128x1xf32> -> tensor<2x128x1xf32>
+  %c = "tosa.matmul"(%a, %b) {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : (tensor<2x128x64xf32>, tensor<2x64x256xf32>) -> tensor<2x128x256xf32>
+  %1 = "tosa.reduce_sum"(%c) {axis = 2 : i32} : (tensor<2x128x256xf32>) -> tensor<2x128x1xf32>
+  return %1 : tensor<2x128x1xf32>
+}
+
+// CHECK-LABEL: @test_reduce_two_outputs
+// CHECK-SAME: -> (tensor<2x128x1xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32}
+// CHECK-SAME: tensor<2x1x256xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_reduce_two_outputs(%a: tensor<2x128x64xf32>, %b: tensor<2x64x256xf32>) -> (tensor<2x128x1xf32>, tensor<2x1x256xf32>) attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x128x256xf32>
+  // CHECK: %[[outGemm:.*]] = rock.gemm %[[outBuf]] = %arg0 * %arg1 {{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1"} : tensor<2x128x256xf32> = tensor<2x128x64xf32> * tensor<2x64x256xf32> -> tensor<2x128x256xf32>
+  // CHECK: %[[outBuf2:.*]] = bufferization.alloc_tensor() : tensor<2x128x1xf32>
+  // CHECK: rock.reduce  sum %[[outGemm]] into %[[outBuf2]] {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 256 : i32} : tensor<2x128x256xf32> into tensor<2x128x1xf32> -> tensor<2x128x1xf32>
+  // CHECK: %[[outBuf3:.*]] = bufferization.alloc_tensor() : tensor<2x1x256xf32>
+  // CHECK: rock.reduce  sum %[[outGemm]] into %[[outBuf3]] {{.*}} {axis = 1 : index, blockSize = 256 : i32, gridSize = 256 : i32} : tensor<2x128x256xf32> into tensor<2x1x256xf32> -> tensor<2x1x256xf32>
+  %c = "tosa.matmul"(%a, %b) {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : (tensor<2x128x64xf32>, tensor<2x64x256xf32>) -> tensor<2x128x256xf32>
+  %1 = "tosa.reduce_sum"(%c) {axis = 2 : i32} : (tensor<2x128x256xf32>) -> tensor<2x128x1xf32>
+  %2 = "tosa.reduce_sum"(%c) {axis = 1 : i32} : (tensor<2x128x256xf32>) -> tensor<2x1x256xf32>
+  return %1, %2 : tensor<2x128x1xf32>, tensor<2x1x256xf32>
+}
+
+// CHECK-LABEL: @test_reduce_two_outputs2
+// CHECK-SAME: -> (tensor<2x128x1xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32}
+// CHECK-SAME: tensor<2x128x256xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_reduce_two_outputs2(%a: tensor<2x128x64xf32>, %b: tensor<2x64x256xf32>) -> (tensor<2x128x1xf32>, tensor<2x128x256xf32>) attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x128x256xf32>
+  // CHECK: %[[outGemm:.*]] = rock.gemm %[[outBuf]] = %arg0 * %arg1 {{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1"} : tensor<2x128x256xf32> = tensor<2x128x64xf32> * tensor<2x64x256xf32> -> tensor<2x128x256xf32>
+  // CHECK: %[[outBuf2:.*]] = bufferization.alloc_tensor() : tensor<2x128x1xf32>
+  // CHECK: rock.reduce  sum %[[outGemm]] into %[[outBuf2]] {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 256 : i32} : tensor<2x128x256xf32> into tensor<2x128x1xf32> -> tensor<2x128x1xf32>
+  %c = "tosa.matmul"(%a, %b) {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : (tensor<2x128x64xf32>, tensor<2x64x256xf32>) -> tensor<2x128x256xf32>
+  %1 = "tosa.reduce_sum"(%c) {axis = 2 : i32} : (tensor<2x128x256xf32>) -> tensor<2x128x1xf32>
+  return %1, %c : tensor<2x128x1xf32>, tensor<2x128x256xf32>
+}
+
+// CHECK-LABEL: @test_add_two_outputs
+// CHECK-SAME: -> (tensor<2x128x256xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32}
+// CHECK-SAME: tensor<2x128x256xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32})
+func.func @test_add_two_outputs(%a: tensor<2x128x64xf32>, %b: tensor<2x64x256xf32>, %arg3: tensor<2x128x256xf32>) -> (tensor<2x128x256xf32>, tensor<2x128x256xf32>) attributes {kernel} {
+  // CHECK: %[[outBuf:.*]] = bufferization.alloc_tensor() : tensor<2x128x256xf32>
+  // CHECK: %[[outGemm:.*]] = rock.gemm %[[outBuf]] = %arg0 * %arg1 {{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1"} : tensor<2x128x256xf32> = tensor<2x128x64xf32> * tensor<2x64x256xf32> -> tensor<2x128x256xf32>
+  // CHECK: tosa.add %[[outGemm]], %arg2 : (tensor<2x128x256xf32>, tensor<2x128x256xf32>) -> tensor<2x128x256xf32>
+  %c = "tosa.matmul"(%a, %b) {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : (tensor<2x128x64xf32>, tensor<2x64x256xf32>) -> tensor<2x128x256xf32>
+  %1 = "tosa.add"(%c, %arg3) {} : (tensor<2x128x256xf32>, tensor<2x128x256xf32>) -> tensor<2x128x256xf32>
+  return %1, %c : tensor<2x128x256xf32>, tensor<2x128x256xf32>
+}
+
+// CHECK-LABEL: @mlir_convolution_multi_reduce
+// CHECK-SAME: -> (tensor<64xf16> {mhal.read_access, rock.prefill = 0.000000e+00 : f16}
+// CHECK-SAME: tensor<2621440xf16> {mhal.read_access, rock.prefill = 0.000000e+00 : f16})
+func.func @mlir_convolution_multi_reduce(%arg0: tensor<320xf16>, %arg1: tensor<32768xf16>, %arg2: tensor<11520xf16>) -> (tensor<64xf16>, tensor<2621440xf16>) attributes {kernel} {
+  %0 = tosa.const_shape  {value = dense<[32, 10, 1, 1, 1]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2, 3, 4]] output_shape [32, 10, 1, 1, 1] : tensor<320xf16> into tensor<32x10x1x1x1xf16>
+  %1 = tosa.transpose %expanded {perms = array<i32: 4, 0, 1, 2, 3>} : (tensor<32x10x1x1x1xf16>) -> tensor<1x32x10x1x1xf16>
+  %2 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<2x32x10x64x64xf16>}> : () -> tensor<2x32x10x64x64xf16>
+  %3 = tosa.add %1, %2 : (tensor<1x32x10x1x1xf16>, tensor<2x32x10x64x64xf16>) -> tensor<2x32x10x64x64xf16>
+  %4 = tosa.const_shape  {value = dense<[320, 4, 3, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %expanded_0 = tensor.expand_shape %arg2 [[0, 1, 2, 3]] output_shape [320, 4, 3, 3] : tensor<11520xf16> into tensor<320x4x3x3xf16>
+  %5 = tosa.const_shape  {value = dense<[2, 4, 64, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %expanded_1 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 4, 64, 64] : tensor<32768xf16> into tensor<2x4x64x64xf16>
+  %6 = tosa.transpose %expanded_1 {perms = array<i32: 0, 2, 3, 1>} : (tensor<2x4x64x64xf16>) -> tensor<2x64x64x4xf16>
+  %7 = tosa.transpose %expanded_0 {perms = array<i32: 0, 2, 3, 1>} : (tensor<320x4x3x3xf16>) -> tensor<320x3x3x4xf16>
+  %8 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %9 = "tosa.const"() <{value = dense<0.000000e+00> : tensor<320xf16>}> : () -> tensor<320xf16>
+  // CHECK: rock.conv{{.*}} {arch = "amdgcn-amd-amdhsa:gfx950", dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], output_layout = ["no", "go", "ko", "ho", "wo"], padding = [1 : index, 1 : index, 1 : index, 1 : index], perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1", strides = [1 : index, 1 : index]} : tensor<1x320x4x3x3xf16>, tensor<2x1x4x64x64xf16>, tensor<2x1x320x64x64xf16> -> tensor<2x1x320x64x64xf16>
+  %10 = tosa.conv2d %6, %7, %9, %8, %8 {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 1, 1, 1, 1>, perf_config = "v3:16,32,4,16,16,4,4,1,2,1,1", stride = array<i64: 1, 1>} : (tensor<2x64x64x4xf16>, tensor<320x3x3x4xf16>, tensor<320xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<2x64x64x320xf16>
+  %11 = tosa.transpose %10 {perms = array<i32: 0, 3, 1, 2>} : (tensor<2x64x64x320xf16>) -> tensor<2x320x64x64xf16>
+  %12 = tosa.const_shape  {value = dense<[2, 32, 10, 64, 64]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %expanded_2 = tensor.expand_shape %11 [[0], [1, 2], [3], [4]] output_shape [2, 32, 10, 64, 64] : tensor<2x320x64x64xf16> into tensor<2x32x10x64x64xf16>
+  %13 = tosa.add %expanded_2, %3 : (tensor<2x32x10x64x64xf16>, tensor<2x32x10x64x64xf16>) -> tensor<2x32x10x64x64xf16>
+  %14 = tosa.const_shape  {value = dense<2621440> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %collapsed = tensor.collapse_shape %13 [[0, 1, 2, 3, 4]] : tensor<2x32x10x64x64xf16> into tensor<2621440xf16>
+  %15 = "tosa.const"() <{value = dense<2.443790e-05> : tensor<2x32x10x64x64xf16>}> : () -> tensor<2x32x10x64x64xf16>
+  %16 = "tosa.const"() <{value = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %17 = tosa.mul %13, %15, %16 : (tensor<2x32x10x64x64xf16>, tensor<2x32x10x64x64xf16>, tensor<1xi8>) -> tensor<2x32x10x64x64xf16>
+  %18 = tosa.const_shape  {value = dense<[2, 32, 40960, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %collapsed_3 = tensor.collapse_shape %17 [[0], [1], [2, 3, 4]] : tensor<2x32x10x64x64xf16> into tensor<2x32x40960xf16>
+  %expanded_4 = tensor.expand_shape %collapsed_3 [[0], [1], [2, 3]] output_shape [2, 32, 40960, 1] : tensor<2x32x40960xf16> into tensor<2x32x40960x1xf16>
+  // CHECK: rock.reduce  sum {{.*}} {axis = 2 : index, blockSize = 256 : i32, gridSize = 10240 : i32} : tensor<2x32x40960x1xf16> into tensor<2x32x1x1xf16> -> tensor<2x32x1x1xf16>
+  %19 = tosa.reduce_sum %expanded_4 {axis = 2 : i32} : (tensor<2x32x40960x1xf16>) -> tensor<2x32x1x1xf16>
+  %20 = tosa.const_shape  {value = dense<[2, 32, 1, 1, 1]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %expanded_5 = tensor.expand_shape %19 [[0], [1], [2], [3, 4]] output_shape [2, 32, 1, 1, 1] : tensor<2x32x1x1xf16> into tensor<2x32x1x1x1xf16>
+  %21 = tosa.const_shape  {value = dense<64> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %collapsed_6 = tensor.collapse_shape %19 [[0, 1, 2, 3]] : tensor<2x32x1x1xf16> into tensor<64xf16>
+  return %collapsed_6, %collapsed : tensor<64xf16>, tensor<2621440xf16>
+}
+
+}

--- a/mlir/test/rocmlir-driver/populate_host_print_splitk.mlir
+++ b/mlir/test/rocmlir-driver/populate_host_print_splitk.mlir
@@ -1,0 +1,65 @@
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -pr --apply-bufferization-pipeline=false | FileCheck %s
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -pr -t f16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=F16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -pr -t bf16 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=BF16
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -pr -t i8 --apply-bufferization-pipeline=false | FileCheck %s --check-prefix=I8
+
+// CHECK-LABEL: func.func @main()
+// CHECK-NEXT: %[[filter:.*]] = memref.alloc() : memref<[[GKCYX:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: affine.for %[[if:.*]] = 0 to [[GKCYX]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[if]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store %{{.*}}, %[[filter]][%[[if]]] : memref<[[GKCYX]]x[[TYPE]]>
+
+// CHECK: %[[input:.*]] = memref.alloc() : memref<[[NGCHIWI:[0-9]+]]x[[TYPE]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x{{.*}}>
+// CHECK-NEXT: affine.for %[[ii:.*]] = 0 to [[NGCHIWI]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[ii]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store %{{.*}}, %[[input]][%[[ii]]] : memref<[[NGCHIWI]]x[[TYPE]]>
+
+// CHECK: %[[output:.*]] = memref.alloc() : memref<[[NGKHOWO:[0-9]+]]x[[TYPE]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<1x{{.*}}>
+// CHECK-NEXT: arith.constant {{.*}} : f32
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<1x{{.*}}>
+// CHECK-NEXT: affine.for %[[io:.*]] = 0 to [[NGKHOWO]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[io]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store %{{.*}}, %[[output]][%[[io]]] : memref<[[NGKHOWO]]x[[TYPE]]>
+
+// CHECK: call @{{.*}}({{.*}}, {{.*}}, {{.*}}) : (memref<[[GKCYX]]x[[TYPE]]>, memref<[[NGCHIWI]]x[[TYPE]]>, memref<[[NGKHOWO]]x[[TYPE]]>) -> ()
+// CHECK-NEXT: memref.cast %{{.*}} : memref<[[NGKHOWO]]x[[TYPE]]> to memref<*x[[TYPE]]>
+// CHECK-NEXT: call @printMemrefF32(%{{.*}}) : (memref<*x[[TYPE]]>) -> ()
+// CHECK-NEXT: memref.dealloc {{.*}} : memref<[[GKCYX]]x[[TYPE]]>
+// CHECK-NEXT: memref.dealloc {{.*}} : memref<[[NGCHIWI]]x[[TYPE]]>
+
+// F16: memref.alloc() : memref<{{.*}}>
+// F16: call @_memcpy_f16_f32_{{[0-9]+}}(%{{.*}}, %{{.*}})
+// BF16: memref.alloc() : memref<{{.*}}>
+// BF16: call @_memcpy_bf16_f32_{{[0-9]+}}(%{{.*}}, %{{.*}})
+// I8: memref.cast %{{.*}} : memref<{{.*}}> to memref<*xi32>
+// I8: call @printMemrefI32(%{{.*}}) : (memref<*xi32>) -> ()
+// F16: memref.dealloc {{.*}} : memref<{{.*}}>
+// BF16: memref.dealloc {{.*}} : memref<{{.*}}>
+// I8: memref.dealloc {{.*}} : memref<{{.*}}>
+// CHECK-NEXT: memref.dealloc {{.*}} : memref<[[NGKHOWO]]x[[TYPE]]>
+// CHECK-NEXT: return

--- a/mlir/test/rocmlir-driver/populate_host_splitk.mlir
+++ b/mlir/test/rocmlir-driver/populate_host_splitk.mlir
@@ -1,0 +1,68 @@
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph --apply-bufferization-pipeline=false | FileCheck %s
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -t f16 --apply-bufferization-pipeline=false | FileCheck %s
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -p -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -t i8 --apply-bufferization-pipeline=false | FileCheck %s
+
+// CHECK-LABEL: func.func @main()
+// CHECK-NEXT: %[[filter:.*]] = memref.alloc() : memref<[[GKCYX:[0-9]+]]x[[TYPE:[a-zA-Z0-9]+]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: arith.constant {{.*}} : [[TYPE]]
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: arith.constant {{.*}} : [[TYPE]]
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: arith.constant {{.*}} : [[TYPE]]
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: affine.for %[[if:.*]] = 0 to [[GKCYX]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[if]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store %{{.*}}, %[[filter]][%[[if]]] : memref<[[GKCYX]]x[[TYPE]]>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[input:.*]] = memref.alloc() : memref<[[NGCHIWI:[0-9]+]]x[[TYPE]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: arith.constant {{.*}} : [[TYPE]]
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: arith.constant {{.*}} : [[TYPE]]
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: arith.constant {{.*}} : [[TYPE]]
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<3x[[TYPE]]>
+// CHECK-NEXT: affine.for %[[ii:.*]] = 0 to [[NGCHIWI]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[ii]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store %{{.*}}, %[[input]][%[[ii]]] : memref<[[NGCHIWI]]x[[TYPE]]>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[output:.*]] = memref.alloc() : memref<[[NGKHOWO:[0-9]+]]x[[OTYPE:.*]]>
+// CHECK-NEXT: arith.constant dense{{.*}} : vector<1x[[OTYPE]]>
+// CHECK-NEXT: arith.constant {{.*}} : [[OTYPE]]
+// CHECK-NEXT: arith.constant {{.*}} : index
+// CHECK-NEXT: vector.insertelement {{.*}} : vector<1x[[OTYPE]]>
+// CHECK-NEXT: affine.for %[[io:.*]] = 0 to [[NGKHOWO]]
+// CHECK-NEXT: affine.apply {{.*}}(%[[io]])
+// CHECK-NEXT: vector.extractelement
+// CHECK-NEXT: memref.store %{{.*}}, %[[output]][%[[io]]] : memref<[[NGKHOWO]]x[[OTYPE]]>
+// CHECK-NEXT: }
+// CHECK-NEXT: call @rock_conv_gkc01_ngc01_ngk01_0_gpu({{.*}}, {{.*}}, {{.*}}) : (memref<[[GKCYX]]x[[TYPE]]>, memref<[[NGCHIWI]]x[[TYPE]]>, memref<[[NGKHOWO]]x[[OTYPE]]>) -> ()
+// CHECK-NEXT: memref.dealloc %[[filter]]
+// CHECK-NEXT: memref.dealloc %[[input]]
+// CHECK-NEXT: memref.dealloc %[[output]]
+// CHECK-NEXT: return
+
+// CHECK: func.func @rock_conv_gkc01_ngc01_ngk01_0_gpu(%{{.*}}: memref<[[GKCYX]]x[[TYPE]]>, %{{.*}}: memref<[[NGCHIWI]]x[[TYPE]]>, %{{.*}}: memref<[[NGKHOWO]]x[[OTYPE]]>)
+// CHECK-NEXT: gpu.alloc  () : memref<[[GKCYX]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[GKCYX]]x[[TYPE]]>,  memref<[[GKCYX]]x[[TYPE]]>
+// CHECK-NEXT: gpu.alloc  () : memref<[[NGCHIWI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[NGCHIWI]]x[[TYPE]]>,  memref<[[NGCHIWI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.alloc  () : memref<[[NGKHOWO]]x[[OTYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[NGKHOWO]]x[[OTYPE]]>,  memref<[[NGKHOWO]]x[[OTYPE]]>
+// CHECK-NEXT: call @rock_conv_gkc01_ngc01_ngk01_0(%{{.*}}, %{{.*}}, %{{.*}}) : (memref<[[GKCYX]]x[[TYPE]]>, memref<[[NGCHIWI]]x[[TYPE]]>, memref<[[NGKHOWO]]x[[OTYPE]]>) -> ()
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[GKCYX]]x[[TYPE]]>,  memref<[[GKCYX]]x[[TYPE]]>
+// CHECK-NEXT: gpu.dealloc  %{{.*}} : memref<[[GKCYX]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[NGCHIWI]]x[[TYPE]]>,  memref<[[NGCHIWI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.dealloc  %{{.*}} : memref<[[NGCHIWI]]x[[TYPE]]>
+// CHECK-NEXT: gpu.memcpy  %{{.*}}, %{{.*}} : memref<[[NGKHOWO]]x[[OTYPE]]>,  memref<[[NGKHOWO]]x[[OTYPE]]>
+// CHECK-NEXT: gpu.dealloc  %{{.*}} : memref<[[NGKHOWO]]x[[OTYPE]]>
+// CHECK-NEXT: return

--- a/mlir/test/rocmlir-driver/populate_random_data_splitk.mlir
+++ b/mlir/test/rocmlir-driver/populate_random_data_splitk.mlir
@@ -1,0 +1,66 @@
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand=none | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=NONE
+
+// NONE-NOT: call @seedRandomValues
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand 1 | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,RAND1,RAND2,FWD
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand 1 -rand_side filter | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,RAND1,FIXED2,FWD
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand 1 -rand_side input | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,RAND2
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand 1 -rand_side filter -operation conv_bwd_data | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,RAND1,FIXED3,BWDDATA
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand 1 -rand_side output  -operation conv_bwd_data | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED1,RAND3,BWDDATA
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand 1 -rand_side input -operation conv_bwd_weight | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,RAND2,FIXED3,BWDWEIGHT
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -perf_config="v3:64,64,8,16,16,4,4,1,2,1,1" -ph -p -rand 1 -rand_side output  -operation conv_bwd_weight | rocmlir-opt -canonicalize | FileCheck %s --check-prefixes=CHECK,HASFIXED,FIXED2,RAND3,BWDWEIGHT
+
+// CHECK-LABEL: @main
+// CHECK-DAG: %[[zero:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[min:.*]] = arith.constant -5 : i16
+// CHECK-DAG: %[[max:.*]] = arith.constant 5 : i16
+// CHECK-DAG: %[[one:.*]] = arith.constant 1 : i32
+// HASFIXED-DAG: %[[one_i16:.*]] = arith.constant 1 : i16
+// CHECK: call @seedRandomValues(%[[one]])
+
+// CHECK: memref.alloc
+// CHECK: affine.for
+// RAND1-NEXT: %[[val1:.*]] = func.call @randomIntegerValue(%[[min]], %[[max]])
+// FIXED1-NEXT: %[[val1:.*]] = func.call @randomIntegerValue(%[[one_i16]], %[[one_i16]])
+// BWDWEIGHT-NEXT: memref.store %[[zero]]
+// RAND1-NEXT: memref.store %[[val1]]
+// FIXED1-NEXT: memref.store %[[val1]]
+// CHECK: memref.alloc
+// CHECK-NEXT: affine.for
+// RAND2-NEXT: %[[val2:.*]] = func.call @randomIntegerValue(%[[min]], %[[max]])
+// FIXED2-NEXT: %[[val2:.*]] = func.call @randomIntegerValue(%[[one_i16]], %[[one_i16]])
+// BWDDATA-NEXT: memref.store %[[zero]]
+// RAND2-NEXT: memref.store %[[val2]]
+// FIXED2-NEXT: memref.store %[[val2]]
+// CHECK: memref.alloc
+// CHECK-NEXT: affine.for
+// RAND3-NEXT: %[[val3:.*]] = func.call @randomIntegerValue(%[[min]], %[[max]])
+// FIXED3-NEXT: %[[val3:.*]] = func.call @randomIntegerValue(%[[one_i16]], %[[one_i16]])
+// FWD-NEXT: memref.store %[[zero]]
+// RAND3-NEXT: memref.store %[[val3]]
+// FIXED3-NEXT: memref.store %[[val3]]
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 2 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=SEED2
+// SEED2: %[[two:.*]] = arith.constant 2 : i32
+// SEED2: call @seedRandomValues(%[[two]])
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- -ph -p -rand 1 -rand_type float -rand_min 1 -rand_max 3 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_FLOAT
+
+// RAND_FLOAT-LABEL: @main
+// RAND_FLOAT-DAG: %[[min:.*]] = arith.constant 1 : i16
+// RAND_FLOAT-DAG: %[[max:.*]] = arith.constant 3 : i16
+// RAND_FLOAT-DAG: %[[one:.*]] = arith.constant 1 : i32
+// RAND_FLOAT: call @seedRandomValues(%[[one]])
+
+// RAND_FLOAT: memref.alloc
+// RAND_FLOAT-NEXT: affine.for
+// RAND_FLOAT-NEXT: %[[val1:.*]] = func.call @randomFloatValue(%[[min]], %[[max]])
+// RAND_FLOAT-NEXT: memref.store %[[val1]]
+// RAND_FLOAT: memref.alloc
+// RAND_FLOAT-NEXT: affine.for
+// RAND_FLOAT-NEXT: %[[val2:.*]] = func.call @randomFloatValue(%[[min]], %[[max]])
+// RAND_FLOAT-NEXT: memref.store %[[val2]]
+// RAND_FLOAT: memref.alloc
+// RAND_FLOAT-NEXT: affine.for
+// RAND_FLOAT-NEXT: %[[val3:.*]] = func.call @randomFloatValue(%[[min]], %[[max]])
+// RAND_FLOAT-NEXT: memref.store %[[val1]]

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1501,7 +1501,7 @@ static LogicalResult populateTensorFillLogic(OpBuilder &b, Location loc,
 static LogicalResult populateRandomTensorFillLogic(OpBuilder &b, Location loc,
                                                    ModuleOp module,
                                                    Type elemType, Value toFill,
-                                                   int idx) {
+                                                   int idx, bool zeroInit) {
   llvm::SmallDenseMap<short, Value> i16vals;
   auto getI16Val = [&](short v) {
     if (i16vals.find(v) == i16vals.end()) {
@@ -1543,18 +1543,22 @@ static LogicalResult populateRandomTensorFillLogic(OpBuilder &b, Location loc,
 
   affine::buildAffineLoopNest(
       b, loc, lowerBounds, upperBounds, steps,
-      [elemType, randFunc, toFillFlat, minConst,
+      [zeroInit, elemType, randFunc, toFillFlat, minConst,
        maxConst](OpBuilder &b, Location loc, ValueRange ivs) {
-        auto randFloatCall = b.create<func::CallOp>(
-            loc, randFunc, ValueRange{minConst, maxConst});
-        Value randFloat = randFloatCall.getResult(0);
         Value randVal;
-        if (elemType.isIntOrIndex())
-          randVal = b.create<arith::FPToSIOp>(loc, elemType, randFloat);
-        else if (!elemType.isF32())
-          randVal = b.create<arith::TruncFOp>(loc, elemType, randFloat);
-        else
-          randVal = randFloat;
+        if (zeroInit) {
+          randVal = rock::createZeroConstantOp(b, loc, elemType);
+        } else {
+          auto randFloatCall = b.create<func::CallOp>(
+              loc, randFunc, ValueRange{minConst, maxConst});
+          Value randFloat = randFloatCall.getResult(0);
+          if (elemType.isIntOrIndex())
+            randVal = b.create<arith::FPToSIOp>(loc, elemType, randFloat);
+          else if (!elemType.isF32())
+            randVal = b.create<arith::TruncFOp>(loc, elemType, randFloat);
+          else
+            randVal = randFloat;
+        }
 
         b.create<memref::StoreOp>(loc, randVal, toFillFlat, ivs);
       });
@@ -3538,6 +3542,10 @@ static LogicalResult populateHostHarnessLogic(
   bool gpuValidation = validationType == "gpu" &&
                        ((hasAccel || isSmallFloatIn) || heuristicValidation);
   bool isRandom = (randomSeed != "fixed" && randomSeed != "none");
+  bool isSplitK =
+      (genParams.perfConfig.empty())
+          ? false
+          : rock::isSplitKRequested(genParams.features, genParams.perfConfig);
 
   if (isRandom) {
     auto seedFunc = makeFuncDecl(module, "seedRandomValues", {b.getI32Type()});
@@ -3609,12 +3617,17 @@ static LogicalResult populateHostHarnessLogic(
         b.create<memref::StoreOp>(loc, value, lvar, ValueRange{index});
       }
     } else if (!isRandom) {
-      SmallVector<float, 3> initPattern = getTensorInitPattern(elemType, idx);
+      bool zeroInit = llvm::is_contained(outIndices, idx) && isSplitK;
+      SmallVector<float> zeroPattern = {0.0f};
+      SmallVector<float> tensorPattern = getTensorInitPattern(elemType, idx);
+      auto initPattern = zeroInit ? zeroPattern : tensorPattern;
+
       if (failed(populateTensorFillLogic(b, loc, initPattern, elemType, lvar)))
         return failure();
     } else {
+      bool zeroInit = llvm::is_contained(outIndices, idx) && isSplitK;
       if (failed(populateRandomTensorFillLogic(b, loc, module, elemType, lvar,
-                                               idx)))
+                                               idx, zeroInit)))
         return failure();
     }
 


### PR DESCRIPTION
In this PR we fix some issues related to split-k tensor initialization:
- Make sure rocmlir-gen code to init by default to 100 actually works (MHALToGPU.cpp)
- Set prefill flags in TosaToRock similarly to what we do for reductions
- rocmlir-gen init output tensor to zero when not cloning and split-k is enabled

