### PR TITLE
Print error if pass order is incorrect when RealizeInt4 is needed on host pipeline

### DIFF
--- a/external/mlir-hal/include/mlir/Dialect/MHAL/IR/MHALOps.td
+++ b/external/mlir-hal/include/mlir/Dialect/MHAL/IR/MHALOps.td
@@ -98,6 +98,7 @@ def MHAL_LaunchOp :
     Operation::result_range getCallResults();
     Operation::result_type_range getCallResultTypes();
     void updateSegmentSizes(MLIRContext *);
+    std::optional<func::FuncOp> getCalledFunc();
   }];
 
   let hasVerifier = 1;

--- a/external/mlir-hal/lib/Conversion/MHALToCPU/MHALToCPU.cpp
+++ b/external/mlir-hal/lib/Conversion/MHALToCPU/MHALToCPU.cpp
@@ -36,17 +36,6 @@ using namespace mlir::mhal;
 //===----------------------------------------------------------------------===//
 
 namespace {
-// Helper to pull out the called func
-static std::optional<func::FuncOp> getCalledFunc(mhal::LaunchOp op) {
-  CallOpInterface callIf(op);
-  if (auto *callable = callIf.resolveCallable()) {
-    if (auto func = dyn_cast<func::FuncOp>(callable))
-      return func;
-  }
-
-  return std::nullopt;
-}
-
 struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
   using OpRewritePattern<mhal::LaunchOp>::OpRewritePattern;
 
@@ -56,7 +45,7 @@ struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
 
     assert(op->getNumResults() == 1); // only 1 mhal.token
 
-    if (auto func = getCalledFunc(op)) {
+    if (auto func = op.getCalledFunc()) {
       // Replace the original `async.execute` with a call to outlined
       // function.
       rw.create<func::CallOp>(loc, *func, op.getArgOperands());

--- a/external/mlir-hal/lib/Conversion/MHALToGPU/MHALToGPU.cpp
+++ b/external/mlir-hal/lib/Conversion/MHALToGPU/MHALToGPU.cpp
@@ -47,20 +47,9 @@ public:
 };
 } // namespace
 
-// Helper to pull out the called func
-static std::optional<func::FuncOp> getCalledFunc(mhal::LaunchOp op) {
-  CallOpInterface callIf(op);
-  if (auto *callable = callIf.resolveCallable()) {
-    if (auto func = dyn_cast<func::FuncOp>(callable))
-      return func;
-  }
-
-  return std::nullopt;
-}
-
 // Get target{gpu} attribute from called func
 static std::optional<mhal::KernelPackageAttr> getGPUTarget(mhal::LaunchOp op) {
-  auto func = getCalledFunc(op);
+  auto func = op.getCalledFunc();
   if (!func.has_value() || func->getNumResults() != 0)
     return std::nullopt;
 
@@ -179,7 +168,7 @@ struct LaunchRewritePattern : public OpRewritePattern<mhal::LaunchOp> {
     auto gridSize = launchDims[0];
     auto blockSize = launchDims[1];
 
-    auto func = *getCalledFunc(op);
+    auto func = *(op.getCalledFunc());
     Location floc = func.getLoc();
 
     // 2. re-materialize gpu.binary @<func_name>_module [#gpu.object<...>]

--- a/external/mlir-hal/lib/Dialect/MHAL/IR/MHALOps.cpp
+++ b/external/mlir-hal/lib/Dialect/MHAL/IR/MHALOps.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -101,6 +102,17 @@ void LaunchOp::updateSegmentSizes(MLIRContext *ctx) {
   (*this)->setAttr(getOperandSegmentSizesAttrName(), operandSegmentSizes);
 
   assert(!(*this)->hasAttr("result_segment_sizes"));
+}
+
+/// Helper to pull out the called func.
+std::optional<func::FuncOp> LaunchOp::getCalledFunc() {
+  CallOpInterface callIf(*this);
+  if (auto *callable = callIf.resolveCallable()) {
+    if (auto func = dyn_cast<func::FuncOp>(callable))
+      return func;
+  }
+
+  return std::nullopt;
 }
 
 LogicalResult LaunchOp::verifySymbolUses(SymbolTableCollection &symbolTable) {

--- a/mlir/test/fusion/pr-e2e/mixr-dot-int4-f16.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-dot-int4-f16.mlir
@@ -5,6 +5,10 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx %s | rocmlir-gen -fut mlir_unpack_dequantizelinear_dot --arch %arch --clone-harness - | rocmlir-driver -host-pipeline=highlevel | rocmlir-gen -ph -fut mlir_unpack_dequantizelinear_dot_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // CHECK: [1 1 1]
 // COM: Runs the MIGraphX pipeline first to rewrite out the int4
+
+// RUN: rocmlir-gen -fut mlir_unpack_dequantizelinear_dot --arch %arch --clone-harness %s | rocmlir-driver -host-pipeline=migraphx
+// XFAIL: *
+// COM: Check that if the pass ordering is incorrect (clone-harness first and then host-pipeline=migraphx), we get a clear error about what is wrong.
 func.func private @mlir_unpack_dequantizelinear_dot(%arg0: !migraphx.shaped<1x4x8xi8, 32x8x1>, %arg1: !migraphx.shaped<1x16x4xf16, 64x4x1>) -> !migraphx.shaped<1x4x4xf16, 16x4x1>  {
   %0 = migraphx.literal (dense<[0.25]> : tensor<1xf16>) : <1xf16, 0>
   %1 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [1, 5, 16]} : <1xf16, 0> -> <1x4x16xf16, 0x0x0>

--- a/mlir/test/fusion/pr-e2e/mixr-dot-int4-f16.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-dot-int4-f16.mlir
@@ -5,10 +5,6 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx %s | rocmlir-gen -fut mlir_unpack_dequantizelinear_dot --arch %arch --clone-harness - | rocmlir-driver -host-pipeline=highlevel | rocmlir-gen -ph -fut mlir_unpack_dequantizelinear_dot_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // CHECK: [1 1 1]
 // COM: Runs the MIGraphX pipeline first to rewrite out the int4
-
-// RUN: rocmlir-gen -fut mlir_unpack_dequantizelinear_dot --arch %arch --clone-harness %s | rocmlir-driver -host-pipeline=migraphx
-// XFAIL: *
-// COM: Check that if the pass ordering is incorrect (clone-harness first and then host-pipeline=migraphx), we get a clear error about what is wrong.
 func.func private @mlir_unpack_dequantizelinear_dot(%arg0: !migraphx.shaped<1x4x8xi8, 32x8x1>, %arg1: !migraphx.shaped<1x16x4xf16, 64x4x1>) -> !migraphx.shaped<1x4x4xf16, 16x4x1>  {
   %0 = migraphx.literal (dense<[0.25]> : tensor<1xf16>) : <1xf16, 0>
   %1 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [1, 5, 16]} : <1xf16, 0> -> <1x4x16xf16, 0x0x0>

--- a/mlir/test/rocmlir-driver/sanity_int4.mlir
+++ b/mlir/test/rocmlir-driver/sanity_int4.mlir
@@ -1,0 +1,11 @@
+// RUN: rocmlir-gen -fut mlir_unpack_dequantizelinear_dot --arch %arch --clone-harness %s | rocmlir-driver -host-pipeline=migraphx | FileCheck %s
+// XFAIL: *
+// COM: Check that if the pass ordering is incorrect (clone-harness first and then host-pipeline=migraphx), we get a clear error about what is wrong.
+func.func private @mlir_unpack_dequantizelinear_dot(%arg0: !migraphx.shaped<1x4x8xi8, 32x8x1>, %arg1: !migraphx.shaped<1x16x4xf16, 64x4x1>) -> !migraphx.shaped<1x4x4xf16, 16x4x1>  {
+  %0 = migraphx.literal (dense<[0.25]> : tensor<1xf16>) : <1xf16, 0>
+  %1 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [1, 5, 16]} : <1xf16, 0> -> <1x4x16xf16, 0x0x0>
+  %2 = migraphx.unpack %arg0 {axis = 2 : i64} : <1x4x8xi8, 32x8x1> -> <1x4x16xi8, 64x16x1>
+  %3 = migraphx.dequantizelinear %2, %1 : <1x4x16xi8, 64x16x1>, <1x4x16xf16, 0x0x0> -> <1x4x16xf16, 64x16x1>
+  %4 = migraphx.dot %3, %arg1 : <1x4x16xf16, 64x16x1>, <1x16x4xf16, 64x4x1> -> <1x4x4xf16, 16x4x1>
+  return %4 : !migraphx.shaped<1x4x4xf16, 16x4x1>
+}

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -214,12 +214,12 @@ static std::optional<func::FuncOp> getCalledFunc(mhal::LaunchOp op) {
 }
 
 // When running migraphx pipeline on the host, if the kernel has
-// an unpack operation that operates on a function argument, 
+// an unpack operation that operates on a function argument,
 // the RealizeInt4 pass will generate invalid IR as it will change
 // the function signature of the kernel, but will not modify the
 // launch op of the wrapper code, thus the call will have a different
-// argument type compared to the called function. 
-// 
+// argument type compared to the called function.
+//
 // In this function we check for this case and return failure if found.
 // More info here: https://github.com/ROCm/rocMLIR-internal/issues/1986
 static LogicalResult isSafeToRunRealizeInt4(ModuleOp &module) {
@@ -236,10 +236,10 @@ static LogicalResult isSafeToRunRealizeInt4(ModuleOp &module) {
       }
     }
     if (launchOps.size() != 1) {
-      llvm::errs() << "Expected to find exactly one mhal.launch op in '" << func.getName()
-                    << "'\n";
+      llvm::errs() << "Expected to find exactly one mhal.launch op in '"
+                   << func.getName() << "'\n";
       return failure();
-    }      
+    }
     mhal::LaunchOp launchOp = launchOps.front();
 
     // Get the callee function.
@@ -254,15 +254,17 @@ static LogicalResult isSafeToRunRealizeInt4(ModuleOp &module) {
         return WalkResult::advance();
       });
       if (hasUnpack) {
-        llvm::errs() << "Kernel contains migraphx.unpack ops; pass ordering is incorrect. Please run rocmlir-gen --clone-harness after lowering your kernel to tosa.\n";
+        llvm::errs() << "Kernel '" << (*calleeFunc).getName()
+                     << "' contains migraphx.unpack ops; pass ordering is "
+                        "incorrect. Please run rocmlir-gen --clone-harness "
+                        "after lowering your kernel to TOSA.\n";
         return failure();
       }
-    }
-    else {
+    } else {
       llvm::errs() << "Failed to get called function from '" << func.getName()
-                    << "'\n";
+                   << "'\n";
       return failure();
-    }    
+    }
   }
   return success();
 }

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -201,6 +201,72 @@ runKernelPipeline(StringRef arch, ModuleOp kmod, bool isHighLevel,
   return pm.run(kmod);
 }
 
