### PR TITLE
Remove deprecated use of find_package

### DIFF
--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -34,7 +34,7 @@ mlir_check_link_libraries(rocmlir-lib-test)
 llvm_canonicalize_cmake_booleans(BUILD_FAT_LIBROCKCOMPILER)
 # Static library target, enabled only when building static libs
 if(BUILD_FAT_LIBROCKCOMPILER)
-  find_package(ROCM 0.8 REQUIRED PATHS /opt/rocm)
+  find_package(ROCmCMakeBuildTools 0.8 REQUIRED PATHS /opt/rocm)
   include(ROCMInstallTargets)
   include(ROCMCreatePackage)
 


### PR DESCRIPTION
`find_package(ROCM)` is deprecated (it continues to work though)
https://rocm.docs.amd.com/projects/ROCmCMakeBuildTools/en/latest/

instead need to use `find_package(ROCmCMakeBuildTools)