### PR TITLE
GEMM+GEMM migraphx integration

### DIFF
--- a/mlir/include/mlir/Conversion/TosaToRock/TosaToRock.h
+++ b/mlir/include/mlir/Conversion/TosaToRock/TosaToRock.h
@@ -37,6 +37,8 @@ void populateTosaToRockTensorConversionPatterns(MLIRContext *context,
 void populateTosaToRockAttentionConversionPatterns(MLIRContext *context,
                                                    RewritePatternSet &patterns);
 
+void populateTosaToRockGemmGemmConversionPatterns(MLIRContext *context,
+                                                  RewritePatternSet &patterns);
 } // namespace tosa
 
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.td
@@ -233,6 +233,16 @@ def RockGemmGemmWrapperInterface : OpInterface<"RockGemmGemmWrapperInterface"> {
         /*methodBody=*/"",
         /*defaultImplementation=*/ ""
       >,
+    InterfaceMethod<
+        /*desc=*/[{
+          Set the index of the elementwise region argument that comes from the first GEMM.
+        }],
+        /*retType=*/"void",
+        /*methodName=*/"setFirstGemmIndex",
+        /*args=*/(ins "uint32_t":$index),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/ ""
+      >,
 
     // TODO: more methods here as needed
   ];

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
+#include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/Tuning/RockTuning.h"
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
@@ -142,7 +143,7 @@ static bool isConstRangeAttribute(Attribute value) {
   return false;
 }
 
-bool isConstRange(Value v) {
+static bool isConstRange(Value v) {
   if (auto cst = v.getDefiningOp<arith::ConstantOp>())
     return isConstRangeAttribute(cst.getValue());
   if (auto cst = v.getDefiningOp<tosa::ConstOp>())
@@ -394,6 +395,140 @@ static LogicalResult setSplitKAttrs(OpT op, rock::GemmFeatures features,
     }
   }
   return success();
+}
+
+// Tosa ops can broadcast values along axes, which allows for
+// element-wise operations without fully-matching dimensions.  The
+// Elementwise trait is strict about matching dimensions, but
+// broadcastable ops are also element-wise, and we know that an
+// additional set of ops are also element-wise.
+static bool isElementwiseOp(Operation *op) {
+  return op->hasTrait<OpTrait::Elementwise>() ||
+         op->hasTrait<OpTrait::ResultsBroadcastableShape>() ||
+         // clang-format off
+    isa<tosa::CastOp,
+        tosa::ClampOp,
+        tosa::ErfOp,
+        tosa::SigmoidOp,
+        tosa::TanhOp,
+        tosa::AbsOp,
+        tosa::CeilOp,
+        tosa::ClzOp,
+        tosa::ExpOp,
+        tosa::FloorOp,
+        tosa::LogOp,
+        tosa::LogicalNotOp,
+        tosa::NegateOp,
+        tosa::ReciprocalOp,
+        tosa::RsqrtOp,
+        tosa::SelectOp,
+        tosa::EqualOp,
+        tosa::GreaterOp,
+        tosa::GreaterEqualOp,
+        tosa::MulOp
+       >(op);
+  // clang-format on
+}
+
+static Value addBlockArgument(OpBuilder &b, Value val, Block *block,
+                              Location loc) {
+  RankedTensorType valType = cast<RankedTensorType>(val.getType());
+  val = block->addArgument(
+      MemRefType::get(valType.getShape(), valType.getElementType()), loc);
+  val = rock::getAsTensor(b, loc, val);
+  return val;
+}
+
+// This function traverse an upward tree where the root is the  input.
+// It traverses the tree until it hit the gemm or last elementwise
+// operation that may or maynot be interleaved with reshape-like ops. Note
+// there is a TODO to explore relaxing reshape-like ops constraints to more
+// of rock.transforms. (See the implementation for the TODO)
+static std::tuple<Value, FailureOr<tosa::MatMulOp>>
+getElementwiseRegion(Value input, OpBuilder &regionBuilder, Block *block,
+                     SmallVector<Value> &elementwiseArgs,
+                     std::optional<Location> loc = std::nullopt,
+                     bool doRewrite = false, int recDepth = 0) {
+  PatternRewriter::InsertionGuard guard(regionBuilder);
+  regionBuilder.setInsertionPointToEnd(block);
+  // If the matmul is found, we return this information to the
+  // root.
+  LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
+                          << "getElementwiseRegion:input=" << input << "\n");
+  if (tosa::MatMulOp matmul = input.getDefiningOp<tosa::MatMulOp>()) {
+    Value matmulMemRef;
+    if (doRewrite) {
+      matmulMemRef = addBlockArgument(regionBuilder, input, block, loc.value());
+      rock::RockGemmGemmWrapperInterface gemmGemmLikeOp =
+          cast<rock::RockGemmGemmWrapperInterface>(block->getParentOp());
+      gemmGemmLikeOp.setFirstGemmIndex(block->getArguments().size() - 1);
+    }
+    LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
+                            << "matmul found. terminating recursion.\n");
+    return {matmulMemRef, matmul};
+  }
+  if (tosa::ConstOp constOp = input.getDefiningOp<tosa::ConstOp>()) {
+    Value newConstOpRes;
+    if (doRewrite) {
+      auto *newConstOp = regionBuilder.clone(*constOp);
+      newConstOpRes = newConstOp->getResult(0);
+    }
+    LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
+                            << "const found. terminating recursion.\n");
+    return {newConstOpRes, failure()};
+  }
+  Operation *op = input.getDefiningOp();
+  // Right now, this is a bit restricted that we only allow reshape-like
+  // ops between in the elementwise tree that get fused to the fusion point.
+  // TODO: however, the latest code gridwise-gemm-to-blockwise should tackle
+  // more cases. The absolute restriction is gemm0Output to Linalg block
+  // should contain invertible transforms, but that's future work.
+  if (!op || (!isElementwiseOp(op) &&
+              !isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(op))) {
+    Value blockArg;
+    if (doRewrite) {
+      blockArg = addBlockArgument(regionBuilder, input, block, loc.value());
+    }
+    elementwiseArgs.push_back(input);
+    LLVM_DEBUG(llvm::dbgs()
+               << std::string(recDepth, '\t')
+               << "unsupported region op found. terminating recursion.\n");
+    return {blockArg, failure()};
+  }
+  // Following section recursively calls into the left and right
+  // sub-tree to grab as much of the elementwise tree rooted on softmax
+  // input.
+  mlir::IRMapping mapper;
+  SmallVector<Value> newOperands;
+
+  FailureOr<mlir::tosa::MatMulOp> maybeMatMul = failure();
+  for (auto operand : op->getOperands()) {
+    auto [result, maybeSubTreeMatMul] =
+        getElementwiseRegion(operand, regionBuilder, block, elementwiseArgs,
+                             loc, doRewrite, recDepth + 1);
+    mapper.map(operand, result);
+    newOperands.push_back(result);
+    if (succeeded(maybeSubTreeMatMul)) {
+      maybeMatMul = maybeSubTreeMatMul;
+    }
+  }
+
+  Value res;
+  if (doRewrite) {
+    auto *newOp = regionBuilder.clone(*op, mapper);
+    res = newOp->getResult(0);
+  }
+  // We convey to the caller the result
+  // of the cloning as well if this subtree
+  // contains the first matmul.
+  if (succeeded(maybeMatMul)) {
+    LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
+                            << "a subtree have a matmul in it.\n");
+    return {res, maybeMatMul};
+  }
+  LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
+                          << "none of subtress have a matmul in it.\n");
+  return {res, failure()};
 }
 
 template <typename OpT>
@@ -906,38 +1041,80 @@ struct CollapseExpandRewritePattern
   }
 };
 