+// Helper to pull out the called func
+// TODO: This should be a class method of mhal::LaunchOp.
+static std::optional<func::FuncOp> getCalledFunc(mhal::LaunchOp op) {
+  CallOpInterface callIf(op);
+  if (auto *callable = callIf.resolveCallable()) {
+    if (auto func = dyn_cast<func::FuncOp>(callable))
+      return func;
+  }
+
+  return std::nullopt;
+}
+
+// When running migraphx pipeline on the host, if the kernel has
+// an unpack operation that operates on a function argument, 
+// the RealizeInt4 pass will generate invalid IR as it will change
+// the function signature of the kernel, but will not modify the
+// launch op of the wrapper code, thus the call will have a different
+// argument type compared to the called function. 
+// 
+// In this function we check for this case and return failure if found.
+// More info here: https://github.com/ROCm/rocMLIR-internal/issues/1986
+static LogicalResult isSafeToRunRealizeInt4(ModuleOp &module) {
+  for (func::FuncOp func : module.getOps<func::FuncOp>()) {
+    if (!func->hasAttr("wrapper"))
+      continue;
+
+    // Get the function called by the wrapper and ensure that the function
+    // does not have the migraphx.unpack op. If it has, the order is wrong.
+    SmallVector<mhal::LaunchOp> launchOps;
+    for (Operation &op : func.getOps()) {
+      if (auto launchOp = dyn_cast<mhal::LaunchOp>(op)) {
+        launchOps.push_back(launchOp);
+      }
+    }
+    if (launchOps.size() != 1) {
+      llvm::errs() << "Expected to find exactly one mhal.launch op in '" << func.getName()
+                    << "'\n";
+      return failure();
+    }      
+    mhal::LaunchOp launchOp = launchOps.front();
+
+    // Get the callee function.
+    if (std::optional<func::FuncOp> calleeFunc = getCalledFunc(launchOp)) {
+      // Check that the callee does not contain any migraphx.unpack ops.
+      bool hasUnpack = false;
+      (*calleeFunc).walk([&](Operation *op) {
+        if (isa<migraphx::UnpackOp>(op)) {
+          hasUnpack = true;
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+      if (hasUnpack) {
+        llvm::errs() << "Kernel contains migraphx.unpack ops; pass ordering is incorrect. Please run rocmlir-gen --clone-harness after lowering your kernel to tosa.\n";
+        return failure();
+      }
+    }
+    else {
+      llvm::errs() << "Failed to get called function from '" << func.getName()
+                    << "'\n";
+      return failure();
+    }    
+  }
+  return success();
+}
+
 static LogicalResult runMLIRPasses(ModuleOp &module,
                                    mlir::PassPipelineCLParser &passPipeline) {
 
@@ -262,6 +328,9 @@ static LogicalResult runMLIRPasses(ModuleOp &module,
   }
 
   if (hostPipelineSet.contains("migraphx")) {
+    if (failed(isSafeToRunRealizeInt4(module))) {
+      return failure();
+    }
     PassManager pm(module->getName(), PassManager::Nesting::Implicit);
     migraphx::addHighLevelPipeline(pm);
     if (failed(pm.run(module))) {

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -233,19 +233,17 @@ static LogicalResult isSafeToRunRealizeInt4(ModuleOp &module) {
     // Get the callee function.
     if (std::optional<func::FuncOp> calleeFunc = launchOp.getCalledFunc()) {
       // Check that the callee does not contain any migraphx.unpack ops.
-      bool hasUnpack = false;
-      (*calleeFunc).walk([&](Operation *op) {
+      auto walkResult = (*calleeFunc).walk([&](Operation *op) {
         if (isa<migraphx::UnpackOp>(op)) {
-          hasUnpack = true;
           return WalkResult::interrupt();
         }
         return WalkResult::advance();
       });
-      if (hasUnpack) {
+      if (walkResult.wasInterrupted()) {
         llvm::errs() << "Kernel '" << (*calleeFunc).getName()
                      << "' contains migraphx.unpack ops; pass ordering is "
                         "incorrect. Please run rocmlir-gen --clone-harness "
-                        "after lowering your kernel to TOSA.\n";
+                        "after running migraphx pipeline.\n";
         return failure();
       }
     } else {

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -201,18 +201,6 @@ runKernelPipeline(StringRef arch, ModuleOp kmod, bool isHighLevel,
   return pm.run(kmod);
 }
 
-// Helper to pull out the called func
-// TODO: This should be a class method of mhal::LaunchOp.
-static std::optional<func::FuncOp> getCalledFunc(mhal::LaunchOp op) {
-  CallOpInterface callIf(op);
-  if (auto *callable = callIf.resolveCallable()) {
-    if (auto func = dyn_cast<func::FuncOp>(callable))
-      return func;
-  }
-
-  return std::nullopt;
-}
-
 // When running migraphx pipeline on the host, if the kernel has
 // an unpack operation that operates on a function argument,
 // the RealizeInt4 pass will generate invalid IR as it will change
@@ -243,7 +231,7 @@ static LogicalResult isSafeToRunRealizeInt4(ModuleOp &module) {
     mhal::LaunchOp launchOp = launchOps.front();
 
     // Get the callee function.
-    if (std::optional<func::FuncOp> calleeFunc = getCalledFunc(launchOp)) {
+    if (std::optional<func::FuncOp> calleeFunc = launchOp.getCalledFunc()) {
       // Check that the callee does not contain any migraphx.unpack ops.
       bool hasUnpack = false;
       (*calleeFunc).walk([&](Operation *op) {

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -5252,6 +5252,7 @@ static void populateCloneHarnessLogic(ModuleOp module) {
   auto loc = originalFunc->getLoc();
   auto wrapperFunc = func::FuncOp::create(loc, testFuncName + "_wrapper",
                                           originalFunc.getFunctionType());
+  wrapperFunc->setAttr("wrapper", b.getUnitAttr());
   Block *block = wrapperFunc.addEntryBlock();
   b.setInsertionPointToStart(block);
   auto launchOp = b.create<mhal::LaunchOp>(loc, originalFunc, ValueRange{},


### PR DESCRIPTION
## Motivation

`MIGraphXRealizeInt4Pass` will remove `migraphx.unpack` and change the data type of the operand to int4 in a function-per-function basis. In the case where the input operand of the `migraphx.unpack` is a function argument, `MIGraphXRealizeInt4Pass` will modify the function signature. Therefore, if such function is being called from another function, `MIGraphXRealizeInt4Pass` will leave the IR in a inconsistent state, since the called function will now have int4 data type, whereas the callee will not expect int4.

The solution to this problem is simply to run the `rocmlir-gen clone-harness` (which will generate the wrapper with the function call to the kernel, thus causing the aforementioned issue) **after** the `kernel-pipeline=migraphx` is executed. By doing this, the `MIGraphXRealizeInt4Pass` has already happened on the kernel function, so when the wrapper calls to kernel it will already have the right type (int4) for both the callee and the caller.

This PR detects this condition and prints an error message to warn the user about this problem and suggesting the user to change the order of the passes to solve the problem.

Note that we could also change the order of all our tests under `mlir/` to make sure the order is correct even if the test does not have `migraphx.unpack`. However the number of tests in this condition is huge and the effort does not seem worth it.

## Technical Details

Adds `isSafeToRunRealizeInt4` before running the `migraphx` host pipeline to check if `MIGraphXRealizeInt4Pass` will break the IR.

This PR also refactors `getCalledFunc` to a class method of `mhal::LaunchOp`.

## Test Plan

Adds a new check with XFAIL to `mlir/test/fusion/pr-e2e/mixr-dot-int4-f16.mlir` to validate that the error is generated.

## Test Result

The test should fail since the order of the passes is incorrect.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
