### PR TITLE
Add missing LDS barriers to attention

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -18,6 +18,7 @@
 // This pass converts rock.gridwise_gemm[_v2] into block- and threadwise ops
 //
 //===-----------------------------------------------------===//
+#include "mlir/Dialect/Affine/Analysis/LoopAnalysis.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/Passes.h"
@@ -52,6 +53,7 @@
 #include "mlir/Dialect/Rock/IR/AccelEmitter.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <optional>
 
 namespace mlir {
 namespace rock {
@@ -749,7 +751,8 @@ struct GridwiseAttentionAccelRewritePattern
       RegsAsMatrixSubTiles toLDSViews, Value storeBuffer,
       Value ldsTileByteBuffer, int64_t kpacksPerBlock, StringRef nonKDimName,
       int64_t kPerBlock, int64_t dPerBlock, int64_t copyKPerThread,
-      int64_t copyDPerThread, bool forceUnroll, bool rotateDWithK) const {
+      int64_t copyDPerThread, bool forceUnroll, bool rotateDWithK,
+      bool barrierBeforeWrite) const {
     Type elemType = cast<MemRefType>(regBuffer.getType()).getElementType();
     ArrayAttr storeBufferViews =
         invertTransforms(rewriter, loc, toLDSViews.threadSubTile);
@@ -772,6 +775,11 @@ struct GridwiseAttentionAccelRewritePattern
     // This will produce a (tid, iter) --> flat LDS view
     wrappedLds = transform(rewriter, wrappedLds, toLDSViews.blockSubTile);
     auto tid = rewriter.create<WorkitemIdOp>(loc, rewriter.getIndexType());
+
+    // add LDS barrier to avoid write before load of previous iteration is done
+    if (barrierBeforeWrite)
+      rewriter.create<LDSBarrierOp>(loc);
+
     rewriter.create<ThreadwiseWriteAllOp>(
         loc, storeBuffer, wrappedLds, /*extraViews=*/rewriter.getArrayAttr({}),
         /*extraIndices=*/ValueRange{tid}, GemmFeatures::none, StoreMethod::Set,
@@ -789,7 +797,7 @@ struct GridwiseAttentionAccelRewritePattern
       uint32_t blockSize, uint32_t gridSize, ArrayRef<StringRef> bidGridOrder,
       ArrayRef<int64_t> bidGridLengths, bool forceUnroll,
       PatternRewriter &rewriter, const accel::AccelEmitter &accelEmitter,
-      LDSLayoutConfigDim ldsLayoutCfg) const {
+      LDSLayoutConfigDim ldsLayoutCfg, bool barrierBeforeWrite) const {
 
     MemRefType destBufferType = cast<MemRefType>(destBuffer.getType());
     mlir::gpu::AddressSpace destBufferAddrSpace =
@@ -858,12 +866,13 @@ struct GridwiseAttentionAccelRewritePattern
       if (failed(maybeLdsStoreViews)) {
         return failure();
       }
+
       LogicalResult storeGemmTileStatus = storeGemmInputTile(
           rewriter, loc, kpack, viewLoadBuffer, maybeLdsStoreViews.value(),
           toLDSRegBuffer, destBuffer, kpacksPerBlock, nonKDimName, kPerBlock,
           dPerBlock, maybeVectorDimInfo->inKPerThread,
           maybeVectorDimInfo->inDPerThread, forceUnroll,
-          ldsLayoutCfg.doRotateWithK);
+          ldsLayoutCfg.doRotateWithK, barrierBeforeWrite);
       if (failed(storeGemmTileStatus)) {
         return failure();
       }
@@ -871,6 +880,8 @@ struct GridwiseAttentionAccelRewritePattern
       assert(!ldsLayoutCfg.doSwapThreadIterSubDims &&
              "doSwapThreadIterSubDims must be false if the destination buffer "
              "is private memory");
+      assert(!barrierBeforeWrite &&
+             "can't add a LDS barrier if the destination buffer is not LDS");
       accel::AccelEmitterParams accelEmitterParams = accelEmitter.getParams();
       int64_t dRepeats = (nonKDimName == "m" ? accelEmitterParams.mRepeats
                                              : accelEmitterParams.nRepeats);
@@ -2083,7 +2094,7 @@ struct GridwiseAttentionAccelRewritePattern
             fromGlobalRegBufferQ, toLDSRegBufferQ, preAccelRegBuffersQ, "n",
             gemm0kpack, gemm0KpacksPerBlock, gemm0NPerBlock, blockSize,
             gridSize, bidGridOrder, gemm0BidGridLengths, forceUnroll, rewriter,
-            *accelEmitterPtrGemm0, ldsLayoutCfgNG0);
+            *accelEmitterPtrGemm0, ldsLayoutCfgNG0, false);
         if (failed(statusLoadQTile)) {
           return failure();
         }
