### PR TITLE
Causal attention

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -217,7 +217,7 @@ def Rock_AttentionOp
           Optional<TensorOrMemRefOf<[I32]>>:$currentSeqLen,
           TensorOrMemRefOf<[F32, F16, BF16]>:$out, UnitAttr:$qTransposed,
           UnitAttr:$kTransposed, UnitAttr:$vTransposed, UnitAttr:$oTransposed,
-          StrAttr:$arch, Rock_GemmFeaturesAttr:$features,
+          UnitAttr:$causal, StrAttr:$arch, Rock_GemmFeaturesAttr:$features,
           OptionalAttr<I32Attr>:$numCU,
           OptionalAttr<RockTuningParamAttrInterface>:$params0,
           OptionalAttr<RockTuningParamAttrInterface>:$params1,
@@ -238,6 +238,8 @@ def Rock_AttentionOp
     transposed. For example, if `qTransposed` is set, then the argument `queries` should be
     a [G] x head_qk x seq_q memory.
 
+    If causal is enabled, we implement causal masking.
+
     Those creating a `rock.attention` must specify the GPU architecture being targetted
     and the number of compute units (numCu) available. The parameters
     `gridSize`, and `blockSize` are optional as they can be inferred by
@@ -252,6 +254,7 @@ def Rock_AttentionOp
     `{` `\n`
         ` ` `qk` `=` (`tr` $qTransposed^)? $queries `*` (`tr` $kTransposed^)? $keys `:` type($queries) `,` type($keys) `\n`
         (`currentSeqLen` `=` `(` $currentSeqLen^ `:` type($currentSeqLen) `)` `\n`)?
+        (`causal` `\n` $causal^)?
         (`qk` `=` `elementwise` (`otherIns` `(` $preSoftmaxElemWiseInputs^ `:` type($preSoftmaxElemWiseInputs) `)`)? $preSoftmaxBody^ `\n`)?
         (`tr` $oTransposed^)? $out `=` `softmax` `(` `qk` `)` `*` (`tr` $vTransposed^)? $values `:` type($values) `->` type($out) `\n`
     `}` attr-dict (`->` type($result)^)?
@@ -496,8 +499,8 @@ def Rock_GridwiseAttentionAccelOp
           MemRefRankOf<[F32, F16, BF16], [3]>:$values,
           Variadic<AnyTensorOrMemRef>:$preSoftmaxElemWiseInputs,
           Optional<MemRefRankOf<[I32], [1]>>:$currentSeqLen,
-          MemRefRankOf<[F32, F16, BF16], [3]>:$out, StrAttr:$arch,
-          Rock_GemmFeaturesAttr:$features, I32Attr:$blockSize,
+          MemRefRankOf<[F32, F16, BF16], [3]>:$out, UnitAttr:$causal,
+          StrAttr:$arch, Rock_GemmFeaturesAttr:$features, I32Attr:$blockSize,
           I32Attr:$gridSize, UnitAttr:$disableQBypassLDS,
           OptionalAttr<IndexAttr>:$prePadG0M,
           OptionalAttr<IndexAttr>:$prePadG0N,

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -1456,7 +1456,8 @@ struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
         /*qTransposed=*/nullptr,
         /*kTransposed=*/nullptr,
         /*vTransposed=*/nullptr,
-        /*oTransposed=*/nullptr, arch,
+        /*oTransposed=*/nullptr,
+        /*causal=*/nullptr, arch,
         rewriter.getAttr<rock::GemmFeaturesAttr>(features), numCUAttr,
         /*params0=*/nullptr, /*params1=*/nullptr,
         /*firstGemmIdx=*/rewriter.getI32IntegerAttr(0));

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -140,7 +140,7 @@ static LogicalResult
 commonAttentionGemmElmtGemm(ConversionPatternRewriter &rw,
                             RockGemmGemmWrapperInterface op, Value a, Value b,
                             Value c, Value out, Value currentSeqLen,
-                            ValueRange elementwiseInputs,
+                            UnitAttr causal, ValueRange elementwiseInputs,
                             Region &preSecondOpRegion, bool enableSoftmax) {
   Location loc = op->getLoc();
 
@@ -218,7 +218,7 @@ commonAttentionGemmElmtGemm(ConversionPatternRewriter &rw,
     prePadG0NAttr = rw.getIndexAttr(gemm0Size.n);
   }
   auto newOp = rw.create<GridwiseAttentionAccelOp>(
-      loc, a, b, c, elementwiseInputs, currentSeqLen, out,
+      loc, a, b, c, elementwiseInputs, currentSeqLen, out, causal,
       rw.getStringAttr(op.getArch()),
       rw.getAttr<rock::GemmFeaturesAttr>(op.getGemmFeatures()), blockSizeAttr,
       gridSizeAttr,
@@ -585,7 +585,7 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
                                          ConversionPatternRewriter &rw) const {
   return commonAttentionGemmElmtGemm(
       rw, op, adaptor.getQueries(), adaptor.getKeys(), adaptor.getValues(),
-      adaptor.getOut(), adaptor.getCurrentSeqLen(),
+      adaptor.getOut(), adaptor.getCurrentSeqLen(), adaptor.getCausalAttr(),
       adaptor.getPreSoftmaxElemWiseInputs(), op.getPreSoftmaxBody(),
       /*enableSoftmax=*/true);
 }
@@ -602,8 +602,9 @@ LogicalResult GemmElementwiseGemmRewritePattern::matchAndRewrite(
     ConversionPatternRewriter &rw) const {
   return commonAttentionGemmElmtGemm(
       rw, op, adaptor.getA(), adaptor.getB(), adaptor.getC(), adaptor.getOut(),
-      /*currentSeqLen=*/nullptr, adaptor.getElemwiseInputs(),
-      op.getPreSecondGemmBody(), /*enableSoftmax=*/false);
+      /*currentSeqLen=*/nullptr, /*causal=*/nullptr,
+      adaptor.getElemwiseInputs(), op.getPreSecondGemmBody(),
+      /*enableSoftmax=*/false);
 }
 
 LogicalResult GemmElementwiseGemmRewritePattern::computeGridSize(

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1383,12 +1383,14 @@ struct GridwiseAttentionAccelRewritePattern
     }
   }
 
