### PR TITLE
CI: Exclude f32 Attention Configs for Navi

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1071,7 +1071,7 @@ pipeline {
                                                             // Tune attention configs
                                                             def attnConfig = "../mlir/utils/performance/configs/tier1-attention-configs"
                                                             def attnConfigToUse = attnConfig
-                                                            if (CHIP == "gfx1100" || CHIP == "gfx1201") {
+                                                            if (CHIP.startsWith("gfx1")) {
                                                                 attnConfigToUse = "tier1-attention-configs-nofp32"
                                                                 sh """
                                                                     grep -v '\\-t f32' ${attnConfig} > ${attnConfigToUse}

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1069,8 +1069,16 @@ pipeline {
                                                                     -c ../mlir/utils/performance/configs/tier1-conv-configs \
                                                                     -t ${WORKSPACE}/MITuna -f mlir_tuning_${CHIP}.tsv 2>&1 | tee -a ${tuningLog}"""
                                                             // Tune attention configs
+                                                            def attnConfig = "../mlir/utils/performance/configs/tier1-attention-configs"
+                                                            def attnConfigToUse = attnConfig
+                                                            if (CHIP == "gfx1100" || CHIP == "gfx1201") {
+                                                                attnConfigToUse = "tier1-attention-configs-nofp32"
+                                                                sh """
+                                                                    grep -v '\\-t f32' ${attnConfig} > ${attnConfigToUse}
+                                                                """
+                                                            }
                                                             sh """../mlir/utils/tuna/tuna-script.sh -o attention \
-                                                                    -c ../mlir/utils/performance/configs/tier1-attention-configs \
+                                                                    -c ${attnConfigToUse} \
                                                                     -t ${WORKSPACE}/MITuna -f mlir_tuning_${CHIP}.tsv 2>&1 | tee -a ${tuningLog}"""
                                                             // Tune gemms with default datatypes, fail if the DB is not created (quick tuning)
                                                             // (Includes int8xint8->int8 for performance comparisons against CK.)


### PR DESCRIPTION
Since there were a lot problems in MITuna when doing this, I thought that we can temporarily skip unsupported dtype (f32 for attn on navi) by not providing configs where -t is f32.

It would resolve https://github.com/ROCm/rocMLIR-internal/issues/1917 and CI then should not fail for this reason, but I would still make follow up ticket to make skipping unsupported dtypes outside of Jenkinsfile when the best way for doing it (if it should be in MITuna and in which module and in which way) is discovered. 

Test: [Tuning weekly task](https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-2003/5/pipeline/640) - attention tuning part ✅