### PR TITLE
Update Docker image to 6.4.2 rocm version

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 MAINTAINER Christopher Austen <chausten@amd.com>
 
-ARG ROCM_VERSION=6.4
+ARG ROCM_VERSION=6.4.2
 ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/${ROCM_VERSION}
 ARG AMDGPU_DEB_REPO=https://repo.radeon.com/amdgpu/${ROCM_VERSION}/ubuntu
 ARG ROCM_BUILD_NAME=jammy

--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -1,4 +1,4 @@
-ARG ROCM_VERSION=6.4
+ARG ROCM_VERSION=6.4.2
 FROM rocm/mlir:rocm${ROCM_VERSION}-latest
 ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
 


### PR DESCRIPTION
The goal is to help resolve memory access fault errors encountered during test execution. These issues previously forced us to reduce the number of threads in CI runs.