-  void setGemm0OutputOutOfScopeKVCache(
-      PatternRewriter &rewriter, Location loc,
+  enum class OutOfScopeType { KVCache, Causal };
+
+  void setGemm0OutputOutOfScope(
+      PatternRewriter &rewriter, Location loc, OutOfScopeType outOfScopeType,
       layout::GridCoordinates gridCoords, Value gemm0OutBuffer,
-      RegsAsMatrixSubTiles gemm0OutSubTileViews, Value currentSeqLen,
-      Value mLoopIV, Value gemm0MBlocksLastIter) const {
-    if (currentSeqLen) {
+      RegsAsMatrixSubTiles gemm0OutSubTileViews, bool enabled, Value mLoopIV,
+      Value gemm0MBlocksLastIter, Value currentSeqLen = nullptr) const {
+    if (enabled) {
       auto isLastIteration = rewriter.create<arith::CmpIOp>(
           loc, arith::CmpIPredicate::eq, mLoopIV, gemm0MBlocksLastIter);
       scf::IfOp ifb = rewriter.create<scf::IfOp>(loc, isLastIteration,
@@ -1422,8 +1424,19 @@ struct GridwiseAttentionAccelRewritePattern
 
           Block::BlockArgListType lowerCoords = loop.getLowerCoords(0);
           Block::BlockArgListType upperCoords = loop.getLowerCoords(1);
-          auto isInvalid = thenb.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::ugt, lowerCoords[2], currentSeqLen);
+          Value isInvalid;
+          switch (outOfScopeType) {
+          case OutOfScopeType::KVCache:
+            assert(currentSeqLen != nullptr);
+            isInvalid = thenb.create<arith::CmpIOp>(
+                loc, arith::CmpIPredicate::ugt, lowerCoords[2], currentSeqLen);
+            break;
+          case OutOfScopeType::Causal:
+            isInvalid = thenb.create<arith::CmpIOp>(
+                loc, arith::CmpIPredicate::ugt, lowerCoords[2], lowerCoords[1]);
+            break;
+          }
+
           scf::IfOp ifb = thenb.create<scf::IfOp>(loc, isInvalid,
                                                   /*withElseRegion=*/false);
           {
@@ -1664,6 +1677,91 @@ struct GridwiseAttentionAccelRewritePattern
     return viewBuilder.get();
   }
 
+  std::tuple<LoopLikeOpInterface, Value, Value>
+  getMLoop(PatternRewriter &rewriter, Location loc,
+           layout::GridCoordinates gridCoordsGemm0LoadCurrSeqLen,
+           Value currentSeqLenTensor, int64_t gemm0MBlocks,
+           int64_t gemm0MPerBlock, int64_t gemm0NPerBlock, bool isCausal,
+           bool isKVCache) const {
+
+    LoopLikeOpInterface mLoopOp;
+    Value gemm0MBlocksLastIter;
+    Value currentSeqLen;
+    Value effectiveSeqLen; // min(currentSeqLen, causalMaskingOut)
+    // This is needed for KV Cache/Causal masking support
+    if (isCausal || isKVCache) {
+      Value zero = rewriter.createOrFold<arith::ConstantIndexOp>(loc, 0);
+      if (isKVCache) {
+        // add dim 1 for thread_read_into (registers)
+        ArrayRef<int64_t> inpShape =
+            cast<ShapedType>(currentSeqLenTensor.getType()).getShape();
+        SmallVector<StringRef> startNames = {"gemmG"};
+        rock::BottomUpTMBuilder addDim(rewriter, startNames, inpShape);
+        addDim.addDim("dummy", 1, 1);
+        addDim.passThrough(ArrayRef<uint32_t>{0}, ArrayRef<uint32_t>{0});
+        auto addDimAttr = addDim.get();
+        Value currentSeqLenTensorAddDim = rewriter.create<rock::TransformOp>(
+            loc, currentSeqLenTensor, addDimAttr);
+        Type currentSeqLenElemType =
+            getElementTypeOrSelf(currentSeqLenTensorAddDim.getType());
+
+        // create registers
+        auto privateMemoryAddressSpace =
+            rewriter.getAttr<gpu::AddressSpaceAttr>(
+                gpu::GPUDialect::getPrivateAddressSpace());
+        auto memrefType = MemRefType::get(
+            {1}, currentSeqLenElemType, AffineMap{}, privateMemoryAddressSpace);
+        auto currentSeqLenLoad = rewriter.create<GpuAllocOp>(loc, memrefType);
+
+        // load from memory to registers
+        rewriter.create<ThreadwiseReadIntoOp>(
+            loc, vectorOfBoolShapedLike(currentSeqLenLoad),
+            currentSeqLenTensorAddDim, currentSeqLenLoad,
+            /*dynamicValidities=*/ValueRange{},
+            /*extraViews=*/rewriter.getArrayAttr({}),
+            /*extraIndices=*/
+            ValueRange{gridCoordsGemm0LoadCurrSeqLen.g_block}, true, true);
+
+        // load from registers
+        Value currentSeqLenValue = rewriter.create<InBoundsLoadOp>(
+            loc, currentSeqLenElemType, currentSeqLenLoad, ValueRange{zero});
+        currentSeqLen = rewriter.createOrFold<arith::IndexCastOp>(
+            loc, rewriter.getIndexType(), currentSeqLenValue);
+        effectiveSeqLen = currentSeqLen;
+      }
+      if (isCausal) {
+        // get max n for block
+        Value nIndex = gridCoordsGemm0LoadCurrSeqLen.n_block;
+        Value constGemm0NPerBlock =
+            rewriter.createOrFold<arith::ConstantIndexOp>(loc, gemm0NPerBlock);
+        Value maxRowOfBlock =
+            rewriter.create<arith::MulIOp>(loc, nIndex, constGemm0NPerBlock);
+
+        if (effectiveSeqLen)
+          maxRowOfBlock = rewriter.create<arith::MinUIOp>(loc, currentSeqLen,
+                                                          maxRowOfBlock);
+
+        effectiveSeqLen = maxRowOfBlock;
+      }
+
+      Value constGemm0MPerBlock =
+          rewriter.createOrFold<arith::ConstantIndexOp>(loc, gemm0MPerBlock);
+      Value numerator = rewriter.create<arith::AddIOp>(loc, effectiveSeqLen,
+                                                       constGemm0MPerBlock);
+      Value gemm0MBlocksEarlyExit = rewriter.createOrFold<arith::DivUIOp>(
+          loc, numerator, constGemm0MPerBlock);
+      Value one = rewriter.createOrFold<arith::ConstantIndexOp>(loc, 1);
+      gemm0MBlocksLastIter =
+          rewriter.createOrFold<arith::SubIOp>(loc, gemm0MBlocksEarlyExit, one);
+
+      mLoopOp =
+          rewriter.create<scf::ForOp>(loc, zero, gemm0MBlocksEarlyExit, one);
+    } else {
+      mLoopOp = rewriter.create<affine::AffineForOp>(loc, 0, gemm0MBlocks, 1);
+    }
+    return std::make_tuple(mLoopOp, gemm0MBlocksLastIter, currentSeqLen);
+  }
+
   LogicalResult matchAndRewrite(GridwiseAttentionAccelOp op,
                                 PatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
@@ -1688,6 +1786,8 @@ struct GridwiseAttentionAccelRewritePattern
     Type elemTypeOut = cast<MemRefType>(trOut.getType()).getElementType();
 
     TypedValue<MemRefType> currentSeqLenTensor = op.getCurrentSeqLen();
+    bool isKVCache = currentSeqLenTensor != nullptr;
+    bool isCausal = op.getCausal();
 
     // Gemm0 out is casted to be elemTypeV
     Type elemTypeQxK = elemTypeV;
@@ -2012,71 +2112,23 @@ struct GridwiseAttentionAccelRewritePattern
     }
 
     bool isReverseGrid = succeeded(rock::getReverseGrid(op));
-    if (isReverseGrid && currentSeqLenTensor) {
+    if (isReverseGrid && (isCausal || isKVCache)) {
       return op.emitError(
-          "reverse grid is not compatible with currentSeqLen\n");
+          "reverse grid is not compatible with causal or currentSeqLen\n");
     }
+
+    auto gridCoordsGemm0mIter0 = layout::makeGxNGridLayout(
+        rewriter, loc, bid,
+        rewriter.createOrFold<arith::ConstantIndexOp>(loc, 0), gemm0NBlocks,
+        gridSize, arch);
 
     LoopLikeOpInterface mLoopOp;
     Value gemm0MBlocksLastIter;
     Value currentSeqLen;
-    // This is needed for KV Cache support
-    if (currentSeqLenTensor) {
-      Value zero = rewriter.createOrFold<arith::ConstantIndexOp>(loc, 0);
-      auto gridCoordsGemm0LoadCurrSeqLen = layout::makeGxNGridLayout(
-          rewriter, loc, bid, zero, gemm0NBlocks, gridSize, arch);
-
-      // add dim 1 for thread_read_into (registers)
-      ArrayRef<int64_t> inpShape =
-          cast<ShapedType>(currentSeqLenTensor.getType()).getShape();
-      SmallVector<StringRef> startNames = {"gemmG"};
-      rock::BottomUpTMBuilder addDim(rewriter, startNames, inpShape);
-      addDim.addDim("dummy", 1, 1);
-      addDim.passThrough(ArrayRef<uint32_t>{0}, ArrayRef<uint32_t>{0});
-      auto addDimAttr = addDim.get();
-      Value currentSeqLenTensorAddDim = rewriter.create<rock::TransformOp>(
-          loc, currentSeqLenTensor, addDimAttr);
-      Type currentSeqLenElemType =
-          getElementTypeOrSelf(currentSeqLenTensorAddDim.getType());
-
-      // create registers
-      auto privateMemoryAddressSpace = rewriter.getAttr<gpu::AddressSpaceAttr>(
-          gpu::GPUDialect::getPrivateAddressSpace());
-      auto memrefType = MemRefType::get({1}, currentSeqLenElemType, AffineMap{},
-                                        privateMemoryAddressSpace);
-      auto currentSeqLenLoad = rewriter.create<GpuAllocOp>(loc, memrefType);
-
-      // load from memory to registers
-      rewriter.create<ThreadwiseReadIntoOp>(
-          loc, vectorOfBoolShapedLike(currentSeqLenLoad),
-          currentSeqLenTensorAddDim, currentSeqLenLoad,
-          /*dynamicValidities=*/ValueRange{},
-          /*extraViews=*/rewriter.getArrayAttr({}),
-          /*extraIndices=*/
-          ValueRange{gridCoordsGemm0LoadCurrSeqLen.g_block}, true, true);
-
-      // load from registers
-      Value currentSeqLenValue = rewriter.create<InBoundsLoadOp>(
-          loc, currentSeqLenElemType, currentSeqLenLoad, ValueRange{zero});
-
-      currentSeqLen = rewriter.createOrFold<arith::IndexCastOp>(
-          loc, rewriter.getIndexType(), currentSeqLenValue);
-
-      Value constGemm0MPerBlock =
-          rewriter.createOrFold<arith::ConstantIndexOp>(loc, gemm0MPerBlock);
-      Value numerator = rewriter.create<arith::AddIOp>(loc, currentSeqLen,
-                                                       constGemm0MPerBlock);
-      Value gemm0MBlocksEarlyExit = rewriter.createOrFold<arith::DivUIOp>(
-          loc, numerator, constGemm0MPerBlock);
-      Value one = rewriter.createOrFold<arith::ConstantIndexOp>(loc, 1);
-      gemm0MBlocksLastIter =
-          rewriter.createOrFold<arith::SubIOp>(loc, gemm0MBlocksEarlyExit, one);
-
-      mLoopOp =
-          rewriter.create<scf::ForOp>(loc, zero, gemm0MBlocksEarlyExit, one);
-    } else {
-      mLoopOp = rewriter.create<affine::AffineForOp>(loc, 0, gemm0MBlocks, 1);
-    }
+    // get mLoop
+    std::tie(mLoopOp, gemm0MBlocksLastIter, currentSeqLen) = getMLoop(
+        rewriter, loc, gridCoordsGemm0mIter0, currentSeqLenTensor, gemm0MBlocks,
+        gemm0MPerBlock, gemm0NPerBlock, isCausal, isKVCache);
     {
       PatternRewriter::InsertionGuard guard(rewriter);
       // workaround for mLoopOp.getBody()
@@ -2258,10 +2310,16 @@ struct GridwiseAttentionAccelRewritePattern
                                        gemm0OutSubTileViewsTrUnPadded, isGfx11);
         }
         // Negative Infinite for extra values (KV cache)
-        setGemm0OutputOutOfScopeKVCache(rewriter, loc, gridCoordsGemm0,
-                                        gemm0OutBuffer, gemm0OutSubTileViewsTr,
-                                        currentSeqLen, mLoopIV,
-                                        gemm0MBlocksLastIter);
+        setGemm0OutputOutOfScope(rewriter, loc, OutOfScopeType::KVCache,
+                                 gridCoordsGemm0, gemm0OutBuffer,
+                                 gemm0OutSubTileViewsTr, isKVCache, mLoopIV,
+                                 gemm0MBlocksLastIter, currentSeqLen);
+
+        // Negative Infinite for extra values (causal masking)
+        setGemm0OutputOutOfScope(rewriter, loc, OutOfScopeType::Causal,
+                                 gridCoordsGemm0, gemm0OutBuffer,
+                                 gemm0OutSubTileViewsTr, isCausal, mLoopIV,
+                                 gemm0MBlocksLastIter);
 
         APInt reductionAxis = APInt(64, 1);
         // Softmax max reduction

--- a/mlir/lib/Dialect/Rock/Transforms/SortDimensionsMemoryLayout.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SortDimensionsMemoryLayout.cpp
@@ -558,8 +558,9 @@ struct AttentionRewritePattern : public OpRewritePattern<rock::AttentionOp> {
         op->getLoc(), op->getResultTypes(), newTensorQ, newTensorK, newTensorV,
         op.getPreSoftmaxElemWiseInputs(), op.getCurrentSeqLen(), op.getOut(),
         transposedQ, transposedK, transposedV, op.getOTransposedAttr(),
-        op.getArchAttr(), op.getFeaturesAttr(), op.getNumCUAttr(),
-        op.getParams0Attr(), op.getParams1Attr(), op.getFirstGemmIdxAttr());
+        op.getCausalAttr(), op.getArchAttr(), op.getFeaturesAttr(),
+        op.getNumCUAttr(), op.getParams0Attr(), op.getParams1Attr(),
+        op.getFirstGemmIdxAttr());
 
     // copy linalg::GenericOp if there's any
     bool linalgOpFound = false;

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -662,6 +662,15 @@ getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
   else
     problemOS << "false" << sep;
 
+  if (isAttention) {
+    auto attentionOp = cast<AttentionOp>(gemmGemmOp);
+    problemOS << "-causal ";
+    if (attentionOp.getCausal())
+      problemOS << "true" << sep;
+    else
+      problemOS << "false" << sep;
+  }
+
   problemOS << "-g " << g << sep;
   if (isAttention) {
     problemOS << "-seq_len_q " << seqLenQ << sep;

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -268,6 +268,25 @@ func.func @rock_attention_kvcache(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x
   return
 }
 
+// CHECK-LABEL: func.func @rock_attention_causal
+// CHECK-SAME: (%[[q:.*]]: memref<1x64x1024xf32>, %[[k:.*]]: memref<1x64x1024xf32>, %[[v:.*]]: memref<1x1024x64xf32>, %[[o:.*]]: memref<1x1024x64xf32>)
+func.func @rock_attention_causal(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x64x1024xf32>, %arg2: memref<1x1024x64xf32>, %arg3: memref<1x1024x64xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908", block_size = 64 : i32, grid_size = 1024 : i32} {
+  // CHECK: rock.gridwise_attention_accel(%[[q]], %[[k]], %[[v]], %[[o]])
+  // CHECK-NEXT: , causal,
+  rock.attention{
+     qk = tr %arg0 * %arg1 : memref<1x64x1024xf32>, memref<1x64x1024xf32>
+     causal
+     %arg3 = softmax(qk) * %arg2 : memref<1x1024x64xf32> -> memref<1x1024x64xf32>
+  } {
+    arch = "amdgcn-amd-amdhsa:gfx908",
+    features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>,
+    params0 = #xldops_attn_params_g0,
+    params1 = #xldops_attn_params_g1,
+    firstGemmIdx = 0 : i32
+  }
+  return
+}
+
 // CHECK-LABEL: func.func @rock_gemmelementwisegemm_simple
 // CHECK-SAME: (%[[a:.*]]: memref<1x64x1024xf32>, %[[b:.*]]: memref<1x64x1024xf32>, %[[c:.*]]: memref<1x1024x64xf32>, %[[o:.*]]: memref<1x1024x64xf32>)
 func.func @rock_gemmelementwisegemm_simple(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x64x1024xf32>, %arg2: memref<1x1024x64xf32>, %arg3: memref<1x1024x64xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908", block_size = 64 : i32, grid_size = 1024 : i32} {

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -345,3 +345,50 @@ func.func @gridwise_attn_kvcache(%arg0: memref<1x384x64xf32>, %arg1: memref<1x64
   } : memref<1x64x384xf32>, memref<1x64x384xf32>, memref<1x384x64xf32>, memref<1xi32>, memref<1x384x64xf32>
   return
 }
+
+// -----
+
+// CHECK: @gridwise_attn_causal_kvcache
+func.func @gridwise_attn_causal_kvcache(%arg0: memref<1x384x64xf32>, %arg1: memref<1x64x384xf32>, %arg2: memref<1x384x64xf32>, %arg3: memref<1x384x64xf32>, %arg4: memref<1xi32>) attributes {block_size = 64 : i32, grid_size = 24 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-"} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 384] -> [1, 384, 64]> : memref<1x384x64xf32> to memref<1x64x384xf32>
+  // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
+  // CHECK-DAG: %[[c12:.+]] = arith.constant 12 : index
+  // CHECK-DAG: %[[workgroupId:.+]] = rock.workgroup_id : index
+  // CHECK-DAG: %[[blockIdN:.+]] = arith.remui %[[workgroupId]], %[[c12]] : index
+  // CHECK: %[[currSeqLenTensor:.+]] = rock.transform %arg4 by #{{.+}} : memref<1xi32> to memref<1x1xi32>
+  // CHECK: %[[registers:.+]] = rock.alloc() : memref<1xi32, #gpu.address_space<private>>
+  // CHECK-NEXT: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%[[currSeqLenTensor]]) [%{{.+}}] -> %[[registers]] : memref<1x1xi32> -> memref<1xi32, #gpu.address_space<private>>, vector<1xi1>
+  // CHECK-NEXT: %[[currSeqLen:.+]] = rock.in_bounds_load %[[registers]][%[[c0]]] : memref<1xi32, #gpu.address_space<private>>, index -> i32
+  // CHECK-NEXT: %[[currSeqLenIndex:.+]] = arith.index_cast %[[currSeqLen]] : i32 to index
+  // CHECK-NEXT: %[[maxRowOfBlock:.+]] = arith.muli %[[blockIdN]], %[[c32]] : index
+  // CHECK-NEXT: %[[minCausalCurrSeqLen:.+]] = arith.minui %[[currSeqLenIndex]], %[[maxRowOfBlock]] : index
+  // CHECK: %[[num:.+]] = arith.addi %[[minCausalCurrSeqLen]], %[[c32]] : index
+  // CHECK-NEXT: %[[numIter:.+]] = arith.divui %[[num]], %[[c32]] : index
+  // CHECK-NEXT: %[[lastIter:.+]] = arith.subi %[[numIter]], %[[c1]] : index
+  // CHECK-NEXT: scf.for %[[iterIndex:.+]] = %[[c0]] to %[[numIter]] step %[[c1]] {
+  // CHECK: %[[comparison:.+]] = arith.cmpi eq, %[[iterIndex]], %[[lastIter]] : index
+  // CHECK-NEXT: scf.if %[[comparison]] {
+  // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs} (%[[dim0:.+]], %[[dim1:.+]], %[[dim2:.+]]) = [{{.*}}]({{.*}}), ({{.*}}) = []
+  // CHECK-NEXT: %[[secondComparison:.+]] = arith.cmpi ugt, %[[dim2]], %[[currSeqLenIndex]] : index
+  // CHECK-NEXT: scf.if %[[secondComparison]] {
+  // CHECK-NEXT: rock.in_bounds_store
+  // CHECK: %[[causalComparison:.+]] = arith.cmpi eq, %[[iterIndex]], %[[lastIter]] : index
+  // CHECK-NEXT: scf.if %[[causalComparison]] {
+  // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs} (%[[dim0:.+]], %[[dim1:.+]], %[[dim2:.+]]) = [{{.*}}]({{.*}}), ({{.*}}) = []
+  // CHECK-NEXT: %[[causalSecondComparison:.+]] = arith.cmpi ugt, %[[dim2]], %[[dim1]] : index
+  // CHECK-NEXT: scf.if %[[causalSecondComparison]] {
+  // CHECK-NEXT: rock.in_bounds_store
+  rock.gridwise_attention_accel(%0, %arg1, %arg2, %arg4, %arg3) features =  mfma|dot|atomic_add|atomic_add_f16 preSoftmaxOps = {} {
+    arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-",
+    blockSize = 64 : i32,
+    causal,
+    gridSize = 24 : i32,
+    operandSegmentSizes = array<i32: 1, 1, 1, 0, 1, 1>,
+    params0 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>,
+    params1 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>,
+    firstGemmIdx = 0 : i32
+  } : memref<1x64x384xf32>, memref<1x64x384xf32>, memref<1x384x64xf32>, memref<1xi32>, memref<1x384x64xf32>
+  return
+}

--- a/mlir/test/e2e/PrAttentionBF16.toml
+++ b/mlir/test/e2e/PrAttentionBF16.toml
@@ -80,6 +80,10 @@ config = "-seq_len_q 128 -seq_len_k 27 -head_dim_qk 64 -head_dim_v 32 --with-att
 [[suite.test]]
 config = "-seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
 
+# causal
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"
+
 # GQA
 [[suite.test]]
 config = "-num_heads_q 4 -num_heads_kv 2 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
@@ -91,3 +95,7 @@ config = "-rand 1 -current_seq_len=17 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 
 # GQA + KV Cache batch=3
 [[suite.test]]
 config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + causal + KV Cache batch=3
+[[suite.test]]
+config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"

--- a/mlir/test/e2e/PrAttentionF16.toml
+++ b/mlir/test/e2e/PrAttentionF16.toml
@@ -80,6 +80,10 @@ config = "-seq_len_q 128 -seq_len_k 27 -head_dim_qk 64 -head_dim_v 32 --with-att
 [[suite.test]]
 config = "-seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
 
+# causal
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"
+
 # GQA
 [[suite.test]]
 config = "-num_heads_q 4 -num_heads_kv 2 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
@@ -91,3 +95,7 @@ config = "-rand 1 -current_seq_len=17 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 
 # GQA + KV Cache batch=3
 [[suite.test]]
 config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + causal + KV Cache batch=3
+[[suite.test]]
+config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"

--- a/mlir/test/e2e/PrAttentionF32.toml
+++ b/mlir/test/e2e/PrAttentionF32.toml
@@ -44,6 +44,10 @@ config = "-seq_len_q 128 -seq_len_k 27 -head_dim_qk 64 -head_dim_v 32 --with-att
 [[suite.test]]
 config = "-seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
 
+# causal
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"
+
 # GQA
 [[suite.test]]
 config = "-num_heads_q 4 -num_heads_kv 2 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
@@ -55,3 +59,7 @@ config = "-rand 1 -current_seq_len=17 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 
 # GQA + KV Cache batch=3
 [[suite.test]]
 config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + causal + KV Cache batch=3
+[[suite.test]]
+config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"

--- a/mlir/test/e2e/PrAttentionI8.toml
+++ b/mlir/test/e2e/PrAttentionI8.toml
@@ -53,6 +53,10 @@ config = "-seq_len_q 128 -seq_len_k 27 -head_dim_qk 64 -head_dim_v 32 --with-att
 [[suite.test]]
 config = "-seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
 
+# causal
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"
+
 # GQA
 [[suite.test]]
 config = "-num_heads_q 4 -num_heads_kv 2 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
@@ -64,3 +68,7 @@ config = "-rand 1 -current_seq_len=17 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 
 # GQA + KV Cache batch=3
 [[suite.test]]
 config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + causal + KV Cache batch=3
+[[suite.test]]
+config = "-rand 1 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"

--- a/mlir/test/fusion/mixr-attention-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-problem-key.mlir
@@ -2,7 +2,7 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
 // CHECK: gfx942
 // CHECK-SAME: 304
-// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -g 1 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3
+// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -g 1 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3
 module 
 {
   func.func private @mlir_attention(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1> {mhal.read_access},

--- a/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q0k0v0-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q0k0v0-e2e.mlir
@@ -5,7 +5,7 @@
 // ALLOW_RETRIES: 2
 // CLONE: [1 1 1]
 
-// EMITKEY: -t f16 -transQ false -transK false -transV false -transO false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
+// EMITKEY: -t f16 -transQ false -transK false -transV false -transO false -causal false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
 
 // VECTORIZATION: qVectorDim: GemmDimension::K
 // VECTORIZATION-NEXT: qVectorLen: 4

--- a/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q0k0v1-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q0k0v1-e2e.mlir
@@ -5,7 +5,7 @@
 // ALLOW_RETRIES: 2
 // CLONE: [1 1 1]
 
-// EMITKEY: -t f16 -transQ false -transK false -transV true -transO false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
+// EMITKEY: -t f16 -transQ false -transK false -transV true -transO false -causal false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
 
 // VECTORIZATION: qVectorDim: GemmDimension::K
 // VECTORIZATION-NEXT: qVectorLen: 4

--- a/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q0k1v0-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q0k1v0-e2e.mlir
@@ -5,7 +5,7 @@
 // ALLOW_RETRIES: 2
 // CLONE: [1 1 1]
 
-// EMITKEY: -t f16 -transQ false -transK true -transV false -transO false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
+// EMITKEY: -t f16 -transQ false -transK true -transV false -transO false -causal false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
 
 // VECTORIZATION: qVectorDim: GemmDimension::K
 // VECTORIZATION-NEXT: qVectorLen: 4

--- a/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q1k0v0-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q1k0v0-e2e.mlir
@@ -5,7 +5,7 @@
 // ALLOW_RETRIES: 2
 // CLONE: [1 1 1]
 
-// EMITKEY: -t f16 -transQ true -transK false -transV false -transO false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
+// EMITKEY: -t f16 -transQ true -transK false -transV false -transO false -causal false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
 
 // VECTORIZATION: qVectorDim: GemmDimension::MorN
 // VECTORIZATION-NEXT: qVectorLen: 8

--- a/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q1k1v1-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/attention-layouts/sliced-attention-q1k1v1-e2e.mlir
@@ -5,7 +5,7 @@
 // ALLOW_RETRIES: 2
 // CLONE: [1 1 1]
 
-// EMITKEY: -t f16 -transQ true -transK true -transV true -transO false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
+// EMITKEY: -t f16 -transQ true -transK true -transV true -transO false -causal false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 16 -head_dim_v 8
 
 // VECTORIZATION: qVectorDim: GemmDimension::MorN
 // VECTORIZATION-NEXT: qVectorLen: 8

--- a/mlir/test/fusion/pr-e2e/attention-layouts/unitdim-attention-q0k0v1-e2e.mlir
+++ b/mlir/test/fusion/pr-e2e/attention-layouts/unitdim-attention-q0k0v1-e2e.mlir
@@ -5,7 +5,7 @@
 // ALLOW_RETRIES: 2
 // CLONE: [1 1 1]
 
-// EMITKEY: -t f16 -transQ false -transK false -transV true -transO false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 1 -head_dim_v 8
+// EMITKEY: -t f16 -transQ false -transK false -transV true -transO false -causal false -g 1 -seq_len_q 32 -seq_len_k 64 -head_dim_qk 1 -head_dim_v 8
 
 // VECTORIZATION: qVectorDim: GemmDimension::MorN
 // VECTORIZATION-NEXT: qVectorLen: 8

--- a/mlir/test/rocmlir-gen/attention-kernel-causal.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-causal.mlir
@@ -1,0 +1,61 @@
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -causal -seq_len_q 512 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 --with-attn-scale -t f32 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope
+
+// CHECK: module attributes {mhal.arch = "[[$ARCH:.*]]"}
+
+// CHECK-LABEL: func.func @rock_attention
+// CHECK-SAME: (%[[queriesRaw:.*0]]: memref<16384xf32>,
+// CHECK-SAME: %[[keysRaw:.*1]]: memref<32768xf32>,
+// CHECK-SAME: %[[valuesRaw:.*2]]: memref<32768xf32>,
+// CHECK-SAME: %[[scaleRaw:.*3]]: memref<524288xf32>,
+// CHECK-SAME: %[[outputRaw:.*4]]: memref<16384xf32>)
+// CHECK-SAME: attributes {kernel, mhal.arch = "[[$ARCH]]"}
+// CHECK-NEXT: %[[queries:.*]] = rock.transform %[[queriesRaw]] {{.*}} : memref<16384xf32> to memref<1x512x32xf32>
+// CHECK-NEXT: %[[keys:.*]] = rock.transform %[[keysRaw]] {{.*}} : memref<32768xf32> to memref<1x32x1024xf32>
+// CHECK-NEXT: %[[values:.*]] = rock.transform %[[valuesRaw]] {{.*}} : memref<32768xf32> to memref<1x1024x32xf32>
+// CHECK-NEXT: %[[scale:.*]] = rock.transform %[[scaleRaw]] {{.*}} : memref<524288xf32> to memref<1x512x1024xf32>
+// CHECK-NEXT: %[[output:.*]] = rock.transform %[[outputRaw]] {{.*}} : memref<16384xf32> to memref<1x512x32xf32>
+
+// CHECK-NEXT: rock.attention
+// CHECK-NEXT: qk = %[[queries]] * %[[keys]]
+// CHECK-NEXT: causal
+// CHECK-NEXT: qk = elementwise otherIns(%[[scale]]
+// CHECK: %[[output]] = softmax(qk) * %[[values]]
+// CHECK: return
+
+// CHECK-LABEL: func.func @host_naive_attention
+// CHECK: %[[qkTensorOrig:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
+
+// CHECK: %[[scaledReshaped:.*]] = tosa.reshape %[[scaledTensorRaw:.*]], %{{.*}} : (tensor<524288xf32>, !tosa.shape<3>) -> tensor<1x512x1024xf32>
+// CHECK: %[[range2:.*]] = "tosa.const"() <{values = {{.*}} : tensor<512xi32>}> : () -> tensor<512xi32>
+// CHECK: %[[range2Reshaped:.*]] = tosa.reshape %[[range2:.*]], %{{.*}} : (tensor<512xi32>, !tosa.shape<3>) -> tensor<1x512x1xi32>
+// CHECK: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x512x1024xi32>}> : () -> tensor<1x512x1024xi32>
+// CHECK: %[[rangeBroadcast2:.*]] = tosa.add %[[zero]], %[[range2Reshaped]] : (tensor<1x512x1024xi32>, tensor<1x512x1xi32>) -> tensor<1x512x1024xi32>
+// CHECK: %[[range3:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
+// CHECK: %[[range3Reshaped:.*]] = tosa.reshape %[[range3:.*]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<3>) -> tensor<1x1x1024xi32>
+// CHECK: %[[zero2:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x512x1024xi32>}> : () -> tensor<1x512x1024xi32>
+// CHECK: %[[rangeBroadcast3:.*]] = tosa.add %[[zero2]], %[[range3Reshaped]] : (tensor<1x512x1024xi32>, tensor<1x1x1024xi32>) -> tensor<1x512x1024xi32>
+// CHECK: %[[mask2:.*]] = tosa.greater %[[rangeBroadcast3]], %[[rangeBroadcast2]] : (tensor<1x512x1024xi32>, tensor<1x512x1024xi32>) -> tensor<1x512x1024xi1>
+// CHECK: %[[ones:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<1x512x1024xf32>}> : () -> tensor<1x512x1024xf32>
+// CHECK: %[[scaleTensor:.*]] = tosa.select %[[mask2]], %[[ones]], %[[scaledReshaped]] : (tensor<1x512x1024xi1>, tensor<1x512x1024xf32>, tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32>
+// CHECK: %[[sqkTensor:.*]] = tosa.mul %[[qkTensorOrig]], %[[scaleTensor]], %{{.*}} : (tensor<1x512x1024xf32>, tensor<1x512x1024xf32>, tensor<1xi8>) -> tensor<1x512x1024xf32>
+
+// CHECK: %[[range4:.*]] = "tosa.const"() <{values = {{.*}} : tensor<512xi32>}> : () -> tensor<512xi32>
+// CHECK: %[[range4Reshaped:.*]] = tosa.reshape %[[range4:.*]], %{{.*}} : (tensor<512xi32>, !tosa.shape<3>) -> tensor<1x512x1xi32>
+// CHECK: %[[zero3:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x512x1024xi32>}> : () -> tensor<1x512x1024xi32>
+// CHECK: %[[rangeBroadcast4:.*]] = tosa.add %[[zero3]], %[[range4Reshaped]] : (tensor<1x512x1024xi32>, tensor<1x512x1xi32>) -> tensor<1x512x1024xi32>
+// CHECK: %[[range5:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
+// CHECK: %[[range5Reshaped:.*]] = tosa.reshape %[[range5:.*]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<3>) -> tensor<1x1x1024xi32>
+// CHECK: %[[zero4:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x512x1024xi32>}> : () -> tensor<1x512x1024xi32>
+// CHECK: %[[rangeBroadcast5:.*]] = tosa.add %[[zero4]], %[[range5Reshaped]] : (tensor<1x512x1024xi32>, tensor<1x1x1024xi32>) -> tensor<1x512x1024xi32>
+// CHECK: %[[mask3:.*]] = tosa.greater %[[rangeBroadcast5]], %[[rangeBroadcast4]] : (tensor<1x512x1024xi32>, tensor<1x512x1024xi32>) -> tensor<1x512x1024xi1>
+// CHECK: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x512x1024xf32>}> : () -> tensor<1x512x1024xf32>
+// CHECK: %[[qkTensor:.*]] = tosa.select %[[mask3]], %[[negInf]], %[[sqkTensor]] : (tensor<1x512x1024xi1>, tensor<1x512x1024xf32>, tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32
+
+// CHECK-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[qkTensor]] {{.*}} : (tensor<1x512x1024xf32>) -> tensor<1x512x1xf32>
+// CHECK-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[qkTensor]], %[[sqkMaxs]] : (tensor<1x512x1024xf32>, tensor<1x512x1xf32>) -> tensor<1x512x1024xf32>
+// CHECK-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedSqkTensor]] : (tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32>
+// CHECK-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : (tensor<1x512x1024xf32>) -> tensor<1x512x1xf32>
+// CHECK-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : (tensor<1x512x1xf32>) -> tensor<1x512x1xf32>
+// CHECK-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : (tensor<1x512x1024xf32>, tensor<1x512x1xf32>, tensor<1xi8>) -> tensor<1x512x1024xf32>
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : (tensor<1x512x1024xf32>, tensor<1x1024x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x512x32xf32>
+// CHECK: return

--- a/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache.mlir
@@ -49,8 +49,9 @@
 // CHECK_SCALE: %[[scaledReshaped:.*]] = tosa.reshape %[[scaledFirstReshaped:.*]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[range2:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
 // CHECK_SCALE: %[[range2Reshaped:.*]] = tosa.reshape %[[range2:.*]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<4>) -> tensor<1x1x1x1024xi32>
+// CHECK_SCALE: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
+// CHECK_SCALE: %[[rangeBroadcast2:.*]] = tosa.add %[[zero]], %[[range2Reshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[zero2:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
-// CHECK_SCALE: %[[rangeBroadcast2:.*]] = tosa.add %[[zero2]], %[[range2Reshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[currSeqLenTensorBroadcast2:.*]] = tosa.add %[[zero2]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[mask2:.*]] = tosa.greater %[[rangeBroadcast2]], %[[currSeqLenTensorBroadcast2]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
 // CHECK_SCALE: %[[one:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
@@ -61,9 +62,10 @@
 // CHECK_SCALE: %[[qkTensorReshaped:.*]] = tosa.reshape %[[sqkTensor]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[range:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
 // CHECK_SCALE: %[[rangeReshaped:.*]] = tosa.reshape %[[range:.*]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<4>) -> tensor<1x1x1x1024xi32>
-// CHECK_SCALE: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
-// CHECK_SCALE: %[[rangeBroadcast:.*]] = tosa.add %[[zero]], %[[rangeReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
-// CHECK_SCALE: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
+// CHECK_SCALE: %[[zero3:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
+// CHECK_SCALE: %[[rangeBroadcast:.*]] = tosa.add %[[zero3]], %[[rangeReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
+// CHECK_SCALE: %[[zero4:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
+// CHECK_SCALE: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero4]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_SCALE: %[[mask:.*]] = tosa.greater %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
 // CHECK_SCALE: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[qkTensorBeforeReshape:.*]] = tosa.select %[[mask]], %[[negInf]], %[[qkTensorReshaped]] : (tensor<1x4x1024x1024xi1>, tensor<1x4x1024x1024xf32>, tensor<1x4x1024x1024xf32>) -> tensor<1x4x1024x1024xf32>
@@ -128,7 +130,8 @@
 // CHECK_NO_SCALE: %[[rangeReshaped:.*]] = tosa.reshape %[[range]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<4>) -> tensor<1x1x1x1024xi32>
 // CHECK_NO_SCALE: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
 // CHECK_NO_SCALE: %[[rangeBroadcast:.*]] = tosa.add %[[zero]], %[[rangeReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
-// CHECK_NO_SCALE: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
+// CHECK_NO_SCALE: %[[zero2:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
+// CHECK_NO_SCALE: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero2]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
 // CHECK_NO_SCALE: %[[mask:.*]] = tosa.greater %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
 // CHECK_NO_SCALE: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
 // CHECK_NO_SCALE: %[[qkTensorBeforeReshape:.*]] = tosa.select %[[mask]], %[[negInf]], %[[qkTensorReshaped]] : (tensor<1x4x1024x1024xi1>, tensor<1x4x1024x1024xf32>, tensor<1x4x1024x1024xf32>) -> tensor<1x4x1024x1024xf32>

--- a/mlir/test/rocmlir-gen/problem-key.mlir
+++ b/mlir/test/rocmlir-gen/problem-key.mlir
@@ -1,17 +1,19 @@
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_1
-// CHECK_1: -t f32 -transQ false -transK false -transV false -transO false -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_1: -t f32 -transQ false -transK false -transV false -transO false -causal false -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -g 4 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_2
-// CHECK_2: -t f16 -transQ false -transK false -transV false -transO false -g 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_2: -t f16 -transQ false -transK false -transV false -transO false -causal false -g 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_3
-// CHECK_3: -t i8 -transQ false -transK false -transV false -transO false -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_3: -t i8 -transQ false -transK false -transV false -transO false -causal false -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 // RUN: rocmlir-gen --arch gfx942 --operation attention -num_heads_q 4 -num_heads_kv 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_4
-// CHECK_4: -t i8 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_4: -t i8 -transQ false -transK false -transV false -transO false -causal false -g 32 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 // RUN: rocmlir-gen --arch gfx942 --operation attention -num_heads_q 4 -num_heads_kv 2 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_5
-// CHECK_5: -t i8 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_5: -t i8 -transQ false -transK false -transV false -transO false -causal false -g 32 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 // RUN: rocmlir-gen --arch gfx942 --operation attention -current_seq_len=16 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_6
-// CHECK_6: -t i8 -transQ false -transK false -transV false -transO false -g 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_6: -t i8 -transQ false -transK false -transV false -transO false -causal false -g 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 // RUN: rocmlir-gen --arch gfx942 --operation attention -current_seq_len=16,16,17,1,30,40,38,12 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_7
-// CHECK_7: -t i8 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_7: -t i8 -transQ false -transK false -transV false -transO false -causal false -g 32 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -causal -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_8
+// CHECK_8: -t f16 -transQ false -transK false -transV false -transO false -causal true -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
 
 // RUN: rocmlir-gen --arch gfx942 --operation conv -t f16 --fil_layout gkc01 --in_layout ngc01 --out_layout ngk01 --batchsize 64 --in_channels 256 --in_h 20 --in_w 20 --out_channels 256 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 3 --padding_w 3 --groupsize 256 --kernel-repeats 1 --perf_config=v3:32,256,2,32,32,4,1,1,2,1,1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_DEPTHWISE_CONV
 // CHECK_DEPTHWISE_CONV: convfp16 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 64 -c 256 -H 20 -W 20 -k 256 -y 7 -x 7 -p 3 -q 3 -u 1 -v 1 -l 1 -j 1 -g 256

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -609,6 +609,11 @@ static llvm::cl::opt<bool> transposeO(
                    "Gxseq_len_qxhead_v (default) or Gxhead_vxseq_len_q"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool>
+    causalMasking("causal",
+                  llvm::cl::desc("whether we implement causal masking"),
+                  llvm::cl::init(false));
+
 //////////////////////////////////////////////////////////////////////////
 ////  Host Generator options
 //////////////////////////////////////////////////////////////////////////
@@ -2452,6 +2457,84 @@ static Value addTensorArgToBlock(OpBuilder &builder, Location loc,
   return funcArgTensor;
 }
 
+static Value applyMask(OpBuilder builder, Location loc, Value inputTensor,
+                       Value mask, float initValue) {
+  auto inpType = cast<RankedTensorType>(inputTensor.getType());
+  ArrayRef<int64_t> inpShape = inpType.getShape();
+
+  // create a tensor with a single value and broadcast it
+  assert(isa<FloatType>(inpType.getElementType()));
+  std::pair<APFloat, llvm::detail::opStatus> floatRes =
+      rock::createAPFloat(inpType.getElementType(), initValue);
+  APFloat fpVal = floatRes.first;
+  auto status = floatRes.second;
+  assert(status == APFloat::opOK);
+
+  DenseElementsAttr initValueAttr = DenseFPElementsAttr::get(
+      RankedTensorType::get(inpShape, inpType.getElementType()), fpVal);
+
+  Value initVal = builder.create<tosa::ConstOp>(loc, initValueAttr.getType(),
+                                                initValueAttr);
+
+  // mask is 1 for values we want to set to "initVal"
+  auto result = createOpAndInfer<tosa::SelectOp>(
+      builder, loc, inpType.getElementType(), mask, initVal, inputTensor);
+  return result;
+}
+
+static Value createRange(OpBuilder builder, Location loc, size_t index,
+                         const ArrayRef<int64_t> inpShape) {
+  assert(index < inpShape.size());
+
+  // create range 0 to inpShape[axis]
+  llvm::SmallVector<int32_t> range;
+  range.reserve(inpShape[index]);
+  for (int i = 0; i < inpShape[index]; i++)
+    range.push_back(i);
+  DenseElementsAttr rangeAttr = DenseIntElementsAttr::get(
+      RankedTensorType::get({inpShape[index]}, builder.getI32Type()), range);
+  Value rangeVal =
+      builder.create<tosa::ConstOp>(loc, rangeAttr.getType(), rangeAttr);
+
+  // reshape
+  ImplicitLocOpBuilder implicitBuilder(loc, builder);
+  SmallVector<int64_t> newShape;
+  newShape.reserve(inpShape.size());
+  for (size_t i = 0; i < inpShape.size(); i++)
+    newShape.push_back((i == index) ? inpShape[index] : 1);
+
+  auto shapeValue = tosa::getTosaConstShape(implicitBuilder, newShape);
+  auto rangeValReshaped = createOpAndInfer<tosa::ReshapeOp>(
+      builder, loc, builder.getI32Type(), rangeVal, shapeValue);
+
+  // broadcast range to inputTensor shape
+  auto outType = RankedTensorType::get(inpShape, builder.getI32Type());
+  auto zeroValue = cast<ElementsAttr>(builder.getZeroAttr(outType));
+  auto zeroTensor = builder.create<tosa::ConstOp>(loc, outType, zeroValue);
+  auto rangeBroadcast = createOpAndInfer<tosa::AddOp>(
+      builder, loc, builder.getI32Type(), zeroTensor, rangeValReshaped);
+
+  return rangeBroadcast;
+}
+
+static Value causalMaskingTosa(OpBuilder builder, Location loc,
+                               Value inputTensor, float initValue) {
+  // create a range for row and column
+  auto inpType = cast<RankedTensorType>(inputTensor.getType());
+  ArrayRef<int64_t> inpShape = inpType.getShape();
+
+  Value rowRange = createRange(builder, loc, 1, inpShape);
+  Value colRange = createRange(builder, loc, 2, inpShape);
+
+  // create mask (diagonal and lower triangular are zero)
+  auto mask = createOpAndInfer<tosa::GreaterOp>(
+      builder, loc, builder.getIntegerType(1), colRange, rowRange);
+
+  // apply mask
+  Value result = applyMask(builder, loc, inputTensor, mask, initValue);
+  return result;
+}
+
 static Value maskKVCacheTosa(OpBuilder builder, Location loc, Value inputTensor,
                              Value currentSeqLenVal, float initValue) {
   // inputTensor is [B*NUM_HEADS, SEQ_LEN_Q, SEQ_LEN_KV], we want to reshape to
@@ -2472,28 +2555,13 @@ static Value maskKVCacheTosa(OpBuilder builder, Location loc, Value inputTensor,
   for (auto v : currentSeqLen)
     assert(v > 0 && v <= inpShape[3]);
 
-  // create range 0 to inpShape[axis]
-  llvm::SmallVector<int32_t> range;
-  range.reserve(inpShape[3]);
-  for (int i = 0; i < inpShape[3]; i++)
-    range.push_back(i);
-  DenseElementsAttr rangeAttr = DenseIntElementsAttr::get(
-      RankedTensorType::get({inpShape[3]}, builder.getI32Type()), range);
-  Value rangeVal =
-      builder.create<tosa::ConstOp>(loc, rangeAttr.getType(), rangeAttr);
+  // generate range
+  Value rangeBroadcast = createRange(builder, loc, 3, inpShape);
 
-  // reshape
-  auto shapeValue =
-      tosa::getTosaConstShape(implicitBuilder, {1, 1, 1, inpShape[3]});
-  auto rangeValReshaped = createOpAndInfer<tosa::ReshapeOp>(
-      builder, loc, builder.getI32Type(), rangeVal, shapeValue);
-
-  // broadcast range to inputTensor shape
+  // zero tensor
   auto outType = RankedTensorType::get(inpShape, builder.getI32Type());
   auto zeroValue = cast<ElementsAttr>(builder.getZeroAttr(outType));
   auto zeroTensor = builder.create<tosa::ConstOp>(loc, outType, zeroValue);
-  auto rangeBroadcast = createOpAndInfer<tosa::AddOp>(
-      builder, loc, builder.getI32Type(), zeroTensor, rangeValReshaped);
 
   // broadcast currentSeqLen
   auto currentSeqLenBroadcast = createOpAndInfer<tosa::AddOp>(
@@ -2504,23 +2572,7 @@ static Value maskKVCacheTosa(OpBuilder builder, Location loc, Value inputTensor,
       createOpAndInfer<tosa::GreaterOp>(builder, loc, builder.getIntegerType(1),
                                         rangeBroadcast, currentSeqLenBroadcast);
 
-  // create a tensor with a single value and broadcast it
-  assert(isa<FloatType>(inpType.getElementType()));
-  std::pair<APFloat, llvm::detail::opStatus> floatRes =
-      rock::createAPFloat(inpType.getElementType(), initValue);
-  APFloat fpVal = floatRes.first;
-  auto status = floatRes.second;
-  assert(status == APFloat::opOK);
-
-  DenseElementsAttr initValueAttr = DenseFPElementsAttr::get(
-      RankedTensorType::get(inpShape, inpType.getElementType()), fpVal);
-
-  Value initVal = builder.create<tosa::ConstOp>(loc, initValueAttr.getType(),
-                                                initValueAttr);
-
-  // mask is 1 for values we want to set to -inf, initVal=-inf
-  auto result = createOpAndInfer<tosa::SelectOp>(
-      builder, loc, inpType.getElementType(), mask, initVal, inputTensor);
+  Value result = applyMask(builder, loc, inputTensor, mask, initValue);
 
   // reshape result back to [B*NUM_HEADS, SEQ_LEN_Q, SEQ_LEN_KV]
   auto origShapeValue = tosa::getTosaConstShape(implicitBuilder, origShape);
@@ -2704,7 +2756,7 @@ static func::FuncOp createGpuAttentionKernel(ModuleOp module,
   auto attention = builder.create<rock::AttentionOp>(
       loc, TypeRange{}, queries, keys, values, elemwiseInputs,
       currentSeqLenTensor, output, transposeQ, transposeK, transposeV,
-      transposeO, archAttr, params.features, numCUAttr,
+      transposeO, causalMasking, archAttr, params.features, numCUAttr,
       /*params0=*/nullptr, /*params1=*/nullptr, /*firstGemmIdx=*/0);
   {
     Block *preSoftmaxElemwiseBlock =
@@ -3219,6 +3271,9 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
       scaleTensor =
           maskKVCacheTosa(builder, loc, scaleTensor, currentSeqLenTensor, 1.0f);
 
+    if (causalMasking)
+      scaleTensor = causalMaskingTosa(builder, loc, scaleTensor, 1.0f);
+
     auto shiftType = RankedTensorType::get({1}, builder.getIntegerType(8));
     auto shiftZeroAttr = DenseElementsAttr::get(
         shiftType, builder.getZeroAttr(builder.getIntegerType(8)));
@@ -3235,15 +3290,21 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
       biasTensor =
           maskKVCacheTosa(builder, loc, biasTensor, currentSeqLenTensor, 0.0f);
 
+    if (causalMasking)
+      biasTensor = causalMaskingTosa(builder, loc, biasTensor, 0.0f);
+
     qkTensor = createOpAndInfer<tosa::AddOp>(
         builder, loc, cast<ShapedType>(biasTensor.getType()).getElementType(),
         qkTensor, biasTensor);
   }
 
-  if (currentSeqLenTensor) {
+  if (currentSeqLenTensor)
     qkTensor = maskKVCacheTosa(builder, loc, qkTensor, currentSeqLenTensor,
                                -std::numeric_limits<float>::infinity());
-  }
+
+  if (causalMasking)
+    qkTensor = causalMaskingTosa(builder, loc, qkTensor,
+                                 -std::numeric_limits<float>::infinity());
 
   constexpr int64_t reductionAxis = 2;
   auto qkMaxs = createOpAndInfer<tosa::ReduceMaxOp>(

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -652,6 +652,7 @@ def getAttentionConfigurations(fileName):
         "-transK": bool_space,
         "-transV": bool_space,
         "-transO": bool_space,
+        "-causal": bool_space,
         "-with-attn-scale": bool_space,
         "-with-attn-bias": bool_space
     }
@@ -932,7 +933,7 @@ class GemmGemmConfiguration(PerfConfiguration):
 class AttentionConfiguration(PerfConfiguration):
     TABLE_COLUMNS = reportUtils.ATTN_TEST_PARAMETERS + ['TFlops']
     def __init__(self, dtype: str, g: int, seq_len_q: int, seq_len_k: int, head_dim_qk: int, head_dim_v: int, with_attn_scale: bool, with_attn_bias: bool,
-                 transQ: bool, transK: bool, transV: bool, transO: bool, arch: str, numCU: int, perf_config: str = ''):
+                 transQ: bool, transK: bool, transV: bool, transO: bool, causal: bool, arch: str, numCU: int, perf_config: str = ''):
         if dtype not in DATA_TYPES_ATTENTION:
             raise ValueError(f"Invalid datatype for a: {dtype}")
         
@@ -948,6 +949,7 @@ class AttentionConfiguration(PerfConfiguration):
         self.transK = transK
         self.transV = transV
         self.transO = transO
+        self.causal = causal
 
         self.arch = arch
         self.chip = GFX_CHIP_RE.search(arch).group(0)
@@ -986,6 +988,7 @@ class AttentionConfiguration(PerfConfiguration):
             self.transK,
             self.transV,
             self.transO,
+            self.causal,
             self.with_attn_scale,
             self.with_attn_bias,
             self.g,
@@ -1003,7 +1006,7 @@ class AttentionConfiguration(PerfConfiguration):
 
     def __repr__(self):
         return f"""AttentionConfiguration(dtype={self.dataType!r}, g={self.g!r}, seq_len_q={self.seq_len_q!r}, seq_len_k={self.seq_len_k!r}, head_dim_qk={self.head_dim_qk!r}, head_dim_v={self.head_dim_v!r}, with_attn_scale={self.with_attn_scale!r}, with_attn_bias={self.with_attn_bias!r},
-                transQ={self.transQ!r}, transK={self.transK!r}, transV={self.transV!r}, transO={self.transO!r}, arch={self.arch!r}, numCU={self.numCU}, perf_config={self.perfConfig})"""
+                transQ={self.transQ!r}, transK={self.transK!r}, transV={self.transV!r}, transO={self.transO!r}, self.causal={self.causal!r}, arch={self.arch!r}, numCU={self.numCU}, perf_config={self.perfConfig})"""
 
     def setPerfConfig(self, perf_config):
         self.perfConfig = perf_config
@@ -1024,6 +1027,7 @@ class AttentionConfiguration(PerfConfiguration):
                            f"-transK={self.transK}",
                            f"-transV={self.transV}",
                            f"-transO={self.transO}",
+                           f"-causal={self.causal}",
                            '--kernel-repeats', str(MLIR_N_REPEATS),
                            f"--perf_config={self.perfConfig}"])
         result += ' '
@@ -1045,6 +1049,7 @@ class AttentionConfiguration(PerfConfiguration):
         transK = False
         transV = False
         transO = False
+        causal = False
         with_attn_scale = False
         with_attn_bias = False
         # Please keep this in sync with mlir::rock::getTuningProblemStr()
@@ -1075,20 +1080,23 @@ class AttentionConfiguration(PerfConfiguration):
                 transV = (val.lower() in ["1", "true"])
             elif opt.endswith("-transO"):
                 transO = (val.lower() in ["1", "true"])
+            elif opt.endswith("-causal"):
+                causal = (val.lower() in ["1", "true"])
             elif opt.endswith("-perf_config"):
                 perf_config = val
             else:
                 raise ValueError(f"Unknown Attention config argument {opt} -> {val}")
-        for v in [dtype, g, seq_len_q, seq_len_k, head_dim_qk, head_dim_v, with_attn_scale, with_attn_bias, transQ, transK, transV, transO]:
+        for v in [dtype, g, seq_len_q, seq_len_k, head_dim_qk, head_dim_v, with_attn_scale, with_attn_bias, transQ, transK, transV, transO, causal]:
             if v is None:
                 raise ValueError("Incomplete Attention configuration")
 
-        return cls(dtype, g, seq_len_q, seq_len_k, head_dim_qk, head_dim_v, with_attn_scale, with_attn_bias, transQ, transK, transV, transO, arch, numCU, perf_config)
+        return cls(dtype, g, seq_len_q, seq_len_k, head_dim_qk, head_dim_v, with_attn_scale, with_attn_bias, transQ, transK, transV, transO, causal, arch, numCU, perf_config)
 
     def toCommandLine(self):
         return (f"-t {self.dataType} "
                 + f"-transQ {str(self.transQ).lower()} -transK {str(self.transK).lower()} "
                 + f"-transV {str(self.transV).lower()} -transO {str(self.transO).lower()} "
+                + f"-causal {str(self.causal).lower()} "
                 + f"-g {self.g} "
                 + f"-seq_len_q {str(self.seq_len_q)} -seq_len_k {str(self.seq_len_k)} -head_dim_qk {str(self.head_dim_qk)} -head_dim_v {str(self.head_dim_v)} "
                 + f"-with-attn-scale {str(self.with_attn_scale).lower()}"

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -23,7 +23,7 @@ CONV_TEST_PARAMETERS = ['Direction', 'DataType', 'Chip', 'numCU', 'FilterLayout'
                         'X', 'DilationH', 'DilationW', 'StrideH', 'StrideW',
                         'PaddingH', 'PaddingW', 'PerfConfig']
 GEMM_TEST_PARAMETERS = ['DataType', 'OutDataType', 'Chip', 'numCU', 'TransA', 'TransB', 'G', 'M', 'K', 'N', 'PerfConfig']
-ATTN_TEST_PARAMETERS = ['DataType', 'Chip', 'numCU', 'TransQ', 'TransK', 'TransV', 'TransO', 'WithAttnScale', 'WithAttnBias', 'G', 'SeqLenQ', 'SeqLenK', 'HeadDimQK', 'HeadDimV', 'PerfConfig']
+ATTN_TEST_PARAMETERS = ['DataType', 'Chip', 'numCU', 'TransQ', 'TransK', 'TransV', 'TransO', 'Causal', 'WithAttnScale', 'WithAttnBias', 'G', 'SeqLenQ', 'SeqLenK', 'HeadDimQK', 'HeadDimV', 'PerfConfig']
 GEMM_GEMM_TEST_PARAMETERS = ['DataType', 'Chip', 'numCU', 'TransA', 'TransB', 'TransC', 'TransO', 'G', 'M', 'K', 'N', 'O', 'PerfConfig']
 ROUND_DIGITS = 2
 


### PR DESCRIPTION
This PR implements efficient causal attention. 
The idea of causal attention is, given the attention matrix (output of first gemm) of shape [B*NUM_HEADS, SEQ_LEN_Q, SEQ_LEN_KV]. Set -inf for elements where key position > query position. This prevents tokens from attending to future positions, maintaining the autoregressive property of LLMs.

The current implementation is just a fusion (see [this](https://github.com/ROCm/rocMLIR/blob/ab200855ab14872a08726f4cd1983d193dc6000e/mlir/test/fusion/pr-e2e/attention/mixr-attention-kvcache-causal.mlir)). So, all the attention matrix is computed, and then invalid values are set to -inf. This PR avoids extra computation by taking into account causal masking. 

Note that this causes blocks to have very different number of iterations, the first block will have 1 iteration, while block N-1 will have N-1 interations. In the future, we can try to improve this by having half the blocks and assigning the work of 0 and N-1 to block 0, 1 and N-2 to block 1, etc.

Migraphx integration will be a future PR.

See the results of this PR vs develop (TFlops). For develop we should use a fusion to set invalid values to -inf, instead we use unfused kernel, so actual results of develop will be worse than shown here.

|  | develop | PR     | Speed up |
| - | ------- | ------ | -------- |
| 0 | 369.47  | 511.15 | 1.3835 |
| 1 | 401.39  | 638.61 | 1.5910 |
| 2 | 418.53  | 651.27 | 1.5561 |
| 3 | 421.61  | 755.04 | 1.7908 |
| 4 | 412.05  | 658.31 | 1.5976 |

These are the attention configs:
```
0: -transK true -t f16 -g 256 -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 128 -head_dim_v 128 -causal
1: -transK true -t f16 -g 128 -seq_len_q 2048 -seq_len_k 2048 -head_dim_qk 128 -head_dim_v 128 -causal
2: -transK true -t f16 -g 64 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -causal
3: -transK true -t f16 -g 32 -seq_len_q 8192 -seq_len_k 8192 -head_dim_qk 128 -head_dim_v 128 -causal
4: -transK true -t f16 -g 16 -seq_len_q 16384 -seq_len_k 16384 -head_dim_qk 128 -head_dim_v 128 -causal
```