### PR TITLE
Check time of tests on Jenkins

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -523,7 +523,7 @@ pipeline {
                                 build_fixedE2ETests("${CODEPATH}")
                                 preMergeCheck("${CODEPATH}")
                                 timeout(time: 60, activity: true, unit: 'MINUTES') {
-                                    sh 'cd build; ninja check-mlir check-rocmlir'
+                                    sh 'cd build; time ninja check-mlir check-rocmlir'
                                 }
                             }
                         }


### PR DESCRIPTION
For debug purposes, it would help identify timeouts.