### PR TITLE
Fix incorrect fusion check

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Rock/IR/CMakeLists.txt
@@ -20,6 +20,7 @@ mlir_tablegen(RockAccelTuningParamAttrInterface.h.inc -gen-attr-interface-decls)
 mlir_tablegen(RockAccelTuningParamAttrInterface.cpp.inc -gen-attr-interface-defs)
 add_public_tablegen_target(MLIRRockAccelTuningParamAttrInterfaceIncGen)
 
+add_mlir_interface(RockGemmFeaturesInterface)
 add_mlir_interface(RockGemmGemmWrapperInterface)
 add_mlir_interface(RockGemmWrapperInterface)
 add_mlir_interface(RockConvInterface)

--- a/mlir/include/mlir/Dialect/Rock/IR/GetRockInfo.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/GetRockInfo.h
@@ -52,10 +52,6 @@ inline rock::GemmFeatures intersectGemmFeatures(rock::GemmFeatures a,
 // the architecture being used, and the type of the op.
 rock::GemmFeatures getFeatures(Operation *op);
 
-// This function returns a boolean value if the underlying op has support for
-// an optional 'GemmFeatures' attribute
-bool opHasOptionalFeature(Operation *op);
-
 } // End namespace rock
 } // End namespace mlir
 #endif // MLIR_DIALECT_ROCK_IR_GETROCKINFO_H

--- a/mlir/include/mlir/Dialect/Rock/IR/Rock.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/Rock.h
@@ -82,6 +82,7 @@ constexpr int64_t maxHardwareWorkgroupSize = 1024;
 
 #include "mlir/Dialect/Rock/IR/RockAcceptingViewOpInterface.h"
 #include "mlir/Dialect/Rock/IR/RockConvInterface.h"
+#include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h"
 #include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/RockWriterOpInterface.h"

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -10,6 +10,7 @@
 #define ROCK_ATTRS
 
 include "mlir/Dialect/Rock/IR/RockBase.td"
+include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td"
 include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.td"
 include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td"
 include "mlir/Dialect/Rock/IR/RockTuningParamAttrInterface.td"

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h
@@ -1,0 +1,25 @@
+//===---- RockGemmFeaturesInterface.h - ops that wrap rock.gemm -*- C++ -*-===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2025 Advanced Micro Devices INc.
+//===----------------------------------------------------------------------===//
+//
+// This file defines RockGemmFeaturesInterface, which abstracts Rock ops for
+// which we would expect to extract GemmFeatures for.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_ROCK_IR_ROCKGEMMFEATURESINTERFACE_H
+#define MLIR_DIALECT_ROCK_IR_ROCKGEMMFEATURESINTERFACE_H
+
+#include "mlir/Dialect/Rock/IR/GemmSize.h"
+#include "mlir/IR/OpDefinition.h"
+
+#include "mlir/Dialect/Rock/IR/RockTypes.h"
+
+#include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h.inc"
+
+#endif // MLIR_DIALECT_ROCK_IR_ROCKGEMMFEATURESINTERFACE_H

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h
@@ -23,3 +23,4 @@
 #include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h.inc"
 
 #endif // MLIR_DIALECT_ROCK_IR_ROCKGEMMFEATURESINTERFACE_H
+

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h
@@ -23,4 +23,3 @@
 #include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h.inc"
 
 #endif // MLIR_DIALECT_ROCK_IR_ROCKGEMMFEATURESINTERFACE_H
-

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td
@@ -1,0 +1,41 @@
+//===------------------ RockGemmFeaturesInterface.td ----------------------===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2025 Advanced Micro Devices Inc.
+//===----------------------------------------------------------------------===//
+//
+// This file defines RockGemmFeaturesInterface, which abstracts Rock ops for
+// which we would expect to extract GemmFeatures for.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ROCK_GEMM_FEATURES_INTERFACE
+#define ROCK_GEMM_FEATURES_INTERFACE
+
+include "mlir/IR/OpBase.td"
+
+def RockGemmFeaturesInterface : OpInterface<"RockGemmFeaturesInterface"> {
+  let description = [{
+    Interface to abstract away operations for which we need to extract
+    information relating to GemmFeatures from.
+  }];
+  let cppNamespace = "::mlir::rock";
+
+  let methods = [
+    InterfaceMethod<
+        /*desc=*/[{
+          Return the type from this op that is needed to calculate GemmFeatures
+        }],
+        /*retType=*/"SmallVector<::mlir::Type>",
+        /*methodName=*/"getTypesForFeature",
+        /*args=*/(ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/""
+      >
+  ];
+}
+
+#endif // ROCK_GEMM_FEATURES_INTERFACE

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td
@@ -39,3 +39,4 @@ def RockGemmFeaturesInterface : OpInterface<"RockGemmFeaturesInterface"> {
 }
 
 #endif // ROCK_GEMM_FEATURES_INTERFACE
+

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td
@@ -1,7 +1,7 @@
 //===------------------ RockGemmFeaturesInterface.td ----------------------===//
 //
-// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2025 Advanced Micro Devices Inc.
@@ -24,19 +24,15 @@ def RockGemmFeaturesInterface : OpInterface<"RockGemmFeaturesInterface"> {
   }];
   let cppNamespace = "::mlir::rock";
 