-// Tosa ops can broadcast values along axes, which allows for
-// element-wise operations without fully-matching dimensions.  The
-// Elementwise trait is strict about matching dimensions, but
-// broadcastable ops are also element-wise, and we know that an
-// additional set of ops are also element-wise.
-static bool isElementwiseOp(Operation *op) {
-  return op->hasTrait<OpTrait::Elementwise>() ||
-         op->hasTrait<OpTrait::ResultsBroadcastableShape>() ||
-         // clang-format off
-    isa<tosa::CastOp,
-        tosa::ClampOp,
-        tosa::ErfOp,
-        tosa::SigmoidOp,
-        tosa::TanhOp,
-        tosa::AbsOp,
-        tosa::CeilOp,
-        tosa::ClzOp,
-        tosa::ExpOp,
-        tosa::FloorOp,
-        tosa::LogOp,
-        tosa::LogicalNotOp,
-        tosa::NegateOp,
-        tosa::ReciprocalOp,
-        tosa::RsqrtOp,
-        tosa::SelectOp,
-        tosa::EqualOp,
-        tosa::GreaterOp,
-        tosa::GreaterEqualOp,
-        tosa::MulOp
-       >(op);
-  // clang-format on
-}
+struct GemmElementwiseGemmRewritePattern
+    : public OpRewritePattern<tosa::MatMulOp>::SplitMatchAndRewrite {
+  using SplitMatchAndRewrite::SplitMatchAndRewrite;
+
+  LogicalResult match(tosa::MatMulOp op) const override {
+    OpBuilder b{op};
+    SmallVector<Value> vec;
+    FailureOr<tosa::MatMulOp> maybeFirstMatMul;
+    std::tie(std::ignore, maybeFirstMatMul) =
+        getElementwiseRegion(op.getA(), b, nullptr, vec);
+
+    if (succeeded(maybeFirstMatMul))
+      LLVM_DEBUG(llvm::dbgs()
+                 << "first matmul = " << maybeFirstMatMul.value() << "\n");
+    else
+      LLVM_DEBUG(llvm::dbgs() << "first matmul not found\n");
+
+    return maybeFirstMatMul;
+  }
+
+  void rewrite(tosa::MatMulOp op, PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto outputType = cast<RankedTensorType>(op.getType());
+    Value output = rewriter.create<bufferization::AllocTensorOp>(
+        loc, outputType, ValueRange{});
+    StringAttr arch;
+    std::optional<uint32_t> numCu;
+    rock::GemmFeatures features;
+    std::tie(arch, numCu, features) = getArchAttributes(op, op.getType());
+    SmallVector<Value> elementwiseOtherArgs;
+
+    FailureOr<tosa::MatMulOp> maybeFirstMatMul;
+    std::tie(std::ignore, maybeFirstMatMul) = getElementwiseRegion(
+        op.getA(), rewriter, nullptr, elementwiseOtherArgs);
+    // This is guranteed by the matcher
+    tosa::MatMulOp firstMatMulOp = maybeFirstMatMul.value();
+    IntegerAttr numCUAttr =
+        numCu.has_value() ? rewriter.getI32IntegerAttr(numCu.value()) : nullptr;
+
+    rock::GemmElementwiseGemmOp gemmElentwiseGemmOp =
+        rewriter.create<rock::GemmElementwiseGemmOp>(
+            loc, outputType, firstMatMulOp.getA(), firstMatMulOp.getB(),
+            op.getB(), elementwiseOtherArgs, output,
+            /*qTransposed=*/nullptr,
+            /*kTransposed=*/nullptr,
+            /*vTransposed=*/nullptr,
+            /*oTransposed=*/nullptr, arch,
+            rewriter.getAttr<rock::GemmFeaturesAttr>(features), numCUAttr,
+            /*params0=*/nullptr, /*params1=*/nullptr,
+            /*firstGemmIdx=*/rewriter.getI32IntegerAttr(0));
+
+    Block *preSecondGemmElemwiseBlock =
+        &gemmElentwiseGemmOp.getPreSecondGemmBody().emplaceBlock();
+    FailureOr<tosa::MatMulOp> maybeMatMul;
+    {
+      PatternRewriter::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(preSecondGemmElemwiseBlock);
+      Value res;
+      std::tie(res, maybeMatMul) =
+          getElementwiseRegion(op.getA(), rewriter, preSecondGemmElemwiseBlock,
+                               elementwiseOtherArgs, loc, true);
+      RankedTensorType resTensorType = cast<RankedTensorType>(res.getType());
+      MemRefType resMemRefType = MemRefType::get(
+          resTensorType.getShape(), resTensorType.getElementType());
+      Value resMemref =
+          rewriter.create<bufferization::ToMemrefOp>(loc, resMemRefType, res);
+      Value outMemref =
+          preSecondGemmElemwiseBlock->addArgument(resMemRefType, loc);
+      rewriter.create<memref::CopyOp>(loc, resMemref, outMemref);
+      rewriter.create<rock::YieldOp>(loc);
+    }
+    rewriter.replaceOp(op, gemmElentwiseGemmOp.getResult());
+  }
+};
 
 struct AttentionRewritePattern
     : public OpRewritePattern<tosa::MatMulOp>::SplitMatchAndRewrite {
@@ -1193,109 +1370,6 @@ struct AttentionRewritePattern
     return reshapeOp;
   }
 
