### PR TITLE
Increase time out on resetGPUs to allow resetting more than 8 GPUs

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -66,8 +66,8 @@ def advancedNodeCheck(Map params) {
 }
 
 def resetGPUs() {
-    // Abort this if runs longer than 5 minutes
-    timeout(time: 5, unit: 'MINUTES') {
+    // Abort this if runs longer than 10 minutes
+    timeout(time: 10, unit: 'MINUTES') {
         // Run the reset, but don't fail the build if anything is wrong
         def rc = sh(
             script: '''


### PR DESCRIPTION
One of the server has 16 GPUs and it take more than 5 minutes to ResetGPUs on it, increase timeout limit to allow such cases.