### PR TITLE
tuna-script: validate tuning file for the presence of data

### DIFF
--- a/mlir/utils/tuna/tuna-script.sh
+++ b/mlir/utils/tuna/tuna-script.sh
@@ -59,13 +59,12 @@ validate_tuning_file() {
         echo "ERROR: $f has duplicate header lines next to each other!"
         exit 1
     fi
-    # NOTE: Temporarily disabled the check for data lines after the header.
-    # Existing checks
-    #data_line=$(awk 'NR>1 && $0 !~ /^\s*$/ && $0 != header {print; exit}' header="$header" "$f")
-    #if [ -z "$data_line" ]; then
-    #    echo "ERROR: $f has no data after header!"
-    #    exit 1
-    #fi
+    # Check for the presence of data after header
+    data_line=$(awk 'NR>1 && $0 !~ /^\s*$/ && $0 != header {print; exit}' header="$header" "$f")
+    if [ -z "$data_line" ]; then
+        echo "ERROR: $f has no data after header!"
+        exit 1
+    fi
 }
 
 function tuna_run


### PR DESCRIPTION
Bring back the check removed in https://github.com/ROCm/rocMLIR/commit/b1750451809cbd2d1910e558f1a754833ced617e

[PR CI Check](https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-1929/1/pipeline/391) - on which occurred error on Tune selected rocmlir configs for attention in [PR 1910](https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-1910/22/pipeline/417/) and [PR 1919](https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-1919/29/pipeline/472/) now seems to have green the Tune selected rocmlir configs phase

I will kick Weekly CI check, but even if it becomes red maybe we should merge this PR since now it will not stop PR CI Checks (still waiting for PR CI check to be finished until the end...), but will make red Weekly CI which is what we initially wanted.

Resolves https://github.com/ROCm/rocMLIR-internal/issues/1950