### PR TITLE
Direct to LDS

### DIFF
--- a/external/llvm-project/mlir/lib/Dialect/Arith/Transforms/EmulateUnsupportedFloats.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Arith/Transforms/EmulateUnsupportedFloats.cpp
@@ -123,7 +123,8 @@ void mlir::arith::populateEmulateUnsupportedFloatsLegality(
                                vector::OuterProductOp, vector::ScanOp>(
       [&](Operation *op) { return converter.isLegal(op); });
   target.addLegalOp<arith::BitcastOp, arith::ExtFOp, arith::TruncFOp,
-                    arith::ConstantOp, vector::SplatOp, vector::BroadcastOp>();
+                    arith::ConstantOp, vector::SplatOp, vector::BroadcastOp,
+                    arith::SelectOp>();
 }
 
 void EmulateUnsupportedFloatsPass::runOnOperation() {

--- a/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
@@ -101,7 +101,8 @@ struct AccelEmitter {
   virtual Value
   wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
                        int64_t blockSize, int64_t dInCopyPerThread,
-                       StringRef dName, bool rotateDWithK,
+                       StringRef dName, bool rotateDWithK, bool directToLds,
+                       bool ldsLayoutDxK,
                        bool doSplitKAcrossThreadsFirst = false) const = 0;
 
   /// This functions creates the subtile views that is :
@@ -115,7 +116,7 @@ struct AccelEmitter {
   virtual FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
       OpBuilder &b, Location loc, int64_t kIters,
       ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
-      int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
+      int64_t dInCopyPerThread, StringRef dName, bool isKContiguousDim,
       bool rotateDWithK, bool doSplitKAcrossThreadsFirst = false) const = 0;
 
   /// Validate the accelerator structure
@@ -176,16 +177,17 @@ struct MfmaEmitter : public AccelEmitter {
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
                           Value bufferC, ValueRange regCOffset) override;
 
-  virtual Value
+  Value
   wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
                        int64_t blockSize, int64_t dInCopyPerThread,
-                       StringRef dName, bool rotateDWithK,
+                       StringRef dName, bool rotateDWithK, bool directToLds,
+                       bool ldsLayoutDxK,
                        bool doSplitKAcrossThreadsFirst = false) const override;
 
-  virtual FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
+  FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
       OpBuilder &b, Location loc, int64_t kIters,
       ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
-      int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
+      int64_t dInCopyPerThread, StringRef dName, bool isKContiguousDim,
       bool rotateDWithK,
       bool doSplitKAcrossThreadsFirst = false) const override;
 
@@ -223,16 +225,17 @@ struct WmmaEmitter : public AccelEmitter {
   void emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA, Value argB,
                           Value bufferC, ValueRange regCOffset) override;
 
-  virtual Value
+  Value
   wrapLDSBufferForLoad(OpBuilder &b, Location loc, Value buffer,
                        int64_t blockSize, int64_t dInCopyPerThread,
-                       StringRef dName, bool rotateDWithK,
+                       StringRef dName, bool rotateDWithK, bool directToLds,
+                       bool ldsLayoutDxK,
                        bool doSplitKAcrossThreadsFirst = false) const override;
 
-  virtual FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
+  FailureOr<RegsAsMatrixSubTiles> createAccelGemmOperandTransforms(
       OpBuilder &b, Location loc, int64_t kIters,
       ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
-      int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
+      int64_t dInCopyPerThread, StringRef dName, bool isKContiguousDim,
       bool rotateDWithK,
       bool doSplitKAcrossThreadsFirst = false) const override;
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -490,14 +490,20 @@ def Rock_GemmFeatures
 def Rock_GemmFeaturesAttr : EnumAttr<Rock_Dialect, Rock_GemmFeatures, "GemmFeatures">;
 
 // GEMM load tile types
-def Rock_GemmLoadTileDefault : I32EnumAttrCase<"Default", 0>;
-def Rock_GemmLoadTileBypassLDS : I32EnumAttrCase<"BypassLDS", 1>;
+def Rock_GemmLoadTileBypassLDS : I32EnumAttrCase<"BypassLDS", 0>;
+def Rock_GemmLoadTileDefault : I32EnumAttrCase<"Default", 1>;
 def Rock_GemmLoadTileDoubleBuffer : I32EnumAttrCase<"DoubleBuffer", 2>;
+def Rock_GemmLoadTileDirectToLDSDefault
+    : I32EnumAttrCase<"DirectToLDSDefault", 3>;
+def Rock_GemmLoadTileDirectToLDSDoubleBuffer
+    : I32EnumAttrCase<"DirectToLDSDoubleBuffer", 4>;
 
 def Rock_GemmLoadTileType
     : Rock_I32Enum<"GemmLoadTileType", "GEMM load tile types",
-                   [Rock_GemmLoadTileDefault, Rock_GemmLoadTileBypassLDS,
-                    Rock_GemmLoadTileDoubleBuffer]> {
+                   [Rock_GemmLoadTileBypassLDS, Rock_GemmLoadTileDefault,
+                    Rock_GemmLoadTileDoubleBuffer,
+                    Rock_GemmLoadTileDirectToLDSDefault,
+                    Rock_GemmLoadTileDirectToLDSDoubleBuffer]> {
   let cppNamespace = "::mlir::rock";
   let genSpecializedAttr = 0;
 }

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1351,8 +1351,10 @@ def Rock_BlockwiseGemmAccelOp
           I32Attr:$inNPerThread, UnitAttr:$rotateMWithK, UnitAttr:$rotateNWithK,
           UnitAttr:$loadAfromLDS, UnitAttr:$loadBfromLDS,
           UnitAttr:$splitKAcrossThreadsFirstA,
-          UnitAttr:$splitKAcrossThreadsFirstB, MemRefOf<AccelArgTypes>:$bufferA,
-          MemRefOf<AccelArgTypes>:$bufferB, MemRefOf<AccelResTypes>:$matrixC,
+          UnitAttr:$splitKAcrossThreadsFirstB, UnitAttr:$directToLDS,
+          UnitAttr:$ldsLayoutMxK, UnitAttr:$ldsLayoutNxK,
+          MemRefOf<LdsBufferTypes>:$bufferA, MemRefOf<LdsBufferTypes>:$bufferB,
+          MemRefOf<AccelResTypes>:$matrixC,
           OptionalAttr<Rock_GemmFeaturesAttr>:$features, I32Attr:$blockSize,
           RockAccelTuningParamAttrInterface:$params)> {
   let summary = "Blockwise GEMM accelerated version";
@@ -1388,9 +1390,9 @@ def Rock_BlockwiseLoadTileOp
           TypeAttr:$elementTypeA, TypeAttr:$elementTypeB,
           TypeAttr:$elementTypeALoad, TypeAttr:$elementTypeBLoad,
           UnitAttr:$rotateWithK, UnitAttr:$swapThreadIterSubDims,
-          Variadic<Index>:$sourceIndices, I64Attr:$G, I64Attr:$M, I64Attr:$N,
-          OptionalAttr<Rock_GemmFeaturesAttr>:$features, I32Attr:$blockSize,
-          RockAccelTuningParamAttrInterface:$params)> {
+          UnitAttr:$LDSLayoutDxK, Variadic<Index>:$sourceIndices, I64Attr:$G,
+          I64Attr:$M, I64Attr:$N, OptionalAttr<Rock_GemmFeaturesAttr>:$features,
+          I32Attr:$blockSize, RockAccelTuningParamAttrInterface:$params)> {
   let summary =
       "Blockwise load tile from global memory to LDS and/or registers";
   let description = [{

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -59,6 +59,7 @@ struct RegsAsMatrixSubTiles {
 struct LDSLayoutConfigDim {
   bool doRotateWithK;
   bool doSwapThreadIterSubDims;
+  bool ldsLayoutDxK;
 };
 
 // This is helper struct to aggregate
@@ -81,12 +82,11 @@ RegsAsMatrixSubTiles transposeSubTileViews(PatternRewriter &rewriter,
 // This function will create views of the register buffer of the loaded tile
 // of a matrix in global memory. Those views will provide sub-tiles of the
 // respective hierarchy within the GPU. See above about RegsAsMatrixSubTiles
-FailureOr<RegsAsMatrixSubTiles>
-getLoadRegsAsTileViews(OpBuilder &b, Location loc, Value globalBuffer,
-                       StringRef dName, ArrayRef<StringRef> bidGridOrder,
-                       ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
-                       int64_t kPerBlock, int64_t dPerBlock, int64_t kPerThread,
-                       int64_t dPerThread, bool isKContigousDim);
+FailureOr<RegsAsMatrixSubTiles> getLoadRegsAsTileViews(
+    OpBuilder &b, Location loc, Value globalBuffer, StringRef dName,
+    ArrayRef<StringRef> bidGridOrder, ArrayRef<int64_t> bidGridLengths,
+    int64_t blockSize, int64_t kPerBlock, int64_t dPerBlock, int64_t kPerThread,
+    int64_t dPerThread, bool isKContiguousDim, bool directToLDS);
 
 // This function will create views of the register buffer of the loaded tile
 // but packed as kOuterPerThread, dPerThread and kPackPerThread for max
@@ -96,7 +96,7 @@ FailureOr<RegsAsMatrixSubTiles> getPackedRegsAsTileViews(
     OpBuilder &b, Location loc, Value globalBuffer, StringRef dName,
     ArrayRef<StringRef> bidGridOrder, ArrayRef<int64_t> bidGridLengths,
     int64_t blockSize, int64_t kPerBlock, int64_t dPerBlock, int64_t kPerThread,
-    int64_t dPerThread, int64_t kpack, bool isKContigousDim,
+    int64_t dPerThread, int64_t kpack, bool isKContiguousDim,
     bool doSwapThreadIterSubDimsForD = false);
 
 bool isWrWAtomicKernel(GemmFeatures features, Type dataType,
@@ -210,7 +210,13 @@ Value getFlattenedMemref(OpBuilder &b, Value nonFlatMemRef);
 
 /// Construct a `memref.view` operation that interprets the buffer `buffer`,
 /// whose elements are bytes, as a buffer of `type`.
-TypedValue<MemRefType> viewBufferAs(OpBuilder &b, Value buffer, Type type);
+TypedValue<MemRefType> viewBufferAs(OpBuilder &b, Value buffer,
+                                    Type elementType);
+
+/// Same as above but the user provides output dimensions.
+TypedValue<MemRefType> viewBufferAs(OpBuilder &b, Value buffer,
+                                    Type elementType,
+                                    ArrayRef<int64_t> dimensions);
 
 // helper to allocate memory on the GPU
 Value gpuAlloc(OpBuilder &b, Location loc, int64_t bufferDim, Type elementType,
@@ -249,7 +255,8 @@ FailureOr<Value> wrapLDSBufferForStore(OpBuilder &b, Location loc, Value buffer,
 
 FailureOr<VectorDimInfo> getVectorDim(Location loc, Value matrix, Type elemType,
                                       int64_t blockSize, int64_t kPerBlock,
-                                      int64_t dPerBlock, int64_t kpack);
+                                      int64_t dPerBlock, int64_t kpack,
+                                      bool directToLDS);
 
 } // end namespace rock
 } // end namespace mlir

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -1139,7 +1139,7 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
               if (newReassocIdx[i] - newReassocIdx[i - 1] != 1) {
                 return rewriter.notifyMatchFailure(
                     op, "CollapseShape op following transpose collapses "
-                        "non-contigous pre-transpose dims.");
+                        "non-contiguous pre-transpose dims.");
               }
             }
           }
@@ -1147,7 +1147,7 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
           // minIdx is the representative of a group that is
           // being collapsed. For e.g. for a collapse of [3,4,5] is assigned
           // with 3 as the representative. I also note that we only allow
-          // collapsing of contigous pre-transpose dims.
+          // collapsing of contiguous pre-transpose dims.
           newReassocIdxMap[newReassocIdx[0]] = newReassocIdx;
         }
 
@@ -1158,7 +1158,7 @@ struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
         DenseMap<int32_t, int32_t> dimMap;
         // The vector of newDims (may) contain a discontinous
         // a range of representative minIdxs. Here we make
-        // it contigous by assigning order idx.
+        // it contiguous by assigning order idx.
         for (size_t i = 0; i < newDimsSorted.size(); i++) {
           dimMap[newDimsSorted[i]] = i;
           newReassocIndicesSorted.push_back(newReassocIdxMap[newDimsSorted[i]]);

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1798,8 +1798,8 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
       dyn_cast_or_null<gpu::AddressSpaceAttr>(srcMemSpaceAttr);
   if (dstMemSpaceAttr &&
       (!gpuDstMemSpaceAttr ||
-       gpuDstMemSpaceAttr.getValue() != gpu::AddressSpace::Private))
-    return emitOpError("dest must be private registers");
+       gpuDstMemSpaceAttr.getValue() == gpu::AddressSpace::Global))
+    return emitOpError("dest must be private registers or LDS");
   ArrayAttr extraViews = getExtraViews();
   ArrayRef<int64_t> inputShape;
   if (extraViews.empty())
@@ -1820,15 +1820,15 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
   VectorType srcVectorType = dyn_cast<VectorType>(srcType.getElementType());
   VectorType dstVectorType = dyn_cast<VectorType>(destType.getElementType());
   if ((srcVectorType || dstVectorType) &&
-      gpuSrcMemSpaceAttr.getValue() != gpu::AddressSpace::Workgroup &&
-      gpuSrcMemSpaceAttr.getValue() != gpu::AddressSpace::Private)
+      (!gpuSrcMemSpaceAttr ||
+       gpuSrcMemSpaceAttr.getValue() == gpu::AddressSpace::Global))
     return emitOpError(
         "Vector buffers are not allowed when we read from global memory");
   if (srcVectorType && dstVectorType) {
     int64_t srcVectorLen = srcVectorType.getNumElements();
     int64_t dstVectorLen = dstVectorType.getNumElements();
     if ((srcVectorLen > dstVectorLen && srcVectorLen % dstVectorLen != 0) ||
-        (dstVectorLen > srcVectorLen && dstVectorLen % dstVectorLen != 0))
+        (dstVectorLen > srcVectorLen && dstVectorLen % srcVectorLen != 0))
       return emitOpError(
           "Vector buffers vector's lengths need to be evenly divisible");
   }

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -41,8 +41,10 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "mlir/Dialect/Rock/IR/AccelEmitter.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace mlir {
 namespace rock {
@@ -471,17 +473,76 @@ struct BlockwiseGemmAccelRewritePattern
     // considered a temporary hack until we have a proper way of "searching"
     // through different schedules (either heuristically or automatically)
 
+    bool directToLDS = op.getDirectToLDS();
     Value wrappedLDSBufferForLoadA, wrappedLDSBufferForLoadB;
     if (loadAFromLDS) {
       wrappedLDSBufferForLoadA = accelEmitterPtr->wrapLDSBufferForLoad(
           b, loc, op.getMatrixA(), op.getBlockSize(), op.getInMPerThread(), "m",
-          op.getRotateMWithK(), op.getSplitKAcrossThreadsFirstA());
+          op.getRotateMWithK(), directToLDS, op.getLdsLayoutMxK(),
+          op.getSplitKAcrossThreadsFirstA());
     }
     if (loadBFromLDS) {
       wrappedLDSBufferForLoadB = accelEmitterPtr->wrapLDSBufferForLoad(
           b, loc, op.getMatrixB(), op.getBlockSize(), op.getInNPerThread(), "n",
-          op.getRotateNWithK(), op.getSplitKAcrossThreadsFirstB());
+          op.getRotateNWithK(), directToLDS, op.getLdsLayoutNxK(),
+          op.getSplitKAcrossThreadsFirstB());
     }
