### PR TITLE
Recover split-k fusion tests removed in last upstream merge

### DIFF
--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f16/mixr-gemm-splitk-add.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f16/mixr-gemm-splitk-add.e2e.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut dot_splitk_add_trunc --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_add_trunc_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_add_trunc --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_add_trunc_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [5,     5,     5,  5,     5,     5,  5,     5,     5,  5,     5,     5,  5,     5,     5]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_add_trunc(%arg0: !migraphx.shaped<1x5x4xf16, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf16, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf16, 15x3x1>) -> !migraphx.shaped<1x5x3xf16, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf16, 20x4x1>, <1x4x3xf16, 12x3x1> -> <1x5x3xf16, 15x3x1>
+    %2 = migraphx.add %0, %arg2 {} : <1x5x3xf16, 15x3x1>, <1x5x3xf16, 15x3x1> -> <1x5x3xf16, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf16, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add-const.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add-const.e2e.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-gen -fut dot_splitk_add_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_add_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_add_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_add_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_add_const(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<10.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %2 = migraphx.add %0, %cst {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add-ext.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add-ext.e2e.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-gen -fut dot_splitk_add_ext --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_add_ext_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_add_ext --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -RMS_threshold=1e-3 -relDiff_threshold=1e-3 -ph -print-results -rand 1 -rand_type float -fut dot_splitk_add_ext_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [5,     5,     5,  5,     5,     5,  5,     5,     5,  5,     5,     5,  5,     5,     5]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_add_ext(%arg0: !migraphx.shaped<1x5x4xf16, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf16, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf16, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf16, 20x4x1>, <1x4x3xf16, 12x3x1> -> <1x5x3xf16, 15x3x1>
+    %2 = migraphx.add %0, %arg2 {} : <1x5x3xf16, 15x3x1>, <1x5x3xf16, 15x3x1> -> <1x5x3xf16, 15x3x1>
+    %3 = migraphx.convert %2 : <1x5x3xf16, 15x3x1> to <1x5x3xf32, 15x3x1>
+    return %3 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add-same.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add-same.e2e.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut dot_splitk_add_same --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_add_same_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_add_same --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_add_same_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK: [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_add_same(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.add %0, %0 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-add.e2e.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut dot_splitk_add --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_add_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_add --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_add_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [5,     5,     5,  5,     5,     5,  5,     5,     5,  5,     5,     5,  5,     5,     5]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_add(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.add %arg2, %0 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-dequantizelinear-reduce.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-dequantizelinear-reduce.e2e.mlir
@@ -1,0 +1,13 @@
+// RUN: rocmlir-gen -fut dot_splitk_dequantizelinear --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_dequantizelinear_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK: [1 1 1]
+  func.func @dot_splitk_dequantizelinear(%arg0: !migraphx.shaped<1x128x1x1xf32, 128x1x1x1>, %arg1: !migraphx.shaped<1x128x56x56xi8, 401408x3136x56x1>, %arg2: !migraphx.shaped<128x128x3x3xi8, 1152x9x3x1>) -> (!migraphx.shaped<1x128x28x28xf32, 100352x784x28x1>, !migraphx.shaped<1x1x28x28xf32, 784x784x28x1>) attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %1 = migraphx.quant_convolution %arg1, %arg2 {perf_config="v3:16,32,16,16,16,16,16,1,2,1,1", dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : <1x128x56x56xi8, 401408x3136x56x1>, <128x128x3x3xi8, 1152x9x3x1> -> <1x128x28x28xi32, 100352x784x28x1>
+    %2 = migraphx.dequantizelinear %1, %arg0 : <1x128x28x28xi32, 100352x784x28x1>, <1x128x1x1xf32, 128x1x1x1> -> <1x128x28x28xf32, 100352x784x28x1>
+    %3 = migraphx.reduce_sum %2 {axes = [1]} : <1x128x28x28xf32, 100352x784x28x1> -> <1x1x28x28xf32, 784x784x28x1>
+    return %2, %3 : !migraphx.shaped<1x128x28x28xf32, 100352x784x28x1>, !migraphx.shaped<1x1x28x28xf32, 784x784x28x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-dequantizelinear.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-dequantizelinear.e2e.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen -fut dot_splitk_dequantizelinear --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_dequantizelinear_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  func.func @dot_splitk_dequantizelinear(%arg0: !migraphx.shaped<1x128x1x1xf32, 128x1x1x1>, %arg1: !migraphx.shaped<1x128x56x56xi8, 401408x3136x56x1>, %arg2: !migraphx.shaped<128x128x3x3xi8, 1152x9x3x1>) -> !migraphx.shaped<1x128x28x28xf32, 100352x784x28x1> attributes{arch = "##TOKEN_ARCH##", enable_splitk_for_tuning, kernel = "mixr"} {
+    %1 = migraphx.quant_convolution %arg1, %arg2 {perf_config="v3:16,32,16,16,16,16,16,1,2,1,1", dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [2, 2]} : <1x128x56x56xi8, 401408x3136x56x1>, <128x128x3x3xi8, 1152x9x3x1> -> <1x128x28x28xi32, 100352x784x28x1>
+    %2 = migraphx.dequantizelinear %1, %arg0 : <1x128x28x28xi32, 100352x784x28x1>, <1x128x1x1xf32, 128x1x1x1> -> <1x128x28x28xf32, 100352x784x28x1>
+    return %2 : !migraphx.shaped<1x128x28x28xf32, 100352x784x28x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-div.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-div.e2e.mlir
@@ -1,0 +1,18 @@
+// RUN: rocmlir-gen -fut dot_splitk_mul --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_mul_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_mul --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_mul_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_mul(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,16,16,16,16,16,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<1.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %1 = migraphx.add %arg2, %cst {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.div %0, %1 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-linear-reduce.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-linear-reduce.e2e.mlir
@@ -1,0 +1,23 @@
+// RUN: rocmlir-gen -fut dot_splitk_linear --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_linear_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_linear --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_linear_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK: [1 1 1]
+  // CHECK:  [21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21]
+  // CHECK:  [63,  63,  63,  63,  63]
+
+  // CLONE: [1 1 1]
+  // CLONE: [1 1 1]
+
+  func.func @dot_splitk_linear(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>, %arg3: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> (!migraphx.shaped<1x5x3xf32, 15x3x1>, !migraphx.shaped<1x5x1xf32, 5x1x1>) attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,16,16,16,16,16,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<3.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %1 = migraphx.add %arg2, %cst {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.mul %0, %1 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    %3 = migraphx.add %0, %arg3 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    %4 = migraphx.add %2, %3 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    %5 = migraphx.reduce_sum %4 {axes = [2]} : <1x5x3xf32, 15x3x1> -> <1x5x1xf32, 5x1x1>
+    return %4, %5 : !migraphx.shaped<1x5x3xf32, 15x3x1>, !migraphx.shaped<1x5x1xf32, 5x1x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-linear.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-linear.e2e.mlir
@@ -1,0 +1,20 @@
+// RUN: rocmlir-gen -fut dot_splitk_linear --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_linear_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_linear --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_linear_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_linear(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>, %arg3: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,16,16,16,16,16,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<3.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %1 = migraphx.add %arg2, %cst {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.mul %0, %1 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    %3 = migraphx.add %0, %arg3 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    %4 = migraphx.add %2, %3 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %4 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-mul-const.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-mul-const.e2e.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-gen -fut dot_splitk_mul_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_mul_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_mul_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_mul_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_mul_const(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<3.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %2 = migraphx.mul %0, %cst {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-mul.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-mul.e2e.mlir
@@ -1,0 +1,18 @@
+// RUN: rocmlir-gen -fut dot_splitk_mul --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_mul_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_mul --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_mul_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_mul(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,16,16,16,16,16,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<3.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %1 = migraphx.add %arg2, %cst {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.mul %0, %1 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-neg.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-neg.e2e.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut dot_splitk_add --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_add_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_add --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_add_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [-4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_add(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.neg %0 {} : <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub-const-other.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub-const-other.e2e.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-gen -fut dot_splitk_sub_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_sub_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_sub_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -relDiff_threshold=2e-6 -ph -print-results -rand 1 -rand_type float -fut dot_splitk_sub_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [-3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_sub_const(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<1.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %2 = migraphx.sub %cst, %0 {} : <1x5x3xf32, 0x0x0>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub-const.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub-const.e2e.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-gen -fut dot_splitk_sub_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_sub_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_sub_const --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -relDiff_threshold=2e-6 -ph -print-results -rand 1 -rand_type float -fut dot_splitk_sub_const_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_sub_const(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<1.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %2 = migraphx.sub %0, %cst {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub-same.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub-same.mlir
@@ -1,0 +1,18 @@
+// RUN: rocmlir-gen -fut dot_splitk_sub_same --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_sub_same_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_sub_same --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand 1 -rand_type float -fut dot_splitk_sub_same_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_sub_same(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %cst = migraphx.literal(dense<2.000000e+00> : tensor<1x5x3xf32>) : <1x5x3xf32, 0x0x0>
+    %1 = migraphx.mul %0, %cst : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 0x0x0> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.sub %1, %0 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-gemm-splitk-sub.e2e.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut dot_splitk_sub --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -print-results -rand none -fut dot_splitk_sub_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut dot_splitk_sub --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -relDiff_threshold=1e-5 -ph -print-results -rand 1 -rand_type float -fut dot_splitk_sub_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// ALLOW_RETRIES: 2
+module {
+  // CHECK: [1 1 1]
+  // CHECK:  [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
+
+  // CLONE: [1 1 1]
+  // CLONE-NEXT: Unranked Memref base
+
+  func.func @dot_splitk_sub(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %0 = migraphx.dot %arg0, %arg1 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1"} : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>
+    %2 = migraphx.sub %0, %arg2 {} : <1x5x3xf32, 15x3x1>, <1x5x3xf32, 15x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-multi-reduce-mo-4d-splitk.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-multi-reduce-mo-4d-splitk.e2e.mlir
@@ -1,7 +1,7 @@
 // RUN: rocmlir-gen -fut mlir_convolution_multi_reduce --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_convolution_multi_reduce_wrapper --verifier clone -relDiff_threshold 0.01 -RMS_threshold 0.01 -absDiff_threshold 0.4 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 
-// We need a check for each output as this test case has three outputs in it.
+// We need a check for each output as this test case has two outputs in it.
 // CHECK: [1 1 1]
 // CHECK: [1 1 1]
 module {

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-multi-reduce-mo-4d-splitk.e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/mixr-multi-reduce-mo-4d-splitk.e2e.mlir
@@ -1,0 +1,20 @@
+// RUN: rocmlir-gen -fut mlir_convolution_multi_reduce --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_convolution_multi_reduce_wrapper --verifier clone -relDiff_threshold 0.01 -RMS_threshold 0.01 -absDiff_threshold 0.4 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+
+// We need a check for each output as this test case has three outputs in it.
+// CHECK: [1 1 1]
+// CHECK: [1 1 1]
+module {
+  func.func @mlir_convolution_multi_reduce(%arg0: !migraphx.shaped<2x32x10x64x64xf32, 0x10x1x0x0>, %arg1: !migraphx.shaped<2x4x64x64xf32, 16384x4096x64x1>, %arg2: !migraphx.shaped<320x4x3x3xf32, 36x9x3x1>) -> (!migraphx.shaped<2x32x1x1x1xf32, 32x1x1x1x1>, !migraphx.shaped<2x32x10x64x64xf32, 1310720x40960x4096x64x1>) attributes{arch = "", enable_splitk_for_tuning, kernel = "mixr"} {
+    %1 = migraphx.literal(dense<2.44140629E-5> : tensor<1xf32>) : <1xf32, 0>
+    %2 = migraphx.convolution %arg1, %arg2 {perf_config="v3:16,32,4,16,16,4,4,1,2,1,1", dilation = [1, 1], group = 1 : i64, padding = [1, 1, 1, 1], padding_mode = 0 : i64, stride = [1, 1]} : <2x4x64x64xf32, 16384x4096x64x1>, <320x4x3x3xf32, 36x9x3x1> -> <2x320x64x64xf32, 1310720x4096x64x1>
+    %3 = migraphx.reshape %2 {dims = [2, 32, 10, 64, 64]} : <2x320x64x64xf32, 1310720x4096x64x1> -> <2x32x10x64x64xf32, 1310720x40960x4096x64x1>
+    %4 = migraphx.add %3, %arg0 : <2x32x10x64x64xf32, 1310720x40960x4096x64x1>, <2x32x10x64x64xf32, 0x10x1x0x0> -> <2x32x10x64x64xf32, 1310720x40960x4096x64x1>
+    %5 = migraphx.multibroadcast %1 {out_dyn_dims = [], out_lens = [2, 32, 10, 64, 64]} : <1xf32, 0> -> <2x32x10x64x64xf32, 0x0x0x0x0>
+    %6 = migraphx.mul %4, %5 : <2x32x10x64x64xf32, 1310720x40960x4096x64x1>, <2x32x10x64x64xf32, 0x0x0x0x0> -> <2x32x10x64x64xf32, 1310720x40960x4096x64x1>
+    %7 = migraphx.reshape %6 {dims = [2, 32, 40960, 1]} : <2x32x10x64x64xf32, 1310720x40960x4096x64x1> -> <2x32x40960x1xf32, 1310720x40960x1x1>
+    %8 = migraphx.reduce_sum %7 {axes = [2]} : <2x32x40960x1xf32, 1310720x40960x1x1> -> <2x32x1x1xf32, 32x1x1x1>
+    %9 = migraphx.reshape %8 {dims = [2, 32, 1, 1, 1]} : <2x32x1x1xf32, 32x1x1x1> -> <2x32x1x1x1xf32, 32x1x1x1x1>
+    return %9, %4 : !migraphx.shaped<2x32x1x1x1xf32, 32x1x1x1x1>, !migraphx.shaped<2x32x10x64x64xf32, 1310720x40960x4096x64x1>
+  }
+}


### PR DESCRIPTION
In this PR we recover the split-k fusion tests we removed in the last upstream merge. It seems https://github.com/ROCm/rocMLIR/pull/1784 solves the issue and tests pass at least on gfx90a, we'll get confirmation once CI passes.