### PR TITLE
CI: Enable Fail-Fast for Parallel Pipeline Stages

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -634,6 +634,7 @@ def withHealthyNode(String baseLabel, Closure<?> healthChecks, Closure<?> body, 
 
 pipeline {
     agent none
+    options { parallelsAlwaysFailFast() }
     parameters {
         // Below should be set statically by Jenkins job
         booleanParam(name: 'nightly', defaultValue: params.nightly ? true : false,


### PR DESCRIPTION
### Validation
Failed fast, releasing agents to be used in other places: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/view/change-requests/job/PR-1962/6/pipeline-overview/

### Motivation
Currently, when a job within a parallel matrix stage fails, the other parallel jobs continue their execution. This is inefficient as it occupies CI agents for extended periods, sometimes hours for long-running jobs like `Tuning` or `parameterSweeps` on a build that is already confirmed to be failing. This wastes valuable server resources and delays feedback to developers.
### Changes Implemented
This PR introduces an "early exit" or "fail-fast" behavior for the entire pipeline. This is achieved by adding the global pipeline option `parallelsAlwaysFailFast()` to the Jenkinsfile.
With this change, as soon as any single job in a matrix fails, Jenkins will immediately terminate all other running and pending jobs within that same matrix.
### Benefits
- **Resource Efficiency:** Frees up CI agents much sooner, making them available for other builds and reducing queue times.
- **Faster Feedback:** Developers are notified of build failures more quickly without waiting for long, unnecessary stages to complete.
- **Cost Savings:** Reduces overall computation time spent on builds that are destined to fail.