+
+    auto loadBuffer = [&](Value buffer, Value wrappedLDSBufferForLoad,
+                          Value loopVar, Type argType, int64_t repeats,
+                          bool loadFromLDS, bool isA) -> Value {
+      Value inputBuffer = buffer;
+      SmallVector<int64_t> shape;
+      if (directToLDS) {
+        shape.push_back(kBasePerThread);
+        auto memrefType = cast<MemRefType>(buffer.getType());
+        assert(memrefType.getRank() == 1);
+        assert(memrefType.getElementType() == b.getI8Type());
+        int64_t numBytes = getByteWidth(argType);
+        if (memrefType.getShape()[0] > kBasePerThread * numBytes) {
+          assert(memrefType.getShape()[0] ==
+                 kBasePerThread * repeats * numBytes);
+          shape.insert(shape.begin(), repeats);
+        } else {
+          assert(memrefType.getShape()[0] == kBasePerThread * numBytes);
+        }
+        // view for generateThreadwiseViewBuffer()
+        buffer = viewBufferAs(b, buffer, argType, shape);
+      }
+
+      if (loadFromLDS) {
+        Value viewForReadInto = buffer;
+        if (directToLDS) {
+          SmallVector<int64_t> shapeForLoad(shape);
+          if (auto vectorType = dyn_cast<VectorType>(argType)) {
+            assert(vectorType.hasRank() == 1 && "Expected rank 1");
+            shapeForLoad[shapeForLoad.size() - 1] =
+                vectorType.getDimSize(0) *
+                shapeForLoad[shapeForLoad.size() - 1];
+          }
+          viewForReadInto = viewBufferAs(
+              b, inputBuffer, getElementTypeOrSelf(argType), shapeForLoad);
+        }
+        // regs = read from LDS
+        ThreadwiseReadIntoOp::create(
+            b, loc, wrappedLDSBufferForLoad, viewForReadInto,
+            b.getArrayAttr({}), ValueRange{tid, loopVar}, /*forceUnroll=*/true,
+            /*useIndexDiffs=*/true);
+      } else {
+        if (cast<ShapedType>(buffer.getType()).getRank() == 1) {
+          StringRef dk = isA ? "mk" : "nk";
+          StringRef indexStr = isA ? "iidx" : "jidx";
+          BottomUpTMBuilder regsBuilder(b, {dk}, {repeats * kBasePerThread},
+                                        loc);
+          regsBuilder.unmerge({indexStr, "k"}, {0, 1}, dk,
+                              {repeats, kBasePerThread});
+          buffer =
+              rock::transform(b, buffer, b.getArrayAttr({regsBuilder.get()}));
+        }
+        buffer = rock::createSliceOfFirstDim(b, loc, buffer, loopVar);
+      }
+      return buffer;
+    };
 
     auto mLoop = affine::AffineForOp::create(b, loc, 0, mRepeats);
     {
@@ -490,22 +551,8 @@ struct BlockwiseGemmAccelRewritePattern
       Value i = mLoop.getInductionVar();
 
       Value bufferA = adaptor.getBufferA();
-      if (loadAFromLDS) {
-        // regsA = read A from LDS
-        ThreadwiseReadIntoOp::create(
-            b, loc, wrappedLDSBufferForLoadA, bufferA, b.getArrayAttr({}),
-            ValueRange{tid, i}, /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-      } else {
-        if (cast<ShapedType>(bufferA.getType()).getRank() == 1) {
-          BottomUpTMBuilder regsBuilder(b, {"mk"}, {mRepeats * kBasePerThread},
-                                        loc);
-          regsBuilder.unmerge({"iidx", "k"}, {0, 1}, "mk",
-                              {mRepeats, kBasePerThread});
-          bufferA =
-              rock::transform(b, bufferA, b.getArrayAttr({regsBuilder.get()}));
-        }
-        bufferA = rock::createSliceOfFirstDim(b, loc, bufferA, i);
-      }
+      bufferA = loadBuffer(bufferA, wrappedLDSBufferForLoadA, i, argTypeA,
+                           mRepeats, loadAFromLDS, true);
       Value viewA =
           accelEmitterPtr->generateThreadwiseViewBufferA(b, loc, bufferA);
 
@@ -516,22 +563,8 @@ struct BlockwiseGemmAccelRewritePattern
         Value j = nLoop.getInductionVar();
 
         Value bufferB = adaptor.getBufferB();
-        if (loadBFromLDS) {
-          // regsB = read B from LDS
-          ThreadwiseReadIntoOp::create(
-              b, loc, wrappedLDSBufferForLoadB, bufferB, b.getArrayAttr({}),
-              ValueRange{tid, j}, /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-        } else {
-          if (cast<ShapedType>(bufferB.getType()).getRank() == 1) {
-            BottomUpTMBuilder regsBBuilder(b, {"nk"},
-                                           {nRepeats * kBasePerThread}, loc);
-            regsBBuilder.unmerge({"jidx", "k"}, {0, 1}, "nk",
-                                 {nRepeats, kBasePerThread});
-            bufferB = rock::transform(b, bufferB,
-                                      b.getArrayAttr({regsBBuilder.get()}));
-          }
-          bufferB = rock::createSliceOfFirstDim(b, loc, bufferB, j);
-        }
+        bufferB = loadBuffer(bufferB, wrappedLDSBufferForLoadB, j, argTypeB,
+                             nRepeats, loadBFromLDS, false);
         Value viewB =
             accelEmitterPtr->generateThreadwiseViewBufferB(b, loc, bufferB);
 
@@ -637,7 +670,7 @@ struct BlockwiseReduceRewritePattern
   }
 
   // This function will append views to target a flat LDS buffer
-  // where non-reduction dims are laid contigously as they are expected
+  // where non-reduction dims are laid contiguously as they are expected
   // function on parallel.
   ArrayAttr createLDSWorkspaceView(
       Location loc, PatternRewriter &rewriter, ArrayAttr regTensorView,

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Rock/IR/GetRockInfo.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
+#include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Rock/Passes.h"
 #include "mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h"
 #include "mlir/Dialect/Rock/utility/builderUtils.h"
@@ -74,12 +75,14 @@ class LoweringBlockwiseLoadTileOp final
       Location loc, PatternRewriter &b,
       const std::unique_ptr<rock::accel::AccelEmitter> &accelEmitterPtr,
       Value tid, StringRef dName, Value ldsView, Value regs, int64_t blockSize,
-      int64_t inDPerThread, bool rotateDWithK, bool forceUnroll) const {
+      int64_t inDPerThread, bool rotateDWithK, bool forceUnroll,
+      bool directToLDS, bool ldsLayoutDxK) const {
 
     // wrapLDSBufferForLoad is reading a single set of Ks into private memory
     // A/B[m/n, 0:kBasePerThread]
     Value ldsViewForLoad = accelEmitterPtr->wrapLDSBufferForLoad(
-        b, loc, ldsView, blockSize, inDPerThread, dName, rotateDWithK);
+        b, loc, ldsView, blockSize, inDPerThread, dName, rotateDWithK,
+        directToLDS, ldsLayoutDxK);
 
     // We enhance the transformation from wrapLDSBufferForLoad using a builder
     // that, given a single index, splits it into "m"("n") and "k" and lets
@@ -154,7 +157,9 @@ class LoweringBlockwiseLoadTileOp final
 
     bool doRotateWithK = op.getRotateWithK();
     bool doSwapThreadIterSubDims = op.getSwapThreadIterSubDims();
-    LDSLayoutConfigDim ldsLayoutConfig{doRotateWithK, doSwapThreadIterSubDims};
+    bool ldsLayoutDxK = op.getLDSLayoutDxK();
+    LDSLayoutConfigDim ldsLayoutConfig{doRotateWithK, doSwapThreadIterSubDims,
+                                       ldsLayoutDxK};
 
     Type elementTypeA = op.getElementTypeA();
     Type elementTypeB = op.getElementTypeB();
@@ -183,8 +188,13 @@ class LoweringBlockwiseLoadTileOp final
     int64_t dPerBlock = isA ? mPerBlock : nPerBlock;
     int64_t copyPerThread = (kPerBlock * dPerBlock) / blockSize;
 
-    FailureOr<VectorDimInfo> maybeVecDimInfo = getVectorDim(
-        loc, source, elementTypeLoad, blockSize, kPerBlock, dPerBlock, kpack);
+    bool directToLDS = loadType == GemmLoadTileType::DirectToLDSDefault ||
+                       loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
+    bool doubleBuffer = loadType == GemmLoadTileType::DoubleBuffer ||
+                        loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
+    FailureOr<VectorDimInfo> maybeVecDimInfo =
+        getVectorDim(loc, source, elementTypeLoad, blockSize, kPerBlock,
+                     dPerBlock, kpack, directToLDS);
     if (failed(maybeVecDimInfo)) {
       return failure();
     }
@@ -210,6 +220,8 @@ class LoweringBlockwiseLoadTileOp final
           MemRefType::get({dRepeats * accelParams.kpackPerThread * kpack},
                           elementType, AffineMap{}, privateMemoryAddressSpace);
       loadBuffer = GpuAllocOp::create(b, loc, loadBufferType);
+    } else if (directToLDS) {
+      loadBuffer = viewBufferAs(b, ldsByteBuffer, elementType);
     } else {
       loadBuffer =
           gpuAlloc(b, loc, copyPerThread, elementType, AddressSpace::Private);
@@ -238,7 +250,7 @@ class LoweringBlockwiseLoadTileOp final
         maybeBufferViews = getLoadRegsAsTileViews(
             b, loc, source, dName, bidGridOrder, bidGridLengths, blockSize,
             kPerBlock, dPerBlock, vecDimInfo.inKPerThread,
-            vecDimInfo.inDPerThread, isKContiguousDim);
+            vecDimInfo.inDPerThread, isKContiguousDim, directToLDS);
       }
       if (failed(maybeBufferViews))
         return failure();
