### PR TITLE
Add i8 in DATA_TYPES_ATTENTION

### DIFF
--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -35,7 +35,7 @@ DATA_TYPES = ['conv', 'convfp16', 'convbfp16', 'convfp8', 'convint8']
 LAYOUTS = ['NHWC', 'NCHW']
 
 DATA_TYPES_GEMM = ['f32', 'f16', 'bf16', 'i8', 'fp8']
-DATA_TYPES_ATTENTION = ['f32', 'f16', 'bf16']
+DATA_TYPES_ATTENTION = ['i8', 'f32', 'f16', 'bf16']
 DATA_TYPES_GEMM_GEMM = ['f32', 'f16', 'bf16']
 DATA_TYPES_CONV_GEMM = ['f32', 'f16', 'bf16']
 OUTPUT_DATA_TYPES_MAP = {'f32': 'f32', 'f16': 'f16', 'bf16': 'bf16', 'i8': 'i32', 'fp8':'f32',


### PR DESCRIPTION
Datatype i8 was missing in DATA_TYPES_ATTENTION in perfRunner.py

Resolves https://github.com/ROCm/rocMLIR-internal/issues/1836