### PR TITLE
Workaround issue 1802

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1992,6 +1992,7 @@ struct GridwiseAttentionAccelRewritePattern
         if (failed(statusLoadQ)) {
           return failure();
         }
+        rewriter.create<LDSBarrierOp>(loc);
 
         TypedValue<MemRefType> ldsTileBufferQ = viewBufferAs(
             rewriter, ldsByteBufferQ, vectorTypeOrSelf(elemTypeQ, gemm0kpack));

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1760,6 +1760,12 @@ struct GridwiseAttentionAccelRewritePattern
     if (doBypassLDSForQ) {
       ldsLayoutCfgNG0.doSwapThreadIterSubDims = false;
     }
+#ifndef ROCK_DEBUG_ATTENTION_REMOVE_SOFTMAX
+    // TODO: Workaround for issue https://github.com/ROCm/rocMLIR-internal/issues/1802
+    // If sumRowBuffer and expMaxDiffRowBuffer are filled with doSwapThreadIterSubDims=true, it does not match with the second GEMM N dimension.
+    // Find a good solution to this.
+    ldsLayoutCfgNG0.doSwapThreadIterSubDims = false;
+#endif
     FailureOr<VectorDimInfo> maybeVectorDimInfoK =
         getVectorDim(rewriter, loc, inK, elemTypeK, blockSize, gemm0KPerBlock,
                      gemm0MPerBlock, gemm0kpack);
@@ -1834,7 +1840,7 @@ struct GridwiseAttentionAccelRewritePattern
     Value accRegBufferGemm0 =
         createBufferForAccelGemmOut(loc, accelParamsGemm0, rewriter);
     // Currently, there is a working assumption that this kernel is meant
-    // support fp32/fp16 This should be guranteed by op verifiers.
+    // support fp32/fp16/bf16. This should be guranteed by op verifiers.
     Type gemmOutElemType = elemTypeQxK;
     Type softmaxInElemType = elemTypeQxK;
     if (elemTypeQ == rewriter.getI8Type()) {
@@ -1990,7 +1996,7 @@ struct GridwiseAttentionAccelRewritePattern
             rewriter, ldsByteBufferQ, vectorTypeOrSelf(elemTypeQ, gemm0kpack));
         loadGemmOperandsFromLDSToRegs(
             rewriter, loc, ldsTileBufferQ, preAccelRegBuffersQ, "n", blockSize,
-            gemm0InMPerThread, *accelEmitterPtrGemm0.get(),
+            gemm0InNPerThread, *accelEmitterPtrGemm0.get(),
             ldsLayoutCfgNG0.doRotateWithK);
         rewriter.create<GpuDeallocOp>(loc, ldsByteBufferQ);
       }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1761,9 +1761,10 @@ struct GridwiseAttentionAccelRewritePattern
       ldsLayoutCfgNG0.doSwapThreadIterSubDims = false;
     }
 #ifndef ROCK_DEBUG_ATTENTION_REMOVE_SOFTMAX
-    // TODO: Workaround for issue https://github.com/ROCm/rocMLIR-internal/issues/1802
-    // If sumRowBuffer and expMaxDiffRowBuffer are filled with doSwapThreadIterSubDims=true, it does not match with the second GEMM N dimension.
-    // Find a good solution to this.
+    // TODO: Workaround for issue
+    // https://github.com/ROCm/rocMLIR-internal/issues/1802 If sumRowBuffer and
+    // expMaxDiffRowBuffer are filled with doSwapThreadIterSubDims=true, it does
+    // not match with the second GEMM N dimension. Find a good solution to this.
     ldsLayoutCfgNG0.doSwapThreadIterSubDims = false;
 #endif
     FailureOr<VectorDimInfo> maybeVectorDimInfoK =

--- a/mlir/test/e2e/PrAttentionBF16.toml
+++ b/mlir/test/e2e/PrAttentionBF16.toml
@@ -3,14 +3,24 @@ prefix = "rocmlir-gen"
 suffix = "--operation attention -t bf16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
-name = "operation"
-values = ["attention"]
-prefix = "--operation "
+name = "transQ"
+values = ["true", "false"]
+prefix = "--transQ="
 
 [[axis]]
 name = "transK"
 values = ["true", "false"]
 prefix = "--transK="
+
+[[axis]]
+name = "transV"
+values = ["true", "false"]
+prefix = "--transV="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
 
 ## attention variant
 [[suite]]

--- a/mlir/test/e2e/PrAttentionF16.toml
+++ b/mlir/test/e2e/PrAttentionF16.toml
@@ -3,14 +3,24 @@ prefix = "rocmlir-gen"
 suffix = "--operation attention -t f16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.02 -absDiff_threshold 0.1 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
-name = "operation"
-values = ["attention"]
-prefix = "--operation "
+name = "transQ"
+values = ["true", "false"]
+prefix = "--transQ="
 
 [[axis]]
 name = "transK"
 values = ["true", "false"]
 prefix = "--transK="
+
+[[axis]]
+name = "transV"
+values = ["true", "false"]
+prefix = "--transV="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
 
 ## attention variant
 [[suite]]

--- a/mlir/test/e2e/PrAttentionF32.toml
+++ b/mlir/test/e2e/PrAttentionF32.toml
@@ -3,14 +3,24 @@ prefix = "rocmlir-gen"
 suffix = "--operation attention -t f32 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.00005 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
-name = "operation"
-values = ["attention"]
-prefix = "--operation "
+name = "transQ"
+values = ["true", "false"]
+prefix = "--transQ="
 
 [[axis]]
 name = "transK"
 values = ["true", "false"]
 prefix = "--transK="
+
+[[axis]]
+name = "transV"
+values = ["true", "false"]
+prefix = "--transV="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
 
 ## attention variant
 [[suite]]

--- a/mlir/test/e2e/PrAttentionI8.toml
+++ b/mlir/test/e2e/PrAttentionI8.toml
@@ -3,24 +3,9 @@ prefix = "rocmlir-gen"
 suffix = "--operation attention -t i8 --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.01 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
-name = "transQ"
-values = ["true", "false"]
-prefix = "--transQ="
-
-[[axis]]
 name = "transK"
 values = ["true", "false"]
 prefix = "--transK="
-
-[[axis]]
-name = "transV"
-values = ["true", "false"]
-prefix = "--transV="
-
-[[axis]]
-name = "transO"
-values = ["true", "false"]
-prefix = "--transO="
 
 ## attention variant
 [[suite]]

--- a/mlir/test/e2e/PrAttentionI8.toml
+++ b/mlir/test/e2e/PrAttentionI8.toml
@@ -3,14 +3,24 @@ prefix = "rocmlir-gen"
 suffix = "--operation attention -t i8 --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.01 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
-name = "operation"
-values = ["attention"]
-prefix = "--operation "
+name = "transQ"
+values = ["true", "false"]
+prefix = "--transQ="
 
 [[axis]]
 name = "transK"
 values = ["true", "false"]
 prefix = "--transK="
+
+[[axis]]
+name = "transV"
+values = ["true", "false"]
+prefix = "--transV="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
 
 ## attention variant
 [[suite]]


### PR DESCRIPTION
Workaround for issue 1802. Disable doSwapThreadIterSubDims for Q and add tests by increasing test coverage of PrAttention*.

Also: add a barrier between loading from memory and storing to LDS when gemm0K == gemm0KPerBlock and doBypassLDSForQ = false. This should not happen as this code is disabled, but it's good to keep it correct just in case.