-  let methods = [
-    InterfaceMethod<
-        /*desc=*/[{
+  let methods = [InterfaceMethod<
+      /*desc=*/[{
           Return the type from this op that is needed to calculate GemmFeatures
         }],
-        /*retType=*/"SmallVector<::mlir::Type>",
-        /*methodName=*/"getTypesForFeature",
-        /*args=*/(ins),
-        /*methodBody=*/"",
-        /*defaultImplementation=*/""
-      >
-  ];
+      /*retType=*/"SmallVector<::mlir::Type>",
+      /*methodName=*/"getTypesForFeature",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/"">];
 }
 
 #endif // ROCK_GEMM_FEATURES_INTERFACE
-

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.td
@@ -32,16 +32,6 @@ def RockGemmGemmWrapperInterface : OpInterface<"RockGemmGemmWrapperInterface"> {
   let methods = [
     InterfaceMethod<
         /*desc=*/[{
-          Return the type from this op that is needed to calculate GemmFeatures
-        }],
-        /*retType=*/"SmallVector<::mlir::Type>",
-        /*methodName=*/"getTypesForFeature",
-        /*args=*/(ins),
-        /*methodBody=*/"return {$_op.getAType(), $_op.getCType()};",
-        /*defaultImplementation=*/""
-      >,
-    InterfaceMethod<
-        /*desc=*/[{
           Return the KernelType of this op
         }],
         /*retType=*/"::mlir::rock::KernelType",

--- a/mlir/include/mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td
@@ -30,16 +30,6 @@ def RockGemmWrapperInterface : OpInterface<"RockGemmWrapperInterface"> {
   let methods = [
     InterfaceMethod<
         /*desc=*/[{
-          Return the type from this op that is needed to calculate GemmFeatures
-        }],
-        /*retType=*/"SmallVector<::mlir::Type>",
-        /*methodName=*/"getTypesForFeature",
-        /*args=*/(ins),
-        /*methodBody=*/"return {$_op.getAType()};",
-        /*defaultImplementation=*/""
-      >,
-    InterfaceMethod<
-        /*desc=*/[{
           Return the KernelType of this op
         }],
         /*retType=*/"::mlir::rock::KernelType",

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -62,12 +62,13 @@ class TensorOrMemRefOf<list<Type> allowedTypes> :
 
 class IndexArrayLength<int n> : ConfinedAttr<IndexArrayAttr, [ArrayMinCount<n>]>;
 
-class Rock_ConvOpBase<string mnemonic, list<Type> inputTypes=[F32, F16, BF16], list<Type> outputTypes=[F32, F16, BF16]> :
-    Rock_Op<mnemonic, [DeclareOpInterfaceMethods<RockGemmWrapperInterface>,
-                       DeclareOpInterfaceMethods<RockConvInterface>,
-                       DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                       DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
-                       RockFusionRoot]>{
+class Rock_ConvOpBase<string mnemonic, list<Type> inputTypes = [F32, F16, BF16],
+                      list<Type> outputTypes = [F32, F16, BF16]>
+    : Rock_Op<mnemonic, [DeclareOpInterfaceMethods<RockGemmWrapperInterface>,
+                         DeclareOpInterfaceMethods<RockConvInterface>,
+                         DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                         DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
+                         RockFusionRoot]> {
   dag commonConvArgs = (ins TensorOrMemRefOf<inputTypes>:$filter,
       TensorOrMemRefOf<inputTypes>:$input,
       TensorOrMemRefOf<outputTypes>:$output,
@@ -496,9 +497,9 @@ def Rock_TensorUntransformCastOp :
 }
 
 def Rock_GridwiseGemmOp
-    : Rock_Op<"gridwise_gemm",
-              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
-               RockFusionRoot]>,
+    : Rock_Op<"gridwise_gemm", [DeclareOpInterfaceMethods<
+                                    RockGemmFeaturesInterface>,
+                                RockFusionRoot]>,
       Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>,
                          "matrix A view", [MemRead]>:$a,
           Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
@@ -519,9 +520,9 @@ def Rock_GridwiseGemmOp
 
 // gridwise_gemm_accel
 def Rock_GridwiseGemmAccelOp
-    : Rock_Op<"gridwise_gemm_accel",
-              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
-               RockFusionRoot]>,
+    : Rock_Op<"gridwise_gemm_accel", [DeclareOpInterfaceMethods<
+                                          RockGemmFeaturesInterface>,
+                                      RockFusionRoot]>,
       Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>,
                          "matrix A view", [MemRead]>:$a,
           Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
@@ -545,7 +546,8 @@ def Rock_GridwiseAttentionAccelOp
     : Rock_Op<"gridwise_attention_accel",
               [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
                DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
-               RockFusionRoot, AttrSizedOperandSegments,]>,
+               RockFusionRoot, AttrSizedOperandSegments,
+]>,
       Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [3]>:$queries,
           MemRefRankOf<[F32, F16, BF16, I8], [3]>:$keys,
           MemRefRankOf<[F32, F16, BF16], [3]>:$values,
@@ -1360,8 +1362,8 @@ defvar AccelResTypes = [VectorOfLengthAndType<[4, 8, 16, 32], [F32, I32, F16, BF
 
 // blockwise_gemm_accel
 def Rock_BlockwiseGemmAccelOp
-    : Rock_Op<"blockwise_gemm_accel",
-              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>]>,
+    : Rock_Op<"blockwise_gemm_accel", [DeclareOpInterfaceMethods<
+                                          RockGemmFeaturesInterface>]>,
       Arguments<(ins MemRefOf<LdsBufferTypes>:$matrixA,
           MemRefOf<LdsBufferTypes>:$matrixB, I32Attr:$inMPerThread,
           I32Attr:$inNPerThread, UnitAttr:$rotateMWithK, UnitAttr:$rotateNWithK,
@@ -1409,8 +1411,8 @@ def Rock_ThreadwiseGemmOp:
 }
 // threadwise_accel_gemm
 def Rock_ThreadwiseAccelGemmOp
-    : Rock_Op<"threadwise_accel_gemm",
-              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>]>,
+    : Rock_Op<"threadwise_accel_gemm", [DeclareOpInterfaceMethods<
+                                           RockGemmFeaturesInterface>]>,
       Arguments<(ins Arg<MemRefOf<NativeMemoryOpTypes>,
                          "source register view A", [MemRead]>:$matrixA,
           Arg<MemRefOf<NativeMemoryOpTypes>,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -175,9 +175,7 @@ def Rock_GemmOp
 }
 
 def Rock_ReduceOp
-    : Rock_Op<"reduce", 
-              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
-               AllElementTypesMatch<["in", "out"]>]>,
+    : Rock_Op<"reduce", [AllElementTypesMatch<["in", "out"]>]>,
       Arguments<(
           ins Arg<TensorOrMemRefOf<[BF16, F16, F32]>, "input", [MemRead]>:$in,
           Arg<TensorOrMemRefOf<[BF16, F16, F32]>,
@@ -192,6 +190,10 @@ def Rock_ReduceOp
   }];
   let extraClassDeclaration = [{
     ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperand(1); }
+
+    SmallVector<::mlir::Type> getTypesForFeature() {
+      return {getIn().getType()};
+    }
   }];
 }
 def Rock_AttentionOp

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -15,6 +15,7 @@
 
 include "mlir/Dialect/Rock/IR/RockAttrDefs.td"
 include "mlir/Dialect/Rock/IR/RockConvInterface.td"
+include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.td"
 include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.td"
 include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.td"
 include "mlir/Dialect/Rock/IR/RockAcceptingViewOpInterface.td"
@@ -65,6 +66,7 @@ class Rock_ConvOpBase<string mnemonic, list<Type> inputTypes=[F32, F16, BF16], l
     Rock_Op<mnemonic, [DeclareOpInterfaceMethods<RockGemmWrapperInterface>,
                        DeclareOpInterfaceMethods<RockConvInterface>,
                        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                       DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
                        RockFusionRoot]>{
   dag commonConvArgs = (ins TensorOrMemRefOf<inputTypes>:$filter,
       TensorOrMemRefOf<inputTypes>:$input,
@@ -132,6 +134,7 @@ def Rock_ConvBwdWeightOp : Rock_ConvOpBase<"conv_bwd_weight">
 
 def Rock_GemmOp
     : Rock_Op<"gemm", [DeclareOpInterfaceMethods<RockGemmWrapperInterface>,
+                       DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
                        RockFusionRoot]>,
       Arguments<(
           ins Arg<TensorOrMemRefOf<GemmInputTypes>, "matrix A", [MemRead]>:$a,
@@ -172,7 +175,9 @@ def Rock_GemmOp
 }
 
 def Rock_ReduceOp
-    : Rock_Op<"reduce", [AllElementTypesMatch<["in", "out"]>]>,
+    : Rock_Op<"reduce", 
+              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
+               AllElementTypesMatch<["in", "out"]>]>,
       Arguments<(
           ins Arg<TensorOrMemRefOf<[BF16, F16, F32]>, "input", [MemRead]>:$in,
           Arg<TensorOrMemRefOf<[BF16, F16, F32]>,
@@ -187,17 +192,13 @@ def Rock_ReduceOp
   }];
   let extraClassDeclaration = [{
     ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperand(1); }
-
-    SmallVector<::mlir::Type> getTypesForFeature() {
-      SmallVector<::mlir::Type> types = {getIn().getType()};
-      return types;
-    }
   }];
 }
 def Rock_AttentionOp
     : Rock_Op<
           "attention", [DeclareOpInterfaceMethods<RockGemmGemmWrapperInterface>,
                         DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                        DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
                         RockFusionRoot, AttrSizedOperandSegments,
                         AttrSizedResultSegments]>,
       Arguments<(ins TensorOrMemRefOf<[F32, F16, BF16, I8]>:$queries,
@@ -265,6 +266,7 @@ def Rock_GemmElementwiseGemmOp
     : Rock_Op<"gemm_elementwise_gemm",
               [DeclareOpInterfaceMethods<RockGemmGemmWrapperInterface>,
                DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+               DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
                RockFusionRoot]>,
       AllElementTypesMatch<["a", "b"]>,
       Arguments<(ins TensorOrMemRefOf<[F32, F16, BF16]>:$a,
@@ -315,6 +317,7 @@ def Rock_ConvElementwiseGemmOp
     : Rock_Op<"conv_elementwise_gemm",
               [DeclareOpInterfaceMethods<RockGemmGemmWrapperInterface>,
                DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+               DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
                RockFusionRoot]>,
       AllElementTypesMatch<["filter", "input"]>,
       Arguments<(ins TensorOrMemRefOf<[F32, F16, BF16]>:$filter,
@@ -491,7 +494,9 @@ def Rock_TensorUntransformCastOp :
 }
 
 def Rock_GridwiseGemmOp
-    : Rock_Op<"gridwise_gemm", [RockFusionRoot]>,
+    : Rock_Op<"gridwise_gemm",
+              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
+               RockFusionRoot]>,
       Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>,
                          "matrix A view", [MemRead]>:$a,
           Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
@@ -508,19 +513,13 @@ def Rock_GridwiseGemmOp
     $c `=` $a `*` $b `storeMethod` `(` $storeMethod `)` (`features` `=` $features^)? attr-dict `:` type($c) `=` type($a) `*` type($b)
   }];
   let hasVerifier = 1;
