### PR TITLE
Fix llvm::SmallVector error on x86 MSVC

### DIFF
--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -204,8 +204,7 @@ void rock::buildKernelPipeline(OpPassManager &pm,
     funcPm.addPass(rock::createRockSugarToLoopsPass());
     funcPm.addPass(rock::createRockCleanMathPass());
     math::MathExtendToSupportedTypesOptions extendToLLVMTypesOptions;
-    SmallVector<std::string, 1> supportedFloats = {"f16"};
-    extendToLLVMTypesOptions.extraTypeStrs = supportedFloats;
+    extendToLLVMTypesOptions.extraTypeStrs = {"f16"};
     extendToLLVMTypesOptions.targetTypeStr = "f32";
     funcPm.addPass(
         math::createMathExtendToSupportedTypes(extendToLLVMTypesOptions));


### PR DESCRIPTION
extraTypeStrs is declared as `::llvm::SmallVector<std::string>`

x86 (32-bit) MSVC builds give an error assigning `SmallVector<std::string, 1>` to extraTypeStrs

We can directly set extraTypeStrs without the temporary