@@ -2095,7 +2106,7 @@ struct GridwiseAttentionAccelRewritePattern
             fromGlobalRegBufferQ, toLDSRegBufferQ, ldsByteBufferQ, "n",
             gemm0kpack, gemm0KpacksPerBlock, gemm0NPerBlock, blockSize,
             gridSize, bidGridOrder, gemm0BidGridLengths, forceUnroll, rewriter,
-            *accelEmitterPtrGemm0, ldsLayoutCfgNG0);
+            *accelEmitterPtrGemm0, ldsLayoutCfgNG0, false);
         if (failed(statusLoadQ)) {
           return failure();
         }
@@ -2164,6 +2175,27 @@ struct GridwiseAttentionAccelRewritePattern
           kLoopIV = rewriter.createOrFold<affine::AffineApplyOp>(
               loc, reverseMap, ValueRange{kLoopIV, kIterationsGemm0Val});
         }
+
+        // LDS Barrier (issue 1811): some threads might be loading from LDS
+        // while others are in the next iteration (here), writing to LDS. This
+        // barrier prevents that.
+        std::optional<uint64_t> mLoopIters = std::nullopt;
+        // mLoopOp can be a scf::ForOp if we are using KV Cache or Causal
+        // masking. If that's the case, we can't know the number of iterations
+        // at compile time.
+        if (auto mLoopAffineFor =
+                dyn_cast<affine::AffineForOp>(mLoopOp.getOperation()))
+          mLoopIters = mlir::affine::getConstantTripCount(mLoopAffineFor);
+
+        bool mIterOneIter = mLoopIters.has_value() && mLoopIters.value() == 1;
+        auto kLoopIters = mlir::affine::getConstantTripCount(kLoopOp);
+        bool kIterOneIter = kLoopIters.has_value() && kLoopIters.value() == 1;
+        // no need to have the barrier if there's just one iteration
+        bool addBarrierFirstGemm = !kIterOneIter || !mIterOneIter;
+        if (addBarrierFirstGemm)
+          LLVM_DEBUG(llvm::dbgs()
+                     << "adding a barrier in the first gemm loop\n");
+
         // if gemm0K is equal to gemm0KPerBlock, the Q tile
         // is already prefetched into regs. See above.
         TypedValue<MemRefType> ldsTileBufferQ;
@@ -2176,14 +2208,19 @@ struct GridwiseAttentionAccelRewritePattern
               toLDSRegBufferQ, ldsByteBufferQ, "n", gemm0kpack,
               gemm0KpacksPerBlock, gemm0NPerBlock, blockSize, gridSize,
               bidGridOrder, gemm0BidGridLengths, forceUnroll, rewriter,
-              *accelEmitterPtrGemm0, ldsLayoutCfgNG0);
+              *accelEmitterPtrGemm0, ldsLayoutCfgNG0, addBarrierFirstGemm);
           if (failed(statusLoadQ)) {
             return failure();
           }
+          // no need to add a barrier in the next call to
+          // loadAndStoreGemmInputTile()
+          addBarrierFirstGemm = false;
           ldsTileBufferQ =
               viewBufferAs(rewriter, ldsByteBufferQ,
                            vectorTypeOrSelf(elemTypeQ, gemm0kpack));
         }