@@ -298,70 +310,74 @@ class LoweringBlockwiseLoadTileOp final
           rock::YieldOp::create(b, loc);
       }
     } else {
-      auto [stageLDSWrite, stageLDSWriteNew] =
-          createOrGetStage(b, loc, "LDSWrite", parentOp);
-      {
-        PatternRewriter::InsertionGuard guard(b);
-        b.setInsertionPointToStart(&stageLDSWrite.getRegion().back());
+      if (!directToLDS) {
+        auto [stageLDSWrite, stageLDSWriteNew] =
+            createOrGetStage(b, loc, "LDSWrite", parentOp);
+        {
+          PatternRewriter::InsertionGuard guard(b);
+          b.setInsertionPointToStart(&stageLDSWrite.getRegion().back());
 
-        // Get current workitem ID.
-        auto tid = WorkitemIdOp::create(b, loc, b.getIndexType());
+          // Get current workitem ID.
+          auto tid = WorkitemIdOp::create(b, loc, b.getIndexType());
 
-        FailureOr<RegsAsMatrixSubTiles> maybeBufferViews =
-            getLoadRegsAsTileViews(b, loc, source, dName, bidGridOrder,
-                                   bidGridLengths, blockSize, kPerBlock,
-                                   dPerBlock, vecDimInfo.inKPerThread,
-                                   vecDimInfo.inDPerThread, isKContiguousDim);
-        if (failed(maybeBufferViews))
-          return failure();
-        // We invert the transforms that are iter --> K x D slice of the tensor
-        // so that we can view loadBuffer as a K x D tensor
-        ArrayAttr loadBufferViews =
-            invertTransforms(b, loc, maybeBufferViews->threadSubTile);
-        Value viewLoadBuffer = transform(b, loadBuffer, loadBufferViews);
+          assert(directToLDS == false);
+          FailureOr<RegsAsMatrixSubTiles> maybeBufferViews =
+              getLoadRegsAsTileViews(
+                  b, loc, source, dName, bidGridOrder, bidGridLengths,
+                  blockSize, kPerBlock, dPerBlock, vecDimInfo.inKPerThread,
+                  vecDimInfo.inDPerThread, isKContiguousDim, directToLDS);
+          if (failed(maybeBufferViews))
+            return failure();
+          // We invert the transforms that are iter --> K x D slice of the
+          // tensor so that we can view loadBuffer as a K x D tensor
+          ArrayAttr loadBufferViews =
+              invertTransforms(b, loc, maybeBufferViews->threadSubTile);
+          Value viewLoadBuffer = transform(b, loadBuffer, loadBufferViews);
 
-        FailureOr<RegsAsMatrixSubTiles> maybeLdsStoreViews =
-            getPackedRegsAsTileViews(
-                b, loc, source, dName, bidGridOrder, bidGridLengths, blockSize,
-                kPerBlock, dPerBlock, vecDimInfo.inKPerThread,
-                vecDimInfo.inDPerThread, kpack, isKContiguousDim,
-                ldsLayoutConfig.doSwapThreadIterSubDims);
-        if (failed(maybeLdsStoreViews))
-          return failure();
+          FailureOr<RegsAsMatrixSubTiles> maybeLdsStoreViews =
+              getPackedRegsAsTileViews(
+                  b, loc, source, dName, bidGridOrder, bidGridLengths,
+                  blockSize, kPerBlock, dPerBlock, vecDimInfo.inKPerThread,
+                  vecDimInfo.inDPerThread, kpack, isKContiguousDim,
+                  ldsLayoutConfig.doSwapThreadIterSubDims);
+          if (failed(maybeLdsStoreViews))
+            return failure();
 
-        ArrayAttr storeBufferViews =
-            invertTransforms(b, loc, maybeLdsStoreViews->threadSubTile);
-        Value viewStoreBuffer = transform(b, storeBuffer, storeBufferViews);
+          ArrayAttr storeBufferViews =
+              invertTransforms(b, loc, maybeLdsStoreViews->threadSubTile);
+          Value viewStoreBuffer = transform(b, storeBuffer, storeBufferViews);
 
-        Type ldsReadType = vectorTypeOrSelf(elementType, kpack);
-        FailureOr<Value> maybeWrappedLds = wrapLDSBufferForStore(
-            b, loc, ldsByteBuffer, ldsReadType, kpacksPerBlock, dName,
-            dPerBlock, vecDimInfo.inKPerThread, vecDimInfo.inDPerThread,
-            ldsLayoutConfig.doRotateWithK);
-        if (failed(maybeWrappedLds))
-          return maybeWrappedLds;
-        // This is KxD view of the flat LDS buffer
-        Value wrappedLds = maybeWrappedLds.value();
-        // This will produce a (tid, iter) --> flat LDS view
-        wrappedLds = transform(b, wrappedLds, maybeLdsStoreViews->blockSubTile);
+          Type ldsReadType = vectorTypeOrSelf(elementType, kpack);
+          FailureOr<Value> maybeWrappedLds = wrapLDSBufferForStore(
+              b, loc, ldsByteBuffer, ldsReadType, kpacksPerBlock, dName,
+              dPerBlock, vecDimInfo.inKPerThread, vecDimInfo.inDPerThread,
+              ldsLayoutConfig.doRotateWithK);
+          if (failed(maybeWrappedLds))
+            return maybeWrappedLds;
+          // This is KxD view of the flat LDS buffer
+          Value wrappedLds = maybeWrappedLds.value();
+          // This will produce a (tid, iter) --> flat LDS view
+          wrappedLds =
+              transform(b, wrappedLds, maybeLdsStoreViews->blockSubTile);
 
-        // Emit potentially-transposing copies to store buffer. This is here
-        // both to enable code motion for fusions and to prevent the accesses to
-        // the memory from breaking software pipelining.
-        ThreadwiseCopyOp::create(b, loc, viewLoadBuffer, ValueRange{},
-                                 viewStoreBuffer, ValueRange{}, false, false);
-        // Emit blockwise stores
-        ThreadwiseWriteAllOp::create(b, loc, storeBuffer, wrappedLds,
-                                     /*extraViews=*/b.getArrayAttr({}),
-                                     /*extraIndices=*/ValueRange{tid},
-                                     StoreMethod::Set,
-                                     /*forceUnroll=*/forceUnroll,
-                                     /*useIndexDiffs=*/true);
-        if (stageLDSWriteNew)
-          rock::YieldOp::create(b, loc);
+          // Emit potentially-transposing copies to store buffer. This is here
+          // both to enable code motion for fusions and to prevent the accesses
+          // to the memory from breaking software pipelining.
+          ThreadwiseCopyOp::create(b, loc, viewLoadBuffer, ValueRange{},
+                                   viewStoreBuffer, ValueRange{}, false, false);
+          // Emit blockwise stores
+          ThreadwiseWriteAllOp::create(b, loc, storeBuffer, wrappedLds,
+                                       /*extraViews=*/b.getArrayAttr({}),
+                                       /*extraIndices=*/ValueRange{tid},
+                                       StoreMethod::Set,
+                                       /*forceUnroll=*/forceUnroll,
+                                       /*useIndexDiffs=*/true);
+          if (stageLDSWriteNew)
+            rock::YieldOp::create(b, loc);
+        }
       }
 
-      if (loadType == GemmLoadTileType::DoubleBuffer) {
+      if (doubleBuffer) {
         // Pipeline pass will remove this if the loop uses pipelining
         LDSBarrierOp::create(b, loc);
 
@@ -378,13 +394,19 @@ class LoweringBlockwiseLoadTileOp final
           // Get current workitem ID.
           auto tid = WorkitemIdOp::create(b, loc, b.getIndexType());
 
-          Type ldsReadType = vectorTypeOrSelf(elementType, kpack);
-          Value ldsViewForGemm = viewBufferAs(b, ldsByteBuffer, ldsReadType);
+          Value ldsViewForGemm;
+          if (directToLDS) {
+            ldsViewForGemm = viewBufferAs(b, ldsByteBuffer, elementType);
+          } else {
+            Type ldsReadType = vectorTypeOrSelf(elementType, kpack);
+            ldsViewForGemm = viewBufferAs(b, ldsByteBuffer, ldsReadType);
+          }
 
           auto copyDPerThread = vecDimInfo.inDPerThread;
           generateReadLoop(loc, b, accelEmitterPtr, tid, dName, ldsViewForGemm,
                            destRegisters, blockSize, copyDPerThread,
-                           ldsLayoutConfig.doRotateWithK, forceUnroll);
+                           ldsLayoutConfig.doRotateWithK, forceUnroll,
+                           directToLDS, ldsLayoutConfig.ldsLayoutDxK);
           if (stageLDSReadNew)
             rock::YieldOp::create(b, loc);
         }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -63,6 +63,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include <cstdint>
 #include <optional>
+#include <tuple>
 
 namespace mlir {
 namespace rock {
@@ -102,6 +103,8 @@ static void loadAndStoreGemmInputTile(
       ldsLayoutCfg.doRotateWithK ? rewriter.getUnitAttr() : nullptr;
   UnitAttr swapThreadIterSubDimsAttr =
       ldsLayoutCfg.doSwapThreadIterSubDims ? rewriter.getUnitAttr() : nullptr;
+  UnitAttr ldsLayoutDxKAttr =
+      ldsLayoutCfg.ldsLayoutDxK ? rewriter.getUnitAttr() : nullptr;
 
   UnitAttr isA = nonKDimName == "m" ? rewriter.getUnitAttr() : nullptr;
   auto loadTypeAttr =
@@ -112,7 +115,7 @@ static void loadAndStoreGemmInputTile(
       rewriter, loc, in, destLDS, destRegs, loadTypeAttr, isA,
       TypeAttr::get(elementTypeA), TypeAttr::get(elementTypeB),
       TypeAttr::get(elementTypeALoad), TypeAttr::get(elementTypeBLoad),
-      rotateWithKAttr, swapThreadIterSubDimsAttr,
+      rotateWithKAttr, swapThreadIterSubDimsAttr, ldsLayoutDxKAttr,
       ValueRange{kIter, gridCoords.g_block, gridCoords.m_block,
                  gridCoords.n_block, tid},
       rewriter.getI64IntegerAttr(G), rewriter.getI64IntegerAttr(M),
@@ -134,32 +137,62 @@ static Value createLDSByteBuffer(PatternRewriter &rewriter, Location loc,
 
 // This fuction creates interrim register buffers to store data in once
 // loaded from the LDS before accelerator intrinsics are called
-static std::tuple<Value, Value> createRegInterrimBufferForAccel(
+static std::tuple<Value, Value, Value, Value> createRegInterrimBufferForAccel(
     Location loc, rock::accel::AccelEmitterParams params,
-    PatternRewriter &rewriter, int64_t mRepeats = 1, int64_t nRepeats = 1) {
-  auto privateMemoryAddressSpace = rewriter.getAttr<gpu::AddressSpaceAttr>(
-      gpu::GPUDialect::getPrivateAddressSpace());
-  int64_t kBasePerThread = params.kBasePerThread;
-
+    PatternRewriter &rewriter, int64_t mRepeats = 1, int64_t nRepeats = 1,
+    bool directToLDS = false) {
+  Value arrayA, arrayB;
+  Value arrayAForLoad, arrayBForLoad;
   Type argTypeA = params.argTypeA;
+  Type argTypeB = params.argTypeB;
+  int64_t kBasePerThread = params.kBasePerThread;
   SmallVector<int64_t, 2> aShape{kBasePerThread};
   if (mRepeats > 1) {
     aShape.insert(aShape.begin(), mRepeats);
   }
-  auto arrayAType =
-      MemRefType::get(aShape, argTypeA, AffineMap{}, privateMemoryAddressSpace);
-  auto arrayA = GpuAllocOp::create(rewriter, loc, arrayAType);
-
-  SmallVector<Value> arrayBRegs;
-  Type argTypeB = params.argTypeB;
   SmallVector<int64_t, 2> bShape{kBasePerThread};
   if (nRepeats > 1) {
     bShape.insert(bShape.begin(), nRepeats);
   }
-  auto arrayBType =
-      MemRefType::get(bShape, argTypeB, AffineMap{}, privateMemoryAddressSpace);
-  auto arrayB = GpuAllocOp::create(rewriter, loc, arrayBType);
-  return {arrayA, arrayB};
+  if (directToLDS) {
+    auto allocBuffer = [](PatternRewriter &b, Location loc, Type argType,
+                          ArrayRef<int64_t> shape) {
+      int64_t length = std::accumulate(shape.begin(), shape.end(), int64_t{1},
+                                       std::multiplies<>());
+
+      Value arrayBase = gpuAlloc(b, loc, length * getByteWidth(argType),
+                                 b.getI8Type(), gpu::AddressSpace::Private);
+
+      SmallVector<int64_t> shapeForLoad(shape);
+      if (auto vectorType = dyn_cast<VectorType>(argType)) {
+        assert(vectorType.hasRank() == 1 && "Expected rank 1");
+        shapeForLoad[shapeForLoad.size() - 1] =
+            vectorType.getDimSize(0) * shapeForLoad[shapeForLoad.size() - 1];
+      }
+      Value arrayForLoad = viewBufferAs(
+          b, arrayBase, getElementTypeOrSelf(argType), shapeForLoad);
+      return std::make_tuple(arrayForLoad, arrayBase);
+    };
+    std::tie(arrayAForLoad, arrayA) =
+        allocBuffer(rewriter, loc, argTypeA, aShape);
+    std::tie(arrayBForLoad, arrayB) =
+        allocBuffer(rewriter, loc, argTypeB, bShape);
+  } else {
+    auto privateMemoryAddressSpace = rewriter.getAttr<gpu::AddressSpaceAttr>(
+        gpu::GPUDialect::getPrivateAddressSpace());
+
+    auto arrayAType = MemRefType::get(aShape, argTypeA, AffineMap{},
+                                      privateMemoryAddressSpace);
+    arrayA = GpuAllocOp::create(rewriter, loc, arrayAType);
+
+    SmallVector<Value> arrayBRegs;
+    auto arrayBType = MemRefType::get(bShape, argTypeB, AffineMap{},
+                                      privateMemoryAddressSpace);
+    arrayB = GpuAllocOp::create(rewriter, loc, arrayBType);
+    arrayAForLoad = arrayA;
+    arrayBForLoad = arrayB;
+  }
+  return {arrayAForLoad, arrayBForLoad, arrayA, arrayB};
 }
 
 // This function creates the accumulator register buffer
@@ -231,23 +264,35 @@ static LogicalResult checkLDSSize(Operation *op, int64_t aBufferBytes,
   return success();
 }
 
-static LDSLayoutConfigDim
-getLDSLayoutConfigDim(Type elementType, int64_t kpack,
-                      const VectorDimInfo &vecDimInfo) {
+static LDSLayoutConfigDim getLDSLayoutConfigDim(Type elementType, int64_t kpack,
+                                                const VectorDimInfo &vecDimInfo,
+                                                bool directToLDS) {
   LDSLayoutConfigDim cfg;
   int64_t maxVlen = 128 / elementType.getIntOrFloatBitWidth();
   int64_t copyDPerThread = vecDimInfo.inDPerThread;
-  bool isKContigousDim = vecDimInfo.vectorDim == GemmDimension::K;
+  bool isKContiguousDim = vecDimInfo.vectorDim == GemmDimension::K;
   // If kpack is less than the hardware max vector length, and we are
   // writing more contiguous kpack elements, there is a possibility to
   // vectorize that we want to preserve (i.e., we favour vectorization over
   // bank conflicts resolution)
   bool isPossibleToVectorizeD = (kpack < maxVlen && copyDPerThread > 1);
-  cfg.doRotateWithK = isKContigousDim && !isPossibleToVectorizeD;
-  cfg.doSwapThreadIterSubDims = !isKContigousDim && !isPossibleToVectorizeD;
+  cfg.doRotateWithK = isKContiguousDim && !isPossibleToVectorizeD;
+  cfg.doSwapThreadIterSubDims = !isKContiguousDim && !isPossibleToVectorizeD;
+  cfg.ldsLayoutDxK = false;
+
+  // For direct to LDS, we can't use rotateWithK or swapThreadIterSubDims
+  // because we there's no LDS write instruction.
+  // Also, we use the same memory layout as the global memory layout (KxD or
+  // DxK).
+  if (directToLDS) {
+    cfg.doRotateWithK = false;
+    cfg.doSwapThreadIterSubDims = false;
+    cfg.ldsLayoutDxK = isKContiguousDim;
+  }
   LLVM_DEBUG(llvm::dbgs() << "rotateWithK: " << cfg.doRotateWithK << "\n"
                           << "doSwapThreadIterSubDimsForM: "
-                          << cfg.doSwapThreadIterSubDims << "\n");
+                          << cfg.doSwapThreadIterSubDims << "\n"
+                          << "ldsLayoutDxK: " << cfg.ldsLayoutDxK << "\n");
   return cfg;
 }
 
@@ -413,13 +458,18 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     int64_t aCopyPerThread = (kPerBlock * mPerBlock) / blockSize;
     int64_t bCopyPerThread = (kPerBlock * nPerBlock) / blockSize;
 
-    FailureOr<VectorDimInfo> maybeVecDimInfoA = getVectorDim(
-        loc, op.getA(), elementTypeA, blockSize, kPerBlock, mPerBlock, kpack);
+    // direct to LDS not supported for non-accel GEMM
+    bool directToLDS = false;
+
+    FailureOr<VectorDimInfo> maybeVecDimInfoA =
+        getVectorDim(loc, op.getA(), elementTypeA, blockSize, kPerBlock,
+                     mPerBlock, kpack, directToLDS);
     if (failed(maybeVecDimInfoA)) {
       return failure();
     }
-    FailureOr<VectorDimInfo> maybeVecDimInfoB = getVectorDim(
-        loc, op.getB(), elementTypeB, blockSize, kPerBlock, nPerBlock, kpack);
+    FailureOr<VectorDimInfo> maybeVecDimInfoB =
+        getVectorDim(loc, op.getB(), elementTypeB, blockSize, kPerBlock,
+                     nPerBlock, kpack, directToLDS);
     if (failed(maybeVecDimInfoB)) {
       return failure();
     }
@@ -438,7 +488,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         b, loc, op.getA(), "m", bidGridOrder, bidGridLengths, blockSize,
         kPerBlock, mPerBlock, maybeVecDimInfoA->inKPerThread,
         maybeVecDimInfoA->inDPerThread,
-        maybeVecDimInfoA->vectorDim == GemmDimension::K);
+        maybeVecDimInfoA->vectorDim == GemmDimension::K, directToLDS);
     if (failed(maybeABufferViews)) {
       return failure();
     }
@@ -447,7 +497,7 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         b, loc, op.getB(), "n", bidGridOrder, bidGridLengths, blockSize,
         kPerBlock, nPerBlock, maybeVecDimInfoB->inKPerThread,
         maybeVecDimInfoB->inDPerThread,
-        maybeVecDimInfoB->vectorDim == GemmDimension::K);
+        maybeVecDimInfoB->vectorDim == GemmDimension::K, false);
     if (failed(maybeBBufferViews)) {
       return failure();
     }
@@ -474,10 +524,10 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     Value storeBufferA = GpuAllocOp::create(b, loc, loadBufferA.getType());
     Value storeBufferB = GpuAllocOp::create(b, loc, loadBufferB.getType());
 
-    LDSLayoutConfigDim ldsLayoutConfigA =
-        getLDSLayoutConfigDim(elementTypeA, kpack, maybeVecDimInfoA.value());
-    LDSLayoutConfigDim ldsLayoutConfigB =
-        getLDSLayoutConfigDim(elementTypeB, kpack, maybeVecDimInfoB.value());
+    LDSLayoutConfigDim ldsLayoutConfigA = getLDSLayoutConfigDim(
+        elementTypeA, kpack, maybeVecDimInfoA.value(), false);
+    LDSLayoutConfigDim ldsLayoutConfigB = getLDSLayoutConfigDim(
+        elementTypeB, kpack, maybeVecDimInfoB.value(), false);
 
     // We invert the transforms that are iter --> K x D slice of the tensor
     // so that we can view loadBuffer as a K x D tensor
@@ -1809,7 +1859,7 @@ struct GridwiseAttentionAccelRewritePattern
     rock::accel::AccelEmitterParams accelParams = accelEmitterPtr.getParams();
     Value wrappedLDSBufferForLoad = accelEmitterPtr.wrapLDSBufferForLoad(
         rewriter, loc, ldsTileBuffer, blockSize, inDPerThread, dName,
-        rotateDWithK);
+        rotateDWithK, false, false);
     int64_t repeats =
         dName == "m" ? accelParams.mRepeats : accelParams.nRepeats;
     affine::AffineForOp mRepeatsLoop =
@@ -1856,8 +1906,8 @@ struct GridwiseAttentionAccelRewritePattern
     if (copyPerThread == 0) {
       return emitError(loc) << "Block size too large, rejecting as invalid.\n";
     }
-    FailureOr<VectorDimInfo> maybeVectorDimInfo =
-        getVectorDim(loc, in, elemType, blockSize, kPerBlock, dPerBlock, kpack);
+    FailureOr<VectorDimInfo> maybeVectorDimInfo = getVectorDim(
+        loc, in, elemType, blockSize, kPerBlock, dPerBlock, kpack, false);
     if (failed(maybeVectorDimInfo)) {
       return failure();
     }
@@ -1872,7 +1922,8 @@ struct GridwiseAttentionAccelRewritePattern
       maybeInBufferViews = getLoadRegsAsTileViews(
           rewriter, loc, in, nonKDimName, bidGridOrder, bidGridLengths,
           blockSize, kPerBlock, dPerBlock, maybeVectorDimInfo->inKPerThread,
-          maybeVectorDimInfo->inDPerThread, vectorDim == GemmDimension::K);
+          maybeVectorDimInfo->inDPerThread, vectorDim == GemmDimension::K,
+          false);
     }
     if (failed(maybeInBufferViews)) {
       return failure();
@@ -2055,12 +2106,12 @@ struct GridwiseAttentionAccelRewritePattern
                                                    gemm0NBlocks};
     FailureOr<VectorDimInfo> maybeVectorDimInfoQ =
         getVectorDim(loc, inQ, elemTypeQLoad, blockSize, gemm0KPerBlock,
-                     gemm0NPerBlock, gemm0kpack);
+                     gemm0NPerBlock, gemm0kpack, false);
     if (failed(maybeVectorDimInfoQ)) {
       return failure();
     }
     LDSLayoutConfigDim ldsLayoutCfgNG0 = getLDSLayoutConfigDim(
-        elemTypeQ, gemm0kpack, maybeVectorDimInfoQ.value());
+        elemTypeQ, gemm0kpack, maybeVectorDimInfoQ.value(), false);
     if (doBypassLDSForQ) {
       ldsLayoutCfgNG0.doSwapThreadIterSubDims = false;
     }
@@ -2074,7 +2125,7 @@ struct GridwiseAttentionAccelRewritePattern
     }
     FailureOr<VectorDimInfo> maybeVectorDimInfoK =
         getVectorDim(loc, inK, elemTypeKLoad, blockSize, gemm0KPerBlock,
-                     gemm0MPerBlock, gemm0kpack);
+                     gemm0MPerBlock, gemm0kpack, false);
     if (failed(maybeVectorDimInfoK)) {
       return failure();
     }
