### PR TITLE
[DO NOT SQUASH] rock.global_load_to_lds for direct to LDS

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
+++ b/external/llvm-project/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
@@ -27,7 +27,8 @@ class Pass;
 /// populateAMDGPUMemorySpaceAttributeConversions().
 void populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                              RewritePatternSet &patterns,
-                                             amdgpu::Chipset chipset);
+                                             amdgpu::Chipset chipset,
+                                             bool hackForDirectToLDS);
 
 /// Remap AMDGPU memory spaces to LLVM address spaces
 /// by mapping amdgpu::AddressSpace::fat_raw_buffer to ptr addrspace(7),

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -468,7 +468,7 @@ struct LDSBarrierOpLowering : public ConvertOpToLLVMPattern<LDSBarrierOp> {
                << chipset.majorVersion;
 
       Location loc = op->getLoc();
-      
+
       // HACK for direct to LDS
       if (hackForDirectToLDS) {
         // unsigned vmCnt = std::min(63u, op.getNum());
@@ -1720,7 +1720,8 @@ struct ConvertAMDGPUToROCDLPass
 
     RewritePatternSet patterns(ctx);
     LLVMTypeConverter converter(ctx);
-    populateAMDGPUToROCDLConversionPatterns(converter, patterns, *maybeChipset, hackForDirectToLDS);
+    populateAMDGPUToROCDLConversionPatterns(converter, patterns, *maybeChipset,
+                                            hackForDirectToLDS);
     LLVMConversionTarget target(getContext());
     target.addIllegalDialect<::mlir::amdgpu::AMDGPUDialect>();
     target.addLegalDialect<::mlir::LLVM::LLVMDialect>();
@@ -1770,12 +1771,11 @@ void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                ROCDL::RawPtrBufferAtomicUminOp>,
            RawBufferOpLowering<RawBufferAtomicCmpswapOp,
                                ROCDL::RawPtrBufferAtomicCmpSwap>,
-           AMDGPUDPPLowering, SchedBarrierOpLowering,
-           MFMAOpLowering, ScaledMFMAOpLowering, WMMAOpLowering,
-           ExtPackedFp8OpLowering, ScaledExtPackedOpLowering,
-           PackedScaledTruncOpLowering, PackedTrunc2xFp8OpLowering,
-           PackedStochRoundFp8OpLowering, GatherToLDSOpLowering>(converter,
-                                                                 chipset);
+           AMDGPUDPPLowering, SchedBarrierOpLowering, MFMAOpLowering,
+           ScaledMFMAOpLowering, WMMAOpLowering, ExtPackedFp8OpLowering,
+           ScaledExtPackedOpLowering, PackedScaledTruncOpLowering,
+           PackedTrunc2xFp8OpLowering, PackedStochRoundFp8OpLowering,
+           GatherToLDSOpLowering>(converter, chipset);
   patterns.add<LDSBarrierOpLowering>(converter, chipset, hackForDirectToLDS);
   patterns.add<AMDGPUSwizzleBitModeLowering>(converter);
 }

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -420,10 +420,13 @@ struct RawBufferOpLowering : public ConvertOpToLLVMPattern<GpuOp> {
 };
 
 struct LDSBarrierOpLowering : public ConvertOpToLLVMPattern<LDSBarrierOp> {
-  LDSBarrierOpLowering(const LLVMTypeConverter &converter, Chipset chipset)
-      : ConvertOpToLLVMPattern<LDSBarrierOp>(converter), chipset(chipset) {}
+  LDSBarrierOpLowering(const LLVMTypeConverter &converter, Chipset chipset,
+                       bool hackForDirectToLDS)
+      : ConvertOpToLLVMPattern<LDSBarrierOp>(converter), chipset(chipset),
+        hackForDirectToLDS(hackForDirectToLDS) {}
 
   Chipset chipset;
+  bool hackForDirectToLDS;
 
   LogicalResult
   matchAndRewrite(LDSBarrierOp op, LDSBarrierOp::Adaptor adaptor,
@@ -465,6 +468,21 @@ struct LDSBarrierOpLowering : public ConvertOpToLLVMPattern<LDSBarrierOp> {
                << chipset.majorVersion;
 
       Location loc = op->getLoc();
+      
+      // HACK for direct to LDS
+      if (hackForDirectToLDS) {
+        // unsigned vmCnt = std::min(63u, op.getNum());
+        unsigned vmCnt = 0;
+
+        // Extract low and high bits and combine while setting all other bits to
+        // 1
+        unsigned lowBits = vmCnt & 0xF;
+        unsigned highBits = vmCnt >> 4 << 14;
+        unsigned otherCnts = ~0xC00F; // C00F has bits 15:14 and 3:0 set
+        unsigned waitValue = lowBits | highBits | otherCnts;
+
+        rewriter.create<ROCDL::SWaitcntOp>(loc, waitValue);
+      }
       rewriter.create<ROCDL::SWaitcntOp>(loc, ldsOnlyBits);
       rewriter.replaceOpWithNewOp<ROCDL::SBarrierOp>(op);
     } else {
@@ -1129,8 +1147,8 @@ struct GatherToLDSOpLowering : public ConvertOpToLLVMPattern<GatherToLDSOp> {
       return transferType.getIntOrFloatBitWidth() / 8;
     }();
 
-    // Currently only 1, 2, and 4 byte loads are supported.
-    if (loadWidth != 1 && loadWidth != 2 && loadWidth != 4)
+    // Currently only 1, 2, 4 and 16 byte loads are supported.
+    if (loadWidth != 1 && loadWidth != 2 && loadWidth != 4 && loadWidth != 16)
       return op.emitOpError("chipset unsupported element size");
 
     Value srcPtr =
@@ -1693,10 +1711,16 @@ struct ConvertAMDGPUToROCDLPass
       emitError(UnknownLoc::get(ctx), "Invalid chipset name: " + chipset);
       return signalPassFailure();
     }
+    // workaround for https://ontrack-internal.amd.com/browse/SWDEV-514726
+    WalkResult walkResult =
+        getOperation()->walk([](amdgpu::GatherToLDSOp) -> WalkResult {
+          return WalkResult::interrupt();
+        });
+    bool hackForDirectToLDS = walkResult.wasInterrupted();
 
     RewritePatternSet patterns(ctx);
     LLVMTypeConverter converter(ctx);
-    populateAMDGPUToROCDLConversionPatterns(converter, patterns, *maybeChipset);
+    populateAMDGPUToROCDLConversionPatterns(converter, patterns, *maybeChipset, hackForDirectToLDS);
     LLVMConversionTarget target(getContext());
     target.addIllegalDialect<::mlir::amdgpu::AMDGPUDialect>();
     target.addLegalDialect<::mlir::LLVM::LLVMDialect>();
@@ -1729,7 +1753,8 @@ void mlir::populateAMDGPUMemorySpaceAttributeConversions(
 
 void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                                    RewritePatternSet &patterns,
-                                                   Chipset chipset) {
+                                                   Chipset chipset,
+                                                   bool hackForDirectToLDS) {
   populateAMDGPUMemorySpaceAttributeConversions(converter);
   patterns
       .add<FatRawBufferCastLowering,
@@ -1745,11 +1770,12 @@ void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                ROCDL::RawPtrBufferAtomicUminOp>,
            RawBufferOpLowering<RawBufferAtomicCmpswapOp,
                                ROCDL::RawPtrBufferAtomicCmpSwap>,
-           AMDGPUDPPLowering, LDSBarrierOpLowering, SchedBarrierOpLowering,
+           AMDGPUDPPLowering, SchedBarrierOpLowering,
            MFMAOpLowering, ScaledMFMAOpLowering, WMMAOpLowering,
            ExtPackedFp8OpLowering, ScaledExtPackedOpLowering,
            PackedScaledTruncOpLowering, PackedTrunc2xFp8OpLowering,
            PackedStochRoundFp8OpLowering, GatherToLDSOpLowering>(converter,
                                                                  chipset);
+  patterns.add<LDSBarrierOpLowering>(converter, chipset, hackForDirectToLDS);
   patterns.add<AMDGPUSwizzleBitModeLowering>(converter);
 }

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -374,7 +374,7 @@ struct LowerGpuOpsToROCDLOpsPass final
       iface->populateConvertToLLVMConversionPatterns(target, converter,
                                                      llvmPatterns);
     }
-    
+
     // workaround for https://ontrack-internal.amd.com/browse/SWDEV-514726
     WalkResult walkResult =
         getOperation()->walk([](amdgpu::GatherToLDSOp) -> WalkResult {

--- a/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -374,9 +374,16 @@ struct LowerGpuOpsToROCDLOpsPass final
       iface->populateConvertToLLVMConversionPatterns(target, converter,
                                                      llvmPatterns);
     }
+    
+    // workaround for https://ontrack-internal.amd.com/browse/SWDEV-514726
+    WalkResult walkResult =
+        getOperation()->walk([](amdgpu::GatherToLDSOp) -> WalkResult {
+          return WalkResult::interrupt();
+        });
+    bool hackForDirectToLDS = walkResult.wasInterrupted();
 
     populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns,
-                                            *maybeChipset);
+                                            *maybeChipset, hackForDirectToLDS);
     // TODO (rocmlir): remove hardcoded passes
     // related PR: https://github.com/llvm/llvm-project/pull/124439
     mlir::vector::populateVectorInsertExtractStridedSliceTransforms(

--- a/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -510,8 +510,9 @@ LogicalResult GatherToLDSOp::verify() {
   } else {
     transferSize = transferType.getIntOrFloatBitWidth();
   }
-  if (transferSize != 8 && transferSize != 16 && transferSize != 32)
-    return emitOpError("Transfering type size must be 8, 16, or 32 bits");
+  if (transferSize != 8 && transferSize != 16 && transferSize != 32 &&
+      transferSize != 128)
+    return emitOpError("Transfering type size must be 8, 16, 32, or 128 bits");
 
   if (!hasGlobalMemorySpace(srcType.getMemorySpace()) &&
       !hasFatRawBufferMemorySpace(srcType.getMemorySpace()))

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/ldsbarrier-hack.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/ldsbarrier-hack.mlir
@@ -1,0 +1,26 @@
+// RUN: mlir-opt %s -convert-amdgpu-to-rocdl=chipset=gfx942 | FileCheck %s --check-prefixes=CHECK,GFX942
+// RUN: mlir-opt %s -convert-amdgpu-to-rocdl=chipset=gfx950 | FileCheck %s --check-prefixes=CHECK,GFX950
+
+// Note: #gpu.address_space<global> is hardcoded to `1` here because the
+// test pass doesn't set up the GPU address space conversions.
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+#amdgpu_fat_buffer_addrspace = 7
+
+// CHECK-LABEL: func @lds_barrier_workaround
+func.func @lds_barrier_workaround(%mem: memref<192xf32, #amdgpu_fat_buffer_addrspace>) {
+  %c0 = arith.constant 0 : index
+  %lds = memref.alloc() : memref<4xf32, #gpu_lds_addrspace>
+  amdgpu.gather_to_lds %mem[%c0], %lds[%c0] : f32, memref<192xf32, #amdgpu_fat_buffer_addrspace>, memref<4xf32, #gpu_lds_addrspace>
+  // GFX942: rocdl.load.to.lds
+  // GFX942-NEXT: rocdl.s.waitcnt -49168
+  // GFX942-NEXT: rocdl.s.waitcnt -7937
+  // GFX942-NEXT: rocdl.s.barrier
+  // GFX950: rocdl.load.to.lds
+  // GFX950-NEXT: rocdl.s.waitcnt -49168
+  // GFX950-NEXT: rocdl.s.waitcnt -7937
+  // GFX950-NEXT: rocdl.s.barrier
+  amdgpu.lds_barrier
+  func.return
+}

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -471,12 +471,21 @@ def Rock_GemmFeatures_AtomicAdd : I32BitEnumAttrCaseBit<"atomic_add", 3>;
 def Rock_GemmFeatures_AtomicAddBF16 : I32BitEnumAttrCaseBit<"atomic_add_bf16", 4>;
 def Rock_GemmFeatures_AtomicAddF16 : I32BitEnumAttrCaseBit<"atomic_add_f16", 5>;
 def Rock_GemmFeatures_AtomicFmaxF32 : I32BitEnumAttrCaseBit<"atomic_fmax_f32", 6>;
+def Rock_GemmFeatures_DirectToLDS32B
+    : I32BitEnumAttrCaseBit<"direct_to_lds_32b", 7>;
+def Rock_GemmFeatures_DirectToLDS128B
+    : I32BitEnumAttrCaseBit<"direct_to_lds_128b", 8>;
 
-def Rock_GemmFeatures : I32BitEnumAttr<"GemmFeatures",
-    "Features that can be enabled on GEMM-based operations",
-    [Rock_GemmFeatures_None, Rock_GemmFeatures_Mfma, Rock_GemmFeatures_Wmma,
-     Rock_GemmFeatures_Dot, Rock_GemmFeatures_AtomicAdd, Rock_GemmFeatures_AtomicAddBF16, 
-     Rock_GemmFeatures_AtomicAddF16, Rock_GemmFeatures_AtomicFmaxF32]> {
+def Rock_GemmFeatures
+    : I32BitEnumAttr<
+          "GemmFeatures",
+          "Features that can be enabled on GEMM-based operations",
+          [Rock_GemmFeatures_None, Rock_GemmFeatures_Mfma,
+           Rock_GemmFeatures_Wmma, Rock_GemmFeatures_Dot,
+           Rock_GemmFeatures_AtomicAdd, Rock_GemmFeatures_AtomicAddBF16,
+           Rock_GemmFeatures_AtomicAddF16, Rock_GemmFeatures_AtomicFmaxF32,
+           Rock_GemmFeatures_DirectToLDS32B,
+           Rock_GemmFeatures_DirectToLDS128B]> {
   let cppNamespace = "::mlir::rock";
   let genSpecializedAttr = 0;
 }

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1062,6 +1062,41 @@ def Rock_GlobalLoadOp :
   let hasVerifier = 1;
 }
 
+// global_load_to_lds
+def Rock_GlobalLoadToLDSOp
+    : Rock_Op<"global_load_to_lds", [AllElementTypesMatch<["source", "dest"]>,
+                                     AttrSizedOperandSegments]>,
+      Arguments<(ins Arg<MemRefOf<SupportedMemoryElems>,
+                         "source memory", [MemRead]>:$source,
+          Arg<MemRefOf<SupportedMemoryElems>,
+              "destination memory", [MemWrite]>:$dest,
+          I1:$valid, TypeAttr:$transferType, Variadic<Index>:$sourceCoord,
+          Variadic<Index>:$destCoord, UnitAttr:$needs64BitIdx,
+          UnitAttr:$canReadOffEnd)> {
+  let summary = "Load from global memory to LDS, applying bounds checks";
+  let description = [{
+    `global_load_to_lds` loads an item or vector of items from the provided memref
+    (applying no coordinate transformations), starting at `sourceCoord` and stores.
+    to LDS. However, if `valid` is false, it will instead store 0s.
+    Note that the lowering of this operation may be optimized when `valid`
+    is unconditionally true.
+
+    If `needs64BitIdx` is present, then this operation will force its containing
+    kernel to be compiled with `index == i64` and will use less-efficient
+    implementations of bounds-checked load.
+
+    If `canReadOffEnd` is present, then the `valid` input is ignored and the
+    bounds-checked implementation of this operation is always used. This
+    is used to simplify the implementation of certain utility kernels.
+  }];
+  let assemblyFormat = [{
+    $source `[` $sourceCoord `]` 
+    `->` $dest `[` $destCoord `]`  `if` $valid attr-dict
+    `:` type($source) `->` type($dest)
+  }];
+  let hasVerifier = 1;
+}
+
 // global_store
 def Rock_GlobalStoreOp
     : Rock_Op<"global_store", [AllElementTypesMatch<["source", "dest"]>]>,

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -46,7 +46,8 @@ static constexpr AmdArchInfo
               /*hasFp8ConversionInstrs=*/false,
               /*hasOcpFp8ConversionInstrs=*/false, /*maxNumXCC=*/1),
     cdna3Info(GemmFeatures::mfma | GemmFeatures::dot |
-                  GemmFeatures::atomic_add | GemmFeatures::atomic_add_f16,
+                  GemmFeatures::atomic_add | GemmFeatures::atomic_add_f16 |
+                  GemmFeatures::direct_to_lds_32b,
               /*waveSize=*/64, /*maxWavesPerEU*/ 10, /*totalSGPRPerEU*/ 512,
               /*totalVGPRPerEU*/ 512, /*totalSharedMemPerCU*/ 65536,
               /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/80,
@@ -54,7 +55,9 @@ static constexpr AmdArchInfo
               /*hasOcpFp8ConversionInstrs=*/false, /*maxNumXCC=*/8),
     cdna35Info(GemmFeatures::mfma | GemmFeatures::dot |
                    GemmFeatures::atomic_add | GemmFeatures::atomic_add_f16 |
-                   GemmFeatures::atomic_add_bf16,
+                   GemmFeatures::atomic_add_bf16 |
+                   GemmFeatures::direct_to_lds_32b |
+                   GemmFeatures::direct_to_lds_128b,
                /*waveSize=*/64, /*maxWavesPerEU*/ 8, /*totalSGPRPerEU*/ 800,
                /*totalVGPRPerEU*/ 512, /*totalSharedMemPerCU*/ 163840,
                /*maxSharedMemPerWG*/ 163840, /*numEUPerCU=*/4, /*minNumCU=*/256,

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1527,22 +1527,49 @@ LogicalResult IndexDiffUpdateOp::verify() {
   return success();
 }
 
-//===-----------------------------------------------------===//
-// GlobalLoadOp
-//===-----------------------------------------------------===//
-LogicalResult GlobalLoadOp::verify() {
-  MemRefType sourceType = getSource().getType();
+template <typename Load>
+static LogicalResult verifyGlobalLoad(Load op) {
+  MemRefType sourceType = op.getSource().getType();
   size_t nDims = sourceType.getRank();
 
-  if (getSourceCoord().size() != nDims)
-    return emitOpError("Expected " + Twine(nDims) + " coordinates for load");
-  if (getCanReadOffEnd() && nDims != 1)
-    return emitOpError("can only have one dimension in canReadOffEnd loads");
+  if (op.getSourceCoord().size() != nDims)
+    return op.emitOpError("Expected " + Twine(nDims) + " coordinates for load");
+  if (op.getCanReadOffEnd() && nDims != 1)
+    return op.emitOpError("can only have one dimension in canReadOffEnd loads");
   Attribute memSpaceAttr = sourceType.getMemorySpace();
   auto gpuMemSpaceAttr = dyn_cast_or_null<gpu::AddressSpaceAttr>(memSpaceAttr);
   if (memSpaceAttr && (!gpuMemSpaceAttr ||
                        gpuMemSpaceAttr.getValue() != gpu::AddressSpace::Global))
-    return emitOpError("Source memref must live in global memory");
+    return op.emitOpError("Source memref must live in global memory");
+  return success();
+}
+
+//===-----------------------------------------------------===//
+// GlobalLoadOp
+//===-----------------------------------------------------===//
+LogicalResult GlobalLoadOp::verify() { return verifyGlobalLoad(*this); }
+
+//===-----------------------------------------------------===//
+// GlobalLoadToLDSOp
+//===-----------------------------------------------------===//
+LogicalResult GlobalLoadToLDSOp::verify() {
+  LogicalResult res = verifyGlobalLoad(*this);
+  if (failed(res))
+    return res;
+
+  MemRefType destType = getDest().getType();
+  Attribute destMemSpaceAttr = destType.getMemorySpace();
+  auto destGpuMemSpaceAttr =
+      dyn_cast_or_null<gpu::AddressSpaceAttr>(destMemSpaceAttr);
+  if (destMemSpaceAttr &&
+      (!destGpuMemSpaceAttr ||
+       destGpuMemSpaceAttr.getValue() != gpu::AddressSpace::Workgroup))
+    return emitOpError("Destination memref must live in workgroup memory");
+
+  int64_t numBits = getTransferType().getIntOrFloatBitWidth();
+  if (numBits != 128 && numBits != 32)
+    return emitOpError(
+        "Direct to LDS is implemented for 128bit and 32bit loads only");
   return success();
 }
 

--- a/mlir/lib/Dialect/Rock/Transforms/AnalyzeMemoryUse.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AnalyzeMemoryUse.cpp
@@ -31,7 +31,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
-#define DEBUG_TYPE "rock-buffer-load-merge"
+#define DEBUG_TYPE "rock-analyze-memory-use"
 
 namespace mlir {
 namespace rock {
@@ -62,6 +62,9 @@ void RockAnalyzeMemoryUsePass::runOnOperation() {
     if (auto globalLoad = dyn_cast<GlobalLoadOp>(op))
       return globalLoad.getNeeds64BitIdx() ? WalkResult::interrupt()
                                            : WalkResult::advance();
+    if (auto globalLoadToLDS = dyn_cast<GlobalLoadToLDSOp>(op))
+      return globalLoadToLDS.getNeeds64BitIdx() ? WalkResult::interrupt()
+                                                : WalkResult::advance();
     if (auto globalStore = dyn_cast<GlobalStoreOp>(op))
       return globalStore.getNeeds64BitIdx() ? WalkResult::interrupt()
                                             : WalkResult::advance();
@@ -85,7 +88,7 @@ void RockAnalyzeMemoryUsePass::runOnOperation() {
         worklist.append(user->getUsers().begin(), user->getUsers().end());
         continue;
       }
-      if (!isa<GlobalLoadOp>(user))
+      if (!isa<GlobalLoadOp>(user) && !isa<GlobalLoadToLDSOp>(user))
         isReadonly = false;
       auto storeOp = dyn_cast<GlobalStoreOp>(user);
       if (!storeOp || storeOp.getStoreMethod() != StoreMethod::Set)

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1276,6 +1276,76 @@ struct GlobalLoadRewritePattern : public OpRewritePattern<GlobalLoadOp> {
   }
 };
 
+struct GlobalLoadToLDSRewritePattern
+    : public OpRewritePattern<GlobalLoadToLDSOp> {
+  using OpRewritePattern<GlobalLoadToLDSOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(GlobalLoadToLDSOp op,
+                                PatternRewriter &b) const override {
+    Location loc = op.getLoc();
+    Value source = op.getSource();
+    Value dest = op.getDest();
+    Value valid = op.getValid();
+    SmallVector<Value> coords(op.getSourceCoord());
+    SmallVector<Value> destCoords(op.getDestCoord());
+
+    llvm::APInt validConst = APInt::getZero(1);
+    bool hasI64Idx = op.getNeeds64BitIdx();
+    bool isAlwaysValid =
+        matchPattern(valid, m_ConstantInt(&validConst)) && validConst.isOne();
+    Value numElems = computeMemRefNumElements(b, loc, source);
+    APInt numElemsConst(64, 0);
+    bool isStaticSize = matchPattern(numElems, m_ConstantInt(&numElemsConst));
+    bool emitOobChecks =
+        !isStaticSize || !isAlwaysValid || (hasI64Idx && op.getCanReadOffEnd());
+
+    APInt numBytes =
+        numElemsConst *
+        (cast<ShapedType>(source.getType()).getElementTypeBitWidth() / 8);
+    // In cases where we need more than 2 GB of offset to index but are still
+    // using 32-bit indexing, we'll need to use buffer operations. In the
+    // dynamic shape case, we'll already be in the i64 case, so we don't set
+    // this.
+    bool useBufferOps = !hasI64Idx && (numBytes.trunc(32).isNegative() ||
+                                       emitOobChecks || op.getCanReadOffEnd());
+
+    if (emitOobChecks && !useBufferOps) {
+      return op->emitError(
+          "If we need to emit OOB checks, we must use buffer ops");
+    }
+
+    source = asGlobal(b, source);
+    if (useBufferOps && emitOobChecks && coords.empty()) {
+      source = zeroDMemrefAsOneD(b, source);
+      coords.push_back(b.createOrFold<ConstantIndexOp>(loc, 0));
+    }
+    if (useBufferOps) {
+      // Implement bounds checks for buffer ops by sending any out of bounds
+      // write off the end of the buffer, causing the hardware to return 0
+      // if the write is out of bounds.
+      if (emitOobChecks) {
+        Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
+        for (Value &c : MutableArrayRef<Value>(coords).drop_back())
+          c = b.create<arith::SelectOp>(loc, valid, c, zeroConstantOp);
+        Value &lastCoord = coords.back();
+        lastCoord = b.create<arith::SelectOp>(loc, valid, lastCoord, numElems);
+      }
+      for (Value &c : MutableArrayRef<Value>(coords))
+        c = b.create<IndexCastOp>(loc, b.getIndexType(), c);
+
+      source = b.create<amdgpu::FatRawBufferCastOp>(
+          loc, source, /*validBytes=*/Value{},
+          /*cacheSwizzleStride=*/Value{},
+          /*boundsCheck=*/(emitOobChecks || op.getCanReadOffEnd()),
+          /*resetOffset=*/false);
+    }
+
+    auto gaterToLDS = b.create<amdgpu::GatherToLDSOp>(
+        loc, source, coords, dest, destCoords, op.getTransferType());
+    b.replaceOp(op, gaterToLDS);
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // GlobalStore lowering.
 //===----------------------------------------------------------------------===//
@@ -1543,8 +1613,9 @@ void RockSugarToLoopsPass::runOnOperation() {
 
   RewritePatternSet patterns(ctx);
   patterns.add<ExtractSliceRewritePattern, InsertSliceRewritePattern,
-               GlobalLoadRewritePattern, GlobalStoreRewritePattern,
-               InBoundsLoadRewritePattern, InBoundsStoreRewritePattern>(ctx);
+               GlobalLoadRewritePattern, GlobalLoadToLDSRewritePattern,
+               GlobalStoreRewritePattern, InBoundsLoadRewritePattern,
+               InBoundsStoreRewritePattern>(ctx);
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
     signalPassFailure();
 

--- a/mlir/test/Dialect/Rock/analyze_memory_use.mlir
+++ b/mlir/test/Dialect/Rock/analyze_memory_use.mlir
@@ -40,6 +40,22 @@ func.func @collapse_case(%arg0: memref<4x4xf32>, %arg1: memref<16xf32>, %arg2: i
   func.return
 }
 
+// CHECK-LABEL: @direct_to_lds_case
+// CHECK-SAME: (%{{.*}}: memref<4xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 16 : i64, llvm.inreg, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.readonly}, %{{.*}}: memref<4xf32> {llvm.align = 16 : i64, llvm.dereferenceable = 16 : i64, llvm.inreg, llvm.noalias, llvm.nocapture, llvm.nofree, llvm.nonnull, llvm.noundef, llvm.writeonly}, %{{.*}}: index)
+func.func @direct_to_lds_case(%arg0: memref<4xf32>, %arg1: memref<4xf32>, %arg2: index) attributes {kernel} {
+  %c0 = arith.constant 0 : index
+  %true = arith.constant true
+  %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
+  %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
+  rock.global_load_to_lds %arg0[%arg2] -> %lds_view[%c0] if %true {transferType = f32} : memref<4xf32> -> memref<4xf32, #gpu.address_space<workgroup>>
+  %v = rock.in_bounds_load %lds_view[%arg2] : memref<4xf32, #gpu.address_space<workgroup>>, index -> vector<4xf32>
+  %buf = rock.alloc() : memref<4xf32, #gpu.address_space<private>>
+  rock.in_bounds_store %v -> %buf[%c0] : vector<4xf32> -> memref<4xf32, #gpu.address_space<private>>, index
+  // CHECK: rock.global_store
+  rock.global_store set %buf[%c0] -> %arg1[%arg2] if %true {length = 1 : index} : memref<4xf32, #gpu.address_space<private>> -> memref<4xf32>
+  func.return
+}
+
 // CHECK-LABEL: @block_readonly_writeonly
 // CHECK-NOT: llvm.readonly
 // CHECK-NOT: llvm.writeonly

--- a/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
@@ -1,0 +1,67 @@
+// RUN: rocmlir-opt --rock-sugar-to-loops %s | FileCheck %s
+
+module {
+// CHECK-LABEL: func.func @load_scalar_in_bounds
+// CHECK-SAME: (%[[mem:.*]]: memref<192xf32>)
+func.func @load_scalar_in_bounds(%mem: memref<192xf32>) {
+    %c0 = arith.constant 0 : index
+    %true = arith.constant true
+    %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
+    %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: amdgpu.gather_to_lds %[[cast]]
+    // CHECK-SAME: f32, memref<192xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0]  if %true {transferType = f32} : memref<192xf32> -> memref<4xf32, #gpu.address_space<workgroup>>
+    return
+}
+
+// CHECK-LABEL: func.func @load_scalar_in_bounds_force_oob
+// CHECK-SAME: (%[[mem:.*]]: memref<192xf32>)
+func.func @load_scalar_in_bounds_force_oob(%mem: memref<192xf32>) {
+    %c0 = arith.constant 0 : index
+    %true = arith.constant true
+    %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
+    %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]] : memref<192xf32, #gpu.address_space<global>> to memref<192xf32, #amdgpu.address_space<fat_raw_buffer>>
+    // CHECK: amdgpu.gather_to_lds %[[fatBuff]]
+    // CHECK-SAME: f32, memref<192xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<4xf32, #gpu.address_space<workgroup>>
+    rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0]  if %true {transferType = f32, canReadOffEnd} : memref<192xf32> -> memref<4xf32, #gpu.address_space<workgroup>>
+    return
+}
+
+// CHECK-LABEL: func.func @load_scalar
+// CHECK-SAME: (%[[mem:.*]]: memref<f32>, %[[idx:.*]]: index)
+func.func @load_scalar_empty_mem(%mem: memref<f32>, %idx: index) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : index
+    %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
+    %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: amdgpu.gather_to_lds %[[cast]]
+    // CHECK-SAME: f32, memref<f32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    rock.global_load_to_lds %mem[] -> %lds_view[%c0] if %true {transferType = f32} 
+        : memref<f32> -> memref<4xf32, #gpu.address_space<workgroup>>
+    return
+}
+
+// CHECK-LABEL: func.func @load_scalar_in_bounds_large
+// CHECK-SAME: (%[[mem:.*]]: memref<1073741825xf32>)
+func.func @load_scalar_in_bounds_large(%mem: memref<1073741825xf32>) {
+    %c0 = arith.constant 0 : index
+    %true = arith.constant true
+    %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
+    %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: amdgpu.gather_to_lds %[[cast]][%c0] 
+    // CHECK-SAME: f32, memref<1073741825xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0] if %true {transferType = f32, needs64BitIdx}
+        : memref<1073741825xf32> -> memref<4xf32, #gpu.address_space<workgroup>>
+    return
+}
+
+}

--- a/mlir/test/common_utils/common.py
+++ b/mlir/test/common_utils/common.py
@@ -15,10 +15,12 @@ def get_arch_features(arch: str):
     major = chip_name[:-2]
     minor = chip_name[-2:]
     if major == 'gfx9':
-        if minor in ['08', '0a', '42']:
+        if minor in ['08', '0a']:
             arch_features = 'mfma|dot|atomic_add|atomic_add_f16'
+        elif minor == '42':
+            arch_features = 'mfma|dot|atomic_add|atomic_add_f16|direct_to_lds_32b'
         elif minor == '50':
-            arch_features = 'mfma|dot|atomic_add|atomic_add_f16|atomic_add_bf16'
+            arch_features = 'mfma|dot|atomic_add|atomic_add_f16|atomic_add_bf16|direct_to_lds_32b|direct_to_lds_128b'
         elif minor == '06':
             arch_features = 'dot'
         else:

--- a/mlir/test/rocmlir-gen/direct-to-lds-128bits-enablement.mlir
+++ b/mlir/test/rocmlir-gen/direct-to-lds-128bits-enablement.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm -t f16 -p | not grep '|direct_to_lds_128b'
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -t f16 -p | not grep '|direct_to_lds_128b'
+
+// RUN: rocmlir-gen --arch gfx950 --operation gemm -t f16 -p | grep '|direct_to_lds_128b' | count 1
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f16 -p | not grep '|direct_to_lds_128b'
+
+// YES: rock.gemm
+// YES-SAME: features = {{[^ ]*}}direct_to_lds_128b
+// NO: rock.gemm
+// NO-NOT: direct_to_lds_128b

--- a/mlir/test/rocmlir-gen/direct-to-lds-32bits-enablement.mlir
+++ b/mlir/test/rocmlir-gen/direct-to-lds-32bits-enablement.mlir
@@ -1,0 +1,10 @@
+// RUN: rocmlir-gen --arch gfx1201 --operation gemm -t f16 -p | not grep '|direct_to_lds_32b'
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -t f16 -p | not grep '|direct_to_lds_32b'
+
+// RUN: rocmlir-gen --arch gfx950 --operation gemm -t f16 -p | grep '|direct_to_lds_32b' | count 1
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f16 -p | grep '|direct_to_lds_32b' | count 1
+
+// YES: rock.gemm
+// YES-SAME: features = {{[^ ]*}}direct_to_lds_32b
+// NO: rock.gemm
+// NO-NOT: direct_to_lds_32b

--- a/mlir/test/rocmlir-gen/gemm-kernel-unitdims.mlir
+++ b/mlir/test/rocmlir-gen/gemm-kernel-unitdims.mlir
@@ -22,7 +22,7 @@
 // ALLUNIT-SAME: <Unmerge{1} ["n"]
 // ALLUNIT-SAME: <AddDim{1} ["g"]
 // ALLUNIT-SAME: <AddDim{1} ["m"]
-// ALLUNIT-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set : memref<1x1x1x[[$OTYPE]]> = memref<1x1x1x[[$ITYPE]]> * memref<1x1x1x[[$ITYPE]]>
+// ALLUNIT-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16|direct_to_lds_32b storeMethod = set : memref<1x1x1x[[$OTYPE]]> = memref<1x1x1x[[$ITYPE]]> * memref<1x1x1x[[$ITYPE]]>
 
 // ONLYG-LABEL: module
 // ONLYG-NEXT: func.func @rock_gemm
@@ -40,7 +40,7 @@
 // ONLYG-SAME: <Unmerge{2} ["g"]
 // ONLYG-SAME: <AddDim{1} ["m"]
 // ONLYG-SAME: <AddDim{1} ["n"]
-// ONLYG-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set : memref<2x1x1x[[$OTYPE]]> = memref<2x1x1x[[$ITYPE]]> * memref<2x1x1x[[$ITYPE]]>
+// ONLYG-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16|direct_to_lds_32b storeMethod = set : memref<2x1x1x[[$OTYPE]]> = memref<2x1x1x[[$ITYPE]]> * memref<2x1x1x[[$ITYPE]]>
 
 // ONLYM-LABEL: module
 // ONLYM-NEXT: func.func @rock_gemm
@@ -58,7 +58,7 @@
 // ONLYM-SAME: <Unmerge{2} ["m"]
 // ONLYM-SAME: <AddDim{1} ["g"]
 // ONLYM-SAME: <AddDim{1} ["n"]
-// ONLYM-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set : memref<1x2x1x[[$OTYPE]]> = memref<1x2x1x[[$ITYPE]]> * memref<1x1x1x[[$ITYPE]]>
+// ONLYM-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16|direct_to_lds_32b storeMethod = set : memref<1x2x1x[[$OTYPE]]> = memref<1x2x1x[[$ITYPE]]> * memref<1x1x1x[[$ITYPE]]>
 
 // ONLYK-LABEL: module
 // ONLYK-NEXT: func.func @rock_gemm
@@ -76,7 +76,7 @@
 // ONLYK-SAME: <Unmerge{1} ["n"]
 // ONLYK-SAME: <AddDim{1} ["g"]
 // ONLYK-SAME: <AddDim{1} ["m"]
-// ONLYK-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set : memref<1x1x1x[[$OTYPE]]> = memref<1x1x2x[[$ITYPE]]> * memref<1x2x1x[[$ITYPE]]>
+// ONLYK-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16|direct_to_lds_32b storeMethod = set : memref<1x1x1x[[$OTYPE]]> = memref<1x1x2x[[$ITYPE]]> * memref<1x2x1x[[$ITYPE]]>
 
 // ONLYN-LABEL: module
 // ONLYN-NEXT: func.func @rock_gemm
@@ -94,4 +94,4 @@
 // ONLYN-SAME: <Unmerge{2} ["n"]
 // ONLYN-SAME: <AddDim{1} ["g"]
 // ONLYN-SAME: <AddDim{1} ["m"]
-// ONLYN-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16 storeMethod = set : memref<1x1x2x[[$OTYPE]]> = memref<1x1x1x[[$ITYPE]]> * memref<1x1x2x[[$ITYPE]]>
+// ONLYN-NEXT: rock.gemm [[gemmOut]] = [[gemmA]] * [[gemmB]] features = mfma|dot|atomic_add|atomic_add_f16|direct_to_lds_32b storeMethod = set : memref<1x1x2x[[$OTYPE]]> = memref<1x1x1x[[$ITYPE]]> * memref<1x1x2x[[$ITYPE]]>

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -426,6 +426,30 @@ static llvm::cl::opt<FeatureToggle> atomicFMaxF32Feature(
                                 "remove atomic_add from the feature list")),
     llvm::cl::init(FeatureToggle::infer));
 
+// directToLDS32B
+static llvm::cl::opt<FeatureToggle> directToLDS32BFeature(
+    "direct_to_lds_32b", llvm::cl::desc("toggle feature direct_to_lds_32b"),
+    llvm::cl::values(
+        clEnumValN(FeatureToggle::infer, "infer",
+                   "use the default value provided by the chip"),
+        clEnumValN(FeatureToggle::on, "on",
+                   "force direct_to_lds_32b into the feature list"),
+        clEnumValN(FeatureToggle::off, "off",
+                   "remove direct_to_lds_32b from the feature list")),
+    llvm::cl::init(FeatureToggle::infer));
+
+// directToLDS128B
+static llvm::cl::opt<FeatureToggle> directToLDS128BFeature(
+    "direct_to_lds_128b", llvm::cl::desc("toggle feature direct_to_lds_128b"),
+    llvm::cl::values(
+        clEnumValN(FeatureToggle::infer, "infer",
+                   "use the default value provided by the chip"),
+        clEnumValN(FeatureToggle::on, "on",
+                   "force direct_to_lds_128b into the feature list"),
+        clEnumValN(FeatureToggle::off, "off",
+                   "remove direct_to_lds_128b from the feature list")),
+    llvm::cl::init(FeatureToggle::infer));
+
 static llvm::cl::opt<std::string>
     filterDataType("fil_dtype",
                    llvm::cl::desc("Data type for filter tensor or matrix A"),
@@ -4721,6 +4745,14 @@ static void generateKernel(MLIRContext *context, GenParams &genParams,
       enabledFeatures =
           bitEnumSet(enabledFeatures, rock::GemmFeatures::atomic_fmax_f32,
                      atomicFMaxF32Feature == FeatureToggle::on);
+    if (directToLDS32BFeature != FeatureToggle::infer)
+      enabledFeatures =
+          bitEnumSet(enabledFeatures, rock::GemmFeatures::direct_to_lds_32b,
+                     directToLDS32BFeature == FeatureToggle::on);
+    if (directToLDS128BFeature != FeatureToggle::infer)
+      enabledFeatures =
+          bitEnumSet(enabledFeatures, rock::GemmFeatures::direct_to_lds_128b,
+                     directToLDS128BFeature == FeatureToggle::on);
 
     if (wmmaFeature == FeatureToggle::infer) {
       // Disable acceleration for mixed types

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -519,12 +519,15 @@ def main() -> bool:
     codepath = args.codepath
     rocmlir_gen_flags = []
     if codepath not in supported_codepath:
-        if 'gfx908' in arch or 'gfx90a' in arch or 'gfx94' in arch:
+        if 'gfx908' in arch or 'gfx90a' in arch:
             codepath = 'mfma'
             rocmlir_gen_flags = ['-mfma=on', '-dot=on', '-atomic_add=on', '-atomic_add_f16=on']
+        elif 'gfx942' in arch:
+            codepath = 'mfma'
+            rocmlir_gen_flags = ['-mfma=on', '-dot=on', '-atomic_add=on', '-atomic_add_f16=on', '-direct_to_lds_32b=on']
         elif 'gfx95' in arch:
             codepath = 'mfma'
-            rocmlir_gen_flags = ['-mfma=on', '-dot=on', '-atomic_add=on', '-atomic_add_f16=on', '-atomic_add_bf16=on']
+            rocmlir_gen_flags = ['-mfma=on', '-dot=on', '-atomic_add=on', '-atomic_add_f16=on', '-atomic_add_bf16=on', '-direct_to_lds_32b=on', '-direct_to_lds_128b=on']
         elif 'gfx906' in arch:
             codepath = 'vanilla'
             rocmlir_gen_flags = ['-mfma=off', '-dot=on', '-atomic_add=off']


### PR DESCRIPTION
In this PR we introduce rock.global_load_to_lds. Also, some changes in external for a workaround + enable 128b global_load_to_lds.

I'll create an upstream PR for enabling 128b global_load_to_lds. The workaround is temporary and there's no need to upstream it.

upstream PR: https://github.com/llvm/llvm-project/pull/147496