### PR TITLE
Add acc_type to MatMulOp

### DIFF
--- a/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
@@ -691,6 +691,14 @@ public:
     auto outputTy = cast<ShapedType>(op.getType());
     auto outputElementTy = outputTy.getElementType();
 
+    auto accTy = outputTy;
+    auto accETy = outputElementTy;
+
+    if (auto attr = op->getAttrOfType<TypeAttr>("acc_type")) {
+      accETy = attr.getValue();
+      accTy = RankedTensorType::get(op.getType().getShape(), accETy);
+    }
+
     SmallVector<Value> dynDims;
     dynDims.resize(cast<ShapedType>(op->getResult(0).getType()).getRank());
 
@@ -708,10 +716,10 @@ public:
 
     SmallVector<Value> filteredDims = condenseValues(dynDims);
 
-    auto zeroAttr = rewriter.getZeroAttr(outputElementTy);
+    auto zeroAttr = rewriter.getZeroAttr(accETy);
     Value zero = rewriter.create<arith::ConstantOp>(loc, zeroAttr);
     auto emptyTensor = rewriter.create<tensor::EmptyOp>(
-        loc, outputTy.getShape(), outputTy.getElementType(), filteredDims);
+        loc, accTy.getShape(), accTy.getElementType(), filteredDims);
     Value zeroTensor = rewriter
                            .create<linalg::FillOp>(loc, ValueRange{zero},
                                                    ValueRange{emptyTensor})
@@ -738,9 +746,17 @@ public:
           op, "input b zero point must be zero for non-int8 integer types");
 
     if (aZpVal == 0 && bZpVal == 0) {
-      rewriter.replaceOpWithNewOp<linalg::BatchMatmulOp>(
-          op, TypeRange{op.getType()},
-          ValueRange{adaptor.getA(), adaptor.getB()}, ValueRange{zeroTensor});
+      auto res = rewriter
+                     .create<linalg::BatchMatmulOp>(
+                         loc, TypeRange{accTy},
+                         ValueRange{adaptor.getA(), adaptor.getB()},
+                         ValueRange{zeroTensor})
+                     ->getResult(0);
+      rewriter.replaceOpWithNewOp<tosa::CastOp>(
+          op,
+          RankedTensorType::get(cast<ShapedType>(res.getType()).getShape(),
+                                outputElementTy),
+          res);
       return success();
     }
 
@@ -748,9 +764,17 @@ public:
         loc, rewriter.getI32IntegerAttr(aZpVal));
     auto bZp = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getI32IntegerAttr(bZpVal));