+        // if we added a barrier in the previous block (load Q), there's no need
+        // to add it again here.
         Value ldsByteBufferK = createLDSByteBuffer(
             rewriter, loc, gemm0KPerBlock * gemm0MPerBlock, elemTypeK);
         LogicalResult statusLoadKTile = loadAndStoreGemmInputTile(
@@ -2191,7 +2228,7 @@ struct GridwiseAttentionAccelRewritePattern
             toLDSRegBufferK, ldsByteBufferK, "m", gemm0kpack,
             gemm0KpacksPerBlock, gemm0MPerBlock, blockSize, gridSize,
             bidGridOrder, gemm0BidGridLengths, forceUnroll, rewriter,
-            *accelEmitterPtrGemm0, ldsLayoutCfgMG0);
+            *accelEmitterPtrGemm0, ldsLayoutCfgMG0, addBarrierFirstGemm);
         if (failed(statusLoadKTile)) {
           return failure();
         }
@@ -2409,12 +2446,13 @@ struct GridwiseAttentionAccelRewritePattern
           // the transposed layout for this gemm.
           gemm1LDSByteBufferB = createLDSByteBuffer(
               rewriter, loc, gemm1LDSByteBufferBSize, elemTypeV);
+
           LogicalResult storeGemm1ATileStatus = storeGemmInputTile(
               rewriter, loc, gemm1kpack, gemm0ExpNMThreadwiseView,
               gemm0OutSubTileNxMViews, gemm0ExpOutBufferToLDS,
               gemm1LDSByteBufferB, gemm1KpacksPerBlock, "n", gemm1KPerBlock,
               gemm1NPerBlock, /*copyKPerThread=*/1, gemm1InNPerThread,
-              forceUnroll, false);
+              forceUnroll, false, false);
           if (failed(storeGemm1ATileStatus)) {
             return failure();
           }
@@ -2445,13 +2483,26 @@ struct GridwiseAttentionAccelRewritePattern
 
           Value ldsByteBufferV = createLDSByteBuffer(
               rewriter, loc, gemm1KPerBlock * gemm1MPerBlock, elemTypeV);
+
+          // LDS Barrier (issue 1811): some threads might be loading from LDS
+          // while others are in the next iteration (here), writing to LDS. This
+          // barrier prevents that. No need to have the barrier if there's just
+          // one iteration
+          auto g1MLoopIters = mlir::affine::getConstantTripCount(g1MLoopOp);
+          bool g1MIterOneIter =
+              g1MLoopIters.has_value() && g1MLoopIters.value() == 1;
+          bool addBarrierSecondGemm = !g1MIterOneIter;
+          if (addBarrierSecondGemm)
+            LLVM_DEBUG(llvm::dbgs()
+                       << "adding a barrier in the second gemm loop\n");
+
           LogicalResult statusLoadVTile = loadAndStoreGemmInputTile(
               loc, inV,
               /*kIter=*/mLoopIV, gridCoordsGemm1, fromGlobalRegBufferV,
               toLDSRegBufferV, ldsByteBufferV, "m", gemm1kpack,
               gemm1KpacksPerBlock, gemm1MPerBlock, blockSize, gridSize,
               bidGridOrder, gemm1BidGridLengths, forceUnroll, rewriter,
-              *accelEmitterPtrGemm1, ldsLayoutCfgMG1);
+              *accelEmitterPtrGemm1, ldsLayoutCfgMG1, addBarrierSecondGemm);
           if (failed(statusLoadVTile)) {
             return failure();
           }

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -392,3 +392,123 @@ func.func @gridwise_attn_causal_kvcache(%arg0: memref<1x384x64xf32>, %arg1: memr
   } : memref<1x64x384xf32>, memref<1x64x384xf32>, memref<1x384x64xf32>, memref<1xi32>, memref<1x384x64xf32>
   return
 }
