### PR TITLE
Allow user to choose softmax type

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -220,7 +220,8 @@ def Rock_AttentionOp
           Optional<TensorOrMemRefOf<[F32, F16, BF16]>>:$lse,
           UnitAttr:$qTransposed, UnitAttr:$kTransposed, UnitAttr:$vTransposed,
           UnitAttr:$oTransposed, UnitAttr:$causal, StrAttr:$arch,
-          Rock_GemmFeaturesAttr:$features, OptionalAttr<I32Attr>:$numCU,
+          Rock_GemmFeaturesAttr:$features, OptionalAttr<TypeAttr>:$softmaxType,
+          OptionalAttr<I32Attr>:$numCU,
           OptionalAttr<RockTuningParamAttrInterface>:$params0,
           OptionalAttr<RockTuningParamAttrInterface>:$params1,
           I32Attr:$firstGemmIdx)>,
@@ -568,6 +569,7 @@ def Rock_GridwiseAttentionAccelOp
           I32Attr:$gridSize, UnitAttr:$disableQBypassLDS,
           OptionalAttr<IndexAttr>:$prePadG0M,
           OptionalAttr<IndexAttr>:$prePadG0N,
+          OptionalAttr<TypeAttr>:$softmaxType,
           RockAccelTuningParamAttrInterface:$params0,
           RockAccelTuningParamAttrInterface:$params1, I32Attr:$firstGemmIdx,
           DefaultValuedOptionalAttr<BoolAttr, "true">:$enableSoftmax)> {

--- a/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
@@ -32,8 +32,16 @@ Value createZeroConstantOp(OpBuilder &b, Location loc, Type type);
 Value createTypeConversionOp(OpBuilder &b, Location loc, Value source,
                              Type destType);
 
+// Utility function to perform cast
+// and copy to another memref using a Linalg Generic.
 void createTypeConversionLaGeneric(PatternRewriter &rewriter, Location loc,
                                    Value src, Value dst);
+
+// Utility function to perform cast
+// and copy to another memref using a vector store.
+void createTypeConversionStore(PatternRewriter &rewriter, Location loc,
+                               Value src, Value dst);
+
 /// Utility function to collapse an multi-dimensional memref to 1D.
 Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source);
 

--- a/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/builderUtils.h
@@ -38,9 +38,9 @@ void createTypeConversionLaGeneric(PatternRewriter &rewriter, Location loc,
                                    Value src, Value dst);
 
 // Utility function to perform cast
-// and copy to another memref using a vector store.
-void createTypeConversionStore(PatternRewriter &rewriter, Location loc,
-                               Value src, Value dst);
+// and copy to another memref using a vector store. This flattens the vectors.
+void createTypeConversionFlatAndStore(PatternRewriter &rewriter, Location loc,
+                                      Value src, Value dst);
 
 /// Utility function to collapse an multi-dimensional memref to 1D.
 Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source);

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -196,6 +196,9 @@ AffineMap getIdxReversalMap(OpBuilder &b);
 // helper to create ReassociationIndices for flattening
 ReassociationIndices getReassociationForFlattening(ShapedType srcTp);
 
+// helper to obtain a flattened memref
+Value getFlattenedMemref(OpBuilder &b, Value nonFlatMemRef);
+
 /// Construct a `memref.view` operation that interprets the buffer `buffer`,
 /// whose elements are bytes, as a buffer of `type`.
 TypedValue<MemRefType> viewBufferAs(OpBuilder &b, Value buffer, Type type);

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -1841,7 +1841,8 @@ struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
         /*kTransposed=*/nullptr,
         /*vTransposed=*/nullptr,
         /*oTransposed=*/nullptr, causalAttr, arch,
-        rewriter.getAttr<rock::GemmFeaturesAttr>(features), numCUAttr,
+        rewriter.getAttr<rock::GemmFeaturesAttr>(features),
+        /*softmaxType=*/nullptr, numCUAttr,
         /*params0=*/nullptr, /*params1=*/nullptr,
         /*firstGemmIdx=*/rewriter.getI32IntegerAttr(0));
 

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1876,6 +1876,10 @@ LogicalResult GridwiseAttentionAccelOp::verify() {
     return emitError("LSE only works for attention.");
   }
 
+  if (!getEnableSoftmax() && getSoftmaxType()) {
+    return emitError("Setting softmax type only works for attention.");
+  }
+
   int64_t linalgOpCount = 0;
   getPreSoftmaxBody().walk([&](linalg::GenericOp genOp) { linalgOpCount++; });
   if (linalgOpCount > 1) {

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -129,12 +129,11 @@ computeGridSizeAttentionGemmElmtGemm(ConversionPatternRewriter &rw, Op op,
   return success();
 }
 
-static LogicalResult
-commonAttentionGemmElmtGemm(ConversionPatternRewriter &rw,
-                            RockGemmGemmWrapperInterface op, Value a, Value b,
-                            Value c, Value out, Value lse, Value currentSeqLen,
-                            UnitAttr causal, ValueRange elementwiseInputs,
-                            Region &preSecondOpRegion, bool enableSoftmax) {
+static LogicalResult commonAttentionGemmElmtGemm(
+    ConversionPatternRewriter &rw, RockGemmGemmWrapperInterface op, Value a,
+    Value b, Value c, Value out, Value lse, Value currentSeqLen,
+    UnitAttr causal, ValueRange elementwiseInputs, Region &preSecondOpRegion,
+    bool enableSoftmax, TypeAttr softmaxType) {
   Location loc = op->getLoc();
 
   if (!isa<MemRefType>(op.getAType()))
@@ -218,8 +217,8 @@ commonAttentionGemmElmtGemm(ConversionPatternRewriter &rw,
       rw.getStringAttr(op.getArch()),
       rw.getAttr<rock::GemmFeaturesAttr>(op.getGemmFeatures()), blockSizeAttr,
       gridSizeAttr,
-      /*disableQBypassLDS=*/nullptr, prePadG0MAttr, prePadG0NAttr, params0,
-      params1, rw.getI32IntegerAttr(op.getFirstGemmIndex()),
+      /*disableQBypassLDS=*/nullptr, prePadG0MAttr, prePadG0NAttr, softmaxType,
+      params0, params1, rw.getI32IntegerAttr(op.getFirstGemmIndex()),
       rw.getBoolAttr(enableSoftmax));
   bool linalgOpFound = false;
   preSecondOpRegion.walk(
@@ -584,7 +583,7 @@ AttentionRewritePattern::matchAndRewrite(AttentionOp op,
       adaptor.getOut(), adaptor.getLse(), adaptor.getCurrentSeqLen(),
       adaptor.getCausalAttr(), adaptor.getPreSoftmaxElemWiseInputs(),
       op.getPreSoftmaxBody(),
-      /*enableSoftmax=*/true);
+      /*enableSoftmax=*/true, op.getSoftmaxTypeAttr());
 }
 
 LogicalResult GemmElementwiseGemmRewritePattern::matchAndRewrite(
@@ -595,7 +594,7 @@ LogicalResult GemmElementwiseGemmRewritePattern::matchAndRewrite(
       /*lse=*/nullptr,
       /*currentSeqLen=*/nullptr, /*causal=*/nullptr,
       adaptor.getElemwiseInputs(), op.getPreSecondGemmBody(),
-      /*enableSoftmax=*/false);
+      /*enableSoftmax=*/false, /*softmaxType=*/nullptr);
 }
 
 void RockGemmToGridwisePass::runOnOperation() {

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1864,8 +1864,8 @@ struct GridwiseAttentionAccelRewritePattern
     bool isKVCache = currentSeqLenTensor != nullptr;
     bool isCausal = op.getCausal();
 
-    // Gemm0 out is casted to be elemTypeV
-    Type elemTypeQxK = elemTypeV;
+    // Gemm0 out is casted to be softmaxType (if null, it's casted to elemTypeV)
+    Type elemTypeQxK = op.getSoftmaxType().value_or(elemTypeV);
 
     auto privateMemoryAddressSpace = rewriter.getAttr<gpu::AddressSpaceAttr>(
         gpu::GPUDialect::getPrivateAddressSpace());
@@ -2018,25 +2018,30 @@ struct GridwiseAttentionAccelRewritePattern
         createBufferForAccelGemmOut(loc, accelParamsGemm0, rewriter);
     // Currently, there is a working assumption that this kernel is meant
     // support fp32/fp16/bf16. This should be guaranteed by op verifiers.
-    Type gemmOutElemType = elemTypeQxK;
-    Type fusionOutElemType = elemTypeQxK;
+    Type gemmOutElemType = elemTypeV;
+    Type fusionOutElemType = elemTypeV;
     if (elemTypeQ == rewriter.getI8Type()) {
       gemmOutElemType = rewriter.getI32Type();
     }
     Value gemm0OutBuffer = createBufferForGemmOut(loc, gemmOutElemType,
                                                   accelParamsGemm0, rewriter);
+    Value softmaxInputBuffer;
+    if (fusionOutElemType != elemTypeQxK) {
+      softmaxInputBuffer =
+          createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
+    }
     SmallVector<StringRef, 3> bidGridOrder = {"g_block", "m_block", "n_block"};
 
     Value fusionOutBuffer = createBufferForGemmOut(loc, fusionOutElemType,
                                                    accelParamsGemm0, rewriter);
     // Buffers for reductions and softmax input
-    Value gemm0OutBufferMax, gemm0OutBufferExp, gemm0OutBufferSum;
+    Value softmaxBufferMax, softmaxBufferExp, softmaxBufferSum;
     if (op.getEnableSoftmax()) {
-      gemm0OutBufferMax =
+      softmaxBufferMax =
           createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
-      gemm0OutBufferExp =
+      softmaxBufferExp =
           createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
-      gemm0OutBufferSum =
+      softmaxBufferSum =
           createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
     }
     // Buffers for gemm 1
@@ -2107,7 +2112,7 @@ struct GridwiseAttentionAccelRewritePattern
       outAccBufferOutTyped = attentionOutAccBuffer;
       if (elemTypeQxK != elemTypeOut) {
         outAccBufferOutTyped = createBufferForGemmOut(
-            loc, elemTypeOut, accelParamsGemm1, rewriter);
+            loc, elemTypeOut, accelParamsGemm1, rewriter, gemm1MBlocks);
       }
       attentionOutAccBufferThreadSubTileViewMaps =
           invertTransforms(rewriter, loc, gemm1OutSubTileViewsTr.threadSubTile);
@@ -2394,16 +2399,23 @@ struct GridwiseAttentionAccelRewritePattern
         return op.emitError("post processing first gemm failed.\n");
       }
       gemm0OutBuffer = maybeFusionOutBuffer.value();
