### PR TITLE
Fix Azure builds

### DIFF
--- a/mlir/utils/performance/common/benchmarkUtils.cpp
+++ b/mlir/utils/performance/common/benchmarkUtils.cpp
@@ -12,6 +12,7 @@
 #include "hip_f8_impl.h"
 
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Azure builds are failing with error that `assert` is undefined. 

Adding `#include <cassert>` to see if it fixes it.