### PR TITLE
perfRunner: skip f32 attention kernels on Navi

### DIFF
--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -760,12 +760,10 @@ def getAttentionConfigurations(fileName):
                     oneConfig = line.strip()
                     for arg, value in zip(args, test_vector):
                         oneConfig = f"{arg} {value} {oneConfig}"
-
-                    # TEMPORARY TO CHECK FORMAT OF ONECONFIG
-                    print(oneConfig)
                     
                     # Check for valid dtypes
-                    if re.search(r"-t\s+(\w+)", oneConfig) not in DATA_TYPES_ATTENTION:
+                    foundDtype = re.search(r"-t\s+(\w+)", oneConfig)
+                    if not foundDtype or foundDtype.group(1) not in DATA_TYPES_ATTENTION:
                         continue
 
                     if oneConfig not in configs:

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -760,6 +760,11 @@ def getAttentionConfigurations(fileName):
                     oneConfig = line.strip()
                     for arg, value in zip(args, test_vector):
                         oneConfig = f"{arg} {value} {oneConfig}"
+
+                    # Skip f32 for attention if executed on Navi
+                    if getChip().startswith("gfx1") and "-t f32" in oneConfig:
+                        continue
+
                     if oneConfig not in configs:
                         configs.append(oneConfig)
     return configs

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -761,8 +761,8 @@ def getAttentionConfigurations(fileName):
                     for arg, value in zip(args, test_vector):
                         oneConfig = f"{arg} {value} {oneConfig}"
 
-                    # Skip f32 for attention if executed on Navi
-                    if getChip().startswith("gfx1") and "-t f32" in oneConfig:
+                    # Check for valid dtypes
+                    if re.search(r"-t\s+(\w+)", oneConfig) not in DATA_TYPES_ATTENTION:
                         continue
 
                     if oneConfig not in configs:

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -761,6 +761,9 @@ def getAttentionConfigurations(fileName):
                     for arg, value in zip(args, test_vector):
                         oneConfig = f"{arg} {value} {oneConfig}"
 
+                    # TEMPORARY TO CHECK FORMAT OF ONECONFIG
+                    print(oneConfig)
+                    
                     # Check for valid dtypes
                     if re.search(r"-t\s+(\w+)", oneConfig) not in DATA_TYPES_ATTENTION:
                         continue


### PR DESCRIPTION
Although `DATA_TYPES_ATTENTION` was changed to be previously defined dynamically based on the architecture, f32 still slipped through on Navi on [some nightly runs](https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir-nightly-all/detail/mlir-nightly-all/1930/pipeline).

This PR should ensure that attention configs with dtype f32 are skipped in getAttentionConfiguration() even if they slip in for an unknown reason.

Resolves https://github.com/ROCm/rocMLIR-internal/issues/1899