@@ -2087,7 +2138,7 @@ struct GridwiseAttentionAccelRewritePattern
                << "kVectorDim: " << maybeVectorDimInfoK->vectorDim << "\n"
                << "kVectorLen: " << maybeVectorDimInfoK->vectorLen << "\n");
     LDSLayoutConfigDim ldsLayoutCfgMG0 = getLDSLayoutConfigDim(
-        elemTypeK, gemm0kpack, maybeVectorDimInfoK.value());
+        elemTypeK, gemm0kpack, maybeVectorDimInfoK.value(), false);
     ldsLayoutCfgMG0.doRotateWithK = false;
     if (doBypassLDSSecondGemm) {
       ldsLayoutCfgMG0.doSwapThreadIterSubDims = false;
@@ -2143,7 +2194,8 @@ struct GridwiseAttentionAccelRewritePattern
     // Note that we dont provide nRepeats because we dont want
     // nRepeats times reg buffer to be created for B of gemm0
     // because we wont be prefetching that.
-    auto [preAccelRegBufferK, preAccelRegBuffersQ] =
+    auto [preAccelRegBufferKForLoad, preAccelRegBuffersQForLoad,
+          preAccelRegBufferK, preAccelRegBuffersQ] =
         createRegInterrimBufferForAccel(loc, accelParamsGemm0, rewriter, 1,
                                         accelParamsGemm0.nRepeats);
     Value accRegBufferGemm0 =
@@ -2190,7 +2242,8 @@ struct GridwiseAttentionAccelRewritePattern
     }
     Value gemm0ExpOutBufferToLDS =
         createBufferForGemmOut(loc, elemTypeV, accelParamsGemm0, rewriter);
-    auto [preAccelRegBufferV, preAccelRegBufferQxK] =
+    auto [preAccelRegBufferVForLoad, preAccelRegBufferQxKForLoad,
+          preAccelRegBufferV, preAccelRegBufferQxK] =
         createRegInterrimBufferForAccel(
             loc, accelParamsGemm1, rewriter, 1,
             doBypassLDSSecondGemm ? accelParamsGemm1.nRepeats : 1);
@@ -2213,7 +2266,7 @@ struct GridwiseAttentionAccelRewritePattern
                                                    gemm1NBlocks};
     FailureOr<VectorDimInfo> maybeVectorDimInfoV =
         getVectorDim(loc, inV, elemTypeVLoad, blockSize, gemm1KPerBlock,
-                     gemm1MPerBlock, gemm1kpack);
+                     gemm1MPerBlock, gemm1kpack, false);
     if (failed(maybeVectorDimInfoV)) {
       return failure();
     }
@@ -2221,7 +2274,7 @@ struct GridwiseAttentionAccelRewritePattern
                << "vVectorDim: " << maybeVectorDimInfoV->vectorDim << "\n"
                << "vVectorLen: " << maybeVectorDimInfoV->vectorLen << "\n");
     LDSLayoutConfigDim ldsLayoutCfgMG1 = getLDSLayoutConfigDim(
-        elemTypeV, gemm1kpack, maybeVectorDimInfoV.value());
+        elemTypeV, gemm1kpack, maybeVectorDimInfoV.value(), false);
     int64_t gemm1InMPerThread = maybeVectorDimInfoV->inDPerThread;
     FailureOr<RegsAsMatrixSubTiles> maybeGemm1OutSubTileViews =
         accelEmitterPtrGemm1->computeOutputTransforms(
@@ -2462,9 +2515,11 @@ struct GridwiseAttentionAccelRewritePattern
             (ldsLayoutCfgNG0.doRotateWithK ? rewriter.getUnitAttr() : nullptr),
             /*loadAfromLDS=*/rewriter.getUnitAttr(), /*loadBfromLDS=*/nullptr,
             /*splitKAcrossThreadsFirstA=*/nullptr,
-            /*splitKAcrossThreadsFirstB=*/nullptr, preAccelRegBufferK,
-            preAccelRegBuffersQ, accRegBufferGemm0, featuresAttr,
-            op.getBlockSizeAttr(), gemm0TuningParams);
+            /*splitKAcrossThreadsFirstB=*/nullptr,
+            /*directToLDS=*/nullptr, /*ldsLayoutMxK=*/nullptr,
+            /*ldsLayoutNxK=*/nullptr, preAccelRegBufferK, preAccelRegBuffersQ,
+            accRegBufferGemm0, featuresAttr, op.getBlockSizeAttr(),
+            gemm0TuningParams);
 
         GpuDeallocOp::create(rewriter, loc, ldsByteBufferK);
       }
@@ -2657,7 +2712,7 @@ struct GridwiseAttentionAccelRewritePattern
                            vectorTypeOrSelf(elemTypeV, gemm1kpack));
           wrappedLDSBufferForLoadB = accelEmitterPtrGemm1->wrapLDSBufferForLoad(
               rewriter, loc, gemm1LDSBufferB, op.getBlockSize(),
-              gemm1InNPerThread, "n", false);
+              gemm1InNPerThread, "n", false, false, false);
         }
 
         affine::AffineForOp g1MLoopOp =
@@ -2746,9 +2801,10 @@ struct GridwiseAttentionAccelRewritePattern
               !doBypassLDSSecondGemm ? rewriter.getUnitAttr() : nullptr,
               /*splitKAcrossThreadsFirstA=*/
               doBypassLDSSecondGemm ? rewriter.getUnitAttr() : nullptr,
-              /*splitKAcrossThreadsFirstB=*/nullptr, preAccelRegBufferV,
-              preAccelRegBufferQxK, accRegBufferGemm1, featuresAttr,
-              op.getBlockSizeAttr(), gemm1TuningParams);
+              /*splitKAcrossThreadsFirstB=*/nullptr, /*directToLDS=*/nullptr,
+              /*ldsLayoutMxK=*/nullptr, /*ldsLayoutNxK=*/nullptr,
+              preAccelRegBufferV, preAccelRegBufferQxK, accRegBufferGemm1,
+              featuresAttr, op.getBlockSizeAttr(), gemm1TuningParams);
 
           GpuDeallocOp::create(rewriter, loc, ldsByteBufferV);
           if (!doBypassLDSSecondGemm)
@@ -2965,14 +3021,33 @@ struct GridwiseGemmAccelRewritePattern
     int64_t bCopyKpacksPerThread =
         math_util::integer_divide_ceil(bCopyPerThread, kpack);
 
+    int64_t scheduleVersion = tuningParams.getScheduleVersion();
+    std::optional<GemmLoadTileType> maybeLoadType =
+        symbolizeGemmLoadTileType(scheduleVersion);
+    if (!maybeLoadType.has_value())
+      return op.emitOpError("schedule version value is incorrect");
+
+    auto loadType = maybeLoadType.value();
+    bool directToLDS = loadType == GemmLoadTileType::DirectToLDSDefault ||
+                       loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
+
+    // If we are using direct to LDS, we need to ensure that the
+    // hardware supports it.
+    if (directToLDS &&
+        !bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b) &&
+        !bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b))
+      return op.emitOpError("Direct to LDS is not supported by the hardware");
+
     // Get the vector copy layout for A and B
-    FailureOr<VectorDimInfo> maybeVecDimInfoA = getVectorDim(
-        loc, matA, elementTypeALoad, blockSize, kPerBlock, mPerBlock, kpack);
+    FailureOr<VectorDimInfo> maybeVecDimInfoA =
+        getVectorDim(loc, matA, elementTypeALoad, blockSize, kPerBlock,
+                     mPerBlock, kpack, directToLDS);
     if (failed(maybeVecDimInfoA)) {
       return failure();
     }
-    FailureOr<VectorDimInfo> maybeVecDimInfoB = getVectorDim(
-        loc, matB, elementTypeBLoad, blockSize, kPerBlock, nPerBlock, kpack);
+    FailureOr<VectorDimInfo> maybeVecDimInfoB =
+        getVectorDim(loc, matB, elementTypeBLoad, blockSize, kPerBlock,
+                     nPerBlock, kpack, directToLDS);
     if (failed(maybeVecDimInfoB)) {
       return failure();
     }
@@ -2999,7 +3074,8 @@ struct GridwiseGemmAccelRewritePattern
                << "aCopyKPerThread: " << maybeVecDimInfoA->inKPerThread << "\n"
                << "bCopyKPerThread: " << maybeVecDimInfoB->inKPerThread << "\n"
                << "copyMPerThread: " << copyMPerThread << "\n"
-               << "copyNPerThread: " << copyNPerThread << "\n");
+               << "copyNPerThread: " << copyNPerThread << "\n"
+               << "directToLDS: " << directToLDS << "\n");
     SmallVector<int64_t, 3> bidGridLengths = {G, mBlocks, nBlocks};
 
     // Get current workgroup ID.
@@ -3014,10 +3090,10 @@ struct GridwiseGemmAccelRewritePattern
         {G, mBlocks, nBlocks, rock::getNumCUValue(op), elementTypeA, destType},
         arch);
 
-    LDSLayoutConfigDim ldsLayoutConfigA =
-        getLDSLayoutConfigDim(elementTypeA, kpack, maybeVecDimInfoA.value());
-    LDSLayoutConfigDim ldsLayoutConfigB =
-        getLDSLayoutConfigDim(elementTypeB, kpack, maybeVecDimInfoB.value());
+    LDSLayoutConfigDim ldsLayoutConfigA = getLDSLayoutConfigDim(
+        elementTypeA, kpack, maybeVecDimInfoA.value(), directToLDS);
+    LDSLayoutConfigDim ldsLayoutConfigB = getLDSLayoutConfigDim(
+        elementTypeB, kpack, maybeVecDimInfoB.value(), directToLDS);
 
     // Obtain Accelerator-related attributes.
     int64_t mPerWave = tuningParams.getMPerWave();
@@ -3071,26 +3147,28 @@ struct GridwiseGemmAccelRewritePattern
 
     Type ldsReadTypeA = vectorTypeOrSelf(elementTypeA, kpack);
     Type ldsReadTypeB = vectorTypeOrSelf(elementTypeB, kpack);
-    Value ldsViewForGemmA = viewBufferAs(b, ldsByteBufferA, ldsReadTypeA);
-    Value ldsViewForGemmB = viewBufferAs(b, ldsByteBufferB, ldsReadTypeB);
+    Value ldsViewForGemmA, ldsViewForGemmB;
 
-    // TODO: add an heuristic to decide if the it should use scheduleV1 or V2.
-    int64_t scheduleVersion = tuningParams.getScheduleVersion();
-    int64_t initiationInterval;
-
-    // Logic to setup buffers for blockwise_gemm_accel.
-    if (scheduleVersion == 2) {
-      initiationInterval = 1;
-    } else if (scheduleVersion == 1) {
-      initiationInterval = 2;
+    if (directToLDS) {
+      ldsViewForGemmA = viewBufferAs(b, ldsByteBufferA, elementTypeA);
+      ldsViewForGemmB = viewBufferAs(b, ldsByteBufferB, elementTypeB);
     } else {
-      llvm_unreachable("unknown gemm schedule version. only "
-                       "gemmScheduleVersions 1 or 2 are supported.");
+      ldsViewForGemmA = viewBufferAs(b, ldsByteBufferA, ldsReadTypeA);
+      ldsViewForGemmB = viewBufferAs(b, ldsByteBufferB, ldsReadTypeB);
     }
 
-    auto [arrayA, arrayB] = createRegInterrimBufferForAccel(
-        loc, params, b, scheduleVersion == 2 ? params.mRepeats : 1,
-        scheduleVersion == 2 ? params.nRepeats : 1);
+    // TODO: add an heuristic to decide if the it should use scheduleV1 or V2.
+    bool doubleBuffering =
+        loadType == GemmLoadTileType::DoubleBuffer ||
+        loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
+
+    // Logic to setup buffers for blockwise_gemm_accel.
+    int64_t initiationInterval = doubleBuffering ? 1 : 2;
+
+    auto [arrayAForLoad, arrayBForLoad, arrayA, arrayB] =
+        createRegInterrimBufferForAccel(
+            loc, params, b, doubleBuffering ? params.mRepeats : 1,
+            doubleBuffering ? params.nRepeats : 1, directToLDS);
     Value regCAllocOp = createBufferForAccelGemmOut(loc, params, b);
 
     zeroAccBuffer(b, loc, regCAllocOp);
@@ -3108,19 +3186,17 @@ struct GridwiseGemmAccelRewritePattern
       b.setInsertionPointToStart(loopOp.getBody());
       Value iv = loopOp.getInductionVar();
 
-      auto loadType = scheduleVersion == 1 ? GemmLoadTileType::Default
-                                           : GemmLoadTileType::DoubleBuffer;
       // Load from global memory to LDS
       loadAndStoreGemmInputTile(
-          loc, matB, /*kiter=*/iv, tid, gridCoords, ldsByteBufferB, arrayB,
-          loadType, "n", blockSize, elementTypeA, elementTypeALoad,
-          elementTypeB, elementTypeBLoad, G, M, N, b, op.getParamsAttr(),
-          featuresAttr, ldsLayoutConfigB);
+          loc, matB, /*kiter=*/iv, tid, gridCoords, ldsByteBufferB,
+          arrayBForLoad, loadType, "n", blockSize, elementTypeA,
+          elementTypeALoad, elementTypeB, elementTypeBLoad, G, M, N, b,
+          op.getParamsAttr(), featuresAttr, ldsLayoutConfigB);
       loadAndStoreGemmInputTile(
-          loc, matA, /*kiter=*/iv, tid, gridCoords, ldsByteBufferA, arrayA,
-          loadType, "m", blockSize, elementTypeA, elementTypeALoad,
-          elementTypeB, elementTypeBLoad, G, M, N, b, op.getParamsAttr(),
-          featuresAttr, ldsLayoutConfigA);
+          loc, matA, /*kiter=*/iv, tid, gridCoords, ldsByteBufferA,
+          arrayAForLoad, loadType, "m", blockSize, elementTypeA,
+          elementTypeALoad, elementTypeB, elementTypeBLoad, G, M, N, b,
+          op.getParamsAttr(), featuresAttr, ldsLayoutConfigA);
 
       // Emit blockwise GEMM. This will load data from LDS (or registers) and
       // compute the MMA at the same time
@@ -3128,6 +3204,8 @@ struct GridwiseGemmAccelRewritePattern
       {
         PatternRewriter::InsertionGuard guard(b);
         b.setInsertionPointToStart(&stage2.getRegion().emplaceBlock());
+        bool loadFromLDS = loadType == GemmLoadTileType::Default ||
+                           loadType == GemmLoadTileType::DirectToLDSDefault;
 
         BlockwiseGemmAccelOp::create(
             b, loc, ldsViewForGemmA, ldsViewForGemmB,
@@ -3135,11 +3213,15 @@ struct GridwiseGemmAccelRewritePattern
             b.getI32IntegerAttr(copyNPerThread),
             (ldsLayoutConfigA.doRotateWithK ? b.getUnitAttr() : nullptr),
             (ldsLayoutConfigB.doRotateWithK ? b.getUnitAttr() : nullptr),
-            /*loadAfromLDS=*/(scheduleVersion == 1 ? b.getUnitAttr() : nullptr),
-            /*loadBfromLDS=*/(scheduleVersion == 1 ? b.getUnitAttr() : nullptr),
+            /*loadAfromLDS=*/(loadFromLDS ? b.getUnitAttr() : nullptr),
+            /*loadBfromLDS=*/(loadFromLDS ? b.getUnitAttr() : nullptr),
             /*splitKAcrossThreadsFirstA=*/nullptr,
-            /*splitKAcrossThreadsFirstB=*/nullptr, arrayA, arrayB, regCAllocOp,
-            featuresAttr, op.getBlockSizeAttr(), op.getParamsAttr());
+            /*splitKAcrossThreadsFirstB=*/nullptr,
+            (directToLDS ? b.getUnitAttr() : nullptr),
+            (ldsLayoutConfigA.ldsLayoutDxK ? b.getUnitAttr() : nullptr),
+            (ldsLayoutConfigB.ldsLayoutDxK ? b.getUnitAttr() : nullptr), arrayA,
+            arrayB, regCAllocOp, featuresAttr, op.getBlockSizeAttr(),
+            op.getParamsAttr());
         YieldOp::create(b, loc);
       }
     }

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Rock/IR/AmdArchDb.h"
 #include "mlir/Dialect/Rock/IR/GetRockInfo.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
@@ -37,6 +38,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -489,6 +491,56 @@ static Value addIterationIndexIfScalar(PatternRewriter &b, Location loc,
   return withIter;
 }
 
