### PR TITLE
CI: Add Retry Logic for SCM Network Failures

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -60,36 +60,60 @@ void gitHealthCheck() {
 
 // Retry checkout without shallow clone if GitSCM chokes on a specific SHA
 void robustScmCheckout() {
-    try {
-        checkout scm
-        return
-    } catch (err) {
-        def msg = "${err}".toLowerCase()
-        if (!msg.contains("reference is not a tree")) {
-            echo "[SCM] Default checkout failed: ${err}"
-            throw err
-        }
-        echo "[SCM] Default checkout failed: ${err}. Retrying with robust scmcheckout"
-        // Build a non-shallow GitSCM pointed at the same repo/ref
-        String repo = scm?.userRemoteConfigs?.getAt(0)?.url
-        String cred = scm?.userRemoteConfigs?.getAt(0)?.credentialsId
-        String ref  = env.CHANGE_ID ? "refs/pull/${env.CHANGE_ID}/head"
-                   : env.BRANCH_NAME ? "refs/heads/${env.BRANCH_NAME}"
-                   : "HEAD"
+    int maxAttempts = 2
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            // This inner 'try' handles the "reference is not a tree" fallback
+            try {
+                echo "[SCM] Attempting checkout (${attempt}/${maxAttempts})..."
+                checkout scm
+                echo "[SCM] Checkout successful"
+                // If checkout succeeds, exit the function immediately
+                return
+            } catch (err) {
+                def msg = "${err}".toLowerCase()
+                if (!msg.contains("reference is not a tree")) {
+                    // If it's not the "reference is not a tree" error, re-throw it to be caught by the outer block
+                    throw err
+                }
 
-        // Map-based GitSCM (no shallow), honoring the ref we want
-        def deepScm = [
-          $class: 'GitSCM',
-          userRemoteConfigs: [[url: repo, credentialsId: cred,
-                               refspec: "+${ref}:${ref}"]],
-          branches: [[name: ref]],
-          doGenerateSubmoduleConfigurations: false,
-          extensions: [
-            [$class: 'CloneOption', depth: 0, shallow: false, noTags: false, honorRefspec: true],
-            [$class: 'CheckoutOption', timeout: 20]
-          ]
-        ]
-        checkout(deepScm)
+                // This is the fallback logic for the "reference is not a tree" error
+                echo "[SCM] Default checkout failed: ${err}. Retrying ONCE with robust deep clone"
+                String repo = scm?.userRemoteConfigs?.getAt(0)?.url
+                String cred = scm?.userRemoteConfigs?.getAt(0)?.credentialsId
+                String ref  = env.CHANGE_ID ? "refs/pull/${env.CHANGE_ID}/head"
+                                          : env.BRANCH_NAME ? "refs/heads/${env.BRANCH_NAME}"
+                                          : "HEAD"
+                
+                def deepScm = [
+                    $class: 'GitSCM',
+                    userRemoteConfigs: [[url: repo, credentialsId: cred, refspec: "+${ref}:${ref}"]],
+                    branches: [[name: ref]],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [
+                        [$class: 'CloneOption', depth: 0, shallow: false, noTags: false, honorRefspec: true],
+                        [$class: 'CheckoutOption', timeout: 20]
+                    ]
+                ]
+                checkout(deepScm)
+                echo "[SCM] Deep clone checkout successful."
+                // If the deep clone succeeds, exit the function
+                return
+            }
+        } catch (err) {
+            // This outer 'catch' block is specifically for retrying network errors
+            def msg = "${err}".toLowerCase()
+            if (msg.contains("connection reset by peer") && attempt < maxAttempts) {
+                echo "[SCM] Attempt ${attempt}/${maxAttempts} failed due to a network error."
+                echo "[SCM] Waiting 2 minutes before retrying..."
+                sleep(time: 2, unit: 'MINUTES')
+                // The loop will now continue to the next attempt.
+            } else {
+                // This is either not a network error, or it was the final attempt. Fail the build
+                echo "[SCM] Unrecoverable SCM error after ${attempt} attempt(s)."
+                throw err
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Problem
The CI pipeline is occasionally failing during the initial SCM checkout phase due to transient network errors, specifically Connection reset by peer. This causes the entire build to fail unnecessarily, impacting CI stability.
### Solution
This PR introduces a retry mechanism to the `robustScmCheckout` function to make it more resilient to these temporary network issues.
### Key Changes
- The entire checkout process is now wrapped in a retry loop that will attempt the checkout up to 2 times.
- If a `connection reset by peer` error is detected, the job will wait for 2 minutes before making the next attempt.
- This change is isolated to network failures and preserves the existing fallback for the `reference is not a tree` error. That logic will now execute within each retry attempt.