### PR TITLE
perfRunner: use regex for exact flag detection in config generation

### DIFF
--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -726,6 +726,10 @@ def getGemmGemmConfigurations(fileName):
     return configs
 
 def attachAttentionDatatypes(config, dtypes):
+    """
+    Expands attention configuration by appending all supported attention data types.
+    Purpose of this function is to be used when there is no data type present in config
+    """
     return [config + f" -t {dt}" for dt in dtypes]
 
 def getAttentionConfigurations(fileName):

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -765,10 +765,10 @@ def getAttentionConfigurations(fileName):
                         if arg not in configline:
                             test_space.append(default_test_space[arg])
                             args.append(arg)
-                    for testVector in itertools.product(*test_space):
+                    for test_vector in itertools.product(*test_space):
                         # Strip to avoid spurious spaces
                         oneConfig = configline.strip()
-                        for arg, value in zip(args, testVector):
+                        for arg, value in zip(args, test_vector):
                             oneConfig = f"{arg} {value} {oneConfig}"
                         if oneConfig not in configs:
                             configs.append(oneConfig)

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -680,7 +680,15 @@ def getConvGemmConfigurations(fileName):
                 test_space = []
                 args = []
                 for arg in default_test_space.keys():
-                    if arg not in line:
+                    """
+                    Next condition checks if a flag is not present in the line. Check with re.search(...)
+                    ensures flags are matched exactly and not as substring.
+
+                    - (?<!\S) ensures that flag is not part of another token (e.g. that -t is not part of -transQ)
+                    - (?!\S) ensures that flag is followed by a space or line end.
+                    - re.escape(arg) ensures that flag, in case it contains special character(s), is matched as it is. 
+                    """
+                    if not re.search(rf"(?<!\S){re.escape(arg)}(?!\S)", line):
                         test_space.append(default_test_space[arg])
                         args.append(arg)
                 for test_vector in itertools.product(*test_space):
@@ -713,7 +721,15 @@ def getGemmGemmConfigurations(fileName):
                 test_space = []
                 args = []
                 for arg in default_test_space.keys():
-                    if arg not in line:
+                    """
+                    Next condition checks if a flag is not present in the line. Check with re.search(...)
+                    ensures flags are matched exactly and not as substring.
+
+                    - (?<!\S) ensures that flag is not part of another token (e.g. that -t is not part of -transQ)
+                    - (?!\S) ensures that flag is followed by a space or line end.
+                    - re.escape(arg) ensures that flag, in case it contains special character(s), is matched as it is. 
+                    """
+                    if not re.search(rf"(?<!\S){re.escape(arg)}(?!\S)", line):
                         test_space.append(default_test_space[arg])
                         args.append(arg)
                 for test_vector in itertools.product(*test_space):

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -774,9 +774,6 @@ def getAttentionConfigurations(fileName):
                     if oneConfig not in configs:
                         configs.append(oneConfig)
 
-                if line not in configs:
-                    configs.append(line)
-
     return configs
 
 

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -753,29 +753,28 @@ def getAttentionConfigurations(fileName):
             lines = configFile.readlines()
             for line in lines:
                 line = line.strip()
-                # Skip empty lines
-                if len(line) == 0 or line[0] == '#':
+                if len(line) == 0 or line.startswith('#'):
                     continue
 
-                if "-t" in line:
-                    newLines = [line]
-                else:
-                    newLines = attachAttentionDatatypes(line, DATA_TYPES_ATTENTION)
+                test_space = []
+                args = []
+                for arg in default_test_space.keys():
+                    if not re.search(rf"(?<!\S){re.escape(arg)}(?!\S)", line):
+                        test_space.append(default_test_space[arg])
+                        args.append(arg)
 
-                for configline in newLines:
-                    test_space = []
-                    args = []
-                    for arg in default_test_space.keys():
-                        if arg not in configline:
-                            test_space.append(default_test_space[arg])
-                            args.append(arg)
+                if args:
                     for test_vector in itertools.product(*test_space):
                         # Strip to avoid spurious spaces
-                        oneConfig = configline.strip()
+                        oneConfig = line.strip()
                         for arg, value in zip(args, test_vector):
                             oneConfig = f"{arg} {value} {oneConfig}"
                         if oneConfig not in configs:
                             configs.append(oneConfig)
+                else:
+                    if line not in configs:
+                        configs.append(line)
+
     return configs
 
 

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -725,6 +725,9 @@ def getGemmGemmConfigurations(fileName):
                         configs.append(oneConfig)
     return configs
 
+def attachAttentionDatatypes(config, dtypes):
+    return [config + f" -t {dt}" for dt in dtypes]
+
 def getAttentionConfigurations(fileName):
     if DATA_TYPES_ATTENTION is None:
         initializeDataTypesAttention()
@@ -749,19 +752,26 @@ def getAttentionConfigurations(fileName):
                 # Skip empty lines
                 if len(line) == 0 or line[0] == '#':
                     continue