+      if (fusionOutElemType == elemTypeQxK)
+        softmaxInputBuffer = gemm0OutBuffer;
 
       // Softmax
       if (op.getEnableSoftmax()) {
+        // convert gemm0OutBuffer to elemTypeQxK
+        if (fusionOutElemType != elemTypeQxK) {
+          createTypeConversionStore(rewriter, loc, gemm0OutBuffer,
+                                    softmaxInputBuffer);
+        }
         // Scale gemm0 output by (1/ln2)
         // So that we can use exp2 instead of exp.
         Value ln2Recip = createConstantFloatOp(
             rewriter, loc, elemTypeQxK, elemTypeQxK, 1.44269504f,
             elemTypeQxK.isF32() ? APFloat::opOK : APFloat::opInexact);
         postProcessFirstGemmSplat<ElementwiseMultOp>(
-            rewriter, loc, gridCoordsGemm0, gemm0OutBuffer,
+            rewriter, loc, gridCoordsGemm0, softmaxInputBuffer,
             gemm0OutSubTileViews,
             ln2Recip.getDefiningOp<arith::ConstantOp>().getValue());
 
@@ -2413,18 +2425,18 @@ struct GridwiseAttentionAccelRewritePattern
         if (hasPadding) {
           bool isGfx11 = arch.contains("gfx11");
           createFirstGemmNegInfPadding(rewriter, loc, gridCoordsGemm0,
-                                       gemm0OutBuffer,
+                                       softmaxInputBuffer,
                                        gemm0OutSubTileViewsTrUnPadded, isGfx11);
         }
         // Negative Infinite for extra values (KV cache)
         setGemm0OutputOutOfScope(rewriter, loc, OutOfScopeType::KVCache,
-                                 gridCoordsGemm0, gemm0OutBuffer,
+                                 gridCoordsGemm0, softmaxInputBuffer,
                                  gemm0OutSubTileViewsTr, isKVCache, mLoopIV,
                                  gemm0MBlocksLastIter, currentSeqLen);
 
         // Negative Infinite for extra values (causal masking)
         setGemm0OutputOutOfScope(rewriter, loc, OutOfScopeType::Causal,
-                                 gridCoordsGemm0, gemm0OutBuffer,
+                                 gridCoordsGemm0, softmaxInputBuffer,
                                  gemm0OutSubTileViewsTr, isCausal, mLoopIV,
                                  gemm0MBlocksLastIter);
 
@@ -2435,7 +2447,8 @@ struct GridwiseAttentionAccelRewritePattern
         TypedValue<MemRefType> ldsReductionWorkspaceBuffer = viewBufferAs(
             rewriter, ldsReductionWorkspaceByteBuffer, elemTypeQxK);
         rewriter.create<BlockwiseBroadcastReduceOp>(
-            loc, gemm0OutBuffer, ldsReductionWorkspaceBuffer, gemm0OutBufferMax,
+            loc, softmaxInputBuffer, ldsReductionWorkspaceBuffer,
+            softmaxBufferMax,
             /*extraOut=*/nullptr, reductionAxis, rock::ReduceMethod::Max,
             gemm0OutSubTileViewsTr.blockSubTile,
             gemm0OutSubTileViewsTr.blockSubTileTidSlice.value(),
@@ -2445,15 +2458,15 @@ struct GridwiseAttentionAccelRewritePattern
 
         // softmax normalization.
         Value gemm0MNThreadwiseView =
-            transform(rewriter, gemm0OutBuffer,
+            transform(rewriter, softmaxInputBuffer,
                       invertTransforms(rewriter, loc,
                                        gemm0OutSubTileViewsTr.threadSubTile));
         Value gemm0MNExpThreadwiseView =
-            transform(rewriter, gemm0OutBufferExp,
+            transform(rewriter, softmaxBufferExp,
                       invertTransforms(rewriter, loc,
                                        gemm0OutSubTileViewsTr.threadSubTile));
         Value gemm0MNMaxThreadwiseView =
-            transform(rewriter, gemm0OutBufferMax,
+            transform(rewriter, softmaxBufferMax,
                       invertTransforms(rewriter, loc,
                                        gemm0OutSubTileViewsTr.threadSubTile));
         expSubstractMaxFromGemm0(rewriter, loc, gemm0MNThreadwiseView,
@@ -2466,8 +2479,8 @@ struct GridwiseAttentionAccelRewritePattern
         TypedValue<MemRefType> ldsReductionWorkspaceSecondBuffer = viewBufferAs(
             rewriter, ldsReductionWorkspaceByteSecondBuffer, elemTypeQxK);
         rewriter.create<BlockwiseBroadcastReduceOp>(
-            loc, gemm0OutBufferExp, ldsReductionWorkspaceSecondBuffer,
-            gemm0OutBufferSum, /*extraOut=*/nullptr, reductionAxis,
+            loc, softmaxBufferExp, ldsReductionWorkspaceSecondBuffer,
+            softmaxBufferSum, /*extraOut=*/nullptr, reductionAxis,
             rock::ReduceMethod::Sum, gemm0OutSubTileViewsTr.blockSubTile,
             gemm0OutSubTileViewsTr.blockSubTileTidSlice.value(),
             gemm0OutSubTileViewsTr.threadSubTile,
@@ -2475,11 +2488,11 @@ struct GridwiseAttentionAccelRewritePattern
         rewriter.create<GpuDeallocOp>(loc,
                                       ldsReductionWorkspaceByteSecondBuffer);
         Value gemm0SumThreadwiseView =
-            transform(rewriter, gemm0OutBufferSum,
+            transform(rewriter, softmaxBufferSum,
                       invertTransforms(rewriter, loc,
                                        gemm0OutSubTileViewsTr.threadSubTile));
         Value gemm0MaxThreadwiseView =
-            transform(rewriter, gemm0OutBufferMax,
+            transform(rewriter, softmaxBufferMax,
                       invertTransforms(rewriter, loc,
                                        gemm0OutSubTileViewsTr.threadSubTile));
         updateRowSum(rewriter, loc, gemm0SumThreadwiseView,
@@ -2490,10 +2503,9 @@ struct GridwiseAttentionAccelRewritePattern
       // Emit blockwise GEMM 1.
       {
         auto gemm0Out =
-            op.getEnableSoftmax() ? gemm0OutBufferExp : gemm0OutBuffer;
+            op.getEnableSoftmax() ? softmaxBufferExp : softmaxInputBuffer;
         if (elemTypeV != elemTypeQxK) {
-          createTypeConversionLaGeneric(rewriter, loc, gemm0Out,
-                                        gemm1RegBufferB);
+          createTypeConversionStore(rewriter, loc, gemm0Out, gemm1RegBufferB);
         } else {
           gemm1RegBufferB = gemm0Out;
         }
@@ -2528,7 +2540,7 @@ struct GridwiseAttentionAccelRewritePattern
           }
           TypedValue<MemRefType> gemm1LDSBufferB =
               viewBufferAs(rewriter, gemm1LDSByteBufferB,
-                           vectorTypeOrSelf(elemTypeQxK, gemm1kpack));
+                           vectorTypeOrSelf(elemTypeV, gemm1kpack));
           wrappedLDSBufferForLoadB = accelEmitterPtrGemm1->wrapLDSBufferForLoad(
               rewriter, loc, gemm1LDSBufferB, op.getBlockSize(),
               gemm1InNPerThread, "n", false);
@@ -2706,8 +2718,10 @@ struct GridwiseAttentionAccelRewritePattern
     Value outAccBuffer =
         op.getEnableSoftmax() ? attentionOutAccBuffer : gemm1OutBuffer;
     if (elemTypeQxK != elemTypeOut) {
-      createTypeConversionLaGeneric(rewriter, loc, outAccBuffer,
-                                    outAccBufferOutTyped);
+      // We flatten output buffer in case gemm1MBlocks > 1
+      // where those are iterated.
+      createTypeConversionStore(rewriter, loc, outAccBuffer,
+                                outAccBufferOutTyped);
     }
     if (lse) {
       // it must be guaranteed by the verifier
@@ -2718,22 +2732,9 @@ struct GridwiseAttentionAccelRewritePattern
       computeLse(rewriter, loc, lseBufferView, sumRowBuffer, maxRowBuffer);
     }
 
-    // We flatten output buffer in case gemm1MBlocks > 1
-    // where those are iterated.
-    Value outAccBufferOutTypedFlat = outAccBufferOutTyped;
     MemRefType outAccBufferOutType =
         cast<MemRefType>(outAccBufferOutTyped.getType());
     int64_t numElementsAttnOut = outAccBufferOutType.getNumElements();
-    if (outAccBufferOutType.getRank() > 1) {
-      Type outAccBufferOutTypedElType = outAccBufferOutType.getElementType();
-      auto outAccBufferOutTypedFlatType =
-          MemRefType::get({numElementsAttnOut}, outAccBufferOutTypedElType,
-                          AffineMap{}, privateMemoryAddressSpace);
-      auto reassociation = getReassociationForFlattening(outAccBufferOutType);
-      outAccBufferOutTypedFlat = rewriter.create<memref::CollapseShapeOp>(
-          loc, outAccBufferOutTypedFlatType, outAccBufferOutTyped,
-          reassociation);
-    }
     // This map will create an upper view [gblock, nblock, flatiter] -> [gblock,
     // miter, nblock, iter]
     TransformMapAttr flatToMiterMap =
@@ -2745,6 +2746,8 @@ struct GridwiseAttentionAccelRewritePattern
     Value zero = rewriter.createOrFold<ConstantIndexOp>(loc, 0);
     auto gridCoordsGemm1 = layout::makeGxNGridLayout(
         rewriter, loc, bid, zero, gemm1NBlocks, gridSize, arch);
+    Value outAccBufferOutTypedFlat =
+        getFlattenedMemref(rewriter, outAccBufferOutTyped);
     rewriter.create<ThreadwiseWriteAllOp>(
         loc, outAccBufferOutTypedFlat, trOut, outGridSubTile,
         /*extraIndices=*/

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1865,7 +1865,7 @@ struct GridwiseAttentionAccelRewritePattern
     bool isCausal = op.getCausal();
 
     // Gemm0 out is casted to be softmaxType (if null, it's casted to elemTypeV)
-    Type elemTypeQxK = op.getSoftmaxType().value_or(elemTypeV);
+    Type elemTypeSoftmax = op.getSoftmaxType().value_or(elemTypeV);
 
     auto privateMemoryAddressSpace = rewriter.getAttr<gpu::AddressSpaceAttr>(
         gpu::GPUDialect::getPrivateAddressSpace());
@@ -2026,9 +2026,9 @@ struct GridwiseAttentionAccelRewritePattern
     Value gemm0OutBuffer = createBufferForGemmOut(loc, gemmOutElemType,
                                                   accelParamsGemm0, rewriter);
     Value softmaxInputBuffer;
-    if (fusionOutElemType != elemTypeQxK) {
-      softmaxInputBuffer =
-          createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
+    if (fusionOutElemType != elemTypeSoftmax) {
+      softmaxInputBuffer = createBufferForGemmOut(loc, elemTypeSoftmax,
+                                                  accelParamsGemm0, rewriter);
     }
     SmallVector<StringRef, 3> bidGridOrder = {"g_block", "m_block", "n_block"};
 
@@ -2037,16 +2037,16 @@ struct GridwiseAttentionAccelRewritePattern
     // Buffers for reductions and softmax input
     Value softmaxBufferMax, softmaxBufferExp, softmaxBufferSum;
     if (op.getEnableSoftmax()) {
-      softmaxBufferMax =
-          createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
-      softmaxBufferExp =
-          createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
-      softmaxBufferSum =
-          createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm0, rewriter);
+      softmaxBufferMax = createBufferForGemmOut(loc, elemTypeSoftmax,
+                                                accelParamsGemm0, rewriter);
+      softmaxBufferExp = createBufferForGemmOut(loc, elemTypeSoftmax,
+                                                accelParamsGemm0, rewriter);
+      softmaxBufferSum = createBufferForGemmOut(loc, elemTypeSoftmax,
+                                                accelParamsGemm0, rewriter);
     }
     // Buffers for gemm 1
     Value gemm1RegBufferB;
-    if (elemTypeV != elemTypeQxK) {
+    if (elemTypeV != elemTypeSoftmax) {
       gemm1RegBufferB =
           createBufferForGemmOut(loc, elemTypeV, accelParamsGemm0, rewriter);
     }
@@ -2060,13 +2060,13 @@ struct GridwiseAttentionAccelRewritePattern
     if (op.getEnableSoftmax()) {
       accRegBufferGemm1 =
           createBufferForAccelGemmOut(loc, accelParamsGemm1, rewriter);
-      gemm1OutBuffer =
-          createBufferForGemmOut(loc, elemTypeQxK, accelParamsGemm1, rewriter);
+      gemm1OutBuffer = createBufferForGemmOut(loc, elemTypeSoftmax,
+                                              accelParamsGemm1, rewriter);
     } else {
       accRegBufferGemm1 = createBufferForAccelGemmOut(loc, accelParamsGemm1,
                                                       rewriter, gemm1MBlocks);
       gemm1OutBuffer = createBufferForGemmOut(
-          loc, elemTypeQxK, accelParamsGemm1, rewriter, gemm1MBlocks);
+          loc, elemTypeSoftmax, accelParamsGemm1, rewriter, gemm1MBlocks);
     }
 
     SmallVector<int64_t, 3> gemm1BidGridLengths = {gemm0G, gemm1MBlocks,
@@ -2108,9 +2108,9 @@ struct GridwiseAttentionAccelRewritePattern
     ArrayAttr attentionOutAccBufferThreadSubTileViewMaps;
     if (op.getEnableSoftmax()) {
       attentionOutAccBuffer = createBufferForGemmOut(
-          loc, elemTypeQxK, accelParamsGemm1, rewriter, gemm1MBlocks);
+          loc, elemTypeSoftmax, accelParamsGemm1, rewriter, gemm1MBlocks);
       outAccBufferOutTyped = attentionOutAccBuffer;
-      if (elemTypeQxK != elemTypeOut) {
+      if (elemTypeSoftmax != elemTypeOut) {
         outAccBufferOutTyped = createBufferForGemmOut(
             loc, elemTypeOut, accelParamsGemm1, rewriter, gemm1MBlocks);
       }
@@ -2118,7 +2118,7 @@ struct GridwiseAttentionAccelRewritePattern
           invertTransforms(rewriter, loc, gemm1OutSubTileViewsTr.threadSubTile);
       // m buffer; this only contains a reduced single value per row
       auto reducedBufferType =
-          MemRefType::get({gemm1MPerThread}, elemTypeQxK, AffineMap{},
+          MemRefType::get({gemm1MPerThread}, elemTypeSoftmax, AffineMap{},
                           /*memorySpace=*/privateMemoryAddressSpace);
       auto negInfSumTyped = createConstantFloatOp(
           rewriter, loc, reducedBufferType.getElementType(),
@@ -2130,8 +2130,9 @@ struct GridwiseAttentionAccelRewritePattern
       rewriter.create<FillOp>(loc, maxRowBuffer, negInfSumTyped);
       // l buffer; this only contains a reduced single value per row
       sumRowBuffer = rewriter.create<rock::GpuAllocOp>(loc, reducedBufferType);
-      rewriter.create<FillOp>(loc, sumRowBuffer,
-                              createZeroConstantOp(rewriter, loc, elemTypeQxK));
+      rewriter.create<FillOp>(
+          loc, sumRowBuffer,
+          createZeroConstantOp(rewriter, loc, elemTypeSoftmax));
       if (lse) {
         Type elemTypeLse = cast<MemRefType>(lse.getType()).getElementType();
         lseBuffer = createBufferForGemmOut(loc, elemTypeLse, accelParamsGemm1,
@@ -2141,7 +2142,7 @@ struct GridwiseAttentionAccelRewritePattern
       zeroAccBuffer(rewriter, loc, attentionOutAccBuffer);
     } else {
       outAccBufferOutTyped = gemm1OutBuffer;
-      if (elemTypeQxK != elemTypeOut) {
+      if (elemTypeSoftmax != elemTypeOut) {
         outAccBufferOutTyped = createBufferForGemmOut(
             loc, elemTypeOut, accelParamsGemm1, rewriter, gemm1MBlocks);
       }
@@ -2399,21 +2400,21 @@ struct GridwiseAttentionAccelRewritePattern
         return op.emitError("post processing first gemm failed.\n");
       }
       gemm0OutBuffer = maybeFusionOutBuffer.value();
-      if (fusionOutElemType == elemTypeQxK)
+      if (fusionOutElemType == elemTypeSoftmax)
         softmaxInputBuffer = gemm0OutBuffer;
 
       // Softmax
       if (op.getEnableSoftmax()) {
-        // convert gemm0OutBuffer to elemTypeQxK
-        if (fusionOutElemType != elemTypeQxK) {
-          createTypeConversionStore(rewriter, loc, gemm0OutBuffer,
-                                    softmaxInputBuffer);
+        // convert gemm0OutBuffer to elemTypeSoftmax
+        if (fusionOutElemType != elemTypeSoftmax) {
+          createTypeConversionFlatAndStore(rewriter, loc, gemm0OutBuffer,
+                                           softmaxInputBuffer);
         }
         // Scale gemm0 output by (1/ln2)
         // So that we can use exp2 instead of exp.
         Value ln2Recip = createConstantFloatOp(
-            rewriter, loc, elemTypeQxK, elemTypeQxK, 1.44269504f,
-            elemTypeQxK.isF32() ? APFloat::opOK : APFloat::opInexact);
+            rewriter, loc, elemTypeSoftmax, elemTypeSoftmax, 1.44269504f,
+            elemTypeSoftmax.isF32() ? APFloat::opOK : APFloat::opInexact);
         postProcessFirstGemmSplat<ElementwiseMultOp>(
             rewriter, loc, gridCoordsGemm0, softmaxInputBuffer,
             gemm0OutSubTileViews,
@@ -2443,9 +2444,9 @@ struct GridwiseAttentionAccelRewritePattern
         APInt reductionAxis = APInt(64, 1);
         // Softmax max reduction
         Value ldsReductionWorkspaceByteBuffer = createLDSByteBuffer(
-            rewriter, loc, reductionWorkspaceSize, elemTypeQxK);
+            rewriter, loc, reductionWorkspaceSize, elemTypeSoftmax);
         TypedValue<MemRefType> ldsReductionWorkspaceBuffer = viewBufferAs(
-            rewriter, ldsReductionWorkspaceByteBuffer, elemTypeQxK);
+            rewriter, ldsReductionWorkspaceByteBuffer, elemTypeSoftmax);
         rewriter.create<BlockwiseBroadcastReduceOp>(
             loc, softmaxInputBuffer, ldsReductionWorkspaceBuffer,
             softmaxBufferMax,
@@ -2475,9 +2476,9 @@ struct GridwiseAttentionAccelRewritePattern
 
         // Softmax sum reduction
         Value ldsReductionWorkspaceByteSecondBuffer = createLDSByteBuffer(
-            rewriter, loc, reductionWorkspaceSize, elemTypeQxK);
+            rewriter, loc, reductionWorkspaceSize, elemTypeSoftmax);
         TypedValue<MemRefType> ldsReductionWorkspaceSecondBuffer = viewBufferAs(
-            rewriter, ldsReductionWorkspaceByteSecondBuffer, elemTypeQxK);
+            rewriter, ldsReductionWorkspaceByteSecondBuffer, elemTypeSoftmax);
         rewriter.create<BlockwiseBroadcastReduceOp>(
             loc, softmaxBufferExp, ldsReductionWorkspaceSecondBuffer,
             softmaxBufferSum, /*extraOut=*/nullptr, reductionAxis,
@@ -2504,8 +2505,9 @@ struct GridwiseAttentionAccelRewritePattern
       {
         auto gemm0Out =
             op.getEnableSoftmax() ? softmaxBufferExp : softmaxInputBuffer;
-        if (elemTypeV != elemTypeQxK) {
-          createTypeConversionStore(rewriter, loc, gemm0Out, gemm1RegBufferB);
+        if (elemTypeV != elemTypeSoftmax) {
+          createTypeConversionFlatAndStore(rewriter, loc, gemm0Out,
+                                           gemm1RegBufferB);
         } else {
           gemm1RegBufferB = gemm0Out;
         }
@@ -2717,11 +2719,11 @@ struct GridwiseAttentionAccelRewritePattern
     }
     Value outAccBuffer =
         op.getEnableSoftmax() ? attentionOutAccBuffer : gemm1OutBuffer;
-    if (elemTypeQxK != elemTypeOut) {
+    if (elemTypeSoftmax != elemTypeOut) {
       // We flatten output buffer in case gemm1MBlocks > 1
       // where those are iterated.
-      createTypeConversionStore(rewriter, loc, outAccBuffer,
-                                outAccBufferOutTyped);
+      createTypeConversionFlatAndStore(rewriter, loc, outAccBuffer,
+                                       outAccBufferOutTyped);
     }
     if (lse) {
       // it must be guaranteed by the verifier

--- a/mlir/lib/Dialect/Rock/Transforms/RockPrepareLLVM.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPrepareLLVM.cpp
@@ -128,6 +128,11 @@ void RockPrepareLLVMPass::runOnOperation() {
   });
   OpBuilder b(&getContext());
 
+  // Our kernels are fine with preserving sign in denorm fp
+  // handling. This helps to avoid extra code that'd be
+  // otherwise generated for exp2.
+  func.setDenormalFpMathAttr(b.getStringAttr("preserve-sign"));
+
   // We'd like to do a bunch of annotating on loads and stores.
   // One thing we need to do is fix up alignments: MLIR's `vector.load` lowers
   // to an `llvm.load` whose allignment matches that of the element type,

--- a/mlir/lib/Dialect/Rock/Transforms/SortDimensionsMemoryLayout.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SortDimensionsMemoryLayout.cpp
@@ -577,8 +577,8 @@ struct AttentionRewritePattern : public OpRewritePattern<rock::AttentionOp> {
         op.getPreSoftmaxElemWiseInputs(), op.getCurrentSeqLen(), op.getOut(),
         op.getLse(), transposedQ, transposedK, transposedV,
         op.getOTransposedAttr(), op.getCausalAttr(), op.getArchAttr(),
-        op.getFeaturesAttr(), op.getNumCUAttr(), op.getParams0Attr(),
-        op.getParams1Attr(), op.getFirstGemmIdxAttr());
+        op.getFeaturesAttr(), op.getSoftmaxTypeAttr(), op.getNumCUAttr(),
+        op.getParams0Attr(), op.getParams1Attr(), op.getFirstGemmIdxAttr());
 
     // copy linalg::GenericOp if there's any
     bool linalgOpFound = false;

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -7,11 +7,13 @@
 //===-----------------------------------------------------===//
 
 #include "mlir/Dialect/Rock/utility/builderUtils.h"
+#include "mlir/Dialect/Rock/utility/loweringUtils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -141,10 +143,6 @@ Value createTypeConversionOp(OpBuilder &b, Location loc, Value source,
   return result;
 }
 
-//===----------------------------------------------------------------------===//
-// Utility function to create a linalg generic block to perform cast
-// and copy to another memref.
-//===----------------------------------------------------------------------===//
 void createTypeConversionLaGeneric(PatternRewriter &rewriter, Location loc,
                                    Value src, Value dst) {
   MemRefType dstType = cast<MemRefType>(dst.getType());
@@ -159,6 +157,25 @@ void createTypeConversionLaGeneric(PatternRewriter &rewriter, Location loc,
                                             dstType.getElementType());
         nestedBuilder.create<linalg::YieldOp>(nestedLoc, cast);
       });
+}
+
+void createTypeConversionStore(PatternRewriter &rewriter, Location loc,
+                               Value src, Value dst) {
+  src = getFlattenedMemref(rewriter, src);
+  dst = getFlattenedMemref(rewriter, dst);
+  auto zeroConstantOp = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  MemRefType srcMemRefType = cast<MemRefType>(src.getType());
+  MemRefType dstMemRefType = cast<MemRefType>(dst.getType());
+  auto superSrcVecType =
+      VectorType::get(srcMemRefType.getShape(), srcMemRefType.getElementType());
+  auto superDestVecType =
+      VectorType::get(dstMemRefType.getShape(), dstMemRefType.getElementType());
+  SmallVector<Value, 2> zeros{(size_t)srcMemRefType.getRank(), zeroConstantOp};
+  auto vectorSrc =
+      rewriter.create<vector::LoadOp>(loc, superSrcVecType, src, zeros);
+  auto vectorSrcCast =
+      createTypeConversionOp(rewriter, loc, vectorSrc, superDestVecType);
+  rewriter.create<vector::StoreOp>(loc, vectorSrcCast, dst, zeros);
 }
 
 Value createCollapseShapeOp(OpBuilder &b, Location loc, Value source) {

--- a/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/builderUtils.cpp
@@ -159,8 +159,8 @@ void createTypeConversionLaGeneric(PatternRewriter &rewriter, Location loc,
       });
 }
 
-void createTypeConversionStore(PatternRewriter &rewriter, Location loc,
-                               Value src, Value dst) {
+void createTypeConversionFlatAndStore(PatternRewriter &rewriter, Location loc,
+                                      Value src, Value dst) {
   src = getFlattenedMemref(rewriter, src);
   dst = getFlattenedMemref(rewriter, dst);
   auto zeroConstantOp = rewriter.create<arith::ConstantIndexOp>(loc, 0);

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -774,6 +774,22 @@ mlir::rock::getReassociationForFlattening(ShapedType srcTp) {
   return reassociation;
 }
 
+Value mlir::rock::getFlattenedMemref(OpBuilder &b, Value nonFlatMemRef) {
+  Location loc = nonFlatMemRef.getLoc();
+  MemRefType nonFlatMemRefType = cast<MemRefType>(nonFlatMemRef.getType());
+  int64_t numElements = nonFlatMemRefType.getNumElements();
+  if (nonFlatMemRefType.getRank() > 1) {
+    Type nonFlatMemRefElType = nonFlatMemRefType.getElementType();
+    auto flatMemRefType =
+        MemRefType::get({numElements}, nonFlatMemRefElType, AffineMap{},
+                        nonFlatMemRefType.getMemorySpace());
+    auto reassociation = getReassociationForFlattening(nonFlatMemRefType);
+    return b.create<memref::CollapseShapeOp>(loc, flatMemRefType, nonFlatMemRef,
+                                             reassociation);
+  }
+  return nonFlatMemRef;
+}
+
 TypedValue<MemRefType> mlir::rock::viewBufferAs(OpBuilder &b, Value buffer,
                                                 Type type) {
   Location loc = buffer.getLoc();

--- a/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
+++ b/mlir/lib/ExecutionEngine/conv-validation-wrappers.cpp
@@ -146,11 +146,13 @@ void mcpuVerify(T *gpuResults, T *validationResults, long long dataSize,
   for (long long i = 0; i < dataSize; ++i) {
     valNum = static_cast<float>(validationResults[i]);
     gpuNum = static_cast<float>(gpuResults[i]);
-    // Update the max magnitutde value
+    // Update the max magnitude value
     float maxNum = std::max(fabs(valNum), fabs(gpuNum));
     maxMag = std::max(maxMag, maxNum);
 
-    if (valNum == gpuNum) {
+    // If cpu value is a denorm, we skip checks.
+    // We need this because we only preserve sign in denorm fp (GPU).
+    if (valNum == gpuNum || std::fpclassify(valNum) == FP_SUBNORMAL) {
       hist_relDiff[0]++;
     } else {
       // We know valNum != gpuNum. If valNum is inf, this branch will simply
@@ -160,7 +162,7 @@ void mcpuVerify(T *gpuResults, T *validationResults, long long dataSize,
       if (std::isinf(valNum))
         valNum = (valNum > 0 ? fp16MaxVal : -fp16MaxVal);
       float absDiff = fabs(valNum - gpuNum);
-      // Update maxAbsDiff and its correspinding pair of values
+      // Update maxAbsDiff and its corresponding pair of values
       if (absDiff > maxAbsDiff) {
         maxVAL_abs = valNum;
         maxGPU_abs = gpuNum;

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -305,6 +305,26 @@ func.func @rock_attention_lse(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x64x1
   return
 }
 
+// CHECK-LABEL: func.func @rock_attention_softmaxtype
+// CHECK-SAME: (%[[q:.*]]: memref<1x64x1024xf16>, %[[k:.*]]: memref<1x64x1024xf16>, %[[v:.*]]: memref<1x1024x64xf16>, %[[lse:.*]]: memref<1x1024xf16>, %[[o:.*]]: memref<1x1024x64xf16>)
+func.func @rock_attention_softmaxtype(%arg0: memref<1x64x1024xf16>, %arg1: memref<1x64x1024xf16>, %arg2: memref<1x1024x64xf16>, %arg3: memref<1x1024xf16>, %arg4: memref<1x1024x64xf16>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908", block_size = 64 : i32, grid_size = 1024 : i32} {
+  // CHECK: rock.gridwise_attention_accel(%[[q]], %[[k]], %[[v]], %[[o]], %[[lse]])
+  // CHECK: softmaxType = f32
+  rock.attention{
+     qk = tr %arg0 * %arg1 : memref<1x64x1024xf16>, memref<1x64x1024xf16>
+     lse = %arg3 : memref<1x1024xf16>
+     %arg4 = softmax(qk) * %arg2 : memref<1x1024x64xf16> -> memref<1x1024x64xf16>
+  } {
+    arch = "amdgcn-amd-amdhsa:gfx908",
+    features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>,
+    params0 = #xldops_attn_params_g0,
+    params1 = #xldops_attn_params_g1,
+    firstGemmIdx = 0 : i32,
+    softmaxType = f32
+  }
+  return
+}
+
 // CHECK-LABEL: func.func @rock_gemmelementwisegemm_simple
 // CHECK-SAME: (%[[a:.*]]: memref<1x64x1024xf32>, %[[b:.*]]: memref<1x64x1024xf32>, %[[c:.*]]: memref<1x1024x64xf32>, %[[o:.*]]: memref<1x1024x64xf32>)
 func.func @rock_gemmelementwisegemm_simple(%arg0: memref<1x64x1024xf32>, %arg1: memref<1x64x1024xf32>, %arg2: memref<1x1024x64xf32>, %arg3: memref<1x1024x64xf32>) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908", block_size = 64 : i32, grid_size = 1024 : i32} {

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -441,6 +441,43 @@ func.func @gridwise_attn_lse_kvcache(%arg0: memref<1x384x64xf32>, %arg1: memref<
 
 // -----
 
+// CHECK-LABEL: @gridwise_attn_softmaxtype
+func.func @gridwise_attn_softmaxtype(%arg0: memref<1x384x64xf16>, %arg1: memref<1x64x384xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>, %arg4: memref<1xi32>, %arg5: memref<1x384xf16>) attributes {block_size = 64 : i32, grid_size = 24 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-"} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 384] -> [1, 384, 64]> : memref<1x384x64xf16> to memref<1x64x384xf16>
+  // CHECK-DAG: %[[log2:.+]] = arith.constant 6.933590e-01 : f16
+  // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
+  // CHECK: %[[currSeqLenTensor:.+]] = rock.transform %arg4 by #{{.+}} : memref<1xi32> to memref<1x1xi32>
+  // CHECK: %[[registers:.+]] = rock.alloc() : memref<1xi32, #gpu.address_space<private>>
+  // CHECK-NEXT: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%[[currSeqLenTensor]]) [%{{.+}}] -> %[[registers]] : memref<1x1xi32> -> memref<1xi32, #gpu.address_space<private>>, vector<1xi1>
+  // CHECK-NEXT: %[[currSeqLen:.+]] = rock.in_bounds_load %[[registers]][%[[c0]]] : memref<1xi32, #gpu.address_space<private>>, index -> i32
+  // CHECK-NEXT: %[[currSeqLenIndex:.+]] = arith.index_cast %[[currSeqLen]] : i32 to index
+  // CHECK: %[[num:.+]] = arith.addi %[[currSeqLenIndex]], %[[c32]] : index
+  // CHECK-NEXT: %[[numIter:.+]] = arith.divui %[[num]], %[[c32]] : index
+  // CHECK-NEXT: %[[lastIter:.+]] = arith.subi %[[numIter]], %[[c1]] : index
+  // CHECK-NEXT: scf.for %[[iterIndex:.+]] = %[[c0]] to %[[numIter]] step %[[c1]] {
+  // CHECK: %[[comparison:.+]] = arith.cmpi eq, %[[iterIndex]], %[[lastIter]] : index
+  // CHECK-NEXT: scf.if %[[comparison]] {
+  // CHECK: rock.blockwise_broadcast_reduce max {{.*}} memref<16xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<16xf32, #gpu.address_space<private>>
+  // CHECK: rock.blockwise_broadcast_reduce sum {{.*}} memref<16xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<16xf32, #gpu.address_space<private>>
+  // CHECK: rock.threadwise_write_all {{.*}} by  set : memref<32xf16, #gpu.address_space<private>> -> memref<1x64x384xf16>
+  // CHECK-NEXT: rock.threadwise_write_all {{.*}} by  set : memref<16xf16, #gpu.address_space<private>> -> memref<1x384xf16>
+  rock.gridwise_attention_accel(%0, %arg1, %arg2, %arg4, %arg3, %arg5) features =  mfma|dot|atomic_add|atomic_add_f16 preSoftmaxOps = {} {
+    arch = "amdgcn-amd-amdhsa:gfx908:sramecc+:xnack-",
+    blockSize = 64 : i32,
+    gridSize = 24 : i32,
+    operandSegmentSizes = array<i32: 1, 1, 1, 0, 1, 1, 1>,
+    params0 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>,
+    params1 = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>,
+    firstGemmIdx = 0 : i32,
+    softmaxType = f32
+  } : memref<1x64x384xf16>, memref<1x64x384xf16>, memref<1x384x64xf16>, memref<1xi32>, memref<1x384x64xf16>, memref<1x384xf16>
+  return
+}
+
+// -----
+
 // CHECK-LABEL: @gridwise_attn_barriers_before_lds_write_issue_1811
 func.func @gridwise_attn_barriers_before_lds_write_issue_1811(%arg0: memref<4096xi8>, %arg1: memref<4096xi8>, %arg2: memref<4096xf16>, %arg3: memref<1xi8>, %arg4: memref<1xf16>, %arg5: memref<4096xf16>) attributes {block_size = 64 : i32, grid_size = 1 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100"} {
   // CHECK: affine.for %{{.*}} = 0 to 2

--- a/mlir/test/rocmlir-gen/attention-kernel-causal.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-causal.mlir
@@ -38,6 +38,7 @@
 // CHECK: %[[ones:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<1x512x1024xf32>}> : () -> tensor<1x512x1024xf32>
 // CHECK: %[[scaleTensor:.*]] = tosa.select %[[mask2]], %[[ones]], %[[scaledReshaped]] : (tensor<1x512x1024xi1>, tensor<1x512x1024xf32>, tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32>
 // CHECK: %[[sqkTensor:.*]] = tosa.mul %[[qkTensorOrig]], %[[scaleTensor]], %{{.*}} : (tensor<1x512x1024xf32>, tensor<1x512x1024xf32>, tensor<1xi8>) -> tensor<1x512x1024xf32>
+// CHECK:  %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : (tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32>
 
 // CHECK: %[[range4:.*]] = "tosa.const"() <{values = {{.*}} : tensor<512xi32>}> : () -> tensor<512xi32>
 // CHECK: %[[range4Reshaped:.*]] = tosa.reshape %[[range4:.*]], %{{.*}} : (tensor<512xi32>, !tosa.shape<3>) -> tensor<1x512x1xi32>
@@ -49,7 +50,7 @@
 // CHECK: %[[rangeBroadcast5:.*]] = tosa.add %[[zero4]], %[[range5Reshaped]] : (tensor<1x512x1024xi32>, tensor<1x1x1024xi32>) -> tensor<1x512x1024xi32>
 // CHECK: %[[mask3:.*]] = tosa.greater %[[rangeBroadcast5]], %[[rangeBroadcast4]] : (tensor<1x512x1024xi32>, tensor<1x512x1024xi32>) -> tensor<1x512x1024xi1>
 // CHECK: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x512x1024xf32>}> : () -> tensor<1x512x1024xf32>
-// CHECK: %[[qkTensor:.*]] = tosa.select %[[mask3]], %[[negInf]], %[[sqkTensor]] : (tensor<1x512x1024xi1>, tensor<1x512x1024xf32>, tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32
+// CHECK: %[[qkTensor:.*]] = tosa.select %[[mask3]], %[[negInf]], %[[sqkTensorCast]] : (tensor<1x512x1024xi1>, tensor<1x512x1024xf32>, tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32>
 
 // CHECK-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[qkTensor]] {{.*}} : (tensor<1x512x1024xf32>) -> tensor<1x512x1xf32>
 // CHECK-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[qkTensor]], %[[sqkMaxs]] : (tensor<1x512x1024xf32>, tensor<1x512x1xf32>) -> tensor<1x512x1024xf32>
@@ -57,5 +58,6 @@
 // CHECK-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : (tensor<1x512x1024xf32>) -> tensor<1x512x1xf32>
 // CHECK-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : (tensor<1x512x1xf32>) -> tensor<1x512x1xf32>
 // CHECK-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : (tensor<1x512x1024xf32>, tensor<1x512x1xf32>, tensor<1xi8>) -> tensor<1x512x1024xf32>
-// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : (tensor<1x512x1024xf32>, tensor<1x1024x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x512x32xf32>
+// CHECK-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : (tensor<1x512x1024xf32>) -> tensor<1x512x1024xf32>
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : (tensor<1x512x1024xf32>, tensor<1x1024x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x512x32xf32>
 // CHECK: return

--- a/mlir/test/rocmlir-gen/attention-kernel-f16.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-f16.mlir
@@ -1,0 +1,38 @@
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 32 -head_dim_v 32 --with-attn-scale -t f16 -pv --apply-bufferization-pipeline=false | rocmlir-opt | FileCheck %s --enable-var-scope
+
+// CHECK: module attributes {mhal.arch = "[[$ARCH:.*]]"}
+
+// CHECK-LABEL: func.func @rock_attention
+// CHECK-SAME: (%[[queriesRaw:.*0]]: memref<32768xf16>,
+// CHECK-SAME: %[[keysRaw:.*1]]: memref<32768xf16>,
+// CHECK-SAME: %[[valuesRaw:.*2]]: memref<32768xf16>,
+// CHECK-SAME: %[[scaleRaw:.*3]]: memref<1048576xf16>,
+// CHECK-SAME: %[[outputRaw:.*4]]: memref<32768xf16>)
+// CHECK-SAME: attributes {kernel, mhal.arch = "[[$ARCH]]"}
+// CHECK-NEXT: %[[queries:.*]] = rock.transform %[[queriesRaw]] {{.*}} : memref<32768xf16> to memref<1x1024x32xf16>
+// CHECK-NEXT: %[[keys:.*]] = rock.transform %[[keysRaw]] {{.*}} : memref<32768xf16> to memref<1x32x1024xf16>
+// CHECK-NEXT: %[[values:.*]] = rock.transform %[[valuesRaw]] {{.*}} : memref<32768xf16> to memref<1x1024x32xf16>
+// CHECK-NEXT: %[[scale:.*]] = rock.transform %[[scaleRaw]] {{.*}} : memref<1048576xf16> to memref<1x1024x1024xf16>
+// CHECK-NEXT: %[[output:.*]] = rock.transform %[[outputRaw]] {{.*}} : memref<32768xf16> to memref<1x1024x32xf16>
+
+// CHECK-NEXT: rock.attention
+// CHECK-NEXT: qk = %[[queries]] * %[[keys]]
+// CHECK-NEXT: qk = elementwise otherIns(%[[scale]]
+// CHECK: %[[output]] = softmax(qk) * %[[values]]
+// CHECK: return
+
+// CHECK-LABEL: func.func @host_naive_attention
+// CHECK: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf16>, tensor<1xf16>) -> [[squareShapeF32:tensor<.*>]]
+// CHECK-DAG: %[[qkTensorCasted:.*]] = tosa.cast %[[qkTensor]] : ([[squareShapeF32]]) -> [[squareShape:tensor<.*>]]
+// CHECK-DAG: %[[sqkTensor:.*]] = tosa.mul %[[qkTensorCasted]], %[[scaleTensor:.*]], %{{.*}} : ([[squareShape]], [[squareShape]], tensor<1xi8>) -> [[squareShape]]
+// CHECK-DAG: %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : ([[squareShape]]) -> [[squareShapeF32]]
+// CHECK-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[sqkTensorCast]] {{.*}} : ([[squareShapeF32]]) -> [[reducedShape:tensor<.*>]]
+// CHECK-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[sqkTensorCast]], %[[sqkMaxs]] : ([[squareShapeF32]], [[reducedShape]]) -> [[squareShapeF32]]
+// CHECK-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedSqkTensor]] : ([[squareShapeF32]]) -> [[squareShapeF32]]
+// CHECK-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShapeF32]]) -> [[reducedShape]]
+// CHECK-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
+// CHECK-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShapeF32]], [[reducedShape]], tensor<1xi8>) -> [[squareShapeF32]] 
+// CHECK-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShapeF32]]) -> [[squareShape]]
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf16>, tensor<1xf16>) -> [[valuesShapeF32:tensor<.*>]]
+// CHECK-DAG: %[[resultTensorCasted:.*]] = tosa.cast %[[resultTensor]] : ([[valuesShapeF32]]) -> [[valuesShape]]
+// CHECK: return

--- a/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache-lse.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache-lse.mlir
@@ -42,29 +42,33 @@
 // CHECK: %[[valuesTensor:.*]] = tensor.collapse_shape %[[valuesAdd]] {{.*}} : tensor<2x2x1024x32xf32> into [[valuesShape:tensor<.*>]]
 // CHECK: %[[qkTensorOrig:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
 
-// CHECK: %[[currSeqLenTensorDumbReshaped:.*]] = tosa.reshape %[[currSeqLenTensor:.*]], %{{.*}} : (tensor<1xi32>, !tosa.shape<1>) -> tensor<1xi32>
-// CHECK: %[[currSeqLenTensorReshaped:.*]] = tosa.reshape %[[currSeqLenTensorDumbReshaped]], %{{.*}} : (tensor<1xi32>, !tosa.shape<4>) -> tensor<1x1x1x1xi32>
-// CHECK: %[[qkTensorReshaped:.*]] = tosa.reshape %[[qkTensorOrig]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
-// CHECK: %[[range:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
-// CHECK: %[[rangeReshaped:.*]] = tosa.reshape %[[range]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<4>) -> tensor<1x1x1x1024xi32>
-// CHECK: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
-// CHECK: %[[rangeBroadcast:.*]] = tosa.add %[[zero]], %[[rangeReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
-// CHECK: %[[zero2:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
-// CHECK: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero2]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
-// CHECK: %[[mask:.*]] = tosa.greater %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
-// CHECK: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
-// CHECK: %[[qkTensorBeforeReshape:.*]] = tosa.select %[[mask]], %[[negInf]], %[[qkTensorReshaped]] : (tensor<1x4x1024x1024xi1>, tensor<1x4x1024x1024xf32>, tensor<1x4x1024x1024xf32>) -> tensor<1x4x1024x1024xf32>
-// CHECK: %[[qkTensor:.*]] = tosa.reshape %[[qkTensorBeforeReshape]], %{{.*}} : (tensor<1x4x1024x1024xf32>, !tosa.shape<3>) -> tensor<4x1024x1024xf32>
+// CHECK-DAG: %[[qkTensorCast:.*]] = tosa.cast %[[qkTensorOrig]] : (tensor<4x1024x1024xf32>) -> tensor<4x1024x1024xf32>
+// CHECK-DAG: %[[currSeqLenTensorDumbReshaped:.*]] = tosa.reshape %[[currSeqLenTensor:.*]], %{{.*}} : (tensor<1xi32>, !tosa.shape<1>) -> tensor<1xi32>
+// CHECK-DAG: %[[currSeqLenTensorReshaped:.*]] = tosa.reshape %[[currSeqLenTensorDumbReshaped]], %{{.*}} : (tensor<1xi32>, !tosa.shape<4>) -> tensor<1x1x1x1xi32>
+// CHECK-DAG: %[[qkTensorReshaped:.*]] = tosa.reshape %[[qkTensorCast]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
+// CHECK-DAG: %[[range:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
+// CHECK-DAG: %[[rangeReshaped:.*]] = tosa.reshape %[[range]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<4>) -> tensor<1x1x1x1024xi32>
+// CHECK-DAG: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
+// CHECK-DAG: %[[rangeBroadcast:.*]] = tosa.add %[[zero]], %[[rangeReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1024xi32>) -> tensor<1x4x1024x1024xi32>
+// CHECK-DAG: %[[zero2:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
+// CHECK-DAG: %[[currSeqLenTensorBroadcast:.*]] = tosa.add %[[zero2]], %[[currSeqLenTensorReshaped]] : (tensor<1x4x1024x1024xi32>, tensor<1x1x1x1xi32>) -> tensor<1x4x1024x1024xi32>
+// CHECK-DAG: %[[mask:.*]] = tosa.greater %[[rangeBroadcast]], %[[currSeqLenTensorBroadcast]] : (tensor<1x4x1024x1024xi32>, tensor<1x4x1024x1024xi32>) -> tensor<1x4x1024x1024xi1>
+// CHECK-DAG: %[[negInf:.*]] = "tosa.const"() <{values = dense<0xFF800000> : tensor<1x4x1024x1024xf32>}> : () -> tensor<1x4x1024x1024xf32>
+// CHECK-DAG: %[[qkTensorBeforeReshape:.*]] = tosa.select %[[mask]], %[[negInf]], %[[qkTensorReshaped]] : (tensor<1x4x1024x1024xi1>, tensor<1x4x1024x1024xf32>, tensor<1x4x1024x1024xf32>) -> tensor<1x4x1024x1024xf32>
+// CHECK-DAG: %[[qkTensor:.*]] = tosa.reshape %[[qkTensorBeforeReshape]], %{{.*}} : (tensor<1x4x1024x1024xf32>, !tosa.shape<3>) -> tensor<4x1024x1024xf32>
 
 // CHECK-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[qkTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
 // CHECK-DAG: %[[normilizedQkTensor:.*]] = tosa.sub %[[qkTensor]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
 // CHECK-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedQkTensor]] : ([[squareShape]]) -> [[squareShape]]
 // CHECK-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape]]
 
-// CHECK-DAG: %[[logL:.*]] = tosa.log %[[expsSumsTensor]] : (tensor<4x1024x1xf32>) -> tensor<4x1024x1xf32>
-// CHECK-DAG: %[[resultLse:.*]] = tosa.add %[[logL]], %[[sqkMaxs]] : (tensor<4x1024x1xf32>, tensor<4x1024x1xf32>) -> tensor<4x1024x1xf32>
+// CHECK-DAG: %[[expsSumsTensorCast:.*]] = tosa.cast %[[expsSumsTensor]] : (tensor<4x1024x1xf32>) -> tensor<4x1024x1xf32>
+// CHECK-DAG: %[[sqkMaxsCast:.*]] = tosa.cast %[[sqkMaxs]] : (tensor<4x1024x1xf32>) -> tensor<4x1024x1xf32>
+// CHECK-DAG: %[[logL:.*]] = tosa.log %[[expsSumsTensorCast]] : (tensor<4x1024x1xf32>) -> tensor<4x1024x1xf32>
+// CHECK-DAG: %[[resultLse:.*]] = tosa.add %[[logL]], %[[sqkMaxsCast]] : (tensor<4x1024x1xf32>, tensor<4x1024x1xf32>) -> tensor<4x1024x1xf32>
 
 // CHECK-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShape]], [[reducedShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> tensor<4x1024x32xf32>
+// CHECK-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> tensor<4x1024x32xf32>
 // CHECK: return

--- a/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-gqa-kvcache.mlir
@@ -59,7 +59,8 @@
 // CHECK_SCALE: %[[scaleTensor:.*]] = tosa.reshape %[[scaleTensorBeforeReshape]], %{{.*}} : (tensor<1x4x1024x1024xf32>, !tosa.shape<3>) -> tensor<4x1024x1024xf32>
 // CHECK_SCALE: %[[sqkTensor:.*]] = tosa.mul %[[qkTensorOrig]], %[[scaleTensor]], %{{.*}} : ([[squareShape]], [[squareShape]], tensor<1xi8>) -> [[squareShape]]
 
-// CHECK_SCALE: %[[qkTensorReshaped:.*]] = tosa.reshape %[[sqkTensor]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
+// CHECK_SCALE: %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : (tensor<4x1024x1024xf32>) -> tensor<4x1024x1024xf32>
+// CHECK_SCALE: %[[qkTensorReshaped:.*]] = tosa.reshape %[[sqkTensorCast]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
 // CHECK_SCALE: %[[range:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
 // CHECK_SCALE: %[[rangeReshaped:.*]] = tosa.reshape %[[range:.*]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<4>) -> tensor<1x1x1x1024xi32>
 // CHECK_SCALE: %[[zero3:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
@@ -77,7 +78,8 @@
 // CHECK_SCALE-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape]]
 // CHECK_SCALE-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK_SCALE-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShape]], [[reducedShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape]], tensor<1xf32>, tensor<1xf32>) -> tensor<4x1024x32xf32>
+// CHECK_SCALE-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape]], tensor<1xf32>, tensor<1xf32>) -> tensor<4x1024x32xf32>
 // CHECK_SCALE: return
 
 // ----
@@ -125,7 +127,8 @@
 
 // CHECK_NO_SCALE: %[[currSeqLenTensorDumbReshaped:.*]] = tosa.reshape %[[currSeqLenTensor:.*]], %{{.*}} : (tensor<1xi32>, !tosa.shape<1>) -> tensor<1xi32>
 // CHECK_NO_SCALE: %[[currSeqLenTensorReshaped:.*]] = tosa.reshape %[[currSeqLenTensorDumbReshaped]], %{{.*}} : (tensor<1xi32>, !tosa.shape<4>) -> tensor<1x1x1x1xi32>
-// CHECK_NO_SCALE: %[[qkTensorReshaped:.*]] = tosa.reshape %[[qkTensorOrig]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
+// CHECK_NO_SCALE: %[[qkTensorCast:.*]] = tosa.cast %[[qkTensorOrig]] : (tensor<4x1024x1024xf32>) -> tensor<4x1024x1024xf32>
+// CHECK_NO_SCALE: %[[qkTensorReshaped:.*]] = tosa.reshape %[[qkTensorCast]], %{{.*}} : (tensor<4x1024x1024xf32>, !tosa.shape<4>) -> tensor<1x4x1024x1024xf32>
 // CHECK_NO_SCALE: %[[range:.*]] = "tosa.const"() <{values = {{.*}} : tensor<1024xi32>}> : () -> tensor<1024xi32>
 // CHECK_NO_SCALE: %[[rangeReshaped:.*]] = tosa.reshape %[[range]], %{{.*}} : (tensor<1024xi32>, !tosa.shape<4>) -> tensor<1x1x1x1024xi32>
 // CHECK_NO_SCALE: %[[zero:.*]] = "tosa.const"() <{values = dense<0> : tensor<1x4x1024x1024xi32>}> : () -> tensor<1x4x1024x1024xi32>
@@ -143,5 +146,6 @@
 // CHECK_NO_SCALE-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape]]
 // CHECK_NO_SCALE-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK_NO_SCALE-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShape]], [[reducedShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_NO_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> tensor<4x1024x32xf32>
+// CHECK_NO_SCALE-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_NO_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> tensor<4x1024x32xf32>
 // CHECK_NO_SCALE: return

--- a/mlir/test/rocmlir-gen/attention-kernel-gqa.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-gqa.mlir
@@ -36,13 +36,15 @@
 // CHECK_SCALE: %[[valuesTensor:.*]] = tensor.collapse_shape %[[valuesAdd]] {{.*}} : tensor<2x2x1024x32xf32> into tensor<4x1024x32xf32>
 // CHECK_SCALE: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
 // CHECK_SCALE-DAG: %[[sqkTensor:.*]] = tosa.mul %[[qkTensor]], %[[scaleTensor:.*]], %{{.*}} : ([[squareShape]], [[squareShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[sqkTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
-// CHECK_SCALE-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[sqkTensor]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
+// CHECK_SCALE-DAG: %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[sqkTensorCast]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
+// CHECK_SCALE-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[sqkTensorCast]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
 // CHECK_SCALE-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedSqkTensor]] : ([[squareShape]]) -> [[squareShape]]
 // CHECK_SCALE-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape]]
 // CHECK_SCALE-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK_SCALE-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShape]], [[reducedShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
+// CHECK_SCALE-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
 // CHECK_SCALE: return
 
 // ----
@@ -81,11 +83,13 @@
 // CHECK_NO_SCALE: %[[valuesAdd:.*]] = tosa.add %{{.*}}, %[[valuesExpanded]] : (tensor<2x2x1024x32xf32>, tensor<2x1x1024x32xf32>) -> tensor<2x2x1024x32xf32>
 // CHECK_NO_SCALE: %[[valuesTensor:.*]] = tensor.collapse_shape %[[valuesAdd]] {{.*}} : tensor<2x2x1024x32xf32> into tensor<4x1024x32xf32>
 // CHECK_NO_SCALE: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
-// CHECK_NO_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[qkTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
-// CHECK_NO_SCALE-DAG: %[[normilizedQkTensor:.*]] = tosa.sub %[[qkTensor]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
+// CHECK_NO_SCALE: %[[qkTensorCast:.*]] = tosa.cast %[[qkTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_NO_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[qkTensorCast]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
+// CHECK_NO_SCALE-DAG: %[[normilizedQkTensor:.*]] = tosa.sub %[[qkTensorCast]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
 // CHECK_NO_SCALE-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedQkTensor]] : ([[squareShape]]) -> [[squareShape]]
 // CHECK_NO_SCALE-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape]]
 // CHECK_NO_SCALE-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK_NO_SCALE-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShape]], [[reducedShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_NO_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
+// CHECK_NO_SCALE-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_NO_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
 // CHECK_NO_SCALE: return

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -24,13 +24,15 @@
 // CHECK_SCALE-LABEL: func.func @host_naive_attention
 // CHECK_SCALE: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
 // CHECK_SCALE-DAG: %[[sqkTensor:.*]] = tosa.mul %[[qkTensor]], %[[scaleTensor:.*]], %{{.*}} : ([[squareShape]], [[squareShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[sqkTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
-// CHECK_SCALE-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[sqkTensor]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
+// CHECK_SCALE-DAG: %[[sqkTensorCast:.*]] = tosa.cast %[[sqkTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[sqkTensorCast]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
+// CHECK_SCALE-DAG: %[[normilizedSqkTensor:.*]] = tosa.sub %[[sqkTensorCast]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
 // CHECK_SCALE-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedSqkTensor]] : ([[squareShape]]) -> [[squareShape]]
 // CHECK_SCALE-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape]]
 // CHECK_SCALE-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK_SCALE-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShape]], [[reducedShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
+// CHECK_SCALE-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
 // CHECK_SCALE: return
 
 // ----
@@ -57,11 +59,13 @@
 
 // CHECK_NO_SCALE-LABEL: func.func @host_naive_attention
 // CHECK_NO_SCALE: %[[qkTensor:.*]] = tosa.matmul %[[queriesTensor:.*]], %[[keysTensor:.*]], %{{.*}}, %{{.*}} : ([[queriesShape:tensor<.*>]], [[keysShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[squareShape:tensor<.*>]]
-// CHECK_NO_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[qkTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
-// CHECK_NO_SCALE-DAG: %[[normilizedQkTensor:.*]] = tosa.sub %[[qkTensor]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
+// CHECK_NO_SCALE: %[[qkTensorCast:.*]] = tosa.cast %[[qkTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_NO_SCALE-DAG: %[[sqkMaxs:.*]] = tosa.reduce_max %[[qkTensorCast]] {{.*}} : ([[squareShape]]) -> [[reducedShape:tensor<.*>]]
+// CHECK_NO_SCALE-DAG: %[[normilizedQkTensor:.*]] = tosa.sub %[[qkTensorCast]], %[[sqkMaxs]] : ([[squareShape]], [[reducedShape]]) -> [[squareShape]]
 // CHECK_NO_SCALE-DAG: %[[expsTensor:.*]] = tosa.exp %[[normilizedQkTensor]] : ([[squareShape]]) -> [[squareShape]]
 // CHECK_NO_SCALE-DAG: %[[expsSumsTensor:.*]] = tosa.reduce_sum %[[expsTensor]] {{.*}} : ([[squareShape]]) -> [[reducedShape]]
 // CHECK_NO_SCALE-DAG: %[[invExpsSums:.*]] = tosa.reciprocal %[[expsSumsTensor]] : ([[reducedShape]]) -> [[reducedShape]]
 // CHECK_NO_SCALE-DAG: %[[softmaxTensor:.*]] = tosa.mul %[[expsTensor]], %[[invExpsSums]], %{{.*}} : ([[squareShape]], [[reducedShape]], tensor<1xi8>) -> [[squareShape]]
-// CHECK_NO_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensor]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
+// CHECK_NO_SCALE-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
+// CHECK_NO_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
 // CHECK_NO_SCALE: return

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -622,6 +622,11 @@ static llvm::cl::opt<bool> returnLSE(
     llvm::cl::desc("whether the attention kernel returns LSE (log-sum-exp)"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<std::string>
+    softmaxDataType("softmax_dtype",
+                    llvm::cl::desc("Data type for softmax (attention)"),
+                    llvm::cl::init("f32"));
+
 //////////////////////////////////////////////////////////////////////////
 ////  Host Generator options
 //////////////////////////////////////////////////////////////////////////
@@ -2848,10 +2853,14 @@ static func::FuncOp createGpuAttentionKernel(ModuleOp module,
   IntegerAttr numCUAttr =
       (num_cu.getNumOccurrences() > 0 ? builder.getI32IntegerAttr(num_cu)
                                       : nullptr);
+
+  auto softmaxType =
+      TypeAttr::get(typeFromString(softmaxDataType.getValue(), ctx));
   auto attention = builder.create<rock::AttentionOp>(
       loc, TypeRange{}, queries, keys, values, elemwiseInputs,
       currentSeqLenTensor, output, lse, transposeQ, transposeK, transposeV,
-      transposeO, causalMasking, archAttr, params.features, numCUAttr,
+      transposeO, causalMasking, archAttr, params.features, softmaxType,
+      numCUAttr,
       /*params0=*/nullptr, /*params1=*/nullptr, /*firstGemmIdx=*/0);
   {
     Block *preSoftmaxElemwiseBlock =
@@ -3708,6 +3717,10 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
         builder, loc, cast<ShapedType>(biasTensor.getType()).getElementType(),
         qkTensor, biasTensor);
   }
+  // cast to softmaxType
+  auto softmaxType = typeFromString(softmaxDataType.getValue(), ctx);
+  qkTensor =
+      createOpAndInfer<tosa::CastOp>(builder, loc, softmaxType, qkTensor);
 
   if (currentSeqLenTensor) {
     qkTensor = maskKVCacheTosa(builder, loc, qkTensor, currentSeqLenTensor,
@@ -3724,35 +3737,33 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
                                  -std::numeric_limits<float>::infinity());
 
   constexpr int64_t reductionAxis = 2;
-  auto qkMaxs = createOpAndInfer<tosa::ReduceMaxOp>(
-      builder, loc, cast<ShapedType>(qkTensor.getType()).getElementType(),
-      qkTensor, reductionAxis);
+  auto qkMaxs = createOpAndInfer<tosa::ReduceMaxOp>(builder, loc, softmaxType,
+                                                    qkTensor, reductionAxis);
   auto normalizedQkTensor = createOpAndInfer<tosa::SubOp>(
-      builder, loc, cast<ShapedType>(qkTensor.getType()).getElementType(),
-      qkTensor, qkMaxs);
-  auto expsTensor = createOpAndInfer<tosa::ExpOp>(
-      builder, loc,
-      cast<ShapedType>(normalizedQkTensor.getType()).getElementType(),
-      normalizedQkTensor);
+      builder, loc, softmaxType, qkTensor, qkMaxs);
+  auto expsTensor = createOpAndInfer<tosa::ExpOp>(builder, loc, softmaxType,
+                                                  normalizedQkTensor);
   auto expsSums = createOpAndInfer<tosa::ReduceSumOp>(
-      builder, loc, cast<ShapedType>(expsTensor.getType()).getElementType(),
-      expsTensor, reductionAxis);
+      builder, loc, softmaxType, expsTensor, reductionAxis);
+  Type resultOutElementType =
+      isQuantized ? Float16Type::get(ctx) : firstGemmOutElemType;
   Value lseTensor;
   // qkMaxs = max x
   // expsSums = sum e^(x-qkMaxs)
   // lse = (log(expsSums) + qkMaxs)
   if (returnLSE) {
-    auto expsSumElemType =
-        cast<ShapedType>(expsSums.getType()).getElementType();
-    lseTensor =
-        createOpAndInfer<tosa::LogOp>(builder, loc, expsSumElemType, expsSums);
-    lseTensor = createOpAndInfer<tosa::AddOp>(builder, loc, expsSumElemType,
-                                              lseTensor, qkMaxs);
+    Value expsSumsForLSE = createOpAndInfer<tosa::CastOp>(
+        builder, loc, resultOutElementType, expsSums);
+    Value qkMaxsForLSE = createOpAndInfer<tosa::CastOp>(
+        builder, loc, resultOutElementType, qkMaxs);
+    lseTensor = createOpAndInfer<tosa::LogOp>(
+        builder, loc, resultOutElementType, expsSumsForLSE);
+    lseTensor = createOpAndInfer<tosa::AddOp>(
+        builder, loc, resultOutElementType, lseTensor, qkMaxsForLSE);
   }
 
-  auto invExpsSums = createOpAndInfer<tosa::ReciprocalOp>(
-      builder, loc, cast<ShapedType>(expsSums.getType()).getElementType(),
-      expsSums);
+  auto invExpsSums =
+      createOpAndInfer<tosa::ReciprocalOp>(builder, loc, softmaxType, expsSums);
 
   auto shiftType = RankedTensorType::get({1}, builder.getIntegerType(8));
   auto shiftZeroAttr = DenseElementsAttr::get(
@@ -3760,10 +3771,9 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
   Value constZero =
       builder.create<tosa::ConstOp>(loc, shiftType, shiftZeroAttr);
   Value softmaxTensor = createOpAndInfer<tosa::MulOp>(
-      builder, loc, cast<ShapedType>(expsSums.getType()).getElementType(),
-      expsTensor, invExpsSums, /*shift=*/constZero);
-  auto resultOutElementType =
-      cast<ShapedType>(softmaxTensor.getType()).getElementType();
+      builder, loc, softmaxType, expsTensor, invExpsSums, /*shift=*/constZero);
+  softmaxTensor = createOpAndInfer<tosa::CastOp>(
+      builder, loc, resultOutElementType, softmaxTensor);
   auto softmaxZp =
       tosa::createZeroPointTensor(builder, loc, softmaxTensor.getType(), 0)
           .value();


### PR DESCRIPTION
This PR is based on https://github.com/ROCm/rocMLIR/pull/1483

We allow users to set the data type that is going to be used for softmax. Note that for performance, we also set denorm handling with preserve-sign.

This doesn't change migraphx behavior, only rocmlir-gen and our tests. We'll have to integrate this feature with migraphx in the future.

The following table compares TFLOPS (MI300X) for f32, f32 denorm=preserve-sign and f16.

| Conf num | f32    | f32 denorm=preserve-sign | f16    | f32/16 | f32denorm/f16 |
| -------- | ------ | ------------------------ | ------ | ------ | ------------- |
| 1        | 29.66  | 31.35                    | 32.75  | 0.91   | 0.96          |
| 2        | 39.63  | 39.42                    | 43.24  | 0.92   | 0.91          |
| 3        | 172.17 | 193.59                   | 201.09 | 0.86   | 0.96          |
| 4        | 67.55  | 66.08                    | 79.81  | 0.85   | 0.83          |
| 5        | 108.14 | 119.23                   | 115.22 | 0.94   | 1.03          |
| 6        | 47.19  | 52.04                    | 56.01  | 0.84   | 0.93          |
| 7        | 50.76  | 55.65                    | 58.61  | 0.87   | 0.95          |
| 8        | 28.96  | 33.42                    | 33.25  | 0.87   | 1.01          |
| 9        | 8.88   | 10.37                    | 10.98  | 0.81   | 0.94          |
| 10       | 48.51  | 48.94                    | 49.83  | 0.97   | 0.98          |
| 11       | 72.12  | 73.41                    | 82.72  | 0.87   | 0.89          |
| 12       | 56.15  | 57.93                    | 62.76  | 0.89   | 0.92          |
| 13       | 144.44 | 159.95                   | 154.18 | 0.94   | 1.04          |
| 14       | 2.39   | 2.78                     | 2.94   | 0.81   | 0.95          |
| 15       | 15.67  | 15.99                    | 15.97  | 0.98   | 1.00          |
| 16       | 4.02   | 4.37                     | 4.89   | 0.82   | 0.90          |
| 17       | 1.26   | 1.28                     | 1.39   | 0.90   | 0.92          |