-  Value addBlockArgument(OpBuilder &b, Value val, Block *block,
-                         Location loc) const {
-    RankedTensorType valType = cast<RankedTensorType>(val.getType());
-    val = block->addArgument(
-        MemRefType::get(valType.getShape(), valType.getElementType()), loc);
-    val = rock::getAsTensor(b, loc, val);
-    return val;
-  }
-
-  // This function traverse an upward tree where the root is the softmax
-  // input. It traverses the tree until it hit the gemm or last elemwise
-  // operation that may or maynot be interleaved with reshape-like ops. Note
-  // there is a TODO to explore relaxing reshape-like ops constraints to more
-  // of rock.transforms. (See the implementation for the TODO)
-  std::tuple<Value, FailureOr<tosa::MatMulOp>> getPreSoftmaxElementwiseRegion(
-      Value input, OpBuilder &regionBuilder, Block *block,
-      SmallVector<Value> &elementwiseArgs,
-      std::optional<Location> loc = std::nullopt, bool doRewrite = false,
-      int recDepth = 0) const {
-    PatternRewriter::InsertionGuard guard(regionBuilder);
-    regionBuilder.setInsertionPointToEnd(block);
-    // If the matmul is found, we return this information to the
-    // root.
-    LLVM_DEBUG(llvm::dbgs()
-               << std::string(recDepth, '\t')
-               << "getPreSoftmaxElementwiseRegion:input=" << input << "\n");
-    if (tosa::MatMulOp matmul = input.getDefiningOp<tosa::MatMulOp>()) {
-      Value matmulMemRef;
-      if (doRewrite) {
-        matmulMemRef =
-            addBlockArgument(regionBuilder, input, block, loc.value());
-        rock::AttentionOp attnOp =
-            cast<rock::AttentionOp>(block->getParentOp());
-        attnOp.setFirstGemmIdx(block->getArguments().size() - 1);
-      }
-      LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
-                              << "matmul found. terminating recursion.\n");
-      return {matmulMemRef, matmul};
-    }
-    if (tosa::ConstOp constOp = input.getDefiningOp<tosa::ConstOp>()) {
-      Value newConstOpRes;
-      if (doRewrite) {
-        auto *newConstOp = regionBuilder.clone(*constOp);
-        newConstOpRes = newConstOp->getResult(0);
-      }
-      LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
-                              << "const found. terminating recursion.\n");
-      return {newConstOpRes, failure()};
-    }
-    Operation *op = input.getDefiningOp();
-    // Right now, this is a bit restricted that we only allow reshape-like
-    // ops between in the elementwise tree that get fused to the fusion point.
-    // TODO: however, the latest code gridwise-gemm-to-blockwise should tackle
-    // more cases. The absolute restriction is gemm0Output to Linalg block
-    // should contain invertible transforms, but that's future work.
-    if (!op || (!isElementwiseOp(op) &&
-                !isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(op))) {
-      Value blockArg;
-      if (doRewrite) {
-        blockArg = addBlockArgument(regionBuilder, input, block, loc.value());
-      }
-      elementwiseArgs.push_back(input);
-      LLVM_DEBUG(llvm::dbgs()
-                 << std::string(recDepth, '\t')
-                 << "unsupported region op found. terminating recursion.\n");
-      return {blockArg, failure()};
-    }
-    // Following section recursively calls into the left and right
-    // sub-tree to grab as much of the elementwise tree rooted on softmax
-    // input.
-    mlir::IRMapping mapper;
-    SmallVector<Value> newOperands;
-
-    FailureOr<mlir::tosa::MatMulOp> maybeMatMul = failure();
-    for (auto operand : op->getOperands()) {
-      auto [result, maybeSubTreeMatMul] = getPreSoftmaxElementwiseRegion(
-          operand, regionBuilder, block, elementwiseArgs, loc, doRewrite,
-          recDepth + 1);
-      mapper.map(operand, result);
-      newOperands.push_back(result);
-      if (succeeded(maybeSubTreeMatMul)) {
-        maybeMatMul = maybeSubTreeMatMul;
-      }
-    }
-
-    Value res;
-    if (doRewrite) {
-      auto *newOp = regionBuilder.clone(*op, mapper);
-      res = newOp->getResult(0);
-    }
-    // We convey to the caller the result
-    // of the cloning as well if this subtree
-    // contains the first matmul.
-    if (succeeded(maybeMatMul)) {
-      LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
-                              << "a subtree have a matmul in it.\n");
-      return {res, maybeMatMul};
-    }
-    LLVM_DEBUG(llvm::dbgs() << std::string(recDepth, '\t')
-                            << "none of subtress have a matmul in it.\n");
-    return {res, failure()};
-  }
-
   LogicalResult match(tosa::MatMulOp op) const override {
     FailureOr<std::tuple<Value, bool, Value>> softmaxInputResult =
         maybeSoftmax(op.getA());
@@ -1316,7 +1390,7 @@ struct AttentionRewritePattern
     SmallVector<Value> vec;
     FailureOr<tosa::MatMulOp> maybeFirstMatMul;
     std::tie(std::ignore, maybeFirstMatMul) =
-        getPreSoftmaxElementwiseRegion(softmaxInput, b, nullptr, vec);
+        getElementwiseRegion(softmaxInput, b, nullptr, vec);
 
     if (succeeded(maybeFirstMatMul)) {
       TypedValue<TensorType> matC = maybeFirstMatMul.value().getOutput();
@@ -1353,7 +1427,7 @@ struct AttentionRewritePattern
     SmallVector<Value> elementwiseOtherArgs;
 
     FailureOr<tosa::MatMulOp> maybeFirstMatMul;
-    std::tie(std::ignore, maybeFirstMatMul) = getPreSoftmaxElementwiseRegion(
+    std::tie(std::ignore, maybeFirstMatMul) = getElementwiseRegion(
         softmaxInput, rewriter, nullptr, elementwiseOtherArgs);
     // This is guranteed by the matcher
     tosa::MatMulOp firstMatMulOp = maybeFirstMatMul.value();
@@ -1385,9 +1459,9 @@ struct AttentionRewritePattern
       PatternRewriter::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(preSoftmaxElemwiseBlock);
       Value res;
-      std::tie(res, maybeMatMul) = getPreSoftmaxElementwiseRegion(
-          softmaxInput, rewriter, preSoftmaxElemwiseBlock, elementwiseOtherArgs,
-          loc, true);
+      std::tie(res, maybeMatMul) =
+          getElementwiseRegion(softmaxInput, rewriter, preSoftmaxElemwiseBlock,
+                               elementwiseOtherArgs, loc, true);
       RankedTensorType resTensorType = cast<RankedTensorType>(res.getType());
       MemRefType resMemRefType = MemRefType::get(
           resTensorType.getShape(), resTensorType.getElementType());
@@ -1549,6 +1623,11 @@ void tosa::populateTosaToRockConversionPatterns(MLIRContext *context,
 void tosa::populateTosaToRockAttentionConversionPatterns(
     MLIRContext *context, RewritePatternSet &patterns) {
   patterns.add<AttentionRewritePattern>(context);
+}
+
+void tosa::populateTosaToRockGemmGemmConversionPatterns(
+    MLIRContext *context, RewritePatternSet &patterns) {
+  patterns.add<GemmElementwiseGemmRewritePattern>(context);
 }
 
 void tosa::populateTosaToRockTensorConversionPatterns(

--- a/mlir/lib/Conversion/TosaToRock/TosaToRockPass.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRockPass.cpp
@@ -48,6 +48,13 @@ public:
     if (failed(applyPatternsGreedily(func, std::move(attentionPatterns))))
       signalPassFailure();
 
+    RewritePatternSet gemmGemmPatterns(&ctx);
+
+    mlir::tosa::populateTosaToRockGemmGemmConversionPatterns(&ctx,
+                                                             gemmGemmPatterns);
+    if (failed(applyPatternsGreedily(func, std::move(gemmGemmPatterns))))
+      signalPassFailure();
+
     RewritePatternSet tensorPatterns(&ctx);
 
     mlir::tosa::populateTosaToRockTensorConversionPatterns(&ctx,

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -2108,6 +2108,10 @@ uint32_t GemmElementwiseGemmOp::getFirstGemmIndex() {
   return getFirstGemmIdx();
 }
 
+void GemmElementwiseGemmOp::setFirstGemmIndex(uint32_t index) {
+  setFirstGemmIdx(index);
+}
+
 GemmGemmSize GemmElementwiseGemmOp::getGemmGemmSize() {
   ShapedType typeA = getA().getType(), typeB = getB().getType(),
              typeC = getC().getType();
@@ -2238,6 +2242,8 @@ bool AttentionOp::getTransposedOut() { return getOTransposed(); }
 KernelType AttentionOp::getKernelType() { return KernelType::Attention; }
 
 uint32_t AttentionOp::getFirstGemmIndex() { return getFirstGemmIdx(); }
+
+void AttentionOp::setFirstGemmIndex(uint32_t index) { setFirstGemmIdx(index); }
 
 GemmGemmSize AttentionOp::getGemmGemmSize() {
   ShapedType typeA = getQueries().getType(), typeB = getKeys().getType(),

--- a/mlir/lib/Dialect/Rock/Transforms/SortDimensionsMemoryLayout.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SortDimensionsMemoryLayout.cpp
@@ -16,10 +16,12 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
+#include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/Passes.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -300,8 +302,8 @@ reorderBatch(Value tensor, const SmallVector<StringRef> &layout,
 }
 
 template <typename ContainerTy, typename ElementTy>
-std::optional<size_t> findIndex(const ContainerTy &container,
-                                const ElementTy &element) {
+static std::optional<size_t> findIndex(const ContainerTy &container,
+                                       const ElementTy &element) {
   auto it = llvm::find(container, element);
   if (it == container.end())
     return std::nullopt;
@@ -314,6 +316,70 @@ static SmallVector<Operation *> getOperations(func::FuncOp &func) {
   func.walk([&ops](OpT operation) { ops.push_back(operation); });
 
   return ops;
+}
+
+static FailureOr<std::tuple<Value, Value, Value, UnitAttr, UnitAttr, UnitAttr>>
+commonGemmGemm(rock::RockGemmGemmWrapperInterface op, Value q, Value k, Value v,
+               PatternRewriter &b) {
+  SmallVector<StringRef> layoutQ{"G", "M", "K"};
+  if (op.getTransposedA())
+    layoutQ = {"G", "K", "M"};
+  if (cast<ShapedType>(q.getType()).getRank() == 2)
+    layoutQ = {layoutQ[1], layoutQ[2]};
+
+  SmallVector<StringRef> layoutK{"G", "K", "N"};
+  if (op.getTransposedB())
+    layoutK = {"G", "N", "K"};
+  if (cast<ShapedType>(k.getType()).getRank() == 2)
+    layoutK = {layoutK[1], layoutK[2]};
+
+  SmallVector<StringRef> layoutV{"G", "K", "N"};
+  if (op.getTransposedC())
+    layoutV = {"G", "N", "K"};
+  if (cast<ShapedType>(k.getType()).getRank() == 2)
+    layoutV = {layoutV[1], layoutV[2]};
+
+  auto maybeSortedQ = sortByMemoryLayout(q, layoutQ, b);
+  auto maybeSortedK = sortByMemoryLayout(k, layoutK, b);
+  auto maybeSortedV = sortByMemoryLayout(v, layoutV, b);
+
+  if (failed(maybeSortedQ) || failed(maybeSortedK) || failed(maybeSortedV))
+    return op.emitOpError("sortByMemoryLayout failed");
+
+  auto sortedQ = maybeSortedQ.value();
+  auto sortedK = maybeSortedK.value();
+  auto sortedV = maybeSortedV.value();
+
+  LLVM_DEBUG(llvm::dbgs() << "sortedQ=" << std::get<0>(sortedQ)
+                          << " sortedK=" << std::get<0>(sortedK)
+                          << " sortedV=" << std::get<0>(sortedV) << "\n");
+
+  // the batch size is currently required to be the first one. If that's not
+  // the case we need to add an extra transform.
+  auto batchReorderQ =
+      reorderBatch(std::get<0>(sortedQ), std::get<1>(sortedQ), "K", b);
+  auto batchReorderK =
+      reorderBatch(std::get<0>(sortedK), std::get<1>(sortedK), "N", b);
+  auto batchReorderV =
+      reorderBatch(std::get<0>(sortedV), std::get<1>(sortedV), "N", b);
+
+  Value newTensorQ = std::get<0>(batchReorderQ);
+  Value newTensorK = std::get<0>(batchReorderK);
+  Value newTensorV = std::get<0>(batchReorderV);
+  UnitAttr transposedQ = std::get<1>(batchReorderQ);
+  UnitAttr transposedK = std::get<1>(batchReorderK);
+  UnitAttr transposedV = std::get<1>(batchReorderV);
+  auto finalLayoutQ = std::get<2>(batchReorderQ);
+  auto finalLayoutK = std::get<2>(batchReorderK);
+  auto finalLayoutV = std::get<2>(batchReorderV);
+
+  // no need to create transforms if it's the same tensor
+  if (finalLayoutQ == layoutQ && finalLayoutK == layoutK &&
+      finalLayoutV == layoutV)
+    return failure();
+
+  return std::make_tuple(newTensorQ, newTensorK, newTensorV, transposedQ,
+                         transposedK, transposedV);
 }
 
 template <typename T>
@@ -479,62 +545,14 @@ struct AttentionRewritePattern : public OpRewritePattern<rock::AttentionOp> {
     auto k = op.getKeys();
     auto v = op.getValues();
 
-    SmallVector<StringRef> layoutQ{"G", "M", "K"};
-    if (op.getQTransposed())
-      layoutQ = {"G", "K", "M"};
-    if (q.getType().getRank() == 2)
-      layoutQ = {layoutQ[1], layoutQ[2]};
-
-    SmallVector<StringRef> layoutK{"G", "K", "N"};
-    if (op.getKTransposed())
-      layoutK = {"G", "N", "K"};
-    if (k.getType().getRank() == 2)
-      layoutK = {layoutK[1], layoutK[2]};
-
-    SmallVector<StringRef> layoutV{"G", "K", "N"};
-    if (op.getVTransposed())
-      layoutV = {"G", "N", "K"};
-    if (k.getType().getRank() == 2)
-      layoutV = {layoutV[1], layoutV[2]};
-
-    auto maybeSortedQ = sortByMemoryLayout(q, layoutQ, b);
-    auto maybeSortedK = sortByMemoryLayout(k, layoutK, b);
-    auto maybeSortedV = sortByMemoryLayout(v, layoutV, b);
-
-    if (failed(maybeSortedQ) || failed(maybeSortedK) || failed(maybeSortedV))
-      return op.emitOpError("sortByMemoryLayout failed");
-
-    auto sortedQ = maybeSortedQ.value();
-    auto sortedK = maybeSortedK.value();
-    auto sortedV = maybeSortedV.value();
-
-    LLVM_DEBUG(llvm::dbgs() << "sortedQ=" << std::get<0>(sortedQ)
-                            << " sortedK=" << std::get<0>(sortedK)
-                            << " sortedV=" << std::get<0>(sortedV) << "\n");
-
-    // the batch size is currently required to be the first one. If that's not
-    // the case we need to add an extra transform.
-    auto batchReorderQ =
-        reorderBatch(std::get<0>(sortedQ), std::get<1>(sortedQ), "K", b);
-    auto batchReorderK =
-        reorderBatch(std::get<0>(sortedK), std::get<1>(sortedK), "N", b);
-    auto batchReorderV =
-        reorderBatch(std::get<0>(sortedV), std::get<1>(sortedV), "N", b);
-
-    Value newTensorQ = std::get<0>(batchReorderQ);
-    Value newTensorK = std::get<0>(batchReorderK);
-    Value newTensorV = std::get<0>(batchReorderV);
-    UnitAttr transposedQ = std::get<1>(batchReorderQ);
-    UnitAttr transposedK = std::get<1>(batchReorderK);
-    UnitAttr transposedV = std::get<1>(batchReorderV);
-    auto finalLayoutQ = std::get<2>(batchReorderQ);
-    auto finalLayoutK = std::get<2>(batchReorderK);
-    auto finalLayoutV = std::get<2>(batchReorderV);
-
-    // no need to create transforms if it's the same tensor
-    if (finalLayoutQ == layoutQ && finalLayoutK == layoutK &&
-        finalLayoutV == layoutV)
+    auto maybeRewrite = commonGemmGemm(op, q, k, v, b);
+    if (failed(maybeRewrite))
       return failure();
+
+    Value newTensorQ, newTensorK, newTensorV;
+    UnitAttr transposedQ, transposedK, transposedV;
+    std::tie(newTensorQ, newTensorK, newTensorV, transposedQ, transposedK,
+             transposedV) = maybeRewrite.value();
 
     auto newOp = b.create<rock::AttentionOp>(
         op->getLoc(), op->getResultTypes(), newTensorQ, newTensorK, newTensorV,
@@ -552,6 +570,47 @@ struct AttentionRewritePattern : public OpRewritePattern<rock::AttentionOp> {
                            newOp.getPreSoftmaxBody().begin());
     }
     b.replaceOp(op, newOp);
+
+    return success();
+  }
+};
+
+struct GemmElementwiseGemmRewritePattern
+    : public OpRewritePattern<rock::GemmElementwiseGemmOp> {
+  using OpRewritePattern<rock::GemmElementwiseGemmOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(rock::GemmElementwiseGemmOp op,
+                                PatternRewriter &rw) const final {
+    auto a = op.getA();
+    auto b = op.getB();
+    auto c = op.getC();
+
+    auto maybeRewrite = commonGemmGemm(op, a, b, c, rw);
+    if (failed(maybeRewrite))
+      return failure();
+
+    Value newTensorQ, newTensorK, newTensorV;
+    UnitAttr transposedQ, transposedK, transposedV;
+    std::tie(newTensorQ, newTensorK, newTensorV, transposedQ, transposedK,
+             transposedV) = maybeRewrite.value();
+
+    auto newOp = rw.create<rock::GemmElementwiseGemmOp>(
+        op->getLoc(), op->getResultTypes(), newTensorQ, newTensorK, newTensorV,
+        op.getElemwiseInputs(), op.getOut(), transposedQ, transposedK,
+        transposedV, op.getOTransposedAttr(), op.getArchAttr(),
+        op.getFeaturesAttr(), op.getNumCUAttr(), op.getParams0Attr(),
+        op.getParams1Attr(), op.getFirstGemmIdxAttr());
+
+    // copy linalg::GenericOp if there's any
+    bool linalgOpFound = false;
+    op.getPreSecondGemmBody().walk(
+        [&linalgOpFound](linalg::GenericOp genOp) { linalgOpFound = true; });
+    if (linalgOpFound) {
+      rw.inlineRegionBefore(op.getPreSecondGemmBody(),
+                            newOp.getPreSecondGemmBody(),
+                            newOp.getPreSecondGemmBody().begin());
+    }
+    rw.replaceOp(op, newOp);
 
     return success();
   }
@@ -594,5 +653,12 @@ void RockSortDimensionsMemoryLayoutPass::runOnOperation() {
   patternsAttention.add<AttentionRewritePattern>(&ctx);
   if (failed(applyOpPatternsGreedily(getOperations<rock::AttentionOp>(func),
                                      std::move(patternsAttention), config)))
+    return signalPassFailure();
+
+  RewritePatternSet patternsGemmElementwiseGemm(&ctx);
+  patternsGemmElementwiseGemm.add<GemmElementwiseGemmRewritePattern>(&ctx);
+  if (failed(applyOpPatternsGreedily(
+          getOperations<rock::GemmElementwiseGemmOp>(func),
+          std::move(patternsGemmElementwiseGemm), config)))
     return signalPassFailure();
 }

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-gemm-gemm.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-gemm-gemm.mlir
@@ -1,0 +1,136 @@
+// RUN: rocmlir-opt --tosa-to-rock %s -verify-diagnostics -o -| FileCheck %s
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm(%arg0: tensor<1x384x64xf32>, %arg1: tensor<1x384x64xf32>, %arg2: tensor<1x384x64xf32>, %arg3: tensor<1x384x384xf32>) -> tensor<1x384x64xf32> attributes {kernel, arch = ""} {
+  %0 = "tosa.transpose"(%arg1) {perms = array<i32: 0, 2, 1>} : (tensor<1x384x64xf32>) -> tensor<1x64x384xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %1 = "tosa.matmul"(%arg0, %0, %a_zp, %b_zp) : (tensor<1x384x64xf32>, tensor<1x64x384xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x384xf32>
+  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
+  %2 = "tosa.mul"(%1, %arg3, %shift) : (tensor<1x384x384xf32>, tensor<1x384x384xf32>, tensor<1xi8>) -> tensor<1x384x384xf32>
+  %9 = "tosa.matmul"(%2, %arg2, %a_zp, %b_zp) : (tensor<1x384x384xf32>, tensor<1x384x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x64xf32>
+  return %9 : tensor<1x384x64xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm_no_scale(%arg0: tensor<1x384x64xf32>, %arg1: tensor<1x384x64xf32>, %arg2: tensor<1x384x64xf32>) -> tensor<1x384x64xf32> attributes {kernel, arch = ""} {
+  %0 = "tosa.transpose"(%arg1) {perms = array<i32: 0, 2, 1>} : (tensor<1x384x64xf32>) -> tensor<1x64x384xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %1 = "tosa.matmul"(%arg0, %0, %a_zp, %b_zp) : (tensor<1x384x64xf32>, tensor<1x64x384xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x384xf32>
+  %9 = "tosa.matmul"(%1, %arg2, %a_zp, %b_zp) : (tensor<1x384x384xf32>, tensor<1x384x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x64xf32>
+  return %9 : tensor<1x384x64xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm_with_bias_only(%arg0: tensor<1x384x64xf32>, %arg1: tensor<1x384x64xf32>, %arg2: tensor<1x384x64xf32>, %arg3: tensor<1x384x384xf32>) -> tensor<1x384x64xf32> attributes {kernel, arch = ""} {
+  %0 = "tosa.transpose"(%arg1) {perms = array<i32: 0, 2, 1>} : (tensor<1x384x64xf32>) -> tensor<1x64x384xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %1 = "tosa.matmul"(%arg0, %0, %a_zp, %b_zp) : (tensor<1x384x64xf32>, tensor<1x64x384xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x384xf32>
+  %2 = "tosa.add"(%1, %arg3) : (tensor<1x384x384xf32>, tensor<1x384x384xf32>) -> tensor<1x384x384xf32>
+  %9 = "tosa.matmul"(%2, %arg2, %a_zp, %b_zp) : (tensor<1x384x384xf32>, tensor<1x384x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x64xf32>
+  return %9 : tensor<1x384x64xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm_with_scale_and_bias(%arg0: tensor<1x384x64xf32>, %arg1: tensor<1x384x64xf32>, %arg2: tensor<1x384x64xf32>, %arg3: tensor<1x384x384xf32>, %arg4: tensor<1x384x384xf32>) -> tensor<1x384x64xf32> attributes {kernel, arch = ""} {
+  %0 = "tosa.transpose"(%arg1) {perms = array<i32: 0, 2, 1>} : (tensor<1x384x64xf32>) -> tensor<1x64x384xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %1 = "tosa.matmul"(%arg0, %0, %a_zp, %b_zp) : (tensor<1x384x64xf32>, tensor<1x64x384xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x384xf32>
+  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
+  %2 = "tosa.mul"(%1, %arg3, %shift) : (tensor<1x384x384xf32>, tensor<1x384x384xf32>, tensor<1xi8>) -> tensor<1x384x384xf32>
+  %3 = "tosa.add"(%2, %arg4) : (tensor<1x384x384xf32>, tensor<1x384x384xf32>) -> tensor<1x384x384xf32>
+  %10 = "tosa.matmul"(%3, %arg2, %a_zp, %b_zp) : (tensor<1x384x384xf32>, tensor<1x384x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x64xf32>
+  return %10 : tensor<1x384x64xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm_with_scale_bias_exp(%arg0: tensor<1x384x64xf32>, %arg1: tensor<1x384x64xf32>, %arg2: tensor<1x384x64xf32>, %arg3: tensor<1x384x384xf32>, %arg4: tensor<1x384x384xf32>) -> tensor<1x384x64xf32> attributes {kernel, arch = ""} {
+  %0 = "tosa.transpose"(%arg1) {perms = array<i32: 0, 2, 1>} : (tensor<1x384x64xf32>) -> tensor<1x64x384xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %1 = "tosa.matmul"(%arg0, %0, %a_zp, %b_zp) : (tensor<1x384x64xf32>, tensor<1x64x384xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x384xf32>
+  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
+  %2 = "tosa.mul"(%1, %arg3, %shift) : (tensor<1x384x384xf32>, tensor<1x384x384xf32>, tensor<1xi8>) -> tensor<1x384x384xf32>
+  %3 = "tosa.add"(%2, %arg4) : (tensor<1x384x384xf32>, tensor<1x384x384xf32>) -> tensor<1x384x384xf32>
+  %exp = "tosa.exp"(%3) : (tensor<1x384x384xf32>) -> tensor<1x384x384xf32>
+  %10 = "tosa.matmul"(%exp, %arg2, %a_zp, %b_zp) : (tensor<1x384x384xf32>, tensor<1x384x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x384x64xf32>
+  return %10 : tensor<1x384x64xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm_with_reshapes(%arg0: tensor<1x12x384x64xf32>, %arg1: tensor<1x12x64x384xf32>, %arg2: tensor<1x12x384x64xf32>) -> (tensor<1x12x384x64xf32>) attributes {kernel, arch = ""} {
+  %collapsed = tensor.collapse_shape %arg0 [[0, 1], [2], [3]] : tensor<1x12x384x64xf32> into tensor<12x384x64xf32>
+  %collapsed_0 = tensor.collapse_shape %arg1 [[0, 1], [2], [3]] : tensor<1x12x64x384xf32> into tensor<12x64x384xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %0 = "tosa.matmul"(%collapsed, %collapsed_0, %a_zp, %b_zp) : (tensor<12x384x64xf32>, tensor<12x64x384xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<12x384x384xf32>
+  %expanded = tensor.expand_shape %0 [[0, 1], [2], [3]] output_shape [1, 12, 384, 384] : tensor<12x384x384xf32> into tensor<1x12x384x384xf32>
+  %collapsed_1 = tensor.collapse_shape %expanded [[0, 1], [2], [3]] : tensor<1x12x384x384xf32> into tensor<12x384x384xf32>
+  %collapsed_2 = tensor.collapse_shape %arg2 [[0, 1], [2], [3]] : tensor<1x12x384x64xf32> into tensor<12x384x64xf32>
+  %7 = "tosa.matmul"(%collapsed_1, %collapsed_2, %a_zp, %b_zp) : (tensor<12x384x384xf32>, tensor<12x384x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<12x384x64xf32>
+  %expanded_3 = tensor.expand_shape %7 [[0, 1], [2], [3]] output_shape [1, 12, 384, 64] : tensor<12x384x64xf32> into tensor<1x12x384x64xf32>
+  return %expanded_3 : tensor<1x12x384x64xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm_with_4d_scale(%arg0: tensor<1x12x256x256xf32> , %arg1: tensor<1x12x256x256xf32>, %arg2: tensor<1x12x256x256xf32>, %arg3: tensor<1x12x256x256xf32>) -> (tensor<1x12x256x256xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {
+  %0 = "tosa.transpose"(%arg3) {perms = array<i32: 0, 1, 3, 2>} : (tensor<1x12x256x256xf32>) -> tensor<1x12x256x256xf32>
+  %collapsed = tensor.collapse_shape %arg2 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %collapsed_0 = tensor.collapse_shape %0 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %1 = "tosa.matmul"(%collapsed, %collapsed_0, %a_zp, %b_zp) : (tensor<12x256x256xf32>, tensor<12x256x256xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<12x256x256xf32>
+  %expanded = tensor.expand_shape %1 [[0, 1], [2], [3]] output_shape [1, 12, 256, 256] : tensor<12x256x256xf32> into tensor<1x12x256x256xf32>
+  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
+  %2 = "tosa.mul"(%expanded, %arg1, %shift) : (tensor<1x12x256x256xf32>, tensor<1x12x256x256xf32>, tensor<1xi8>) -> tensor<1x12x256x256xf32>
+  %collapsed_1 = tensor.collapse_shape %2 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %collapsed_2 = tensor.collapse_shape %arg0 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %9 = "tosa.matmul"(%collapsed_1, %collapsed_2, %a_zp, %b_zp) : (tensor<12x256x256xf32>, tensor<12x256x256xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<12x256x256xf32>
+  %expanded_3 = tensor.expand_shape %9 [[0, 1], [2], [3]] output_shape [1, 12, 256, 256] : tensor<12x256x256xf32> into tensor<1x12x256x256xf32>
+  return %expanded_3 : tensor<1x12x256x256xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+func.func @self_gemm_gemm_with_dot_product(%arg0: tensor<1x1x64xf32>, %arg1: tensor<1x1x64xf32>, %arg2: tensor<1x1x64xf32>, %arg3: tensor<1x1x1xf32>, %arg4: tensor<1x1x1xf32>) -> tensor<1x1x64xf32> attributes {kernel, arch = ""} {
+  %0 = "tosa.transpose"(%arg1) {perms = array<i32: 0, 2, 1>} : (tensor<1x1x64xf32>) -> tensor<1x64x1xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %1 = "tosa.matmul"(%arg0, %0, %a_zp, %b_zp) : (tensor<1x1x64xf32>, tensor<1x64x1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x1x1xf32>
+  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
+  %2 = "tosa.mul"(%1, %arg3, %shift) : (tensor<1x1x1xf32>, tensor<1x1x1xf32>, tensor<1xi8>) -> tensor<1x1x1xf32>
+  %3 = "tosa.add"(%2, %arg4) : (tensor<1x1x1xf32>, tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
+  %8 = "tosa.matmul"(%3, %arg2, %a_zp, %b_zp) : (tensor<1x1x1xf32>, tensor<1x1x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x1x64xf32>
+  return %8 : tensor<1x1x64xf32>
+}
+
+// CHECK: rock.gemm_elementwise_gemm
+// CHECK: elementwise otherIns(%arg2, %arg3 : tensor<786432xi8>, tensor<786432xf32>)
+// CHECK: firstGemmIdx = 1 : i32
+func.func @mlir_gemm_gemm_where(%arg0: tensor<786432xf32>, %arg1: tensor<786432xf32>, %arg2: tensor<786432xi8>, %arg3: tensor<786432xf32>, %arg4: tensor<786432xf32>) -> tensor<786432xf32> attributes {arch = "gfx942", kernel = "mixr"} {
+  %expanded = tensor.expand_shape %arg4 [[0, 1, 2, 3]] output_shape [1, 12, 256, 256] : tensor<786432xf32> into tensor<1x12x256x256xf32>
+  %expanded_0 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [1, 12, 256, 256] : tensor<786432xf32> into tensor<1x12x256x256xf32>
+  %expanded_1 = tensor.expand_shape %arg2 [[0, 1, 2, 3]] output_shape [1, 12, 256, 256] : tensor<786432xi8> into tensor<1x12x256x256xi8>
+  %expanded_2 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [1, 12, 256, 256] : tensor<786432xf32> into tensor<1x12x256x256xf32>
+  %expanded_3 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [1, 12, 256, 256] : tensor<786432xf32> into tensor<1x12x256x256xf32>
+  %1 = tosa.transpose %expanded_3 {perms = array<i32: 0, 1, 3, 2>} : (tensor<1x12x256x256xf32>) -> tensor<1x12x256x256xf32>
+  %expanded_4 = tensor.expand_shape %arg0 [[0, 1, 2]] output_shape [12, 256, 256] : tensor<786432xf32> into tensor<12x256x256xf32>
+  %collapsed = tensor.collapse_shape %1 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %2 = tosa.matmul %expanded_4, %collapsed, %a_zp, %b_zp : (tensor<12x256x256xf32>, tensor<12x256x256xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<12x256x256xf32>
+  %expanded_5 = tensor.expand_shape %2 [[0, 1], [2], [3]] output_shape [1, 12, 256, 256] : tensor<12x256x256xf32> into tensor<1x12x256x256xf32>
+  %3 = "tosa.const"() <{values = dense<1.250000e-01> : tensor<1x12x256x256xf32>}> : () -> tensor<1x12x256x256xf32>
+  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
+  %4 = tosa.mul %expanded_5, %3, %shift : (tensor<1x12x256x256xf32>, tensor<1x12x256x256xf32>, tensor<1xi8>) -> tensor<1x12x256x256xf32>
+  %5 = tosa.cast %expanded_1 : (tensor<1x12x256x256xi8>) -> tensor<1x12x256x256xi1>
+  %6 = tosa.select %5, %4, %expanded_0 : (tensor<1x12x256x256xi1>, tensor<1x12x256x256xf32>, tensor<1x12x256x256xf32>) -> tensor<1x12x256x256xf32>
+  %collapsed_6 = tensor.collapse_shape %6 [[0, 1], [2], [3]] : tensor<1x12x256x256xf32> into tensor<12x256x256xf32>
+  %expanded_7 = tensor.expand_shape %arg4 [[0, 1, 2]] output_shape [12, 256, 256] : tensor<786432xf32> into tensor<12x256x256xf32>
+  %13 = tosa.matmul %collapsed_6, %expanded_7, %a_zp, %b_zp : (tensor<12x256x256xf32>, tensor<12x256x256xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<12x256x256xf32>
+  %expanded_8 = tensor.expand_shape %13 [[0, 1], [2], [3]] output_shape [1, 12, 256, 256] : tensor<12x256x256xf32> into tensor<1x12x256x256xf32>
+  %collapsed_9 = tensor.collapse_shape %13 [[0, 1, 2]] : tensor<12x256x256xf32> into tensor<786432xf32>
+  return %collapsed_9 : tensor<786432xf32>
+}

--- a/mlir/test/Dialect/Rock/lowering_sort_dimensions_memory_layout.mlir
+++ b/mlir/test/Dialect/Rock/lowering_sort_dimensions_memory_layout.mlir
@@ -221,3 +221,32 @@ func.func @test_mlir_slice_add_literal_weights_convolution(%arg0: memref<1638400
   memref.copy %10, %arg1 : memref<819200xf16> to memref<819200xf16>
   return
 }
+
+// CHECK-LABEL: test_gemm_gemm
+func.func @test_gemm_gemm(%arg0: memref<1024xf32>, %arg1: memref<1024xf32>, %arg2: memref<512xf32>, %arg3: memref<256xf32>) attributes {kernel, arch = ""} {
+  %0 = rock.transform %arg2 by <affine_map<(d0, d1, d2) -> ((d0 * 8 + d1) * 64 + d2)> by [<Unmerge{1, 8, 64} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [1, 8, 64] -> [512]> : memref<512xf32> to memref<1x8x64xf32>
+  %1 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["dim0", "dim2", "dim1"] at [0, 1, 2] -> ["dim0", "dim2", "dim1"] at [0, 2, 1]>] bounds = [1, 64, 8] -> [1, 8, 64]> : memref<1x8x64xf32> to memref<1x64x8xf32>
+  %2 = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> ((d0 * 64 + d1) * 16 + d2)> by [<Unmerge{1, 64, 16} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [1, 64, 16] -> [1024]> : memref<1024xf32> to memref<1x64x16xf32>
+  %3 = rock.transform %2 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["dim0", "dim2", "dim1"] at [0, 1, 2] -> ["dim0", "dim2", "dim1"] at [0, 2, 1]>] bounds = [1, 16, 64] -> [1, 64, 16]> : memref<1x64x16xf32> to memref<1x16x64xf32>
+  %4 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> ((d0 * 32 + d1) * 32 + d2)> by [<Unmerge{1, 32, 32} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [1, 32, 32] -> [1024]> : memref<1024xf32> to memref<1x32x32xf32>
+  %5 = rock.transform %4 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["dim0", "dim2", "dim1"] at [0, 1, 2] -> ["dim0", "dim2", "dim1"] at [0, 2, 1]>] bounds = [1, 32, 32] -> [1, 32, 32]> : memref<1x32x32xf32> to memref<1x32x32xf32>
+  %6 = rock.transform %5 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<Slice{0, 1, 0, 32, 0, 16} ["dim0_sliced", "dim1_sliced", "dim2_sliced"] at [0, 1, 2] -> ["dim0", "dim1", "dim2"] at [0, 1, 2]>] bounds = [1, 32, 16] -> [1, 32, 32]> : memref<1x32x32xf32> to memref<1x32x16xf32>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x32x8xf32>
+
+  // CHECK: %[[a:.*]] = rock.transform %{{.*}} memref<16x1x32xf32> to memref<1x16x32xf32>
+  // CHECK: %[[b:.*]] = rock.transform %{{.*}} memref<64x1x16xf32> to memref<1x64x16xf32>
+  // CHECK: rock.gemm_elementwise_gemm
+  // CHECK-NEXT: ab = tr %[[a]] * tr %[[b]]
+  rock.gemm_elementwise_gemm{
+    ab = %6 * %3 : memref<1x32x16xf32>, memref<1x16x64xf32>
+    ab = elementwise {
+  ^bb0(%arg4: memref<1x32x64xf32>, %arg5: memref<1x32x64xf32>):
+    memref.copy %arg4, %arg5 : memref<1x32x64xf32> to memref<1x32x64xf32>
+    rock.yield
+  }
+    %alloc = ab * %1 : memref<1x64x8xf32> -> memref<1x32x8xf32>
+  } {arch = "gfx942:sramecc+:xnack-", features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>, firstGemmIdx = 0 : i32}
+  %7 = rock.transform %alloc by <affine_map<(d0) -> (0, d0 floordiv 8, d0 mod 8)> by [<Merge{1, 32, 8} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [256] -> [1, 32, 8]> : memref<1x32x8xf32> to memref<256xf32>
+  memref.copy %7, %arg3 : memref<256xf32> to memref<256xf32>
+  return
+}

--- a/mlir/test/fusion/mixr-gemm-gemm-problem-key.mlir
+++ b/mlir/test/fusion/mixr-gemm-gemm-problem-key.mlir
@@ -1,0 +1,18 @@
+
+// RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
+// CHECK: gfx942
+// CHECK-SAME: 304
+// CHECK-SAME: -t f32 -transA false -transB false -transC false -transO false -g 1 -m 7 -n 7 -k 3 -gemmO 3
+module 
+{
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>,
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1>) 
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1>)  attributes {kernel, arch = "gfx942", num_cu = 304 : i64} {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %biased = migraphx.add %0, %arg3 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %2 = migraphx.dot %biased, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %2 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/lit.local.cfg
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/lit.local.cfg
@@ -1,0 +1,2 @@
+if (not config.arch_support_mfma):
+  config.unsupported = True

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/mixr-gemm-gemm-tier1-f32-case1.mlir
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/mixr-gemm-gemm-tier1-f32-case1.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x12x384x64xf32, 294912x24576x64x1>, %arg1: !migraphx.shaped<1x12x64x384xf32, 294912x24576x384x1>, %arg2: !migraphx.shaped<1x12x384x64xf32, 294912x24576x64x1>) -> (!migraphx.shaped<1x12x384x64xf32, 294912x24576x64x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x12x384x64xf32, 294912x24576x64x1>, <1x12x64x384xf32, 294912x24576x384x1> -> <1x12x384x384xf32, 1769472x147456x384x1>
+    %1 = migraphx.dot %0, %arg2: <1x12x384x384xf32, 1769472x147456x384x1>, <1x12x384x64xf32, 294912x24576x64x1> -> <1x12x384x64xf32, 294912x24576x64x1>
+    return %1 : !migraphx.shaped<1x12x384x64xf32, 294912x24576x64x1>
+  }
+}

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/mixr-gemm-gemm-tier1-f32-case2.mlir
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/mixr-gemm-gemm-tier1-f32-case2.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<2x16x384x64xf32, 393216x24576x64x1>, %arg1: !migraphx.shaped<2x16x64x384xf32, 393216x24576x384x1>, %arg2: !migraphx.shaped<2x16x384x64xf32, 393216x24576x64x1>) -> (!migraphx.shaped<2x16x384x64xf32, 393216x24576x64x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <2x16x384x64xf32, 393216x24576x64x1>, <2x16x64x384xf32, 393216x24576x384x1> -> <2x16x384x384xf32, 2359296x147456x384x1>
+    %1 = migraphx.dot %0, %arg2: <2x16x384x384xf32, 2359296x147456x384x1>, <2x16x384x64xf32, 393216x24576x64x1> -> <2x16x384x64xf32, 393216x24576x64x1>
+    return %1 : !migraphx.shaped<2x16x384x64xf32, 393216x24576x64x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/lit.local.cfg
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/lit.local.cfg
@@ -1,0 +1,2 @@
+if (not config.arch_support_mfma):
+  config.unsupported = True

--- a/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a0b0c0-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a0b0c0-e2e.mlir
@@ -1,0 +1,27 @@
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=EMITKEY
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// RUN: rocmlir-gen --clone-harness -arch gfx942:sramecc+:xnack- -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets gfx942:sramecc+:xnack- | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full --debug-only=rock-gridwise-to-blockwise -o /dev/null 2>&1 | FileCheck %s --check-prefix=VECTORIZATION
+
+// ALLOW_RETRIES: 2
+// CLONE: [1 1 1]
+
+// EMITKEY: -t f32 -transA false -transB false -transC false -transO false -g 1 -m 32 -n 64 -k 16 -gemmO 8
+
+// VECTORIZATION: qVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: qVectorLen: 4
+// VECTORIZATION: kVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: kVectorLen: 4
+// VECTORIZATION: vVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: vVectorLen: 4
+
+module {
+  func.func @test(%arg0: !migraphx.shaped<1x32x32xf32, 1024x1x32>, %arg1: !migraphx.shaped<1x64x16xf32, 1024x1x64>, %arg2: !migraphx.shaped<1x8x64xf32, 512x1x8>) -> !migraphx.shaped<1x32x8xf32, 256x8x1> {
+    %sliced0 = migraphx.slice %arg0 {axes = [1], ends = [16], starts = [0]} : <1x32x32xf32, 1024x1x32> -> <1x16x32xf32, 1024x1x32>
+    %trans0 = migraphx.transpose %sliced0 {permutation = [0, 2, 1]} : <1x16x32xf32, 1024x1x32> -> <1x32x16xf32, 1024x32x1>
+    %trans1 = migraphx.transpose %arg1 {permutation = [0, 2, 1]} : <1x64x16xf32, 1024x1x64> -> <1x16x64xf32, 1024x64x1>
+    %0 = migraphx.dot %trans0, %trans1: !migraphx.shaped<1x32x16xf32, 1024x32x1>, !migraphx.shaped<1x16x64xf32, 1024x64x1> -> !migraphx.shaped<1x32x64xf32, 2048x64x1>
+    %trans2 = migraphx.transpose %arg2 {permutation = [0, 2, 1]} : <1x8x64xf32, 512x1x8> -> <1x64x8xf32, 512x8x1>
+    %2 = migraphx.dot %0, %trans2: !migraphx.shaped<1x32x64xf32, 2048x64x1>, !migraphx.shaped<1x64x8xf32, 512x8x1> -> !migraphx.shaped<1x32x8xf32, 256x8x1>
+    return %2 : !migraphx.shaped<1x32x8xf32, 256x8x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a0b0c1-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a0b0c1-e2e.mlir
@@ -1,0 +1,26 @@
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=EMITKEY
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// RUN: rocmlir-gen --clone-harness -arch gfx942:sramecc+:xnack- -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets gfx942:sramecc+:xnack- | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full --debug-only=rock-gridwise-to-blockwise -o /dev/null 2>&1 | FileCheck %s --check-prefix=VECTORIZATION
+
+// ALLOW_RETRIES: 2
+// CLONE: [1 1 1]
+
+// EMITKEY: -t f32 -transA false -transB false -transC true -transO false -g 1 -m 32 -n 64 -k 16 -gemmO 8
+
+// VECTORIZATION: qVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: qVectorLen: 4
+// VECTORIZATION: kVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: kVectorLen: 4
+// VECTORIZATION: vVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: vVectorLen: 4
+
+module {
+  func.func @test(%arg0: !migraphx.shaped<1x32x32xf32, 1024x1x32>, %arg1: !migraphx.shaped<1x64x16xf32, 1024x1x64>, %arg2: !migraphx.shaped<1x64x8xf32, 512x1x64>) -> !migraphx.shaped<1x32x8xf32, 256x8x1> {
+    %sliced0 = migraphx.slice %arg0 {axes = [1], ends = [16], starts = [0]} : <1x32x32xf32, 1024x1x32> -> <1x16x32xf32, 1024x1x32>
+    %trans0 = migraphx.transpose %sliced0 {permutation = [0, 2, 1]} : <1x16x32xf32, 1024x1x32> -> <1x32x16xf32, 1024x32x1>
+    %trans1 = migraphx.transpose %arg1 {permutation = [0, 2, 1]} : <1x64x16xf32, 1024x1x64> -> <1x16x64xf32, 1024x64x1>
+    %0 = migraphx.dot %trans0, %trans1: !migraphx.shaped<1x32x16xf32, 1024x32x1>, !migraphx.shaped<1x16x64xf32, 1024x64x1> -> !migraphx.shaped<1x32x64xf32, 2048x64x1>
+    %2 = migraphx.dot %0, %arg2: !migraphx.shaped<1x32x64xf32, 2048x64x1>, !migraphx.shaped<1x64x8xf32, 512x1x64> -> !migraphx.shaped<1x32x8xf32, 256x8x1>
+    return %2 : !migraphx.shaped<1x32x8xf32, 256x8x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a0b1c0-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a0b1c0-e2e.mlir
@@ -1,0 +1,26 @@
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=EMITKEY
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// RUN: rocmlir-gen --clone-harness -arch gfx942:sramecc+:xnack- -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets gfx942:sramecc+:xnack- | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full --debug-only=rock-gridwise-to-blockwise -o /dev/null 2>&1 | FileCheck %s --check-prefix=VECTORIZATION
+
+// ALLOW_RETRIES: 2
+// CLONE: [1 1 1]
+
+// EMITKEY: -t f32 -transA false -transB true -transC false -transO false -g 1 -m 32 -n 64 -k 16 -gemmO 8
+
+// VECTORIZATION: qVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: qVectorLen: 4
+// VECTORIZATION: kVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: kVectorLen: 4
+// VECTORIZATION: vVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: vVectorLen: 4
+
+module {
+  func.func @test(%arg0: !migraphx.shaped<1x32x32xf32, 1024x1x32>, %arg1: !migraphx.shaped<1x16x64xf32, 1024x1x16>, %arg2: !migraphx.shaped<1x8x64xf32, 512x1x8>) -> !migraphx.shaped<1x32x8xf32, 256x8x1> {
+    %sliced0 = migraphx.slice %arg0 {axes = [1], ends = [16], starts = [0]} : <1x32x32xf32, 1024x1x32> -> <1x16x32xf32, 1024x1x32>
+    %trans0 = migraphx.transpose %sliced0 {permutation = [0, 2, 1]} : <1x16x32xf32, 1024x1x32> -> <1x32x16xf32, 1024x32x1>
+    %0 = migraphx.dot %trans0, %arg1: !migraphx.shaped<1x32x16xf32, 1024x32x1>, !migraphx.shaped<1x16x64xf32, 1024x1x16> -> !migraphx.shaped<1x32x64xf32, 2048x64x1>
+    %trans2 = migraphx.transpose %arg2 {permutation = [0, 2, 1]} : <1x8x64xf32, 512x1x8> -> <1x64x8xf32, 512x8x1>
+    %2 = migraphx.dot %0, %trans2: !migraphx.shaped<1x32x64xf32, 2048x64x1>, !migraphx.shaped<1x64x8xf32, 512x8x1> -> !migraphx.shaped<1x32x8xf32, 256x8x1>
+    return %2 : !migraphx.shaped<1x32x8xf32, 256x8x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a1b0c0-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a1b0c0-e2e.mlir
@@ -1,0 +1,26 @@
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=EMITKEY
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// RUN: rocmlir-gen --clone-harness -arch gfx942:sramecc+:xnack- -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets gfx942:sramecc+:xnack- | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full --debug-only=rock-gridwise-to-blockwise -o /dev/null 2>&1 | FileCheck %s --check-prefix=VECTORIZATION
+
+// ALLOW_RETRIES: 2
+// CLONE: [1 1 1]
+
+// EMITKEY: -t f32 -transA true -transB false -transC false -transO false -g 1 -m 32 -n 64 -k 16 -gemmO 8
+
+// VECTORIZATION: qVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: qVectorLen: 4
+// VECTORIZATION: kVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: kVectorLen: 4
+// VECTORIZATION: vVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: vVectorLen: 4
+
+module {
+  func.func @test(%arg0: !migraphx.shaped<1x32x32xf32, 1024x1x32>, %arg1: !migraphx.shaped<1x64x16xf32, 1024x1x64>, %arg2: !migraphx.shaped<1x8x64xf32, 512x1x8>) -> !migraphx.shaped<1x32x8xf32, 256x8x1> {
+    %trans1 = migraphx.transpose %arg1 {permutation = [0, 2, 1]} : <1x64x16xf32, 1024x1x64> -> <1x16x64xf32, 1024x64x1>
+    %sliced0 = migraphx.slice %arg0 {axes = [2], ends = [16], starts = [0]} : <1x32x32xf32, 1024x1x32> -> <1x32x16xf32, 1024x1x32>
+    %0 = migraphx.dot %sliced0, %trans1: !migraphx.shaped<1x32x16xf32, 1024x1x32>, !migraphx.shaped<1x16x64xf32, 1024x64x1> -> !migraphx.shaped<1x32x64xf32, 2048x64x1>
+    %trans2 = migraphx.transpose %arg2 {permutation = [0, 2, 1]} : <1x8x64xf32, 512x1x8> -> <1x64x8xf32, 512x8x1>
+    %2 = migraphx.dot %0, %trans2: !migraphx.shaped<1x32x64xf32, 2048x64x1>, !migraphx.shaped<1x64x8xf32, 512x8x1> -> !migraphx.shaped<1x32x8xf32, 256x8x1>
+    return %2 : !migraphx.shaped<1x32x8xf32, 256x8x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a1b1c1-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/sliced-gemm-gemm-a1b1c1-e2e.mlir
@@ -1,0 +1,24 @@
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=EMITKEY
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// RUN: rocmlir-gen --clone-harness -arch gfx942:sramecc+:xnack- -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets gfx942:sramecc+:xnack- | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full --debug-only=rock-gridwise-to-blockwise -o /dev/null 2>&1 | FileCheck %s --check-prefix=VECTORIZATION
+
+// ALLOW_RETRIES: 2
+// CLONE: [1 1 1]
+
+// EMITKEY: -t f32 -transA true -transB true -transC true -transO false -g 1 -m 32 -n 64 -k 16 -gemmO 8
+
+// VECTORIZATION: qVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: qVectorLen: 4
+// VECTORIZATION: kVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: kVectorLen: 4
+// VECTORIZATION: vVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: vVectorLen: 4
+
+module {
+  func.func @test(%arg0: !migraphx.shaped<1x32x32xf32, 1024x1x32>, %arg1: !migraphx.shaped<1x16x64xf32, 1024x1x16>, %arg2: !migraphx.shaped<1x64x8xf32, 512x1x64>) -> !migraphx.shaped<1x32x8xf32, 256x8x1> {
+    %sliced0 = migraphx.slice %arg0 {axes = [2], ends = [16], starts = [0]} : <1x32x32xf32, 1024x1x32> -> <1x32x16xf32, 1024x1x32>
+    %0 = migraphx.dot %sliced0, %arg1: !migraphx.shaped<1x32x16xf32, 1024x1x32>, !migraphx.shaped<1x16x64xf32, 1024x1x16> -> !migraphx.shaped<1x32x64xf32, 2048x64x1>
+    %2 = migraphx.dot %0, %arg2: !migraphx.shaped<1x32x64xf32, 2048x64x1>, !migraphx.shaped<1x64x8xf32, 512x1x64> -> !migraphx.shaped<1x32x8xf32, 256x8x1>
+    return %2 : !migraphx.shaped<1x32x8xf32, 256x8x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/unitdim-gemm-gemm-a0b0c1-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm-layouts/unitdim-gemm-gemm-a0b0c1-e2e.mlir
@@ -1,0 +1,23 @@
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=EMITKEY
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets %arch | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CLONE
+// RUN: rocmlir-gen --clone-harness -arch gfx942:sramecc+:xnack- -fut test %s | rocmlir-driver -kernel-pipeline migraphx | rocmlir-driver -host-pipeline migraphx,highlevel -targets gfx942:sramecc+:xnack- | rocmlir-gen -ph -verifier clone -fut test_wrapper - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full --debug-only=rock-gridwise-to-blockwise -o /dev/null 2>&1 | FileCheck %s --check-prefix=VECTORIZATION
+
+// ALLOW_RETRIES: 2
+// CLONE: [1 1 1]
+
+// EMITKEY: -t f32 -transA false -transB false -transC true -transO false -g 1 -m 32 -n 64 -k 1 -gemmO 8
+
+// VECTORIZATION: qVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: qVectorLen: 4
+// VECTORIZATION: kVectorDim: GemmDimension::MorN
+// VECTORIZATION-NEXT: kVectorLen: 4
+// VECTORIZATION: vVectorDim: GemmDimension::K
+// VECTORIZATION-NEXT: vVectorLen: 4
+
+module {
+  func.func @test(%arg0: !migraphx.shaped<1x32x1xf32, 32x1x1>, %arg1: !migraphx.shaped<1x1x64xf32, 64x1x1>, %arg2: !migraphx.shaped<1x64x8xf32, 512x1x64>) -> !migraphx.shaped<1x32x8xf32, 256x8x1> {
+    %0 = migraphx.dot %arg0, %arg1: !migraphx.shaped<1x32x1xf32, 32x1x1>, !migraphx.shaped<1x1x64xf32, 64x1x1> -> !migraphx.shaped<1x32x64xf32, 2048x64x1>
+    %2 = migraphx.dot %0, %arg2: !migraphx.shaped<1x32x64xf32, 2048x64x1>, !migraphx.shaped<1x64x8xf32, 512x1x64> -> !migraphx.shaped<1x32x8xf32, 256x8x1>
+    return %2 : !migraphx.shaped<1x32x8xf32, 256x8x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/lit.local.cfg
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/lit.local.cfg
@@ -1,0 +1,2 @@
+if (not config.arch_support_mfma):
+  config.unsupported = True

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-bias.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-bias.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>,
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1>) 
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %biased = migraphx.add %0, %arg3 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.dot %biased, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %1 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-complex-tree-elemwise.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-complex-tree-elemwise.mlir
@@ -1,0 +1,27 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>, 
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>, 
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1>,
+                                    %arg4: !migraphx.shaped<1x7x7xf32, 49x7x1>,
+
+                                    %arg5: !migraphx.shaped<1x7x7xf32, 49x7x1>,
+                                    %arg6: !migraphx.shaped<1x7x7xf32, 49x7x1>,
+
+                                    %arg7: !migraphx.shaped<1x7x7xf32, 49x7x1>)
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    // Inputs that that undergo leaf level elemwise ops
+    %sub = migraphx.sub %arg3, %arg4: <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %add = migraphx.add %arg5, %arg6: <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    // second level
+    %scaled = migraphx.mul %0, %sub : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %biased = migraphx.add %scaled, %add : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.dot %biased, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %1 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-const-scale.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-const-scale.mlir
@@ -1,0 +1,13 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>, %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>, %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>) -> (!migraphx.shaped<1x7x3xf32, 21x3x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %cst = migraphx.literal (dense<1.250000e-01> : tensor<1xf32>) : <1xf32, 0>
+    %cst1 = migraphx.multibroadcast %cst {out_dyn_dims = [], out_lens = [1, 7, 7]} : <1xf32, 0> -> <1x7x7xf32, 0x0x0>
+    %scaled = migraphx.mul %0, %cst1 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 0x0x0> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.dot %scaled, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %1 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale-and-bias.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale-and-bias.mlir
@@ -1,0 +1,17 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>, 
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>, 
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>, 
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1>,
+                                    %arg4: !migraphx.shaped<1x7x7xf32, 49x7x1>)
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %scaled = migraphx.mul %0, %arg3 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %biased = migraphx.add %scaled, %arg4 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.dot %biased, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %1 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale-bias-exp.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale-bias-exp.mlir
@@ -1,0 +1,18 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>, 
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>, 
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>, 
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1>,
+                                    %arg4: !migraphx.shaped<1x7x7xf32, 49x7x1>)
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %scaled = migraphx.mul %0, %arg3 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %exp = migraphx.exp %scaled : <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %biased = migraphx.add %exp, %arg4 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.dot %biased, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %1 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale-cross.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale-cross.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x128x64xf32, 8192x64x1>,
+                                    %arg1: !migraphx.shaped<1x64x27xf32, 1728x27x1>,
+                                    %arg2: !migraphx.shaped<1x27x64xf32, 1728x64x1>,
+                                    %arg3: !migraphx.shaped<1x128x27xf32, 3456x27x1>) 
+                                    -> (!migraphx.shaped<1x128x64xf32, 8192x64x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x128x64xf32, 8192x64x1>, <1x64x27xf32, 1728x27x1> -> <1x128x27xf32, 3456x27x1>
+    %biased = migraphx.mul %0, %arg3 : <1x128x27xf32, 3456x27x1>, <1x128x27xf32, 3456x27x1> -> <1x128x27xf32, 3456x27x1>
+    %1 = migraphx.dot %biased, %arg2: <1x128x27xf32, 3456x27x1>, <1x27x64xf32, 1728x64x1> -> <1x128x64xf32, 8192x64x1>
+    return %1 : !migraphx.shaped<1x128x64xf32, 8192x64x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded-scale.mlir
@@ -1,0 +1,11 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>, %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>, %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>, %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1>) -> (!migraphx.shaped<1x7x3xf32, 21x3x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %scaled = migraphx.mul %0, %arg3 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.dot %scaled, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %1 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-padded.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>, %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>, %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>) -> (!migraphx.shaped<1x7x3xf32, 21x3x1>) {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.dot %0, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %1 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-scale-reshape-4d.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm-scale-reshape-4d.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1>, 
+                            %arg1: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1>, 
+                            %arg2: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1>, 
+                            %arg3: !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1>) 
+                            -> (!migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1>) {
+    %0 = migraphx.transpose %arg3 {permutation = [0, 1, 3, 2]} : <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    %1 = migraphx.dot %arg2, %0 : <1x4x32x32xf32, 4096x1024x32x1>, <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    %2 = migraphx.mul %1, %arg1 : <1x4x32x32xf32, 4096x1024x32x1>, <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    %3 = migraphx.dot %2, %arg0 : <1x4x32x32xf32, 4096x1024x32x1>, <1x4x32x32xf32, 4096x1024x32x1> -> <1x4x32x32xf32, 4096x1024x32x1>
+    return %3 : !migraphx.shaped<1x4x32x32xf32, 4096x1024x32x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-gemm.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen -fut mlir_gemm_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_gemm(%arg0: !migraphx.shaped<1x64x64xf32, 4096x64x1>, %arg1: !migraphx.shaped<1x64x64xf32, 4096x64x1>, %arg2: !migraphx.shaped<1x64x64xf32, 4096x64x1>) -> (!migraphx.shaped<1x64x64xf32, 4096x64x1>) {
+    %0 = migraphx.dot %arg0, %arg1: !migraphx.shaped<1x64x64xf32, 4096x64x1>, !migraphx.shaped<1x64x64xf32, 4096x64x1> -> !migraphx.shaped<1x64x64xf32, 4096x64x1>
+    %1 = migraphx.dot %0, %arg2: !migraphx.shaped<1x64x64xf32, 4096x64x1>, !migraphx.shaped<1x64x64xf32, 4096x64x1> -> !migraphx.shaped<1x64x64xf32, 4096x64x1>
+    return %1 : !migraphx.shaped<1x64x64xf32, 4096x64x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-where-gemm.mlir
+++ b/mlir/test/fusion/pr-e2e/gemm-gemm/mixr-gemm-where-gemm.mlir
@@ -1,0 +1,16 @@
+// RUN: rocmlir-gen -fut mlir_gemm_where_gemm --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_gemm_where_gemm_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// ALLOW_RETRIES: 2
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_gemm_where_gemm(%arg0: !migraphx.shaped<1x12x256x256xf32, 786432x65536x256x1>, %arg1: !migraphx.shaped<1x12x256x256xf32, 786432x65536x256x1>, %arg2: !migraphx.shaped<1x12x256x256xi8, 786432x65536x256x1>, %arg3: !migraphx.shaped<1x12x256x256xf32, 786432x65536x256x1>, %arg4: !migraphx.shaped<1x12x256x256xf32, 786432x65536x256x1>) -> !migraphx.shaped<1x12x256x256xf32, 786432x65536x256x1>
+  {
+    %0 = migraphx.literal(dense<1.250000e-01> : tensor<1xf32>) : <1xf32, 0>
+    %1 = migraphx.transpose %arg1 {permutation = [0, 1, 3, 2]} : <1x12x256x256xf32, 786432x65536x256x1> -> <1x12x256x256xf32, 786432x65536x1x256>
+    %2 = migraphx.dot %arg0, %1 : <1x12x256x256xf32, 786432x65536x256x1>, <1x12x256x256xf32, 786432x65536x1x256> -> <1x12x256x256xf32, 786432x65536x256x1>
+    %3 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [1, 12, 256, 256]} : <1xf32, 0> -> <1x12x256x256xf32, 0x0x0x0>
+    %4 = migraphx.mul %2, %3 : <1x12x256x256xf32, 786432x65536x256x1>, <1x12x256x256xf32, 0x0x0x0> -> <1x12x256x256xf32, 786432x65536x256x1>
+    %5 = migraphx.where %arg2, %4, %arg3 : <1x12x256x256xi8, 786432x65536x256x1>, <1x12x256x256xf32, 786432x65536x256x1>, <1x12x256x256xf32, 786432x65536x256x1> -> <1x12x256x256xf32, 786432x65536x256x1>
+    %6 = migraphx.dot %5, %arg4 : <1x12x256x256xf32, 786432x65536x256x1>, <1x12x256x256xf32, 786432x65536x256x1> -> <1x12x256x256xf32, 786432x65536x256x1>
+    return %6 : !migraphx.shaped<1x12x256x256xf32, 786432x65536x256x1>
+  }
+}


### PR DESCRIPTION
This PR depends on https://github.com/ROCm/rocMLIR/pull/1774, that PR needs to be merged first.

In this PR we add migraphx integration and end-to-end tests in migraphx dialect. The end-to-end tests are based on attention tests.

TODO:
- [x] Merge https://github.com/ROCm/rocMLIR/pull/1774 first