-                test_space = []
-                args = []
-                for arg in default_test_space.keys():
-                    if arg not in line:
-                        test_space.append(default_test_space[arg])
-                        args.append(arg)
-                for test_vector in itertools.product(*test_space):
-                    # Strip to avoid spurious spaces
-                    oneConfig = line.strip()
-                    for arg, value in zip(args, test_vector):
-                        oneConfig = f"{arg} {value} {oneConfig}"
-                    if oneConfig not in configs:
-                        configs.append(oneConfig)
+
+                if "-t" in line:
+                    newLines = [line]
+                else:
+                    newLines = attachAttentionDatatypes(line, DATA_TYPES_ATTENTION)
+
+                for configline in newLines:
+                    testSpace = []
+                    args = []
+                    for arg in default_test_space.keys():
+                        if arg not in configline:
+                            testSpace.append(default_test_space[arg])
+                            args.append(arg)
+                    for testVector in itertools.product(*testSpace):
+                        # Strip to avoid spurious spaces
+                        oneConfig = configline.strip()
+                        for arg, value in zip(args, testVector):
+                            oneConfig = f"{arg} {value} {oneConfig}"
+                        if oneConfig not in configs:
+                            configs.append(oneConfig)
     return configs
 
 

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -725,13 +725,6 @@ def getGemmGemmConfigurations(fileName):
                         configs.append(oneConfig)
     return configs
 
-def attachAttentionDatatypes(config, dtypes):
-    """
-    Expands attention configuration by appending all supported attention data types.
-    Purpose of this function is to be used when there is no data type present in config
-    """
-    return [config + f" -t {dt}" for dt in dtypes]
-
 def getAttentionConfigurations(fileName):
     if DATA_TYPES_ATTENTION is None:
         initializeDataTypesAttention()

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -759,13 +759,13 @@ def getAttentionConfigurations(fileName):
                     newLines = attachAttentionDatatypes(line, DATA_TYPES_ATTENTION)
 
                 for configline in newLines:
-                    testSpace = []
+                    test_space = []
                     args = []
                     for arg in default_test_space.keys():
                         if arg not in configline:
-                            testSpace.append(default_test_space[arg])
+                            test_space.append(default_test_space[arg])
                             args.append(arg)
-                    for testVector in itertools.product(*testSpace):
+                    for testVector in itertools.product(*test_space):
                         # Strip to avoid spurious spaces
                         oneConfig = configline.strip()
                         for arg, value in zip(args, testVector):

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -740,6 +740,7 @@ def getAttentionConfigurations(fileName):
         "-with-attn-scale": bool_space,
         "-with-attn-bias": bool_space
     }
+
     configs = []
     if fileName:
         with open(fileName, 'r') as configFile:
@@ -752,21 +753,29 @@ def getAttentionConfigurations(fileName):
                 test_space = []
                 args = []
                 for arg in default_test_space.keys():
+                    """
+                    Next condition checks if a flag is not present in the line. Check with re.search(...)
+                    ensures flags are matched exactly and not as substring.
+
+                    - (?<!\S) ensures that flag is not part of another token (e.g. that -t is not part of -transQ)
+                    - (?!\S) ensures that flag is followed by a space or line end.
+                    - re.escape(arg) ensures that flag, in case it contains special character(s), is matched as it is. 
+                    """
                     if not re.search(rf"(?<!\S){re.escape(arg)}(?!\S)", line):
                         test_space.append(default_test_space[arg])
                         args.append(arg)
 
-                if args:
-                    for test_vector in itertools.product(*test_space):
-                        # Strip to avoid spurious spaces
-                        oneConfig = line.strip()
-                        for arg, value in zip(args, test_vector):
-                            oneConfig = f"{arg} {value} {oneConfig}"
-                        if oneConfig not in configs:
-                            configs.append(oneConfig)
-                else:
-                    if line not in configs:
-                        configs.append(line)
+
+                for test_vector in itertools.product(*test_space):
+                    # Strip to avoid spurious spaces
+                    oneConfig = line.strip()
+                    for arg, value in zip(args, test_vector):
+                        oneConfig = f"{arg} {value} {oneConfig}"
+                    if oneConfig not in configs:
+                        configs.append(oneConfig)
+
+                if line not in configs:
+                    configs.append(line)
 
     return configs
 


### PR DESCRIPTION
Fix a bug in `getAttentonConfigurations()` where missing flags were not reliably detected when absent in config. Bug was caused by using `if arg not in line:` because it checked if flag was/was't present, but considered that it was present in case it was part of other flag (e.g. it recognized `-t` was present when it was actually substring of` -transQ`). Fix introduces using regex to detect if the flag is present or not more precisely. This PR adjusts` getConvGemmConfigurations()` and `getGemmGemmConfigurations()` too to use the same flag detection logic.

- Resolves https://github.com/ROCm/rocMLIR-internal/issues/1850