### PR TITLE
tuneMLIRKernels stdout

### DIFF
--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -167,6 +167,7 @@ def tuneMLIRKernels(configs, confClass, paths: Paths, options: Options):
             config = confClass.fromCommandLine(commandLine, options.arch, options.numCU)
             tuningLoop = subprocess.Popen([paths.mlir_paths.rocmlir_tuning_driver_path, f"--tuning-space={options.tuningSpaceKind}", testVector],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            kernelGen.stdout.close()
 
         # Tune, printing progress as we go to avoid CI timeouts
         winningConfig, maxTFlops = getWinningConfig(tuningLoop.stdout, testVector, config, allData, paths, options)


### PR DESCRIPTION
This PR is made to test (on CI) if adding potentially missing `kernelGen.stdout.close()` will solve the problem we are having with tuningRunner in Tune MLIR phase.