### PR TITLE
Change SeqLen to 384 from 1 in accuracy checker scripts

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1551,8 +1551,8 @@ pipeline {
                                         dir('MIGraphX/tools/accuracy') {
                                             withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1']) {
                                                 sh 'python3 accuracy_checker.py --onnx /MIGraphXDeps/resnet50-v1-7.onnx'
-                                                sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/bert_base_cased_1.onnx'
-                                                sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/distilgpt2_1.onnx'
+                                                sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/bert_base_cased_1.onnx --input-dim input_ids:1,384'
+                                                sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/distilgpt2_1.onnx --input-dim input_ids:1,384'
                                             }
                                         }
                                     }


### PR DESCRIPTION
## Motivation

Model has seqLen of {1, 1} if not specified. This causes compilation failure in migraphx right now. https://github.com/ROCm/AMDMIGraphX/issues/4203

Our nightly CI is broken right now because of this issue. 

Compilation crash is fixed by https://github.com/ROCm/AMDMIGraphX/pull/4218 in MIGraphX. 

But seqLen of `{1, 1}` is not really a case that clients would encounter. Therefore this PR changes that to make it `{1, 384}`. 


## Technical Details

`accuracy_checker.py` script takes `--input-dim` parameter to change shapes of the input parameter of the model. 

## Test Plan

- [x] Running locally passes without any crashes. 
- [x] I'll trigger nightly CI with just MIGraphX stage. It should pass. 

## Test Result

- [x] Running locally passes. 
- [ ] Nightly CI run with MIGraphX stage [pending ](https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-1948/2/pipeline-overview/)


