### PR TITLE
CI: Add Inactivity Timeout for Agent Allocation

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -3,6 +3,9 @@
 import groovy.transform.Field
 import java.util.concurrent.ConcurrentHashMap
 
+// The timeout for node allocation in minutes
+int NODE_ALLOCATION_TIMEOUT = 80
+
 // ConcurrentHashMap helps when we need to write variables in parallel
 // one instance for the whole run
 @Field
@@ -629,25 +632,27 @@ def withHealthyNode(String baseLabel, Closure<?> healthChecks, Closure<?> body, 
         blacklist.each { expr.append(' && !').append(it) }
 
         echo "[withHealthyNode] attempt #${attempt}: looking for '${expr}'"
-        node(expr.toString()) {
-            // Retry ONLY the health-check. We don't want to retry the actual stages
-            try {
-                stage("Health checks on ${env.NODE_NAME}") {
-                    healthChecks()
-                    gitHealthCheck()
+        timeout(time: NODE_ALLOCATION_TIMEOUT, unit: 'MINUTES', activity: true) {
+            node(expr.toString()) {
+                // Retry ONLY the health-check. We don't want to retry the actual stages
+                try {
+                    stage("Health checks on ${env.NODE_NAME}") {
+                        healthChecks()
+                        gitHealthCheck()
+                    }
+                } catch (Exception err) {
+                    echo "[withHealthyNode] ❌  ${env.NODE_NAME} rejected: ${err}"
+                    blacklist << env.NODE_NAME
+                    // return exits the node {} block here, not the whole function. Some groovy magic
+                    return
                 }
-            } catch (Exception err) {
-                echo "[withHealthyNode] ❌  ${env.NODE_NAME} rejected: ${err}"
-                blacklist << env.NODE_NAME
-                // return exits the node {} block here, not the whole function. Some groovy magic
-                return
+                stage("Node selected") {
+                    // Health-check passed. Do real work
+                    echo "[withHealthyNode] ✅  using ${env.NODE_NAME}"
+                }
+                body()
+                done = true
             }
-            stage("Node selected") {
-                // Health-check passed. Do real work
-                echo "[withHealthyNode] ✅  using ${env.NODE_NAME}"
-            }
-            body()
-            done = true
         }
     }
 

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -4,7 +4,7 @@ import groovy.transform.Field
 import java.util.concurrent.ConcurrentHashMap
 
 // The timeout for node allocation in minutes
-int NODE_ALLOCATION_TIMEOUT = 80
+int NODE_ALLOCATION_TIMEOUT = 240
 
 // ConcurrentHashMap helps when we need to write variables in parallel
 // one instance for the whole run
@@ -632,27 +632,31 @@ def withHealthyNode(String baseLabel, Closure<?> healthChecks, Closure<?> body, 
         blacklist.each { expr.append(' && !').append(it) }
 
         echo "[withHealthyNode] attempt #${attempt}: looking for '${expr}'"
-        timeout(time: NODE_ALLOCATION_TIMEOUT, unit: 'MINUTES', activity: true) {
-            node(expr.toString()) {
-                // Retry ONLY the health-check. We don't want to retry the actual stages
-                try {
-                    stage("Health checks on ${env.NODE_NAME}") {
-                        healthChecks()
-                        gitHealthCheck()
+        try {
+            timeout(time: NODE_ALLOCATION_TIMEOUT, unit: 'MINUTES', activity: true) {
+                node(expr.toString()) {
+                    // Retry ONLY the health-check. We don't want to retry the actual stages
+                    try {
+                        stage("Health checks on ${env.NODE_NAME}") {
+                            healthChecks()
+                            gitHealthCheck()
+                        }
+                    } catch (Exception err) {
+                        echo "[withHealthyNode] ❌  ${env.NODE_NAME} rejected: ${err}"
+                        blacklist << env.NODE_NAME
+                        // return exits the node {} block here, not the whole function. Some groovy magic
+                        return
                     }
-                } catch (Exception err) {
-                    echo "[withHealthyNode] ❌  ${env.NODE_NAME} rejected: ${err}"
-                    blacklist << env.NODE_NAME
-                    // return exits the node {} block here, not the whole function. Some groovy magic
-                    return
+                    stage("Node selected") {
+                        // Health-check passed. Do real work
+                        echo "[withHealthyNode] ✅  using ${env.NODE_NAME}"
+                    }
+                    body()
+                    done = true
                 }
-                stage("Node selected") {
-                    // Health-check passed. Do real work
-                    echo "[withHealthyNode] ✅  using ${env.NODE_NAME}"
-                }
-                body()
-                done = true
             }
+        } catch (org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution.ExceededTimeout e) {
+            error "Timed out after ${NODE_ALLOCATION_TIMEOUT} minutes. Could not allocate a healthy agent matching the label '${expr}' within the specified limit."
         }
     }
 


### PR DESCRIPTION
### Description
This pull request introduces an 80-minute inactivity timeout when waiting for a Jenkins agent (node) to become available.
### Problem
Currently, if the CI system is under heavy load and no agents matching a required label are available, a build can remain in the queue indefinitely. This leads to very long-running "stuck" builds on some matrix branches while others can be running already and since we need either all to finish or all to fail, that problem just reduces capacity while providing no feedback and can hide underlying capacity issues.
### Solution
This change addresses the problem by wrapping the node allocation logic inside the `withHealthyNode` helper function with a `timeout` step.
The key aspects of this implementation are:
1. **Inactivity Timeout**: It uses the `activity: true` parameter. This ensures the timeout only applies during periods of complete inactivity (i.e., waiting in the queue for an agent). Once an agent is allocated and starts executing steps, the log output it generates continuously resets the timer, preventing the timeout from interrupting a long-running but active build.
2. **Configurable Variable**: A new `NODE_ALLOCATION_TIMEOUT` variable has been added at the top of the Jenkinsfile, making it easy to adjust the wait time in the future.
3. Wrapped the `timeout` block in a `try {} catch {}` with a clear error message `error "Timed out after ${NODE_ALLOCATION_TIMEOUT} minutes. Could not allocate a healthy agent matching the label '${expr}' within the specified limit."`