### PR TITLE
Use target branch for the premerge checks

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -201,7 +201,7 @@ void preMergeCheck(String codepath) {
           ln -s build/compile_commands.json compile_commands.json
         fi
         '''
-        def targetBranch = "${env.CHANGE_TARGET}"
+        def targetBranch = env.CHANGE_TARGET
         if(targetBranch == null || targetBranch == '') {
             targetBranch = "origin/develop"
         } 

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -202,7 +202,7 @@ void preMergeCheck(String codepath) {
         fi
         '''
         def targetBranch = env.CHANGE_TARGET
-        if(targetBranch == null || targetBranch == '') {
+        if (!targetBranch) {
             targetBranch = "origin/develop"
         }
         if (params.ignoreExternalLinting == true) {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -201,11 +201,15 @@ void preMergeCheck(String codepath) {
           ln -s build/compile_commands.json compile_commands.json
         fi
         '''
+        def targetBranch = ${env.CHANGE_TARGET}
+        if(targetBranch == null || targetBranch == '') {
+            targetBranch = origin/develop
+        }
         if (params.ignoreExternalLinting == true) {
-            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${params.rocMLIRTargetBranch} --ignore-external"
+            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${targetBranch} --ignore-external"
         }
         else {
-            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${params.rocMLIRTargetBranch}"
+            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${targetBranch}"
         }
     } else {
         echo "Static Test step skipped"
@@ -530,9 +534,6 @@ pipeline {
                description: 'The MIGraphX branch/commit to verify against.')
         string(name: 'CKBranch', defaultValue: 'develop',
             description: 'The Composable Kernel branch to be used with the job')
-        string(name: 'rocMLIRTargetBranch', defaultValue: 'origin/develop',
-            description: 'The target branch the PR is intended to merge with')
-
 
         // Each below control whether to run a individual stage from parallel run
         // They default to true or empty but developer can toggle them for debugging purpose

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -201,10 +201,10 @@ void preMergeCheck(String codepath) {
           ln -s build/compile_commands.json compile_commands.json
         fi
         '''
-        def targetBranch = ${env.CHANGE_TARGET}
+        def targetBranch = "${env.CHANGE_TARGET}"
         if(targetBranch == null || targetBranch == '') {
-            targetBranch = origin/develop
-        }
+            targetBranch = "origin/develop"
+        } 
         if (params.ignoreExternalLinting == true) {
             sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${targetBranch} --ignore-external"
         }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -203,13 +203,13 @@ void preMergeCheck(String codepath) {
         '''
         def targetBranch = env.CHANGE_TARGET
         if (!targetBranch) {
-            targetBranch = "origin/develop"
+            targetBranch = "develop"
         }
         if (params.ignoreExternalLinting == true) {
-            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${targetBranch} --ignore-external"
+            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=origin/${targetBranch} --ignore-external"
         }
         else {
-            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${targetBranch}"
+            sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=origin/${targetBranch}"
         }
     } else {
         echo "Static Test step skipped"

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -204,7 +204,7 @@ void preMergeCheck(String codepath) {
         def targetBranch = env.CHANGE_TARGET
         if(targetBranch == null || targetBranch == '') {
             targetBranch = "origin/develop"
-        } 
+        }
         if (params.ignoreExternalLinting == true) {
             sh "python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py --base-commit=${targetBranch} --ignore-external"
         }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -305,6 +305,7 @@ void setHeartbeat() {
 
 String getLabelFromCodepath(String codepath) {
     echo "codepath is ${codepath}"
+    def label = ''
     if (codepath == "mfma") {
         label = 'mlir && (gfx950 || gfx942 || gfx908 || gfx90a)'
     } else if (codepath == "navi21") {

--- a/mlir/utils/jenkins/static-checks/premerge-checks.py
+++ b/mlir/utils/jenkins/static-checks/premerge-checks.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
         "-b", "--base-commit",
         type=str,
         default='origin/develop',
-        help="The base commit to lint againts"
+        help="The base commit to lint against"
   )
   parser.add_argument('--ignore-external', action='store_true', default=False)
   parsed_args = parser.parse_args(args)


### PR DESCRIPTION
PRs that are targetted against release branch still use `origin/develop` branch as the base commit for premerge checks which leads to false positive formatting errors. 

This PR aim to fix that by querying target branch for a PR. If it is not a PR it will default to using origin/develop