### PR TITLE
Use migraphx.greater instead of migraphx.greater_or_equal

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -77,8 +77,7 @@ def MIGraphX_DivOp :
     MIGraphX_ElementwiseBinaryOp<"div">;
 def MIGraphX_PowOp :
     MIGraphX_ElementwiseBinaryOp<"pow">;
-def MIGraphX_GreaterOrEqual :
-    MIGraphX_ElementwiseBinaryOp<"greater_or_equal">;
+def MIGraphX_Greater : MIGraphX_ElementwiseBinaryOp<"greater">;
 
 def MIGraphX_ClipOp :
     MIGraphX_Op<"clip">,

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -1208,12 +1208,11 @@ struct WhereConverter final : public OpConversionPattern<migraphx::WhereOp> {
                   ConversionPatternRewriter &rewriter) const final;
 };
 
-struct GreaterOrEqualConverter final
-    : public OpConversionPattern<migraphx::GreaterOrEqual> {
-  using OpConversionPattern<migraphx::GreaterOrEqual>::OpConversionPattern;
+struct GreaterConverter final : public OpConversionPattern<migraphx::Greater> {
+  using OpConversionPattern<migraphx::Greater>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(migraphx::GreaterOrEqual op, OpAdaptor adaptor,
+  matchAndRewrite(migraphx::Greater op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // namespace
@@ -1306,17 +1305,17 @@ WhereConverter::matchAndRewrite(migraphx::WhereOp op, OpAdaptor adaptor,
   return success();
 }
 
-LogicalResult GreaterOrEqualConverter::matchAndRewrite(
-    migraphx::GreaterOrEqual op, OpAdaptor adaptor,
-    ConversionPatternRewriter &rewriter) const {
+LogicalResult
+GreaterConverter::matchAndRewrite(migraphx::Greater op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const {
   Value inA = adaptor.getInA();
   Value inB = adaptor.getInB();
 
   // Create a new tensor type with I1 element type
   auto newType =
       RankedTensorType::get(op.getType().getShape(), rewriter.getI1Type());
-  auto goe = rewriter.createOrFold<tosa::GreaterEqualOp>(op->getLoc(), newType,
-                                                         inA, inB);
+  auto goe =
+      rewriter.createOrFold<tosa::GreaterOp>(op->getLoc(), newType, inA, inB);
   rewriter.replaceOpWithNewOp<tosa::CastOp>(op, adaptor.getInA().getType(),
                                             goe);
 
@@ -1509,8 +1508,8 @@ void migraphx::populateMIGraphXToTosaConversionPatterns(
                TrivialConverter<TanhOp, tosa::TanhOp>, QuantizeLinearConverter,
                DeQuantizeLinearConverter, ConvertConverter, NegConverter,
                ReluConverter, SoftmaxConverter, LiteralConverter, ClipConverter,
-               WhereConverter, GreaterOrEqualConverter>(typeConverter,
-                                                        patterns.getContext());
+               WhereConverter, GreaterConverter>(typeConverter,
+                                                 patterns.getContext());
 }
 
 void mlir::migraphx::populateMIGraphXFuncBoundaryToTosaConversionPatterns(

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -1210,10 +1210,10 @@ struct AttentionRewritePattern
         return failure();
 
       auto pred = select.getInput1();
-      if (auto greaterEqual =
-              getDefiningNonReshapeOpNonCastOp<tosa::GreaterEqualOp>(pred)) {
+      if (auto greater =
+              getDefiningNonReshapeOpNonCastOp<tosa::GreaterOp>(pred)) {
         // input1 is a constant with a range from 0 to maxSeqLen
-        auto input1 = greaterEqual.getInput1();
+        auto input1 = greater.getInput1();
         FailureOr<Value> maybeNonZero1 = addBroadcast(input1);
         if (failed(maybeNonZero1))
           return failure();
@@ -1231,7 +1231,7 @@ struct AttentionRewritePattern
           return failure();
 
         // input2 comes from argument: currentSeqLen
-        auto input2 = greaterEqual.getInput2();
+        auto input2 = greater.getInput2();
         FailureOr<Value> maybeNonZero2 = addBroadcast(input2);
         if (failed(maybeNonZero2))
           return failure();

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1423,7 +1423,7 @@ struct GridwiseAttentionAccelRewritePattern
           Block::BlockArgListType lowerCoords = loop.getLowerCoords(0);
           Block::BlockArgListType upperCoords = loop.getLowerCoords(1);
           auto isInvalid = thenb.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::uge, lowerCoords[2], currentSeqLen);
+              loc, arith::CmpIPredicate::ugt, lowerCoords[2], currentSeqLen);
           scf::IfOp ifb = thenb.create<scf::IfOp>(loc, isInvalid,
                                                   /*withElseRegion=*/false);
           {
@@ -2064,11 +2064,8 @@ struct GridwiseAttentionAccelRewritePattern
 
       Value constGemm0MPerBlock =
           rewriter.createOrFold<arith::ConstantIndexOp>(loc, gemm0MPerBlock);
-      Value constGemm0MPerBlockM1 =
-          rewriter.createOrFold<arith::ConstantIndexOp>(loc,
-                                                        gemm0MPerBlock - 1);
       Value numerator = rewriter.create<arith::AddIOp>(loc, currentSeqLen,
-                                                       constGemm0MPerBlockM1);
+                                                       constGemm0MPerBlock);
       Value gemm0MBlocksEarlyExit = rewriter.createOrFold<arith::DivUIOp>(
           loc, numerator, constGemm0MPerBlock);
       Value one = rewriter.createOrFold<arith::ConstantIndexOp>(loc, 1);

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -572,23 +572,23 @@ module  {
     return %0 : !migraphx.shaped<1x12x100x64xf32, 76800x6400x64x1>
   }
   
-  // CHECK-LABEL: func.func @func_greaterorequal
-  // CHECK: %[[ge:.+]] = tosa.greater_equal {{.*}} : (tensor<1x36x384x64xi32>, tensor<1x36x384x64xi32>) -> tensor<1x36x384x64xi1>
+  // CHECK-LABEL: func.func @func_greater
+  // CHECK: %[[ge:.+]] = tosa.greater {{.*}} : (tensor<1x36x384x64xi32>, tensor<1x36x384x64xi32>) -> tensor<1x36x384x64xi1>
   // CHECK-NEXT: tosa.cast %[[ge]] : (tensor<1x36x384x64xi1>) -> tensor<1x36x384x64xi32>
-  func.func @func_greaterorequal(%arg0: !migraphx.shaped<1x36x384x64xi32, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xi32, 884736x24576x64x1> attributes{kernel, arch = ""} {
+  func.func @func_greater(%arg0: !migraphx.shaped<1x36x384x64xi32, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xi32, 884736x24576x64x1> attributes{kernel, arch = ""} {
     %cst = migraphx.literal (dense<1> : tensor<1x36x384x64xi32>) : <1x36x384x64xi32, 884736x24576x64x1>
     %0 = migraphx.add %arg0, %cst : <1x36x384x64xi32, 884736x24576x64x1>, <1x36x384x64xi32, 884736x24576x64x1> -> <1x36x384x64xi32, 884736x24576x64x1>
-    %1 = migraphx.greater_or_equal %arg0, %0 : <1x36x384x64xi32, 884736x24576x64x1>, <1x36x384x64xi32, 884736x24576x64x1> -> <1x36x384x64xi32, 884736x24576x64x1>
+    %1 = migraphx.greater %arg0, %0 : <1x36x384x64xi32, 884736x24576x64x1>, <1x36x384x64xi32, 884736x24576x64x1> -> <1x36x384x64xi32, 884736x24576x64x1>
     return %1 : !migraphx.shaped<1x36x384x64xi32, 884736x24576x64x1>
   }
 
-  // CHECK-LABEL: func.func @func_greaterorequal_si32
-  // CHECK: %[[ge:.+]] = tosa.greater_equal {{.*}} : (tensor<1x36x384x64xi32>, tensor<1x36x384x64xi32>) -> tensor<1x36x384x64xi1>
+  // CHECK-LABEL: func.func @func_greater_si32
+  // CHECK: %[[ge:.+]] = tosa.greater {{.*}} : (tensor<1x36x384x64xi32>, tensor<1x36x384x64xi32>) -> tensor<1x36x384x64xi1>
   // CHECK-NEXT: tosa.cast %[[ge]] : (tensor<1x36x384x64xi1>) -> tensor<1x36x384x64xi32>
-  func.func @func_greaterorequal_si32(%arg0: !migraphx.shaped<1x36x384x64xsi32, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xsi32, 884736x24576x64x1> attributes{kernel, arch = ""} {
+  func.func @func_greater_si32(%arg0: !migraphx.shaped<1x36x384x64xsi32, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xsi32, 884736x24576x64x1> attributes{kernel, arch = ""} {
     %cst = migraphx.literal (dense<1> : tensor<1x36x384x64xsi32>) : <1x36x384x64xsi32, 884736x24576x64x1>
     %0 = migraphx.add %arg0, %cst : <1x36x384x64xsi32, 884736x24576x64x1>, <1x36x384x64xsi32, 884736x24576x64x1> -> <1x36x384x64xsi32, 884736x24576x64x1>
-    %1 = migraphx.greater_or_equal %arg0, %0 : <1x36x384x64xsi32, 884736x24576x64x1>, <1x36x384x64xsi32, 884736x24576x64x1> -> <1x36x384x64xsi32, 884736x24576x64x1>
+    %1 = migraphx.greater %arg0, %0 : <1x36x384x64xsi32, 884736x24576x64x1>, <1x36x384x64xsi32, 884736x24576x64x1> -> <1x36x384x64xsi32, 884736x24576x64x1>
     return %1 : !migraphx.shaped<1x36x384x64xsi32, 884736x24576x64x1>
   }
 }

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-attention-kvcache.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-attention-kvcache.mlir
@@ -24,7 +24,7 @@ func.func @mlir_attention(%arg0: tensor<12288xf16> {mhal.read_access}, %arg1: te
   %7 = tosa.add %cst, %6 : (tensor<1x1x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
   %expanded_5 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<32xi32> into tensor<1x32x1x1xi32>
   %8 = tosa.add %expanded_5, %6 : (tensor<1x32x1x1xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
-  %9 = tosa.greater_equal %7, %8 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
+  %9 = tosa.greater %7, %8 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
   %10 = tosa.cast %9 : (tensor<1x32x1x1024xi1>) -> tensor<1x32x1x1024xi32>
   %11 = tosa.cast %10 : (tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
@@ -73,7 +73,7 @@ func.func @mlir_attention_bias(%arg0: tensor<12288xf16> {mhal.read_access}, %arg
   %8 = tosa.add %cst, %7 : (tensor<1x1x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
   %expanded_6 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<32xi32> into tensor<1x32x1x1xi32>
   %9 = tosa.add %expanded_6, %7 : (tensor<1x32x1x1xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
-  %10 = tosa.greater_equal %8, %9 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
+  %10 = tosa.greater %8, %9 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
   %11 = tosa.cast %10 : (tensor<1x32x1x1024xi1>) -> tensor<1x32x1x1024xi32>
   %12 = tosa.cast %11 : (tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
@@ -123,7 +123,7 @@ func.func @mlir_attention_scale(%arg0: tensor<12288xf16> {mhal.read_access}, %ar
   %8 = tosa.add %cst, %7 : (tensor<1x1x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
   %expanded_6 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<32xi32> into tensor<1x32x1x1xi32>
   %9 = tosa.add %expanded_6, %7 : (tensor<1x32x1x1xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
-  %10 = tosa.greater_equal %8, %9 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
+  %10 = tosa.greater %8, %9 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
   %11 = tosa.cast %10 : (tensor<1x32x1x1024xi1>) -> tensor<1x32x1x1024xi32>
   %12 = tosa.cast %11 : (tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi8>
   %13 = tosa.mul %4, %6, %shift : (tensor<1x32x1x1024xf16>, tensor<1x32x1x1024xf16>, tensor<1xi8>) -> tensor<1x32x1x1024xf16>
@@ -174,7 +174,7 @@ func.func @mlir_attention_scale_bias(%arg0: tensor<12288xf16> {mhal.read_access}
   %9 = tosa.add %cst, %8 : (tensor<1x1x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
   %expanded_7 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<32xi32> into tensor<1x32x1x1xi32>
   %10 = tosa.add %expanded_7, %8 : (tensor<1x32x1x1xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi32>
-  %11 = tosa.greater_equal %9, %10 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
+  %11 = tosa.greater %9, %10 : (tensor<1x32x1x1024xi32>, tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi1>
   %12 = tosa.cast %11 : (tensor<1x32x1x1024xi1>) -> tensor<1x32x1x1024xi32>
   %13 = tosa.cast %12 : (tensor<1x32x1x1024xi32>) -> tensor<1x32x1x1024xi8>
   %14 = tosa.mul %5, %7, %shift : (tensor<1x32x1x1024xf16>, tensor<1x32x1x1024xf16>, tensor<1xi8>) -> tensor<1x32x1x1024xf16>
@@ -227,14 +227,14 @@ func.func @mlir_causal_attention(%arg0: tensor<24576xf16>, %arg1: tensor<262144x
   %cst_5 = arith.constant dense<[[1], [2]]> : tensor<2x1xi32>
   %cst_6 = arith.constant dense<[[[[1], [2]]]]> : tensor<1x1x2x1xi32>
   %15 = tosa.add %cst_6, %11 : (tensor<1x1x2x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %16 = tosa.greater_equal %12, %15 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %16 = tosa.greater %12, %15 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %17 = tosa.cast %16 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %18 = tosa.cast %17 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %19 = tosa.cast %18 : (tensor<1x32x2x64xi8>) -> tensor<1x32x2x64xi1>
   %20 = tosa.select %19, %13, %expanded_4 : (tensor<1x32x2x64xi1>, tensor<1x32x2x64xf16>, tensor<1x32x2x64xf16>) -> tensor<1x32x2x64xf16>
   %expanded_7 = tensor.expand_shape %3 [[0], [1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<1x32xi32> into tensor<1x32x1x1xi32>
   %21 = tosa.add %expanded_7, %11 : (tensor<1x32x1x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %22 = tosa.greater_equal %12, %21 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %22 = tosa.greater %12, %21 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %23 = tosa.cast %22 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %24 = tosa.cast %23 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -282,14 +282,14 @@ func.func @mlir_causal_attention2(%arg0: tensor<24576xf16>, %arg1: tensor<262144
   %expanded_4 = tensor.expand_shape %9 [[0, 1], [2], [3]] output_shape [1, 32, 2, 64] : tensor<32x2x64xf16> into tensor<1x32x2x64xf16>
   %10 = tosa.add %cst_0, %2 : (tensor<1x1x1x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
   %11 = tosa.add %cst, %2 : (tensor<1x1x2x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %12 = tosa.greater_equal %10, %11 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %12 = tosa.greater %10, %11 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %13 = tosa.cast %12 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %14 = tosa.cast %13 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %15 = tosa.cast %14 : (tensor<1x32x2x64xi8>) -> tensor<1x32x2x64xi1>
   %16 = tosa.select %15, %1, %expanded_4 : (tensor<1x32x2x64xi1>, tensor<1x32x2x64xf16>, tensor<1x32x2x64xf16>) -> tensor<1x32x2x64xf16>
   %expanded_5 = tensor.expand_shape %6 [[0], [1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<1x32xi32> into tensor<1x32x1x1xi32>
   %17 = tosa.add %expanded_5, %2 : (tensor<1x32x1x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %18 = tosa.greater_equal %10, %17 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %18 = tosa.greater %10, %17 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %19 = tosa.cast %18 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %20 = tosa.cast %19 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -336,14 +336,14 @@ func.func @mlir_causal_attention_nokvcache_wrongtype(%arg0: tensor<24576xf16>, %
   %expanded_4 = tensor.expand_shape %9 [[0, 1], [2], [3]] output_shape [1, 32, 2, 64] : tensor<32x2x64xf16> into tensor<1x32x2x64xf16>
   %10 = tosa.add %cst_0, %2 : (tensor<1x1x1x64xf32>, tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xf32>
   %11 = tosa.add %cst, %2 : (tensor<1x1x2x1xf32>, tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xf32>
-  %12 = tosa.greater_equal %10, %11 : (tensor<1x32x2x64xf32>, tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xi1>
+  %12 = tosa.greater %10, %11 : (tensor<1x32x2x64xf32>, tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xi1>
   %13 = tosa.cast %12 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xf32>
   %14 = tosa.cast %13 : (tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xi8>
   %15 = tosa.cast %14 : (tensor<1x32x2x64xi8>) -> tensor<1x32x2x64xi1>
   %16 = tosa.select %15, %1, %expanded_4 : (tensor<1x32x2x64xi1>, tensor<1x32x2x64xf16>, tensor<1x32x2x64xf16>) -> tensor<1x32x2x64xf16>
   %expanded_5 = tensor.expand_shape %6 [[0], [1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<1x32xf32> into tensor<1x32x1x1xf32>
   %17 = tosa.add %expanded_5, %2 : (tensor<1x32x1x1xf32>, tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xf32>
-  %18 = tosa.greater_equal %10, %17 : (tensor<1x32x2x64xf32>, tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xi1>
+  %18 = tosa.greater %10, %17 : (tensor<1x32x2x64xf32>, tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xi1>
   %19 = tosa.cast %18 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xf32>
   %20 = tosa.cast %19 : (tensor<1x32x2x64xf32>) -> tensor<1x32x2x64xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -391,14 +391,14 @@ func.func @mlir_causal_attention_nokvcache_noblockarg(%arg0: tensor<24576xf16>, 
   %expanded_4 = tensor.expand_shape %9 [[0, 1], [2], [3]] output_shape [1, 32, 2, 64] : tensor<32x2x64xf16> into tensor<1x32x2x64xf16>
   %10 = tosa.add %cst_0, %2 : (tensor<1x1x1x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
   %11 = tosa.add %cst, %2 : (tensor<1x1x2x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %12 = tosa.greater_equal %10, %11 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %12 = tosa.greater %10, %11 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %13 = tosa.cast %12 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %14 = tosa.cast %13 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %15 = tosa.cast %14 : (tensor<1x32x2x64xi8>) -> tensor<1x32x2x64xi1>
   %16 = tosa.select %15, %1, %expanded_4 : (tensor<1x32x2x64xi1>, tensor<1x32x2x64xf16>, tensor<1x32x2x64xf16>) -> tensor<1x32x2x64xf16>
   %expanded_5 = tensor.expand_shape %6 [[0], [1, 2, 3]] output_shape [1, 32, 1, 1] : tensor<1x32xi32> into tensor<1x32x1x1xi32>
   %17 = tosa.add %expanded_5, %2 : (tensor<1x32x1x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %18 = tosa.greater_equal %10, %17 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %18 = tosa.greater %10, %17 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %19 = tosa.cast %18 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %20 = tosa.cast %19 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -443,13 +443,13 @@ func.func @mlir_causal_attention_nokvcache_wrongbroadcast(%arg0: tensor<24576xf1
   %expanded_4 = tensor.expand_shape %7 [[0, 1], [2], [3]] output_shape [1, 32, 2, 64] : tensor<32x2x64xf16> into tensor<1x32x2x64xf16>
   %8 = tosa.add %cst_0, %2 : (tensor<1x1x1x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
   %9 = tosa.add %cst, %2 : (tensor<1x1x2x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %10 = tosa.greater_equal %8, %9 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %10 = tosa.greater %8, %9 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %11 = tosa.cast %10 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %12 = tosa.cast %11 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %13 = tosa.cast %12 : (tensor<1x32x2x64xi8>) -> tensor<1x32x2x64xi1>
   %14 = tosa.select %13, %1, %expanded_4 : (tensor<1x32x2x64xi1>, tensor<1x32x2x64xf16>, tensor<1x32x2x64xf16>) -> tensor<1x32x2x64xf16>
   %15 = tosa.add %expanded, %2 : (tensor<1x1x1x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %16 = tosa.greater_equal %8, %15 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %16 = tosa.greater %8, %15 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %17 = tosa.cast %16 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %18 = tosa.cast %17 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
@@ -494,13 +494,13 @@ func.func @mlir_causal_attention_nokvcache_wrongrange(%arg0: tensor<24576xf16>, 
   %expanded_4 = tensor.expand_shape %7 [[0, 1], [2], [3]] output_shape [1, 32, 2, 64] : tensor<32x2x64xf16> into tensor<1x32x2x64xf16>
   %8 = tosa.add %cst_0, %2 : (tensor<1x1x1x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
   %9 = tosa.add %cst, %2 : (tensor<1x1x2x1xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %10 = tosa.greater_equal %8, %9 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %10 = tosa.greater %8, %9 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %11 = tosa.cast %10 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %12 = tosa.cast %11 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %13 = tosa.cast %12 : (tensor<1x32x2x64xi8>) -> tensor<1x32x2x64xi1>
   %14 = tosa.select %13, %1, %expanded_4 : (tensor<1x32x2x64xi1>, tensor<1x32x2x64xf16>, tensor<1x32x2x64xf16>) -> tensor<1x32x2x64xf16>
   %15 = tosa.add %expanded, %2 : (tensor<1x1x1x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi32>
-  %16 = tosa.greater_equal %8, %15 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
+  %16 = tosa.greater %8, %15 : (tensor<1x32x2x64xi32>, tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi1>
   %17 = tosa.cast %16 : (tensor<1x32x2x64xi1>) -> tensor<1x32x2x64xi32>
   %18 = tosa.cast %17 : (tensor<1x32x2x64xi32>) -> tensor<1x32x2x64xi8>
   %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -318,21 +318,20 @@ func.func @gridwise_attn_kvcache(%arg0: memref<1x384x64xf32>, %arg1: memref<1x64
   %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 384] -> [1, 384, 64]> : memref<1x384x64xf32> to memref<1x64x384xf32>
   // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
   // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
-  // CHECK-DAG: %[[c31:.+]] = arith.constant 31 : index
   // CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
   // CHECK: %[[currSeqLenTensor:.+]] = rock.transform %arg4 by #{{.+}} : memref<1xi32> to memref<1x1xi32>
   // CHECK: %[[registers:.+]] = rock.alloc() : memref<1xi32, #gpu.address_space<private>>
   // CHECK-NEXT: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%[[currSeqLenTensor]]) [%{{.+}}] -> %[[registers]] : memref<1x1xi32> -> memref<1xi32, #gpu.address_space<private>>, vector<1xi1>
   // CHECK-NEXT: %[[currSeqLen:.+]] = rock.in_bounds_load %[[registers]][%[[c0]]] : memref<1xi32, #gpu.address_space<private>>, index -> i32
   // CHECK-NEXT: %[[currSeqLenIndex:.+]] = arith.index_cast %[[currSeqLen]] : i32 to index
-  // CHECK: %[[num:.+]] = arith.addi %[[currSeqLenIndex]], %[[c31]] : index
+  // CHECK: %[[num:.+]] = arith.addi %[[currSeqLenIndex]], %[[c32]] : index
   // CHECK-NEXT: %[[numIter:.+]] = arith.divui %[[num]], %[[c32]] : index
   // CHECK-NEXT: %[[lastIter:.+]] = arith.subi %[[numIter]], %[[c1]] : index
   // CHECK-NEXT: scf.for %[[iterIndex:.+]] = %[[c0]] to %[[numIter]] step %[[c1]] {
   // CHECK: %[[comparison:.+]] = arith.cmpi eq, %[[iterIndex]], %[[lastIter]] : index
   // CHECK-NEXT: scf.if %[[comparison]] {
   // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs} (%[[dim0:.+]], %[[dim1:.+]], %[[dim2:.+]]) = [{{.*}}]({{.*}}), ({{.*}}) = []
-  // CHECK-NEXT: %[[secondComparison:.+]] = arith.cmpi uge, %[[dim2]], %[[currSeqLenIndex]] : index
+  // CHECK-NEXT: %[[secondComparison:.+]] = arith.cmpi ugt, %[[dim2]], %[[currSeqLenIndex]] : index
   // CHECK-NEXT: scf.if %[[secondComparison]] {
   // CHECK-NEXT: rock.in_bounds_store
   rock.gridwise_attention_accel(%0, %arg1, %arg2, %arg4, %arg3) features =  mfma|dot|atomic_add|atomic_add_f16 preSoftmaxOps = {} {

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-bias.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-bias.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 1 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 0 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
@@ -14,7 +14,7 @@ module {
     %11 = migraphx.multibroadcast %0 {out_lens = [1, 32, 1, 1024]} : <1xf16, 1> -> <1x32x1x1024xf16, 0x0x0x0>
     %12 = migraphx.multibroadcast %2 {out_lens = [1, 32, 1, 1024]} : <1024xi32, 1> -> <1x32x1x1024xi32, 0x0x0x1>
     %13 = migraphx.multibroadcast %arg3 {out_lens = [1, 32, 1, 1024]} : <1x32xi32, 32x1> -> <1x32x1x1024xi32, 32x1x0x0>
-    %14 = migraphx.greater_or_equal %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
+    %14 = migraphx.greater %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
     %15 = migraphx.convert %14 : <1x32x1x1024xi32, 32768x1024x1024x1> to <1x32x1x1024xi8, 32768x1024x1024x1>
     %16 = migraphx.mul %qk_biased, %11 : <1x32x1x1024xf16, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0> -> <1x32x1x1024xf16, 32768x1024x1024x1>
     %17 = migraphx.where %15, %10, %16 : <1x32x1x1024xi8, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0>, <1x32x1x1024xf16, 32768x1024x1024x1> -> <1x32x1x1024xf16, 32768x1024x1024x1>

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-causal.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-causal.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 1 -rand_max_int 64 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 0 -rand_max_int 64 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
@@ -15,12 +15,12 @@ module {
     %9 = migraphx.multibroadcast %1 {out_dyn_dims = [], out_lens = [1, 32, 2, 64]} : <1xf16, 1> -> <1x32x2x64xf16, 0x0x0x0>
     %10 = migraphx.reshape %0 {dims = [2, 1]} : <2xsi32, 1> -> <2x1xsi32, 1x1>
     %11 = migraphx.multibroadcast %10 {out_dyn_dims = [], out_lens = [1, 32, 2, 64]} : <2x1xsi32, 1x1> -> <1x32x2x64xsi32, 0x0x1x0>
-    %12 = migraphx.greater_or_equal %7, %11 : <1x32x2x64xsi32, 0x0x0x1>, <1x32x2x64xsi32, 0x0x1x0> -> <1x32x2x64xsi32, 4096x128x64x1>
+    %12 = migraphx.greater %7, %11 : <1x32x2x64xsi32, 0x0x0x1>, <1x32x2x64xsi32, 0x0x1x0> -> <1x32x2x64xsi32, 4096x128x64x1>
     %13 = migraphx.convert %12 {target_type = 0 : i64} : <1x32x2x64xsi32, 4096x128x64x1> to <1x32x2x64xsi8, 4096x128x64x1>
     %14 = migraphx.where %13, %8, %6 : <1x32x2x64xsi8, 4096x128x64x1>, <1x32x2x64xf16, 0x0x0x0>, <1x32x2x64xf16, 4096x128x64x1> -> <1x32x2x64xf16, 4096x128x64x1>
     %15 = migraphx.reshape %arg3 {dims = [1, 32, 1, 1]} : <1x32xsi32, 0x0> -> <1x32x1x1xsi32, 32x1x1x1>
     %16 = migraphx.multibroadcast %15 {out_dyn_dims = [], out_lens = [1, 32, 2, 64]} : <1x32x1x1xsi32, 32x1x1x1> -> <1x32x2x64xsi32, 32x1x0x0>
-    %17 = migraphx.greater_or_equal %7, %16 : <1x32x2x64xsi32, 0x0x0x1>, <1x32x2x64xsi32, 32x1x0x0> -> <1x32x2x64xsi32, 4096x128x64x1>
+    %17 = migraphx.greater %7, %16 : <1x32x2x64xsi32, 0x0x0x1>, <1x32x2x64xsi32, 32x1x0x0> -> <1x32x2x64xsi32, 4096x128x64x1>
     %18 = migraphx.convert %17 {target_type = 0 : i64} : <1x32x2x64xsi32, 4096x128x64x1> to <1x32x2x64xsi8, 4096x128x64x1>
     %19 = migraphx.mul %14, %9 : <1x32x2x64xf16, 4096x128x64x1>, <1x32x2x64xf16, 0x0x0x0> -> <1x32x2x64xf16, 4096x128x64x1>
     %20 = migraphx.where %18, %8, %19 : <1x32x2x64xsi8, 4096x128x64x1>, <1x32x2x64xf16, 0x0x0x0>, <1x32x2x64xf16, 4096x128x64x1> -> <1x32x2x64xf16, 4096x128x64x1>

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-scale-bias.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-scale-bias.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 1 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 0 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
@@ -15,7 +15,7 @@ module {
     %11 = migraphx.multibroadcast %0 {out_lens = [1, 32, 1, 1024]} : <1xf16, 1> -> <1x32x1x1024xf16, 0x0x0x0>
     %12 = migraphx.multibroadcast %2 {out_lens = [1, 32, 1, 1024]} : <1024xi32, 1> -> <1x32x1x1024xi32, 0x0x0x1>
     %13 = migraphx.multibroadcast %arg3 {out_lens = [1, 32, 1, 1024]} : <1x32xi32, 32x1> -> <1x32x1x1024xi32, 32x1x0x0>
-    %14 = migraphx.greater_or_equal %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
+    %14 = migraphx.greater %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
     %15 = migraphx.convert %14 : <1x32x1x1024xi32, 32768x1024x1024x1> to <1x32x1x1024xi8, 32768x1024x1024x1>
     %16 = migraphx.mul %qk_biased, %11 : <1x32x1x1024xf16, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0> -> <1x32x1x1024xf16, 32768x1024x1024x1>
     %17 = migraphx.where %15, %10, %16 : <1x32x1x1024xi8, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0>, <1x32x1x1024xf16, 32768x1024x1024x1> -> <1x32x1x1024xf16, 32768x1024x1024x1>

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-scale.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-scale.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 1 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 0 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
@@ -14,7 +14,7 @@ module {
     %11 = migraphx.multibroadcast %0 {out_lens = [1, 32, 1, 1024]} : <1xf16, 1> -> <1x32x1x1024xf16, 0x0x0x0>
     %12 = migraphx.multibroadcast %2 {out_lens = [1, 32, 1, 1024]} : <1024xi32, 1> -> <1x32x1x1024xi32, 0x0x0x1>
     %13 = migraphx.multibroadcast %arg3 {out_lens = [1, 32, 1, 1024]} : <1x32xi32, 32x1> -> <1x32x1x1024xi32, 32x1x0x0>
-    %14 = migraphx.greater_or_equal %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
+    %14 = migraphx.greater %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
     %15 = migraphx.convert %14 : <1x32x1x1024xi32, 32768x1024x1024x1> to <1x32x1x1024xi8, 32768x1024x1024x1>
     %16 = migraphx.mul %qk_scaled, %11 : <1x32x1x1024xf16, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0> -> <1x32x1x1024xf16, 32768x1024x1024x1>
     %17 = migraphx.where %15, %10, %16 : <1x32x1x1024xi8, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0>, <1x32x1x1024xf16, 32768x1024x1024x1> -> <1x32x1x1024xf16, 32768x1024x1024x1>

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-si32.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-si32.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 1 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 0 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
@@ -14,7 +14,7 @@ module {
     %8 = migraphx.multibroadcast %2 {out_dyn_dims = [], out_lens = [1, 32, 1, 1024]} : <1024xsi32, 1> -> <1x32x1x1024xsi32, 0x0x0x1>
     %9 = migraphx.reshape %arg3 {dims = [1, 32, 1, 1]} : <1x32xsi32, 1x0> -> <1x32x1x1xsi32, 32x1x1x1>
     %10 = migraphx.multibroadcast %9 {out_dyn_dims = [], out_lens = [1, 32, 1, 1024]} : <1x32x1x1xsi32, 32x1x1x1> -> <1x32x1x1024xsi32, 32x1x1x0>
-    %11 = migraphx.greater_or_equal %8, %10 : <1x32x1x1024xsi32, 0x0x0x1>, <1x32x1x1024xsi32, 32x1x1x0> -> <1x32x1x1024xsi32, 32768x1024x1024x1>
+    %11 = migraphx.greater %8, %10 : <1x32x1x1024xsi32, 0x0x0x1>, <1x32x1x1024xsi32, 32x1x1x0> -> <1x32x1x1024xsi32, 32768x1024x1024x1>
     %12 = migraphx.convert %11 {target_type = 0 : i64} : <1x32x1x1024xsi32, 32768x1024x1024x1> to <1x32x1x1024xsi8, 32768x1024x1024x1>
     %13 = migraphx.mul %5, %7 : <1x32x1x1024xf16, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0> -> <1x32x1x1024xf16, 32768x1024x1024x1>
     %14 = migraphx.where %12, %6, %13 : <1x32x1x1024xsi8, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0>, <1x32x1x1024xf16, 32768x1024x1024x1> -> <1x32x1x1024xf16, 32768x1024x1024x1>

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 1 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 0 -rand_max_int 1024 -rand_type_int_for_inputs=3 -rand 1 -rand_type float -fut mlir_attention_wrapper -RMS_threshold 0.01  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
@@ -13,7 +13,7 @@ module {
     %11 = migraphx.multibroadcast %0 {out_lens = [1, 32, 1, 1024]} : <1xf16, 1> -> <1x32x1x1024xf16, 0x0x0x0>
     %12 = migraphx.multibroadcast %2 {out_lens = [1, 32, 1, 1024]} : <1024xi32, 1> -> <1x32x1x1024xi32, 0x0x0x1>
     %13 = migraphx.multibroadcast %arg3 {out_lens = [1, 32, 1, 1024]} : <1x32xi32, 32x1> -> <1x32x1x1024xi32, 32x1x0x0>
-    %14 = migraphx.greater_or_equal %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
+    %14 = migraphx.greater %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
     %15 = migraphx.convert %14 : <1x32x1x1024xi32, 32768x1024x1024x1> to <1x32x1x1024xi8, 32768x1024x1024x1>
     %16 = migraphx.mul %9, %11 : <1x32x1x1024xf16, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0> -> <1x32x1x1024xf16, 32768x1024x1024x1>
     %17 = migraphx.where %15, %10, %16 : <1x32x1x1024xi8, 32768x1024x1024x1>, <1x32x1x1024xf16, 0x0x0x0>, <1x32x1x1024xf16, 32768x1024x1024x1> -> <1x32x1x1024xf16, 32768x1024x1024x1>

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache_f32.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 1 -rand_max_int 1024 -rand_type_int_for_inputs=3 -relDiff_threshold 0.00005 -rand 1 -rand_type float -fut mlir_attention_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand_min_int 0 -rand_max_int 1024 -rand_type_int_for_inputs=3 -relDiff_threshold 0.00005 -rand 1 -rand_type float -fut mlir_attention_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // ALLOW_RETRIES: 2
 // CHECK: [1 1 1]
 module {
@@ -13,7 +13,7 @@ module {
     %11 = migraphx.multibroadcast %0 {out_lens = [1, 32, 1, 1024]} : <1xf32, 1> -> <1x32x1x1024xf32, 0x0x0x0>
     %12 = migraphx.multibroadcast %2 {out_lens = [1, 32, 1, 1024]} : <1024xi32, 1> -> <1x32x1x1024xi32, 0x0x0x1>
     %13 = migraphx.multibroadcast %arg3 {out_lens = [1, 32, 1, 1024]} : <1x32xi32, 32x1> -> <1x32x1x1024xi32, 32x1x0x0>
-    %14 = migraphx.greater_or_equal %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
+    %14 = migraphx.greater %12, %13 : <1x32x1x1024xi32, 0x0x0x1>, <1x32x1x1024xi32, 32x1x0x0> -> <1x32x1x1024xi32, 32768x1024x1024x1>
     %15 = migraphx.convert %14 : <1x32x1x1024xi32, 32768x1024x1024x1> to <1x32x1x1024xi8, 32768x1024x1024x1>
     %16 = migraphx.mul %9, %11 : <1x32x1x1024xf32, 32768x1024x1024x1>, <1x32x1x1024xf32, 0x0x0x0> -> <1x32x1x1024xf32, 32768x1024x1024x1>
     %17 = migraphx.where %15, %10, %16 : <1x32x1x1024xi8, 32768x1024x1024x1>, <1x32x1x1024xf32, 0x0x0x0>, <1x32x1x1024xf32, 32768x1024x1024x1> -> <1x32x1x1024xf32, 32768x1024x1024x1>

--- a/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache.mlir
@@ -52,7 +52,7 @@
 // CHECK_SCALE: %[[zero2:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[rangeBroadcast2:.*]] = tosa.add %[[zero2]], %[[range2Reshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[currSeqLenTensorBroadcast2:.*]] = tosa.add %[[zero2]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
-// CHECK_SCALE: %[[mask2:.*]] = tosa.greater_equal %[[rangeBroadcast2]], %[[currSeqLenTensorBroadcast2]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
+// CHECK_SCALE: %[[mask2:.*]] = tosa.greater %[[rangeBroadcast2]], %[[currSeqLenTensorBroadcast2]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
 // CHECK_SCALE: %[[one:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[scaleTensorBeforeReshape:.*]] = tosa.select %[[mask2]], %[[one]], %[[scaledReshaped]] : (tensor<1x4x1024x1024xi1>, tensor<1x4x1024x1024xf32>, tensor<1x4x1024x1024xf32>) -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[scaleTensor:.*]] = tosa.reshape %[[scaleTensorBeforeReshape]], %{{.*}} : (tensor<1x4x1024x1024xf32>, !tosa.shape<3>) -> tensor<4x1024x1024xf32>
@@ -64,7 +64,7 @@
 // CHECK_SCALE: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[rangeBroadcast:.*]] = tosa.add %[[zero]], %[[rangeReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
-// CHECK_SCALE: %[[mask:.*]] = tosa.greater_equal %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
+// CHECK_SCALE: %[[mask:.*]] = tosa.greater %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
 // CHECK_SCALE: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[qkTensorBeforeReshape:.*]] = tosa.select %[[mask]], %[[negInf]], %[[qkTensorReshaped]] : (tensor<1x4x1024x1024xi1>, tensor<1x4x1024x1024xf32>, tensor<1x4x1024x1024xf32>) -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[qkTensor:.*]] = tosa.reshape %[[qkTensorBeforeReshape]], %{{.*}} : (tensor<1x4x1024x1024xf32>, !tosa.shape<3>) -> tensor<4x1024x1024xf32>
@@ -129,7 +129,7 @@
 // CHECK_NO_SCALE: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
 // CHECK_NO_SCALE: %[[rangeBroadcast:.*]] = tosa.add %[[zero]], %[[rangeReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_NO_SCALE: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
-// CHECK_NO_SCALE: %[[mask:.*]] = tosa.greater_equal %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
+// CHECK_NO_SCALE: %[[mask:.*]] = tosa.greater %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
 // CHECK_NO_SCALE: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
 // CHECK_NO_SCALE: %[[qkTensorBeforeReshape:.*]] = tosa.select %[[mask]], %[[negInf]], %[[qkTensorReshaped]] : (tensor<1x4x1024x1024xi1>, tensor<1x4x1024x1024xf32>, tensor<1x4x1024x1024xf32>) -> tensor<1x4x1024x1024xf32>
 // CHECK_NO_SCALE: %[[qkTensor:.*]] = tosa.reshape %[[qkTensorBeforeReshape]], %{{.*}} : (tensor<1x4x1024x1024xf32>, !tosa.shape<3>) -> tensor<4x1024x1024xf32>

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -2500,9 +2500,9 @@ static Value maskKVCacheTosa(OpBuilder builder, Location loc, Value inputTensor,
       builder, loc, builder.getI32Type(), zeroTensor, currentSeqLenVal);
 
   // create mask
-  auto mask = createOpAndInfer<tosa::GreaterEqualOp>(
-      builder, loc, builder.getIntegerType(1), rangeBroadcast,
-      currentSeqLenBroadcast);
+  auto mask =
+      createOpAndInfer<tosa::GreaterOp>(builder, loc, builder.getIntegerType(1),
+                                        rangeBroadcast, currentSeqLenBroadcast);
 
   // create a tensor with a single value and broadcast it
   assert(isa<FloatType>(inpType.getElementType()));


### PR DESCRIPTION
migraphx team asked us to use greater instead of greater_or_equal, so that their kv-cache integration code becomes easier.