+/// This function transforms [..., tid, item] into [item, wave_id, wave_tid].
+/// This is used to compute the LDS pointer for global to LDS. Note that the
+/// pointer has to be wavefront-uniform. Because the global to LDS instructions
+/// will do an implicit offset by 4 * lane_id bytes for size <= 4 bytes
+/// and 16 * lane_id bytes for larger sizes.
+static FailureOr<ArrayAttr>
+getGlobalToLDSTransform(ThreadwiseReadIntoOp op, PatternRewriter &b,
+                        Location loc,
+                        const SmallVector<Value, 3> &readStartCoords,
+                        const ArrayAttr &sourceTransforms, int64_t blockSize,
+                        int64_t waveSize, bool isGlobalToLDS) {
+  ArrayAttr globalToLDSTransform = b.getArrayAttr({});
+  // Transform used to compute LDS pointer for global to LDS
+  if (isGlobalToLDS) {
+    if (sourceTransforms.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << "sourceTransforms is empty.\n");
+      return failure();
+    }
+    TransformMapAttr topMap = cast<TransformMapAttr>(sourceTransforms[0]);
+
+    // Create views as gridwise sub-tile of C
+    if (readStartCoords.size() < 2) {
+      return b.notifyMatchFailure(
+          loc, "read_into must have at least 2 extra indices");
+    }
+    SmallVector<StringRef> nonLDSDims = {};
+    SmallVector<StringRef> dims = {};
+    for (size_t i = 0; i < readStartCoords.size() - 2; i++) {
+      auto dim = b.getStringAttr(std::to_string(i));
+      dims.push_back(dim);
+      nonLDSDims.push_back(dim);
+    }
+    dims.push_back(b.getStringAttr("tid"));
+    dims.push_back(b.getStringAttr("item"));
+    TopDownTMBuilder splitMemoryCoords(b, dims, topMap.getUpperBounds(), loc);
+    for (auto dim : nonLDSDims) {
+      splitMemoryCoords.ignore(dim);
+    }
+
+    int64_t waveId = blockSize / waveSize;
+    splitMemoryCoords.merge({"wave", "wave_tid"}, {1, 2}, "tid",
+                            {waveId, waveSize});
+    splitMemoryCoords.passThrough({"item"}, 0, {"item"});
+    TransformMapAttr splitMemoryCoordsAttr = splitMemoryCoords.get();
+    globalToLDSTransform = b.getArrayAttr({splitMemoryCoordsAttr});
+  }
+
+  return globalToLDSTransform;
+}
+
 LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
     ThreadwiseReadIntoOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &b) const {
@@ -503,10 +555,54 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
   Value dest = adaptor.getDest();
   MemRefType dstBufferType = cast<MemRefType>(dest.getType());
 
-  int64_t numValues = dstBufferType.getNumElements();
-
   bool isSrcVectorBuffer = isa<VectorType>(sourceViewType.getElementType());
   bool isDstVectorBuffer = isa<VectorType>(dstBufferType.getElementType());
+
+  auto [buffer, transforms, needs64BitIdx] = untransform(b, sourceView);
+  // Unless specified it is assumed to be global
+  auto srcBufferType = cast<MemRefType>(buffer.getType());
+  gpu::AddressSpace srcAddrSpace = gpu::AddressSpace::Global;
+  if (srcBufferType.getMemorySpace()) {
+    srcAddrSpace =
+        cast<gpu::AddressSpaceAttr>(srcBufferType.getMemorySpace()).getValue();
+  }
+  auto destBufferType = cast<MemRefType>(dest.getType());
+  gpu::AddressSpace dstAddrSpace = gpu::AddressSpace::Private;
+  if (destBufferType.getMemorySpace()) {
+    dstAddrSpace =
+        cast<gpu::AddressSpaceAttr>(destBufferType.getMemorySpace()).getValue();
+  }
+  bool isGlobalToLDS = srcAddrSpace == gpu::AddressSpace::Global &&
+                       dstAddrSpace == gpu::AddressSpace::Workgroup;
+
+  int64_t numValues = dstBufferType.getNumElements();
+  bool hwDirectToLDS128b, hwDirectToLDS32b;
+  if (isGlobalToLDS) {
+    if (transforms.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << "transforms is empty.\n");
+      return failure();
+    }
+    TransformMapAttr topMap = cast<TransformMapAttr>(transforms[0]);
+    numValues = topMap.getUpperBounds().asArrayRef().back();
+    assert(!isSrcVectorBuffer &&
+           "Global to LDS should not have vector buffers, not implemented yet");
+    assert(!isDstVectorBuffer &&
+           "Global to LDS should not have vector buffers, not implemented yet");
+
+    auto arch = getArch(op);
+    if (failed(arch))
+      return emitError(loc) << "can't get arch\n";
+    auto features = rock::lookupArchInfo(arch.value()).defaultFeatures;
+    hwDirectToLDS128b =
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b);
+    hwDirectToLDS32b =
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
+    if (!hwDirectToLDS128b && !hwDirectToLDS32b) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Direct to LDS is not supported by the hardware\n");
+      return failure();
+    }
+  }
 
   size_t extraIdxCount = op.getExtraIndices().size();
   // We are vectorizing in the iter dimension, not block ID or thread ID
@@ -551,15 +647,6 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
     }
   }
 
-  auto [buffer, transforms, needs64BitIdx] = untransform(b, sourceView);
-  // Unless specified it is assumed to be global
-  auto srcBufferType = cast<MemRefType>(buffer.getType());
-  gpu::AddressSpace srcAddrSpace = gpu::AddressSpace::Global;
-  if (srcBufferType.getMemorySpace()) {
-    srcAddrSpace =
-        cast<gpu::AddressSpaceAttr>(srcBufferType.getMemorySpace()).getValue();
-  }
-
   LLVM_DEBUG(llvm::dbgs() << "Max vectorization for read_into = "
                           << vectorSrcLen << "\n");
   bool forceUnroll = op.getForceUnroll();
@@ -578,6 +665,24 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
 
   SmallVector<Attribute> transformAttrs;
 
+  // get block size and wave size
+  auto maybeBlocksize = rock::getBlockSize(op);
+  if (failed(maybeBlocksize))
+    return b.notifyMatchFailure(loc, "must have a block size attribute");
+  int64_t blockSize = maybeBlocksize.value().getValue().getSExtValue();
+  auto maybeArch = rock::getArch(op);
+  if (failed(maybeArch))
+    return b.notifyMatchFailure(loc, "must have an arch attribute");
+  int64_t waveSize = rock::lookupArchInfo(maybeArch.value()).waveSize;
+
+  auto maybeGlobalToLDSTransform =
+      getGlobalToLDSTransform(op, b, loc, readStartCoords, transforms,
+                              blockSize, waveSize, isGlobalToLDS);
+  if (failed(maybeGlobalToLDSTransform))
+    return b.notifyMatchFailure(loc, "failed to get global to LDS transform");
+
+  auto globalToLDSTransform = maybeGlobalToLDSTransform.value();
+
   bool recordsValidity =
       op.getValidityRecord() && !op.getValidityRecord().use_empty();
   Value validityInit = nullptr;
@@ -587,11 +692,16 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
     validityInit = vector::SplatOp::create(
         b, loc, op.getValidityRecord().getType(), trueConst);
   }
+  SmallVector<ValueRange> inits{readStartCoords, readStartCoords};
+  SmallVector<Attribute> loopTransforms{transforms, b.getArrayAttr({})};
+  if (isGlobalToLDS) {
+    inits.push_back(inits[0]);
+    loopTransforms.push_back(globalToLDSTransform);
+  }
+
   auto loadLoop = TransformingForOp::create(
-      b, loc, ArrayRef<ValueRange>{readStartCoords, readStartCoords},
-      ArrayRef<Attribute>{transforms, b.getArrayAttr({})}, bounds, strides,
-      forceUnroll, useIndexDiffs,
-      recordsValidity ? ValueRange{validityInit} : std::nullopt);
+      b, loc, inits, loopTransforms, bounds, strides, forceUnroll,
+      useIndexDiffs, recordsValidity ? ValueRange{validityInit} : std::nullopt);
   {
     OpBuilder::InsertionGuard guard(b);
     b.setInsertionPointToStart(loadLoop.getBody());
@@ -620,15 +730,68 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
                                 validityToStore, validityRecord, destIndex);
     }
 
-    if (srcAddrSpace == gpu::AddressSpace::Global) {
+    if (srcAddrSpace == gpu::AddressSpace::Global &&
+        dstAddrSpace == gpu::AddressSpace::Private) {
       Value loaded = GlobalLoadOp::create(b, loc, loadType, buffer, validity,
                                           loadLoop.getLowerCoords(/*domain=*/0),
                                           needs64BitIdx);
       InBoundsStoreOp::create(b, loc, loaded, dest, destIndex);
+    } else if (isGlobalToLDS) {
+      int64_t loadTypeByteWidth = getByteWidth(loadType);
+      if (loadTypeByteWidth != 16 && loadTypeByteWidth != 4)
+        return b.notifyMatchFailure(loc, "global to LDS is only supported for "
+                                         "128-bit or 32-bit loads currently");
+      ValueRange ldsCoords = loadLoop.getLowerCoords(/*domain=*/2);
+      Value item = ldsCoords[0];
+      Value waveId = ldsCoords[1];
+      // LDS index is index=item*(workgroup size)*16+wave_id*(wave size)*16 (in
+      // bytes)
+      int64_t constantNumElements;
+      Type directToLDSType;
+      if (loadTypeByteWidth == 16) {
+        assert(128 % dstBufferType.getElementTypeBitWidth() == 0);
+        constantNumElements = 128 / dstBufferType.getElementTypeBitWidth();
+        directToLDSType = b.getF128Type();
+        if (!hwDirectToLDS128b) {
+          LLVM_DEBUG(
+              llvm::dbgs()
+              << "128 bits direct to LDS is not supported by the hardware\n");
+          return failure();
+        }
+      } else {
+        assert(32 % dstBufferType.getElementTypeBitWidth() == 0);
+        constantNumElements = 32 / dstBufferType.getElementTypeBitWidth();
+        directToLDSType = b.getF32Type();
+        if (!hwDirectToLDS32b) {
+          LLVM_DEBUG(
+              llvm::dbgs()
+              << "32 bits direct to LDS is not supported by the hardware\n");
+          return failure();
+        }
+      }
+      assert(srcStride == constantNumElements);
+
+      // no need to multiply blockSize by constantNumElements, because the
+      // stride of the loop is already srcStride
+      Value itemConst = b.create<arith::ConstantIndexOp>(loc, blockSize);
+      Value ldsIndex = b.create<arith::MulIOp>(loc, item, itemConst);
+      Value waveIdConst =
+          b.create<arith::ConstantIndexOp>(loc, waveSize * constantNumElements);
+      Value ldsIndexWave = b.create<arith::MulIOp>(loc, waveId, waveIdConst);
+      // LDS index is wavefront-uniform as that is needed by load to LDS
+      // instruction
+      ldsIndex = b.create<arith::AddIOp>(loc, ldsIndex, ldsIndexWave);
+      GlobalLoadToLDSOp::create(b, loc, buffer, dest, validity, directToLDSType,
+                                loadLoop.getLowerCoords(/*domain=*/0),
+                                ValueRange{ldsIndex}, needs64BitIdx);
     } else {
       if (needs64BitIdx)
         return b.notifyMatchFailure(
             loc, "non-global address spaces must have 32-bit pointers");
+
+      if (dstAddrSpace != gpu::AddressSpace::Private)
+        return b.notifyMatchFailure(loc, "destination must be private");
+
       scf::IfOp ifb = scf::IfOp::create(b, loc, loadType, validity,
                                         /*withElseRegion=*/true);
       {

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/RockTuningParamAttrInterface.h"
+#include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h"
 #include "mlir/Dialect/Rock/Tuning/RockTuning.h"
 #include "mlir/Dialect/Rock/utility/fusionUtils.h"
@@ -261,11 +262,28 @@ static void createGemmTuningRangeBF(TuningParamSet *newSpace,
       {64, 128, 256}, {32, 64, 128}, {32, 64, 128}, {4, 8, 16}, {2, 4}, {2, 4}};
 
   // only enable tuning over gemm schedules when doing exhaustive tuning
-  auto getGemmSchedules = [](const TuningParamSetKind &tuningKind) {
+  auto getGemmSchedules = [&gemmOp](const TuningParamSetKind &tuningKind) {
+    auto features =
+        rock::lookupArchInfo(rock::getArchValue(gemmOp)).defaultFeatures;
+    bool directToLDS =
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b) ||
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
+
+    std::vector<GemmLoadTileType> loadTypes{GemmLoadTileType::Default};
     if (tuningKind == TuningParamSetKind::Exhaustive) {
-      return std::vector<uint32_t>{1, 2};
+      loadTypes.push_back(GemmLoadTileType::DoubleBuffer);
+      if (directToLDS) {
+        loadTypes.push_back(GemmLoadTileType::DirectToLDSDefault);
+        loadTypes.push_back(GemmLoadTileType::DirectToLDSDoubleBuffer);
+      }
     }
-    return std::vector<uint32_t>{1};
+    std::vector<uint32_t> schedules;
+    schedules.reserve(loadTypes.size());
+
+    for (auto loadType : loadTypes)
+      schedules.push_back(static_cast<uint32_t>(loadType));
+
+    return schedules;
   };
 
   // M/block N/block K/block M/wave N/wave kPack scheduleVersion

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -410,6 +410,7 @@ Value MfmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
                                         Value buffer, int64_t blockSize,
                                         int64_t dInCopyPerThread,
                                         StringRef dName, bool rotateDWithK,
+                                        bool directToLds, bool ldsLayoutDxK,
                                         bool doSplitKAcrossThreadsFirst) const {
 
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
@@ -428,6 +429,15 @@ Value MfmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
   int64_t inputSpanLen = mfmaAttr.inputSpanLen;
   int64_t kpackPerThread = accelEmitterParams.kpackPerThread;
   bool isKReduction = mfmaAttr.isKReduction;
+  int64_t kIter = kpackPerThread;
+  // Note that when directToLDS is disabled, we are loading vector<kpackxdtype>
+  // from LDS, so we load kpackPerThread. When directToLDS is enabled, we
+  // load vector<1xdtype>, so each thread will load kpackPerThread * kPack.
+  if (directToLds) {
+    kIter *= kPack;
+    kPerBlock *= kPack;
+    assert(!rotateDWithK && "rotateDWithK must not be enabled for directToLds");
+  }
 
   // Extract relevant derived parameters
   int64_t mWaves = mPerBlock / mPerWave;
@@ -442,7 +452,7 @@ Value MfmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
   SmallVector<Attribute> transformAttrs;
   if (!isKReduction) {
     TopDownTMBuilder splitTid(b, {"tid", "d_iter", "k_iter"},
-                              {blockSize, dRepeats, kpackPerThread});
+                              {blockSize, dRepeats, kIter});
     splitTid.merge({"wave_id", "lane_id"}, {0, 1}, "tid",
                    {blockSize / waveSize, waveSize});
 
@@ -479,14 +489,17 @@ Value MfmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
         rotateIf(rotateDWithK, toLDSRowCol, toLDSRowColAttr, stride, "d",
                  dPerBlock, 0, "k", kPerBlock, {}, {"k"}, transformAttrs);
 
-    offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
+    if (ldsLayoutDxK)
+      offset.unmerge("source_offset", 0, {"d", "k"}, {dPerBlock, kPerBlock});
+    else
+      offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
 
     TransformMapAttr offsetAttr = offset.get();
     transformAttrs.push_back(offsetAttr);
 
   } else {
     TopDownTMBuilder splitTid(b, {"tid", "d_iter", "k_iter"},
-                              {blockSize, dRepeats, kpackPerThread});
+                              {blockSize, dRepeats, kIter});
     splitTid.merge(
         {"wave_id", "blk_id", "blk_td"}, {0, 1, 2}, "tid",
         {blockSize / waveSize, waveSize / inputSpanLen, inputSpanLen});
@@ -514,11 +527,11 @@ Value MfmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
     if (doSplitKAcrossThreadsFirst) {
       // k = blk_id + (waveSize / inputSpanLen) * k_i
       toLDSRowCol.unmerge("k", 1, {"k_iter", "blk_id"},
-                          {kpackPerThread, waveSize / inputSpanLen});
+                          {kIter, waveSize / inputSpanLen});
     } else {
       // k = k_i + kpackPerBlock * blk_id
       toLDSRowCol.unmerge("k", 1, {"blk_id", "k_iter"},
-                          {waveSize / inputSpanLen, kpackPerThread});
+                          {waveSize / inputSpanLen, kIter});
     }
 
     toLDSRowCol.ignore(otherWaveDim);
@@ -531,7 +544,10 @@ Value MfmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
         rotateIf(rotateDWithK, toLDSRowCol, toLDSRowColAttr, stride, "d",
                  dPerBlock, 0, "k", kPerBlock, {}, {"k"}, transformAttrs);
 