-
-  // Return the type from this op that is needed to calculate GemmFeatures
-  let extraClassDeclaration = [{
-    SmallVector<::mlir::Type> getTypesForFeature() {
-      SmallVector<::mlir::Type> types = {getA().getType()};
-      return types;
-    }
-  }];
 }
 
 // gridwise_gemm_accel
 def Rock_GridwiseGemmAccelOp
-    : Rock_Op<"gridwise_gemm_accel", [RockFusionRoot]>,
+    : Rock_Op<"gridwise_gemm_accel",
+              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
+               RockFusionRoot]>,
       Arguments<(ins Arg<MemRefRankOf<GemmInputTypes, [3]>,
                          "matrix A view", [MemRead]>:$a,
           Arg<MemRefRankOf<GemmInputTypes, [3]>, "matrix B view", [MemRead]>:$b,
@@ -537,21 +536,14 @@ def Rock_GridwiseGemmAccelOp
     `(` operands `)` `storeMethod` `(` $storeMethod `)` (`features` `=` $features^)? attr-dict `:` type(operands)
   }];
   let hasVerifier = 1;
-
-  // Return the type from this op that is needed to calculate GemmFeatures
-  let extraClassDeclaration = [{
-    SmallVector<::mlir::Type> getTypesForFeature() {
-      SmallVector<::mlir::Type> types = {getA().getType()};
-      return types;
-    }
-  }];
 }
 
 // gridwise_attention_accel
 def Rock_GridwiseAttentionAccelOp
     : Rock_Op<"gridwise_attention_accel",
               [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-               RockFusionRoot, AttrSizedOperandSegments]>,
+               DeclareOpInterfaceMethods<RockGemmFeaturesInterface>,
+               RockFusionRoot, AttrSizedOperandSegments,]>,
       Arguments<(ins MemRefRankOf<[F32, F16, BF16, I8], [3]>:$queries,
           MemRefRankOf<[F32, F16, BF16, I8], [3]>:$keys,
           MemRefRankOf<[F32, F16, BF16], [3]>:$values,
@@ -576,15 +568,6 @@ def Rock_GridwiseAttentionAccelOp
     `(` operands `)` (`features` `=` $features^)? `preSoftmaxOps` `=` $preSoftmaxBody attr-dict `:` type(operands)
   }];
   let hasVerifier = 1;
-
-  // Return the type from this op that is needed to calculate GemmFeatures
-  let extraClassDeclaration = [{
-    SmallVector<::mlir::Type> getTypesForFeature() {
-      SmallVector<::mlir::Type> types = {getKeys().getType(),
-                                         getValues().getType()};
-      return types;
-    }
-  }];
 }
 
 // Memory allocation on GPU memory hierachy.
@@ -1374,7 +1357,8 @@ defvar AccelResTypes = [VectorOfLengthAndType<[4, 8, 16, 32], [F32, I32, F16, BF
 
 // blockwise_gemm_accel
 def Rock_BlockwiseGemmAccelOp
-    : Rock_Op<"blockwise_gemm_accel">,
+    : Rock_Op<"blockwise_gemm_accel",
+              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>]>,
       Arguments<(ins MemRefOf<LdsBufferTypes>:$matrixA,
           MemRefOf<LdsBufferTypes>:$matrixB, I32Attr:$inMPerThread,
           I32Attr:$inNPerThread, UnitAttr:$rotateMWithK, UnitAttr:$rotateNWithK,
@@ -1396,14 +1380,6 @@ def Rock_BlockwiseGemmAccelOp
                         $bufferB `from` $matrixB (`features` `=` $features^)? attr-dict
     `:` type($matrixC) `+` `` `=` type($bufferA) `from` type($matrixA) `*`
                                   type($bufferB) `from` type($matrixB)
-  }];
-
-  // Return the type from this op that is needed to calculate GemmFeatures
-  let extraClassDeclaration = [{
-    SmallVector<::mlir::Type> getTypesForFeature() {
-      SmallVector<::mlir::Type> types = {getMatrixA().getType()};
-      return types;
-    }
   }];
 }
 
@@ -1430,7 +1406,8 @@ def Rock_ThreadwiseGemmOp:
 }
 // threadwise_accel_gemm
 def Rock_ThreadwiseAccelGemmOp
-    : Rock_Op<"threadwise_accel_gemm">,
+    : Rock_Op<"threadwise_accel_gemm",
+              [DeclareOpInterfaceMethods<RockGemmFeaturesInterface>]>,
       Arguments<(ins Arg<MemRefOf<NativeMemoryOpTypes>,
                          "source register view A", [MemRead]>:$matrixA,
           Arg<MemRefOf<NativeMemoryOpTypes>,
@@ -1452,14 +1429,6 @@ def Rock_ThreadwiseAccelGemmOp
     `:` type($matrixC) `+` `` `=` type($matrixA) `*` type($matrixB)
   }];
   let hasVerifier = 1;
-
-  // Return the type from this op that is needed to calculate GemmFeatures
-  let extraClassDeclaration = [{
-    SmallVector<::mlir::Type> getTypesForFeature() {
-      SmallVector<::mlir::Type> types = {getMatrixA().getType()};
-      return types;
-    }
-  }];
 }
 
 // blockwise_broadcasting_reduction

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -187,6 +187,11 @@ def Rock_ReduceOp
   }];
   let extraClassDeclaration = [{
     ::mlir::OpOperand* getOutArgument() { return &(*this)->getOpOperand(1); }
+
+    SmallVector<::mlir::Type> getTypesForFeature() {
+      SmallVector<::mlir::Type> types = {getIn().getType()};
+      return types;
+    }
   }];
 }
 def Rock_AttentionOp

