### PR TITLE
Limit number of workers

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -345,35 +345,33 @@ def rebootNode() {
 
 void build_fixedE2ETests(String codepath) {
     // Limit the number of lit workers to 8 for navi21/navi3x codepath on nightly CI as a workaround for issue#702
-    limit_lit_workers = false
+    // Second update re lit workers, it looks like MI100 and MI250 also have issues with number of lit workers, 
+    // see issue#1845 and issue#1841
     llvm_lit_log_level = '-v'
     if ( (codepath == 'navi21') && (params.nightly == true) ) {
-        limit_lit_workers = true
     }
     if (codepath == 'navi3x'  || codepath == 'navi4x') {
         // print verbose logs for all the tests on Navi3x for the debugging purposes
         llvm_lit_log_level = '-va'
-        limit_lit_workers = true
     }
     buildProject('check-mlir-build-only check-rocmlir-build-only', """
               -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=${params.nightly ? '0' : '1'}
               -DROCMLIR_DRIVER_E2E_TEST_ENABLED=${params.nightly ? '1' : '0'}
               -DROCK_E2E_TEST_ENABLED=${params.nightly ? '1' : '0'}
               -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=1
-              -DLLVM_LIT_ARGS='${llvm_lit_log_level} --time-tests --timeout=3600 --max-failures=1 ${ limit_lit_workers ? '-j 8' : '-j 40' }'
+              -DLLVM_LIT_ARGS='${llvm_lit_log_level} --time-tests --timeout=3600 --max-failures=1 -j 8'
               -DCMAKE_EXPORT_COMPILE_COMMANDS=1
              """)
 }
 
 void check_randomE2ETests(String codepath) {
     // Limit the number of lit workers to 8 for navi21/navi3x codepath on nightly CI as a workaround for issue#702
-    limit_lit_workers = false
+    // Second update re lit workers, it looks like MI100 and MI250 also have issues with number of lit workers, 
+    // see issue#1845 and issue#1841
     llvm_lit_log_level='-v'
     if ( (codepath == 'navi21') && (params.nightly == true) ) {
-        limit_lit_workers = true
     }
     if ( (codepath == 'navi3x'  || codepath == 'navi4x') && (params.nightly == true) ) {
-        limit_lit_workers = true
         // print verbose logs for all the tests on Navi3x for debugging purposes
         llvm_lit_log_level='-va'
     }
@@ -383,7 +381,7 @@ void check_randomE2ETests(String codepath) {
               -DROCK_E2E_TEST_ENABLED=1
               -DROCMLIR_DRIVER_RANDOM_DATA_SEED=1
               -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=0
-              -DLLVM_LIT_ARGS='${llvm_lit_log_level} --time-tests --timeout=3600 --max-failures=1 ${ limit_lit_workers ? '-j 8' : '-j 40' }'
+              -DLLVM_LIT_ARGS='${llvm_lit_log_level} --time-tests --timeout=3600 --max-failures=1 -j 8'
               -DCMAKE_EXPORT_COMPILE_COMMANDS=1
              """)
 }

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -111,7 +111,7 @@ pipeline {
                                             -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=1
                                             -DROCMLIR_DRIVER_E2E_TEST_ENABLED=0
                                             -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=1
-                                            -DLLVM_LIT_ARGS=-v
+                                            -DLLVM_LIT_ARGS='-v --time-tests --timeout=3600 --max-failures=1 -j 8'
                                             -DCMAKE_EXPORT_COMPILE_COMMANDS=1
                                             """)
                                         }


### PR DESCRIPTION
Limit number of workers to 8. This doesn't seem to affect MI300 but there's no way to tell them apart currently, only "mfma". IMO let's fix this and we can iterate in the future to allow more workers.

Solves: https://github.com/ROCm/rocMLIR-internal/issues/1845 and https://github.com/ROCm/rocMLIR-internal/issues/1841