-    offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
+    if (ldsLayoutDxK)
+      offset.unmerge("source_offset", 0, {"d", "k"}, {dPerBlock, kPerBlock});
+    else
+      offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
 
     TransformMapAttr offsetAttr = offset.get();
     transformAttrs.push_back(offsetAttr);
@@ -555,7 +571,7 @@ llvm::FailureOr<RegsAsMatrixSubTiles>
 MfmaEmitter::createAccelGemmOperandTransforms(
     OpBuilder &b, Location loc, int64_t kIters,
     ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
-    int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
+    int64_t dInCopyPerThread, StringRef dName, bool isKContiguousDim,
     bool rotateDWithK, bool doSplitKAcrossThreadsFirst) const {
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
   StringRef otherWaveDim = dName == "m" ? "wave_n" : "wave_m";
@@ -599,7 +615,7 @@ MfmaEmitter::createAccelGemmOperandTransforms(
         loc);
     {
       splitIter.passThrough({"k_loop", "g_block", "m_block", "n_block", "tid"});
-      if (isKContigousDim) {
+      if (isKContiguousDim) {
         splitIter.merge({"drepeat", "kpack_iter", "kpack"}, {5, 6, 7}, "iter",
                         {dRepeats, kpackPerThread, kPack});
       } else {
@@ -794,6 +810,7 @@ Value WmmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
                                         Value buffer, int64_t blockSize,
                                         int64_t dInCopyPerThread,
                                         StringRef dName, bool rotateDWithK,
+                                        bool directToLds, bool ldsLayoutDxK,
                                         bool doSplitKAcrossThreadsFirst) const {
 
   // Extract relevant tuning parameters
@@ -803,6 +820,9 @@ Value WmmaEmitter::wrapLDSBufferForLoad(OpBuilder &b, Location loc,
   int64_t mPerWave = tuningParams.getMPerWave();
   int64_t nPerWave = tuningParams.getNPerWave();
   int64_t kPack = tuningParams.getKpack();
+  // TODO: gfx10 supports directToLDS. Implement it.
+  assert(!directToLds && "direct to LDS not supported for WMMA");
+  assert(!ldsLayoutDxK && "WMMA only supports LDS layout KxD for now");
 
   // Extract relevant emitter parameters
   int64_t kpackPerThread = accelEmitterParams.kpackPerThread;
@@ -885,7 +905,7 @@ llvm::FailureOr<RegsAsMatrixSubTiles>
 WmmaEmitter::createAccelGemmOperandTransforms(
     OpBuilder &b, Location loc, int64_t kIters,
     ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
-    int64_t dInCopyPerThread, StringRef dName, bool isKContigousDim,
+    int64_t dInCopyPerThread, StringRef dName, bool isKContiguousDim,
     bool rotateDWithK, bool doSplitKAcrossThreadsFirst) const {
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
   StringRef otherWaveDim = dName == "m" ? "wave_n" : "wave_m";
@@ -926,7 +946,7 @@ WmmaEmitter::createAccelGemmOperandTransforms(
         loc);
     {
       splitIter.passThrough({"k_loop", "g_block", "m_block", "n_block", "tid"});
-      if (isKContigousDim) {
+      if (isKContiguousDim) {
         splitIter.merge({"drepeat", "kpack_iter", "kpack"}, {5, 6, 7}, "iter",
                         {dRepeats, kpackPerThread, kPack});
       } else {

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -183,8 +183,8 @@ Type mlir::rock::vectorTypeOrSelf(Type elementType, int64_t len) {
 static void makeLoadRegsTidMerge(TopDownTMBuilder &viewBuilder,
                                  StringRef dThreadName, int64_t dThreads,
                                  int64_t kThreads, ArrayRef<unsigned> outDims,
-                                 bool isKContigousDim) {
-  if (isKContigousDim) {
+                                 bool isKContiguousDim) {
+  if (isKContiguousDim) {
     viewBuilder.merge({dThreadName, "k_thread"}, outDims, "tid",
                       {dThreads, kThreads});
   } else {
@@ -197,8 +197,8 @@ static void makeLoadRegsIterMerge(TopDownTMBuilder &viewBuilder,
                                   StringRef dIterName, int64_t dPerThread,
                                   int64_t kPerThread,
                                   ArrayRef<unsigned> outDims,
-                                  bool isKContigousDim) {
-  if (isKContigousDim) {
+                                  bool isKContiguousDim) {
+  if (isKContiguousDim) {
     viewBuilder.merge({dIterName, "k_iter"}, outDims, "iter",
                       {dPerThread, kPerThread});
   } else {
@@ -211,7 +211,7 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getLoadRegsAsTileViews(
     OpBuilder &b, Location loc, Value globalBuffer, StringRef dName,
     ArrayRef<StringRef> bidGridOrder, ArrayRef<int64_t> bidGridLengths,
     int64_t blockSize, int64_t kPerBlock, int64_t dPerBlock, int64_t kPerThread,
-    int64_t dPerThread, bool isKContigousDim) {
+    int64_t dPerThread, bool isKContiguousDim, bool directToLDS) {
   if (dName != "m" && dName != "n") {
     return emitError(loc, "expected dName to be m or n but got " + dName);
   }
@@ -246,17 +246,30 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getLoadRegsAsTileViews(
     gridwiseSplitId.passThrough(
         {"k_loop", bidGridOrder[0], bidGridOrder[1], bidGridOrder[2]});
     makeLoadRegsTidMerge(gridwiseSplitId, dThreadName, dThreads, kThreads,
-                         {4, 5}, isKContigousDim);
+                         {4, 5}, isKContiguousDim);
     makeLoadRegsIterMerge(gridwiseSplitId, dIterName, dPerThread, kPerThread,
-                          {6, 7}, isKContigousDim);
+                          {6, 7}, isKContiguousDim);
     TransformMapAttr splitIdAttr = gridwiseSplitId.get();
     auto toGlobalIdx = TopDownTMBuilder::below(gridwiseSplitId, splitIdAttr);
     toGlobalIdx.passThrough({"g"}, {0}, {"g_block"});
-    toGlobalIdx.unmerge("k", 1, {"k_loop", "k_thread", "k_iter"},
-                        {kGlobal / kPerBlock, kThreads, kPerThread});
-
-    toGlobalIdx.unmerge(dName, 2, {thisBlockDim, dThreadName, dIterName},
-                        {dGlobal / dPerBlock, dThreads, dPerThread});
+    if (directToLDS) {
+      if (isKContiguousDim) {
+        toGlobalIdx.unmerge("k", 1, {"k_loop", "k_thread", "k_iter"},
+                            {kGlobal / kPerBlock, kThreads, kPerThread});
+        toGlobalIdx.unmerge(dName, 2, {thisBlockDim, dIterName, dThreadName},
+                            {dGlobal / dPerBlock, dPerThread, dThreads});
+      } else {
+        toGlobalIdx.unmerge("k", 1, {"k_loop", "k_iter", "k_thread"},
+                            {kGlobal / kPerBlock, kPerThread, kThreads});
+        toGlobalIdx.unmerge(dName, 2, {thisBlockDim, dThreadName, dIterName},
+                            {dGlobal / dPerBlock, dThreads, dPerThread});
+      }
+    } else {
+      toGlobalIdx.unmerge("k", 1, {"k_loop", "k_thread", "k_iter"},
+                          {kGlobal / kPerBlock, kThreads, kPerThread});
+      toGlobalIdx.unmerge(dName, 2, {thisBlockDim, dThreadName, dIterName},
+                          {dGlobal / dPerBlock, dThreads, dPerThread});
+    }
 
     toGlobalIdx.ignore(otherBlockDim);
     TransformMapAttr toGlobalIdxAttr = toGlobalIdx.get();
@@ -291,7 +304,7 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
     OpBuilder &b, Location loc, Value globalBuffer, StringRef dName,
     ArrayRef<StringRef> bidGridOrder, ArrayRef<int64_t> bidGridLengths,
     int64_t blockSize, int64_t kPerBlock, int64_t dPerBlock, int64_t kPerThread,
-    int64_t dPerThread, int64_t kpack, bool isKContigousDim,
+    int64_t dPerThread, int64_t kpack, bool isKContiguousDim,
     bool doSwapThreadIterSubDimsForD) {
   if (dName != "m" && dName != "n") {
     return emitError(loc, "expected dName to be m or n but got " + dName);
@@ -331,7 +344,7 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
     gridwiseSplitId.passThrough(
         {"k_loop", bidGridOrder[0], bidGridOrder[1], bidGridOrder[2]});
     makeLoadRegsTidMerge(gridwiseSplitId, dThreadName, dThreads, kThreads,
-                         {4, 5}, isKContigousDim);
+                         {4, 5}, isKContiguousDim);
     gridwiseSplitId.merge({"kouterPerThread", dIterName, "kpackPerThread"},
                           {6, 7, 8}, "iter",
                           {kOuterPerThread, dPerThread, kpackPerThread});
@@ -748,21 +761,44 @@ Value mlir::rock::getFlattenedMemref(OpBuilder &b, Value nonFlatMemRef) {
 }
 
 TypedValue<MemRefType> mlir::rock::viewBufferAs(OpBuilder &b, Value buffer,
-                                                Type type) {
+                                                Type elementType,
+                                                ArrayRef<int64_t> dimensions) {
   Location loc = buffer.getLoc();
   Value zeroByteOffset = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
   auto bufferType = cast<MemRefType>(buffer.getType());
-  int64_t byteWidth = getByteWidth(type);
+  int64_t byteWidth = getByteWidth(elementType);
   assert(bufferType.getRank() == 1 &&
          "Buffer type must be a 1D memref for viewBufferAs");
+  assert(bufferType.getElementType() == b.getI8Type() &&
+         "Buffer type must be a i8 memref for viewBufferAs");
+
   int64_t numBytes = bufferType.getShape()[0];
+  int64_t numElements = std::accumulate(dimensions.begin(), dimensions.end(),
+                                        int64_t{1}, std::multiplies<>());
   assert(numBytes % byteWidth == 0 && "Can't evenly fit type into buffer");
-  int64_t length = numBytes / byteWidth;
-  auto newBufferType = bufferType.cloneWith({length}, type);
+  assert(numBytes / byteWidth == numElements &&
+         "Provided dimensions don't match buffer size");
+
+  auto newBufferType = MemRefType::get(dimensions, elementType, nullptr,
+                                       bufferType.getMemorySpace());
   auto view =
       memref::ViewOp::create(b, loc, newBufferType, buffer, zeroByteOffset,
                              /*dynamic dim sizes=*/ValueRange{});
   return TypedValue<MemRefType>(view.getResult());
+}
+
+TypedValue<MemRefType> mlir::rock::viewBufferAs(OpBuilder &b, Value buffer,
+                                                Type elementType) {
+  auto bufferType = cast<MemRefType>(buffer.getType());
+  assert(bufferType.getRank() == 1 &&
+         "Buffer type must be a 1D memref for viewBufferAs");
+  assert(bufferType.getElementType() == b.getI8Type() &&
+         "Buffer type must be a i8 memref for viewBufferAs");
+  int64_t byteWidth = getByteWidth(elementType);
+  int64_t numBytes = bufferType.getShape()[0];
+  assert(numBytes % byteWidth == 0 && "Can't evenly fit type into buffer");
+  int64_t length = numBytes / byteWidth;
+  return viewBufferAs(b, buffer, elementType, {length});
 }
 
 Value mlir::rock::gpuAlloc(OpBuilder &b, Location loc, int64_t bufferDim,
@@ -913,22 +949,72 @@ bestGlobalVectorization(Value matrix, int64_t copyDPerThread,
       matrix.getDefiningOp());
   int64_t dVectorLen = dVectorRes.max;
 
-  if (kVectorLen > dVectorLen) {
-    kVectorLen = math_util::gcd(kVectorLen, copyKPerThread);
+  kVectorLen = math_util::gcd(kVectorLen, copyKPerThread);
+  dVectorLen = math_util::gcd(dVectorLen, copyDPerThread);
+  if (kVectorLen > dVectorLen)
     return {GemmDimension::K, kVectorLen};
-  }
 
-  if (dVectorLen > kVectorLen) {
-    dVectorLen = math_util::gcd(dVectorLen, copyDPerThread);
+  if (dVectorLen > kVectorLen)
     return {GemmDimension::MorN, dVectorLen};
+
+  return {tiebreaker, tiebreaker == GemmDimension::K ? kVectorLen : dVectorLen};
+}
+
+/// Compute a thread copy layout, i.e., how many elements a single thread (or
+/// workitem) reads along K and M (independently on how we vectorize the reads).
+/// This function is used when we are copying directly to LDS.
+static FailureOr<std::tuple<GemmDimension, int64_t, int64_t>>
+computeCopyPerThreadDirectToLDS(Value matrix, Type elementType,
+                                int64_t copyPerThread, int64_t kPerBlock,
+                                int64_t dPerBlock, int64_t kpack,
+                                int64_t targetBits, Location loc) {
+  int64_t copyKPerThread = 0;
+  int64_t copyDPerThread = 0;
+  // TODO: we need targetBits=96 if we want direct to LDS for f6
+  if (targetBits % elementType.getIntOrFloatBitWidth() != 0)
+    return failure();
+
+  int64_t inputDimLen = targetBits / elementType.getIntOrFloatBitWidth();
+
+  VectorizationResult dVectorRes =
+      getMaxVectorization(matrix, static_cast<uint32_t>(GemmDimension::MorN),
+                          inputDimLen, matrix.getDefiningOp());
+  int64_t dVectorLen = dVectorRes.max;
+  VectorizationResult kVectorRes =
+      getMaxVectorization(matrix, static_cast<uint32_t>(GemmDimension::K),
+                          inputDimLen, matrix.getDefiningOp());
+  int64_t kVectorLen = kVectorRes.max;
+  auto dim = (dVectorLen > kVectorLen) ? GemmDimension::MorN : GemmDimension::K;
+
+  int64_t copyFastestDimPerThread;
+  if (dim == GemmDimension::MorN) {
+    copyDPerThread = math_util::gcd(dVectorLen, copyPerThread);
+    copyKPerThread = copyPerThread / copyDPerThread;
+    copyFastestDimPerThread = copyDPerThread;
+  } else {
+    copyKPerThread = math_util::gcd(kVectorLen, copyPerThread);
+    copyDPerThread = copyPerThread / copyKPerThread;
+    copyFastestDimPerThread = copyKPerThread;
   }
 
-  return {tiebreaker, kVectorLen};
+  // if the fastest dimension doesn't match inputDimLen. We can't use direct to
+  // LDS.
+  if (copyFastestDimPerThread != inputDimLen) {
+    return failure();
+  }
+
+  if (copyKPerThread == 0 || copyDPerThread == 0) {
+    return failure();
+  }
+  if (kPerBlock < copyKPerThread || dPerBlock < copyDPerThread) {
+    return failure();
+  }
+  return std::make_tuple(dim, copyKPerThread, copyDPerThread);
 }
 
 /// Compute a thread copy layout, i.e., how many elements a single thread (or
 /// workitem) reads along K and M (independently on how we vectorize the reads)
-static FailureOr<std::pair<int64_t, int64_t>>
+static FailureOr<std::tuple<GemmDimension, int64_t, int64_t>>
 computeCopyPerThread(Type elementType, int64_t copyPerThread, int64_t kPerBlock,
                      int64_t dPerBlock, int64_t kpack, Location loc) {
 
@@ -939,12 +1025,15 @@ computeCopyPerThread(Type elementType, int64_t copyPerThread, int64_t kPerBlock,
   int64_t copyKPerThread = 0;
   int64_t copyDPerThread = 0;
 
+  GemmDimension dim;
   if (kpack == 1) {
     copyDPerThread = math_util::gcd(maxVlen, copyPerThread);
     copyKPerThread = copyPerThread / copyDPerThread;
+    dim = GemmDimension::MorN;
   } else {
     copyKPerThread = math_util::gcd(maxVlen, copyPerThread);
     copyDPerThread = copyPerThread / copyKPerThread;
+    dim = GemmDimension::K;
   }
 
   if (copyKPerThread == 0 || copyDPerThread == 0) {
@@ -955,9 +1044,9 @@ computeCopyPerThread(Type elementType, int64_t copyPerThread, int64_t kPerBlock,
   if (kPerBlock < copyKPerThread || dPerBlock < copyDPerThread) {
     return mlir::emitError(loc)
            << "gemmA per thread copy smaller than per"
-           << " block copy, incohereant tuning parameters\n";
+           << " block copy, incoherent tuning parameters\n";
   }
-  return std::make_pair(copyKPerThread, copyDPerThread);
+  return std::make_tuple(dim, copyKPerThread, copyDPerThread);
 }
 
 FailureOr<Value> mlir::rock::wrapLDSBufferForStore(
@@ -1018,23 +1107,69 @@ FailureOr<Value> mlir::rock::wrapLDSBufferForStore(
 FailureOr<VectorDimInfo>
 mlir::rock::getVectorDim(Location loc, Value matrix, Type elemType,
                          int64_t blockSize, int64_t kPerBlock,
-                         int64_t dPerBlock, int64_t kpack) {
+                         int64_t dPerBlock, int64_t kpack, bool directToLDS) {
+  FailureOr<std::tuple<GemmDimension, int64_t, int64_t>> maybeCopyDPerThread =
+      failure();
   int64_t copyPerThread = (kPerBlock * dPerBlock) / blockSize;
-  auto maybeCopyDPerThread = computeCopyPerThread(
-      elemType, copyPerThread, kPerBlock, dPerBlock, kpack, loc);
+  if (directToLDS) {
+    auto arch = getArch(matrix.getDefiningOp());
+    if (failed(arch))
+      return emitError(loc) << "can't get arch\n";
+    auto features = rock::lookupArchInfo(arch.value()).defaultFeatures;
+    bool directToLDS128b =
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b);
+    bool directToLDS32b =
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
+    assert(directToLDS128b || directToLDS32b);
+
+    // For direct to LDS, we will try if we can load 128b per thread first.
+    // If not possible, we will try 32b. If not possible, we can't use direct to
+    // LDS.
+    if (directToLDS128b)
+      maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
+          matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack, 128,
+          loc);
+
+    if (failed(maybeCopyDPerThread) && directToLDS32b)
+      maybeCopyDPerThread =
+          computeCopyPerThreadDirectToLDS(matrix, elemType, copyPerThread,
+                                          kPerBlock, dPerBlock, kpack, 32, loc);
+  } else {
+    maybeCopyDPerThread = computeCopyPerThread(
+        elemType, copyPerThread, kPerBlock, dPerBlock, kpack, loc);
+  }
   if (failed(maybeCopyDPerThread))
     return failure();
 
-  int64_t copyKPerThread = (*maybeCopyDPerThread).first;
-  int64_t copyDPerThread = (*maybeCopyDPerThread).second;
-  // Find the best way of vectorizing the layout
+  GemmDimension vectorDim = std::get<0>(maybeCopyDPerThread.value());
+  int64_t copyKPerThread = std::get<1>(maybeCopyDPerThread.value());
+  int64_t copyDPerThread = std::get<2>(maybeCopyDPerThread.value());
+  int64_t vectorLen;
   GemmDimension vectorTiebreaker =
       (kpack > 1) ? GemmDimension::K : GemmDimension::MorN;
-  int64_t vectorLen;
-  GemmDimension vectorDim;
-  std::tie(vectorDim, vectorLen) =
-      bestGlobalVectorization(matrix, copyDPerThread, copyKPerThread,
-                              vectorTiebreaker, kPerBlock, dPerBlock);
+  if (directToLDS) {
+    // with direct to LDS, we will keep the same fastest dimension
+    // computeCopyPerThreadDirectToLDS chose.
+    if (vectorDim == GemmDimension::K) {
+      VectorizationResult kVectorRes = getMaxVectorization(
+          matrix, static_cast<uint32_t>(GemmDimension::K), /*inputDimLen=*/
+          math_util::gcd(copyKPerThread * copyDPerThread, kPerBlock),
+          matrix.getDefiningOp());
+      vectorLen = math_util::gcd(kVectorRes.max, copyKPerThread);
+    } else {
+      VectorizationResult dVectorRes = getMaxVectorization(
+          matrix, static_cast<uint32_t>(GemmDimension::MorN), /*inputDimLen=*/
+          math_util::gcd(copyDPerThread * copyKPerThread, dPerBlock),
+          matrix.getDefiningOp());
+      vectorLen = math_util::gcd(dVectorRes.max, copyDPerThread);
+    }
+  } else {
+    // Find the best way of vectorizing the layout
+    std::tie(vectorDim, vectorLen) =
+        bestGlobalVectorization(matrix, copyDPerThread, copyKPerThread,
+                                vectorTiebreaker, kPerBlock, dPerBlock);
+  }
+
   return VectorDimInfo{vectorDim, vectorLen, copyKPerThread, copyDPerThread,
                        vectorTiebreaker};
 }

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -973,7 +973,7 @@ VectorizationResult mlir::rock::getMaxVectorization(
 }
 
 void mlir::rock::collapseContiguousMerges(Value transformed) {
-  ContiguousMergesMap contigousMerges = findContiguousGroups(transformed);
+  ContiguousMergesMap contiguousMerges = findContiguousGroups(transformed);
   SmallVector<TransformOp> transformOps;
   std::tie(std::ignore, std::ignore) = untransform(transformed, transformOps);
   for (TransformOp trOp : llvm::reverse(transformOps)) {
@@ -989,8 +989,8 @@ void mlir::rock::collapseContiguousMerges(Value transformed) {
         ops.push_back(op);
         continue;
       }
-      auto mergeData = contigousMerges.find({map, op});
-      if (mergeData == contigousMerges.end()) {
+      auto mergeData = contiguousMerges.find({map, op});
+      if (mergeData == contiguousMerges.end()) {
         ops.push_back(op);
         continue;
       }
@@ -1017,7 +1017,7 @@ void mlir::rock::collapseContiguousMerges(Value transformed) {
         continue;
       }
       LLVM_DEBUG({
-        llvm::dbgs() << "[collapseContigousMerges] Updating: " << op << " to ";
+        llvm::dbgs() << "[collapseContiguousMerges] Updating: " << op << " to ";
         llvm::interleaveComma(newLengths, llvm::dbgs());
         llvm::dbgs() << "\n";
       });

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -150,3 +150,34 @@ func.func @rock_blockwise_gemm_accel_fp8_bf8_ocp_double_buffer(%matrixA : memref
   } : memref<4xvector<16xf32>, #gpu.address_space<private>> += memref<4xvector<8xf8E4M3FN>, #gpu.address_space<private>> from memref<1024xvector<8xf8E4M3FN>, #gpu.address_space<workgroup>> * memref<4xvector<8xf8E5M2>, #gpu.address_space<private>> from memref<1024xvector<8xf8E5M2>, #gpu.address_space<workgroup>>
   return
 }
+
+// CHECK-LABEL: @rock_blockwise_gemm_accel_direct_to_lds
+func.func @rock_blockwise_gemm_accel_direct_to_lds(%matrixA : memref<256xvector<2xf32>, #wg>, %matrixB : memref<256xvector<2xf32>, #wg>,
+                                                %bufferA : memref<16xi8, #priv>, %bufferB : memref<16xi8, #priv>,
+                                                %matrixC : memref<4xvector<16xf32>, #priv>) {
+
+  %c0 = arith.constant 0 : index
+  // CHECK:  rock.threadwise_accel_gemm
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
+    arch = "amdgcn-amd-amdhsa:gfx950:sramecc+:xnack-",
+    blockSize= 256 : i32,
+    inMPerThread = 2 : i32,
+    inNPerThread = 2 : i32,
+    directToLDS,
+    ldsLayoutMxK,
+    ldsLayoutNxK,
+    params = #rock.xdlops_gemm_derived_params<
+      kpackPerBlock = 2,
+      kpack = 2,
+      mPerBlock = 128,
+      mPerWave = 64,
+      nPerBlock = 128,
+      nPerWave = 64,
+      mnPerXdl = 32,
+      splitKFactor = 1, 
+      scheduleVersion = 1, 
+      outputSwizzle = 2,
+      forceUnroll = true>
+  } : memref<4xvector<16xf32>, #priv> += memref<16xi8, #priv> from memref<256xvector<2xf32>, #wg> * memref<16xi8, #priv> from memref<256xvector<2xf32>, #wg>
+  return
+}

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_wmma.mlir
@@ -10,7 +10,7 @@ func.func @rock_blockwise_gemm_accel_wmma(%matrixA : memref<16xvector<8xf16>, #w
   // CHECK: affine.for {{.*}} = 0 to 1
   // CHECK: rock.threadwise_read_into
   // CHECK: rock.threadwise_accel_gemm
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = wmma{
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB  from %matrixB features = wmma{
     arch = "amdgcn-amd-amdhsa:gfx1100",
     blockSize = 32 : i32,
     inMPerThread = 2 : i32,
@@ -58,7 +58,7 @@ func.func @rock_blockwise_gemm_accel_wmma_largekpack(%matrixA : memref<32xvector
       scheduleVersion = 1, 
       outputSwizzle = 2,
       forceUnroll = true>
-  } : memref<1xvector<8xf32>, #priv> += memref<1xvector<16xf16>, #priv> from memref<32xvector<8xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<32xvector<8xf16>, #wg>
+  } : memref<1xvector<8xf32>, #priv> += memref<1xvector<16xf16>, #priv>  from memref<32xvector<8xf16>, #wg> * memref<1xvector<16xf16>, #priv> from memref<32xvector<8xf16>, #wg>
   return
 }
 

--- a/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_fusion_ops.mlir
@@ -1,5 +1,5 @@
 // Note: this should be in a post-fusion pass
-// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise -rock-threadwise-gemm-lowering --canonicalize %s | FileCheck --enable-var-scope %s
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt -rock-blockwise-gemm-to-threadwise -rock-threadwise-gemm-lowering --canonicalize | FileCheck --enable-var-scope %s
 
 // CHECK-DAG: #[[$ON_OP:transform_map[0-9]*]] = #rock.transform_map{{.*}}PassThrough{{.*}}[0, 1, 2]{{.*}}[0, 1, 2]
 #transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)>
@@ -21,10 +21,15 @@
     <Pad{2, 0} ["z"] at [3] -> ["z"] at [3]>]
   bounds = [3, 2, 64, 32] -> [3, 2, 64, 30]>
 
+#transform_map4 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2 - 2)>
+by [<PassThrough ["1", "0"] at [0, 1]  -> ["1", "0"] at [0, 1]>,
+  <Pad{2, 0} ["z"] at [2] -> ["z"] at [2]>]
+bounds = [1, 128, 32] -> [1, 128, 30]>
+
 
 // CHECK-LABEL: func @threadwise_read_into
 // CHECK-SAME: [[source:%.+]]: memref<2x64x30xf32>, [[dest:%.+]]: memref<32xf32, #gpu.address_space<private>>
-func.func @threadwise_read_into( %source: memref<2x64x30xf32>, %dest: memref<32xf32, #gpu.address_space<private>>) {
+func.func @threadwise_read_into( %source: memref<2x64x30xf32>, %dest: memref<32xf32, #gpu.address_space<private>>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK-DAG: [[zero:%.+]] = arith.constant 0
   // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
   // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
@@ -48,7 +53,7 @@ func.func @threadwise_read_into( %source: memref<2x64x30xf32>, %dest: memref<32x
 
 // CHECK-LABEL: func @threadwise_read_into_scalar
 // CHECK-SAME: [[source:%.+]]: memref<f32>, [[dest:%.+]]: memref<1xf32, #gpu.address_space<private>>
-func.func @threadwise_read_into_scalar(%source: memref<f32>, %dest: memref<1xf32, #gpu.address_space<private>>) {
+func.func @threadwise_read_into_scalar(%source: memref<f32>, %dest: memref<1xf32, #gpu.address_space<private>>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK-DAG: [[zero:%.+]] = arith.constant 0
   // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
   // CHECK-SAME: () = [#transform_map{{[0-9]*}}]([[zero]])
@@ -67,7 +72,7 @@ func.func @threadwise_read_into_scalar(%source: memref<f32>, %dest: memref<1xf32
 
 // CHECK-LABEL: func @threadwise_read_into_extra_idx
 // CHECK-SAME: [[source:%.+]]: memref<3x2x64x30xf32>, [[dest:%.+]]: memref<32xf32, #gpu.address_space<private>>
-func.func @threadwise_read_into_extra_idx( %source: memref<3x2x64x30xf32>, %dest: memref<32xf32, #gpu.address_space<private>>) {
+func.func @threadwise_read_into_extra_idx( %source: memref<3x2x64x30xf32>, %dest: memref<32xf32, #gpu.address_space<private>>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK-DAG: [[zero:%.+]] = arith.constant 0
   // CHECK-DAG: [[extra_idx:%.+]] = arith.constant 1
   // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
@@ -94,7 +99,7 @@ func.func @threadwise_read_into_extra_idx( %source: memref<3x2x64x30xf32>, %dest
 
 // CHECK-LABEL: func @threadwise_write_all
 // CHECK-SAME: [[source:%.+]]: memref<32xf32, #gpu.address_space<private>>, [[dest:%.+]]: memref<2x64x30xf32>
-func.func @threadwise_write_all(%source: memref<32xf32, #gpu.address_space<private>>, %dest: memref<2x64x30xf32>) attributes {arch = "amdgcn-amd-amdhsa:gfx906"} {
+func.func @threadwise_write_all(%source: memref<32xf32, #gpu.address_space<private>>, %dest: memref<2x64x30xf32>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK-DAG: [[zero:%.+]] = arith.constant 0
   // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
   // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
@@ -117,7 +122,7 @@ func.func @threadwise_write_all(%source: memref<32xf32, #gpu.address_space<priva
 
 // CHECK-LABEL: func @threadwise_write_all_scalar
 // CHECK-SAME: [[source:%.+]]: memref<1xf32, #gpu.address_space<private>>, [[dest:%.+]]: memref<f32>
-func.func @threadwise_write_all_scalar(%source: memref<1xf32, #gpu.address_space<private>>, %dest: memref<f32>) attributes {arch = "amdgcn-amd-amdhsa:gfx906"} {
+func.func @threadwise_write_all_scalar(%source: memref<1xf32, #gpu.address_space<private>>, %dest: memref<f32>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK-DAG: [[zero:%.+]] = arith.constant 0
   // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
   // CHECK-SAME: ([[i:%.+]]) = []([[zero]])
@@ -135,7 +140,7 @@ func.func @threadwise_write_all_scalar(%source: memref<1xf32, #gpu.address_space
 
 // CHECK-LABEL: func @threadwise_write_all_extra_idx
 // CHECK-SAME: [[source:%.+]]: memref<32xf32, #gpu.address_space<private>>, [[dest:%.+]]: memref<3x2x64x30xf32>
-func.func @threadwise_write_all_extra_idx(%source: memref<32xf32, #gpu.address_space<private>>, %dest: memref<3x2x64x30xf32>) {
+func.func @threadwise_write_all_extra_idx(%source: memref<32xf32, #gpu.address_space<private>>, %dest: memref<3x2x64x30xf32>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK-DAG: [[zero:%.+]] = arith.constant 0
   // CHECK-DAG: [[extra_idx:%.+]] = arith.constant 2
   // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
@@ -160,7 +165,7 @@ func.func @threadwise_write_all_extra_idx(%source: memref<32xf32, #gpu.address_s
 
 // CHECK-LABEL: func @threadwise_read_into_big_to_small_vec
 // CHECK-SAME: %[[source:.+]]: memref<4xvector<8xf16>, #gpu.address_space<workgroup>>, %[[dest:.+]]: memref<8xvector<4xf16>, #gpu.address_space<private>>
-func.func @threadwise_read_into_big_to_small_vec(%source: memref<4xvector<8xf16>, #gpu.address_space<workgroup>>, %dest: memref<8xvector<4xf16>, #gpu.address_space<private>>) {
+func.func @threadwise_read_into_big_to_small_vec(%source: memref<4xvector<8xf16>, #gpu.address_space<workgroup>>, %dest: memref<8xvector<4xf16>, #gpu.address_space<private>>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [4] strides [1] {
     // CHECK-DAG: %[[ldval:.+]] = scf.if
@@ -179,7 +184,7 @@ func.func @threadwise_read_into_big_to_small_vec(%source: memref<4xvector<8xf16>
 
 // CHECK-LABEL: func @threadwise_read_into_scalar_to_vec
 // CHECK-SAME: %[[source:.+]]: memref<32xf16, #gpu.address_space<workgroup>>, %[[dest:.+]]: memref<8xvector<4xf16>, #gpu.address_space<private>>
-func.func @threadwise_read_into_scalar_to_vec(%source: memref<32xf16, #gpu.address_space<workgroup>>, %dest: memref<8xvector<4xf16>, #gpu.address_space<private>>) {
+func.func @threadwise_read_into_scalar_to_vec(%source: memref<32xf16, #gpu.address_space<workgroup>>, %dest: memref<8xvector<4xf16>, #gpu.address_space<private>>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [32] strides [8] {
     // CHECK-DAG: %[[ldval:.+]] = scf.if
@@ -198,7 +203,7 @@ func.func @threadwise_read_into_scalar_to_vec(%source: memref<32xf16, #gpu.addre
 
 // CHECK-LABEL: func @threadwise_read_into_small_to_big_vec
 // CHECK-SAME: %[[source:.+]]: memref<8xvector<4xf16>, #gpu.address_space<workgroup>>, %[[dest:.+]]: memref<4xvector<8xf16>, #gpu.address_space<private>>
-func.func @threadwise_read_into_small_to_big_vec(%source: memref<8xvector<4xf16>, #gpu.address_space<workgroup>>, %dest: memref<4xvector<8xf16>, #gpu.address_space<private>>) {
+func.func @threadwise_read_into_small_to_big_vec(%source: memref<8xvector<4xf16>, #gpu.address_space<workgroup>>, %dest: memref<4xvector<8xf16>, #gpu.address_space<private>>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [8] strides [1] {
     // CHECK-DAG: %[[ldval:.+]] = scf.if
@@ -220,7 +225,7 @@ func.func @threadwise_read_into_small_to_big_vec(%source: memref<8xvector<4xf16>
 // CHECK-SAME: [[source:%.+]]: memref<2x64x30xf32, #gpu.address_space<private>>, [[dest:%.+]]: memref<32xf32, #gpu.address_space<private>>, [[validIn:%.+]]: vector<32xi1>
 func.func @threadwise_read_into_validities(%source: memref<2x64x30xf32, #gpu.address_space<private>>,
     %dest: memref<32xf32, #gpu.address_space<private>>,
-    %validIn: vector<32xi1>) -> vector<32xi1> {
+    %validIn: vector<32xi1>) -> vector<32xi1> attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
   // CHECK-DAG: [[trues:%.+]] = arith.constant dense<true>
   // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
   // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
@@ -248,4 +253,32 @@ func.func @threadwise_read_into_validities(%source: memref<2x64x30xf32, #gpu.add
     if [%validIn]
     : memref<2x64x32xf32, #gpu.address_space<private>> -> memref<32xf32, #gpu.address_space<private>>, vector<32xi1>
   func.return %validOut : vector<32xi1>
+}
+
+// Note: We hardcode gfx950 arch to make sure we can use rock.global_load_to_lds
+// CHECK-LABEL: func @threadwise_read_into_lds
+// CHECK-SAME: [[source:%.+]]: memref<1x128x30xf16>, [[dest:%.+]]: memref<8192xi8, #gpu.address_space<workgroup>>
+func.func @threadwise_read_into_lds(%source: memref<1x128x30xf16>, %lds: memref<8192xi8, #gpu.address_space<workgroup>>) attributes {block_size = 128 : i32, arch = "gfx950:sramecc+:xnack-"} {
+  // CHECK-DAG: [[c128:%.+]] = arith.constant 128 : index
+  // CHECK-DAG: [[zero:%.+]] = arith.constant 0 : index
+  // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id : index
+  // CHECK-DAG: [[tid:%.+]] = rock.workitem_id : index
+  // CHECK-DAG: [[ldsView:%.+]] = memref.view {{.*}} memref<8192xi8, #gpu.address_space<workgroup>> to memref<4096xf16, #gpu.address_space<workgroup>>
+  // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
+  // CHECK-SAME: bounds [1, 1, 32]
+  // CHECK-SAME: strides [1, 1, 2]
+  // CHECK-NEXT: [[ldsIndex0:%.+]] = arith.muli %{{.*}}, [[c128]] : index
+  // CHECK-NEXT: [[ldsIndex1:%.+]] = arith.muli %{{.*}}, [[c128]] : index
+  // CHECK-NEXT: [[ldsIndex:%.+]] = arith.addi [[ldsIndex0]], [[ldsIndex1]] : index
+  // CHECK-NEXT: rock.global_load_to_lds [[source]]{{.*}} -> [[ldsView]][[[ldsIndex]]] if {{.*}} {transferType = f32} : memref<1x128x30xf16> -> memref<4096xf16, #gpu.address_space<workgroup>>
+
+  %view = rock.transform %source by #transform_map4 : memref<1x128x30xf16> to memref<1x128x32xf16>
+  %bid = rock.workgroup_id : index
+  %tid = rock.workitem_id : index
+  %c0 = arith.constant 0 : index
+  %view_lds = memref.view %lds[%c0][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<4096xf16, #gpu.address_space<workgroup>>
+  %55 = rock.threadwise_read_into {forceUnroll, useIndexDiffs} 
+    [](%view) [%bid, %tid] -> %view_lds 
+    : memref<1x128x32xf16> -> memref<4096xf16, #gpu.address_space<workgroup>>, vector<4096xi1>
+  func.return
 }

--- a/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
+++ b/mlir/test/Dialect/Rock/ops_blockwise_f16.mlir
@@ -85,7 +85,7 @@ func.func @rock_blockwise_gemm_accel_one_result_f16(%matrixA : memref<8192xf16, 
                                           %bufferA : memref<4xvector<4xf16>, 5>, %bufferB : memref<4xvector<4xf16>, 5>,
                                           %matrixC : memref<1xvector<32xf32>, 5>) {
   %c0f = arith.constant 0.0 : f16
-  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB from %matrixB features = mfma {
+  rock.blockwise_gemm_accel %matrixC += %bufferA from %matrixA * %bufferB  from %matrixB features = mfma {
     arch = "amdgcn-amd-amdhsa:gfx90a",
     blockSize = 256 : i32,
     inMPerThread = 2 : i32,

--- a/mlir/test/Dialect/Rock/test_multi_buffer.mlir
+++ b/mlir/test/Dialect/Rock/test_multi_buffer.mlir
@@ -165,7 +165,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
       // CHECK: rock.threadwise_write_all {{.*}} -> [](%[[t11]])
       rock.threadwise_write_all {forceUnroll, useIndexDiffs} %20 -> [](%41) [%6] by  set : memref<16xf16, #gpu.address_space<private>> -> memref<256x16xvector<8xf16>, #gpu.address_space<workgroup>>
       rock.lds_barrier
-      rock.blockwise_gemm_accel %49 += %47 from %view_4 * %48 from %view_6 {blockSize = 256 : i32, inMPerThread = 2 : i32, inNPerThread = 2 : i32, params = #xldops_gemm_params, rotateMWithK, loadAfromLDS, loadBfromLDS} : memref<1xvector<16xf32>, #gpu.address_space<private>> += memref<8xvector<4xf16>, #gpu.address_space<private>> from memref<512xvector<8xf16>, #gpu.address_space<workgroup>> * memref<8xvector<4xf16>, #gpu.address_space<private>> from memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+      rock.blockwise_gemm_accel %49 += %47 from %view_4 * %48 from %view_6 features =  mfma|dot|atomic_add|atomic_add_f16 {arch = "amdgcn-amd-amdhsa:gfx90a", blockSize = 256 : i32, inMPerThread = 2 : i32, inNPerThread = 2 : i32, params = #xldops_gemm_params, rotateMWithK} : memref<1xvector<16xf32>, #gpu.address_space<private>> += memref<8xvector<4xf16>, #gpu.address_space<private>> from memref<512xvector<8xf16>, #gpu.address_space<workgroup>> * memref<8xvector<4xf16>, #gpu.address_space<private>> from memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
       rock.lds_barrier
     }
     return

--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -45,6 +45,7 @@ if (ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED)
     PrConvElementwiseGemmF32SplitK
     PrConvElementwiseGemmF16SplitK
     PrConvElementwiseGemmBF16SplitK
+    PrGemmDirectToLDS
   )
   set(GEN_MODE "")
 endif()
@@ -74,6 +75,9 @@ if (ROCK_E2E_TEST_ENABLED)
   gemm_split_k_f16
   gemm_split_k_bf16
   gemm_split_k_f32
+  )
+  list(APPEND CONFIGS
+  GemmDirectToLDS
   )
 endif()
 # Create a list for dummy files

--- a/mlir/test/e2e/GemmDirectToLDS.cfg
+++ b/mlir/test/e2e/GemmDirectToLDS.cfg
@@ -1,0 +1,2 @@
+if not 'direct_to_lds_32b' in config.features and not 'direct_to_lds_128b' in config.features:
+  config.unsupported = True

--- a/mlir/test/e2e/GemmDirectToLDS.toml
+++ b/mlir/test/e2e/GemmDirectToLDS.toml
@@ -1,0 +1,42 @@
+directory = "GemmDirectToLDS"
+prefix = "rocmlir-gen"
+suffix = "--operation gemm --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "transA"
+values = ["true", "false"]
+prefix = "--transA="
+
+[[axis]]
+name = "transB"
+values = ["true", "false"]
+prefix = "--transB="
+
+[[axis]]
+name = "transC"
+values = ["true", "false"]
+prefix = "--transC="
+
+# Note: only one fp8 variant is tested as that's enough for a sanity check
+[[axis]]
+name = "data type"
+values = ["f32", "f16", "bf16", "i8", "fp8_fp8"]
+prefix = "-t "
+
+[[axis]]
+name = "schedule_version"
+values = ["v3:64,64,16,32,32,8,1,3,2,1,1", "v3:64,64,8,32,32,8,1,4,2,1,1"]
+prefix = "-perf_config="
+
+## Direct to LDS
+[[suite]]
+name = "gemm_direct_to_lds"
+
+[[suite.test]]
+config = "-g 3 -m 1024 -k 768 -n 1024"
+
+[[suite.test]]
+config = "-g 1 -m 512 -k 1 -n 512"
+
+[[suite.test]]
+config = "-g 1 -m 512 -k 32 -n 512"

--- a/mlir/test/e2e/PrGemmDirectToLDS.cfg
+++ b/mlir/test/e2e/PrGemmDirectToLDS.cfg
@@ -1,0 +1,2 @@
+if not 'direct_to_lds_32b' in config.features and not 'direct_to_lds_128b' in config.features:
+  config.unsupported = True

--- a/mlir/test/e2e/PrGemmDirectToLDS.toml
+++ b/mlir/test/e2e/PrGemmDirectToLDS.toml
@@ -1,0 +1,20 @@
+directory = "PrGemmDirectToLDS"
+prefix = "rocmlir-gen"
+suffix = "--operation gemm --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "data type"
+values = ["f16"]
+prefix = "-t "
+
+[[axis]]
+name = "schedule_version"
+values = ["v3:64,64,16,32,32,8,1,3,2,1,1", "v3:64,64,8,32,32,8,1,4,2,1,1"]
+prefix = "-perf_config="
+
+## Direct to LDS
+[[suite]]
+name = "pr_gemm_direct_to_lds"
+
+[[suite.test]]
+config = "-g 1 -m 512 -k 32 -n 512"

--- a/mlir/test/rocmlir-gen/emit-tuning-space.mlir
+++ b/mlir/test/rocmlir-gen/emit-tuning-space.mlir
@@ -3,3 +3,12 @@
 
 // RUN: rocmlir-gen --arch gfx90a --operation=gemm -t f32 -g 1 -m 64 -k 128 -n 64 --num_cu=32 --emit-tuning-space=full | FileCheck %s --check-prefixes=CHECK-MI
 // CHECK-MI: v3:64,64,8,16,16,4,4,1,2,1,1
+
+// RUN: rocmlir-gen --arch gfx950 --operation=gemm -t f32 -g 1 -m 64 -k 128 -n 64 --num_cu=32 --emit-tuning-space=exhaustive | FileCheck %s --check-prefixes=CHECK-EXHAUSTIVE-DOUBLEBUFFER
+// CHECK-EXHAUSTIVE-DOUBLEBUFFER: v3:64,64,8,16,16,4,4,2,2,1,1
+
+// RUN: rocmlir-gen --arch gfx950 --operation=gemm -t f32 -g 1 -m 64 -k 128 -n 64 --num_cu=32 --emit-tuning-space=exhaustive | FileCheck %s --check-prefixes=CHECK-EXHAUSTIVE-DIRECTTOLDS-SINGLE
+// CHECK-EXHAUSTIVE-DIRECTTOLDS-SINGLE: v3:64,64,8,16,16,4,4,3,2,1,1
+
+// RUN: rocmlir-gen --arch gfx950 --operation=gemm -t f32 -g 1 -m 64 -k 128 -n 64 --num_cu=32 --emit-tuning-space=exhaustive | FileCheck %s --check-prefixes=CHECK-EXHAUSTIVE-DIRECTTOLDS-DOUBLE
+// CHECK-EXHAUSTIVE-DIRECTTOLDS-DOUBLE: v3:64,64,8,16,16,4,4,4,2,1,1

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -901,7 +901,7 @@ static llvm::cl::opt<F8TypesChoice> forceF8Types(
                                 "'OCP' or 'OFP8' types")),
     llvm::cl::init(F8TypesChoice::Arch));
 
-enum class GEMMScheduleVersion : int { V1 = 1, V2 = 2 };
+enum class GEMMScheduleVersion : int { V1 = 1, V2 = 2, V3 = 3, V4 = 4 };
 
 static llvm::cl::opt<GEMMScheduleVersion> gemmScheduleVersion(
     "schedule_version",
@@ -909,7 +909,9 @@ static llvm::cl::opt<GEMMScheduleVersion> gemmScheduleVersion(
         "select amongst different available scheduling strategies for GEMM"),
     llvm::cl::values(
         clEnumValN(GEMMScheduleVersion::V1, "1", "Select GEMM Schedule V1"),
-        clEnumValN(GEMMScheduleVersion::V2, "2", "Select GEMM Schedule V2")),
+        clEnumValN(GEMMScheduleVersion::V2, "2", "Select GEMM Schedule V2"),
+        clEnumValN(GEMMScheduleVersion::V3, "3", "Select GEMM Schedule V3"),
+        clEnumValN(GEMMScheduleVersion::V4, "4", "Select GEMM Schedule V4")),
     llvm::cl::init(GEMMScheduleVersion::V1));
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -454,7 +454,7 @@ VANILLA_PERF_CONFIG = itertools.product(
     # splitKFactor (exponent)
     range(0, 1),
     # scheduleVersion
-    range(1, 3)
+    range(1, 5)
 )
 
 def to_vanilla_perf_config_test(params, options: Options) -> MLIROnlyConfig:


### PR DESCRIPTION
In this PR we make the following changes to enable direct to LDS:
- rock.threadwise_read_into can store to LDS (lowers to rock.global_load_to_lds introduced in PR https://github.com/ROCm/rocMLIR/pull/1905)
- changes to allow single and double buffering with direct to LDS (merges globalLoad + LDSStore into one stage).

Note that we introduced this as 2 extra scheduling versions (single buffering + direct to LDS, double buffering + direct to LDS). But this is probably not the final version, we can remove these two in the future and make a static decision about when to use direct to LDS. 

Current limitations of this implementation:
- Backend bugs that affect performance: https://ontrack-internal.amd.com/browse/SWDEV-521121 and https://ontrack-internal.amd.com/browse/SWDEV-514726
- We only use 4-byte and 16-byte loads
- Loading from LDS will produce bank conflicts
- combination of big tensor (need to use i64 index) + conditional load => failure to compile. This might be fixed with conditional ds_stores, we need to investigate. However, I think this is low priority

Example of current performance:

batch size = 256, m = n = 16, k = 1024. Tuning params = v3:16,16,8,16,16,4,4,scheduling,2,1,1
scheduling = 1,2,3,4 (3 and 4 are direct to LDS):

|   | scheduling                  |                              | ns   |
| - | --------------------------- | ---------------------------- | ---- |
| 0 | single buff                 | v3:16,16,8,16,16,4,4,1,2,1,1 | 5380 |
| 1 | double buff                 | v3:16,16,8,16,16,4,4,2,2,1,1 | 5229 |
| 2 | single buff + direct to LDS | v3:16,16,8,16,16,4,4,3,2,1,1 | 4591 |
| 3 | double buff + direct to LDS | v3:16,16,8,16,16,4,4,4,2,1,1 | 4662 |

We can see a ~10% improvement in this particular case.

TODO:
- [x] merge https://github.com/ROCm/rocMLIR/pull/1905
- [x] add tests
- [x] measure current performance