### PR TITLE
conv+gemm support

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Generator/ConvGenerator.h
+++ b/mlir/include/mlir/Dialect/Rock/Generator/ConvGenerator.h
@@ -98,7 +98,7 @@ public:
 
   void setPerfConfig(StringRef perfConfig);
 
-  ConvolutionDims getConvolutionDims() const;
+  static ConvolutionDims getConvolutionDims(const Config *config);
 
   static inline constexpr int64_t outputDim(int64_t inputLen, int64_t filLen,
                                             int64_t leftPadLen,
@@ -117,8 +117,8 @@ public:
                               ArrayRef<int64_t> outputDims,
                               ArrayRef<int64_t> filterDims);
 
-  LogicalResult genConvModule(ModuleOp &module, int kernel_id = -1,
-                              bool is_verifier = false,
+  LogicalResult genConvModule(ModuleOp &module, int rawKernelId = -1,
+                              bool isVerifier = false,
                               bool ignoreTuning = false);
 
   func::FuncOp getKernelFunc() const;

--- a/mlir/include/mlir/Dialect/Rock/IR/ConvolutionDims.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/ConvolutionDims.h
@@ -37,7 +37,7 @@ struct ConvolutionDims {
                   int64_t g)
       : fil(fil), out(out), in(in), k(k), c(c), n(n), g(g) {}
 
-  static ConvolutionDims fromOp(Operation *op);
+  static ConvolutionDims fromOp(Operation *op, bool enableOutput = true);
 };
 
 } // namespace rock

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -65,12 +65,14 @@ def KernelTypeConvBwdWeight : I32EnumAttrCase<"ConvBwdWeight", 2>;
 def KernelTypeGemm : I32EnumAttrCase<"Gemm", 3>;
 def KernelTypeAttention : I32EnumAttrCase<"Attention", 4>;
 def KernelTypeGemmElementwiseGemm : I32EnumAttrCase<"GemmElementwiseGemm", 5>;
+def KernelTypeConvElementwiseGemm : I32EnumAttrCase<"ConvElementwiseGemm", 6>;
 
 def KernelType
     : Rock_I32Enum<"KernelType", "Any of the possible types of a rock kernel",
                    [KernelTypeConv, KernelTypeConvBwdData,
                     KernelTypeConvBwdWeight, KernelTypeGemm,
-                    KernelTypeAttention, KernelTypeGemmElementwiseGemm]>;
+                    KernelTypeAttention, KernelTypeGemmElementwiseGemm,
+                    KernelTypeConvElementwiseGemm]>;
 
 /// TransformType
 def PassThrough : I32EnumAttrCase<"PassThrough", 0>;

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -313,6 +313,58 @@ def Rock_GemmElementwiseGemmOp
   }];
 }
 
+def Rock_ConvElementwiseGemmOp
+    : Rock_Op<"conv_elementwise_gemm",
+              [DeclareOpInterfaceMethods<RockGemmGemmWrapperInterface>,
+               DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+               RockFusionRoot]>,
+      AllElementTypesMatch<["filter", "input"]>,
+      Arguments<(ins TensorOrMemRefOf<[F32, F16, BF16]>:$filter,
+          TensorOrMemRefOf<[F32, F16, BF16]>:$input,
+          TensorOrMemRefOf<[F32, F16, BF16]>:$c,
+          Variadic<AnyTensorOrMemRef>:$elemwiseInputs,
+          TensorOrMemRefOf<[F32, F16, BF16]>:$out, UnitAttr:$cTransposed,
+          UnitAttr:$oTransposed, StrAttr:$arch, Rock_GemmFeaturesAttr:$features,
+          OptionalAttr<I32Attr>:$numCU, IndexArrayLength<4>:$padding,
+          IndexArrayLength<2>:$strides, IndexArrayLength<2>:$dilations,
+          OptionalAttr<RockTuningParamAttrInterface>:$params0,
+          OptionalAttr<RockTuningParamAttrInterface>:$params1,
+          I32Attr:$firstGemmIdx)>,
+      Results<(outs Optional<TensorOf<[F32, F16, BF16]>>:$result)> {
+  let summary = "CONV-elementwise-GEMM operation";
+  let description = [{
+    Performs the operation out = preSecondGemmBody(conv_forward(filter, input), elemwiseInputs) * c.
+
+    This operation performs fused CONV-elementwise-GEMM. There is an optional element-wise
+    fusion just before the second GEMM, defined by `preSecondGemmBody` with inputs `elemwiseInputs`.
+
+    If none of the `transposed` attributes are set, then `c` is [G] x N x O and `out` is [G] x M x O, 
+    where G is the optional group dimension (which is assumed to be 1 if not set). Note that input and
+    filter layouts are defined by attributes "input_layout" and "filter_layout".
+
+    The transpose attributes allow for the non-group dimensions of the matrix to be
+    transposed. For example, if `cTransposed` is set, then the argument `c` should be
+    a [G] x O x M memory.
+
+    Those creating a `rock.conv_elementwise_gemm` must specify the GPU architecture being targetted
+    and the number of compute units (numCu) available. The parameters
+    `gridSize`, and `blockSize` are optional as they can be inferred by
+    a tuning process or a heuristic, but they must be set before the `conv_elementwise_gemm` is
+    lowered into the `gridwise_attention_accel` stage of the code generation pipeline.
+
+    `features` specifies what hardware features can be used in the generated code.
+  }];
+  let hasVerifier = 1;
+  let regions = (region AnyRegion:$preSecondGemmBody);
+  let assemblyFormat = [{
+    `{` `\n`
+        ` ` `ab` `=` `conv` `(` $filter `,` $input `)` `:` type($filter) `,` type($input) `\n`
+        (`ab` `=` `elementwise` (`otherIns` `(` $elemwiseInputs^ `:` type($elemwiseInputs) `)`)? $preSecondGemmBody^ `\n`)?
+        (`tr` $oTransposed^)? $out `=` `ab` `*` (`tr` $cTransposed^)? $c `:` type($c) `->` type($out) `\n`
+    `}` attr-dict (`->` type($result)^)?
+  }];
+}
+
 def Rock_InitKernelOp :
     Rock_Op<"init_kernel", []>,
     Arguments<(ins AnyTensorOrMemRef:$buffer,

--- a/mlir/include/mlir/Dialect/Rock/Passes.td
+++ b/mlir/include/mlir/Dialect/Rock/Passes.td
@@ -18,7 +18,9 @@ def RockViewToTransformPass : Pass<"rock-view-to-transform", "::mlir::func::Func
 }
 
 def RockConvToGemmPass : Pass<"rock-conv-to-gemm", "::mlir::func::FuncOp"> {
-  let summary = "expand convolution into coordinate transformations and gemm";
+  let summary = "expand convolution into coordinate transformations and gemm. "
+                "Additionally, it also convert rock.conv_elementwise_gemm into "
+                "rock.gemm_elementwise_gemm";
   let dependentDialects = ["rock::RockDialect", "memref::MemRefDialect", "arith::ArithDialect",
     "scf::SCFDialect", "gpu::GPUDialect"];
 }

--- a/mlir/include/mlir/Dialect/Rock/Tuning/ConvContext.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/ConvContext.h
@@ -67,6 +67,9 @@ struct ConvolutionContext {
 // Populate ConvContext from a given Convolution Op.
 // TODO(whchung): adopt ConvolutionOp OpTrait check after supporting PR is in.
 ConvolutionContext populateConvContext(Operation *op);
+
+ConvolutionContext populateConvContextFromConvGemm(ConvElementwiseGemmOp op);
+
 } // namespace rock
 } // namespace mlir
 #endif // MLIR_DIALECT_ROCK_CONVCONTEXT_H

