### PR TITLE
Install rocMLIR requirements in MITuna venv

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -148,4 +148,6 @@ RUN wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.34-linux-glibc2
 # --ignore-installed because of problems upgrading PyYAML.  See also -U.
 ADD "https://raw.githubusercontent.com/ROCm/MITuna/pf-tuna-rocmlir-3/requirements.txt" tuna-requirements.txt
 RUN python3 -m venv /tuna-venv && . /tuna-venv/bin/activate && \
-    python3 -m pip install -r tuna-requirements.txt --ignore-installed
+    python3 -m pip install -r tuna-requirements.txt --ignore-installed && \
+    python3 -m pip install -r llvm-requirements.txt --ignore-installed && \
+    python3 -m pip install -r requirements.txt --ignore-installed


### PR DESCRIPTION
Add LLVM and rocMLIR requirements to MITuna virtual environment.