+
+// -----
+
+// CHECK: @gridwise_attn_barriers_before_lds_write_issue_1811
+func.func @gridwise_attn_barriers_before_lds_write_issue_1811(%arg0: memref<4096xi8>, %arg1: memref<4096xi8>, %arg2: memref<4096xf16>, %arg3: memref<1xi8>, %arg4: memref<1xf16>, %arg5: memref<4096xf16>) attributes {block_size = 64 : i32, grid_size = 1 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
+  // CHECK: affine.for %{{.*}} = 0 to 2
+  // CHECK: rock.threadwise_read_into
+  // CHECK: affine.for %{{.*}} = 0 to 2 {
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK: rock.lds_barrier
+  // CHECK-NEXT: rock.threadwise_write_all {{.*}} : memref<64xi8, #gpu.address_space<private>> -> memref<64x64xvector<8xi8>, #gpu.address_space<workgroup>>
+  // CHECK: affine.for %{{.*}} = 0 to 2 {
+  // CHECK: rock.lds_barrier
+  // CHECK-NEXT: rock.threadwise_write_all {{.*}} : memref<16xf16, #gpu.address_space<private>> -> memref<64x16xvector<8xf16>, #gpu.address_space<workgroup>>
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{64, 64} ["seq_q", "head_qk"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 64, 64] -> [4096]> : memref<4096xi8> to memref<1x64x64xi8>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{64, 64} ["seq_k", "head_qk"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 64, 64] -> [4096]> : memref<4096xi8> to memref<1x64x64xi8>
+  %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{64, 64} ["head_v", "seq_k"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 64, 64] -> [4096]> : memref<4096xf16> to memref<1x64x64xf16>
+  %3 = rock.transform %arg3 by <affine_map<(d0, d1, d2) -> (d2)> by [<Unmerge{1} ["seq_k"] at [2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>, <AddDim{1} ["seq_q"] at [1] -> [] at []>] bounds = [1, 1, 1] -> [1]> : memref<1xi8> to memref<1x1x1xi8>
+  %4 = rock.transform %arg4 by <affine_map<(d0, d1, d2) -> (d2)> by [<Unmerge{1} ["seq_k"] at [2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>, <AddDim{1} ["seq_q"] at [1] -> [] at []>] bounds = [1, 1, 1] -> [1]> : memref<1xf16> to memref<1x1x1xf16>
+  %5 = rock.transform %arg5 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{64, 64} ["seq_q", "head_v"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 64, 64] -> [4096]> : memref<4096xf16> to memref<1x64x64xf16>
+  %6 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 64] -> [1, 64, 64]> : memref<1x64x64xi8> to memref<1x64x64xi8>
+  %7 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0N"] at [1, 2] -> ["gemm0K", "gemm0N"] at [2, 1]>] bounds = [1, 64, 64] -> [1, 64, 64]> : memref<1x64x64xi8> to memref<1x64x64xi8>
+  %8 = rock.transform %2 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm1K", "gemm1N"] at [1, 2] -> ["gemm1K", "gemm1N"] at [2, 1]>] bounds = [1, 64, 64] -> [1, 64, 64]> : memref<1x64x64xf16> to memref<1x64x64xf16>
+  %9 = rock.transform %6 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 64} ["gemm0KPad"] at [1] -> ["gemm0K"] at [1]>, <PassThrough ["gemm0N"] at [2] -> ["gemm0N"] at [2]>] bounds = [1, 128, 64] -> [1, 64, 64]> : memref<1x64x64xi8> to memref<1x128x64xi8>
+  %10 = rock.transform %7 by <affine_map<(d0, d1, d2) -> (d0, d1, d2)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 64} ["gemm0KPad"] at [1] -> ["gemm0K"] at [1]>, <PassThrough ["gemm0M"] at [2] -> ["gemm0M"] at [2]>] bounds = [1, 128, 64] -> [1, 64, 64]> : memref<1x64x64xi8> to memref<1x128x64xi8>
+  rock.gridwise_attention_accel(%9, %10, %8, %3, %4, %5) features =  wmma|dot|atomic_add|atomic_fmax_f32 preSoftmaxOps = {
+  ^bb0(%arg6: memref<1x64x64xi32>, %arg7: memref<1x1x1xi8>, %arg8: memref<1x1x1xf16>, %arg9: memref<1x64x64xf16>):
+    %11 = rock.transform %arg6 by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{1, 64} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [64, 64] -> [1, 64, 64]> : memref<1x64x64xi32> to memref<64x64xi32>
+    %12 = rock.transform %arg7 by <affine_map<() -> (0, 0, 0)> by [<ConstDim{0, 1} [] at [] -> ["const0"] at [0]>, <ConstDim{0, 1} [] at [] -> ["const1"] at [1]>, <ConstDim{0, 1} [] at [] -> ["const2"] at [2]>] bounds = [] -> [1, 1, 1]> : memref<1x1x1xi8> to memref<i8>
+    %13 = rock.transform %arg8 by <affine_map<() -> (0, 0, 0)> by [<ConstDim{0, 1} [] at [] -> ["const0"] at [0]>, <ConstDim{0, 1} [] at [] -> ["const1"] at [1]>, <ConstDim{0, 1} [] at [] -> ["const2"] at [2]>] bounds = [] -> [1, 1, 1]> : memref<1x1x1xf16> to memref<f16>
+    %alloc = memref.alloc() : memref<1x64x64xf16>
+    %14 = rock.transform %alloc by <affine_map<(d0, d1) -> (0, d0, d1)> by [<Merge{64} ["dim0"] at [0] -> ["exp1"] at [1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <ConstDim{0, 1} [] at [] -> ["unit0"] at [0]>] bounds = [64, 64] -> [1, 64, 64]> : memref<1x64x64xf16> to memref<64x64xf16>
+    %15 = rock.transform %12 by <affine_map<(d0, d1) -> ()> by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>] bounds = [1, 1] -> []> : memref<i8> to memref<1x1xi8>
+    %16 = rock.transform %15 by <affine_map<(d0, d1) -> (0, 0)> by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <Broadcast{1} ["dim1"] at [1] -> ["dim1"] at [1]>] bounds = [64, 64] -> [1, 1]> : memref<1x1xi8> to memref<64x64xi8>
+    %17 = rock.transform %13 by <affine_map<(d0, d1) -> ()> by [<AddDim{1} ["exp0"] at [0] -> [] at []>, <AddDim{1} ["exp1"] at [1] -> [] at []>] bounds = [1, 1] -> []> : memref<f16> to memref<1x1xf16>
+    %18 = rock.transform %17 by <affine_map<(d0, d1) -> (0, 0)> by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <Broadcast{1} ["dim1"] at [1] -> ["dim1"] at [1]>] bounds = [64, 64] -> [1, 1]> : memref<1x1xf16> to memref<64x64xf16>
+    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%11, %16, %18 : memref<64x64xi32>, memref<64x64xi8>, memref<64x64xf16>) outs(%14 : memref<64x64xf16>) attrs =  {rock.majorTensorNumber = 0 : index} {
+    ^bb0(%in: i32, %in_0: i8, %in_1: f16, %out: f16):
+      %19 = arith.extsi %in_0 : i8 to i32
+      %20 = arith.subi %in, %19 : i32
+      %21 = arith.sitofp %20 : i32 to f16
+      %22 = arith.mulf %21, %in_1 : f16
+      linalg.yield %22 : f16
+    }
+    memref.copy %alloc, %arg9 : memref<1x64x64xf16> to memref<1x64x64xf16>
+    rock.yield
+  } {arch = "amdgcn-amd-amdhsa:gfx1100", blockSize = 64 : i32, firstGemmIdx = 0 : i32, gridSize = 1 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 2, 0, 1>, params0 = #rock.wmma_gemm_params<kpackPerBlock = 16, mPerBlock = 32, nPerBlock = 64, kpack = 8, mPerWave = 32, nPerWave = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>, params1 = #rock.wmma_gemm_params<kpackPerBlock = 4, mPerBlock = 32, nPerBlock = 64, kpack = 8, mPerWave = 32, nPerWave = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>} : memref<1x128x64xi8>, memref<1x128x64xi8>, memref<1x64x64xf16>, memref<1x1x1xi8>, memref<1x1x1xf16>, memref<1x64x64xf16>
+  return
+}
+
+// -----
+
+// CHECK: @gridwise_attn_barriers_before_lds_write_issue_1844
+func.func @gridwise_attn_barriers_before_lds_write_issue_1844(%arg0: memref<32768xf16>, %arg1: memref<32768xf16>, %arg2: memref<32768xf16>, %arg3: memref<32768xf16>) attributes {block_size = 256 : i32, grid_size = 2 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-"} {
+  // CHECK: affine.for %{{.*}} = 0 to 1
+  // CHECK: rock.threadwise_read_into
+  // CHECK: affine.for %{{.*}} = 0 to 2 {
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK: rock.lds_barrier
+  // CHECK-NEXT: rock.threadwise_write_all {{.*}} : memref<64xf16, #gpu.address_space<private>> -> memref<256x64xvector<4xf16>, #gpu.address_space<workgroup>>
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK-NOT: rock.lds_barrier
+  // CHECK: rock.threadwise_write_all {{.*}} : memref<64xf16, #gpu.address_space<private>> -> memref<256x64xvector<4xf16>, #gpu.address_space<workgroup>>
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{256, 128} ["m", "k"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 128] -> [32768]> : memref<32768xf16> to memref<1x256x128xf16>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{256, 128} ["n", "k"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 128] -> [32768]> : memref<32768xf16> to memref<1x256x128xf16>
+  %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{256, 128} ["n", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 128] -> [32768]> : memref<32768xf16> to memref<1x256x128xf16>
+  %3 = rock.transform %arg3 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{256, 128} ["m", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 256, 128] -> [32768]> : memref<32768xf16> to memref<1x256x128xf16>
+  %4 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 128, 256] -> [1, 256, 128]> : memref<1x256x128xf16> to memref<1x128x256xf16>
+  %5 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0N"] at [1, 2] -> ["gemm0K", "gemm0N"] at [2, 1]>] bounds = [1, 128, 256] -> [1, 256, 128]> : memref<1x256x128xf16> to memref<1x128x256xf16>
+  rock.gridwise_attention_accel(%4, %5, %2, %3) features =  mfma|dot|atomic_add|atomic_add_f16 preSoftmaxOps = {
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", blockSize = 256 : i32, enableSoftmax = false, firstGemmIdx = 0 : i32, gridSize = 2 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 1>, params0 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 128, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>, params1 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 128, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>} : memref<1x128x256xf16>, memref<1x128x256xf16>, memref<1x256x128xf16>, memref<1x256x128xf16>
+  return
+}
+
+// -----
+
+// CHECK: @gridwise_attn_barriers_before_lds_write_nobarriers
+func.func @gridwise_attn_barriers_before_lds_write_nobarriers(%arg0: memref<16384xf16>, %arg1: memref<16384xf16>, %arg2: memref<16384xf16>, %arg3: memref<16384xf16>) attributes {block_size = 256 : i32, grid_size = 1 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-"} {
+  // CHECK: affine.for %{{.*}} = 0 to 1
+  // CHECK: rock.threadwise_read_into
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK-NOT: rock.lds_barrier
+  // CHECK: rock.threadwise_write_all {{.*}} : memref<64xf16, #gpu.address_space<private>> -> memref<256x64xvector<4xf16>, #gpu.address_space<workgroup>>
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK-NOT: rock.lds_barrier
+  // CHECK: rock.threadwise_write_all {{.*}} : memref<64xf16, #gpu.address_space<private>> -> memref<256x64xvector<4xf16>, #gpu.address_space<workgroup>>
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{128, 128} ["m", "k"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 128] -> [16384]> : memref<16384xf16> to memref<1x128x128xf16>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{128, 128} ["n", "k"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 128] -> [16384]> : memref<16384xf16> to memref<1x128x128xf16>
+  %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{128, 128} ["n", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 128] -> [16384]> : memref<16384xf16> to memref<1x128x128xf16>
+  %3 = rock.transform %arg3 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{128, 128} ["m", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 128] -> [16384]> : memref<16384xf16> to memref<1x128x128xf16>
+  %4 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 128, 128] -> [1, 128, 128]> : memref<1x128x128xf16> to memref<1x128x128xf16>
+  %5 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0N"] at [1, 2] -> ["gemm0K", "gemm0N"] at [2, 1]>] bounds = [1, 128, 128] -> [1, 128, 128]> : memref<1x128x128xf16> to memref<1x128x128xf16>
+  rock.gridwise_attention_accel(%4, %5, %2, %3) features =  mfma|dot|atomic_add|atomic_add_f16 preSoftmaxOps = {
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", blockSize = 256 : i32, enableSoftmax = false, firstGemmIdx = 0 : i32, gridSize = 1 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 1>, params0 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 128, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>, params1 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 128, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>} : memref<1x128x128xf16>, memref<1x128x128xf16>, memref<1x128x128xf16>, memref<1x128x128xf16>
+  return
+}
+
+// -----
+
+// CHECK: @gridwise_attn_barriers_before_lds_write_nofallback_barrier
+func.func @gridwise_attn_barriers_before_lds_write_nofallback_barrier(%arg0: memref<32768xf16>, %arg1: memref<32768xf16>, %arg2: memref<16384xf16>, %arg3: memref<16384xf16>) attributes {block_size = 256 : i32, grid_size = 1 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-"} {
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK: affine.for %{{.*}} = 0 to 2 {
+  // CHECK: rock.lds_barrier
+  // CHECK-NEXT: rock.threadwise_write_all {{.*}} : memref<64xf16, #gpu.address_space<private>> -> memref<256x64xvector<4xf16>, #gpu.address_space<workgroup>>
+  // CHECK: rock.threadwise_write_all {{.*}} : memref<64xf16, #gpu.address_space<private>> -> memref<256x64xvector<4xf16>, #gpu.address_space<workgroup>>
+  // CHECK: affine.for %{{.*}} = 0 to 1 {
+  // CHECK-NOT: rock.lds_barrier
+  // CHECK: rock.threadwise_write_all {{.*}} : memref<64xf16, #gpu.address_space<private>> -> memref<256x64xvector<4xf16>, #gpu.address_space<workgroup>>
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1 * 256 + d2)> by [<Unmerge{128, 256} ["m", "k"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 256] -> [32768]> : memref<32768xf16> to memref<1x128x256xf16>
+  %1 = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> (d1 * 256 + d2)> by [<Unmerge{128, 256} ["n", "k"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 256] -> [32768]> : memref<32768xf16> to memref<1x128x256xf16>
+  %2 = rock.transform %arg2 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{128, 128} ["n", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 128] -> [16384]> : memref<16384xf16> to memref<1x128x128xf16>
+  %3 = rock.transform %arg3 by <affine_map<(d0, d1, d2) -> (d1 * 128 + d2)> by [<Unmerge{128, 128} ["m", "gemmO"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 128, 128] -> [16384]> : memref<16384xf16> to memref<1x128x128xf16>
+  %4 = rock.transform %0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 256, 128] -> [1, 128, 256]> : memref<1x128x256xf16> to memref<1x256x128xf16>
+  %5 = rock.transform %1 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0N"] at [1, 2] -> ["gemm0K", "gemm0N"] at [2, 1]>] bounds = [1, 256, 128] -> [1, 128, 256]> : memref<1x128x256xf16> to memref<1x256x128xf16>
+  rock.gridwise_attention_accel(%4, %5, %2, %3) features =  mfma|dot|atomic_add|atomic_add_f16 preSoftmaxOps = {
+  } {arch = "amdgcn-amd-amdhsa:gfx942:sramecc+:xnack-", blockSize = 256 : i32, enableSoftmax = false, firstGemmIdx = 0 : i32, gridSize = 1 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 1>, params0 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 128, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>, params1 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 128, nPerBlock = 128, kpack = 4, mPerWave = 128, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>} : memref<1x256x128xf16>, memref<1x256x128xf16>, memref<1x128x128xf16>, memref<1x128x128xf16>
+  return
+}

--- a/mlir/test/e2e/PrGemmElementwiseGemmF16.toml
+++ b/mlir/test/e2e/PrGemmElementwiseGemmF16.toml
@@ -33,10 +33,9 @@ config = "-m 64 -n 64 -k 64 -gemmO 64"
 [[suite.test]]
 config = "-m 64 -n 64 -k 64 -gemmO 64 -perf_config attn:v1:64,64,256,4,64,64,8,1"
 
-# disable this test untill https://github.com/ROCm/rocMLIR-internal/issues/1844 is fixed
 # Check lds bypass config
-# [[suite.test]]
-# config = "-m 256 -n 256 -k 128 -gemmO 128 -perf_config attn:v1:128,128,128,32,128,32,4,1"
+[[suite.test]]
+config = "-m 256 -n 256 -k 128 -gemmO 128 -perf_config attn:v1:128,128,128,32,128,32,4,1"
 
 # check a case where MPerBlock != gemm1M
 [[suite.test]]


### PR DESCRIPTION
There is a race condition that was reproducible on navi and MI100. If there is more than one iteration, some threads might be loading from LDS while others are in the next iteration writing to the same buffer. We add a barrier to prevent that. If the number of iterations is one, there's no need for the barrier.

solves: https://github.com/ROCm/rocMLIR-internal/issues/1811 https://github.com/ROCm/rocMLIR-internal/issues/1844