--- a/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
+++ b/mlir/lib/Dialect/Rock/Generator/ConvGenerator.cpp
@@ -360,7 +360,7 @@ LogicalResult ConvGenerator::needExtraPadBwdWeight(OpBuilder &builder,
   assert(dir == ConvOpType::BwdWeight &&
          "This method should only be called for wrw ops");
 
-  ConvolutionDims convDims = getConvolutionDims();
+  ConvolutionDims convDims = getConvolutionDims(&config);
   GemmSize gemmSize = GemmSize::fromConvolution(dir, convDims);
 
   needExtraPad = false;
@@ -738,19 +738,19 @@ void ConvGenerator::setPerfConfig(StringRef perfConfig) {
   config.perfConfig = perfConfig.str();
 }
 
-ConvolutionDims ConvGenerator::getConvolutionDims() const {
-  auto inDim = canonicalizeDims(config.inputDimension, config.inputLayout);
-  auto filDim = canonicalizeDims(config.filterDimension, config.filterLayout);
-  auto outDim = canonicalizeDims(config.outputDimension, config.outputLayout);
+ConvolutionDims ConvGenerator::getConvolutionDims(const Config *config) {
+  auto inDim = canonicalizeDims(config->inputDimension, config->inputLayout);
+  auto filDim = canonicalizeDims(config->filterDimension, config->filterLayout);
+  auto outDim = canonicalizeDims(config->outputDimension, config->outputLayout);
 
   SmallVector<int64_t> inDims;
-  for (size_t i = 0; i < config.inputLayout.size() - 3; i++)
+  for (size_t i = 0; i < config->inputLayout.size() - 3; i++)
     inDims.push_back(inDim[std::to_string(i)]);
   SmallVector<int64_t> filDims;
-  for (size_t i = 0; i < config.filterLayout.size() - 3; i++)
+  for (size_t i = 0; i < config->filterLayout.size() - 3; i++)
     filDims.push_back(filDim[std::to_string(i)]);
   SmallVector<int64_t> outDims;
-  for (size_t i = 0; i < config.outputLayout.size() - 3; i++)
+  for (size_t i = 0; i < config->outputLayout.size() - 3; i++)
     outDims.push_back(outDim[std::to_string(i)]);
 
   return ConvolutionDims(filDims, outDims, inDims, filDim["k"], filDim["c"],
@@ -758,8 +758,7 @@ ConvolutionDims ConvGenerator::getConvolutionDims() const {
 }
 
 LogicalResult ConvGenerator::genConvModule(ModuleOp &module, int rawKernelId,
-                                           bool is_verifier,
-                                           bool ignoreTuning) {
+                                           bool isVerifier, bool ignoreTuning) {
   OpBuilder builder(module.getContext());
 
   Type filterDataType = getFilterDataType(builder);
@@ -805,7 +804,7 @@ LogicalResult ConvGenerator::genConvModule(ModuleOp &module, int rawKernelId,
   auto funcType = builder.getFunctionType(physicalFuncArgTypes, {});
 
   std::string kernelName = config.kernelBaseName;
-  if (is_verifier) {
+  if (isVerifier) {
     kernelName += "_ver";
   }
 
@@ -848,7 +847,7 @@ LogicalResult ConvGenerator::genConvModule(ModuleOp &module, int rawKernelId,
                                                  config.scheduleVersion));
   }
   module.push_back(func);
-  if (!is_verifier)
+  if (!isVerifier)
     module->setAttr(archAttr.getName(), archAttr.getValue());
   if (func.getName() != kernelName) {
     return failure();

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Rock/Generator/ConvGenerator.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.h"
@@ -48,6 +49,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/SMLoc.h"
@@ -396,22 +398,23 @@ void RockDialect::initialize() {
 //===----------------------------------------------------------------------===//
 // Convolution operations
 //===----------------------------------------------------------------------===//
-ConvolutionDims ConvolutionDims::fromOp(Operation *op) {
+ConvolutionDims ConvolutionDims::fromOp(Operation *op, bool enableOutput) {
   auto filterLayoutAttr = op->getAttrOfType<ArrayAttr>("filter_layout");
   auto inputLayoutAttr = op->getAttrOfType<ArrayAttr>("input_layout");
-  auto outputLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("output_layout");
+  ArrayAttr outputLayoutAttr;
+  if (enableOutput)
+    outputLayoutAttr = op->template getAttrOfType<ArrayAttr>("output_layout");
 
   // Get shape of filter tensor.
-  auto filterType = cast<MemRefType>(op->getOperand(0).getType());
+  auto filterType = cast<ShapedType>(op->getOperand(0).getType());
   ArrayRef<int64_t> filterShape = filterType.getShape();
 
   // Get shape of input tensor.
-  auto inputType = cast<MemRefType>(op->getOperand(1).getType());
+  auto inputType = cast<ShapedType>(op->getOperand(1).getType());
   ArrayRef<int64_t> inputShape = inputType.getShape();
 
   // Get shape of output tensor.
-  auto outputType = cast<MemRefType>(op->getOperand(2).getType());
+  auto outputType = cast<ShapedType>(op->getOperand(2).getType());
   ArrayRef<int64_t> outputShape = outputType.getShape();
 
   int64_t y, x, z, ho, wo, dout, hi, wi, di, k, c, n, g;
@@ -420,15 +423,13 @@ ConvolutionDims ConvolutionDims::fromOp(Operation *op) {
   for (unsigned i = 0; i < filterLayoutAttr.size(); ++i) {
     auto filterAttr = cast<StringAttr>(filterLayoutAttr.getValue()[i]);
     auto inputAttr = cast<StringAttr>(inputLayoutAttr.getValue()[i]);
-    auto outputAttr = cast<StringAttr>(outputLayoutAttr.getValue()[i]);
+    StringAttr outputAttr;
+    if (enableOutput)
+      outputAttr = cast<StringAttr>(outputLayoutAttr.getValue()[i]);
 
-    if (filterAttr.getValue() == "y") {
+    if (filterAttr.getValue() == "0" || filterAttr.getValue() == "y") {
       y = filterShape[i];
-    } else if (filterAttr.getValue() == "0") {
-      y = filterShape[i];
-    } else if (filterAttr.getValue() == "x") {
-      x = filterShape[i];
-    } else if (filterAttr.getValue() == "1") {
+    } else if (filterAttr.getValue() == "x" || filterAttr.getValue() == "1") {
       x = filterShape[i];
     } else if (filterAttr.getValue() == "2") {
       z = filterShape[i];
@@ -440,13 +441,9 @@ ConvolutionDims ConvolutionDims::fromOp(Operation *op) {
       g = filterShape[i];
     }
 
-    if (inputAttr.getValue() == "hi") {
+    if (inputAttr.getValue() == "hi" || inputAttr.getValue() == "0i") {
       hi = inputShape[i];
-    } else if (inputAttr.getValue() == "wi") {
-      wi = inputShape[i];
-    } else if (inputAttr.getValue() == "0i") {
-      hi = inputShape[i];
-    } else if (inputAttr.getValue() == "1i") {
+    } else if (inputAttr.getValue() == "wi" || inputAttr.getValue() == "1i") {
       wi = inputShape[i];
     } else if (inputAttr.getValue() == "2i") {
       di = inputShape[i];
@@ -454,16 +451,15 @@ ConvolutionDims ConvolutionDims::fromOp(Operation *op) {
       n = inputShape[i];
     }
 
-    if (outputAttr.getValue() == "ho") {
-      ho = outputShape[i];
-    } else if (outputAttr.getValue() == "wo") {
-      wo = outputShape[i];
-    } else if (outputAttr.getValue() == "0o") {
-      ho = outputShape[i];
-    } else if (outputAttr.getValue() == "1o") {
-      wo = outputShape[i];
-    } else if (outputAttr.getValue() == "2o") {
-      dout = outputShape[i];
+    if (enableOutput) {
+      if (outputAttr.getValue() == "ho" || outputAttr.getValue() == "0o") {
+        ho = outputShape[i];
+      } else if (outputAttr.getValue() == "wo" ||
+                 outputAttr.getValue() == "1o") {
+        wo = outputShape[i];
+      } else if (outputAttr.getValue() == "2o") {
+        dout = outputShape[i];
+      }
     }
   }
 
@@ -482,6 +478,7 @@ ConvolutionDims ConvolutionDims::fromOp(Operation *op) {
 ConvOpType mlir::rock::convOpTypeFromKernelType(KernelType kernelType) {
   switch (kernelType) {
   case KernelType::Conv:
+  case KernelType::ConvElementwiseGemm:
     return ConvOpType::Fwd;
   case KernelType::ConvBwdData:
     return ConvOpType::BwdData;
@@ -591,9 +588,8 @@ static LogicalResult verifyGemmTypes(Operation *op, GemmFeatures features,
 }
 
 static LogicalResult verifyGemmTypes(RockGemmWrapperInterface gemmOp) {
-  Type elemTypeA = gemmOp.getAType(), elemTypeB = gemmOp.getBType();
-  Type elemTypeC = cast<ShapedType>(gemmOp.getOutArgument()->get().getType())
-                       .getElementType();
+  Type elemTypeA = gemmOp.getAType(), elemTypeB = gemmOp.getBType(),
+       elemTypeC = gemmOp.getCType();
 
   return verifyGemmTypes(gemmOp, gemmOp.getGemmFeatures(), gemmOp.getArch(),
                          elemTypeA, elemTypeB, elemTypeC);
@@ -2210,6 +2206,101 @@ void GemmElementwiseGemmOp::getEffects(
 
   effects.emplace_back(read, &getAMutable());
   effects.emplace_back(read, &getBMutable());
+  effects.emplace_back(read, &getCMutable());
+  for (auto &regionArg : getElemwiseInputsMutable())
+    effects.emplace_back(read, &regionArg);
+}
+
+//===-----------------------------------------------------===//
+// ConvElementwiseGemmOp
+//===-----------------------------------------------------===//
+
+OpOperand *ConvElementwiseGemmOp::getOutArgument() {
+  return &(*this)->getOpOperand(getNumOperands() - 1);
+}
+
+Type ConvElementwiseGemmOp::getOutType() { return getOut().getType(); }
+
+Type ConvElementwiseGemmOp::getAType() {
+  auto size = getGemmGemmSize();
+  auto elementType = getInput().getType().getElementType();
+  int64_t dim1 = getTransposedA() ? size.k : size.n;
+  int64_t dim2 = getTransposedA() ? size.n : size.k;
+  return MemRefType::get({size.g, dim1, dim2}, elementType);
+}
+
+Type ConvElementwiseGemmOp::getBType() {
+  auto size = getGemmGemmSize();
+  auto elementType = getFilter().getType().getElementType();
+  int64_t dim1 = getTransposedB() ? size.m : size.k;
+  int64_t dim2 = getTransposedB() ? size.k : size.m;
+  return MemRefType::get({size.g, dim1, dim2}, elementType);
+}
+
+Type ConvElementwiseGemmOp::getCType() { return getC().getType(); }
+
+bool ConvElementwiseGemmOp::getTransposedA() {
+  // see ConvToGemm pass
+  return true;
+}
+
+bool ConvElementwiseGemmOp::getTransposedB() {
+  // see ConvToGemm pass
+  return false;
+}
+
+bool ConvElementwiseGemmOp::getTransposedC() { return getCTransposed(); }
+
+bool ConvElementwiseGemmOp::getTransposedOut() { return getOTransposed(); }
+
+KernelType ConvElementwiseGemmOp::getKernelType() {
+  return KernelType::ConvElementwiseGemm;
+}
+
+uint32_t ConvElementwiseGemmOp::getFirstGemmIndex() {
+  return getFirstGemmIdx();
+}
+
+void ConvElementwiseGemmOp::setFirstGemmIndex(uint32_t index) {
+  setFirstGemmIdx(index);
+}
+
+GemmGemmSize ConvElementwiseGemmOp::getGemmGemmSize() {
+  auto strideVal = extractFromIntegerArrayAttr<int64_t>(getStrides());
+  auto dilationVal = extractFromIntegerArrayAttr<int64_t>(getDilations());
+  auto paddingVal = extractFromIntegerArrayAttr<int64_t>(getPadding());
+  auto sizes = ConvolutionDims::fromOp(*this, false);
+
+  // generate sizes.out with ConvGenerator
+  sizes.out[0] = rock::ConvGenerator::outputDim(sizes.in[0], sizes.fil[0],
+                                                paddingVal[0], paddingVal[1],
+                                                strideVal[0], dilationVal[0]);
+  sizes.out[1] = rock::ConvGenerator::outputDim(sizes.in[1], sizes.fil[1],
+                                                paddingVal[2], paddingVal[3],
+                                                strideVal[1], dilationVal[1]);
+
+  rock::GemmSize gemmSize =
+      rock::GemmSize::fromConvolution(rock::ConvOpType::Fwd, sizes);
+  ArrayRef<int64_t> dimsC = getC().getType().getShape();
+  int64_t offsetC = dimsC.size() == 2 ? 0 : 1;
+  int64_t g = gemmSize.g, m = gemmSize.m, k = gemmSize.k, n = gemmSize.n,
+          o = dimsC[offsetC + (getCTransposed() ? 0 : 1)];
+  return GemmGemmSize(g, m, k, n, o);
+}
+
+LogicalResult ConvElementwiseGemmOp::verify() {
+  return verifyGemmPlusGemmLikeOp(*this, /*currentSeqLen=*/nullptr);
+}
+
+void ConvElementwiseGemmOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  auto *read = MemoryEffects::Read::get();
+  auto *write = MemoryEffects::Write::get();
+  effects.emplace_back(read, &getOutMutable());
+  effects.emplace_back(write, &getOutMutable());
+
+  effects.emplace_back(read, &getFilterMutable());
+  effects.emplace_back(read, &getInputMutable());
   effects.emplace_back(read, &getCMutable());
   for (auto &regionArg : getElemwiseInputsMutable())
     effects.emplace_back(read, &regionArg);

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -274,11 +274,12 @@ void AffixTuningParameters::affixTuningParametersImpl(
   OpBuilder builder(op.getContext());
   bool isAccel = rock::isAccel(op.getGemmFeatures());
   if (!isAccel) {
-    op.emitError("Currently, attention/gemm+gemm op is only "
+    op.emitError("Currently, attention/gemm+gemm/conv+gemm op is only "
                  "supported on GPUs "
                  "with matrix accelerator extentions");
     return signalPassFailure();
   }
+
   Attribute params0 = op.getGemm0Params().value_or(nullptr);
   // set a default one if params is not provided
   StringAttr perfConfigStrAttr =

--- a/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -229,6 +229,8 @@ void mlir::rock::registerBufferizableOpInterfaceExternalModels(
     AttentionOp::attachInterface<GemmLikeInterface<AttentionOp>>(*ctx);
     GemmElementwiseGemmOp::attachInterface<
         GemmLikeInterface<GemmElementwiseGemmOp>>(*ctx);
+    ConvElementwiseGemmOp::attachInterface<
+        GemmLikeInterface<ConvElementwiseGemmOp>>(*ctx);
 
     TransformOp::attachInterface<TransformOpInterface>(*ctx);
     TensorUntransformCastOp::attachInterface<TensorUntransformCastOpInterface>(

--- a/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
@@ -16,11 +16,13 @@
 // ============================================================
 //
 // This pass converts rock.conv into rock.transform and
-// rock.gemm.
+// rock.gemm. Additionally, it also convert rock.conv_elementwise_gemm
+// into rock.gemm_elementwise_gemm.
 //
 //===-----------------------------------------------------===//
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/GemmSize.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
@@ -47,7 +49,9 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 #include <iterator>
+#include <tuple>
 
 namespace mlir {
 namespace rock {
@@ -119,23 +123,31 @@ void matchUnderlyingOrder(SmallVectorImpl<StringRef> &names,
 template <typename T>
 LogicalResult getConvDimNames(T op, SmallVectorImpl<StringRef> &filterNames,
                               SmallVectorImpl<StringRef> &inputNames,
-                              SmallVectorImpl<StringRef> &outputNames) {
+                              SmallVectorImpl<StringRef> &outputNames,
+                              bool enableOutput = true) {
   auto filterLayoutAttr =
       op->template getAttrOfType<ArrayAttr>("filter_layout");
   auto inputLayoutAttr = op->template getAttrOfType<ArrayAttr>("input_layout");
-  auto outputLayoutAttr =
-      op->template getAttrOfType<ArrayAttr>("output_layout");
 
   unsigned size = filterLayoutAttr.size();
-  if (size != inputLayoutAttr.size() || size != outputLayoutAttr.size())
+  ArrayAttr outputLayoutAttr;
+  if (enableOutput) {
+    outputLayoutAttr = op->template getAttrOfType<ArrayAttr>("output_layout");
+    if (size != outputLayoutAttr.size())
+      return op.emitOpError(
+          "All convolution layouts must have the same length");
+  }
+
+  if (size != inputLayoutAttr.size())
     return op.emitOpError("All convolution layouts must have the same length");
 
   filterNames.reserve(size);
   inputNames.reserve(size);
-  outputNames.reserve(size);
+  if (enableOutput)
+    outputNames.reserve(size);
 
-  auto update_old_name = [](StringAttr name) {
-    auto ctx = name.getContext();
+  auto updateOldName = [](StringAttr name) {
+    auto *ctx = name.getContext();
     if (name == "y")
       return StringAttr::get(ctx, "0");
     if (name == "x")
@@ -155,15 +167,18 @@ LogicalResult getConvDimNames(T op, SmallVectorImpl<StringRef> &filterNames,
 
   for (unsigned i = 0; i < size; ++i) {
     auto filterAttr =
-        update_old_name(cast<StringAttr>(filterLayoutAttr.getValue()[i]));
+        updateOldName(cast<StringAttr>(filterLayoutAttr.getValue()[i]));
     auto inputAttr =
-        update_old_name(cast<StringAttr>(inputLayoutAttr.getValue()[i]));
-    auto outputAttr =
-        update_old_name(cast<StringAttr>(outputLayoutAttr.getValue()[i]));
+        updateOldName(cast<StringAttr>(inputLayoutAttr.getValue()[i]));
 
     filterNames.push_back(filterAttr.getValue());
     inputNames.push_back(inputAttr.getValue());
-    outputNames.push_back(outputAttr.getValue());
+
+    if (enableOutput) {
+      auto outputAttr =
+          updateOldName(cast<StringAttr>(outputLayoutAttr.getValue()[i]));
+      outputNames.push_back(outputAttr.getValue());
+    }
   }
 
   SmallVector<StringRef> filterCheck{"k", "g", "c"};
@@ -178,7 +193,8 @@ LogicalResult getConvDimNames(T op, SmallVectorImpl<StringRef> &filterNames,
 
   if (failed(checkNames(filterNames, filterCheck, "filter", op)) ||
       failed(checkNames(inputNames, inputCheck, "input", op)) ||
-      failed(checkNames(outputNames, outputCheck, "output", op))) {
+      (enableOutput &&
+       failed(checkNames(outputNames, outputCheck, "output", op)))) {
     return failure();
   }
 
@@ -318,12 +334,13 @@ struct ZeroInitKernelRewritePattern final
     Value initOp;
     auto initValueAttr = op.getInitValueAttr();
     if (initValueAttr) {
-      if (auto floatInitValueAttr = cast<FloatAttr>(initValueAttr.value())) {
+      if (auto floatInitValueAttr =
+              dyn_cast<FloatAttr>(initValueAttr.value())) {
         auto initValue = floatInitValueAttr.getValue().convertToFloat();
         initOp =
             createConstantFloatOp(b, loc, storeType, elementType, initValue);
       } else if (auto intInitValueAttr =
-                     cast<IntegerAttr>(initValueAttr.value())) {
+                     dyn_cast<IntegerAttr>(initValueAttr.value())) {
         auto initValue = intInitValueAttr.getValue().getSExtValue();
         initOp = createConstantIntOp(b, loc, storeType, elementType, initValue);
       } else {
@@ -419,8 +436,8 @@ struct ConvertingCopyKernelRewritePattern final
 ///
 /// To enable usage in rewrite patterns, returns failure() when no change is
 /// made.
-LogicalResult makeToLayoutLikeFromLayoutAlong(
-    PatternRewriter &b, RockConvInterface op, StringRef fromLayoutAttrName,
+static LogicalResult makeToLayoutLikeFromLayoutAlong(
+    PatternRewriter &b, Operation *op, StringRef fromLayoutAttrName,
     TypedValue<ShapedType> toArg, StringRef toLayoutAttrName,
     const llvm::StringMap<StringAttr> &mapping) {
   llvm::SmallVector<StringAttr> expectedOrder;
@@ -475,7 +492,7 @@ LogicalResult makeToLayoutLikeFromLayoutAlong(
              std::back_inserter(oldToLayoutRefs));
   ArrayRef<int64_t> toShape = toArg.getType().getShape();
 
-  BottomUpTMBuilder relayout(b, oldToLayoutRefs, toShape, op.getLoc());
+  BottomUpTMBuilder relayout(b, oldToLayoutRefs, toShape, op->getLoc());
   llvm::StringMap<uint32_t> newToLayoutIdxs;
   for (auto pair : llvm::enumerate(newToLayout)) {
     StringRef value = cast<StringAttr>(pair.value()).getValue();
@@ -487,7 +504,7 @@ LogicalResult makeToLayoutLikeFromLayoutAlong(
   relayoutWrapped.passThrough(oldToLayoutRefs);
   TransformMapAttr relayoutAttr = relayout.get();
 
-  Value transformed = b.create<TransformOp>(op.getLoc(), toArg, relayoutAttr);
+  Value transformed = b.create<TransformOp>(op->getLoc(), toArg, relayoutAttr);
   for (OpOperand &operand : op->getOpOperands())
     if (operand.get() == toArg)
       operand.set(transformed);
@@ -526,8 +543,31 @@ struct MatchLayoutsToInput final
   }
 };
 
+struct MatchFilterToInput final
+    : public OpRewritePattern<ConvElementwiseGemmOp> {
+  using OpRewritePattern<ConvElementwiseGemmOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConvElementwiseGemmOp op,
+                                PatternRewriter &b) const override {
+    TypedValue<ShapedType> filter = op.getFilter();
+    llvm::StringMap<StringAttr> inputToFilter = {{"ci", b.getStringAttr("c")},
+                                                 {"hi", b.getStringAttr("y")},
+                                                 {"wi", b.getStringAttr("x")}};
+
+    for (auto i = 0; i < filter.getType().getRank() - 3; i++) {
+      auto key = b.getStringAttr(Twine(i) + Twine("i"));
+      inputToFilter.insert_or_assign(key, b.getStringAttr(Twine(i)));
+    }
+
+    LogicalResult didReLayoutFilter = makeToLayoutLikeFromLayoutAlong(
+        b, op, "input_layout", filter, "filter_layout", inputToFilter);
+    return didReLayoutFilter;
+  }
+};
+
 /// Lowerings for particular convolution algorithms (TODO, new file?)
-LogicalResult backwardWeightAtomicAdd(ConvBwdWeightOp op, PatternRewriter &b) {
+FailureOr<std::tuple<Value, Value, Value>>
+backwardWeightAtomicAdd(ConvBwdWeightOp op, PatternRewriter &b) {
   Location loc = op.getLoc();
 
   Attribute tuningParams = op.getParamsAttr();
@@ -559,7 +599,7 @@ LogicalResult backwardWeightAtomicAdd(ConvBwdWeightOp op, PatternRewriter &b) {
   // The 1st kernel will conduct the actual backward weight convolution using
   // atomic adds.
   if (!isAccel)
-    return op->emitOpError("atomic add kernel requires gemm acceleration");
+    return op.emitOpError("atomic add kernel requires gemm acceleration");
 
   // Get shape of input tensor.
   ShapedType inputType = op.getInput().getType();
@@ -576,9 +616,8 @@ LogicalResult backwardWeightAtomicAdd(ConvBwdWeightOp op, PatternRewriter &b) {
   ConvolutionDims convDims = ctx.getConvDims();
 
   llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
-  if (failed(getConvDimNames(op, filterNames, inputNames, outputNames))) {
+  if (failed(getConvDimNames(op, filterNames, inputNames, outputNames)))
     return failure();
-  }
 
   Value gemmFilter, gemmInput, gemmOutput;
   // Transform filter tensor.
@@ -764,10 +803,11 @@ LogicalResult backwardWeightAtomicAdd(ConvBwdWeightOp op, PatternRewriter &b) {
   // Finally, erase the original Conv op.
   b.eraseOp(op);
 
-  return success();
+  return std::make_tuple(Value(), Value(), Value());
 }
 
-LogicalResult backwardData(ConvBwdDataOp op, PatternRewriter &b) {
+FailureOr<std::tuple<Value, Value, Value>> backwardData(ConvBwdDataOp op,
+                                                        PatternRewriter &b) {
   Location loc = op.getLoc();
   IntegerAttr kernelIdAttr = op.getKernelIdAttr();
 
@@ -1127,48 +1167,38 @@ LogicalResult backwardData(ConvBwdDataOp op, PatternRewriter &b) {
   // Finally, erase the original Conv op.
   b.eraseOp(op);
 
-  return success();
+  return std::make_tuple(Value(), Value(), Value());
 }
 
 template <typename T>
-struct ConvRewritePattern : public OpRewritePattern<T> {
-  const static ArgumentFields fields;
-  const static ConvOpType convOpType;
-  using OpRewritePattern<T>::OpRewritePattern;
+static FailureOr<std::tuple<Value, Value, Value>>
+commonConvRewrite(T op, PatternRewriter &b, ConvolutionContext &ctx,
+                  ConvOpType convOpType) {
+  GemmFeatures features = op.getFeatures();
 
-  LogicalResult matchAndRewrite(T op, PatternRewriter &b) const override {
-    GemmFeatures features = op.getFeatures();
+  Type dataType = op.getInput().getType().getElementType();
+  if (ConvOpType::BwdData == convOpType) {
+    return backwardData(cast<ConvBwdDataOp>(op), b);
+  }
+  Location loc = op.getLoc();
 
-    Type dataType = op.getInput().getType().getElementType();
-    if (ConvOpType::BwdData == convOpType) {
-      return backwardData(cast<ConvBwdDataOp>(op), b);
-    }
-    Location loc = op.getLoc();
+  // Get shapes
+  ArrayRef<int64_t> filterShape = op.getFilter().getType().getShape();
+  ArrayRef<int64_t> inputShape = op.getInput().getType().getShape();
 
-    ConvolutionContext ctx = populateConvContext(op);
+  // Obtain convolution parameters: padding / dilation / stride.
+  auto dilations = ctx.getDilationVal();
+  auto strides = ctx.getStrideVal();
+  ConvolutionDims convDims = ctx.getConvDims();
+  const bool notConvGemm = !std::is_same_v<T, ConvElementwiseGemmOp>;
 
-    // Get shape of filter tensor.
-    ShapedType filterType = op.getFilter().getType();
-    ArrayRef<int64_t> filterShape = filterType.getShape();
+  llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
+  if (failed(getConvDimNames(op, filterNames, inputNames, outputNames,
+                             notConvGemm))) {
+    return failure();
+  }
 
-    // Get shape of input tensor.
-    ShapedType inputType = op.getInput().getType();
-    ArrayRef<int64_t> inputShape = inputType.getShape();
-
-    // Get shape of output tensor.
-    ShapedType outputType = op.getOutput().getType();
-    ArrayRef<int64_t> outputShape = outputType.getShape();
-
-    // Obtain convolution parameters: padding / dilation / stride.
-    auto dilations = ctx.getDilationVal();
-    auto strides = ctx.getStrideVal();
-    ConvolutionDims convDims = ctx.getConvDims();
-
-    llvm::SmallVector<StringRef, 5> filterNames, inputNames, outputNames;
-    if (failed(getConvDimNames(op, filterNames, inputNames, outputNames))) {
-      return failure();
-    }
-
+  if constexpr (notConvGemm) {
     auto tuningParams = op.getParamsAttr();
     GemmSize gemmSize = op.getGemmSize();
     std::optional<GemmSize> maybeGemmExtraPad;
@@ -1186,161 +1216,166 @@ struct ConvRewritePattern : public OpRewritePattern<T> {
         isWrWAtomicKernel(features, dataType, maybeGemmExtraPad.has_value())) {
       return backwardWeightAtomicAdd(cast<ConvBwdWeightOp>(op), b);
     }
+  }
 
-    // Transform filter tensor.
+  // Transform filter tensor.
 
-    // set layout attribute.
-    // Weight tensor transformation for ConvOp
-    // - PassThrough G dimension to dimension 0, name it gemmG.
-    // - Merge non-K dimensions to dimension 1, name it as gemmK.
-    //   Optimization: If non-K dimensions are consecutive, apply unfold.
-    // - PassThrough K dimension to dimension 2, name it as gemmM.
-    //
-    // Weight tensor transformation for ConvBwdWeightOp
-    // - PassThrough G dimension to dimension 0, name it gemmG
-    // - PassThrough K dimension to dimension 1, name it as gemmM.
-    // - Merge non-K dimensions to dimension 2, name it as gemmN.
-    SmallVector<StringRef, 5> filterNonKDims;
-    for (StringRef name : filterNames)
-      if (name != "g" && name != "k")
-        filterNonKDims.push_back(name);
+  // set layout attribute.
+  // Weight tensor transformation for ConvOp
+  // - PassThrough G dimension to dimension 0, name it gemmG.
+  // - Merge non-K dimensions to dimension 1, name it as gemmK.
+  //   Optimization: If non-K dimensions are consecutive, apply unfold.
+  // - PassThrough K dimension to dimension 2, name it as gemmM.
+  //
+  // Weight tensor transformation for ConvBwdWeightOp
+  // - PassThrough G dimension to dimension 0, name it gemmG
+  // - PassThrough K dimension to dimension 1, name it as gemmM.
+  // - Merge non-K dimensions to dimension 2, name it as gemmN.
+  SmallVector<StringRef, 5> filterNonKDims;
+  for (StringRef name : filterNames)
+    if (name != "g" && name != "k")
+      filterNonKDims.push_back(name);
 
-    BottomUpTMBuilder filterTransform(b, filterNames, filterShape, loc);
-    filterTransform.passThrough({"gemmG"}, {0}, {"g"});
-    switch (convOpType) {
-    case ConvOpType::Fwd:
-      filterTransform.merge("gemmK", 1, filterNonKDims);
-      filterTransform.passThrough({"gemmM"}, {2}, {"k"});
-      break;
-    case ConvOpType::BwdWeight:
-      filterTransform.passThrough({"gemmM"}, {1}, {"k"});
-      filterTransform.merge("gemmN", 2, filterNonKDims);
-      break;
-    case ConvOpType::BwdData:
-      llvm_unreachable("Backward data has been sent elsewhere");
-      break;
+  BottomUpTMBuilder filterTransform(b, filterNames, filterShape, loc);
+  filterTransform.passThrough({"gemmG"}, {0}, {"g"});
+  switch (convOpType) {
+  case ConvOpType::Fwd:
+    filterTransform.merge("gemmK", 1, filterNonKDims);
+    filterTransform.passThrough({"gemmM"}, {2}, {"k"});
+    break;
+  case ConvOpType::BwdWeight:
+    filterTransform.passThrough({"gemmM"}, {1}, {"k"});
+    filterTransform.merge("gemmN", 2, filterNonKDims);
+    break;
+  case ConvOpType::BwdData:
+    llvm_unreachable("Backward data has been sent elsewhere");
+    break;
+  }
+
+  TransformMapAttr filterTransformAttr = filterTransform.get();
+  Value gemmFilter =
+      b.create<TransformOp>(loc, op.getFilter(), filterTransformAttr);
+
+  // Transform input tensor.
+  // Input tensor step 1: padded input.
+
+  // set layout attribute.
+  // Padded input tensor transformation:
+  // - Pass through ni, gi, and ci, not renaming them
+  // - Pad hi and wi as specified in padding attributes, renaming them to
+  // 0ipad and 1ipad
+  BottomUpTMBuilder padInputTransform(b, inputNames, inputShape, loc);
+  padInputTransform.passThrough("ni");
+  padInputTransform.passThrough("gi");
+  padInputTransform.passThrough("ci");
+
+  llvm::SmallVector<uint32_t, 2> padOutDims;
+  llvm::SmallVector<StringRef, 2> outs;
+  llvm::SmallVector<StringRef, 2> ins;
+  for (size_t i = 0; i < convDims.in.size(); i++) {
+    padOutDims.push_back(padInputTransform.startIndex(std::to_string(i) + "i"));
+    outs.push_back(b.getStringAttr(Twine(i) + "ipad"));
+    ins.push_back(b.getStringAttr(Twine(i) + "i"));
+  }
+  padInputTransform.pad(outs, padOutDims, ins, ctx.getPaddingVal());
+
+  TransformMapAttr padInputTransformAttr = padInputTransform.get();
+
+  Value paddedInput =
+      b.create<TransformOp>(loc, op.getInput(), padInputTransformAttr);
+
+  // Input tensor step 2 : embedded input.
+  // Embedded input tensor transformation:
+  // - PassThrough gi, ni, and ci
+  // - Embed 0ipad to y and ho with size filter y by output h and
+  //   coefficients dilations[0] and strides[0]
+  // - Embed 1ipad to x and wo with size filter x by output h and
+  //   coefficients dilations[1] and strides[1]
+
+  llvm::StringMap<SmallVector<StringRef, 2>> expansions;
+  for (size_t i = 0; i < convDims.in.size(); i++) {
+    StringAttr key = b.getStringAttr(Twine(i) + "ipad");
+    StringAttr val1 = b.getStringAttr(Twine(i));
+    StringAttr val2 = b.getStringAttr(Twine(i) + "o");
+    expansions.insert({key, {val1, val2}});
+  }
+  llvm::StringMap<uint32_t> embeddedInputDims =
+      expandNamesInPlace(padInputTransform, expansions);
+
+  BottomUpTMBuilder embedInputTransform =
+      BottomUpTMBuilder::above(padInputTransform, padInputTransformAttr);
+  BottomUpTMTopDimsWrapper embedInputWrap(embedInputTransform,
+                                          std::move(embeddedInputDims));
+  embedInputWrap.passThrough({"ni", "gi", "ci"});
+  assert(convDims.fil.size() == convDims.out.size());
+  for (auto [i, filLen] : llvm::enumerate(convDims.fil)) {
+    StringAttr val1 = b.getStringAttr(Twine(i));
+    StringAttr val2 = b.getStringAttr(Twine(i) + "o");
+    StringAttr val3 = b.getStringAttr(Twine(i) + "ipad");
+    if (filLen != 1) {
+      embedInputWrap.embed({val1, val2}, {filLen, convDims.out[i]}, val3,
+                           {dilations[i], strides[i]});
+    } else if (strides[i] != 1) {
+      embedInputWrap.addDim(val1, filLen);
+      embedInputWrap.embed({val2}, {convDims.out[i]}, val3, {strides[i]});
+    } else {
+      embedInputWrap.addDim(val1, filLen);
+      embedInputWrap.passThrough(val2, val3);
     }
+  }
 
-    TransformMapAttr filterTransformAttr = filterTransform.get();
-    Value gemmFilter =
-        b.create<TransformOp>(loc, op.getFilter(), filterTransformAttr);
+  TransformMapAttr embedInputTransformAttr = embedInputTransform.get();
+  Value embeddedInput =
+      b.create<TransformOp>(loc, paddedInput, embedInputTransformAttr);
 
-    // Transform input tensor.
-    // Input tensor step 1: padded input.
+  // Input tensor step 3: GEMM'd input
+  //
+  // - PassThrough gi to dimension 0 and name it gemmG, then
+  // For ConvOp:
+  // - Merge ci, y, x dimensions to dimension 1, name it as gemmK.
+  // - Merge ni, ho, wo dimensions to dimension 2, name it as gemmN.
+  //
+  // For ConvBwdWeightOp:
+  // - Part 1: Merge ni, ho, wo dimensions to dimension 1, name it as gemmK.
+  // - Part 2: Merge ci, y, x dimensions to dimension 2, name it as gemmN.
 
-    // set layout attribute.
-    // Padded input tensor transformation:
-    // - Pass through ni, gi, and ci, not renaming them
-    // - Pad hi and wi as specified in padding attributes, renaming them to
-    // 0ipad and 1ipad
-    BottomUpTMBuilder padInputTransform(b, inputNames, inputShape, loc);
-    padInputTransform.passThrough("ni");
-    padInputTransform.passThrough("gi");
-    padInputTransform.passThrough("ci");
+  auto gemmInputTransform =
+      BottomUpTMBuilder::above(embedInputTransform, embedInputTransformAttr);
+  gemmInputTransform.passThrough({"gemmG"}, {0}, {"gi"});
 
-    llvm::SmallVector<uint32_t, 2> padOutDims;
-    llvm::SmallVector<StringRef, 2> outs;
-    llvm::SmallVector<StringRef, 2> ins;
-    for (size_t i = 0; i < convDims.in.size(); i++) {
-      padOutDims.push_back(
-          padInputTransform.startIndex(std::to_string(i) + "i"));
-      outs.push_back(b.getStringAttr(Twine(i) + "ipad"));
-      ins.push_back(b.getStringAttr(Twine(i) + "i"));
-    }
-    padInputTransform.pad(outs, padOutDims, ins, ctx.getPaddingVal());
+  llvm::SmallVector<StringRef, 3> nonNHWDims = {"ci"};
+  for (size_t i = 0; i < convDims.in.size(); i++)
+    nonNHWDims.push_back(b.getStringAttr(Twine(i)));
+  matchUnderlyingOrder(nonNHWDims, gemmInputTransform);
+  llvm::SmallVector<StringRef, 3> nhwDims = {"ni"};
+  for (size_t i = 0; i < convDims.out.size(); i++)
+    nhwDims.push_back(b.getStringAttr(Twine(i) + "o"));
+  matchUnderlyingOrder(nhwDims, gemmInputTransform);
 
-    TransformMapAttr padInputTransformAttr = padInputTransform.get();
+  llvm::SmallVector<StringRef, 3> mergeToK, mergeToN;
+  switch (convOpType) {
+  case ConvOpType::Fwd:
+    mergeToK = std::move(nonNHWDims);
+    mergeToN = std::move(nhwDims);
+    break;
+  case ConvOpType::BwdWeight:
+    mergeToK = std::move(nhwDims);
+    mergeToN = std::move(nonNHWDims);
+    break;
+  case ConvOpType::BwdData:
+    llvm_unreachable("Backward data is in another function");
+  }
+  gemmInputTransform.merge("gemmK", 1, mergeToK);
+  gemmInputTransform.merge("gemmN", 2, mergeToN);
 
-    Value paddedInput =
-        b.create<TransformOp>(loc, op.getInput(), padInputTransformAttr);
+  TransformMapAttr gemmInputTransformAttr = gemmInputTransform.get();
+  Value gemmInput =
+      b.create<TransformOp>(loc, embeddedInput, gemmInputTransformAttr);
 
-    // Input tensor step 2 : embedded input.
-    // Embedded input tensor transformation:
-    // - PassThrough gi, ni, and ci
-    // - Embed 0ipad to y and ho with size filter y by output h and
-    //   coefficients dilations[0] and strides[0]
-    // - Embed 1ipad to x and wo with size filter x by output h and
-    //   coefficients dilations[1] and strides[1]
-
-    llvm::StringMap<SmallVector<StringRef, 2>> expansions;
-    for (size_t i = 0; i < convDims.in.size(); i++) {
-      StringAttr key = b.getStringAttr(Twine(i) + "ipad");
-      StringAttr val1 = b.getStringAttr(Twine(i));
-      StringAttr val2 = b.getStringAttr(Twine(i) + "o");
-      expansions.insert({key, {val1, val2}});
-    }
-    llvm::StringMap<uint32_t> embeddedInputDims =
-        expandNamesInPlace(padInputTransform, expansions);
-
-    BottomUpTMBuilder embedInputTransform =
-        BottomUpTMBuilder::above(padInputTransform, padInputTransformAttr);
-    BottomUpTMTopDimsWrapper embedInputWrap(embedInputTransform,
-                                            std::move(embeddedInputDims));
-    embedInputWrap.passThrough({"ni", "gi", "ci"});
-    assert(convDims.fil.size() == convDims.out.size());
-    for (auto [i, filLen] : llvm::enumerate(convDims.fil)) {
-      StringAttr val1 = b.getStringAttr(Twine(i));
-      StringAttr val2 = b.getStringAttr(Twine(i) + "o");
-      StringAttr val3 = b.getStringAttr(Twine(i) + "ipad");
-      if (filLen != 1) {
-        embedInputWrap.embed({val1, val2}, {filLen, convDims.out[i]}, val3,
-                             {dilations[i], strides[i]});
-      } else if (strides[i] != 1) {
-        embedInputWrap.addDim(val1, filLen);
-        embedInputWrap.embed({val2}, {convDims.out[i]}, val3, {strides[i]});
-      } else {
-        embedInputWrap.addDim(val1, filLen);
-        embedInputWrap.passThrough(val2, val3);
-      }
-    }
-
-    TransformMapAttr embedInputTransformAttr = embedInputTransform.get();
-    Value embeddedInput =
-        b.create<TransformOp>(loc, paddedInput, embedInputTransformAttr);
-
-    // Input tensor step 3: GEMM'd input
-    //
-    // - PassThrough gi to dimension 0 and name it gemmG, then
-    // For ConvOp:
-    // - Merge ci, y, x dimensions to dimension 1, name it as gemmK.
-    // - Merge ni, ho, wo dimensions to dimension 2, name it as gemmN.
-    //
-    // For ConvBwdWeightOp:
-    // - Part 1: Merge ni, ho, wo dimensions to dimension 1, name it as gemmK.
-    // - Part 2: Merge ci, y, x dimensions to dimension 2, name it as gemmN.
-
-    auto gemmInputTransform =
-        BottomUpTMBuilder::above(embedInputTransform, embedInputTransformAttr);
-    gemmInputTransform.passThrough({"gemmG"}, {0}, {"gi"});
-
-    llvm::SmallVector<StringRef, 3> nonNHWDims = {"ci"};
-    for (size_t i = 0; i < convDims.in.size(); i++)
-      nonNHWDims.push_back(b.getStringAttr(Twine(i)));
-    matchUnderlyingOrder(nonNHWDims, gemmInputTransform);
-    llvm::SmallVector<StringRef, 3> nhwDims = {"ni"};
-    for (size_t i = 0; i < convDims.out.size(); i++)
-      nhwDims.push_back(b.getStringAttr(Twine(i) + "o"));
-    matchUnderlyingOrder(nhwDims, gemmInputTransform);
-
-    llvm::SmallVector<StringRef, 3> mergeToK, mergeToN;
-    switch (convOpType) {
-    case ConvOpType::Fwd:
-      mergeToK = std::move(nonNHWDims);
-      mergeToN = std::move(nhwDims);
-      break;
-    case ConvOpType::BwdWeight:
-      mergeToK = std::move(nhwDims);
-      mergeToN = std::move(nonNHWDims);
-      break;
-    case ConvOpType::BwdData:
-      llvm_unreachable("Backward data is in another function");
-    }
-    gemmInputTransform.merge("gemmK", 1, mergeToK);
-    gemmInputTransform.merge("gemmN", 2, mergeToN);
-
-    TransformMapAttr gemmInputTransformAttr = gemmInputTransform.get();
-    Value gemmInput =
-        b.create<TransformOp>(loc, embeddedInput, gemmInputTransformAttr);
+  Value gemmOutput;
+  if constexpr (notConvGemm) {
+    // Get shape of output tensor.
+    ArrayRef<int64_t> outputShape = op.getOutput().getType().getShape();
 
     // Transform output tensor.
     // - PassThrough G to dimension 0, name it gemmG, then
@@ -1373,8 +1408,74 @@ struct ConvRewritePattern : public OpRewritePattern<T> {
     }
 
     TransformMapAttr outputTransformAttr = outputTransform.get();
-    Value gemmOutput =
+    gemmOutput =
         b.create<TransformOp>(loc, op.getOutput(), outputTransformAttr);
+  }
+
+  return std::make_tuple(gemmFilter, gemmInput, gemmOutput);
+}
+
+struct ConvGemmRewritePattern : public OpRewritePattern<ConvElementwiseGemmOp> {
+  using OpRewritePattern<ConvElementwiseGemmOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConvElementwiseGemmOp op,
+                                PatternRewriter &b) const override {
+
+    ConvolutionContext ctx = populateConvContextFromConvGemm(op);
+
+    auto maybeArgs = commonConvRewrite(op, b, ctx, ConvOpType::Fwd);
+    if (failed(maybeArgs))
+      return failure();
+    Value gemmFilter, gemmInput;
+    std::tie(gemmFilter, gemmInput, std::ignore) = maybeArgs.value();
+
+    // emit rock.gemm_elementwise_gemm op
+    Location loc = op.getLoc();
+
+    // note that here A = input, B = filter, ConvToGemm is the opposite
+    auto newOp = b.create<rock::GemmElementwiseGemmOp>(
+        loc, op->getResultTypes(), gemmInput, gemmFilter, op.getC(),
+        op.getElemwiseInputs(), op.getOut(),
+        /*aTransposed=*/b.getUnitAttr(), /*bTransposed=*/nullptr,
+        op.getCTransposedAttr(), op.getOTransposedAttr(), op.getArchAttr(),
+        op.getFeaturesAttr(), op.getNumCUAttr(), op.getParams0Attr(),
+        op.getParams1Attr(), op.getFirstGemmIdxAttr());
+
+    // copy linalg::GenericOp if there's any
+    bool linalgOpFound = false;
+    op.getPreSecondGemmBody().walk(
+        [&linalgOpFound](linalg::GenericOp genOp) { linalgOpFound = true; });
+    if (linalgOpFound) {
+      b.inlineRegionBefore(op.getPreSecondGemmBody(),
+                           newOp.getPreSecondGemmBody(),
+                           newOp.getPreSecondGemmBody().begin());
+    }
+    b.replaceOp(op, newOp);
+
+    return success();
+  }
+};
+
+template <typename T>
+struct ConvRewritePattern : public OpRewritePattern<T> {
+  const static ArgumentFields fields;
+  const static ConvOpType convOpType;
+  using OpRewritePattern<T>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(T op, PatternRewriter &b) const override {
+    ConvolutionContext ctx = populateConvContext(op);
+    auto maybeArgs = commonConvRewrite(op, b, ctx, convOpType);
+    if (failed(maybeArgs))
+      return failure();
+    Value gemmFilter, gemmInput, gemmOutput;
+    std::tie(gemmFilter, gemmInput, gemmOutput) = maybeArgs.value();
+
+    // backward conv was run, no need to keep running the pass
+    if (gemmFilter == nullptr && gemmInput == nullptr &&
+        gemmOutput == nullptr) {
+      assert(convOpType != ConvOpType::Fwd);
+      return success();
+    }
 
     SmallVector<Value, 3> arguments = {gemmFilter, gemmInput, gemmOutput};
 
@@ -1384,6 +1485,8 @@ struct ConvRewritePattern : public OpRewritePattern<T> {
     gemmC = arguments[fields.gridwiseGemmArgumentPosition[2]];
 
     // Emit rock.gemm op.
+    Location loc = op.getLoc();
+    auto tuningParams = op.getParamsAttr();
     auto storeMethod = b.getAttr<StoreMethodAttr>(StoreMethod::Set);
     b.create<GemmOp>(loc, getResultType(op, gemmC), gemmA, gemmB, gemmC,
                      /*aTransposed=*/b.getUnitAttr(), /*bTransposed=*/nullptr,
@@ -1435,7 +1538,7 @@ template struct ConvRewritePattern<ConvBwdWeightOp>;
 void RockConvToGemmPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   RewritePatternSet preConvToGemmPatterns(ctx);
-  preConvToGemmPatterns.add<MatchLayoutsToInput>(ctx);
+  preConvToGemmPatterns.add<MatchLayoutsToInput, MatchFilterToInput>(ctx);
 
   if (failed(applyPatternsGreedily(getOperation(),
                                    std::move(preConvToGemmPatterns)))) {
@@ -1446,10 +1549,12 @@ void RockConvToGemmPass::runOnOperation() {
   ConversionTarget target(*ctx);
 
   target.addIllegalOp<rock::ConvOp, rock::ConvBwdDataOp, rock::ConvBwdWeightOp,
-                      rock::InitKernelOp, rock::ConvertingCopyKernelOp>();
+                      rock::InitKernelOp, rock::ConvertingCopyKernelOp,
+                      rock::ConvElementwiseGemmOp>();
   target.addLegalOp<rock::TransformOp, rock::GemmOp, rock::WorkgroupIdOp,
                     rock::WorkitemIdOp, rock::GlobalLoadOp, rock::GlobalStoreOp,
-                    rock::GpuAllocOp, rock::InBoundsStoreOp>();
+                    rock::GpuAllocOp, rock::InBoundsStoreOp,
+                    rock::GemmElementwiseGemmOp>();
   // Below are required legalize for the lowering of ConvBwdWeightOp
   target.addLegalDialect<arith::ArithDialect, memref::MemRefDialect,
                          scf::SCFDialect>();
@@ -1457,8 +1562,9 @@ void RockConvToGemmPass::runOnOperation() {
   RewritePatternSet patterns(ctx);
   patterns
       .add<ConvRewritePattern<ConvOp>, ConvRewritePattern<ConvBwdDataOp>,
-           ConvRewritePattern<ConvBwdWeightOp>, ZeroInitKernelRewritePattern,
-           ConvertingCopyKernelRewritePattern>(ctx);
+           ConvRewritePattern<ConvBwdWeightOp>, ConvGemmRewritePattern,
+           ZeroInitKernelRewritePattern, ConvertingCopyKernelRewritePattern>(
+          ctx);
 
   if (failed(applyPartialConversion(getOperation(), target,
                                     std::move(patterns)))) {

--- a/mlir/lib/Dialect/Rock/Tuning/ConvContext.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/ConvContext.cpp
@@ -1,8 +1,10 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
+#include "mlir/Dialect/Rock/Generator/ConvGenerator.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/Tuning/ConvContext.h"
 #include "mlir/Dialect/Rock/utility/AmdArchDb.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace mlir;
 using namespace mlir::rock;
@@ -105,4 +107,72 @@ ConvolutionContext mlir::rock::populateConvContext(Operation *op) {
 
   return {archVal,     numCu,      opType, dimIndexAndSize, strideVal,
           dilationVal, paddingVal, gemmId, dataTypeA,       dataTypeB};
+}
+
+ConvolutionContext
+mlir::rock::populateConvContextFromConvGemm(ConvElementwiseGemmOp op) {
+  auto archVal = op->getAttrOfType<StringAttr>("arch").getValue();
+  int numCu = getOptionalIntAttribute(op, "numCU",
+                                      rock::lookupArchInfo(archVal).minNumCU);
+  int gemmId = getOptionalIntAttribute(op, "gemmId", 0);
+
+  llvm::StringMap<DimIndexAndSize> dimIndexAndSize;
+
+  auto filterLayoutAttr = op->getAttrOfType<ArrayAttr>("filter_layout");
+  auto inputLayoutAttr = op->getAttrOfType<ArrayAttr>("input_layout");
+  SmallVector<StringAttr, 5> outLayoutSpec;
+
+  auto strideVal = extractFromIntegerArrayAttr<int64_t>(op.getStrides());
+  auto dilationVal = extractFromIntegerArrayAttr<int64_t>(op.getDilations());
+  auto paddingVal = extractFromIntegerArrayAttr<int64_t>(op.getPadding());
+
+  populateDimIndexAndSize(
+      filterLayoutAttr,
+      cast<MemRefType>(op->getOperand(0).getType()).getShape(),
+      dimIndexAndSize);
+  auto inputShape = cast<MemRefType>(op->getOperand(1).getType()).getShape();
+  populateDimIndexAndSize(inputLayoutAttr, inputShape, dimIndexAndSize);
+
+  // ["ni", "gi", "ci", "0i", "1i"] -> ["no", "go", "ko", "0o", "1o"]
+  // input_layout = ["ni", "hi", "wi", "gi", "ci"], output_layout = ["no", "go",
+  // "ko", "ho", "wo"]
+  int64_t kernelSizeH = dimIndexAndSize["0"].size;
+  int64_t kernelSizeW = dimIndexAndSize["1"].size;
+  for (size_t i = 0; i < inputShape.size(); ++i) {
+    auto key = cast<StringAttr>(inputLayoutAttr.getValue()[i]).getValue();
+    auto inputSize = inputShape[i];
+    if (key == "ni") {
+      auto newKey =
+          StringAttr::get(inputLayoutAttr.getContext(), std::string("no"));
+      dimIndexAndSize[newKey] = {i, inputSize};
+    } else if (key == "hi" || key == "0i") {
+      int64_t ho = rock::ConvGenerator::outputDim(inputSize, kernelSizeH,
+                                                  paddingVal[0], paddingVal[1],
+                                                  strideVal[0], dilationVal[0]);
+      auto newKey =
+          StringAttr::get(inputLayoutAttr.getContext(), std::string("0o"));
+      dimIndexAndSize[newKey] = {i, ho};
+    } else if (key == "wi" || key == "1i") {
+      int64_t wo = rock::ConvGenerator::outputDim(inputSize, kernelSizeW,
+                                                  paddingVal[2], paddingVal[3],
+                                                  strideVal[1], dilationVal[1]);
+      auto newKey =
+          StringAttr::get(inputLayoutAttr.getContext(), std::string("1o"));
+      dimIndexAndSize[newKey] = {i, wo};
+    } else if (key == "gi") {
+      auto newKey =
+          StringAttr::get(inputLayoutAttr.getContext(), std::string("go"));
+      dimIndexAndSize[newKey] = {i, inputSize};
+    } else if (key == "ci") {
+      auto newKey =
+          StringAttr::get(inputLayoutAttr.getContext(), std::string("ko"));
+      dimIndexAndSize[newKey] = {i, dimIndexAndSize["k"].size};
+    } else {
+      llvm_unreachable("Invalid key");
+    }
+  }
+  Type dataTypeA = op.getAType(), dataTypeB = op.getBType();
+
+  return {archVal,     numCu,      ConvOpType::Fwd, dimIndexAndSize, strideVal,
+          dilationVal, paddingVal, gemmId,          dataTypeA,       dataTypeB};
 }

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -25,6 +25,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/LogicalResult.h"
 #include <algorithm>
 
 namespace mlir {
@@ -514,8 +515,8 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind) {
         return WalkResult::interrupt();
       });
   if (!findPrimary.wasInterrupted() && !findGemmGemm.wasInterrupted()) {
-    llvm::report_fatal_error("Expected to find GEMM, convolution, attention or "
-                             "gemm+gemm op, and didn't.");
+    llvm::report_fatal_error("Expected to find GEMM, convolution, attention, "
+                             "gemm+gemm or conv+gemm op, and didn't.");
   }
   return newSpace;
 }
@@ -575,6 +576,85 @@ TuningTable *tuningTableCreate() {
 }
 
 static LogicalResult
+extractLayouts(Operation *op, llvm::StringMap<unsigned> &fLayoutMap,
+               llvm::StringMap<unsigned> &iLayoutMap,
+               llvm::StringMap<unsigned> &oLayoutMap, SmallString<6> &fLayout,
+               SmallString<6> &iLayout, SmallString<6> &oLayout,
+               bool computeOutput = true) {
+  // Extract layout information
+  auto filterLayoutAttr = op->getAttrOfType<ArrayAttr>("filter_layout");
+  auto inputLayoutAttr = op->getAttrOfType<ArrayAttr>("input_layout");
+  ArrayAttr outputLayoutAttr;
+  if (computeOutput)
+    outputLayoutAttr = op->getAttrOfType<ArrayAttr>("output_layout");
+
+  unsigned size = filterLayoutAttr.size();
+
+  for (unsigned i = 0; i < size; ++i) {
+    auto filterAttr = cast<StringAttr>(filterLayoutAttr.getValue()[i]);
+    StringRef fKey = filterAttr.getValue();
+    if (fKey == "y")
+      fKey = "0";
+    if (fKey == "x")
+      fKey = "1";
+    fLayoutMap[fKey] = i;
+    auto inputAttr = cast<StringAttr>(inputLayoutAttr.getValue()[i]);
+    StringRef iKey = inputAttr.getValue();
+    if (iKey == "hi")
+      iKey = "0i";
+    if (iKey == "wi")
+      iKey = "1i";
+    iLayoutMap[iKey] = i;
+    if (computeOutput) {
+      auto outputAttr = cast<StringAttr>(outputLayoutAttr.getValue()[i]);
+      StringRef oKey = outputAttr.getValue();
+      if (oKey == "ho")
+        oKey = "0o";
+      if (oKey == "wo")
+        oKey = "1o";
+      oLayoutMap[oKey] = i;
+    }
+  }
+
+  fLayout.assign(size, '#');
+  iLayout.assign(size, '#');
+  oLayout.assign(size, '#');
+
+  // dimensions need to be mapped 1 to 1.
+  fLayout[fLayoutMap["k"]] = 'N';
+  fLayout[fLayoutMap["c"]] = 'C';
+  fLayout[fLayoutMap["g"]] = 'G';
+  iLayout[iLayoutMap["ni"]] = 'N';
+  iLayout[iLayoutMap["ci"]] = 'C';
+  iLayout[iLayoutMap["gi"]] = 'G';
+  if (computeOutput) {
+    oLayout[oLayoutMap["no"]] = 'N';
+    oLayout[oLayoutMap["ko"]] = 'C';
+    oLayout[oLayoutMap["go"]] = 'G';
+  }
+
+  for (unsigned i = 0; i < size - 3; i++) {
+    std::string key = std::to_string(i);
+    char val = '0' + i;
+    fLayout[fLayoutMap[key]] = val;
+    iLayout[iLayoutMap[key + "i"]] = val;
+    if (computeOutput)
+      oLayout[oLayoutMap[key + "o"]] = val;
+  }
+
+  if (computeOutput) {
+    if (llvm::any_of(llvm::concat<const char>(fLayout, iLayout, oLayout),
+                     [](const char c) { return c == '#'; }))
+      return failure();
+  } else {
+    if (llvm::any_of(llvm::concat<const char>(fLayout, iLayout),
+                     [](const char c) { return c == '#'; }))
+      return failure();
+  }
+  return success();
+}
+
+static LogicalResult
 getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
                     SmallVectorImpl<char> &out) {
   int32_t numCU = rock::lookupArchInfo(gemmGemmOp.getArch()).minNumCU;
@@ -596,9 +676,9 @@ getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
   ArrayRef<int64_t> qShape = cast<MemRefType>(gemmGemmOp.getAType()).getShape();
   ArrayRef<int64_t> kShape = cast<MemRefType>(gemmGemmOp.getBType()).getShape();
   ArrayRef<int64_t> vShape = cast<MemRefType>(gemmGemmOp.getCType()).getShape();
-  int64_t g = qShape[0];
 
   bool isAttention = isa<AttentionOp>(gemmGemmOp);
+  bool isConvGemm = isa<ConvElementwiseGemmOp>(gemmGemmOp);
 
   Type elemTypeQ = cast<MemRefType>(gemmGemmOp.getAType()).getElementType();
   problemOS << "-t ";
@@ -614,32 +694,47 @@ getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
     return gemmGemmOp.emitError("invalid type:") << elemTypeQ << "\n";
   }
 
-  // TransQ
-  if (isAttention)
-    problemOS << "-transQ ";
-  else
-    problemOS << "-transA ";
-  if (gemmGemmOp.getTransposedA()) {
-    seqLenQ = qShape[2];
-    headDimQK = qShape[1];
-    problemOS << "true" << sep;
-  } else {
-    seqLenQ = qShape[1];
-    headDimQK = qShape[2];
-    problemOS << "false" << sep;
-  }
+  // Extract layout information
+  llvm::StringMap<unsigned> fLayoutMap, iLayoutMap, oLayoutMap;
+  SmallString<6> fLayout, iLayout, oLayout;
 
-  // TransK
-  if (isAttention)
-    problemOS << "-transK ";
-  else
-    problemOS << "-transB ";
-  if (gemmGemmOp.getTransposedB()) {
-    seqLenK = kShape[1];
-    problemOS << "true" << sep;
+  if (isConvGemm) {
+    if (failed(extractLayouts(gemmGemmOp, fLayoutMap, iLayoutMap, oLayoutMap,
+                              fLayout, iLayout, oLayout, false)))
+      return gemmGemmOp.emitError("layout can't be extracted");
+
+    // filter layout
+    problemOS << "-f " << fLayout << sep;
+    // input layout
+    problemOS << "-I " << iLayout << sep;
   } else {
-    seqLenK = kShape[2];
-    problemOS << "false" << sep;
+    // TransQ
+    if (isAttention)
+      problemOS << "-transQ ";
+    else
+      problemOS << "-transA ";
+    if (gemmGemmOp.getTransposedA()) {
+      seqLenQ = qShape[2];
+      headDimQK = qShape[1];
+      problemOS << "true" << sep;
+    } else {
+      seqLenQ = qShape[1];
+      headDimQK = qShape[2];
+      problemOS << "false" << sep;
+    }
+
+    // TransK
+    if (isAttention)
+      problemOS << "-transK ";
+    else
+      problemOS << "-transB ";
+    if (gemmGemmOp.getTransposedB()) {
+      seqLenK = kShape[1];
+      problemOS << "true" << sep;
+    } else {
+      seqLenK = kShape[2];
+      problemOS << "false" << sep;
+    }
   }
 
   // TransV
@@ -671,12 +766,52 @@ getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
       problemOS << "false" << sep;
   }
 
-  problemOS << "-g " << g << sep;
+  if (!isConvGemm)
+    problemOS << "-g " << qShape[0] << sep;
+
   if (isAttention) {
     problemOS << "-seq_len_q " << seqLenQ << sep;
     problemOS << "-seq_len_k " << seqLenK << sep;
     problemOS << "-head_dim_qk " << headDimQK << sep;
     problemOS << "-head_dim_v " << headDimV;
+  } else if (isConvGemm) {
+    auto convGemmOp = cast<ConvElementwiseGemmOp>(gemmGemmOp);
+    ArrayRef<int64_t> inShape = convGemmOp.getInput().getType().getShape();
+    ArrayRef<int64_t> filShape = convGemmOp.getFilter().getType().getShape();
+
+    // N
+    problemOS << "-n " << inShape[iLayoutMap["ni"]] << sep;
+    // C
+    problemOS << "-c " << inShape[iLayoutMap["ci"]] * inShape[iLayoutMap["gi"]]
+              << sep;
+    // H
+    problemOS << "-H " << inShape[iLayoutMap["0i"]] << sep;
+    // W
+    problemOS << "-W " << inShape[iLayoutMap["1i"]] << sep;
+    // K
+    problemOS << "-k " << filShape[fLayoutMap["k"]] * filShape[fLayoutMap["g"]]
+              << sep;
+    // Y
+    problemOS << "-y " << filShape[fLayoutMap["0"]] << sep;
+    // X
+    problemOS << "-x " << filShape[fLayoutMap["1"]] << sep;
+
+    auto paddingVal =
+        extractFromIntegerArrayAttr<int64_t>(convGemmOp.getPadding());
+    auto strideVal =
+        extractFromIntegerArrayAttr<int64_t>(convGemmOp.getStrides());
+    auto dilationVal =
+        extractFromIntegerArrayAttr<int64_t>(convGemmOp.getDilations());
+
+    // padding
+    problemOS << "-p " << paddingVal[0] << " -q " << paddingVal[2] << sep;
+    // stride
+    problemOS << "-u " << strideVal[0] << " -v " << strideVal[1] << sep;
+    // dilation
+    problemOS << "-l " << dilationVal[0] << " -j " << dilationVal[1] << sep;
+    // group
+    problemOS << "-g " << inShape[iLayoutMap["gi"]] << sep;
+    problemOS << "-gemmO " << headDimV;
   } else {
     problemOS << "-m " << seqLenQ << sep;
     problemOS << "-n " << seqLenK << sep;
@@ -721,72 +856,11 @@ static LogicalResult getTuningProblemStr(rock::RockGemmWrapperInterface gemmIF,
     ArrayRef<int64_t> filShape = filType.getShape();
 
     // Extract layout information
-    auto filterLayoutAttr =
-        gemmOp->template getAttrOfType<ArrayAttr>("filter_layout");
-    auto inputLayoutAttr =
-        gemmOp->template getAttrOfType<ArrayAttr>("input_layout");
-    auto outputLayoutAttr =
-        gemmOp->template getAttrOfType<ArrayAttr>("output_layout");
-
-    unsigned size = filterLayoutAttr.size();
-    llvm::StringMap<unsigned> fLayoutMap;
-    llvm::StringMap<unsigned> iLayoutMap;
-    llvm::StringMap<unsigned> oLayoutMap;
-
-    for (unsigned i = 0; i < size; ++i) {
-      auto filterAttr = cast<StringAttr>(filterLayoutAttr.getValue()[i]);
-      StringRef fKey = filterAttr.getValue();
-      if (fKey == "y")
-        fKey = "0";
-      if (fKey == "x")
-        fKey = "1";
-      fLayoutMap[fKey] = i;
-      auto inputAttr = cast<StringAttr>(inputLayoutAttr.getValue()[i]);
-      StringRef iKey = inputAttr.getValue();
-      if (iKey == "hi")
-        iKey = "0i";
-      if (iKey == "wi")
-        iKey = "1i";
-      iLayoutMap[iKey] = i;
-      auto outputAttr = cast<StringAttr>(outputLayoutAttr.getValue()[i]);
-      StringRef oKey = outputAttr.getValue();
-      if (oKey == "ho")
-        oKey = "0o";
-      if (oKey == "wo")
-        oKey = "1o";
-      oLayoutMap[oKey] = i;
-    }
-
-    SmallString<6> fLayout;
-    SmallString<6> iLayout;
-    SmallString<6> oLayout;
-    fLayout.assign(size, '#');
-    iLayout.assign(size, '#');
-    oLayout.assign(size, '#');
-
-    // dimensions need to be mapped 1 to 1.
-    fLayout[fLayoutMap["k"]] = 'N';
-    fLayout[fLayoutMap["c"]] = 'C';
-    fLayout[fLayoutMap["g"]] = 'G';
-    iLayout[iLayoutMap["ni"]] = 'N';
-    iLayout[iLayoutMap["ci"]] = 'C';
-    iLayout[iLayoutMap["gi"]] = 'G';
-    oLayout[oLayoutMap["no"]] = 'N';
-    oLayout[oLayoutMap["ko"]] = 'C';
-    oLayout[oLayoutMap["go"]] = 'G';
-
-    for (unsigned i = 0; i < size - 3; i++) {
-      std::string key = std::to_string(i);
-      char val = '0' + i;
-      fLayout[fLayoutMap[key]] = val;
-      iLayout[iLayoutMap[key + "i"]] = val;
-      oLayout[oLayoutMap[key + "o"]] = val;
-    }
-
-    if (llvm::any_of(llvm::concat<const char>(fLayout, iLayout, oLayout),
-                     [](const char c) { return c == '#'; })) {
-      return failure();
-    }
+    llvm::StringMap<unsigned> fLayoutMap, iLayoutMap, oLayoutMap;
+    SmallString<6> fLayout, iLayout, oLayout;
+    if (failed(extractLayouts(gemmOp, fLayoutMap, iLayoutMap, oLayoutMap,
+                              fLayout, iLayout, oLayout)))
+      return convIF.emitError("layout can't be extracted");
 
     // Please keep these in sync with mlir/utils/performance/perfRunner.py
 

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -566,6 +566,66 @@ func.func @rock_gemm_gemm_mperblockg1_mfma(%arg0: memref<1x384x64xf32>, %arg1: m
   return
 }
 
+// CHECK-LABEL: func.func @rock_conv_gemm_default
+// CHECK-SAME: block_size = 32
+// GRID-LABEL: func.func @rock_conv_gemm_default
+// GRID-SAME: grid_size = 64
+func.func @rock_conv_gemm_default(%arg0: memref<1x128x256x1x1xf16>, %arg1: memref<2x1x256x32x32xf16>, %arg2: memref<1x128x64xf16>, %arg3: memref<1x2048x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // CHECK: rock.conv_elementwise_gemm
+  // CHECK: #rock.wmma_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  rock.conv_elementwise_gemm{
+   ab = conv(%arg0, %arg1) : memref<1x128x256x1x1xf16>, memref<2x1x256x32x32xf16>
+   %arg3 = ab * %arg2 : memref<1x128x64xf16> -> memref<1x2048x64xf16>
+  } {arch = "amdgcn-amd-amdhsa:gfx1100", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures wmma|dot|atomic_add|atomic_fmax_f32>, filter_layout = ["g", "k", "c", "0", "1"], firstGemmIdx = 0 : i32, input_layout = ["ni", "gi", "ci", "0i", "1i"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]}
+  return
+}
+
+// CHECK-LABEL: func.func @rock_conv_gemm_large
+// CHECK-SAME: block_size = 256
+// GRID-LABEL: func.func @rock_conv_gemm_large
+// GRID-SAME: grid_size = 256
+func.func @rock_conv_gemm_large(%arg0: memref<1x128x256x3x3xf32>, %arg1: memref<2x1x256x128x128xf32>, %arg2: memref<1x128x128xf32>, %arg3: memref<1x32768x128xf32>) {
+  // CHECK: rock.conv_elementwise_gemm
+  // CHECK: params0 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 2, mPerBlock = 128, nPerBlock = 128, kpack = 8, mPerWave = 64, nPerWave = 64, mnPerXdl = 64, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK: params1 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 16, mPerBlock = 128, nPerBlock = 128, kpack = 8, mPerWave = 64, nPerWave = 64, mnPerXdl = 64, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  rock.conv_elementwise_gemm{
+   ab = conv(%arg0, %arg1) : memref<1x128x256x3x3xf32>, memref<2x1x256x128x128xf32>
+   %arg3 = ab * %arg2 : memref<1x128x128xf32> -> memref<1x32768x128xf32>
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>, perf_config = "attn:v1:128,128,128,2,64,64,8,1", filter_layout = ["g", "k", "c", "0", "1"], firstGemmIdx = 0 : i32, input_layout = ["ni", "gi", "ci", "0i", "1i"], padding = [1 : index, 1 : index, 1 : index, 1 : index], strides = [1 : index, 1 : index]}
+  return
+}
+
+// CHECK-LABEL: func.func @rock_conv_gemm_mperblockg1_wmma
+// CHECK-SAME: block_size = 128
+// GRID-LABEL: func.func @rock_conv_gemm_mperblockg1_wmma
+// GRID-SAME: grid_size = 256
+func.func @rock_conv_gemm_mperblockg1_wmma(%arg0: memref<1x128x256x1x1xf16>, %arg1: memref<2x1x256x128x128xf16>, %arg2: memref<1x128x128xf16>, %arg3: memref<1x32768x128xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // CHECK: rock.conv_elementwise_gemm
+  // CHECK: #rock.wmma_gemm_params<kpackPerBlock = 2, mPerBlock = 128, nPerBlock = 128, kpack = 8, mPerWave = 64, nPerWave = 64, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK: #rock.wmma_gemm_params<kpackPerBlock = 16, mPerBlock = 256, nPerBlock = 128, kpack = 8, mPerWave = 128, nPerWave = 64, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+
+  rock.conv_elementwise_gemm{
+   ab = conv(%arg0, %arg1) : memref<1x128x256x1x1xf16>, memref<2x1x256x128x128xf16>
+   %arg3 = ab * %arg2 : memref<1x128x128xf16> -> memref<1x32768x128xf16>
+  } {arch = "amdgcn-amd-amdhsa:gfx1100", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures wmma|dot|atomic_add|atomic_fmax_f32>, perf_config = "attn:v1:128,256,128,2,64,64,8,1", filter_layout = ["g", "k", "c", "0", "1"], firstGemmIdx = 0 : i32, input_layout = ["ni", "gi", "ci", "0i", "1i"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]}
+  return
+}
+
+// CHECK-LABEL: func.func @rock_conv_gemm_mperblockg1_mfma
+// CHECK-SAME: block_size = 256
+// GRID-LABEL: func.func @rock_conv_gemm_mperblockg1_mfma
+// GRID-SAME: grid_size = 256
+func.func @rock_conv_gemm_mperblockg1_mfma(%arg0: memref<1x128x256x1x1xf32>, %arg1: memref<2x1x256x128x128xf32>, %arg2: memref<1x128x128xf32>, %arg3: memref<1x32768x128xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // CHECK: rock.conv_elementwise_gemm
+  // CHECK: #rock.xdlops_gemm_derived_params<kpackPerBlock = 2, mPerBlock = 128, nPerBlock = 128, kpack = 8, mPerWave = 64, nPerWave = 64, mnPerXdl = 64, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK: #rock.xdlops_gemm_derived_params<kpackPerBlock = 16, mPerBlock = 256, nPerBlock = 128, kpack = 8, mPerWave = 128, nPerWave = 64, mnPerXdl = 64, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  rock.conv_elementwise_gemm{
+   ab = conv(%arg0, %arg1) : memref<1x128x256x1x1xf32>, memref<2x1x256x128x128xf32>
+   %arg3 = ab * %arg2 : memref<1x128x128xf32> -> memref<1x32768x128xf32>
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>, perf_config = "attn:v1:128,256,128,2,64,64,8,1", filter_layout = ["g", "k", "c", "0", "1"], firstGemmIdx = 0 : i32, input_layout = ["ni", "gi", "ci", "0i", "1i"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]}
+  return
+}
+
 // CHECK-LABEL: func.func @rock_conv_tuning
 // GRID-LABEL: func.func @rock_conv_tuning
 func.func @rock_conv_tuning(%arg0: memref<1x1x1x3x3xf32>, %arg1: memref<64x1x1x14x14xf32>, %arg2: memref<64x1x1x14x14xf32>) attributes {kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-"} {

--- a/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params_invalid.mlir
@@ -20,6 +20,15 @@ func.func @rock_gemm_gemm_invalid_perf_config(%arg0: memref<1x384x64xf16>, %arg1
   return
 }
 
+func.func @rock_conv_gemm_invalid_perf_config(%arg0: memref<1x128x256x1x1xf16>, %arg1: memref<2x1x256x32x32xf16>, %arg2: memref<1x128x128xf16>, %arg3: memref<1x2048x128xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // expected-error @+1 {{The provided perf config is not valid}}
+  rock.conv_elementwise_gemm{
+    ab = conv(%arg0, %arg1) : memref<1x128x256x1x1xf16>, memref<2x1x256x32x32xf16>
+    %arg3 = ab * %arg2 : memref<1x128x128xf16> -> memref<1x2048x128xf16>
+  } {arch = "amdgcn-amd-amdhsa:gfx1100", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures wmma|dot|atomic_add|atomic_fmax_f32>, perf_config = "attn:v1:128,128,16,8,32,64,8,1", filter_layout = ["g", "k", "c", "0", "1"], firstGemmIdx = 0 : i32, input_layout = ["ni", "gi", "ci", "0i", "1i"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]}
+  return
+}
+
 func.func @rock_conv_schedulev2(%filter : memref<1x128x8x3x3xf32>, %input : memref<128x1x8x32x32xf32>, %output : memref<128x1x128x30x30xf32>) attributes {schedule_version =  #rock.schedule_version<2>} {
   // expected-error @+1 {{kernel has both perf_config and schedule_version attribute set. Please modify schedule version directly inside perf_config and remove schedule_version}}
   rock.conv(%filter, %input, %output) features = mfma|dot|atomic_add|atomic_add_f16 {

--- a/mlir/test/Dialect/Rock/conv_to_gemm.mlir
+++ b/mlir/test/Dialect/Rock/conv_to_gemm.mlir
@@ -1,8 +1,24 @@
 // RUN: rocmlir-opt --rock-conv-to-gemm --mlir-print-local-scope --split-input-file %s | FileCheck %s
 
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d1 * 64 + d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2) * 64 + d4)>
+#map2 = affine_map<(d0, d1, d2) -> (d1 * 256 + d2)>
+#map4 = affine_map<(d0, d1, d2) -> (d1 * 3136 + d2)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (((d1 * 3 + d2) * 3 + d3) * 64 + d4)>
+#transform_map = #rock.transform_map<#map by [<Unmerge{256, 64} ["k", "c"] at [1, 4] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>, <AddDim{1} ["0"] at [2] -> [] at []>, <AddDim{1} ["1"] at [3] -> [] at []>] bounds = [1, 256, 1, 1, 64] -> [16384]>
+#transform_map1 = #rock.transform_map<#map1 by [<Unmerge{64, 14, 14, 64} ["n", "0", "1", "c"] at [0, 1, 2, 4] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [3] -> [] at []>] bounds = [64, 14, 14, 1, 64] -> [802816]>
+#transform_map2 = #rock.transform_map<#map2 by [<Unmerge{256, 256} ["m", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 256] -> [65536]>
+#transform_map3 = #rock.transform_map<#map2 by [<Unmerge{3136, 256} ["n", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 3136, 256] -> [802816]>
+#transform_map4 = #rock.transform_map<#map2 by [<Unmerge{256, 256} ["m", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 256] -> [65536]>
+#transform_map5 = #rock.transform_map<#map5 by [<Unmerge{256, 3, 3, 64} ["k", "0", "1", "c"] at [1, 2, 3, 4] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 3, 3, 64] -> [147456]>
+#transform_map6 = #rock.transform_map<#map2 by [<Unmerge{256, 256} ["m", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 256] -> [65536]>
+#transform_map7 = #rock.transform_map<#map2 by [<Unmerge{9216, 256} ["n", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 9216, 256] -> [2359296]>
+
+
 // CHECK-LABEL: @nhwc_1x1
 // CHECK: <AddDim{1} ["0"] at [1] -> [] at []>, <PassThrough ["0o"] at [2] -> ["0ipad"] at [1]>, <AddDim{1} ["1"] at [3] -> [] at []>, <PassThrough ["1o"] at [4] -> ["1ipad"] at [2]>
 // CHECK-NOT: Embed
+// CHECK: rock.gemm
 func.func @nhwc_1x1(%arg0: memref<16384xf16>, %arg1: memref<802816xf16>, %arg2: memref<3211264xf16>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3, d4) -> ((d0 * 256 + d1 + d2 + d3) * 64 + d4)> by [<Unmerge{1, 256, 1, 1, 64} ["g", "k", "0", "1", "c"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [1, 256, 1, 1, 64] -> [16384]> : memref<16384xf16> to memref<1x256x1x1x64xf16>
   %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2 + d3) * 64 + d4)> by [<Unmerge{64, 14, 14, 1, 64} ["ni", "0i", "1i", "gi", "ci"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 14, 14, 1, 64] -> [802816]> : memref<802816xf16> to memref<64x14x14x1x64xf16>
@@ -13,6 +29,7 @@ func.func @nhwc_1x1(%arg0: memref<16384xf16>, %arg1: memref<802816xf16>, %arg2: 
 
 // CHECK-LABEL: @nhwc_1x1_stride_2
 // CHECK: <AddDim{1} ["0"] at [1] -> [] at []>, <Embed{2} ["0o"] at [2] -> ["0ipad"] at [1]>, <AddDim{1} ["1"] at [3] -> [] at []>, <Embed{2} ["1o"] at [4] -> ["1ipad"] at [2]>
+// CHECK: rock.gemm
 func.func @nhwc_1x1_stride_2(%arg0: memref<16384xf16>, %arg1: memref<802816xf16>, %arg2: memref<802816xf16>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3, d4) -> ((d0 * 256 + d1 + d2 + d3) * 64 + d4)> by [<Unmerge{1, 256, 1, 1, 64} ["g", "k", "0", "1", "c"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [1, 256, 1, 1, 64] -> [16384]> : memref<16384xf16> to memref<1x256x1x1x64xf16>
   %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2 + d3) * 64 + d4)> by [<Unmerge{64, 14, 14, 1, 64} ["ni", "0i", "1i", "gi", "ci"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 14, 14, 1, 64] -> [802816]> : memref<802816xf16> to memref<64x14x14x1x64xf16>
@@ -23,10 +40,72 @@ func.func @nhwc_1x1_stride_2(%arg0: memref<16384xf16>, %arg1: memref<802816xf16>
 
 // CHECK-LABEL: @nhwc_3x3
 // CHECK: <Embed{1, 1} ["0", "0o"] at [1, 2] -> ["0ipad"] at [1]>, <Embed{1, 1} ["1", "1o"] at [3, 4] -> ["1ipad"] at [2]>
+// CHECK: rock.gemm
 func.func @nhwc_3x3(%arg0: memref<147456xf16>, %arg1: memref<802816xf16>, %arg2: memref<2359296xf16>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, kernel = 0 : i32, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3, d4) -> ((((d0 * 256 + d1) * 3 + d2) * 3 + d3) * 64 + d4)> by [<Unmerge{1, 256, 3, 3, 64} ["g", "k", "0", "1", "c"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [1, 256, 3, 3, 64] -> [147456]> : memref<147456xf16> to memref<1x256x3x3x64xf16>
   %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 14 + d1) * 14 + d2 + d3) * 64 + d4)> by [<Unmerge{64, 14, 14, 1, 64} ["ni", "0i", "1i", "gi", "ci"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 14, 14, 1, 64] -> [802816]> : memref<802816xf16> to memref<64x14x14x1x64xf16>
   %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2, d3, d4) -> (((d0 * 12 + d1) * 12 + d2 + d3) * 256 + d4)> by [<Unmerge{64, 12, 12, 1, 256} ["no", "0o", "1o", "go", "ko"] at [0, 1, 2, 3, 4] -> ["raw"] at [0]>] bounds = [64, 12, 12, 1, 256] -> [2359296]> : memref<2359296xf16> to memref<64x12x12x1x256xf16>
   rock.conv(%0, %1, %2) features =  dot|atomic_add|atomic_fmax_f32|wmma {arch = "amdgcn-amd-amdhsa:gfx1100", derivedBlockSize = 128 : i32, dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "0", "1", "c"], input_layout = ["ni", "0i", "1i", "gi", "ci"], numCU = 96 : i32, output_layout = ["no", "0o", "1o", "go", "ko"], padding = [0 : index, 0 : index, 0 : index, 0 : index], params = #rock.wmma_gemm_params<kpackPerBlock = 4, mPerBlock = 256, nPerBlock = 64, kpack = 8, mPerWave = 64, nPerWave = 64, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>, strides = [1 : index, 1 : index]} : memref<1x256x3x3x64xf16>, memref<64x14x14x1x64xf16>, memref<64x12x12x1x256xf16>
+  return
+}
+
+// CHECK-LABEL: @conv_gemm_nhwc_1x1
+// CHECK: <AddDim{1} ["0"] at [1] -> [] at []>, <PassThrough ["0o"] at [2] -> ["0ipad"] at [1]>, <AddDim{1} ["1"] at [3] -> [] at []>, <PassThrough ["1o"] at [4] -> ["1ipad"] at [2]>
+// CHECK-NOT: Embed
+// CHECK: rock.gemm_elementwise_gemm
+func.func @conv_gemm_nhwc_1x1(%arg0: memref<16384xf32>, %arg1: memref<802816xf32>, %arg2: memref<65536xf32>, %arg3: memref<3211264xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-"} {
+  %0 = rock.transform %arg0 by #transform_map : memref<16384xf32> to memref<1x256x1x1x64xf32>
+  %1 = rock.transform %arg1 by #transform_map1 : memref<802816xf32> to memref<64x14x14x1x64xf32>
+  %2 = rock.transform %arg2 by #transform_map2 : memref<65536xf32> to memref<1x256x256xf32>
+  %3 = rock.transform %arg3 by #transform_map3 : memref<3211264xf32> to memref<1x12544x256xf32>
+  rock.conv_elementwise_gemm{
+    ab = conv(%0, %1) : memref<1x256x1x1x64xf32>, memref<64x14x14x1x64xf32>
+    ab = elementwise {
+  ^bb0(%arg4: memref<1x256x12544xf32>, %arg5: memref<1x256x12544xf32>):
+    memref.copy %arg4, %arg5 : memref<1x256x12544xf32> to memref<1x256x12544xf32>
+    rock.yield
+  }
+    %3 = ab * %2 : memref<1x256x256xf32> -> memref<1x12544x256xf32>
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>, filter_layout = ["g", "k", "0", "1", "c"], firstGemmIdx = 0 : i32, input_layout = ["ni", "0i", "1i", "gi", "ci"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]}
+  return
+}
+
+// CHECK-LABEL: @conv_gemm_nhwc_1x1_stride_2
+// CHECK: <AddDim{1} ["0"] at [1] -> [] at []>, <Embed{2} ["0o"] at [2] -> ["0ipad"] at [1]>, <AddDim{1} ["1"] at [3] -> [] at []>, <Embed{2} ["1o"] at [4] -> ["1ipad"] at [2]>
+// CHECK: rock.gemm_elementwise_gemm
+func.func @conv_gemm_nhwc_1x1_stride_2(%arg0: memref<16384xf32>, %arg1: memref<802816xf32>, %arg2: memref<65536xf32>, %arg3: memref<802816xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-"} {
+  %0 = rock.transform %arg0 by #transform_map : memref<16384xf32> to memref<1x256x1x1x64xf32>
+  %1 = rock.transform %arg1 by #transform_map1 : memref<802816xf32> to memref<64x14x14x1x64xf32>
+  %2 = rock.transform %arg2 by #transform_map4 : memref<65536xf32> to memref<1x256x256xf32>
+  %3 = rock.transform %arg3 by #transform_map3 : memref<802816xf32> to memref<1x3136x256xf32>
+  rock.conv_elementwise_gemm{
+    ab = conv(%0, %1) : memref<1x256x1x1x64xf32>, memref<64x14x14x1x64xf32>
+    ab = elementwise {
+  ^bb0(%arg4: memref<1x256x3136xf32>, %arg5: memref<1x256x3136xf32>):
+    memref.copy %arg4, %arg5 : memref<1x256x3136xf32> to memref<1x256x3136xf32>
+    rock.yield
+  }
+    %3 = ab * %2 : memref<1x256x256xf32> -> memref<1x3136x256xf32>
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>, filter_layout = ["g", "k", "0", "1", "c"], firstGemmIdx = 0 : i32, input_layout = ["ni", "0i", "1i", "gi", "ci"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [2 : index, 2 : index]}
+  return
+}
+
+// CHECK-LABEL: @conv_gemm_nhwc_3x3
+// CHECK: <Embed{1, 1} ["0", "0o"] at [1, 2] -> ["0ipad"] at [1]>, <Embed{1, 1} ["1", "1o"] at [3, 4] -> ["1ipad"] at [2]>
+// CHECK: rock.gemm_elementwise_gemm
+func.func @conv_gemm_nhwc_3x3(%arg0: memref<147456xf32>, %arg1: memref<802816xf32>, %arg2: memref<65536xf32>, %arg3: memref<2359296xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-"} {
+  %0 = rock.transform %arg0 by #transform_map5 : memref<147456xf32> to memref<1x256x3x3x64xf32>
+  %1 = rock.transform %arg1 by #transform_map1 : memref<802816xf32> to memref<64x14x14x1x64xf32>
+  %2 = rock.transform %arg2 by #transform_map6 : memref<65536xf32> to memref<1x256x256xf32>
+  %3 = rock.transform %arg3 by #transform_map7 : memref<2359296xf32> to memref<1x9216x256xf32>
+  rock.conv_elementwise_gemm{
+    ab = conv(%0, %1) : memref<1x256x3x3x64xf32>, memref<64x14x14x1x64xf32>
+    ab = elementwise {
+  ^bb0(%arg4: memref<1x256x9216xf32>, %arg5: memref<1x256x9216xf32>):
+    memref.copy %arg4, %arg5 : memref<1x256x9216xf32> to memref<1x256x9216xf32>
+    rock.yield
+  }
+    %3 = ab * %2 : memref<1x256x256xf32> -> memref<1x9216x256xf32>
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", dilations = [1 : index, 1 : index], features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>, filter_layout = ["g", "k", "0", "1", "c"], firstGemmIdx = 0 : i32, input_layout = ["ni", "0i", "1i", "gi", "ci"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]}
   return
 }

--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -36,6 +36,9 @@ if (ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED)
     PrGemmElementwiseGemmF32
     PrGemmElementwiseGemmF16
     PrGemmElementwiseGemmBF16
+    PrConvElementwiseGemmF32
+    PrConvElementwiseGemmF16
+    PrConvElementwiseGemmBF16
   )
   set(GEN_MODE "")
 endif()

--- a/mlir/test/e2e/PrConvElementwiseGemmBF16.cfg
+++ b/mlir/test/e2e/PrConvElementwiseGemmBF16.cfg
@@ -1,0 +1,2 @@
+if (not config.arch_support_mfma) and (not config.arch_support_wmma):
+  config.unsupported = True

--- a/mlir/test/e2e/PrConvElementwiseGemmBF16.toml
+++ b/mlir/test/e2e/PrConvElementwiseGemmBF16.toml
@@ -1,0 +1,33 @@
+directory = "PrConvElementwiseGemmBF16"
+prefix = "rocmlir-gen"
+suffix = "--operation conv_gemm -t bf16 --arch %arch -pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "transC"
+values = ["true", "false"]
+prefix = "--transC="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
+
+[[axis]]
+name = "layout"
+values = ["-fil_layout=gkcyx -in_layout=ngchw", "-fil_layout=gkyxc -in_layout=nhwgc"]
+
+## conv+gemm variant
+[[suite]]
+name = "pr_conv_gemm_bf16"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=2 -in_channels=256 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0 -gemmO=128"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=2 -conv_stride_w=2 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=2 -dilation_w=2 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"

--- a/mlir/test/e2e/PrConvElementwiseGemmF16.cfg
+++ b/mlir/test/e2e/PrConvElementwiseGemmF16.cfg
@@ -1,0 +1,2 @@
+if (not config.arch_support_mfma) and (not config.arch_support_wmma):
+  config.unsupported = True

--- a/mlir/test/e2e/PrConvElementwiseGemmF16.toml
+++ b/mlir/test/e2e/PrConvElementwiseGemmF16.toml
@@ -1,0 +1,33 @@
+directory = "PrConvElementwiseGemmF16"
+prefix = "rocmlir-gen"
+suffix = "--operation conv_gemm -t f16 --arch %arch -pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "transC"
+values = ["true", "false"]
+prefix = "--transC="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
+
+[[axis]]
+name = "layout"
+values = ["-fil_layout=gkcyx -in_layout=ngchw", "-fil_layout=gkyxc -in_layout=nhwgc"]
+
+## conv+gemm variant
+[[suite]]
+name = "pr_conv_gemm_f16"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=2 -in_channels=256 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0 -gemmO=128"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=2 -conv_stride_w=2 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=2 -dilation_w=2 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"

--- a/mlir/test/e2e/PrConvElementwiseGemmF32.cfg
+++ b/mlir/test/e2e/PrConvElementwiseGemmF32.cfg
@@ -1,0 +1,2 @@
+if (not config.arch_support_mfma):
+  config.unsupported = True

--- a/mlir/test/e2e/PrConvElementwiseGemmF32.toml
+++ b/mlir/test/e2e/PrConvElementwiseGemmF32.toml
@@ -1,0 +1,33 @@
+directory = "PrConvElementwiseGemmF32"
+prefix = "rocmlir-gen"
+suffix = "--operation conv_gemm -t f32 --arch %arch -pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "transC"
+values = ["true", "false"]
+prefix = "--transC="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
+
+[[axis]]
+name = "layout"
+values = ["-fil_layout=gkcyx -in_layout=ngchw", "-fil_layout=gkyxc -in_layout=nhwgc"]
+
+## conv+gemm variant
+[[suite]]
+name = "pr_conv_gemm_f32"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=2 -in_channels=256 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0 -gemmO=128"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=1 -dilation_w=1 -conv_stride_h=2 -conv_stride_w=2 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"
+
+[[suite.test]]
+config = "-groupsize=1 -batchsize=64 -in_channels=128 -out_channels=128 -in_h=28 -in_w=28 -fil_h=3 -fil_w=3 -dilation_h=2 -dilation_w=2 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=1 -padding_h_r=1 -padding_w_l=1 -padding_w_r=1 -gemmO=64"

--- a/mlir/test/rocmlir-gen/conv-elementwise-gemm-kernel.mlir
+++ b/mlir/test/rocmlir-gen/conv-elementwise-gemm-kernel.mlir
@@ -1,0 +1,25 @@
+// RUN: rocmlir-gen --arch gfx942:sramecc+:xnack- --operation conv_gemm -groupsize=1 -batchsize=2 -in_channels=256 -out_channels=128 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 -dilation_h=1 -dilation_w=1 -conv_stride_h=1 -conv_stride_w=1 -padding_h_l=0 -padding_h_r=0 -padding_w_l=0 -padding_w_r=0 -gemmO=128 --transC=true --transO=false -fil_layout=gkcyx -in_layout=ngchw -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope
+
+// CHECK: module attributes {mhal.arch = "[[$ARCH:.*]]"}
+
+// CHECK-LABEL: func.func @rock_conv_gemm
+// CHECK-SAME: (%[[filterRaw:.*0]]: memref<32768xf32>,
+// CHECK-SAME: %[[inputRaw:.*1]]: memref<524288xf32>,
+// CHECK-SAME: %[[cRaw:.*2]]: memref<16384xf32>,
+// CHECK-SAME: %[[outputRaw:.*3]]: memref<262144xf32>)
+// CHECK-SAME: attributes {kernel, mhal.arch = "[[$ARCH]]"}
+// CHECK-NEXT: %[[filter:.*]] = rock.transform %[[filterRaw]] {{.*}} : memref<32768xf32> to memref<1x128x256x1x1xf32>
+// CHECK-NEXT: %[[input:.*]] = rock.transform %[[inputRaw]] {{.*}} : memref<524288xf32> to memref<2x1x256x32x32xf32>
+// CHECK-NEXT: %[[c:.*]] = rock.transform %[[cRaw]] {{.*}} : memref<16384xf32> to memref<1x128x128xf32>
+// CHECK-NEXT: %[[output:.*]] = rock.transform %[[outputRaw]] {{.*}} : memref<262144xf32> to memref<1x2048x128xf32>
+
+// CHECK-NEXT: rock.conv_elementwise_gemm
+// CHECK-NEXT: ab = conv(%[[filter]], %[[input]])
+// CHECK: %[[output]] = ab * tr %[[c]]
+// CHECK: return
+
+// CHECK-LABEL: func.func @host_naive_conv_gemm
+// CHECK: %[[convTensor:.*]] = tosa.conv2d %[[inputTensor:.*]], %[[filterTensor:.*]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<2x32x32x256xf32>, tensor<128x1x1x256xf32>, tensor<128xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<2x32x32x128xf32>
+// CHECK-DAG: %[[abTensor:.*]] = tosa.reshape %[[convTensor]], %{{.*}} : (tensor<2x32x32x128xf32>, !tosa.shape<3>) -> tensor<1x2048x128xf32>
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[abTensor]], %[[cTensor:.*]], %{{.*}}, %{{.*}} : (tensor<1x2048x128xf32>, tensor<1x128x128xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x2048x128xf32>
+// CHECK: return

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -42,6 +42,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IntegerSet.h"
 #include "mlir/IR/Location.h"
@@ -101,7 +102,9 @@ static llvm::cl::opt<rock::KernelType> operation(
         clEnumValN(rock::KernelType::Attention, "attention",
                    "Attention operation of transformer models"),
         clEnumValN(rock::KernelType::GemmElementwiseGemm, "gemm_gemm",
-                   "gemm+elementwise+gemm operation")),
+                   "gemm+elementwise+gemm operation"),
+        clEnumValN(rock::KernelType::ConvElementwiseGemm, "conv_gemm",
+                   "conv+elementwise+gemm operation")),
     llvm::cl::value_desc("kernel type"),
     llvm::cl::init(rock::KernelType::Conv));
 
@@ -1090,6 +1093,10 @@ static void populateDefaults() {
   const bool isAttention = operation == rock::KernelType::Attention;
   const bool isGemmElntwiseGemm =
       operation == rock::KernelType::GemmElementwiseGemm;
+  const bool isConvElntwiseGemm =
+      operation == rock::KernelType::ConvElementwiseGemm;
+
+  // here we treat ConvElementwiseGemm as a convolution as well
   const bool isConv = !(isGemm || isAttention || isGemmElntwiseGemm);
   // Default f32 if we passed no `-t` arguments at all.
   if (outputDataType.empty()) {
@@ -1112,6 +1119,9 @@ static void populateDefaults() {
       gemmM = 1024;
       gemmK = 769;
       gemmN = 512;
+      gemmO = 769;
+    }
+    if (isConvElntwiseGemm) {
       gemmO = 769;
     }
     if (isAttention) {
@@ -1194,8 +1204,11 @@ static void populateDefaults() {
   }
 }
 
-auto getRequiredArgs(std::optional<rock::KernelType> kernelType) {
+static auto getRequiredArgs(std::optional<rock::KernelType> kernelType) {
   using RequiredArgsType = std::vector<const llvm::cl::opt<int64_t> *>;
+  const static RequiredArgsType requiredConvArgs = {
+      &groupSize,  &batchSize,     &inputChannel, &inputHeight,
+      &inputWidth, &outputChannel, &filterWidth,  &filterHeight};
   switch (kernelType.value()) {
   case rock::KernelType::Gemm: {
     const static RequiredArgsType requiredGemmArgs = {&groupSize, &gemmM,
@@ -1212,10 +1225,12 @@ auto getRequiredArgs(std::optional<rock::KernelType> kernelType) {
         &groupSize, &sequenceLengthQ, &sequenceLengthK, &headDimQK, &headDimV};
     return requiredAttenArgs;
   }
+  case rock::KernelType::ConvElementwiseGemm: {
+    RequiredArgsType requiredConvElntwiseGemmArgs(requiredConvArgs);
+    requiredConvElntwiseGemmArgs.push_back(&gemmO);
+    return requiredConvElntwiseGemmArgs;
+  }
   default: {
-    const static RequiredArgsType requiredConvArgs = {
-        &groupSize,  &batchSize,     &inputChannel, &inputHeight,
-        &inputWidth, &outputChannel, &filterWidth,  &filterHeight};
     return requiredConvArgs;
   }
   };
@@ -1231,10 +1246,11 @@ static LogicalResult detectMissingArguments() {
   }
 
   if (operation == rock::KernelType::Attention ||
-      operation == rock::KernelType::GemmElementwiseGemm) {
+      operation == rock::KernelType::GemmElementwiseGemm ||
+      operation == rock::KernelType::ConvElementwiseGemm) {
     if (dataTypeAlias.getValue().empty()) {
-      llvm::errs()
-          << "Type of the Attention/gemm+gemm operation is not specified\n";
+      llvm::errs() << "Type of the attention/gemm+gemm/conv+gemm operation is "
+                      "not specified\n";
       return failure();
     }
   }
@@ -2383,8 +2399,38 @@ getAttentionDimNames(SmallVectorImpl<SmallVector<StringRef>> &result,
     result.emplace_back(SmallVector<StringRef>{gName, seqQName, headVName});
 }
 
-static void getGemmElentwiseGemmTypes(SmallVectorImpl<Type> &result,
-                                      ArrayRef<Type> elemTypes) {
+static rock::GemmSize
+getConvElementwiseGemmTypes(SmallVectorImpl<Type> &result,
+                            const rock::ConvGenerator::Config *config,
+                            ArrayRef<Type> elemTypes) {
+  // determine gemmM and gemmN from convolution sizes
+  rock::ConvolutionDims convDims =
+      rock::ConvGenerator::getConvolutionDims(config);
+  rock::GemmSize gemmSize =
+      rock::GemmSize::fromConvolution(rock::ConvOpType::Fwd, convDims);
+
+  SmallVector<int64_t> filterDims(config->filterDimension.begin(),
+                                  config->filterDimension.end()),
+      inputDims(config->inputDimension.begin(), config->inputDimension.end()),
+      cDims = {1, transposeC ? gemmO : gemmSize.m,
+               transposeC ? gemmSize.m : gemmO},
+      outDims = {1, transposeO ? gemmO : gemmSize.n,
+                 transposeO ? gemmSize.n : gemmO};
+
+  MemRefType filterType = MemRefType::get(filterDims, elemTypes[0]),
+             inputType = MemRefType::get(inputDims, elemTypes[1]),
+             cType = MemRefType::get(cDims, elemTypes[2]),
+             outType = MemRefType::get(outDims, elemTypes[3]);
+  result.push_back(filterType);
+  result.push_back(inputType);
+  result.push_back(cType);
+  result.push_back(outType);
+
+  return gemmSize;
+}
+
+static void getGemmElementwiseGemmTypes(SmallVectorImpl<Type> &result,
+                                        ArrayRef<Type> elemTypes) {
   SmallVector<int64_t> aDims = {groupSize, transposeA ? gemmK : gemmM,
                                 transposeA ? gemmM : gemmK},
                        bDims = {groupSize, transposeB ? gemmN : gemmK,
@@ -2405,8 +2451,35 @@ static void getGemmElentwiseGemmTypes(SmallVectorImpl<Type> &result,
 }
 
 static void
-getGemmElentwiseGemmDimNames(SmallVectorImpl<SmallVector<StringRef>> &result,
-                             ArrayRef<Type> elementTypes) {
+getConvElementwiseGemmDimNames(SmallVectorImpl<SmallVector<StringRef>> &result,
+                               const rock::ConvGenerator::Config *config,
+                               ArrayRef<Type> elementTypes) {
+
+  SmallVector<StringRef> filterLayoutSpec;
+  SmallVector<StringRef> inputLayoutSpec;
+  for (auto &key : config->filterLayout)
+    filterLayoutSpec.push_back(StringRef(&key, 1));
+  for (auto &key : config->inputLayout)
+    inputLayoutSpec.push_back(StringRef(&key, 1));
+
+  result.reserve(elementTypes.size());
+  constexpr StringLiteral gName = "g", m = "m", n = "n", gemmO = "gemmO";
+
+  result.emplace_back(filterLayoutSpec);
+  result.emplace_back(inputLayoutSpec);
+  if (transposeC)
+    result.emplace_back(SmallVector<StringRef>{gName, gemmO, m});
+  else
+    result.emplace_back(SmallVector<StringRef>{gName, m, gemmO});
+  if (transposeO)
+    result.emplace_back(SmallVector<StringRef>{gName, gemmO, n});
+  else
+    result.emplace_back(SmallVector<StringRef>{gName, n, gemmO});
+}
+
+static void
+getGemmElementwiseGemmDimNames(SmallVectorImpl<SmallVector<StringRef>> &result,
+                               ArrayRef<Type> elementTypes) {
   result.reserve(elementTypes.size());
   constexpr StringLiteral gName = "g", m = "m", n = "n", k = "k",
                           gemmO = "gemmO";
@@ -2830,9 +2903,116 @@ static func::FuncOp createGpuAttentionKernel(ModuleOp module,
   module.push_back(func);
   return func;
 }
+static func::FuncOp
+createGpuConvElementwiseGemmKernel(ModuleOp module, const GenParams &params) {
+  MLIRContext *ctx = module.getContext();
+  Location loc = module->getLoc();
+  OpBuilder builder(ctx);
 
-static func::FuncOp createGpuGemmElentwiseGemmKernel(ModuleOp module,
-                                                     const GenParams &params) {
+  // Set mhal.arch on module to make compilation pipeline work
+  StringAttr archAttr = builder.getStringAttr(params.arch);
+  if (!module->hasAttr("mhal.arch"))
+    module->setAttr("mhal.arch", archAttr);
+
+  const auto *config = params.convConfig.value();
+  SmallVector<Type, 5> argTypes;
+  rock::GemmSize firstGemmSize =
+      getConvElementwiseGemmTypes(argTypes, config, params.types);
+  SmallVector<Type, 5> flatArgTypes =
+      llvm::map_to_vector(argTypes, rock::getFlattenedType);
+
+  SmallVector<NamedAttribute, 2> funcAttrs = {
+      builder.getNamedAttr("kernel", builder.getUnitAttr()),
+      builder.getNamedAttr("mhal.arch", archAttr)};
+
+  constexpr StringLiteral kernelName("rock_conv_gemm");
+  auto func = builder.create<func::FuncOp>(
+      loc, kernelName, builder.getFunctionType(flatArgTypes, {}), funcAttrs);
+  if (reverse_grid) {
+    func->setAttr(rock::ReverseGridAttrAttr::getMnemonic(),
+                  builder.getUnitAttr());
+  }
+
+  Block *block = func.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  SmallVector<Value> unflattenedArgs;
+  SmallVector<SmallVector<StringRef>> allNames;
+  getConvElementwiseGemmDimNames(allNames, config, params.types);
+  rock::expandFlatFunctionArguments(builder, func, allNames, argTypes,
+                                    unflattenedArgs);
+
+  Value filter = unflattenedArgs[0];
+  Value input = unflattenedArgs[1];
+  Value c = unflattenedArgs[2];
+  Value output = unflattenedArgs[3];
+  SmallVector<Value> elemwiseInputs;
+
+  IntegerAttr numCUAttr =
+      (num_cu.getNumOccurrences() > 0 ? builder.getI32IntegerAttr(num_cu)
+                                      : nullptr);
+
+  SmallVector<int64_t, 8> pad;
+  for (const auto &[left, right] :
+       zip(config->paddingLeftDims, config->paddingRightDims)) {
+    pad.push_back(left);
+    pad.push_back(right);
+  }
+  auto convElntGemm = builder.create<rock::ConvElementwiseGemmOp>(
+      loc, TypeRange{}, filter, input, c, elemwiseInputs, output, transposeC,
+      transposeO, archAttr, params.features, numCUAttr,
+      builder.getIndexArrayAttr(pad),
+      builder.getIndexArrayAttr(config->strideDims),
+      builder.getIndexArrayAttr(config->dilationDims),
+      /*params0=*/nullptr, /*params1=*/nullptr, /*firstGemmIdx=*/0);
+  {
+    Block *preSecondGemmBlock =
+        &convElntGemm.getPreSecondGemmBody().emplaceBlock();
+    PatternRewriter::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(preSecondGemmBlock);
+    ShapedType aType = cast<ShapedType>(filter.getType());
+    ArrayRef<int64_t> aShape = aType.getShape();
+    Type abElemType = aType.getElementType();
+    MemRefType abMemRefType = MemRefType::get(
+        {aShape[0], firstGemmSize.m, firstGemmSize.n}, abElemType);
+    Value abMemRef = preSecondGemmBlock->addArgument(abMemRefType, loc);
+    Value abTensor = rock::getAsTensor(builder, loc, abMemRef);
+    MemRefType resMemRefType =
+        MemRefType::get({aShape[0], firstGemmSize.m, firstGemmSize.n},
+                        cast<ShapedType>(abTensor.getType()).getElementType());
+    Value resMemref =
+        builder.create<bufferization::ToMemrefOp>(loc, resMemRefType, abTensor);
+    Value outMemref = preSecondGemmBlock->addArgument(resMemRefType, loc);
+    builder.create<memref::CopyOp>(loc, resMemref, outMemref);
+    builder.create<rock::YieldOp>(loc);
+  }
+
+  if (!params.perfConfig.empty())
+    convElntGemm->setAttr("perf_config",
+                          builder.getStringAttr(params.perfConfig));
+
+  // convolution attributes
+  SmallVector<StringAttr, 5> filterLayoutSpec;
+  SmallVector<StringAttr, 5> inputLayoutSpec;
+  for (auto &key : config->filterLayout)
+    filterLayoutSpec.push_back(builder.getStringAttr(StringRef(&key, 1)));
+  for (auto &key : config->inputLayout)
+    inputLayoutSpec.push_back(builder.getStringAttr(StringRef(&key, 1) + "i"));
+
+  convElntGemm->setAttr("filter_layout",
+                        builder.getArrayAttr(ArrayRef<Attribute>(
+                            filterLayoutSpec.begin(), filterLayoutSpec.end())));
+  convElntGemm->setAttr("input_layout",
+                        builder.getArrayAttr(ArrayRef<Attribute>(
+                            inputLayoutSpec.begin(), inputLayoutSpec.end())));
+
+  builder.create<func::ReturnOp>(loc);
+  module.push_back(func);
+  return func;
+}
+
+static func::FuncOp
+createGpuGemmElementwiseGemmKernel(ModuleOp module, const GenParams &params) {
   MLIRContext *ctx = module.getContext();
   Location loc = module->getLoc();
   OpBuilder builder(ctx);
@@ -2843,7 +3023,7 @@ static func::FuncOp createGpuGemmElentwiseGemmKernel(ModuleOp module,
     module->setAttr("mhal.arch", archAttr);
 
   SmallVector<Type, 5> argTypes;
-  getGemmElentwiseGemmTypes(argTypes, params.types);
+  getGemmElementwiseGemmTypes(argTypes, params.types);
   SmallVector<Type, 5> flatArgTypes =
       llvm::map_to_vector(argTypes, rock::getFlattenedType);
 
@@ -2864,7 +3044,7 @@ static func::FuncOp createGpuGemmElentwiseGemmKernel(ModuleOp module,
 
   SmallVector<Value> unflattenedArgs;
   SmallVector<SmallVector<StringRef>> allNames;
-  getGemmElentwiseGemmDimNames(allNames, params.types);
+  getGemmElementwiseGemmDimNames(allNames, params.types);
   rock::expandFlatFunctionArguments(builder, func, allNames, argTypes,
                                     unflattenedArgs);
 
@@ -3006,10 +3186,37 @@ static func::FuncOp createCpuGemmKernelWithMlir(ModuleOp module,
   return func;
 }
 
+static Value squeeze(OpBuilder &builder, Location loc, Value src,
+                     size_t squeezeDim) {
+  auto origShape = cast<ShapedType>(src.getType()).getShape();
+  assert(origShape[squeezeDim] == 1);
+  SmallVector<int64_t> newShape;
+  newShape.reserve(origShape.size() - 1);
+
+  // Copy all elements except the one at squeezeDim
+  for (size_t i = 0; i < origShape.size(); ++i) {
+    if (i != squeezeDim) {
+      newShape.push_back(origShape[i]);
+    }
+  }
+  ImplicitLocOpBuilder implicitBuilder(loc, builder);
+  auto shapeValue = tosa::getTosaConstShape(implicitBuilder, newShape);
+  return builder.create<tosa::ReshapeOp>(loc, src, shapeValue);
+}
+
 static Value transposeMatrix(OpBuilder &builder, Location loc, Value src,
                              ArrayRef<int32_t> perm) {
   auto elemType = cast<RankedTensorType>(src.getType()).getElementType();
   return createOpAndInfer<tosa::TransposeOp>(builder, loc, elemType, src, perm);
+}
+
+static Value convOutToGemmA(OpBuilder &builder, Location loc, Value convOut,
+                            rock::GemmSize firstGemmSize) {
+  // tensor<bxhxwxc> -> tensor<1x(bxhxw)xc>
+  SmallVector<int64_t> newShape = {1, firstGemmSize.n, firstGemmSize.m};
+  ImplicitLocOpBuilder implicitBuilder(loc, builder);
+  auto shapeValue = tosa::getTosaConstShape(implicitBuilder, newShape);
+  return builder.create<tosa::ReshapeOp>(loc, convOut, shapeValue);
 }
 
 static Type getAccType(Type inputType, OpBuilder builder) {
@@ -3025,6 +3232,188 @@ static Type getAccType(Type inputType, OpBuilder builder) {
 }
 
 static func::FuncOp
+createCpuConvElementwiseGemmKernelWithMlir(ModuleOp module,
+                                           const GenParams &params) {
+  MLIRContext *ctx = module.getContext();
+  OpBuilder builder(ctx);
+  Location loc = module->getLoc();
+
+  const auto *config = params.convConfig.value();
+  SmallVector<Type, 5> argTypes;
+  rock::GemmSize firstGemmSize =
+      getConvElementwiseGemmTypes(argTypes, config, params.types);
+
+  SmallVector<Type, 5> flatArgTypes =
+      llvm::map_to_vector(argTypes, rock::getFlattenedType);
+
+  constexpr llvm::StringLiteral cpuKernName("host_naive_conv_gemm");
+  auto func = builder.create<func::FuncOp>(
+      loc, cpuKernName, builder.getFunctionType(flatArgTypes, {}));
+
+  Block *block = func.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  auto getTensorForBlockArg = [&builder, &loc, &block,
+                               &argTypes](unsigned blockArgIndex,
+                                          bool isWritable = false) {
+    constexpr bool isRestrict{true};
+    Value flatTensor = builder.create<bufferization::ToTensorOp>(
+        loc, block->getArgument(blockArgIndex), isRestrict, isWritable);
+    ArrayRef<int64_t> origShape =
+        cast<ShapedType>(argTypes[blockArgIndex]).getShape();
+
+    Value reshapedTensor;
+    ImplicitLocOpBuilder implicitBuilder(loc, builder);
+    if (origShape.size() == 2) {
+      SmallVector<int64_t, 3> expShape(origShape.size() + 1, 0);
+      expShape[0] = 1;
+      llvm::copy(origShape, expShape.begin() + 1);
+      auto shapeValue = tosa::getTosaConstShape(implicitBuilder, expShape);
+      reshapedTensor =
+          builder.create<tosa::ReshapeOp>(loc, flatTensor, shapeValue);
+    } else {
+      auto shapeValue = tosa::getTosaConstShape(implicitBuilder, origShape);
+      reshapedTensor =
+          builder.create<tosa::ReshapeOp>(loc, flatTensor, shapeValue);
+    }
+    return reshapedTensor;
+  };
+
+  ConvTensorDimInfo filterInfo = parseConvTensorLayout(config->filterLayout,
+                                                       config->filterDimension,
+                                                       'k', 'c'),
+                    inputInfo = parseConvTensorLayout(
+                        config->inputLayout, config->inputDimension, 'n', 'c');
+
+  auto filterTensor = getTensorForBlockArg(0);
+  filterTensor = squeeze(builder, loc, filterTensor, filterInfo.gDim);
+  int32_t kDim = (filterInfo.nonImg1Dim < filterInfo.gDim)
+                     ? filterInfo.nonImg1Dim
+                     : filterInfo.nonImg1Dim - 1;
+  int32_t cDim = (filterInfo.nonImg2Dim < filterInfo.gDim)
+                     ? filterInfo.nonImg2Dim
+                     : filterInfo.nonImg2Dim - 1;
+  int32_t hDim = (filterInfo.imageDims[0] < filterInfo.gDim)
+                     ? filterInfo.imageDims[0]
+                     : filterInfo.imageDims[0] - 1;
+  int32_t wDim = (filterInfo.imageDims[1] < filterInfo.gDim)
+                     ? filterInfo.imageDims[1]
+                     : filterInfo.imageDims[1] - 1;
+  filterTensor =
+      transposeMatrix(builder, loc, filterTensor, {kDim, hDim, wDim, cDim});
+  auto inputTensor = getTensorForBlockArg(1);
+  inputTensor = squeeze(builder, loc, inputTensor, inputInfo.gDim);
+  int32_t nDim = (inputInfo.nonImg1Dim < inputInfo.gDim)
+                     ? inputInfo.nonImg1Dim
+                     : inputInfo.nonImg1Dim - 1;
+  cDim = (inputInfo.nonImg2Dim < inputInfo.gDim) ? inputInfo.nonImg2Dim
+                                                 : inputInfo.nonImg2Dim - 1;
+  hDim = (inputInfo.imageDims[0] < inputInfo.gDim) ? inputInfo.imageDims[0]
+                                                   : inputInfo.imageDims[0] - 1;
+  wDim = (inputInfo.imageDims[1] < inputInfo.gDim) ? inputInfo.imageDims[1]
+                                                   : inputInfo.imageDims[1] - 1;
+  inputTensor =
+      transposeMatrix(builder, loc, inputTensor, {nDim, hDim, wDim, cDim});
+
+  auto cTensor = getTensorForBlockArg(2);
+  if (transposeC) {
+    cTensor = transposeMatrix(builder, loc, cTensor, {0, 2, 1});
+  }
+  auto inputZp =
+      tosa::createZeroPointTensor(builder, loc, inputTensor.getType(), 0)
+          .value();
+  auto weightZp =
+      tosa::createZeroPointTensor(builder, loc, filterTensor.getType(), 0)
+          .value();
+
+  // TODO: if/when tosa::matmul has acc_type implemented, we can use it here to
+  // be more similar to what the gpu code does
+  Type convOutElemType = params.types[2];
+  // accumulate in 32 bit
+  Type firstAccType = getAccType(params.types[0], builder);
+  assert(firstAccType == getAccType(params.types[1], builder));
+
+  auto biasTy = RankedTensorType::get(
+      cast<ShapedType>(filterTensor.getType()).getShape()[0], firstAccType);
+  auto biasTensor = builder.create<tosa::ConstOp>(
+      loc, biasTy, cast<ElementsAttr>(builder.getZeroAttr(biasTy)));
+
+  SmallVector<int64_t> pads;
+  assert(config->paddingLeftDims.size() == config->paddingRightDims.size());
+  for (size_t i = 0; i < config->paddingLeftDims.size(); i++) {
+    pads.push_back(config->paddingLeftDims[i]);
+    pads.push_back(config->paddingRightDims[i]);
+  }
+
+  // Determine the accumulation type based on the output type.
+  Type accType;
+  if (isa<FloatType>(params.types[0]) &&
+      params.types[0].getIntOrFloatBitWidth() >= 16) {
+    accType = builder.getF32Type();
+  } else if (isa<FloatType>(params.types[0]) &&
+             params.types[0].getIntOrFloatBitWidth() <= 8) {
+    accType = builder.getF16Type();
+  } else if (isa<IntegerType>(params.types[0])) {
+    accType = builder.getI32Type();
+  }
+
+  Value convOutBeforeConversion = createOpAndInfer<tosa::Conv2DOp>(
+      builder, loc, firstAccType, inputTensor, filterTensor, biasTensor,
+      inputZp, weightZp, builder.getDenseI64ArrayAttr(pads),
+      builder.getDenseI64ArrayAttr(config->strideDims),
+      builder.getDenseI64ArrayAttr(config->dilationDims), accType,
+      builder.getI64IntegerAttr(groupSize));
+
+  Value convOut = builder.createOrFold<tosa::CastOp>(
+      loc,
+      cast<ShapedType>(convOutBeforeConversion.getType())
+          .clone(convOutElemType),
+      convOutBeforeConversion);
+
+  // convert conv output to matmul A matrix
+  // tensor<bxhxwxkxf16> -> tensor<1x(b*h*w)xkxf16>
+  Value gemmA = convOutToGemmA(builder, loc, convOut, firstGemmSize);
+  auto abZp =
+      tosa::createZeroPointTensor(builder, loc, gemmA.getType(), 0).value();
+  auto cZp =
+      tosa::createZeroPointTensor(builder, loc, cTensor.getType(), 0).value();
+  Type secondGemmOutElemType = params.types[3];
+  // accumulate in 32 bit
+  Type secondAccType = getAccType(convOutElemType, builder);
+  assert(secondAccType == getAccType(params.types[2], builder));
+  Value resultTensorBeforeConversion = createOpAndInfer<tosa::MatMulOp>(
+      builder, loc, secondAccType, gemmA, cTensor, abZp, cZp);
+
+  Value resultTensor = builder.createOrFold<tosa::CastOp>(
+      loc,
+      cast<ShapedType>(resultTensorBeforeConversion.getType())
+          .clone(secondGemmOutElemType),
+      resultTensorBeforeConversion);
+
+  if (transposeO) {
+    resultTensor = transposeMatrix(builder, loc, resultTensor, {0, 2, 1});
+  }
+
+  Value output = block->getArguments().back();
+  auto outputType = cast<MemRefType>(output.getType());
+
+  ImplicitLocOpBuilder implicitBuilder(loc, builder);
+  auto shapeValue =
+      tosa::getTosaConstShape(implicitBuilder, outputType.getShape());
+  auto flatResultTensor =
+      builder.create<tosa::ReshapeOp>(loc, resultTensor, shapeValue);
+
+  auto flatResultMemref = builder.create<bufferization::ToMemrefOp>(
+      loc, outputType, flatResultTensor);
+
+  builder.create<memref::CopyOp>(loc, flatResultMemref, output);
+
+  builder.create<func::ReturnOp>(loc);
+  module.push_back(func);
+  return func;
+}
+
+static func::FuncOp
 createCpuGemmElementwiseGemmKernelWithMlir(ModuleOp module,
                                            const GenParams &params) {
   MLIRContext *ctx = module.getContext();
@@ -3032,7 +3421,7 @@ createCpuGemmElementwiseGemmKernelWithMlir(ModuleOp module,
   Location loc = module->getLoc();
 
   SmallVector<Type, 5> argTypes;
-  getGemmElentwiseGemmTypes(argTypes, params.types);
+  getGemmElementwiseGemmTypes(argTypes, params.types);
   SmallVector<Type, 5> flatArgTypes =
       llvm::map_to_vector(argTypes, rock::getFlattenedType);
 
@@ -3630,7 +4019,7 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
 // on the presense of mhal::PrefillAttr. This is to mimic the
 // requirement on the kernel launcher to do the same for the
 // expected funtionality.
-void insertPrefills(func::FuncOp fut) {
+static void insertPrefills(func::FuncOp fut) {
   SmallVector<ModuleOp, 1> innerModules;
   fut->getParentOfType<ModuleOp>().walk(
       [&](ModuleOp module) { innerModules.push_back(module); });
@@ -3656,9 +4045,7 @@ void insertPrefills(func::FuncOp fut) {
             auto elementType = cast<MemRefType>(type).getElementType();
             Attribute init;
             if (llvm::isa<FloatType>(elementType)) {
-              // TODO: to be fixed in
-              // https://github.com/ROCm/rocMLIR-internal/issues/1770
-              init = builder.getFloatAttr(elementType, 0.0);
+              init = builder.getFloatAttr(elementType, 100.0);
             } else {
               assert(llvm::isa<IntegerType>(elementType) &&
                      "expecting `int` element type");
@@ -3685,7 +4072,7 @@ void insertPrefills(func::FuncOp fut) {
 }
 
 // Convert the mhal.launch/mhal.await pattern back to func.call.
-void undoAsyncLaunchPass(Operation *cloneFunc) {
+static void undoAsyncLaunchPass(Operation *cloneFunc) {
   SymbolTableCollection symbolTable;
   auto walker = [&](Operation *op) {
     OpBuilder builder(op);
@@ -3815,7 +4202,21 @@ static void insertValidationCalls(const GenParams &genParams, OpBuilder &b,
     }
   } else if (validationType != "clone") { // -pv_with_cpp or -pv_with_mlir (-pv)
     // Emit call to host_<conv>
-    if (genParams.convConfig.has_value()) {
+    if (genParams.operation == rock::KernelType::ConvElementwiseGemm) {
+      if (validationType == "cpp") {
+        llvm::errs()
+            << "External conv elementwise gemm validator is not available\n";
+        exit(1);
+      }
+      if (groupSize != 1) {
+        llvm::errs()
+            << "Group convolution not supported for conv+gemm in rocmlir-gen\n";
+        exit(1);
+      }
+      auto cpuConvElementwiseGemmFunc =
+          createCpuConvElementwiseGemmKernelWithMlir(module, genParams);
+      b.create<func::CallOp>(loc, cpuConvElementwiseGemmFunc, valVars);
+    } else if (genParams.convConfig.has_value()) {
       const auto &genConfig = **genParams.convConfig;
       auto cpuConvFunc = createCPUConvFunc(module, genConfig);
       b.create<func::CallOp>(loc, cpuConvFunc, valVars);
@@ -3949,6 +4350,9 @@ static LogicalResult populateHostHarnessLogic(
       outIndices.push_back(0);
       break;
     case rock::KernelType::GemmElementwiseGemm:
+      outIndices.push_back(3);
+      break;
+    case rock::KernelType::ConvElementwiseGemm:
       outIndices.push_back(3);
       break;
     case rock::KernelType::Attention:
@@ -4196,8 +4600,12 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
   const bool isAttention = operation == rock::KernelType::Attention;
   const bool isGemmElntwiseGemm =
       operation == rock::KernelType::GemmElementwiseGemm;
+  const bool isConvElntwiseGemm =
+      operation == rock::KernelType::ConvElementwiseGemm;
+
+  // ConvElementwiseGemm is treated as convolution
   const bool isConv = !(isGemm || isAttention || isGemmElntwiseGemm);
-  auto convConfigStr = populateConvConfig.getValue();
+  const auto &convConfigStr = populateConvConfig.getValue();
 
   if (!convConfigStr.empty() && !isConv) {
     llvm::errs() << "Cannot use --conv-config with gemm/attention/gemm+gemm "
@@ -4311,7 +4719,7 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
         genParams.types.push_back(elemType);
       }
       genParams.convConfig = std::nullopt;
-      (void)createGpuGemmElentwiseGemmKernel(module, genParams);
+      (void)createGpuGemmElementwiseGemmKernel(module, genParams);
     } else if (isAttention) {
       auto elemType = typeFromString(inputDataType.getValue(), context);
       // We only support first-gemm i8 version of attention
@@ -4413,9 +4821,11 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
         exit(1);
       }
 
-      genParams.types.push_back(convGenerator.getFilterDataType(builder));
-      genParams.types.push_back(convGenerator.getInputDataType(builder));
-      genParams.types.push_back(convGenerator.getOutputDataType(builder));
+      if (!isConvElntwiseGemm) {
+        genParams.types.push_back(convGenerator.getFilterDataType(builder));
+        genParams.types.push_back(convGenerator.getInputDataType(builder));
+        genParams.types.push_back(convGenerator.getOutputDataType(builder));
+      }
       genParams.convConfig = &convGenerator.getConfig();
     }
   }
@@ -4428,7 +4838,16 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
 
   if (genParams.convConfig.has_value()) {
     const auto &genConfig = **genParams.convConfig;
-    if (genCPUKernel.getValue()) {
+    if (isConvElntwiseGemm) {
+      constexpr size_t numArgs{4};
+      // Note: In the current implementation, all operands have the same type.
+      // This behaviour enforced by `-t`. See, detectMissingArguments()
+      auto elemType = typeFromString(inputDataType.getValue(), context);
+      for (size_t argIdx{0}; argIdx < numArgs; ++argIdx) {
+        genParams.types.push_back(elemType);
+      }
+      (void)createGpuConvElementwiseGemmKernel(module, genParams);
+    } else if (genCPUKernel.getValue()) {
       (void)createCPUConvFunc(module, genConfig);
     } else {
       // Populate the module.

--- a/mlir/utils/performance/perfCommonUtils.py
+++ b/mlir/utils/performance/perfCommonUtils.py
@@ -7,6 +7,7 @@ class Operation(enum.IntEnum):
   FUSION = 3
   ATTENTION = 4
   GEMM_GEMM = 5
+  CONV_GEMM = 6
 
   @staticmethod
   def fromName(name: str) -> 'self':
@@ -19,6 +20,8 @@ class Operation(enum.IntEnum):
       return Operation.ATTENTION
     elif name == 'gemm_gemm':
       return Operation.GEMM_GEMM
+    elif name == 'conv_gemm':
+      return Operation.CONV_GEMM
     elif name == 'fusion':
       return Operation.FUSION
     else:

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -37,10 +37,24 @@ LAYOUTS = ['NHWC', 'NCHW']
 DATA_TYPES_GEMM = ['f32', 'f16', 'bf16', 'i8', 'fp8']
 DATA_TYPES_ATTENTION = ['f32', 'f16', 'bf16']
 DATA_TYPES_GEMM_GEMM = ['f32', 'f16', 'bf16']
+DATA_TYPES_CONV_GEMM = ['f32', 'f16', 'bf16']
 OUTPUT_DATA_TYPES_MAP = {'f32': 'f32', 'f16': 'f16', 'bf16': 'bf16', 'i8': 'i32', 'fp8':'f32',
                          'fp8_fp8': 'f32', 'fp8_bf8': 'f32', 'bf8_fp8': 'f32',
                          'bf8_bf8': 'f32'}
 MLIR_N_REPEATS = 5
+
+MLIR_FILTER_LAYOUTS = {"NCHW": "kcyx", "NCHWG": "kcyxg", "NHWC": "kyxc", "NHWCG": "kyxcg",
+                        "NC01": "kc01", "NC01G": "kc01g", "N01C": "k01c", "N01CG": "k01cg",
+                        "GNC01":"gkc01", "GN01C":"gk01c"}
+MLIR_OUTPUT_LAYOUTS = {"NCHW": "nkhw", "NCHWG": "nkhwg", "NHWC": "nhwk", "NHWCG": "nhwkg",
+                        "NC01": "nk01", "NC01G": "nk01g", "N01C": "n01k", "N01CG": "n01kg",
+                        "NGC01":"ngk01", "N01GC": "n01gk"}
+INVERSE_FILTER_LAYOUTS = {v: k for k, v in MLIR_FILTER_LAYOUTS.items()}
+INVERSE_OUTPUT_LAYOUTS = {v: k for k, v in MLIR_OUTPUT_LAYOUTS.items()}
+
+FILTER_LAYOUT_MAP = {'N':'k', 'C':'c', 'H':'0', 'W':'1', 'G':'g'}
+INPUT_LAYOUT_MAP = {'N':'n', 'C':'c', 'H':'0', 'W':'1', 'G':'g'}
+OUTPUT_LAYOUT_MAP = {'N':'n', 'C':'k', 'H':'0', 'W':'1', 'G':'g'}
 
 # Compiled regexp object used for extracting elapsed time from MIOpenDriver's output
 ELAPSED_TIME_RE = re.compile(r"Elapsed: ([0-9\.]*) ms")
@@ -386,19 +400,6 @@ class ConvConfiguration(PerfConfiguration):
             result += ' '.join(rocmlir_gen_flags.split())
         return result
 
-    MLIR_FILTER_LAYOUTS = {"NCHW": "kcyx", "NCHWG": "kcyxg", "NHWC": "kyxc", "NHWCG": "kyxcg",
-                           "NC01": "kc01", "NC01G": "kc01g", "N01C": "k01c", "N01CG": "k01cg",
-                           "GNC01":"gkc01", "GN01C":"gk01c"}
-    MLIR_OUTPUT_LAYOUTS = {"NCHW": "nkhw", "NCHWG": "nkhwg", "NHWC": "nhwk", "NHWCG": "nhwkg",
-                           "NC01": "nk01", "NC01G": "nk01g", "N01C": "n01k", "N01CG": "n01kg",
-                           "NGC01":"ngk01", "N01GC": "n01gk"}
-    filterLayoutMap = {'N':'k', 'C':'c', 'H':'0', 'W':'1', 'G':'g'}
-    inputLayoutMap = {'N':'n', 'C':'c', 'H':'0', 'W':'1', 'G':'g'}
-    outputLayoutMap = {'N':'n', 'C':'k', 'H':'0', 'W':'1', 'G':'g'}
-
-    INVERSE_FILTER_LAYOUTS = {v: k for k, v in MLIR_FILTER_LAYOUTS.items()}
-    INVERSE_OUTPUT_LAYOUTS = {v: k for k, v in MLIR_OUTPUT_LAYOUTS.items()}
-
     @classmethod
     def fromCommandLine(cls, argv, arch, numCU):
         # determine dataType from argv[1]
@@ -492,8 +493,8 @@ class ConvConfiguration(PerfConfiguration):
     def toCommandLine(self):
         return (f"conv{ {'f32':'', 'f16':'fp16', 'bf16':'bfp16', 'i8':'int8','fp8_fp8':'fp8_fp8', 'fp8': 'fp8'}[self.dataType]} "
                 + f"-F { {'fwd':1, 'bwd':2, 'wrw':4}[self.direction]} "
-                + f"-f {self.INVERSE_FILTER_LAYOUTS[self.filterLayout]} -I {self.inputLayout.upper()} "
-                + f"-O {self.INVERSE_OUTPUT_LAYOUTS[self.outputLayout]} "
+                + f"-f {INVERSE_FILTER_LAYOUTS[self.filterLayout]} -I {self.inputLayout.upper()} "
+                + f"-O {INVERSE_OUTPUT_LAYOUTS[self.outputLayout]} "
                 + f"-n {self.n} -c {self.c} -H {self.hi} -W {self.wi} -k {self.k} "
                 + f"-y {self.y} -x {self.x} -p {self.paddingH} -q {self.paddingW} "
                 + f"-u {self.convStrideH} -v {self.convStrideW} -l {self.dilationH} "
@@ -511,9 +512,9 @@ class ConvConfiguration(PerfConfiguration):
         self.dataType = dtype
         self.direction = direction
 
-        self.filterLayout = ''.join(self.filterLayoutMap.get(c, c).lower() for c in filterLayout)
-        self.inputLayout = ''.join(self.inputLayoutMap.get(c, c).lower() for c in inputLayout)
-        self.outputLayout = ''.join(self.outputLayoutMap.get(c, c).lower() for c in outputLayout)
+        self.filterLayout = ''.join(FILTER_LAYOUT_MAP.get(c, c).lower() for c in filterLayout)
+        self.inputLayout = ''.join(INPUT_LAYOUT_MAP.get(c, c).lower() for c in inputLayout)
+        self.outputLayout = ''.join(OUTPUT_LAYOUT_MAP.get(c, c).lower() for c in outputLayout)
 
         self.n = n
         self.c = c
@@ -609,6 +610,39 @@ def getGemmConfigurations(fileName, dataTypes=DATA_TYPES_GEMM, outDataTypeMap=OU
                 oneConfig = f"{dataTypeString}{outDataTypeString}{transAString}{transBString}{line}".strip()
                 if oneConfig not in configs:
                     configs.append(oneConfig)
+    return configs
+
+def getConvGemmConfigurations(fileName):
+    bool_space = ['false', 'true']
+    default_test_space = {
+        "-t": DATA_TYPES_CONV_GEMM,
+        "-f": LAYOUTS,
+        "-I": LAYOUTS,
+        "-transC": bool_space,
+        "-transO": bool_space,
+    }
+    configs = []
+    if fileName:
+        with open(fileName, 'r') as configFile:
+            lines = configFile.readlines()
+            for line in lines:
+                line = line.strip()
+                # Skip empty lines
+                if len(line) == 0 or line[0] == '#':
+                    continue
+                test_space = []
+                args = []
+                for arg in default_test_space.keys():
+                    if arg not in line:
+                        test_space.append(default_test_space[arg])
+                        args.append(arg)
+                for test_vector in itertools.product(*test_space):
+                    # Strip to avoid spurious spaces
+                    oneConfig = line.strip()
+                    for arg, value in zip(args, test_vector):
+                        oneConfig = f"{arg} {value} {oneConfig}"
+                    if oneConfig not in configs:
+                        configs.append(oneConfig)
     return configs
 
 def getGemmGemmConfigurations(fileName):
@@ -792,6 +826,223 @@ class GemmConfiguration(PerfConfiguration):
         self.chip = GFX_CHIP_RE.search(arch).group(0)
         self.numCU = numCU
 
+class ConvGemmConfiguration(PerfConfiguration):
+    TABLE_COLUMNS = reportUtils.CONV_GEMM_TEST_PARAMETERS + ['TFlops']
+
+    def __init__(self, dtype: str, filterLayout: str, inputLayout:str, 
+                 transC: bool, transO: bool, n: int, c: int, 
+                 hi: int, wi: int, k: int, y: int, x: int, o: int, 
+                 convStrideH: int, convStrideW: int, paddingH: int, paddingW: int,
+                dilationH: int, dilationW: int, group: int,
+                 arch: str, numCU: int, perf_config: str = ''):
+        if dtype not in DATA_TYPES_CONV_GEMM:
+            raise ValueError(f"Invalid datatype for a: {dtype}")
+
+        self.dataType = dtype
+        
+        self.filterLayout = ''.join(FILTER_LAYOUT_MAP.get(c, c).lower() for c in filterLayout)
+        self.inputLayout = ''.join(INPUT_LAYOUT_MAP.get(c, c).lower() for c in inputLayout)
+        self.transC = transC
+        self.transO = transO
+        
+        self.n = n
+        self.c = c
+        self.hi = hi
+        self.wi = wi
+        self.k = k
+        self.y = y
+        self.x = x
+        self.o = o
+
+        self.convStrideH = convStrideH
+        self.convStrideW = convStrideW
+        self.paddingH = paddingH
+        self.paddingW = paddingW
+        self.dilationH = dilationH
+        self.dilationW = dilationW
+
+        self.group = group
+        self.arch = arch
+        self.chip = GFX_CHIP_RE.search(arch).group(0)
+        self.numCU = numCU
+        self.perfConfig = perf_config
+
+        self.ho = math.floor((self.hi + self.paddingH * 2 - (self.y - 1) * self.dilationH - 1 ) / self.convStrideH) + 1
+        self.wo = math.floor((self.wi + self.paddingW * 2 - (self.x - 1) * self.dilationW - 1 ) / self.convStrideW) + 1
+
+    def computeTFlops(self, ns):
+        # NaN will propagate as expected
+        # Repeats are handled by the fact that we're using avarageNs
+        assert(self.k % self.group == 0)
+        assert(self.c % self.group == 0)
+
+        first_conv_flops = 2.0 * self.n * (self.c//self.group) * self.k * self.ho * self.wo * self.y * self.x
+        first_gemm_m = self.k
+        first_gemm_n = self.n * self.ho * self.wo
+        batch_second_gemm = 1.0
+        second_matmul_flops = 2.0 * batch_second_gemm * first_gemm_m * first_gemm_n * self.o
+        total_flops = first_conv_flops + second_matmul_flops
+
+        return total_flops / (float(ns) * 1e-9) / 1e12
+
+    def tableEntry(self, nanoSeconds):
+        result = {}
+        values = [
+            self.dataType,
+            self.chip,
+            self.numCU,
+            self.filterLayout, 
+            self.inputLayout,
+            self.transC,
+            self.transO,
+            self.n,
+            self.c, 
+            self.hi, 
+            self.wi, 
+            self.k, 
+            self.y, 
+            self.x,
+            self.o,
+            self.dilationH, self.dilationW,
+            self.convStrideH, self.convStrideW, 
+            self.paddingH, self.paddingW,
+            self.perfConfig,
+            self.computeTFlops(nanoSeconds)
+        ]
+        assert(len(self.TABLE_COLUMNS) == len(values))
+        for k, v in zip(self.TABLE_COLUMNS, values):
+            result[k] = v
+        return result
+
+    def __repr__(self):
+        attrs = ', '.join(f"{key}={repr(value)!r}" for key, value in self.__dict__.items())
+        return f"{self.__class__.__name__}({attrs})"
+    
+    def setPerfConfig(self, perf_config):
+        self.perfConfig = perf_config
+
+    def generateMlirDriverCommandLine(self, rocmlir_gen_flags):
+        result = ' '.join(['-operation', 'conv_gemm',
+                           '-t', self.dataType,
+                           '--arch', self.arch,
+                           f'--num_cu={self.numCU}',
+                           f'--fil_layout={self.filterLayout}',
+                           f'--in_layout={self.inputLayout}',
+                           f'--transC={self.transC}',
+                           f'--transO={self.transO}',
+                           f'--batchsize={self.n}',
+                           f'--in_channels={self.c}',
+                           f'--in_h={self.hi}',
+                           f'--in_w={self.wi}',
+                           f'--out_channels={self.k}',
+                           f'--fil_h={self.y}',
+                           f'--fil_w={self.x}',
+                           f'--dilation_h={self.dilationH}',
+                           f'--dilation_w={self.dilationW}',
+                           f'--conv_stride_h={self.convStrideH}',
+                           f'--conv_stride_w={self.convStrideW}',
+                           f'--padding_h={self.paddingH}',
+                           f'--padding_w={self.paddingW}',
+                           f'--groupsize={self.group}',
+                           f'--gemmO={self.o}',
+                           f'--kernel-repeats={MLIR_N_REPEATS}',
+                           f"--perf_config={self.perfConfig}"])
+        result += ' '
+        if rocmlir_gen_flags != '':
+            result += ' '.join(rocmlir_gen_flags.split())
+        return result
+
+    @classmethod
+    def fromCommandLine(cls, argv, arch, numCU):
+        # optional defaults
+        perf_config = ''
+        dtype = None
+        n = None
+        c = None
+        hi = None
+        wi = None
+        k = None
+        y = None
+        x = None
+        o = None
+        convStrideH = None
+        convStrideW = None
+        paddingH = None
+        paddingW = None
+        dilationH = None
+        dilationW = None
+        group = None
+        filterLayout = None
+        inputLayout = None
+        transC = False
+        transO = False
+        # Please keep this in sync with mlir::rock::getTuningProblemStr()
+        for i in range(0, len(argv), 2):
+            opt = argv[i]
+            val = argv[i + 1]
+            if opt.endswith("-t"):
+                dtype = val
+            elif opt.endswith("-n"):
+                n = int(val)
+            elif opt.endswith("-c"):
+                c = int(val)
+            elif opt.endswith("-H"):
+                hi = int(val)
+            elif opt.endswith("-W"):
+                wi = int(val)
+            elif opt.endswith("-k"):
+                k = int(val)
+            elif opt.endswith("-y"):
+                y = int(val)
+            elif opt.endswith("-x"):
+                x = int(val)
+            elif opt.endswith("-gemmO"):
+                o = int(val)
+            elif opt == '-u':
+                convStrideH = int(val)
+            elif opt == '-v':
+                convStrideW = int(val)
+            elif opt == '-p':
+                paddingH = int(val)
+            elif opt == '-q':
+                paddingW = int(val)
+            elif opt == '-l':
+                dilationH = int(val)
+            elif opt == '-j':
+                dilationW = int(val)
+            elif opt == '-g':
+                group = int(val)
+            elif opt == '-f':
+                filterLayout = val
+            elif opt == '-I':
+                inputLayout = val
+            elif opt.endswith("-transC"):
+                transC = (val.lower() in ["1", "true"])
+            elif opt.endswith("-transO"):
+                transO = (val.lower() in ["1", "true"])
+            elif opt.endswith("-perf_config"):
+                perf_config = val
+            else:
+                raise ValueError(f"Unknown conv+gemm config argument {opt} -> {val}")
+        for v in [dtype, n, c, hi, wi, k, y, x, o, convStrideH, convStrideW, paddingH, paddingW, 
+                  dilationH, dilationW, group, filterLayout, inputLayout, transC, transO]:
+            if v is None:
+                raise ValueError("Incomplete conv+gemm configuration")
+            
+        return cls(dtype, filterLayout, inputLayout, transC, transO, n, c, hi, wi, k, y, x, o, 
+                   convStrideH, convStrideW, paddingH, paddingW, dilationH, dilationW, group, 
+                   arch, numCU, perf_config)
+    
+    def toCommandLine(self):
+        return (f"-t {self.dataType} "
+                + f"-f {INVERSE_FILTER_LAYOUTS[self.filterLayout]} -I {self.inputLayout.upper()} "
+                + f"-transC {str(self.transC).lower()} -transO {str(self.transO).lower()} "
+                + f"-n {self.n} -c {self.c} -H {self.hi} -W {self.wi} -k {self.k} "
+                + f"-y {self.y} -x {self.x} -p {self.paddingH} -q {self.paddingW} "
+                + f"-u {self.convStrideH} -v {self.convStrideW} -l {self.dilationH} "
+                + f"-j {self.dilationW} -g {self.group}"
+                + f"-gemmO {str(self.o)}")
+
 class GemmGemmConfiguration(PerfConfiguration):
     TABLE_COLUMNS = reportUtils.GEMM_GEMM_TEST_PARAMETERS + ['TFlops']
     def __init__(self, dtype: str, g: int, m: int, k: int, n: int, o: int, 
@@ -916,10 +1167,10 @@ class GemmGemmConfiguration(PerfConfiguration):
             elif opt.endswith("-perf_config"):
                 perf_config = val
             else:
-                raise ValueError(f"Unknown GEMM+GEMM config argument {opt} -> {val}")
+                raise ValueError(f"Unknown gemm+gemm config argument {opt} -> {val}")
         for v in [dtype, g, m, k, n, o, transA, transB, transC, transO]:
             if v is None:
-                raise ValueError("Incomplete GEMM+GEMM configuration")
+                raise ValueError("Incomplete gemm+gemm configuration")
 
         return cls(dtype, g, m, k, n, o, transA, transB, transC, transO, arch, numCU, perf_config)
 
@@ -1565,7 +1816,7 @@ def main(args=None):
         allow_abbrev=False,
     )
 
-    parser.add_argument("--op", "--operation", choices=['conv', 'gemm', 'fusion', 'attention', 'gemm_gemm'],
+    parser.add_argument("--op", "--operation", choices=['conv', 'gemm', 'fusion', 'attention', 'gemm_gemm', 'conv_gemm'],
         default='conv',
         help="Operation to benchmark")
 
@@ -1699,6 +1950,9 @@ def main(args=None):
     elif opType == Operation.GEMM_GEMM:
         confClass = GemmGemmConfiguration
         externalLib = None
+    elif opType == Operation.CONV_GEMM:
+        confClass = ConvGemmConfiguration
+        externalLib = None
 
     configs_path = None if parsed_args.config else parsed_args.configs_file
     paths = create_paths(configs_path, parsed_args.mlir_build_dir)
@@ -1712,6 +1966,8 @@ def main(args=None):
         configs = getAttentionConfigurations(paths.configuration_file_path)
     elif opType == Operation.GEMM_GEMM:
         configs = getGemmGemmConfigurations(paths.configuration_file_path)
+    elif opType == Operation.CONV_GEMM:
+        configs = getConvGemmConfigurations(paths.configuration_file_path)
 
     if parsed_args.external or parsed_args.batch_external or parsed_args.batch_all:
         if not foundExternalTool(paths, opType, externalLib):

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -25,6 +25,9 @@ CONV_TEST_PARAMETERS = ['Direction', 'DataType', 'Chip', 'numCU', 'FilterLayout'
 GEMM_TEST_PARAMETERS = ['DataType', 'OutDataType', 'Chip', 'numCU', 'TransA', 'TransB', 'G', 'M', 'K', 'N', 'PerfConfig']
 ATTN_TEST_PARAMETERS = ['DataType', 'Chip', 'numCU', 'TransQ', 'TransK', 'TransV', 'TransO', 'Causal', 'WithAttnScale', 'WithAttnBias', 'G', 'SeqLenQ', 'SeqLenK', 'HeadDimQK', 'HeadDimV', 'PerfConfig']
 GEMM_GEMM_TEST_PARAMETERS = ['DataType', 'Chip', 'numCU', 'TransA', 'TransB', 'TransC', 'TransO', 'G', 'M', 'K', 'N', 'O', 'PerfConfig']
+CONV_GEMM_TEST_PARAMETERS = ['DataType', 'Chip', 'numCU', 'FilterLayout', 'InputLayout', 'TransC', 'TransO',
+                             'N', 'C', 'H', 'W', 'K', 'Y', 'X', 'DilationH', 'DilationW', 'StrideH', 'StrideW',
+                             'PaddingH', 'PaddingW', 'O', 'PerfConfig']
 ROUND_DIGITS = 2
 
 def geoMean(data):

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -16,6 +16,7 @@ from perfRunner import ConvConfiguration
 from perfRunner import GemmConfiguration
 from perfRunner import AttentionConfiguration
 from perfRunner import GemmGemmConfiguration
+from perfRunner import ConvGemmConfiguration
 from perfRunner import Paths
 from perfCommonUtils import CORRECT_RESULT_RE
 
@@ -251,7 +252,7 @@ def main(args=None):
         allow_abbrev=False,
     )
 
-    parser.add_argument("--op", "--operation", choices=['conv', 'gemm', 'fusion', 'attention', 'gemm_gemm'],
+    parser.add_argument("--op", "--operation", choices=['conv', 'gemm', 'fusion', 'attention', 'gemm_gemm', 'conv_gemm'],
         default='conv',
         help="Operation for tuning")
 
@@ -378,6 +379,8 @@ def main(args=None):
         confClass = AttentionConfiguration
     elif opType == Operation.GEMM_GEMM:
         confClass = GemmGemmConfiguration
+    elif opType == Operation.CONV_GEMM:
+        confClass = ConvGemmConfiguration
     else:
         raise RuntimeError("Tuning operation was not provided/found")
 
@@ -392,6 +395,8 @@ def main(args=None):
         configs = perfRunner.getAttentionConfigurations(paths.configuration_file_path)
     elif opType == Operation.GEMM_GEMM:
         configs = perfRunner.getGemmGemmConfigurations(paths.configuration_file_path)
+    elif opType == Operation.CONV_GEMM:
+        configs = perfRunner.getConvGemmConfigurations(paths.configuration_file_path)
 
     winners, allData = tuneMLIRKernels(configs, confClass, paths, options)
 


### PR DESCRIPTION
conv+gemm support. Migraphx integration will be added in a follow-up PR.
List of changes:
- ConvElementwiseGemmOp operation
- Adapt RockConvToGemmPass to handle conv+gemm as well
- Adapt ConvolutionContext to work with conv+gemm
- Tuning changes for conv+gemm
- Add tests