### PR TITLE
Make number of LIT workers 8 by default

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -351,15 +351,9 @@ def rebootNode() {
 }
 
 int setLitWorkerCount() {
-    int limit_lit_workers
+    int limit_lit_workers = 8
     def gpu_arch = get_gpu_architecture()
-    if (gpu_arch.contains('gfx10') || gpu_arch.contains('gfx11') || gpu_arch.contains('gfx12')) {
-        limit_lit_workers = 16
-    } else if (gpu_arch.contains('gfx908')) {
-        limit_lit_workers = 8
-    } else if (gpu_arch.contains('gfx90a')) {
-        limit_lit_workers = 30
-    } else {
+    if (gpu_arch.contains('gfx942') || gpu_arch.contains('gfx950')) {
         limit_lit_workers = 40
     }
     return limit_lit_workers

--- a/mlir/utils/jenkins/Jenkinsfile.downstream
+++ b/mlir/utils/jenkins/Jenkinsfile.downstream
@@ -124,7 +124,7 @@ pipeline {
                                             -DROCMLIR_DRIVER_PR_E2E_TEST_ENABLED=1
                                             -DROCMLIR_DRIVER_E2E_TEST_ENABLED=0
                                             -DROCMLIR_DRIVER_TEST_GPU_VALIDATION=1
-                                            -DLLVM_LIT_ARGS='-v --time-tests --timeout=3600 --max-failures=1 -j 30'
+                                            -DLLVM_LIT_ARGS='-v --time-tests --timeout=3600 --max-failures=1 -j 8'
                                             -DCMAKE_EXPORT_COMPILE_COMMANDS=1
                                             """)
                                         }


### PR DESCRIPTION
It looks like after the fix we are still getting memory errors; in this PR we reduce the number of workers because it seems this solved the issue for gfx908 (setting it to 8). See https://github.com/ROCm/rocMLIR/pull/1865 for more context.

Examples:
https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-1862/7/pipeline 
https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-1862/9/pipeline/460
https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-1862/10/pipeline/449