### PR TITLE
Prepare Jenkinsfiles for rocm-6.4

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -67,11 +67,11 @@ String dockerArgs() {
 
 String dockerImage() {
     // If this is being changed please change Dockerfile.migraphx-ci's base image as well
-    return 'rocm/mlir:rocm6.3-latest'
+    return 'rocm/mlir:rocm6.4-latest'
 }
 
 String dockerImageCIMIGraphX() {
-    return 'rocm/mlir-migraphx-ci:rocm6.3-latest'
+    return 'rocm/mlir-migraphx-ci:rocm6.4-latest'
 }
 
 void preMergeCheck(String codepath) {

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -24,7 +24,7 @@ String dockerArgs() {
 }
 
 String dockerImage() {
-    return 'rocm/mlir:rocm6.3-latest'
+    return 'rocm/mlir:rocm6.4-latest'
 }
 
 

--- a/mlir/utils/jenkins/Jenkinsfile.release
+++ b/mlir/utils/jenkins/Jenkinsfile.release
@@ -26,7 +26,7 @@ String dockerArgs() {
 }
 
 String dockerImage() {
-    return 'rocm/mlir:rocm6.3-latest'
+    return 'rocm/mlir:rocm6.4-latest'
 }
 
 pipeline {


### PR DESCRIPTION
Prepare Jenkinsfiles to use rocm6.4
(Dockerfiles in the [previous PR](https://github.com/ROCm/rocMLIR/pull/1808))

Resolves https://github.com/ROCm/rocMLIR-internal/issues/1789