### PR TITLE
Fix Docker image tag (rocm6.4 instead of rocm6.4.2)

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -1,4 +1,4 @@
-ARG ROCM_VERSION=6.4.2
+ARG ROCM_VERSION=6.4
 FROM rocm/mlir:rocm${ROCM_VERSION}-latest
 ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
 


### PR DESCRIPTION
The Dockerfile was previously referencing a non-existent image tag: `rocm/mlir:rocm6.4.2-latest`, which causes the image build to fail. Although the `ROCM_VERSION` was set to `6.4.2`, the image being created and pushed during CI  uses the shortened version tag `rocm6.4-latest`, not `rocm6.4.2-latest` as initially expected.
Link: http://ml-ci.amd.com:21096/job/MLIR/job/rocm-docker/1653/console#:~:text=ERROR%3A%20failed%20to%20solve%3A%20rocm/mlir%3Arocm6.4.2%2Dlatest%3A%20failed%20to%20resolve%20source%20metadata%20for%20docker.io/rocm/mlir%3Arocm6.4.2%2Dlatest%3A%20docker.io/rocm/mlir%3Arocm6.4.2%2Dlatest%3A%20not%20found