-    rewriter.replaceOpWithNewOp<linalg::QuantizedBatchMatmulOp>(
-        op, TypeRange{op.getType()},
-        ValueRange{adaptor.getA(), adaptor.getB(), aZp, bZp}, zeroTensor);
+    auto res = rewriter
+                   .create<linalg::QuantizedBatchMatmulOp>(
+                       loc, TypeRange{accTy},
+                       ValueRange{adaptor.getA(), adaptor.getB(), aZp, bZp},
+                       zeroTensor)
+                   ->getResult(0);
+    rewriter.replaceOpWithNewOp<tosa::CastOp>(
+        op,
+        RankedTensorType::get(cast<ShapedType>(res.getType()).getShape(),
+                              outputElementTy),
+        res);
 
     return success();
   }

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -452,8 +452,9 @@ static LogicalResult verifyConvOpModes(T op) {
   if (inputEType.isInteger(16) && !accType.isInteger(48))
     return op.emitOpError("accumulator type for i16 tensor is not i48");
 
-  if (isa<Float8E5M2Type, Float8E4M3Type>(inputEType) && !accType.isF16())
-    return op.emitOpError("accumulator type for f8 tensor is not f16");
+  // This check is commented out to allow f32 accumulation for f8 inputs
+  // if (isa<Float8E5M2Type, Float8E4M3Type>(inputEType) && !accType.isF16())
+  //   return op.emitOpError("accumulator type for f8 tensor is not f16");
 
   if (inputEType.isF16() && !(accType.isF16() || accType.isF32()))
     return op.emitOpError("accumulator type for f16 tensor is not f16/f32");

--- a/external/llvm-project/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg-named.mlir
+++ b/external/llvm-project/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg-named.mlir
@@ -16,6 +16,20 @@ func.func @matmul(%arg0: tensor<1x5x3xf32>, %arg1: tensor<1x3x6xf32>) -> (tensor
 
 // -----
 
+// CHECK-LABEL: @matmul_acc
+func.func @matmul_acc(%arg0: tensor<1x5x3xf16>, %arg1: tensor<1x3x6xf16>) -> (tensor<1x5x6xf16>) {
+  // CHECK: [[C0:%.+]] = arith.constant 0
+  // CHECK: [[INIT:%.+]] = tensor.empty()
+  // CHECK: [[FILLED:%.+]] = linalg.fill ins([[C0]] : f32) outs([[INIT]] : tensor<1x5x6xf32>) -> tensor<1x5x6xf32>
+  // CHECK: [[BMM_RESULT:%.+]] = linalg.batch_matmul ins(%arg0, %arg1 : tensor<1x5x3xf16>, tensor<1x3x6xf16>) outs([[FILLED]] : tensor<1x5x6xf32>) -> tensor<1x5x6xf32>
+  // CHECK: [[CAST:%.+]] = tosa.cast [[BMM_RESULT]] : (tensor<1x5x6xf32>) -> tensor<1x5x6xf16>
+  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %0 = tosa.matmul %arg0, %arg1, %a_zp, %b_zp {acc_type = f32} : (tensor<1x5x3xf16>, tensor<1x3x6xf16>, tensor<1xf16>, tensor<1xf16>)  -> tensor<1x5x6xf16>
+  return %0 : tensor<1x5x6xf16>
+}
+
+// -----
 
 // CHECK-LABEL: @matmul_quantized
 func.func @matmul_quantized(%arg0: tensor<1x5x3xi8>, %arg1: tensor<1x3x6xi8>) -> (tensor<1x5x6xi32>) {
@@ -28,6 +42,22 @@ func.func @matmul_quantized(%arg0: tensor<1x5x3xi8>, %arg1: tensor<1x3x6xi8>) ->
   %a_zp = "tosa.const"() <{values = dense<1> : tensor<1xi8>}> : () -> tensor<1xi8>
   %b_zp = "tosa.const"() <{values = dense<2> : tensor<1xi8>}> : () -> tensor<1xi8>
   %0 = tosa.matmul %arg0, %arg1, %a_zp, %b_zp : (tensor<1x5x3xi8>, tensor<1x3x6xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<1x5x6xi32>
+  return %0 : tensor<1x5x6xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @matmul_quantized_acc
+func.func @matmul_quantized_acc(%arg0: tensor<1x5x3xi8>, %arg1: tensor<1x3x6xi8>) -> (tensor<1x5x6xi32>) {
+  // CHECK: [[C0:%.+]] = arith.constant 0
+  // CHECK: [[INIT:%.+]] = tensor.empty()
+  // CHECK: [[FILLED:%.+]] = linalg.fill ins([[C0]] : i32) outs([[INIT]] : tensor<1x5x6xi32>) -> tensor<1x5x6xi32>
+  // CHECK: [[ONE:%.+]] = arith.constant 1
+  // CHECK: [[TWO:%.+]] = arith.constant 2
+  // CHECK: linalg.quantized_batch_matmul ins(%arg0, %arg1, [[ONE]], [[TWO]] : tensor<1x5x3xi8>, tensor<1x3x6xi8>, i32, i32) outs([[FILLED]] : tensor<1x5x6xi32>) -> tensor<1x5x6xi32>
+  %a_zp = "tosa.const"() <{values = dense<1> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %b_zp = "tosa.const"() <{values = dense<2> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %0 = tosa.matmul %arg0, %arg1, %a_zp, %b_zp {acc_type = i32} : (tensor<1x5x3xi8>, tensor<1x3x6xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<1x5x6xi32>
   return %0 : tensor<1x5x6xi32>
 }
 

--- a/external/llvm-project/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/invalid.mlir
@@ -86,23 +86,24 @@ func.func @test_conv2d_acc_type(%arg0: tensor<1x29x29x4xi16>, %arg1: tensor<16x3
 
 // -----
 
-func.func @test_conv2d_acc_type(%arg0: tensor<1x29x29x4xf8E5M2>, %arg1: tensor<16x3x3x4xf8E5M2>, %arg2: tensor<16xf16>) -> tensor<1x27x27x16xf16> {
-  %zp = "tosa.const"() {values = dense<0.0> : tensor<1xf8E5M2>} : () -> tensor<1xf8E5M2>
-  // expected-error@+1 {{'tosa.conv2d' op accumulator type for f8 tensor is not f16}}
-  %0 = tosa.conv2d %arg0, %arg1, %arg2, %zp, %zp {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
-           : (tensor<1x29x29x4xf8E5M2>, tensor<16x3x3x4xf8E5M2>, tensor<16xf16>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x27x27x16xf16>
-  return %0 : tensor<1x27x27x16xf16>
-}
+// Commented out to allow f32 accumulation of f8 inputs
+// func.func @test_conv2d_acc_type(%arg0: tensor<1x29x29x4xf8E5M2>, %arg1: tensor<16x3x3x4xf8E5M2>, %arg2: tensor<16xf16>) -> tensor<1x27x27x16xf16> {
+//   %zp = "tosa.const"() {values = dense<0.0> : tensor<1xf8E5M2>} : () -> tensor<1xf8E5M2>
+//   %0 = tosa.conv2d %arg0, %arg1, %arg2, %zp, %zp {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// disabled-exp-error@+1 {{'tosa.conv2d' op accumulator type for f8 tensor is not f16}}
+//            : (tensor<1x29x29x4xf8E5M2>, tensor<16x3x3x4xf8E5M2>, tensor<16xf16>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x27x27x16xf16>
+//   return %0 : tensor<1x27x27x16xf16>
+// }
 
 // -----
 
-func.func @test_conv2d_acc_type(%arg0: tensor<1x29x29x4xf8E4M3>, %arg1: tensor<16x3x3x4xf8E4M3>, %arg2: tensor<16xf16>) -> tensor<1x27x27x16xf16> {
-  %zp = "tosa.const"() {values = dense<0.0> : tensor<1xf8E4M3>} : () -> tensor<1xf8E4M3>
-  // expected-error@+1 {{'tosa.conv2d' op accumulator type for f8 tensor is not f16}}
-  %0 = tosa.conv2d %arg0, %arg1, %arg2, %zp, %zp {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
-           : (tensor<1x29x29x4xf8E4M3>, tensor<16x3x3x4xf8E4M3>, tensor<16xf16>, tensor<1xf8E4M3>, tensor<1xf8E4M3>) -> tensor<1x27x27x16xf16>
-  return %0 : tensor<1x27x27x16xf16>
-}
+// func.func @test_conv2d_acc_type(%arg0: tensor<1x29x29x4xf8E4M3>, %arg1: tensor<16x3x3x4xf8E4M3>, %arg2: tensor<16xf16>) -> tensor<1x27x27x16xf16> {
+//   %zp = "tosa.const"() {values = dense<0.0> : tensor<1xf8E4M3>} : () -> tensor<1xf8E4M3>
+//   %0 = tosa.conv2d %arg0, %arg1, %arg2, %zp, %zp {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// disabled-exp--error@+1 {{'tosa.conv2d' op accumulator type for f8 tensor is not f16}}
+//            : (tensor<1x29x29x4xf8E4M3>, tensor<16x3x3x4xf8E4M3>, tensor<16xf16>, tensor<1xf8E4M3>, tensor<1xf8E4M3>) -> tensor<1x27x27x16xf16>
+//   return %0 : tensor<1x27x27x16xf16>
+// }
 
 // -----
 

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -365,19 +365,13 @@ LogicalResult ConvConverter<ConvType>::matchAndRewrite(
 
   // Determine the accumulation type based on the output type.
   Type accType;
-  if (isa<FloatType>(elementTy) && elementTy.getIntOrFloatBitWidth() >= 16) {
+  if (isa<FloatType>(elementTy)) {
     accType = rewriter.getF32Type();
     // accType is not used by rocMLIR when converting tosa to rock.
-    // accType for Float8 type is required to be Float16 as per TOSA v1.0 spec
-    // therefore just set it as required, it is being ignored anyways for GPU
-    // lowering using rocMLIR. [Risk]: CPU may generate different results
-    // compared to GPU if accType gets used on CPU lowering path. Currently it
-    // seems none of the TosaToXYZ converter uses this attribute.
-  } else if (isa<FloatType>(elementTy) &&
-             elementTy.getIntOrFloatBitWidth() <= 8) {
-    accType = rewriter.getF16Type();
   } else if (isa<IntegerType>(elementTy)) {
     accType = rewriter.getI32Type();
+  } else {
+    llvm_unreachable("not expected type");
   }
   // convolution config attributes
   if (dims == 1) {
@@ -497,6 +491,17 @@ LogicalResult DotConverter<DotType>::matchAndRewrite(
   // Construct tosa.matmul.
   auto mop =
       rewriter.create<tosa::MatMulOp>(loc, newOutType, inA, inB, aZp, bZp);
+
+  // Determine the accumulation type based on the output type.
+  Type accType;
+  if (isa<FloatType>(elementTy)) {
+    accType = rewriter.getF32Type();
+  } else if (isa<IntegerType>(elementTy)) {
+    accType = rewriter.getI32Type();
+  } else {
+    llvm_unreachable("not expected type");
+  }
+  mop->setAttr("acc_type", TypeAttr::get(accType));
 
   // Convert optional attributes
   if (auto attr = (*op).template getAttrOfType<StringAttr>("perf_config"))

--- a/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa.mlir
@@ -191,7 +191,7 @@ func.func @conv1d_add(%arg0: !migraphx.shaped<1x64x224xf32, 0x1x0>, %arg1: !migr
 func.func @conv2d_float8(%arg0: !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>, %arg1: !migraphx.shaped<16x16x1x1xf8E5M2, 16x1x1x1>) -> !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1> {
   // CHECK-COUNT-2: tosa.transpose
   // CHECK: tosa.conv2d
-  // CHECK-SAME: {acc_type = f16, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x16xf8E5M2>, tensor<16x1x1x16xf8E5M2>, tensor<16xf8E5M2>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x4x4x16xf8E5M2>
+  // CHECK-SAME: {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x16xf8E5M2>, tensor<16x1x1x16xf8E5M2>, tensor<16xf8E5M2>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x4x4x16xf8E5M2>
   %0 = migraphx.convolution %arg0, %arg1 {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : <1x16x4x4xf8E5M2, 256x16x4x1>, <16x16x1x1xf8E5M2, 16x1x1x1> -> <1x16x4x4xf8E5M2, 256x16x4x1>
   return %0 : !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>
 }
@@ -201,7 +201,17 @@ func.func @conv2d_float8(%arg0: !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>, %
 func.func @quant_conv2d_float8(%arg0: !migraphx.shaped<1x16x4x4xf8E5M2, 256x16x4x1>, %arg1: !migraphx.shaped<16x16x1x1xf8E5M2, 16x1x1x1>) -> !migraphx.shaped<1x16x4x4xf32, 256x16x4x1> {
   // CHECK-COUNT-2: tosa.transpose
   // CHECK: tosa.conv2d
-  // CHECK-SAME: {acc_type = f16, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x16xf8E5M2>, tensor<16x1x1x16xf8E5M2>, tensor<16xf32>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x4x4x16xf32>
+  // CHECK-SAME: {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x16xf8E5M2>, tensor<16x1x1x16xf8E5M2>, tensor<16xf32>, tensor<1xf8E5M2>, tensor<1xf8E5M2>) -> tensor<1x4x4x16xf32>
   %0 = migraphx.quant_convolution %arg0, %arg1 {dilation = [1, 1], group = 1 : i64, padding = [0, 0, 0, 0], padding_mode = 0 : i64, stride = [1, 1]} : <1x16x4x4xf8E5M2, 256x16x4x1>, <16x16x1x1xf8E5M2, 16x1x1x1> -> <1x16x4x4xf32, 256x16x4x1>
   return %0 : !migraphx.shaped<1x16x4x4xf32, 256x16x4x1>
+}
+
+// -----
+
+// CHECK-LABEL: @dot_f16
+func.func @dot_f16(%arg0: !migraphx.shaped<8x64x64x320xf16, 1310720x20480x320x1>, %arg1: !migraphx.shaped<8x64x320x320xf16, 6553600x102400x320x1>) -> !migraphx.shaped<8x64x64x320xf16, 1310720x20480x320x1>  attributes {kernel = "mixr"} {
+ // CHECK: tosa.matmul
+ // CHECK-SAME: {acc_type = f32, perf_config = "v2:16,16,8,16,16,4,1,1,1"} : (tensor<512x64x320xf16>, tensor<512x320x320xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<512x64x320xf16>
+  %4 = migraphx.dot %arg0, %arg1 {perf_config = "v2:16,16,8,16,16,4,1,1,1"} : <8x64x64x320xf16, 1310720x20480x320x1>, <8x64x320x320xf16, 6553600x102400x320x1> -> <8x64x64x320xf16, 1310720x20480x320x1>
+  return %4 : !migraphx.shaped<8x64x64x320xf16, 1310720x20480x320x1>
 }

--- a/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/mixr-to-tosa-ops.mlir
@@ -213,7 +213,7 @@ module  {
 
   // CHECK-LABEL: func.func @matmul
   // CHECK: tosa.matmul
-  // CHECK-SAME: (tensor<2x256x384xf32>, tensor<2x384x768xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<2x256x768xf32>
+  // CHECK-SAME: {acc_type = f32} : (tensor<2x256x384xf32>, tensor<2x384x768xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<2x256x768xf32>
   func.func @matmul(%arg0: !migraphx.shaped<2x256x384xf32, 98304x384x1>, %arg1: !migraphx.shaped<2x384x768xf32, 294912x768x1>) -> !migraphx.shaped<2x256x768xf32, 196608x768x1> {
     %0 = migraphx.dot %arg0, %arg1 : <2x256x384xf32, 98304x384x1>, <2x384x768xf32, 294912x768x1> -> <2x256x768xf32, 196608x768x1>
      return %0 : !migraphx.shaped<2x256x768xf32, 196608x768x1>
@@ -221,6 +221,7 @@ module  {
 
   // CHECK-LABEL: func.func @quant_matmul
   // CHECK: tosa.matmul
+   // CHECK-SAME: {acc_type = i32}
   func.func @quant_matmul(%arg0: !migraphx.shaped<2x256x384xi8, 98304x384x1>, %arg1: !migraphx.shaped<2x384x768xi8, 294912x768x1>) -> !migraphx.shaped<2x256x768xi32, 196608x768x1> {
     %0 = migraphx.quant_dot %arg0, %arg1 : <2x256x384xi8, 98304x384x1>, <2x384x768xi8, 294912x768x1> -> <2x256x768xi32, 196608x768x1>
      return %0 : !migraphx.shaped<2x256x768xi32, 196608x768x1>
@@ -228,6 +229,7 @@ module  {
 
   // CHECK-LABEL: func.func @quant_matmul_fp8
   // CHECK: tosa.matmul
+  // CHECK-SAME: {acc_type = f32}
   func.func @quant_matmul_fp8(%arg0: !migraphx.shaped<1x12x1024x64xf8E4M3FNUZ, 786432x64x768x1>, %arg1: !migraphx.shaped<1x12x64x1024xf8E4M3FNUZ, 786432x64x1x768>) -> !migraphx.shaped<1x12x1024x1024xf32, 12582912x1048576x1024x1> {
     %0 = migraphx.quant_dot %arg0, %arg1 : <1x12x1024x64xf8E4M3FNUZ, 786432x64x768x1>, <1x12x64x1024xf8E4M3FNUZ, 786432x64x1x768> -> <1x12x1024x1024xf32, 12582912x1048576x1024x1>
      return %0 : !migraphx.shaped<1x12x1024x1024xf32, 12582912x1048576x1024x1>
@@ -235,6 +237,7 @@ module  {
 
   // CHECK-LABEL: func.func @quant_matmul_fp8_ocp
   // CHECK: tosa.matmul
+  // CHECK-SAME: {acc_type = f32}
   func.func @quant_matmul_fp8_ocp(%arg0: !migraphx.shaped<1x12x1024x64xf8E4M3FN, 786432x64x768x1>, %arg1: !migraphx.shaped<1x12x64x1024xf8E4M3FN, 786432x64x1x768>) -> !migraphx.shaped<1x12x1024x1024xf32, 12582912x1048576x1024x1> {
     %0 = migraphx.quant_dot %arg0, %arg1 : <1x12x1024x64xf8E4M3FN, 786432x64x768x1>, <1x12x64x1024xf8E4M3FN, 786432x64x1x768> -> <1x12x1024x1024xf32, 12582912x1048576x1024x1>
      return %0 : !migraphx.shaped<1x12x1024x1024xf32, 12582912x1048576x1024x1>
@@ -242,6 +245,7 @@ module  {
 
   // CHECK-LABEL: func.func @matmul_larger_batch
   // CHECK: tosa.matmul
+  // CHECK-SAME: {acc_type = f32}
   func.func @matmul_larger_batch(%arg0: !migraphx.shaped<2x16x256x384xf32, 1572864x98304x384x1>, %arg1: !migraphx.shaped<2x16x384x768xf32, 4718592x294912x768x1>) -> !migraphx.shaped<2x16x256x768xf32, 3145728x196608x768x1> {
     %0 = migraphx.dot %arg0, %arg1 : <2x16x256x384xf32, 1572864x98304x384x1>, <2x16x384x768xf32, 4718592x294912x768x1> -> <2x16x256x768xf32, 3145728x196608x768x1>
      return %0 : !migraphx.shaped<2x16x256x768xf32, 3145728x196608x768x1>
@@ -249,6 +253,7 @@ module  {
 
   // CHECK-LABEL: func.func @matmul_rank2
   // CHECK: tosa.matmul
+  // CHECK-SAME: {acc_type = f32}
   func.func @matmul_rank2(%arg0: !migraphx.shaped<32x72xf32, 72x1>, %arg1: !migraphx.shaped<72x64xf32, 64x1>) -> !migraphx.shaped<32x64xf32, 64x1> {
     %0 = migraphx.dot %arg0, %arg1 : <32x72xf32, 72x1>, <72x64xf32, 64x1> -> <32x64xf32, 64x1>
      return %0 : !migraphx.shaped<32x64xf32, 64x1>
@@ -268,6 +273,7 @@ module  {
     // CHECK-DAG: %[[ADD:.*]] = tosa.add %[[CST0]], %[[INPUT]]
     %1 = migraphx.dot %arg1, %0 : <64x64x768xf16, 49152x768x1>, <64x768x2304xf16, 0x2304x1> -> <64x64x2304xf16, 147456x2304x1>
     // CHECK-DAG: %[[MATMUL:.*]] = tosa.matmul %[[ARG1]], %[[ADD]]
+    // CHECK-SAME: {acc_type = f32}
     // CHECK-DAG: %[[BIASED:.*]] = tosa.add %[[MATMUL]], %[[ARG0]]
     // CHECK-DAG: %[[constshape5:.+]] = tosa.const_shape  {values = dense<9437184> : tensor<1xindex>} : () -> !tosa.shape<1>
     // CHECK-DAG: %[[RET:.*]] = tosa.reshape %[[BIASED]], %[[constshape5]]
@@ -289,6 +295,7 @@ module  {
     // CHECK-DAG: %[[ADD:.*]] = tosa.add %[[CST0]], %[[ARG2]]
     %1 = migraphx.dot %arg1, %0 : <64x64x768xf16, 49152x768x1>, <64x768x2304xf16, 0x2304x1> -> <64x64x2304xf16, 147456x2304x1>
     // CHECK-DAG: %[[MATMUL:.*]] = tosa.matmul %[[ARG1]], %[[ADD]]
+    // CHECK-SAME: {acc_type = f32}
     // CHECK-DAG: %[[BIASED:.*]] = tosa.add %[[MATMUL]], %[[ARG0]]
     // CHECK-DAG: %[[constshape5:.+]] = tosa.const_shape  {values = dense<9437184> : tensor<1xindex>} : () -> !tosa.shape<1>
     // CHECK-DAG: %[[RET:.*]] = tosa.reshape %[[BIASED]], %[[constshape5]]
@@ -314,6 +321,7 @@ module  {
     // CHECK-DAG: %[[RESHAPE1:.*]] = tosa.reshape %[[ADD]], %[[constshape5]]
     %1 = migraphx.dot %arg1, %0 : <2x4x8x64x768xf16, 1572864x393216x49152x768x1>, <2x4x8x768x2304xf16, 0x0x0x2304x1> -> <2x4x8x64x2304xf16, 4718592x1179648x147456x2304x1>
     // CHECK-DAG: %[[MATMUL:.*]] = tosa.matmul %[[RESHAPE0]], %[[RESHAPE1]]
+    // CHECK-SAME: {acc_type = f32}
     // CHECK: %[[RESHAPE2:.*]] = tosa.reshape %[[MATMUL]], %[[constshape3]]
     %2 = migraphx.add %1, %arg0 : <2x4x8x64x2304xf16, 4718592x1179648x147456x2304x1>, <2x4x8x64x2304xf16, 4718592x1179648x147456x2304x1> -> <2x4x8x64x2304xf16, 4718592x1179648x147456x2304x1>
     return %2 : !migraphx.shaped<2x4x8x64x2304xf16, 4718592x1179648x147456x2304x1>
@@ -617,6 +625,7 @@ module  {
 
   // CHECK-LABEL: func.func @func_dot_mul
   // CHECK: tosa.matmul
+  // CHECK-SAME: {acc_type = f32}
   // CHECK: tosa.mul
   func.func @func_dot_mul(%arg0: !migraphx.shaped<1x5x4xf32, 20x4x1>, %arg1: !migraphx.shaped<1x4x3xf32, 12x3x1>, %arg2: !migraphx.shaped<1x5x3xf32, 15x3x1>) -> !migraphx.shaped<1x5x3xf32, 15x3x1> attributes{kernel, arch = ""} {
     %0 = migraphx.dot %arg0, %arg1 : <1x5x4xf32, 20x4x1>, <1x4x3xf32, 12x3x1> -> <1x5x3xf32, 15x3x1>

--- a/mlir/test/Dialect/MIGraphX/integration/mixr-dot-acc-f16.e2e.mlir
+++ b/mlir/test/Dialect/MIGraphX/integration/mixr-dot-acc-f16.e2e.mlir
@@ -1,0 +1,8 @@
+// RUN: rocmlir-gen -fut dot_acc_f16 --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut dot_acc_f16_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+module {
+  func.func @dot_acc_f16(%arg0: !migraphx.shaped<8x64x64x320xf16, 1310720x20480x320x1>, %arg1: !migraphx.shaped<8x64x320x320xf16, 6553600x102400x320x1>) -> !migraphx.shaped<8x64x64x320xf16, 1310720x20480x320x1>  attributes {kernel = "mixr"} {
+    %4 = migraphx.dot %arg0, %arg1 {perf_config = "v2:16,16,8,16,16,4,1,1,1"} : <8x64x64x320xf16, 1310720x20480x320x1>, <8x64x320x320xf16, 6553600x102400x320x1> -> <8x64x64x320xf16, 1310720x20480x320x1>
+    return %4 : !migraphx.shaped<8x64x64x320xf16, 1310720x20480x320x1>
+  }
+}

--- a/mlir/test/rocmlir-gen/attention-kernel-f16.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-f16.mlir
@@ -22,10 +22,9 @@
 // CHECK: return
 
 // CHECK-LABEL: func.func @host_naive_attention
-// CHECK: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf16>, tensor<1xf16>) -> [[squareShapeF32:tensor<.*>]]
-// CHECK-DAG: %[[qkTensorCasted:.*]] = tosa.cast %[[qkTensor]] : ([[squareShapeF32]]) -> [[squareShape:tensor<.*>]]
-// CHECK-DAG: %[[sqkTensor:.*]] = tosa.mul %[[qkTensorCasted]], %[[scaleTensor:.*]], %{{.*}} : ([[squareShape]], [[squareShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK-DAG: %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : ([[squareShape]]) -> [[squareShapeF32]]
+// CHECK: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} {acc_type = f32} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf16>, tensor<1xf16>) -> [[squareShape:tensor<.*>]]
+// CHECK-DAG: %[[sqkTensor:.*]] = tosa.mul %[[qkTensor]], %[[scaleTensor:.*]], %{{.*}} : ([[squareShape]], [[squareShape]], tensor<1xi8>) -> [[squareShape]]
+// CHECK-DAG: %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : ([[squareShape]]) -> [[squareShapeF32:tensor<.*>]]
 // CHECK-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[sqkTensorCast]] {{.*}} : ([[squareShapeF32]]) -> [[reducedShape:tensor<.*>]]
 // CHECK-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[sqkTensorCast]], %[[sqkMaxs]] : ([[squareShapeF32]], [[reducedShape]]) -> [[squareShapeF32]]
 // CHECK-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedSqkTensor]] : ([[squareShapeF32]]) -> [[squareShapeF32]]
@@ -33,6 +32,5 @@
 // CHECK-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShapeF32]], [[reducedShape]], tensor<1xi8>) -> [[squareShapeF32]] 
 // CHECK-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShapeF32]]) -> [[squareShape]]
-// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf16>, tensor<1xf16>) -> [[valuesShapeF32:tensor<.*>]]
-// CHECK-DAG: %[[resultTensorCasted:.*]] = tosa.cast %[[resultTensor]] : ([[valuesShapeF32]]) -> [[valuesShape]]
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} {acc_type = f32} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf16>, tensor<1xf16>) -> [[squareShape:tensor<.*>]]
 // CHECK: return

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -22,7 +22,7 @@
 // CHECK_SCALE: return
 
 // CHECK_SCALE-LABEL: func.func @host_naive_attention
-// CHECK_SCALE: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
+// CHECK_SCALE: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} {acc_type = f32} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
 // CHECK_SCALE-DAG: %[[sqkTensor:.*]] = tosa.mul %[[qkTensor]], %[[scaleTensor:.*]], %{{.*}} : ([[squareShape]], [[squareShape]], tensor<1xi8>) -> [[squareShape]]
 // CHECK_SCALE-DAG: %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : ([[squareShape]]) -> [[squareShape]]
 // CHECK_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[sqkTensorCast]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]

--- a/mlir/test/rocmlir-gen/conv-elementwise-gemm-kernel.mlir
+++ b/mlir/test/rocmlir-gen/conv-elementwise-gemm-kernel.mlir
@@ -21,5 +21,5 @@
 // CHECK-LABEL: func.func @host_naive_conv_gemm
 // CHECK: %[[convTensor:.*]] = tosa.conv2d %[[inputTensor:.*]], %[[filterTensor:.*]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<2x32x32x256xf32>, tensor<128x1x1x256xf32>, tensor<128xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<2x32x32x128xf32>
 // CHECK-DAG: %[[abTensor:.*]] = tosa.reshape %[[convTensor]], %{{.*}} : (tensor<2x32x32x128xf32>, !tosa.shape<3>) -> tensor<1x2048x128xf32>
-// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[abTensor]], %[[cTensor:.*]], %{{.*}}, %{{.*}} : (tensor<1x2048x128xf32>, tensor<1x128x128xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x2048x128xf32>
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[abTensor]], %[[cTensor:.*]], %{{.*}}, %{{.*}} {acc_type = f32} : (tensor<1x2048x128xf32>, tensor<1x128x128xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x2048x128xf32>
 // CHECK: return

--- a/mlir/test/rocmlir-gen/gemm-elementwise-gemm-kernel.mlir
+++ b/mlir/test/rocmlir-gen/gemm-elementwise-gemm-kernel.mlir
@@ -20,5 +20,5 @@
 
 // CHECK-LABEL: func.func @host_naive_gemm_gemm
 // CHECK: %[[abTensor:.*]] = tosa.matmul %[[aTensor:.*]], %[[bTensor:.*]], %{{.*}}, %{{.*}} : ([[aShape:tensor<.*>]], [[bShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
-// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[abTensor]], %[[cTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[cShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[cShape]]
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[abTensor]], %[[cTensor:.*]], %{{.*}}, %{{.*}} {acc_type = f32} : ([[squareShape]], [[cShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[cShape]]
 // CHECK: return

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -3364,15 +3364,13 @@ createCpuConvElementwiseGemmKernelWithMlir(ModuleOp module,
       tosa::createZeroPointTensor(builder, loc, filterTensor.getType(), 0)
           .value();
 
-  // TODO: if/when tosa::matmul has acc_type implemented, we can use it here to
-  // be more similar to what the gpu code does
   Type convOutElemType = params.types[2];
   // accumulate in 32 bit
   Type firstAccType = getAccType(params.types[0], builder);
   assert(firstAccType == getAccType(params.types[1], builder));
 
   auto biasTy = RankedTensorType::get(
-      cast<ShapedType>(filterTensor.getType()).getShape()[0], firstAccType);
+      cast<ShapedType>(filterTensor.getType()).getShape()[0], convOutElemType);
   auto biasTensor = builder.create<tosa::ConstOp>(
       loc, biasTy, cast<ElementsAttr>(builder.getZeroAttr(biasTy)));
 
@@ -3383,30 +3381,12 @@ createCpuConvElementwiseGemmKernelWithMlir(ModuleOp module,
     pads.push_back(config->paddingRightDims[i]);
   }
 
-  // Determine the accumulation type based on the output type.
-  Type accType;
-  if (isa<FloatType>(params.types[0]) &&
-      params.types[0].getIntOrFloatBitWidth() >= 16) {
-    accType = builder.getF32Type();
-  } else if (isa<FloatType>(params.types[0]) &&
-             params.types[0].getIntOrFloatBitWidth() <= 8) {
-    accType = builder.getF16Type();
-  } else if (isa<IntegerType>(params.types[0])) {
-    accType = builder.getI32Type();
-  }
-
-  Value convOutBeforeConversion = createOpAndInfer<tosa::Conv2DOp>(
-      builder, loc, firstAccType, inputTensor, filterTensor, biasTensor,
+  Value convOut = createOpAndInfer<tosa::Conv2DOp>(
+      builder, loc, convOutElemType, inputTensor, filterTensor, biasTensor,
       inputZp, weightZp, builder.getDenseI64ArrayAttr(pads),
       builder.getDenseI64ArrayAttr(config->strideDims),
-      builder.getDenseI64ArrayAttr(config->dilationDims), accType,
+      builder.getDenseI64ArrayAttr(config->dilationDims), firstAccType,
       builder.getI64IntegerAttr(groupSize));
-
-  Value convOut = builder.createOrFold<tosa::CastOp>(
-      loc,
-      cast<ShapedType>(convOutBeforeConversion.getType())
-          .clone(convOutElemType),
-      convOutBeforeConversion);
 
   // convert conv output to matmul A matrix
   // tensor<bxhxwxkxf16> -> tensor<1x(b*h*w)xkxf16>
@@ -3419,14 +3399,10 @@ createCpuConvElementwiseGemmKernelWithMlir(ModuleOp module,
   // accumulate in 32 bit
   Type secondAccType = getAccType(convOutElemType, builder);
   assert(secondAccType == getAccType(params.types[2], builder));
-  Value resultTensorBeforeConversion = createOpAndInfer<tosa::MatMulOp>(
-      builder, loc, secondAccType, gemmA, cTensor, abZp, cZp);
-
-  Value resultTensor = builder.createOrFold<tosa::CastOp>(
-      loc,
-      cast<ShapedType>(resultTensorBeforeConversion.getType())
-          .clone(secondGemmOutElemType),
-      resultTensorBeforeConversion);
+  auto resultTensorMatMul = createOpAndInfer<tosa::MatMulOp>(
+      builder, loc, secondGemmOutElemType, gemmA, cTensor, abZp, cZp);
+  resultTensorMatMul->setAttr("acc_type", TypeAttr::get(secondAccType));
+  Value resultTensor = resultTensorMatMul.getResult();
 
   if (transposeO) {
     resultTensor = transposeMatrix(builder, loc, resultTensor, {0, 2, 1});
@@ -3516,19 +3492,14 @@ createCpuGemmElementwiseGemmKernelWithMlir(ModuleOp module,
   auto bZp =
       tosa::createZeroPointTensor(builder, loc, bTensor.getType(), 0).value();
 
-  // TODO: if/when tosa::matmul has acc_type implemented, we can use it here to
-  // be more similar to what the gpu code does
   Type firstGemmOutElemType = params.types[2];
   // accumulate in 32 bit
   Type firstAccType = getAccType(params.types[0], builder);
   assert(firstAccType == getAccType(params.types[1], builder));
-  Value abTensorBeforeConversion = createOpAndInfer<tosa::MatMulOp>(
-      builder, loc, firstAccType, aTensor, bTensor, aZp, bZp);
-  Value abTensor = builder.createOrFold<tosa::CastOp>(
-      loc,
-      cast<ShapedType>(abTensorBeforeConversion.getType())
-          .clone(firstGemmOutElemType),
-      abTensorBeforeConversion);
+  auto abTensorMatMul = createOpAndInfer<tosa::MatMulOp>(
+      builder, loc, firstGemmOutElemType, aTensor, bTensor, aZp, bZp);
+  abTensorMatMul->setAttr("acc_type", TypeAttr::get(firstAccType));
+  Value abTensor = abTensorMatMul.getResult();
 
   auto abZp =
       tosa::createZeroPointTensor(builder, loc, abTensor.getType(), 0).value();
@@ -3538,13 +3509,10 @@ createCpuGemmElementwiseGemmKernelWithMlir(ModuleOp module,
   // accumulate in 32 bit
   Type secondAccType = getAccType(firstGemmOutElemType, builder);
   assert(secondAccType == getAccType(params.types[2], builder));
-  Value resultTensorBeforeConversion = createOpAndInfer<tosa::MatMulOp>(
-      builder, loc, secondAccType, abTensor, cTensor, abZp, cZp);
-  Value resultTensor = builder.createOrFold<tosa::CastOp>(
-      loc,
-      cast<ShapedType>(resultTensorBeforeConversion.getType())
-          .clone(secondGemmOutElemType),
-      resultTensorBeforeConversion);
+  auto resultTensorMatMul = createOpAndInfer<tosa::MatMulOp>(
+      builder, loc, secondGemmOutElemType, abTensor, cTensor, abZp, cZp);
+  resultTensorMatMul->setAttr("acc_type", TypeAttr::get(secondAccType));
+  Value resultTensor = resultTensorMatMul.getResult();
 
   if (transposeO) {
     resultTensor = transposeMatrix(builder, loc, resultTensor, {0, 2, 1});
@@ -3643,18 +3611,14 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
   auto keysZp =
       tosa::createZeroPointTensor(builder, loc, keysTensor.getType(), 0)
           .value();
-  // TODO: if/when tosa::matmul has acc_type implemented, we can use it here to
-  // be more similar to what the gpu code does
   // accumulate in 32 bit
   Type firstAccType = getAccType(firstGemmOutElemType, builder);
   assert(firstAccType == getAccType(params.types[1], builder));
-  Value qkTensorBeforeConversion = createOpAndInfer<tosa::MatMulOp>(
-      builder, loc, firstAccType, queriesTensor, keysTensor, queriesZp, keysZp);
-  Value qkTensor = builder.createOrFold<tosa::CastOp>(
-      loc,
-      cast<ShapedType>(qkTensorBeforeConversion.getType())
-          .clone(firstGemmOutElemType),
-      qkTensorBeforeConversion);
+  auto qkTensorMatMul = createOpAndInfer<tosa::MatMulOp>(
+      builder, loc, firstGemmOutElemType, queriesTensor, keysTensor, queriesZp,
+      keysZp);
+  qkTensorMatMul->setAttr("acc_type", TypeAttr::get(firstAccType));
+  Value qkTensor = qkTensorMatMul.getResult();
 
   // get currentSeqLenTensor
   Value currentSeqLenTensor;
@@ -3794,18 +3758,13 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
       tosa::createZeroPointTensor(builder, loc, valuesTensor.getType(), 0)
           .value();
 
-  // TODO: if/when tosa::matmul has acc_type implemented, we can use it here to
-  // be more similar to what the gpu code does
   // accumulate in 32 bit
   Type secondAccType = getAccType(resultOutElementType, builder);
-  Value resultTensorBeforeConversion = createOpAndInfer<tosa::MatMulOp>(
-      builder, loc, secondAccType, softmaxTensor, valuesTensor, softmaxZp,
-      valuesZp);
-  Value resultTensor = builder.createOrFold<tosa::CastOp>(
-      loc,
-      cast<ShapedType>(resultTensorBeforeConversion.getType())
-          .clone(resultOutElementType),
-      resultTensorBeforeConversion);
+  auto resultTensorMatMul = createOpAndInfer<tosa::MatMulOp>(
+      builder, loc, resultOutElementType, softmaxTensor, valuesTensor,
+      softmaxZp, valuesZp);
+  resultTensorMatMul->setAttr("acc_type", TypeAttr::get(secondAccType));
+  Value resultTensor = resultTensorMatMul.getResult();
 
   if (transposeO) {
     resultTensor = transposeMatrix(builder, loc, resultTensor, {0, 2, 1});


### PR DESCRIPTION
This PR adds support for the acc_type option in the TOSA MatMulOp and utilizes it during CPU validation code generation.
close: https://github.com/ROCm/rocMLIR-internal/issues/1788
close: https://github.com/ROCm/rocMLIR-internal/issues/1816