--- a/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
@@ -4,6 +4,7 @@ add_rocmlir_dialect_library(MLIRRockOps
   GetRockInfo.cpp
   TransformMapBuilder.cpp
   RockDialect.cpp
+  RockGemmFeaturesInterface.cpp
   RockGemmWrapperInterface.cpp
   RockGemmGemmWrapperInterface.cpp
   RockConvInterface.cpp
@@ -19,6 +20,8 @@ add_rocmlir_dialect_library(MLIRRockOps
 
   DEPENDS
   MLIRRockAttrDefsIncGen
+  MLIRRockGemmFeaturesInterfaceIncGen
+  MLIRRockGemmFeaturesInterfaceIncGen
   MLIRRockGemmWrapperInterfaceIncGen
   MLIRRockGemmGemmWrapperInterfaceIncGen
   MLIRRockTuningParamAttrInterfaceIncGen

--- a/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
@@ -21,7 +21,6 @@ add_rocmlir_dialect_library(MLIRRockOps
   DEPENDS
   MLIRRockAttrDefsIncGen
   MLIRRockGemmFeaturesInterfaceIncGen
-  MLIRRockGemmFeaturesInterfaceIncGen
   MLIRRockGemmWrapperInterfaceIncGen
   MLIRRockGemmGemmWrapperInterfaceIncGen
   MLIRRockTuningParamAttrInterfaceIncGen

--- a/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
+++ b/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
@@ -131,16 +131,6 @@ int64_t mlir::rock::getNumCUValue(Operation *op) {
   return minCU;
 }
 
-bool mlir::rock::opHasOptionalFeature(Operation *op) {
-  bool hasOptionalFeature =
-      llvm::TypeSwitch<Operation *, bool>(op)
-          .Case<RockGemmFeaturesInterface>(
-              [](auto opWithFeatures) { return true; })
-          .Default([](Operation *op) -> bool { return false; });
-
-  return hasOptionalFeature;
-}
-
 mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
   // First, check to see if the func has a 'features' attribute.
   auto func = getParentFuncOp(op);
@@ -164,7 +154,7 @@ mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
   // Get the types needed for feature calculation using TypeSwitch
   SmallVector<Type> typesForFeature =
       llvm::TypeSwitch<Operation *, SmallVector<Type>>(op)
-          .Case<RockGemmFeaturesInterface>(
+          .Case<RockGemmFeaturesInterface, rock::ReduceOp>(
               [](auto opWithFeatures) {
                 return opWithFeatures.getTypesForFeature();
               })

--- a/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
+++ b/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
@@ -153,11 +153,8 @@ mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
 
     // If the initial op is a func and there is no `features` attribute, then
     // we cannot proceed
-    if (isa<func::FuncOp>(op) || isa<gpu::GPUFuncOp>(op)) {
-      if (auto module = op->getParentOfType<mlir::ModuleOp>())
-        llvm::errs() << *module << "\n";
+    if (isa<func::FuncOp>(op) || isa<gpu::GPUFuncOp>(op))
       llvm_unreachable("Trying to get 'features' for an invalid func op");
-    }
   }
 
   // Next, check to see if the op has a 'features' attribute.
@@ -172,7 +169,8 @@ mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
       llvm::TypeSwitch<Operation *, SmallVector<Type>>(op)
           .Case<rock::GridwiseGemmOp, rock::GridwiseGemmAccelOp,
                 rock::BlockwiseGemmAccelOp, rock::ThreadwiseAccelGemmOp,
-                rock::GridwiseAttentionAccelOp, RockGemmGemmWrapperInterface,
+                rock::GridwiseAttentionAccelOp, rock::ReduceOp,
+                RockGemmGemmWrapperInterface,
                 RockGemmWrapperInterface>([](auto opWithFeatures) {
             return opWithFeatures.getTypesForFeature();
           })

--- a/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
+++ b/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
@@ -153,8 +153,11 @@ mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
 
     // If the initial op is a func and there is no `features` attribute, then
     // we cannot proceed
-    if (isa<func::FuncOp>(op) || isa<gpu::GPUFuncOp>(op))
+    if (isa<func::FuncOp>(op) || isa<gpu::GPUFuncOp>(op)) {
+      if (auto module = op->getParentOfType<mlir::ModuleOp>())
+        llvm::errs() << *module << "\n";
       llvm_unreachable("Trying to get 'features' for an invalid func op");
+    }
   }
 
   // Next, check to see if the op has a 'features' attribute.

--- a/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
+++ b/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
@@ -134,10 +134,7 @@ int64_t mlir::rock::getNumCUValue(Operation *op) {
 bool mlir::rock::opHasOptionalFeature(Operation *op) {
   bool hasOptionalFeature =
       llvm::TypeSwitch<Operation *, bool>(op)
-          .Case<rock::GridwiseGemmOp, rock::GridwiseGemmAccelOp,
-                rock::BlockwiseGemmAccelOp, rock::ThreadwiseAccelGemmOp,
-                rock::GridwiseAttentionAccelOp, RockGemmGemmWrapperInterface,
-                RockGemmWrapperInterface>(
+          .Case<RockGemmFeaturesInterface>(
               [](auto opWithFeatures) { return true; })
           .Default([](Operation *op) -> bool { return false; });
 
@@ -167,10 +164,7 @@ mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
   // Get the types needed for feature calculation using TypeSwitch
   SmallVector<Type> typesForFeature =
       llvm::TypeSwitch<Operation *, SmallVector<Type>>(op)
-          .Case<rock::GridwiseGemmOp, rock::GridwiseGemmAccelOp,
-                rock::BlockwiseGemmAccelOp, rock::ThreadwiseAccelGemmOp,
-                rock::GridwiseAttentionAccelOp, rock::ReduceOp,
-                RockGemmGemmWrapperInterface, RockGemmWrapperInterface>(
+          .Case<RockGemmFeaturesInterface>(
               [](auto opWithFeatures) {
                 return opWithFeatures.getTypesForFeature();
               })

--- a/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
+++ b/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
@@ -170,10 +170,10 @@ mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
           .Case<rock::GridwiseGemmOp, rock::GridwiseGemmAccelOp,
                 rock::BlockwiseGemmAccelOp, rock::ThreadwiseAccelGemmOp,
                 rock::GridwiseAttentionAccelOp, rock::ReduceOp,
-                RockGemmGemmWrapperInterface,
-                RockGemmWrapperInterface>([](auto opWithFeatures) {
-            return opWithFeatures.getTypesForFeature();
-          })
+                RockGemmGemmWrapperInterface, RockGemmWrapperInterface>(
+              [](auto opWithFeatures) {
+                return opWithFeatures.getTypesForFeature();
+              })
           .Default([](Operation *op) -> SmallVector<Type> {
             llvm_unreachable("Trying to get feature type on unsupported op");
           });

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/Rock/Generator/ConvGenerator.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
+#include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.h"
 #include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/RockGemmWrapperInterface.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
@@ -670,6 +671,22 @@ OpOperand *ConvBwdWeightOp::getOutArgument() {
   return &(*this)->getOpOperand(0);
 }
 
+SmallVector<mlir::Type> GemmOp::getTypesForFeature() {
+  return {getAType()};
+}
+
+SmallVector<mlir::Type> ConvOp::getTypesForFeature() {
+  return {getAType()};
+}
+
+SmallVector<mlir::Type> ConvBwdDataOp::getTypesForFeature() {
+  return {getAType()};
+}
+
+SmallVector<mlir::Type> ConvBwdWeightOp::getTypesForFeature() {
+  return {getAType()};
+}
+
 GemmSize ConvOp::getGemmSize() {
   auto sizes = ConvolutionDims::fromOp(*this);
   return GemmSize::fromConvolution(ConvOpType::Fwd, sizes);
@@ -951,6 +968,14 @@ static LogicalResult verifyGridwiseGemm(GridOp op) {
            << n << " cannot be greater than int32_max " << intMax;
 
   return success();
+}
+
+SmallVector<mlir::Type> GridwiseGemmOp::getTypesForFeature() {
+  return {getA().getType()};
+}
+
+SmallVector<mlir::Type> GridwiseGemmAccelOp::getTypesForFeature() {
+  return {getA().getType()};
 }
 
 LogicalResult GridwiseGemmOp::verify() { return verifyGridwiseGemm(*this); }
@@ -1857,6 +1882,13 @@ LogicalResult BlockwiseGemmOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// BlockwiseGemmAccelOp
+//===----------------------------------------------------------------------===//
+SmallVector<mlir::Type> BlockwiseGemmAccelOp::getTypesForFeature() {
+  return {getMatrixA().getType()};
+}
+
+//===----------------------------------------------------------------------===//
 // ThreadwiseGemmOp
 //===----------------------------------------------------------------------===//
 LogicalResult ThreadwiseGemmOp::verify() {
@@ -1878,6 +1910,10 @@ LogicalResult ThreadwiseGemmOp::verify() {
 //===----------------------------------------------------------------------===//
 // ThreadwiseAccelGemmOp
 //===----------------------------------------------------------------------===//
+SmallVector<mlir::Type> ThreadwiseAccelGemmOp::getTypesForFeature() {
+  return {getMatrixA().getType()};
+}
+
 LogicalResult ThreadwiseAccelGemmOp::verify() {
   ArrayRef<int64_t> aShape = getMatrixA().getType().getShape(),
                     bShape = getMatrixB().getType().getShape(),
@@ -1923,6 +1959,10 @@ LogicalResult GridwiseAttentionAccelOp::verify() {
         "More than 1 linalg generic op found in pre softmax fusion point.");
   }
   return success();
+}
+
+SmallVector<mlir::Type> GridwiseAttentionAccelOp::getTypesForFeature() {
+  return {getKeys().getType(), getValues().getType()};
 }
 
 void GridwiseAttentionAccelOp::getEffects(
@@ -1980,6 +2020,10 @@ void WorkitemIdOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
 //===-----------------------------------------------------===//
 // ReduceOp
 //===-----------------------------------------------------===//
+
+SmallVector<mlir::Type> ReduceOp::getTypesForFeature() {
+  return {getIn().getType()};
+}
 
 LogicalResult ReduceOp::verify() {
   APInt axis = getAxis();
@@ -2165,6 +2209,10 @@ Region &GemmElementwiseGemmOp::getPreSecondGemmRegion() {
   return getPreSecondGemmBody();
 }
 
+SmallVector<mlir::Type> GemmElementwiseGemmOp::getTypesForFeature() {
+  return {getAType(), getCType()};
+}
+
 GemmGemmSize GemmElementwiseGemmOp::getGemmGemmSize() {
   ShapedType typeA = getA().getType(), typeB = getB().getType(),
              typeC = getC().getType();
@@ -2341,6 +2389,10 @@ Region &ConvElementwiseGemmOp::getPreSecondGemmRegion() {
   return getPreSecondGemmBody();
 }
 
+SmallVector<mlir::Type> ConvElementwiseGemmOp::getTypesForFeature() {
+  return {getAType(), getCType()};
+}
+
 GemmGemmSize ConvElementwiseGemmOp::getGemmGemmSize() {
   auto strideVal = extractFromIntegerArrayAttr<int64_t>(getStrides());
   auto dilationVal = extractFromIntegerArrayAttr<int64_t>(getDilations());
@@ -2432,6 +2484,10 @@ GemmGemmSize AttentionOp::getGemmGemmSize() {
           n = dimsB[offsetB + (getKTransposed() ? 0 : 1)],
           o = dimsC[offsetC + (getVTransposed() ? 1 : 0)];
   return GemmGemmSize(g, m, k, n, o);
+}
+
+SmallVector<mlir::Type> AttentionOp::getTypesForFeature() {
+  return {getAType(), getCType()};
 }
 
 LogicalResult AttentionOp::verify() {

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -671,13 +671,9 @@ OpOperand *ConvBwdWeightOp::getOutArgument() {
   return &(*this)->getOpOperand(0);
 }
 
-SmallVector<mlir::Type> GemmOp::getTypesForFeature() {
-  return {getAType()};
-}
+SmallVector<mlir::Type> GemmOp::getTypesForFeature() { return {getAType()}; }
 
-SmallVector<mlir::Type> ConvOp::getTypesForFeature() {
-  return {getAType()};
-}
+SmallVector<mlir::Type> ConvOp::getTypesForFeature() { return {getAType()}; }
 
 SmallVector<mlir::Type> ConvBwdDataOp::getTypesForFeature() {
   return {getAType()};

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -2020,11 +2020,6 @@ void WorkitemIdOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
 //===-----------------------------------------------------===//
 // ReduceOp
 //===-----------------------------------------------------===//
-
-SmallVector<mlir::Type> ReduceOp::getTypesForFeature() {
-  return {getIn().getType()};
-}
-
 LogicalResult ReduceOp::verify() {
   APInt axis = getAxis();
   ArrayRef<int64_t> inpShape = cast<ShapedType>(getIn().getType()).getShape();

--- a/mlir/lib/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp
@@ -1,0 +1,21 @@
+//===------------------- RockGemmFeaturesInterface.cpp --------------------===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2025 Advanced Micro Devices INc.
+//===----------------------------------------------------------------------===//
+//
+// This file defines RockGemmFeaturesInterface, which abstracts Rock ops for
+// which we would expect to extract GemmFeatures for.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Rock/IR/Rock.h"
+
+namespace mlir {
+namespace rock {
+#include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp.inc"
+} // namespace rock
+} // namespace mlir

--- a/mlir/lib/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp
@@ -19,3 +19,4 @@ namespace rock {
 #include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp.inc"
 } // namespace rock
 } // namespace mlir
+

--- a/mlir/lib/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp
@@ -19,4 +19,3 @@ namespace rock {
 #include "mlir/Dialect/Rock/IR/RockGemmFeaturesInterface.cpp.inc"
 } // namespace rock
 } // namespace mlir
-

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -102,7 +102,7 @@ void AffixTuningParameters::runOnOperation() {
   // constantly needing to recompute this value at later points in the pipeline.
   SmallVector<rock::GemmFeatures> allFeatures;
   func.walk([&](Operation *op) {
-    if (rock::opHasOptionalFeature(op))
+    if (isa<RockGemmFeaturesInterface>(op))
       allFeatures.push_back(rock::getFeatures(op));
   });
 

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -216,8 +216,8 @@ LogicalResult mlir::rock::testFusionLegalityReduce(func::FuncOp func) {
                               GemmFeatures::atomic_fmax_f32))
         return WalkResult::interrupt();
     } else {
-      if (failed(validOutputAtomicAdd(outElemType,
-                                      rock::getFeatures(reduceOp))))
+      if (failed(
+              validOutputAtomicAdd(outElemType, rock::getFeatures(reduceOp))))
         return WalkResult::interrupt();
     }
     return WalkResult::advance();

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -212,11 +212,12 @@ LogicalResult mlir::rock::testFusionLegalityReduce(func::FuncOp func) {
       if (!isa<Float32Type>(outElemType))
         return WalkResult::interrupt();
 
-      if (!bitEnumContainsAll(rock::getFeatures(func),
+      if (!bitEnumContainsAll(rock::getFeatures(reduceOp),
                               GemmFeatures::atomic_fmax_f32))
         return WalkResult::interrupt();
     } else {
-      if (failed(validOutputAtomicAdd(outElemType, rock::getFeatures(func))))
+      if (failed(validOutputAtomicAdd(outElemType,
+                                      rock::getFeatures(reduceOp))))
         return WalkResult::interrupt();
     }
     return WalkResult::advance();

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -99,3 +99,4 @@ target_link_libraries(mlir-reduce-fusible-test
   MLIRCAPIGPU
   MLIRRockPipeline
 )
+

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_OPTIONAL_SOURCES
   mixr_cobj.cc
   mixr_split_k.cpp
   mixr_full.c
+  reduce_fusible.cpp
 )
 
 set(LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD})
@@ -81,5 +82,20 @@ target_link_libraries(mlir-mixr-split-k-test
   MLIRCAPIRock
   MLIRCAPIGPU
   MLIRMIGraphXPipeline
+  MLIRRockPipeline
+)
+
+add_llvm_executable(mlir-reduce-fusible-test
+  EXCLUDE_FROM_ALL
+  reduce_fusible.cpp
+  )
+llvm_update_compile_flags(mlir-reduce-fusible-test)
+
+target_link_libraries(mlir-reduce-fusible-test
+  PRIVATE
+  MLIRCAPIIR
+  MLIRCAPIRegisterRocMLIR
+  MLIRCAPIRock
+  MLIRCAPIGPU
   MLIRRockPipeline
 )

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -71,23 +71,23 @@ static bool testReduceFusible(MlirContext ctx) {
   // Parse the module from the string
   MlirStringRef moduleStr = mlirStringRefCreateFromCString(mlirModuleText);
   MlirModule moduleOp = mlirModuleCreateParse(ctx, moduleStr);
-  
+
   if (mlirModuleIsNull(moduleOp)) {
     std::cerr << "Failed to parse module" << std::endl;
     return false;
   }
-  
+
   // Create performance configuration string
   std::string perfConfigStr = "v3:64,64,16,32,32,4,4,1,2,1,1";
   MlirStringRef perfStr = mlirStringRefCreateFromCString(perfConfigStr.c_str());
-  
+
   // Test whether the module is fusible
   const bool isFusible = mlirIsModuleFusible(moduleOp, perfStr);
   std::cout << "is fusible: " << isFusible << std::endl;
-  
+
   // Clean up
   mlirModuleDestroy(moduleOp);
-  
+
   return true;
 }
 int main(int argc, char *argv[]) {
@@ -102,10 +102,10 @@ int main(int argc, char *argv[]) {
 
   // Test the module fusibility
   bool isOk = testReduceFusible(ctx);
-  
+
   // Clean up
   mlirContextDestroy(ctx);
-  
+
   if (!isOk) {
     printf("FAILED!\n");
     return 1;

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -113,3 +113,4 @@ int main(int argc, char *argv[]) {
 
   return 0;
 }
+

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -113,4 +113,3 @@ int main(int argc, char *argv[]) {
 
   return 0;
 }
-

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -1,0 +1,113 @@
+// Check that we can properly use `mlirIsModuleFusible` on ReduceOps without
+// having GemmFeatures set on the func
+
+// RUN: mlir-reduce-fusible-test 2>&1 | FileCheck %s --check-prefix=REDUCE_FUSIBLE
+
+// REDUCE_FUSIBLE: is fusible: 0
+
+#include "mlir-c/Dialect/Rock.h"
+#include "mlir-c/RegisterRocMLIR.h"
+
+#include <iostream>
+#include <string>
+
+static bool testReduceFusible(MlirContext ctx) {
+  // clang-format off
+  const char *mlirModuleText = R"mlir(
+    module {
+      func.func @mlir_convolution_reshape_reshape_broadcast_add_mul_reshape_reduce_sum_reshape_mul_mul_reshape_reduce_sum_reshape(%arg0: memref<32768xf32>, %arg1: memref<11520xf32>, %arg2: memref<320xf32>, %arg3: memref<64xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32}, %arg4: memref<64xf32> {mhal.read_access, rock.prefill = 0.000000e+00 : f32}, %arg5: memref<2621440xf32>) attributes {arch = "gfx942:sramecc+:xnack-", enable_splitk_for_tuning, kernel = "mixr", num_cu = 304 : i64} {
+        %cst = arith.constant 2.44140629E-5 : f32
+        %0 = rock.transform %arg1 by <affine_map<(d0, d1, d2, d3) -> (((d0 * 4 + d1) * 3 + d2) * 3 + d3)> by [<Unmerge{320, 4, 3, 3} ["exp0", "exp1", "exp2", "exp3"] at [0, 1, 2, 3] -> ["dim0"] at [0]>] bounds = [320, 4, 3, 3] -> [11520]> : memref<11520xf32> to memref<320x4x3x3xf32>
+        %1 = rock.transform %arg0 by <affine_map<(d0, d1, d2, d3) -> (((d0 * 4 + d1) * 64 + d2) * 64 + d3)> by [<Unmerge{2, 4, 64, 64} ["exp0", "exp1", "exp2", "exp3"] at [0, 1, 2, 3] -> ["dim0"] at [0]>] bounds = [2, 4, 64, 64] -> [32768]> : memref<32768xf32> to memref<2x4x64x64xf32>
+        %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x320x64x64xf32>
+        %2 = rock.transform %1 by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 4 + d2, d3, d4)> by [<PassThrough ["n", "h", "w"] at [0, 3, 4] -> ["n", "h", "w"] at [0, 2, 3]>, <Unmerge{1, 4} ["g", "c"] at [1, 2] -> ["c"] at [1]>] bounds = [2, 1, 4, 64, 64] -> [2, 4, 64, 64]> : memref<2x4x64x64xf32> to memref<2x1x4x64x64xf32>
+        %3 = rock.transform %0 by <affine_map<(d0, d1, d2, d3, d4) -> (d0 * 320 + d1, d2, d3, d4)> by [<PassThrough ["c", "y", "x"] at [2, 3, 4] -> ["c", "y", "x"] at [1, 2, 3]>, <Unmerge{1, 320} ["g", "k"] at [0, 1] -> ["k"] at [0]>] bounds = [1, 320, 4, 3, 3] -> [320, 4, 3, 3]> : memref<320x4x3x3xf32> to memref<1x320x4x3x3xf32>
+        %4 = rock.transform %alloc by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 320 + d2, d3, d4)> by [<PassThrough ["n", "h", "w"] at [0, 3, 4] -> ["n", "h", "w"] at [0, 2, 3]>, <Unmerge{1, 320} ["g", "k"] at [1, 2] -> ["k"] at [1]>] bounds = [2, 1, 320, 64, 64] -> [2, 320, 64, 64]> : memref<2x320x64x64xf32> to memref<2x1x320x64x64xf32>
+        %5 = rock.transform %3 by <affine_map<(d0, d1, d2, d3, d4) -> (d3, d0, d1, d2, d4)> by [<PassThrough ["dim1", "dim2", "dim3", "dim0", "dim4"] at [0, 1, 2, 3, 4] -> ["dim1", "dim2", "dim3", "dim0", "dim4"] at [1, 2, 3, 0, 4]>] bounds = [320, 4, 3, 1, 3] -> [1, 320, 4, 3, 3]> : memref<1x320x4x3x3xf32> to memref<320x4x3x1x3xf32>
+        %6 = rock.transform %2 by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d1, d2, d4)> by [<PassThrough ["dim0", "dim2", "dim3", "dim1", "dim4"] at [0, 1, 2, 3, 4] -> ["dim0", "dim2", "dim3", "dim1", "dim4"] at [0, 2, 3, 1, 4]>] bounds = [2, 4, 64, 1, 64] -> [2, 1, 4, 64, 64]> : memref<2x1x4x64x64xf32> to memref<2x4x64x1x64xf32>
+        rock.conv(%3, %2, %4) {dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "gi", "ci", "hi", "wi"], output_layout = ["no", "go", "ko", "ho", "wo"], padding = [1 : index, 1 : index, 1 : index, 1 : index], strides = [1 : index, 1 : index]} : memref<1x320x4x3x3xf32>, memref<2x1x4x64x64xf32>, memref<2x1x320x64x64xf32>
+        %7 = rock.transform %alloc by <affine_map<(d0, d1, d2, d3, d4) -> (d0, d1 * 10 + d2, d3, d4)> by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <Unmerge{32, 10} ["exp1", "exp2"] at [1, 2] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [3] -> ["dim2"] at [2]>, <PassThrough ["dim3"] at [4] -> ["dim3"] at [3]>] bounds = [2, 32, 10, 64, 64] -> [2, 320, 64, 64]> : memref<2x320x64x64xf32> to memref<2x32x10x64x64xf32>
+        %8 = rock.transform %arg2 by <affine_map<(d0, d1, d2, d3, d4) -> (d1 * 10 + d2)> by [<Unmerge{32, 10} ["exp1", "exp2"] at [1, 2] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>, <AddDim{1} ["unit3"] at [3] -> [] at []>, <AddDim{1} ["unit4"] at [4] -> [] at []>] bounds = [1, 32, 10, 1, 1] -> [320]> : memref<320xf32> to memref<1x32x10x1x1xf32>
+        %9 = rock.transform %8 by <affine_map<(d0, d1, d2, d3, d4) -> (0, d1, d2, 0, 0)> by [<Broadcast{1} ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [2]>, <Broadcast{1} ["dim3"] at [3] -> ["dim3"] at [3]>, <Broadcast{1} ["dim4"] at [4] -> ["dim4"] at [4]>] bounds = [2, 32, 10, 64, 64] -> [1, 32, 10, 1, 1]> : memref<1x32x10x1x1xf32> to memref<2x32x10x64x64xf32>
+        %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x32x10x64x64xf32>
+        linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%7, %9 : memref<2x32x10x64x64xf32>, memref<2x32x10x64x64xf32>) outs(%alloc_0 : memref<2x32x10x64x64xf32>) {
+        ^bb0(%in: f32, %in_5: f32, %out: f32):
+        %15 = arith.addf %in, %in_5 : f32
+        linalg.yield %15 : f32
+        }
+        %10 = rock.transform %alloc_0 by <affine_map<(d0) -> (d0 floordiv 1310720, (d0 mod 1310720) floordiv 40960, (d0 mod 40960) floordiv 4096, (d0 mod 4096) floordiv 64, d0 mod 64)> by [<Merge{2, 32, 10, 64, 64} ["dim0"] at [0] -> ["col0", "col1", "col2", "col3", "col4"] at [0, 1, 2, 3, 4]>] bounds = [2621440] -> [2, 32, 10, 64, 64]> : memref<2x32x10x64x64xf32> to memref<2621440xf32>
+        %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x32x10x64x64xf32>
+        linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%alloc_0 : memref<2x32x10x64x64xf32>) outs(%alloc_1 : memref<2x32x10x64x64xf32>) {
+        ^bb0(%in: f32, %out: f32):
+        %15 = arith.mulf %in, %cst : f32
+        linalg.yield %15 : f32
+        }
+        %11 = rock.transform %alloc_1 by <affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 4096, (d2 mod 4096) floordiv 64, d2 mod 64)> by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Merge{10, 64, 64} ["dim2"] at [2] -> ["col2", "col3", "col4"] at [2, 3, 4]>] bounds = [2, 32, 40960] -> [2, 32, 10, 64, 64]> : memref<2x32x10x64x64xf32> to memref<2x32x40960xf32>
+        %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<2x32x1xf32>
+        rock.reduce  sum %11 into %alloc_2 {axis = 2 : index, blockSize = 256 : i32, gridSize = 6080 : i32} : memref<2x32x40960xf32> into memref<2x32x1xf32>
+        %12 = rock.transform %alloc_2 by <affine_map<(d0) -> (d0 floordiv 32, d0 mod 32, 0)> by [<Merge{2, 32, 1} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [64] -> [2, 32, 1]> : memref<2x32x1xf32> to memref<64xf32>
+        %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<2x32x10x64x64xf32>
+        linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%alloc_0 : memref<2x32x10x64x64xf32>) outs(%alloc_3 : memref<2x32x10x64x64xf32>) {
+        ^bb0(%in: f32, %out: f32):
+        %15 = arith.mulf %in, %in : f32
+        %16 = arith.mulf %15, %cst : f32
+        linalg.yield %16 : f32
+        }
+        %13 = rock.transform %alloc_3 by <affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 4096, (d2 mod 4096) floordiv 64, d2 mod 64)> by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Merge{10, 64, 64} ["dim2"] at [2] -> ["col2", "col3", "col4"] at [2, 3, 4]>] bounds = [2, 32, 40960] -> [2, 32, 10, 64, 64]> : memref<2x32x10x64x64xf32> to memref<2x32x40960xf32>
+        %alloc_4 = memref.alloc() {alignment = 64 : i64} : memref<2x32x1xf32>
+        rock.reduce  sum %13 into %alloc_4 {axis = 2 : index, blockSize = 256 : i32, gridSize = 6080 : i32} : memref<2x32x40960xf32> into memref<2x32x1xf32>
+        %14 = rock.transform %alloc_4 by <affine_map<(d0) -> (d0 floordiv 32, d0 mod 32, 0)> by [<Merge{2, 32, 1} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [64] -> [2, 32, 1]> : memref<2x32x1xf32> to memref<64xf32>
+        memref.copy %12, %arg3 : memref<64xf32> to memref<64xf32>
+        memref.copy %14, %arg4 : memref<64xf32> to memref<64xf32>
+        memref.copy %10, %arg5 : memref<2621440xf32> to memref<2621440xf32>
+        return
+      }
+    }
+    )mlir";
+  // clang-format on
+
+  // Parse the module from the string
+  MlirStringRef moduleStr = mlirStringRefCreateFromCString(mlirModuleText);
+  MlirModule moduleOp = mlirModuleCreateParse(ctx, moduleStr);
+  
+  if (mlirModuleIsNull(moduleOp)) {
+    std::cerr << "Failed to parse module" << std::endl;
+    return false;
+  }
+  
+  // Create performance configuration string
+  std::string perfConfigStr = "v3:64,64,16,32,32,4,4,1,2,1,1";
+  MlirStringRef perfStr = mlirStringRefCreateFromCString(perfConfigStr.c_str());
+  
+  // Test whether the module is fusible
+  const bool isFusible = mlirIsModuleFusible(moduleOp, perfStr);
+  std::cout << "is fusible: " << isFusible << std::endl;
+  
+  // Clean up
+  mlirModuleDestroy(moduleOp);
+  
+  return true;
+}
+int main(int argc, char *argv[]) {
+  // Create MLIR context and register dialects
+  MlirContext ctx = mlirContextCreate();
+  MlirDialectRegistry registry = mlirDialectRegistryCreate();
+  mlirRegisterRocMLIRDialects(registry);
+  mlirRegisterRocMLIRPasses();
+  mlirContextAppendDialectRegistry(ctx, registry);
+  mlirContextLoadAllAvailableDialects(ctx);
+  mlirDialectRegistryDestroy(registry);
+
+  // Test the module fusibility
+  bool isOk = testReduceFusible(ctx);
+  
+  // Clean up
+  mlirContextDestroy(ctx);
+  
+  if (!isOk) {
+    printf("FAILED!\n");
+    return 1;
+  }
+
+  return 0;
+}

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -85,10 +85,7 @@ static bool testReduceFusible(MlirContext ctx) {
   // Clean up
   mlirModuleDestroy(moduleOp);
 
-  if (!isFusible)
-    return true;
-
-  return false;
+  return !isFusible;
 }
 int main(int argc, char *argv[]) {
   // Create MLIR context and register dialects

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -1,7 +1,8 @@
 // Check that we can properly use `mlirIsModuleFusible` on ReduceOps without
 // having GemmFeatures set on the func
 
-// RUN: mlir-reduce-fusible-test 2>&1 | FileCheck %s --check-prefix=REDUCE_FUSIBLE
+// RUN: mlir-reduce-fusible-test 2>&1 | FileCheck %s
+// --check-prefix=REDUCE_FUSIBLE
 
 // REDUCE_FUSIBLE: is fusible: 0
 
@@ -69,23 +70,23 @@ static bool testReduceFusible(MlirContext ctx) {
   // Parse the module from the string
   MlirStringRef moduleStr = mlirStringRefCreateFromCString(mlirModuleText);
   MlirModule moduleOp = mlirModuleCreateParse(ctx, moduleStr);
-  
+
   if (mlirModuleIsNull(moduleOp)) {
     std::cerr << "Failed to parse module" << std::endl;
     return false;
   }
-  
+
   // Create performance configuration string
   std::string perfConfigStr = "v3:64,64,16,32,32,4,4,1,2,1,1";
   MlirStringRef perfStr = mlirStringRefCreateFromCString(perfConfigStr.c_str());
-  
+
   // Test whether the module is fusible
   const bool isFusible = mlirIsModuleFusible(moduleOp, perfStr);
   std::cout << "is fusible: " << isFusible << std::endl;
-  
+
   // Clean up
   mlirModuleDestroy(moduleOp);
-  
+
   return true;
 }
 int main(int argc, char *argv[]) {
@@ -100,10 +101,10 @@ int main(int argc, char *argv[]) {
 
   // Test the module fusibility
   bool isOk = testReduceFusible(ctx);
-  
+
   // Clean up
   mlirContextDestroy(ctx);
-  
+
   if (!isOk) {
     printf("FAILED!\n");
     return 1;

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -2,10 +2,8 @@
 // having GemmFeatures set on the func
 
 // clang-format off
-// RUN: mlir-reduce-fusible-test 2>&1 | FileCheck %s --check-prefix=REDUCE_FUSIBLE
+// RUN: mlir-reduce-fusible-test
 // clang-format on
-
-// REDUCE_FUSIBLE: is fusible: 0
 
 #include "mlir-c/Dialect/Rock.h"
 #include "mlir-c/RegisterRocMLIR.h"
@@ -83,12 +81,14 @@ static bool testReduceFusible(MlirContext ctx) {
 
   // Test whether the module is fusible
   const bool isFusible = mlirIsModuleFusible(moduleOp, perfStr);
-  std::cout << "is fusible: " << isFusible << std::endl;
-
+ 
   // Clean up
   mlirModuleDestroy(moduleOp);
 
-  return true;
+  if (!isFusible)
+    return true;
+
+  return false;
 }
 int main(int argc, char *argv[]) {
   // Create MLIR context and register dialects
@@ -107,7 +107,7 @@ int main(int argc, char *argv[]) {
   mlirContextDestroy(ctx);
 
   if (!isOk) {
-    printf("FAILED!\n");
+    std::cout << "FAILED!" << std::endl;
     return 1;
   }
 

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -1,8 +1,9 @@
 // Check that we can properly use `mlirIsModuleFusible` on ReduceOps without
 // having GemmFeatures set on the func
 
-// RUN: mlir-reduce-fusible-test 2>&1 | FileCheck %s
-// --check-prefix=REDUCE_FUSIBLE
+// clang-format off
+// RUN: mlir-reduce-fusible-test 2>&1 | FileCheck %s --check-prefix=REDUCE_FUSIBLE
+// clang-format on
 
 // REDUCE_FUSIBLE: is fusible: 0
 
@@ -70,23 +71,23 @@ static bool testReduceFusible(MlirContext ctx) {
   // Parse the module from the string
   MlirStringRef moduleStr = mlirStringRefCreateFromCString(mlirModuleText);
   MlirModule moduleOp = mlirModuleCreateParse(ctx, moduleStr);
-
+  
   if (mlirModuleIsNull(moduleOp)) {
     std::cerr << "Failed to parse module" << std::endl;
     return false;
   }
-
+  
   // Create performance configuration string
   std::string perfConfigStr = "v3:64,64,16,32,32,4,4,1,2,1,1";
   MlirStringRef perfStr = mlirStringRefCreateFromCString(perfConfigStr.c_str());
-
+  
   // Test whether the module is fusible
   const bool isFusible = mlirIsModuleFusible(moduleOp, perfStr);
   std::cout << "is fusible: " << isFusible << std::endl;
-
+  
   // Clean up
   mlirModuleDestroy(moduleOp);
-
+  
   return true;
 }
 int main(int argc, char *argv[]) {
@@ -101,10 +102,10 @@ int main(int argc, char *argv[]) {
 
   // Test the module fusibility
   bool isOk = testReduceFusible(ctx);
-
+  
   // Clean up
   mlirContextDestroy(ctx);
-
+  
   if (!isOk) {
     printf("FAILED!\n");
     return 1;

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -94,6 +94,7 @@ set(ROCMLIR_TEST_DEPENDS
   mlir-mixr-capi-test
   mlir-mixr-fullc-test
   mlir-mixr-split-k-test
+  mlir-reduce-fusible-test
 )
 
 list(APPEND ROCMLIR_TEST_DEPENDS

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1534,7 +1534,7 @@ pipeline {
                                     ]) {
                                         dir('MIGraphX/build') {
                                             timeout(time: 120, activity: true, unit: 'MINUTES') {
-                                                withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1']) {
+                                                withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1', 'MIGRAPHX_ENABLE_EXTRA_MLIR=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1', 'MIGRAPHX_ENABLE_SPLIT_REDUCE=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1']) {
                                                     // run test_verify for accuracy and run MLIR related unit-tests
                                                     sh 'make -j$(nproc) test_verify test_gpu_mlir test_gpu_fuse_mlir'
                                                     // Verify ResNet50, Bert, Gpt2
@@ -1549,7 +1549,7 @@ pipeline {
                                         }
                                         //Accuracy_checker will compare outputs from MIGraphX and onnx runtime
                                         dir('MIGraphX/tools/accuracy') {
-                                            withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1']) {
+                                            withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1', 'MIGRAPHX_ENABLE_EXTRA_MLIR=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1', 'MIGRAPHX_ENABLE_SPLIT_REDUCE=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1']) {
                                                 sh 'python3 accuracy_checker.py --onnx /MIGraphXDeps/resnet50-v1-7.onnx'
                                                 sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/bert_base_cased_1.onnx --input-dim input_ids:1,384'
                                                 sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/distilgpt2_1.onnx --input-dim input_ids:1,384'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1534,7 +1534,7 @@ pipeline {
                                     ]) {
                                         dir('MIGraphX/build') {
                                             timeout(time: 120, activity: true, unit: 'MINUTES') {
-                                                withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1', 'MIGRAPHX_ENABLE_EXTRA_MLIR=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1', 'MIGRAPHX_ENABLE_SPLIT_REDUCE=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1']) {
+                                                withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1', 'MIGRAPHX_ENABLE_EXTRA_MLIR=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1', 'MIGRAPHX_ENABLE_SPLIT_REDUCE=1']) {
                                                     // run test_verify for accuracy and run MLIR related unit-tests
                                                     sh 'make -j$(nproc) test_verify test_gpu_mlir test_gpu_fuse_mlir'
                                                     // Verify ResNet50, Bert, Gpt2
@@ -1549,7 +1549,7 @@ pipeline {
                                         }
                                         //Accuracy_checker will compare outputs from MIGraphX and onnx runtime
                                         dir('MIGraphX/tools/accuracy') {
-                                            withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1', 'MIGRAPHX_ENABLE_EXTRA_MLIR=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1', 'MIGRAPHX_ENABLE_SPLIT_REDUCE=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1']) {
+                                            withEnv(['MIGRAPHX_MLIR_USE_SPECIFIC_OPS=convolution,fused,dot,attention', 'MIGRAPHX_ENABLE_MLIR_INPUT_FUSION=1', 'MIGRAPHX_ENABLE_MLIR_REDUCE_FUSION=1', 'MIGRAPHX_MLIR_ENABLE_SPLITK=1', 'MIGRAPHX_ENABLE_EXTRA_MLIR=1', 'MIGRAPHX_DISABLE_LAYERNORM_FUSION=1', 'MIGRAPHX_ENABLE_SPLIT_REDUCE=1']) {
                                                 sh 'python3 accuracy_checker.py --onnx /MIGraphXDeps/resnet50-v1-7.onnx'
                                                 sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/bert_base_cased_1.onnx --input-dim input_ids:1,384'
                                                 sh 'python3 accuracy_checker.py --fill1 --onnx /MIGraphXDeps/distilgpt2_1.onnx --input-dim input_ids:1,384'


### PR DESCRIPTION
## Motivation

There is currently a failure with how we calculate `GemmFeatures` on ops that leads to an error in MIGraphX. See parent issue: https://github.com/ROCm/rocMLIR-internal/issues/1961

## Technical Details

In `AffixTuningParameters` we will calculate the `GemmFeatures` based on the ops in the func, at which point we will then write this as an attribute to the func. The problem with this is that MIGraphX, and other users of rocMLIR, could query `isModuleFusible` at any point, potentially before AffixTuningParameters has run. This is perfectly legal behavior, but there was a bug in fusionUtils that expected the `GemmFeatures` to have already been written to the func when `isModuleFusible` was called. 

The fix for this that I came up with was to call `rock::getFeatures` directly on ReduceOps and teach `getFeatures` how to handle these ops.

I also added in a new CAPI test as we seemingly did not have one testing fusibility of reduce ops.

## Test Plan

- Add new isModuleFusible test for ReduceOps
- rocMLIR LIT tests
- Failing MIGraphX job (test_conv* tests)

## Test Result

- [x] rocMLIR LIT tests
- [x] Failing MIGraphX job (test_conv* tests)
  - Additionally ran all of the MLIR Debug tests just to sanity check


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
