### PR TITLE
Update mixr-gemm-gemm tests for unsupported arch

### DIFF
--- a/mlir/test/fusion/e2e/lit.local.cfg
+++ b/mlir/test/fusion/e2e/lit.local.cfg
@@ -3,3 +3,5 @@
 if not config.enable_rock_driver_any_e2e_test or config.no_AMD_GPU:
   config.unsupported = True
 
+if not config.arch_support_mfma and not config.arch_support_wmma:
+  config.excludes = ['mixr-gemm-gemm']

--- a/mlir/test/fusion/e2e/lit.local.cfg
+++ b/mlir/test/fusion/e2e/lit.local.cfg
@@ -5,3 +5,4 @@ if not config.enable_rock_driver_any_e2e_test or config.no_AMD_GPU:
 
 if not config.arch_support_mfma and not config.arch_support_wmma:
   config.excludes = ['mixr-gemm-gemm']
+

--- a/mlir/test/fusion/e2e/mixr-gemm-gemm/lit.local.cfg
+++ b/mlir/test/fusion/e2e/mixr-gemm-gemm/lit.local.cfg
@@ -1,3 +1,0 @@
-if not config.arch_support_mfma and not config.arch_support_wmma:
-  config.unsupported = True
-


### PR DESCRIPTION
## Motivation

This PR addresses the issue identified in Navi2X LIT tests: https://github.com/ROCm/rocMLIR-internal/issues/1976

## Technical Details

The `lit.local.cfg` that was added for mixr-gemm-gemm tests (found here: mlir/test/fusion/e2e/mixr-gemm-gemm/lit.local.cfg) wasn't properly being picked up by the LIT test infrastructure. This was leading to the `config.unsupported` not being run, and the two tests mentioned in the issue failing. The fix for this is to update mlir/test/fusion/e2e/lit.local.cfg so that we are using `config.excludes` to not run the entire directory of mixr-gemm-gemm tests.

## Test Plan

- [x] LIT tests on Navi2X
- [x] LIT tests on the CI

## Test Result

- [x] LIT tests on Navi2X
- [x] LIT tests on the CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
