### PR TITLE
Add proper CPU lowering for 2D `tosa::CustomOp` with arbitrary stride, dilation, and input padding

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -453,11 +453,7 @@ def Tosa_TransposeConv2DOp : Tosa_ConvOp<"transpose_conv2d"> {
 
       Tosa_IntArrayAttr4:$out_pad, Tosa_IntArrayAttr2:$stride,
       TypeAttrOf<Tosa_AccType>:$acc_type,
-      DefaultValuedOptionalAttr<BoolAttr, "false">:$local_bound,
-      // rocMLIR Customizations
-      OptionalAttr<I64Attr>:$group, OptionalAttr<Tosa_IntArrayAttr2>:$dilation,
-      OptionalAttr<Tosa_IntArrayAttr4>:$pad
-      // End of rocMLIR Customizations
+      DefaultValuedOptionalAttr<BoolAttr, "false">:$local_bound
   );
 
   let results = (outs

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -3630,66 +3630,37 @@ LogicalResult TransposeConv2DOp::verify() {
   if (!outputType)
     return success();
 
-  // Fetch (optional) pad & dilation; apply defaults if absent.
-  SmallVector<int64_t, 4> inPad;
-  if (auto inPadOpt = getPad()) {
-    inPad.assign(inPadOpt->begin(), inPadOpt->end());
-  } else {
-    inPad = {0, 0, 0, 0}; // [top, bottom, left, right]
-  }
-
-  SmallVector<int64_t, 2> dilation;
-  if (auto dilationOpt = getDilation()) {
-    dilation.assign(dilationOpt->begin(), dilationOpt->end());
-  } else {
-    dilation = {1, 1};
-  }
-
   const auto inputType = llvm::dyn_cast<RankedTensorType>(getInput().getType());
   if (inputType && weightType) {
     const int64_t inputHeight = inputType.getDimSize(1);
     const int64_t kernelHeight = weightType.getDimSize(1);
     const int64_t outputHeight = outputType.getDimSize(1);
 
-    if (!ShapedType::isDynamic(inputHeight) &&
-        !ShapedType::isDynamic(outputHeight)) {
-      // rocMLIR customization: Update the formulas to make use of the optional
-      // input padding and dilation values that we have
-      if (outputHeight != (inputHeight - 1) * strideY + outPadTop +
-                          outPadBottom + ((kernelHeight - 1) * dilation[0]) +
-                          1 - inPad[0] - inPad[1]) {
+    if (ShapedType::isStatic(inputHeight) &&
+        ShapedType::isStatic(outputHeight)) {
+      if (outputHeight !=
+          (inputHeight - 1) * strideY + outPadTop + outPadBottom + kernelHeight)
         return emitOpError(
-                    "dimension mismatch: expected OH = (IH - 1) * "
-                    "stride_y + out_pad_top + out_pad_bottom + ((KH - 1) * "
-                    "dilation_y + 1) - pad_top - pad_bottom, but got: ")
-                << outputHeight << " != (" << inputHeight << " - 1) * "
-                << strideY << " + " << outPadTop << " + "
-                << outPadBottom << " + ((" << kernelHeight
-                << " - 1) * " << dilation[0] << " + 1) - "
-                << inPad[0] << " - " << inPad[1];
-      } 
+                   "dimension mismatch: expected OH == (IH - 1) * stride_y "
+                   "+ out_pad_top + out_pad_bottom + KH, but got ")
+               << outputHeight << " != (" << inputHeight << " - 1) * "
+               << strideY << " + " << outPadTop << " + " << outPadBottom
+               << " + " << kernelHeight;
     }
 
     const int64_t inputWidth = inputType.getDimSize(2);
     const int64_t kernelWidth = weightType.getDimSize(2);
     const int64_t outputWidth = outputType.getDimSize(2);
 
-    if (!ShapedType::isDynamic(inputWidth) &&
-        !ShapedType::isDynamic(outputWidth)) {
-      // rocMLIR customization: Update the formulas to make use of the optional
-      // input padding and dilation values that we have
-      if (outputWidth != (inputWidth - 1) * strideX + outPadLeft + outPadRight + 
-                              ((kernelWidth - 1) * dilation[1] + 1) -
-                              inPad[2] - inPad[3]) {
+    if (ShapedType::isStatic(inputWidth) && ShapedType::isStatic(outputWidth)) {
+      if (outputWidth !=
+          (inputWidth - 1) * strideX + outPadLeft + outPadRight + kernelWidth)
         return emitOpError(
-                    "dimension mismatch: expected OW = (IW - 1) * "
-                    "stride_x + out_pad_left + out_pad_right + (KW - 1) * "
-                    "dilation_x + 1 - pad_left - pad_right, but got: ")
-                << outputWidth << " != (" << inputWidth << " - 1) * "
-                << strideX << " + " << outPadLeft << " + " << outPadRight
-                << " + ((" << kernelWidth << " - 1) * " << dilation[1]
-                << " + 1) - " << inPad[2] - inPad[3];
-      }
+                   "dimension mismatch: expected OW == (IW - 1) * stride_x "
+                   "+ out_pad_left + out_pad_right + KW, but got ")
+               << outputWidth << " != (" << inputWidth << " - 1) * " << strideX
+               << " + " << outPadLeft << " + " << outPadRight << " + "
+               << kernelWidth;
     }
   }
 

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -3630,46 +3630,44 @@ LogicalResult TransposeConv2DOp::verify() {
   if (!outputType)
     return success();
 
-  auto inPad = getPad();
-  auto dilation = getDilation();
+  // Fetch (optional) pad & dilation; apply defaults if absent.
+  SmallVector<int64_t, 4> inPad;
+  if (auto inPadOpt = getPad()) {
+    inPad.assign(inPadOpt->begin(), inPadOpt->end());
+  } else {
+    inPad = {0, 0, 0, 0}; // [top, bottom, left, right]
+  }
+
+  SmallVector<int64_t, 2> dilation;
+  if (auto dilationOpt = getDilation()) {
+    dilation.assign(dilationOpt->begin(), dilationOpt->end());
+  } else {
+    dilation = {1, 1};
+  }
+
   const auto inputType = llvm::dyn_cast<RankedTensorType>(getInput().getType());
   if (inputType && weightType) {
     const int64_t inputHeight = inputType.getDimSize(1);
     const int64_t kernelHeight = weightType.getDimSize(1);
     const int64_t outputHeight = outputType.getDimSize(1);
 
-    // output_shape[i] = stride[i] * (input_size[i] - 1) + output_padding[i] +
-    // ((kernel_shape[i] - 1) * dilations[i] + 1)
-    //                   - pads[start_i] - pads[end_i]
-
     if (!ShapedType::isDynamic(inputHeight) &&
         !ShapedType::isDynamic(outputHeight)) {
-      // rocMLIR customization: If we have input padding and dilations then we
-      // want to use the more accurate formula that properly accounts for these
-      // values
-      if (inPad && dilation) {
-        if (outputHeight != (inputHeight - 1) * strideY + outPadTop +
-                                ((kernelHeight - 1) * (*dilation)[0] + 1) -
-                                (*inPad)[0] - (*inPad)[1]) {
-          return emitOpError(
-                     "dimension mismatch: expected OH = (IH - 1) * "
-                     "stride_y + out_pad_top + ((KH - 1) * dilation_y + "
-                     "1) - pad_top - pad_bottom, but got: ")
-                 << outputHeight << " != (" << inputHeight << " - 1) * "
-                 << strideY << " + " << outPadTop << " + ((" << kernelHeight
-                 << " - 1) * " << (*dilation)[0] << " + 1) - "
-                 << (*inPad)[0] - (*inPad)[1];
-        }
-      } else {
-        if (outputHeight != (inputHeight - 1) * strideY + outPadTop +
-                                outPadBottom + kernelHeight)
-          return emitOpError(
-                     "dimension mismatch: expected OH == (IH - 1) * stride_y "
-                     "+ out_pad_top + out_pad_bottom + KH, but got ")
-                 << outputHeight << " != (" << inputHeight << " - 1) * "
-                 << strideY << " + " << outPadTop << " + " << outPadBottom
-                 << " + " << kernelHeight;
-      }
+      // rocMLIR customization: Update the formulas to make use of the optional
+      // input padding and dilation values that we have
+      if (outputHeight != (inputHeight - 1) * strideY + outPadTop +
+                          outPadBottom + ((kernelHeight - 1) * dilation[0]) +
+                          1 - inPad[0] - inPad[1]) {
+        return emitOpError(
+                    "dimension mismatch: expected OH = (IH - 1) * "
+                    "stride_y + out_pad_top + out_pad_bottom + ((KH - 1) * "
+                    "dilation_y + 1) - pad_top - pad_bottom, but got: ")
+                << outputHeight << " != (" << inputHeight << " - 1) * "
+                << strideY << " + " << outPadTop << " + "
+                << outPadBottom << " + ((" << kernelHeight
+                << " - 1) * " << dilation[0] << " + 1) - "
+                << inPad[0] << " - " << inPad[1];
+      } 
     }
 
     const int64_t inputWidth = inputType.getDimSize(2);
@@ -3678,31 +3676,19 @@ LogicalResult TransposeConv2DOp::verify() {
 
     if (!ShapedType::isDynamic(inputWidth) &&
         !ShapedType::isDynamic(outputWidth)) {
-      // rocMLIR customization: If we have input padding and dilations then we
-      // want to use the more accurate formula that properly accounts for these
-      // values
-      if (inPad && dilation) {
-        if (outputWidth != (inputWidth - 1) * strideX + outPadLeft +
-                               ((kernelWidth - 1) * (*dilation)[1] + 1) -
-                               (*inPad)[2] - (*inPad)[3]) {
-          return emitOpError(
-                     "dimension mismatch: expected OW = (IW - 1) * "
-                     "stride_x + out_pad_left + (KW - 1) * dilation_x + "
-                     "1 - pad_left - pad_right, but got: ")
-                 << outputWidth << " != (" << inputWidth << " - 1) * "
-                 << strideX << " + " << outPadLeft << " + ((" << kernelWidth
-                 << " - 1) * " << (*dilation)[1] << " + 1) - "
-                 << (*inPad)[2] - (*inPad)[3];
-        }
-      } else {
-        if (outputWidth !=
-            (inputWidth - 1) * strideX + outPadLeft + outPadRight + kernelWidth)
-          return emitOpError(
-                     "dimension mismatch: expected OW == (IW - 1) * stride_x "
-                     "+ out_pad_left + out_pad_right + KW, but got ")
-                 << outputWidth << " != (" << inputWidth << " - 1) * "
-                 << strideX << " + " << outPadLeft << " + " << outPadRight
-                 << " + " << kernelWidth;
+      // rocMLIR customization: Update the formulas to make use of the optional
+      // input padding and dilation values that we have
+      if (outputWidth != (inputWidth - 1) * strideX + outPadLeft + outPadRight + 
+                              ((kernelWidth - 1) * dilation[1] + 1) -
+                              inPad[2] - inPad[3]) {
+        return emitOpError(
+                    "dimension mismatch: expected OW = (IW - 1) * "
+                    "stride_x + out_pad_left + out_pad_right + (KW - 1) * "
+                    "dilation_x + 1 - pad_left - pad_right, but got: ")
+                << outputWidth << " != (" << inputWidth << " - 1) * "
+                << strideX << " + " << outPadLeft << " + " << outPadRight
+                << " + ((" << kernelWidth << " - 1) * " << dilation[1]
+                << " + 1) - " << inPad[2] - inPad[3];
       }
     }
   }

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
@@ -24,35 +24,6 @@ using namespace mlir::tosa;
 
 namespace {
 
-// If this is a backward-data (transpose) conv lowered from MIGraphX, its
-// filter logical in/out channels are reversed relative to forward Conv2D.
-FailureOr<std::tuple<Value, ShapedType>>
-swapInputOutputDimensions(OpBuilder &rewriter, Operation *op,
-                          Value weight, ShapedType weightTy) {
-  if (auto kindAttr = op->getAttrOfType<StringAttr>("conv_kind");
-      kindAttr && kindAttr.getValue() == "bwd_data") {
-    // Expected current shape: [K, H, W, C] but Conv2D expects [O, H, W, I]
-    // Swap K<->C => permutation {3,1,2,0}.
-    auto wShape = weightTy.getShape();
-    SmallVector<int64_t, 4> swappedShape{
-        wShape[3], // C becomes O
-        wShape[1],
-        wShape[2],
-        wShape[0]  // K becomes I
-    };
-    auto swappedTy =
-        RankedTensorType::get(swappedShape, weightTy.getElementType());
-    weight = rewriter.create<tosa::TransposeOp>(
-        op->getLoc(), swappedTy, weight,
-        rewriter.getDenseI32ArrayAttr({3, 1, 2, 0}));
-    weightTy = cast<ShapedType>(weight.getType());
-
-    return std::make_tuple(weight, weightTy);
-  }
-
-  return failure();
-}
-
 class TransposeConvNonStridedConverter
     : public OpRewritePattern<tosa::TransposeConv2DOp> {
 public:
@@ -72,22 +43,6 @@ public:
     llvm::ArrayRef<int64_t> stride = op.getStride();
     llvm::ArrayRef<int64_t> pad = op.getOutPad();
 
-    // Fetch dilation (default {1,1})
-    SmallVector<int64_t, 2> dilationVals = {1, 1};
-    if (auto dilOpt = op.getDilation()) {
-      dilationVals[0] = (*dilOpt)[0];
-      dilationVals[1] = (*dilOpt)[1];
-    }
-
-    // Fetch input pads (default zeros)
-    SmallVector<int64_t, 4> inPadVals(4, 0);
-    if (auto padOpt = op.getPad()) {
-      inPadVals[0] = (*padOpt)[0]; // top
-      inPadVals[1] = (*padOpt)[1]; // bottom
-      inPadVals[2] = (*padOpt)[2]; // left
-      inPadVals[3] = (*padOpt)[3]; // right
-    }
-
     // If striding is all 1 we can modify padding and reverse the kernel along
     // the x/y direction to make it a regular convolution. This is much simpler
     // then handling striding....
@@ -98,43 +53,14 @@ public:
         !biasTy.hasStaticShape() || !resultTy.hasStaticShape())
       return failure();
 
-    // Swap dimensions if needed
-    auto swapOr = swapInputOutputDimensions(rewriter, op, weight, weightTy);
-    if (succeeded(swapOr)) {
-      weight = std::get<0>(swapOr.value());
-      weightTy = std::get<1>(swapOr.value());
-    }
-
     int64_t kernelHeight = weightTy.getDimSize(1);
     int64_t kernelWidth = weightTy.getDimSize(2);
-    int64_t effKHm1 = (kernelHeight - 1) * dilationVals[0];
-    int64_t effKWm1 = (kernelWidth - 1) * dilationVals[1];
 
-    // Conv2D padding derived from ConvTranspose (ONNX/PyTorch style)
-    // convPadTop    = effKHm1 - inPadTop    + outPadTop
-    // convPadBottom = effKHm1 - inPadBottom + outPadBottom
-    // convPadLeft   = effKWm1 - inPadLeft   + outPadLeft
-    // convPadRight  = effKWm1 - inPadRight  + outPadRight
-    SmallVector<int64_t, 4> convPad = {
-        effKHm1 - inPadVals[0] + pad[0],
-        effKHm1 - inPadVals[1] + pad[1],
-        effKWm1 - inPadVals[2] + pad[2],
-        effKWm1 - inPadVals[3] + pad[3]
-    };
-
-    bool needSlice = false;
-    SmallVector<int64_t,4> negExcess(4,0);
-    for (int i=0;i<4;++i) {
-      if (convPad[i] < 0) {
-        negExcess[i] = -convPad[i];
-        convPad[i] = 0;
-        needSlice = true;
-      }
-    }
-
-    if (needSlice)
-      return rewriter.notifyMatchFailure(op, "Cannot currently handle negative "
-                                             "padding values.");
+    llvm::SmallVector<int64_t> convPad(4, 0);
+    convPad[0] = kernelHeight - 1 + pad[0];
+    convPad[1] = kernelHeight - 1 + pad[1];
+    convPad[2] = kernelWidth - 1 + pad[2];
+    convPad[3] = kernelWidth - 1 + pad[3];
 
     auto reverse1 =
         tosa::ReverseOp::create(rewriter, loc, weightTy, weight,
@@ -147,9 +73,8 @@ public:
         rewriter, loc, resultTy, input, reverse2, bias, op.getInputZp(),
         op.getWeightZp(), rewriter.getDenseI64ArrayAttr(convPad),
         rewriter.getDenseI64ArrayAttr(stride),
-        rewriter.getDenseI64ArrayAttr(dilationVals),
-        /* acc_type = */ op.getAccType(),
-        op->getAttrOfType<IntegerAttr>("group"));
+        rewriter.getDenseI64ArrayAttr({1, 1}),
+        /* acc_type = */ op.getAccType(), /*group=*/nullptr);
 
     rewriter.replaceOp(op, conv2d);
     return success();
@@ -180,29 +105,6 @@ public:
     llvm::ArrayRef<int64_t> pad = op.getOutPad();
     llvm::ArrayRef<int64_t> stride = op.getStride();
 
-    // Swap dimensions if needed
-    auto swapOr = swapInputOutputDimensions(rewriter, op, weight, weightTy);
-    if (succeeded(swapOr)) {
-      weight = std::get<0>(swapOr.value());
-      weightTy = std::get<1>(swapOr.value());
-    }
-
-    // Fetch dilation (default {1,1})
-    SmallVector<int64_t, 2> dilationVals = {1, 1};
-    if (auto dilOpt = op.getDilation()) {
-      dilationVals[0] = (*dilOpt)[0];
-      dilationVals[1] = (*dilOpt)[1];
-    }
-
-    // Fetch input padding (default {0, 0, 0, 0})
-    SmallVector<int64_t, 4> inPadVals = {0, 0, 0, 0};
-    if (auto inPadOpt = op.getPad()) {
-      inPadVals[0] = (*inPadOpt)[0];
-      inPadVals[1] = (*inPadOpt)[1];
-      inPadVals[2] = (*inPadOpt)[2];
-      inPadVals[3] = (*inPadOpt)[3];
-    }
-
     // If strides are all 1 we dont need to use this one.
     if (llvm::all_of(stride, [](int64_t v) { return v == 1; }))
       return rewriter.notifyMatchFailure(op, "non-one stride found.");
@@ -217,6 +119,16 @@ public:
     int64_t weightHeight = weightTy.getDimSize(1);
     int64_t weightWidth = weightTy.getDimSize(2);
     int64_t inputChannels = weightTy.getDimSize(3);
+
+    // Pad the weight so that it is modulo of the striding.
+    llvm::SmallVector<int64_t, 8> weightPadding = {0, 0, 0, 0, 0, 0, 0, 0};
+    weightPadding[3] =
+        (weightHeight % stride[0]) ? (stride[0] - weightHeight % stride[0]) : 0;
+    weightPadding[5] =
+        (weightWidth % stride[1]) ? (stride[1] - weightWidth % stride[1]) : 0;
+
+    Value weightPaddingVal =
+        getTosaConstShape(rewriter, op->getLoc(), weightPadding);
 
     // Get and verify zero points.
     FailureOr<int64_t> maybeIZp = op.getInputZeroPoint();
@@ -246,109 +158,6 @@ public:
         createPadConstTensor(builder, op->getLoc(), input, inputZpVal);
     const Value weightPadConst =
         createPadConstTensor(builder, op->getLoc(), input, weightZpVal);
-
-    // Helper to create a scalar pad value (weight zero-point)
-    auto createWeightPadConst = [&](Value like) -> Value {
-      return createPadConstTensor(builder, loc, like, weightZpVal);
-    };
-
-    // Explicitly materialize dilation in the weight tensor by inserting
-    // (d-1) rows / columns of zero between the original kernel rows and
-    // columns. After this expansion we can treat dilation as 1
-    // for the remainder of the lowering.
-    if (dilationVals[0] > 1 || dilationVals[1] > 1) {
-      int64_t dH = dilationVals[0];
-      int64_t dW = dilationVals[1];
-
-      // Expand height: iterate original over original rows, slice each 1-row
-      // slab, and (except for the final row) pad (dH-1) zero rows below it.
-      SmallVector<Value> heightPieces;
-      for (int64_t h = 0; h < weightHeight; ++h) {
-        llvm::SmallVector<int64_t, 4> begin = {0, h, 0, 0};
-        llvm::SmallVector<int64_t, 4> size = {outputChannels, 1, weightWidth,
-                                              inputChannels};
-        Value beginVal = getTosaConstShape(rewriter, loc, begin);
-        Value sizeVal = getTosaConstShape(rewriter, loc, size);
-        Value slice = CreateOpAndInferShape<tosa::SliceOp>(
-                          rewriter, loc, UnrankedTensorType::get(weightETy),
-                          weight, beginVal, sizeVal)
-                          .getResult();
-        int64_t padRows = (h == weightHeight - 1) ? 0 : (dH - 1);
-        if (padRows > 0) {
-          llvm::SmallVector<int64_t, 8> padSpec =
-                            {0, 0, 0, padRows, 0, 0, 0, 0};
-          Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
-          slice = CreateOpAndInferShape<tosa::PadOp>(
-                      rewriter, loc, UnrankedTensorType::get(weightETy), slice,
-                      padSpecVal, createWeightPadConst(weight))
-                      .getResult();
-        }
-        heightPieces.push_back(slice);
-      }
-      weight = CreateOpAndInferShape<tosa::ConcatOp>(
-                   rewriter, loc, UnrankedTensorType::get(weightETy),
-                   SmallVector<Value>(heightPieces.begin(), heightPieces.end()),
-                   rewriter.getI32IntegerAttr(1))
-                   .getResult();
-
-      // Update dims after height expansion
-      weightTy = cast<ShapedType>(weight.getType());
-      weightHeight = weightTy.getDimSize(1); // now (origH-1)*dH + 1
-
-      // Expand width similarly if horizontal dilation > 1.
-      if (dW > 1) {
-        SmallVector<Value> widthPieces;
-        for (int64_t w = 0; w < weightWidth; ++w) {
-          llvm::SmallVector<int64_t, 4> begin = {0, 0, w, 0};
-          llvm::SmallVector<int64_t, 4> size = {outputChannels, weightHeight,
-                                                1, inputChannels};
-          Value beginVal = getTosaConstShape(rewriter, loc, begin);
-          Value sizeVal = getTosaConstShape(rewriter, loc, size);
-          Value slice = CreateOpAndInferShape<tosa::SliceOp>(
-                            rewriter, loc, UnrankedTensorType::get(weightETy),
-                            weight, beginVal, sizeVal)
-                            .getResult();
-          int64_t padCols = (w == weightWidth - 1) ? 0 : (dW - 1);
-          if (padCols > 0) {
-            llvm::SmallVector<int64_t, 8> padSpec =
-                              {0, 0, 0, 0, 0, padCols, 0, 0};
-            Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
-            slice = CreateOpAndInferShape<tosa::PadOp>(
-                        rewriter, loc, UnrankedTensorType::get(weightETy),
-                        slice, padSpecVal, createWeightPadConst(weight))
-                        .getResult();
-          }
-          widthPieces.push_back(slice);
-        }
-        weight = CreateOpAndInferShape<tosa::ConcatOp>(
-                     rewriter, loc, UnrankedTensorType::get(weightETy),
-                     SmallVector<Value>(widthPieces.begin(), widthPieces.end()),
-                     rewriter.getI32IntegerAttr(2))
-                     .getResult();
-      }
-
-      // Update type/dims post width expansion.
-      weightTy = cast<ShapedType>(weight.getType());
-      weightWidth = weightTy.getDimSize(2);
-
-      // After explicit expansion, treat dilation as 1 for the remainder.
-      dilationVals = {1, 1};
-    }
-
-    // We want to capture the height and width values after dilation expansion,
-    // but before padding is added later on.
-    int64_t origWeightHeight = weightHeight;
-    int64_t origWeightWidth  = weightWidth;
-
-    // Pad the weight so that it is modulo of the striding.
-    llvm::SmallVector<int64_t, 8> weightPadding = {0, 0, 0, 0, 0, 0, 0, 0};
-    weightPadding[3] =
-        (weightHeight % stride[0]) ? (stride[0] - weightHeight % stride[0]) : 0;
-    weightPadding[5] =
-        (weightWidth % stride[1]) ? (stride[1] - weightWidth % stride[1]) : 0;
-
-    Value weightPaddingVal =
-        getTosaConstShape(rewriter, op->getLoc(), weightPadding);
 
     weight = CreateOpAndInferShape<tosa::PadOp>(
         rewriter, loc, UnrankedTensorType::get(weightETy), weight,
@@ -392,20 +201,10 @@ public:
 
     // We need to pad the input far enough that we can pull all values.
     llvm::SmallVector<int64_t, 8> inputPadding = {0, 0, 0, 0, 0, 0, 0, 0};
-
-    // If the op has input padding, make sure to use that. If not, default back
-    // to using the legacy logic.
-    if (op.getPad().has_value()) {
-      inputPadding[2] = inPadVals[0];
-      inputPadding[3] = inPadVals[1];
-      inputPadding[4] = inPadVals[2];
-      inputPadding[5] = inPadVals[3];
-    } else {
-      inputPadding[2] += restridedWeightTy.getDimSize(1) - 1;
-      inputPadding[3] += restridedWeightTy.getDimSize(1) - 1;
-      inputPadding[4] += restridedWeightTy.getDimSize(2) - 1;
-      inputPadding[5] += restridedWeightTy.getDimSize(2) - 1;
-    }
+    inputPadding[2] += restridedWeightTy.getDimSize(1) - 1;
+    inputPadding[3] += restridedWeightTy.getDimSize(1) - 1;
+    inputPadding[4] += restridedWeightTy.getDimSize(2) - 1;
+    inputPadding[5] += restridedWeightTy.getDimSize(2) - 1;
 
     Value inputPaddingVal =
         getTosaConstShape(rewriter, op->getLoc(), inputPadding);
@@ -441,7 +240,7 @@ public:
                        /*pad=*/rewriter.getDenseI64ArrayAttr({0, 0, 0, 0}),
                        /*stride=*/rewriter.getDenseI64ArrayAttr({1, 1}),
                        /*dilation=*/rewriter.getDenseI64ArrayAttr({1, 1}),
-                       op.getAccType(), op->getAttrOfType<IntegerAttr>("group"))
+                       /* acc_type = */ op.getAccType(), /*group=*/nullptr)
                        .getResult();
 
     // Factor the resulting width / height.
@@ -478,51 +277,11 @@ public:
         rewriter, loc, UnrankedTensorType::get(resultETy), conv2d,
         convReshapeDims1Value);
 
-    // Effective pad = outPad + (k - 1) - (inPad * stride)
-    // Each input padded row/col expands to stride rows/cols in the upsampled
-    // domain.
-    int64_t effPadTop  = pad[0] + (origWeightHeight - stride[0]) - inPadVals[0]*stride[0];
-    int64_t effPadLeft = pad[2] + (origWeightWidth  - stride[1]) - inPadVals[2]*stride[1];
-
-    // When we shrink from the orignal size to kPrime by grouping stride phases,
-    // we discard some positions that existed in the conceptual upsampled view.
-    // The total span of the original field is kOrig -1, and the span
-    // represented after factoring is kPrime - 1. The difference is the values
-    // that have been lost
-    int64_t kHPrime = restridedWeightTy.getDimSize(1);
-    int64_t kWPrime = restridedWeightTy.getDimSize(2);
-    auto lost = [](int64_t Korig, int64_t kPrime, int64_t S) {
-      return (Korig - 1) - (kPrime - 1)*S;
-    };
-    int64_t lostH = lost(origWeightHeight, kHPrime, stride[0]);
-    int64_t lostW = lost(origWeightWidth,  kWPrime, stride[1]);
-
-    // If stride factoring compresses a dimension to a single spatial position,
-    // i.e., kPrime == 1, then we dropped a ring of values around that position.
-    // To keep the result centered, update effPad by the half the lost distance.
-    if (kHPrime == 1 && lostH > 0)
-      effPadTop += lostH / 2;
-    if (kWPrime == 1 && lostW > 0)
-      effPadLeft += lostW / 2;
-
-    int64_t resultSliceTop;
-    int64_t resultSliceLeft;
-    int64_t resultPadTop;
-    int64_t resultPadLeft;
-    // Convert effective padding into slice (crop) and post-pad just like the
-    // prior logic but now using effPad*.
-    if (op.getPad().has_value()) {
-      resultSliceTop = std::max<int64_t>(0, -effPadTop);
-      resultSliceLeft = std::max<int64_t>(0, -effPadLeft);
-      resultPadTop = std::max<int64_t>(0, effPadTop);
-      resultPadLeft = std::max<int64_t>(0, effPadLeft);
-    } else {
-      // Default to using legacy logic if input padding is not present
-      resultSliceTop = std::max<int64_t>(0, -pad[0]);
-      resultSliceLeft = std::max<int64_t>(0, -pad[2]);
-      resultPadTop = std::max<int64_t>(0, pad[0]);
-      resultPadLeft = std::max<int64_t>(0, pad[2]);
-    }
+    // Determine the amount to slice / pad from the result start.
+    int64_t resultSliceTop = std::max<int64_t>(0, -pad[0]);
+    int64_t resultSliceLeft = std::max<int64_t>(0, -pad[2]);
+    int64_t resultPadTop = std::max<int64_t>(0, pad[0]);
+    int64_t resultPadLeft = std::max<int64_t>(0, pad[2]);
 
     // Try to slice the targetted result size, cap to the convolutions width.
     int64_t resultSliceHeight =

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
@@ -24,6 +24,35 @@ using namespace mlir::tosa;
 
 namespace {
 
+// If this is a backward-data (transpose) conv lowered from MIGraphX, its
+// filter logical in/out channels are reversed relative to forward Conv2D.
+FailureOr<std::tuple<Value, ShapedType>>
+swapInputOutputDimensions(OpBuilder &rewriter, Operation *op,
+                          Value weight, ShapedType weightTy) {
+  if (auto kindAttr = op->getAttrOfType<StringAttr>("conv_kind");
+      kindAttr && kindAttr.getValue() == "bwd_data") {
+    // Expected current shape: [K, H, W, C] but Conv2D expects [O, H, W, I]
+    // Swap K<->C => permutation {3,1,2,0}.
+    auto wShape = weightTy.getShape();
+    SmallVector<int64_t, 4> swappedShape{
+        wShape[3], // C becomes O
+        wShape[1],
+        wShape[2],
+        wShape[0]  // K becomes I
+    };
+    auto swappedTy =
+        RankedTensorType::get(swappedShape, weightTy.getElementType());
+    weight = rewriter.create<tosa::TransposeOp>(
+        op->getLoc(), swappedTy, weight,
+        rewriter.getDenseI32ArrayAttr({3, 1, 2, 0}));
+    weightTy = cast<ShapedType>(weight.getType());
+
+    return std::make_tuple(weight, weightTy);
+  }
+
+  return failure();
+}
+
 class TransposeConvNonStridedConverter
     : public OpRewritePattern<tosa::TransposeConv2DOp> {
 public:
@@ -68,6 +97,13 @@ public:
     if (!inputTy.hasStaticShape() || !weightTy.hasStaticShape() ||
         !biasTy.hasStaticShape() || !resultTy.hasStaticShape())
       return failure();
+
+    // Swap dimensions if needed
+    auto swapOr = swapInputOutputDimensions(rewriter, op, weight, weightTy);
+    if (succeeded(swapOr)) {
+      weight = std::get<0>(swapOr.value());
+      weightTy = std::get<1>(swapOr.value());
+    }
 
     int64_t kernelHeight = weightTy.getDimSize(1);
     int64_t kernelWidth = weightTy.getDimSize(2);
@@ -144,24 +180,11 @@ public:
     llvm::ArrayRef<int64_t> pad = op.getOutPad();
     llvm::ArrayRef<int64_t> stride = op.getStride();
 
-    // If this is a backward-data (transpose) conv lowered from MIGraphX, its
-    // filter logical in/out channels are reversed relative to forward Conv2D.
-    if (auto kindAttr = op->getAttrOfType<StringAttr>("conv_kind");
-        kindAttr && kindAttr.getValue() == "bwd_data") {
-      // Expected current shape: [K, H, W, C] but Conv2D expects [O, H, W, I]
-      // Swap K<->C => permutation {3,1,2,0}.
-      auto wShape = weightTy.getShape();
-      SmallVector<int64_t, 4> swappedShape{
-          wShape[3], // C becomes O
-          wShape[1],
-          wShape[2],
-          wShape[0]  // K becomes I
-      };
-      auto swappedTy =
-          RankedTensorType::get(swappedShape, weightTy.getElementType());
-      weight = rewriter.create<tosa::TransposeOp>(
-          loc, swappedTy, weight, rewriter.getDenseI32ArrayAttr({3, 1, 2, 0}));
-      weightTy = cast<ShapedType>(weight.getType());
+    // Swap dimensions if needed
+    auto swapOr = swapInputOutputDimensions(rewriter, op, weight, weightTy);
+    if (succeeded(swapOr)) {
+      weight = std::get<0>(swapOr.value());
+      weightTy = std::get<1>(swapOr.value());
     }
 
     // Fetch dilation (default {1,1})

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
@@ -43,6 +43,22 @@ public:
     llvm::ArrayRef<int64_t> stride = op.getStride();
     llvm::ArrayRef<int64_t> pad = op.getOutPad();
 
+    // Fetch dilation (default {1,1})
+    SmallVector<int64_t, 2> dilationVals = {1, 1};
+    if (auto dilOpt = op.getDilation()) {
+      dilationVals[0] = (*dilOpt)[0];
+      dilationVals[1] = (*dilOpt)[1];
+    }
+
+    // Fetch input pads (default zeros)
+    SmallVector<int64_t, 4> inPadVals(4, 0);
+    if (auto padOpt = op.getPad()) {
+      inPadVals[0] = (*padOpt)[0]; // top
+      inPadVals[1] = (*padOpt)[1]; // bottom
+      inPadVals[2] = (*padOpt)[2]; // left
+      inPadVals[3] = (*padOpt)[3]; // right
+    }
+
     // If striding is all 1 we can modify padding and reverse the kernel along
     // the x/y direction to make it a regular convolution. This is much simpler
     // then handling striding....
@@ -55,12 +71,34 @@ public:
 
     int64_t kernelHeight = weightTy.getDimSize(1);
     int64_t kernelWidth = weightTy.getDimSize(2);
+    int64_t effKHm1 = (kernelHeight - 1) * dilationVals[0];
+    int64_t effKWm1 = (kernelWidth - 1) * dilationVals[1];
 
-    llvm::SmallVector<int64_t> convPad(4, 0);
-    convPad[0] = kernelHeight - 1 + pad[0];
-    convPad[1] = kernelHeight - 1 + pad[1];
-    convPad[2] = kernelWidth - 1 + pad[2];
-    convPad[3] = kernelWidth - 1 + pad[3];
+    // Conv2D padding derived from ConvTranspose (ONNX/PyTorch style)
+    // convPadTop    = effKHm1 - inPadTop    + outPadTop
+    // convPadBottom = effKHm1 - inPadBottom + outPadBottom
+    // convPadLeft   = effKWm1 - inPadLeft   + outPadLeft
+    // convPadRight  = effKWm1 - inPadRight  + outPadRight
+    SmallVector<int64_t, 4> convPad = {
+        effKHm1 - inPadVals[0] + pad[0],
+        effKHm1 - inPadVals[1] + pad[1],
+        effKWm1 - inPadVals[2] + pad[2],
+        effKWm1 - inPadVals[3] + pad[3]
+    };
+
+    bool needSlice = false;
+    SmallVector<int64_t,4> negExcess(4,0);
+    for (int i=0;i<4;++i) {
+      if (convPad[i] < 0) {
+        negExcess[i] = -convPad[i];
+        convPad[i] = 0;
+        needSlice = true;
+      }
+    }
+
+    if (needSlice)
+      return rewriter.notifyMatchFailure(op, "Cannot currently handle negative "
+                                             "padding values.");
 
     auto reverse1 =
         tosa::ReverseOp::create(rewriter, loc, weightTy, weight,
@@ -73,8 +111,9 @@ public:
         rewriter, loc, resultTy, input, reverse2, bias, op.getInputZp(),
         op.getWeightZp(), rewriter.getDenseI64ArrayAttr(convPad),
         rewriter.getDenseI64ArrayAttr(stride),
-        rewriter.getDenseI64ArrayAttr({1, 1}),
-        /* acc_type = */ op.getAccType(), /*group=*/nullptr);
+        rewriter.getDenseI64ArrayAttr(dilationVals),
+        /* acc_type = */ op.getAccType(),
+        op->getAttrOfType<IntegerAttr>("group"));
 
     rewriter.replaceOp(op, conv2d);
     return success();
@@ -105,9 +144,41 @@ public:
     llvm::ArrayRef<int64_t> pad = op.getOutPad();
     llvm::ArrayRef<int64_t> stride = op.getStride();
 
-    // If striding is all 1 we can modify padding and reverse the kernel along
-    // the x/y direction to make it a regular convolution. This is much simpler
-    // then handling striding....
+    // If this is a backward-data (transpose) conv lowered from MIGraphX, its
+    // filter logical in/out channels are reversed relative to forward Conv2D.
+    if (auto kindAttr = op->getAttrOfType<StringAttr>("conv_kind");
+        kindAttr && kindAttr.getValue() == "bwd_data") {
+      // Expected current shape: [K, H, W, C] but Conv2D expects [O, H, W, I]
+      // Swap K<->C => permutation {3,1,2,0}.
+      auto wShape = weightTy.getShape();
+      SmallVector<int64_t, 4> swappedShape{
+          wShape[3], // C becomes O
+          wShape[1],
+          wShape[2],
+          wShape[0]  // K becomes I
+      };
+      auto swappedTy =
+          RankedTensorType::get(swappedShape, weightTy.getElementType());
+      weight = rewriter.create<tosa::TransposeOp>(
+          loc, swappedTy, weight, rewriter.getDenseI32ArrayAttr({3, 1, 2, 0}));
+      weightTy = cast<ShapedType>(weight.getType());
+    }
+
+    // Fetch dilation (default {1,1})
+    SmallVector<int64_t, 2> dilationVals = {1, 1};
+    if (auto dilOpt = op.getDilation()) {
+      dilationVals[0] = (*dilOpt)[0];
+      dilationVals[1] = (*dilOpt)[1];
+    }
+
+    // Fetch input padding (default {0, 0, 0, 0})
+    SmallVector<int64_t, 4> inPadVals = {0, 0, 0, 0};
+    if (auto inPadOpt = op.getPad()) {
+      inPadVals[0] = (*inPadOpt)[0];
+      inPadVals[1] = (*inPadOpt)[1];
+      inPadVals[2] = (*inPadOpt)[2];
+      inPadVals[3] = (*inPadOpt)[3];
+    }
 
     // If strides are all 1 we dont need to use this one.
     if (llvm::all_of(stride, [](int64_t v) { return v == 1; }))
@@ -123,16 +194,6 @@ public:
     int64_t weightHeight = weightTy.getDimSize(1);
     int64_t weightWidth = weightTy.getDimSize(2);
     int64_t inputChannels = weightTy.getDimSize(3);
-
-    // Pad the weight so that it is modulo of the striding.
-    llvm::SmallVector<int64_t, 8> weightPadding = {0, 0, 0, 0, 0, 0, 0, 0};
-    weightPadding[3] =
-        (weightHeight % stride[0]) ? (stride[0] - weightHeight % stride[0]) : 0;
-    weightPadding[5] =
-        (weightWidth % stride[1]) ? (stride[1] - weightWidth % stride[1]) : 0;
-
-    Value weightPaddingVal =
-        getTosaConstShape(rewriter, op->getLoc(), weightPadding);
 
     // Get and verify zero points.
     FailureOr<int64_t> maybeIZp = op.getInputZeroPoint();
@@ -162,6 +223,109 @@ public:
         createPadConstTensor(builder, op->getLoc(), input, inputZpVal);
     const Value weightPadConst =
         createPadConstTensor(builder, op->getLoc(), input, weightZpVal);
+
+    // Helper to create a scalar pad value (weight zero-point)
+    auto createWeightPadConst = [&](Value like) -> Value {
+      return createPadConstTensor(builder, loc, like, weightZpVal);
+    };
+
+    // Explicitly materialize dilation in the weight tensor by inserting
+    // (d-1) rows / columns of zero between the original kernel rows and
+    // columns. After this expansion we can treat dilation as 1
+    // for the remainder of the lowering.
+    if (dilationVals[0] > 1 || dilationVals[1] > 1) {
+      int64_t dH = dilationVals[0];
+      int64_t dW = dilationVals[1];
+
+      // Expand height: iterate original over original rows, slice each 1-row
+      // slab, and (except for the final row) pad (dH-1) zero rows below it.
+      SmallVector<Value> heightPieces;
+      for (int64_t h = 0; h < weightHeight; ++h) {
+        llvm::SmallVector<int64_t, 4> begin = {0, h, 0, 0};
+        llvm::SmallVector<int64_t, 4> size = {outputChannels, 1, weightWidth,
+                                              inputChannels};
+        Value beginVal = getTosaConstShape(rewriter, loc, begin);
+        Value sizeVal = getTosaConstShape(rewriter, loc, size);
+        Value slice = CreateOpAndInferShape<tosa::SliceOp>(
+                          rewriter, loc, UnrankedTensorType::get(weightETy),
+                          weight, beginVal, sizeVal)
+                          .getResult();
+        int64_t padRows = (h == weightHeight - 1) ? 0 : (dH - 1);
+        if (padRows > 0) {
+          llvm::SmallVector<int64_t, 8> padSpec =
+                            {0, 0, 0, padRows, 0, 0, 0, 0};
+          Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
+          slice = CreateOpAndInferShape<tosa::PadOp>(
+                      rewriter, loc, UnrankedTensorType::get(weightETy), slice,
+                      padSpecVal, createWeightPadConst(weight))
+                      .getResult();
+        }
+        heightPieces.push_back(slice);
+      }
+      weight = CreateOpAndInferShape<tosa::ConcatOp>(
+                   rewriter, loc, UnrankedTensorType::get(weightETy),
+                   SmallVector<Value>(heightPieces.begin(), heightPieces.end()),
+                   rewriter.getI32IntegerAttr(1))
+                   .getResult();
+
+      // Update dims after height expansion
+      weightTy = cast<ShapedType>(weight.getType());
+      weightHeight = weightTy.getDimSize(1); // now (origH-1)*dH + 1
+
+      // Expand width similarly if horizontal dilation > 1.
+      if (dW > 1) {
+        SmallVector<Value> widthPieces;
+        for (int64_t w = 0; w < weightWidth; ++w) {
+          llvm::SmallVector<int64_t, 4> begin = {0, 0, w, 0};
+          llvm::SmallVector<int64_t, 4> size = {outputChannels, weightHeight,
+                                                1, inputChannels};
+          Value beginVal = getTosaConstShape(rewriter, loc, begin);
+          Value sizeVal = getTosaConstShape(rewriter, loc, size);
+          Value slice = CreateOpAndInferShape<tosa::SliceOp>(
+                            rewriter, loc, UnrankedTensorType::get(weightETy),
+                            weight, beginVal, sizeVal)
+                            .getResult();
+          int64_t padCols = (w == weightWidth - 1) ? 0 : (dW - 1);
+          if (padCols > 0) {
+            llvm::SmallVector<int64_t, 8> padSpec =
+                              {0, 0, 0, 0, 0, padCols, 0, 0};
+            Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
+            slice = CreateOpAndInferShape<tosa::PadOp>(
+                        rewriter, loc, UnrankedTensorType::get(weightETy),
+                        slice, padSpecVal, createWeightPadConst(weight))
+                        .getResult();
+          }
+          widthPieces.push_back(slice);
+        }
+        weight = CreateOpAndInferShape<tosa::ConcatOp>(
+                     rewriter, loc, UnrankedTensorType::get(weightETy),
+                     SmallVector<Value>(widthPieces.begin(), widthPieces.end()),
+                     rewriter.getI32IntegerAttr(2))
+                     .getResult();
+      }
+
+      // Update type/dims post width expansion.
+      weightTy = cast<ShapedType>(weight.getType());
+      weightWidth = weightTy.getDimSize(2);
+
+      // After explicit expansion, treat dilation as 1 for the remainder.
+      dilationVals = {1, 1};
+    }
+
+    // We want to capture the height and width values after dilation expansion,
+    // but before padding is added later on.
+    int64_t origWeightHeight = weightHeight;
+    int64_t origWeightWidth  = weightWidth;
+
+    // Pad the weight so that it is modulo of the striding.
+    llvm::SmallVector<int64_t, 8> weightPadding = {0, 0, 0, 0, 0, 0, 0, 0};
+    weightPadding[3] =
+        (weightHeight % stride[0]) ? (stride[0] - weightHeight % stride[0]) : 0;
+    weightPadding[5] =
+        (weightWidth % stride[1]) ? (stride[1] - weightWidth % stride[1]) : 0;
+
+    Value weightPaddingVal =
+        getTosaConstShape(rewriter, op->getLoc(), weightPadding);
 
     weight = CreateOpAndInferShape<tosa::PadOp>(
         rewriter, loc, UnrankedTensorType::get(weightETy), weight,
@@ -205,10 +369,20 @@ public:
 
     // We need to pad the input far enough that we can pull all values.
     llvm::SmallVector<int64_t, 8> inputPadding = {0, 0, 0, 0, 0, 0, 0, 0};
-    inputPadding[2] += restridedWeightTy.getDimSize(1) - 1;
-    inputPadding[3] += restridedWeightTy.getDimSize(1) - 1;
-    inputPadding[4] += restridedWeightTy.getDimSize(2) - 1;
-    inputPadding[5] += restridedWeightTy.getDimSize(2) - 1;
+
+    // If the op has input padding, make sure to use that. If not, default back
+    // to using the legacy logic.
+    if (op.getPad().has_value()) {
+      inputPadding[2] = inPadVals[0];
+      inputPadding[3] = inPadVals[1];
+      inputPadding[4] = inPadVals[2];
+      inputPadding[5] = inPadVals[3];
+    } else {
+      inputPadding[2] += restridedWeightTy.getDimSize(1) - 1;
+      inputPadding[3] += restridedWeightTy.getDimSize(1) - 1;
+      inputPadding[4] += restridedWeightTy.getDimSize(2) - 1;
+      inputPadding[5] += restridedWeightTy.getDimSize(2) - 1;
+    }
 
     Value inputPaddingVal =
         getTosaConstShape(rewriter, op->getLoc(), inputPadding);
@@ -244,7 +418,7 @@ public:
                        /*pad=*/rewriter.getDenseI64ArrayAttr({0, 0, 0, 0}),
                        /*stride=*/rewriter.getDenseI64ArrayAttr({1, 1}),
                        /*dilation=*/rewriter.getDenseI64ArrayAttr({1, 1}),
-                       /* acc_type = */ op.getAccType(), /*group=*/nullptr)
+                       op.getAccType(), op->getAttrOfType<IntegerAttr>("group"))
                        .getResult();
 
     // Factor the resulting width / height.
@@ -281,11 +455,51 @@ public:
         rewriter, loc, UnrankedTensorType::get(resultETy), conv2d,
         convReshapeDims1Value);
 
-    // Determine the amount to slice / pad from the result start.
-    int64_t resultSliceTop = std::max<int64_t>(0, -pad[0]);
-    int64_t resultSliceLeft = std::max<int64_t>(0, -pad[2]);
-    int64_t resultPadTop = std::max<int64_t>(0, pad[0]);
-    int64_t resultPadLeft = std::max<int64_t>(0, pad[2]);
+    // Effective pad = outPad + (k - 1) - (inPad * stride)
+    // Each input padded row/col expands to stride rows/cols in the upsampled
+    // domain.
+    int64_t effPadTop  = pad[0] + (origWeightHeight - stride[0]) - inPadVals[0]*stride[0];
+    int64_t effPadLeft = pad[2] + (origWeightWidth  - stride[1]) - inPadVals[2]*stride[1];
+
+    // When we shrink from the orignal size to kPrime by grouping stride phases,
+    // we discard some positions that existed in the conceptual upsampled view.
+    // The total span of the original field is kOrig -1, and the span
+    // represented after factoring is kPrime - 1. The difference is the values
+    // that have been lost
+    int64_t kHPrime = restridedWeightTy.getDimSize(1);
+    int64_t kWPrime = restridedWeightTy.getDimSize(2);
+    auto lost = [](int64_t Korig, int64_t kPrime, int64_t S) {
+      return (Korig - 1) - (kPrime - 1)*S;
+    };
+    int64_t lostH = lost(origWeightHeight, kHPrime, stride[0]);
+    int64_t lostW = lost(origWeightWidth,  kWPrime, stride[1]);
+
+    // If stride factoring compresses a dimension to a single spatial position,
+    // i.e., kPrime == 1, then we dropped a ring of values around that position.
+    // To keep the result centered, update effPad by the half the lost distance.
+    if (kHPrime == 1 && lostH > 0)
+      effPadTop += lostH / 2;
+    if (kWPrime == 1 && lostW > 0)
+      effPadLeft += lostW / 2;
+
+    int64_t resultSliceTop;
+    int64_t resultSliceLeft;
+    int64_t resultPadTop;
+    int64_t resultPadLeft;
+    // Convert effective padding into slice (crop) and post-pad just like the
+    // prior logic but now using effPad*.
+    if (op.getPad().has_value()) {
+      resultSliceTop = std::max<int64_t>(0, -effPadTop);
+      resultSliceLeft = std::max<int64_t>(0, -effPadLeft);
+      resultPadTop = std::max<int64_t>(0, effPadTop);
+      resultPadLeft = std::max<int64_t>(0, effPadLeft);
+    } else {
+      // Default to using legacy logic if input padding is not present
+      resultSliceTop = std::max<int64_t>(0, -pad[0]);
+      resultSliceLeft = std::max<int64_t>(0, -pad[2]);
+      resultPadTop = std::max<int64_t>(0, pad[0]);
+      resultPadLeft = std::max<int64_t>(0, pad[2]);
+    }
 
     // Try to slice the targetted result size, cap to the convolutions width.
     int64_t resultSliceHeight =

--- a/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/Tosa/Transforms/TosaDecomposeTransposeConv.cpp
@@ -105,6 +105,10 @@ public:
     llvm::ArrayRef<int64_t> pad = op.getOutPad();
     llvm::ArrayRef<int64_t> stride = op.getStride();
 
+    // If striding is all 1 we can modify padding and reverse the kernel along
+    // the x/y direction to make it a regular convolution. This is much simpler
+    // then handling striding....
+
     // If strides are all 1 we dont need to use this one.
     if (llvm::all_of(stride, [](int64_t v) { return v == 1; }))
       return rewriter.notifyMatchFailure(op, "non-one stride found.");

--- a/external/llvm-project/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/invalid.mlir
@@ -223,7 +223,7 @@ func.func @test_transpose_conv2d_invalid_stride_x(%arg0: tensor<1x32x32x8xf32>, 
 // -----
 
 func.func @test_transpose_conv2d_invalid_output_height(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x1x1x8xf32>, %arg2: tensor<16xf32>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<1x33x32x16xf32> {
-  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OH == (IH - 1) * stride_y + out_pad_top + out_pad_bottom + KH, but got 33 != (32 - 1) * 1 + 0 + 0 + 1}}
+  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OH = (IH - 1) * stride_y + out_pad_top + out_pad_bottom + ((KH - 1) * dilation_y + 1) - pad_top - pad_bottom, but got: 33 != (32 - 1) * 1 + 0 + 0 + ((1 - 1) * 1 + 1) - 0 - 0}}
   %0 = tosa.transpose_conv2d %arg0, %arg1, %arg2, %arg3, %arg4 {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 33, 32, 16>, stride = array<i64: 1, 1>} : (tensor<1x32x32x8xf32>, tensor<16x1x1x8xf32>, tensor<16xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x33x32x16xf32>
   return %0 : tensor<1x33x32x16xf32>
 }
@@ -231,7 +231,7 @@ func.func @test_transpose_conv2d_invalid_output_height(%arg0: tensor<1x32x32x8xf
 // -----
 
 func.func @test_transpose_conv2d_invalid_output_width(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x1x1x8xf32>, %arg2: tensor<16xf32>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<1x32x40x16xf32> {
-  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OW == (IW - 1) * stride_x + out_pad_left + out_pad_right + KW, but got 40 != (32 - 1) * 1 + 0 + 0 + 1}}
+  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OW = (IW - 1) * stride_x + out_pad_left + out_pad_right + (KW - 1) * dilation_x + 1 - pad_left - pad_right, but got: 40 != (32 - 1) * 1 + 0 + 0 + ((1 - 1) * 1 + 1) - 0}}
   %0 = tosa.transpose_conv2d %arg0, %arg1, %arg2, %arg3, %arg4 {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 32, 40, 16>, stride = array<i64: 1, 1>} : (tensor<1x32x32x8xf32>, tensor<16x1x1x8xf32>, tensor<16xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x40x16xf32>
   return %0 : tensor<1x32x40x16xf32>
 }

--- a/external/llvm-project/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/external/llvm-project/mlir/test/Dialect/Tosa/invalid.mlir
@@ -223,7 +223,7 @@ func.func @test_transpose_conv2d_invalid_stride_x(%arg0: tensor<1x32x32x8xf32>, 
 // -----
 
 func.func @test_transpose_conv2d_invalid_output_height(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x1x1x8xf32>, %arg2: tensor<16xf32>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<1x33x32x16xf32> {
-  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OH = (IH - 1) * stride_y + out_pad_top + out_pad_bottom + ((KH - 1) * dilation_y + 1) - pad_top - pad_bottom, but got: 33 != (32 - 1) * 1 + 0 + 0 + ((1 - 1) * 1 + 1) - 0 - 0}}
+  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OH == (IH - 1) * stride_y + out_pad_top + out_pad_bottom + KH, but got 33 != (32 - 1) * 1 + 0 + 0 + 1}}
   %0 = tosa.transpose_conv2d %arg0, %arg1, %arg2, %arg3, %arg4 {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 33, 32, 16>, stride = array<i64: 1, 1>} : (tensor<1x32x32x8xf32>, tensor<16x1x1x8xf32>, tensor<16xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x33x32x16xf32>
   return %0 : tensor<1x33x32x16xf32>
 }
@@ -231,7 +231,7 @@ func.func @test_transpose_conv2d_invalid_output_height(%arg0: tensor<1x32x32x8xf
 // -----
 
 func.func @test_transpose_conv2d_invalid_output_width(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x1x1x8xf32>, %arg2: tensor<16xf32>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<1x32x40x16xf32> {
-  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OW = (IW - 1) * stride_x + out_pad_left + out_pad_right + (KW - 1) * dilation_x + 1 - pad_left - pad_right, but got: 40 != (32 - 1) * 1 + 0 + 0 + ((1 - 1) * 1 + 1) - 0}}
+  // expected-error@+1 {{'tosa.transpose_conv2d' op dimension mismatch: expected OW == (IW - 1) * stride_x + out_pad_left + out_pad_right + KW, but got 40 != (32 - 1) * 1 + 0 + 0 + 1}}
   %0 = tosa.transpose_conv2d %arg0, %arg1, %arg2, %arg3, %arg4 {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 32, 40, 16>, stride = array<i64: 1, 1>} : (tensor<1x32x32x8xf32>, tensor<16x1x1x8xf32>, tensor<16xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x40x16xf32>
   return %0 : tensor<1x32x40x16xf32>
 }

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -80,7 +80,7 @@ LogicalResult verifyConvTranspose(tosa::CustomOp op,
   int64_t strideZ = 1;
   if (convDims == 3)
     strideZ = strides[2];
-                                    
+
   if (strideY < 1 || strideX < 1 || strideZ < 1)
     return op.emitOpError("expect all stride values to be >= 1, got [")
            << strides << "]";
@@ -338,7 +338,7 @@ public:
     // A negative padding value would require cropping, "slicing", the result
     // to properly emulate negative padding.
     bool needSlice = false;
-    SmallVector<int64_t,4> negExcess(convDims * 2, 0);
+    SmallVector<int64_t, 4> negExcess(convDims * 2, 0);
     for (int i = 0; i < convDims * 2; ++i) {
       if (convPad[i] < 0) {
         negExcess[i] = -convPad[i];
@@ -365,18 +365,17 @@ public:
           rewriter.getDenseI64ArrayAttr(convPad),
           rewriter.getDenseI64ArrayAttr(stride),
           rewriter.getDenseI64ArrayAttr(dilationVals),
-          /* acc_type = */ accType,
-          op->getAttrOfType<IntegerAttr>("group"));
+          /* acc_type = */ accType, op->getAttrOfType<IntegerAttr>("group"));
     } else {
       Value reverse3 =
           tosa::ReverseOp::create(rewriter, loc, weightTy, reverse2,
                                   /* axis = */ rewriter.getI32IntegerAttr(3));
-      convOp = tosa::Conv3DOp::create(rewriter, loc, resultTy, input, reverse3,
-                                      bias, inputZp, weightZp,
-                                      rewriter.getDenseI64ArrayAttr(convPad),
-                                      rewriter.getDenseI64ArrayAttr(stride),
-                                      rewriter.getDenseI64ArrayAttr(dilationVals),
-                                      /* acc_type = */ accType);
+      convOp = tosa::Conv3DOp::create(
+          rewriter, loc, resultTy, input, reverse3, bias, inputZp, weightZp,
+          rewriter.getDenseI64ArrayAttr(convPad),
+          rewriter.getDenseI64ArrayAttr(stride),
+          rewriter.getDenseI64ArrayAttr(dilationVals),
+          /* acc_type = */ accType);
     }
 
     rewriter.replaceOp(op, convOp);

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -45,6 +45,157 @@ struct RocmlirCustomTosaDecomposePass
   void runOnOperation() override;
 };
 
+// This is mostly a copy of the verification op that exists for
+// tosa::TransposeConv2DOp in upstream with the output shape checks updated
+// to properly account for input padding and dilation.
+// See here for the formula being used:
+// https://onnx.ai/onnx/operators/onnx__ConvTranspose.html
+LogicalResult verifyCustomOp(tosa::CustomOp op) {
+  llvm::ArrayRef<int64_t> strides =
+        cast<DenseI64ArrayAttr>(op->getAttr("stride"));
+  const int64_t strideY = strides[0];
+  const int64_t strideX = strides[1];
+
+  if (strideY < 1 || strideX < 1)
+    return op.emitOpError("expect all stride values to be >= 1, got [")
+           << strides << "]";
+
+  const auto checkPadAgainstKernelDim =
+      [&](int64_t pad_value, int64_t kernel_dim_size,
+             llvm::StringRef pad_name,
+             llvm::StringRef kernel_dim_name) -> LogicalResult {
+    if (pad_value <= -kernel_dim_size)
+      return op.emitOpError("expected ")
+             << pad_name << " > -" << kernel_dim_name
+             << ", but got: " << pad_name << "=" << pad_value << " and "
+             << kernel_dim_name << "=" << kernel_dim_size;
+    return success();
+  };
+
+  llvm::ArrayRef<int64_t> outPad =
+        cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
+  const int64_t outPadTop = outPad[0];
+  const int64_t outPadBottom = outPad[1];
+  const int64_t outPadLeft = outPad[2];
+  const int64_t outPadRight = outPad[3];
+
+  Value weight = op->getOperand(1);
+  const auto weightType =
+      llvm::dyn_cast<RankedTensorType>(weight.getType());
+
+  if (weightType) {
+    const int64_t kernelHeight = weightType.getDimSize(1);
+    if (ShapedType::isStatic(kernelHeight)) {
+      if (failed(checkPadAgainstKernelDim(outPadTop, kernelHeight,
+                                          "out_pad_top", "KH")))
+        return failure();
+
+      if (failed(checkPadAgainstKernelDim(outPadBottom, kernelHeight,
+                                          "out_pad_bottom", "KH")))
+        return failure();
+    }
+
+    const int64_t kernelWidth = weightType.getDimSize(2);
+    if (ShapedType::isStatic(kernelWidth)) {
+      if (failed(checkPadAgainstKernelDim(outPadLeft, kernelWidth,
+                                          "out_pad_left", "KW")))
+        return failure();
+
+      if (failed(checkPadAgainstKernelDim(outPadRight, kernelWidth,
+                                          "out_pad_right", "KW")))
+        return failure();
+    }
+  }
+
+  // Rest of the checks depend on the output type being a RankedTensorType
+  const auto outputType =
+      llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+  if (!outputType)
+    return success();
+
+  // Fetch pad & dilation;
+  SmallVector<int64_t, 2> dilation = {1, 1};
+  if (auto dilOpt = cast<DenseI64ArrayAttr>(op->getAttr("dilation"))) {
+    dilation[0] = (dilOpt)[0];
+    dilation[1] = (dilOpt)[1];
+  }
+
+  // Fetch input pads (default zeros)
+  SmallVector<int64_t, 4> inPad(4, 0);
+  if (auto padOpt = cast<DenseI64ArrayAttr>(op->getAttr("pad"))) {
+    inPad[0] = (padOpt)[0]; // top
+    inPad[1] = (padOpt)[1]; // bottom
+    inPad[2] = (padOpt)[2]; // left
+    inPad[3] = (padOpt)[3]; // right
+  }
+
+  Value input = op->getOperand(0);
+  const auto inputType = llvm::dyn_cast<RankedTensorType>(input.getType());
+  if (inputType && weightType) {
+    const int64_t inputHeight = inputType.getDimSize(1);
+    const int64_t kernelHeight = weightType.getDimSize(1);
+    const int64_t outputHeight = outputType.getDimSize(1);
+
+    if (!ShapedType::isDynamic(inputHeight) &&
+        !ShapedType::isDynamic(outputHeight)) {
+      if (outputHeight != (inputHeight - 1) * strideY + outPadTop +
+                          outPadBottom + ((kernelHeight - 1) * dilation[0]) +
+                          1 - inPad[0] - inPad[1]) {
+        return op.emitOpError(
+                    "dimension mismatch: expected OH = (IH - 1) * "
+                    "stride_y + out_pad_top + out_pad_bottom + ((KH - 1) * "
+                    "dilation_y + 1) - pad_top - pad_bottom, but got: ")
+                << outputHeight << " != (" << inputHeight << " - 1) * "
+                << strideY << " + " << outPadTop << " + "
+                << outPadBottom << " + ((" << kernelHeight
+                << " - 1) * " << dilation[0] << " + 1) - "
+                << inPad[0] << " - " << inPad[1];
+      } 
+    }
+
+    const int64_t inputWidth = inputType.getDimSize(2);
+    const int64_t kernelWidth = weightType.getDimSize(2);
+    const int64_t outputWidth = outputType.getDimSize(2);
+
+    if (!ShapedType::isDynamic(inputWidth) &&
+        !ShapedType::isDynamic(outputWidth)) {
+      if (outputWidth != (inputWidth - 1) * strideX + outPadLeft + outPadRight + 
+                              ((kernelWidth - 1) * dilation[1] + 1) -
+                              inPad[2] - inPad[3]) {
+        return op.emitOpError(
+                    "dimension mismatch: expected OW = (IW - 1) * "
+                    "stride_x + out_pad_left + out_pad_right + (KW - 1) * "
+                    "dilation_x + 1 - pad_left - pad_right, but got: ")
+                << outputWidth << " != (" << inputWidth << " - 1) * "
+                << strideX << " + " << outPadLeft << " + " << outPadRight
+                << " + ((" << kernelWidth << " - 1) * " << dilation[1]
+                << " + 1) - " << inPad[2] - inPad[3];
+      }
+    }
+  }
+
+  Value bias = op->getOperand(2);
+  const auto biasType = llvm::dyn_cast<RankedTensorType>(bias.getType());
+
+  if (!biasType)
+    return success();
+
+  const int64_t biasChannels = biasType.getDimSize(0);
+
+  // Skip further checks if bias is dynamic
+  if (biasChannels == ShapedType::kDynamic)
+    return success();
+
+  const int64_t outputChannels = outputType.getDimSize(3);
+  if (!ShapedType::isDynamic(outputChannels) &&
+      biasChannels != outputChannels && biasChannels != 1)
+    return op.emitOpError(
+               "bias channels expected to be equal to output channels (")
+           << outputChannels << ") or 1, got " << biasChannels;
+
+  return success();
+}
+
 // If this is a backward-data (transpose) conv lowered from MIGraphX, its
 // filter logical in/out channels are reversed relative to forward Conv2D.
 FailureOr<std::tuple<Value, ShapedType>>
@@ -87,6 +238,9 @@ public:
       return rewriter.notifyMatchFailure(op, "should have 5 or more operands");
     if (op.getNumResults() != 1)
       return rewriter.notifyMatchFailure(op, "should have 1 result");
+
+    if (failed(verifyCustomOp(op)))
+      return failure();
 
     Location loc = op->getLoc();
     Value input = op->getOperand(0);
@@ -267,6 +421,9 @@ public:
       return rewriter.notifyMatchFailure(op, "should have 5 or more operands");
     if (op.getNumResults() != 1)
       return rewriter.notifyMatchFailure(op, "should have 1 result");
+
+    if (failed(verifyCustomOp(op)))
+      return failure();
 
     Location loc = op->getLoc();
     Value input = op->getOperand(0);

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -100,7 +100,7 @@ public:
     ShapedType resultTy = cast<ShapedType>(op->getResult(0).getType());
 
     // Translate acc_type, padding and stride attributes.
-    llvm::ArrayRef<int64_t> pad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
+    llvm::ArrayRef<int64_t> outPad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
     llvm::ArrayRef<int64_t> stride =
         cast<DenseI64ArrayAttr>(op->getAttr("stride"));
     auto accTypeAttr = cast<TypeAttr>(op->getAttr("acc_type"));
@@ -166,15 +166,17 @@ public:
     // Conv2D/Conv3D padding derived from ConvTranspose (ONNX/PyTorch style)
     // convPad = effK - inPad + outPad
     SmallVector<int64_t, 4> convPad(convDims * 2, 0);
-    convPad[0] = effKHm1 - inPadVals[0] + pad[0];
-    convPad[1] = effKHm1 - inPadVals[1] + pad[1];
-    convPad[2] = effKWm1 - inPadVals[2] + pad[2];
-    convPad[3] = effKWm1 - inPadVals[3] + pad[3];
+    convPad[0] = effKHm1 - inPadVals[0] + outPad[0];
+    convPad[1] = effKHm1 - inPadVals[1] + outPad[1];
+    convPad[2] = effKWm1 - inPadVals[2] + outPad[2];
+    convPad[3] = effKWm1 - inPadVals[3] + outPad[3];
     if (convDims == 3) {
-      convPad[4] = effKDm1 - inPadVals[4] + pad[4];
-      convPad[5] = effKDm1 - inPadVals[5] + pad[5];
+      convPad[4] = effKDm1 - inPadVals[4] + outPad[4];
+      convPad[5] = effKDm1 - inPadVals[5] + outPad[5];
     }
 
+    // A negative padding value would require cropping, "slicing", the result
+    // to properly emulate negative padding.
     bool needSlice = false;
     SmallVector<int64_t,4> negExcess(convDims * 2, 0);
     for (int i = 0; i < convDims * 2; ++i) {
@@ -282,7 +284,7 @@ public:
     Type resultETy = resultTy.getElementType();
 
     // Translate acc_type, padding and stride attributes.
-    llvm::ArrayRef<int64_t> pad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
+    llvm::ArrayRef<int64_t> outPad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
     llvm::ArrayRef<int64_t> stride =
         cast<DenseI64ArrayAttr>(op->getAttr("stride"));
     auto accTypeAttr = cast<TypeAttr>(op->getAttr("acc_type"));
@@ -588,8 +590,8 @@ public:
     // Effective pad = outPad + (k - 1) - (inPad * stride)
     // Each input padded row/col expands to stride rows/cols in the upsampled
     // domain.
-    int64_t effPadTop  = pad[0] + (origWeightHeight - stride[0]) - inPadVals[0]*stride[0];
-    int64_t effPadLeft = pad[2] + (origWeightWidth  - stride[1]) - inPadVals[2]*stride[1];
+    int64_t effPadTop  = outPad[0] + (origWeightHeight - stride[0]) - inPadVals[0]*stride[0];
+    int64_t effPadLeft = outPad[2] + (origWeightWidth  - stride[1]) - inPadVals[2]*stride[1];
 
     // When we shrink from the orignal size to kPrime by grouping stride phases,
     // we discard some positions that existed in the conceptual upsampled view.
@@ -625,10 +627,10 @@ public:
       resultPadLeft = std::max<int64_t>(0, effPadLeft);
     } else {
       // Default to using legacy logic if input padding is not present
-      resultSliceTop = std::max<int64_t>(0, -pad[0]);
-      resultSliceLeft = std::max<int64_t>(0, -pad[2]);
-      resultPadTop = std::max<int64_t>(0, pad[0]);
-      resultPadLeft = std::max<int64_t>(0, pad[2]);
+      resultSliceTop = std::max<int64_t>(0, -outPad[0]);
+      resultSliceLeft = std::max<int64_t>(0, -outPad[2]);
+      resultPadTop = std::max<int64_t>(0, outPad[0]);
+      resultPadLeft = std::max<int64_t>(0, outPad[2]);
     }
 
     // Try to slice the targetted result size, cap to the convolutions width.

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -687,7 +687,9 @@ void mlir::rock::populateRocmlirCustomTosaDecomposeTarget(
     ConversionTarget &target) {
   target.addLegalDialect<tosa::TosaDialect>();
   target.addDynamicallyLegalOp<tosa::CustomOp>([](tosa::CustomOp op) {
-    return op.getDomainName() != ROCK_CUSTOMOP_DOMAIN_NAME;
+    return op.getDomainName() != ROCK_CUSTOMOP_DOMAIN_NAME ||
+            (op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_DATA &&
+            op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_WEIGHT);
   });
 }
 

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -50,7 +50,28 @@ struct RocmlirCustomTosaDecomposePass
 // to properly account for input padding and dilation.
 // See here for the formula being used:
 // https://onnx.ai/onnx/operators/onnx__ConvTranspose.html
-LogicalResult verifyCustomOp(tosa::CustomOp op) {
+LogicalResult verifyConvTranspose(tosa::CustomOp op,
+                                  PatternRewriter &rewriter) {
+  // Make sure this is a transpose conv op.
+  if (op.getDomainName() != ROCK_CUSTOMOP_DOMAIN_NAME)
+    return rewriter.notifyMatchFailure(op, "domain isn't rocmlir");
+  if (op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_DATA)
+    return rewriter.notifyMatchFailure(op, "isn't a conv_bwd_data");
+  if (op.getNumOperands() < 5)
+    return rewriter.notifyMatchFailure(op, "should have 5 or more operands");
+  if (op.getNumResults() != 1)
+    return rewriter.notifyMatchFailure(op, "should have 1 result");
+
+  const auto outputType =
+      llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+  if (!outputType)
+    return failure();
+
+  // Currently, we cannot handle supporting arbitrary Conv3D transpose ops, so
+  // for now we return failure().
+  if (outputType.getRank() == 5)
+    return failure();
+
   llvm::ArrayRef<int64_t> strides =
         cast<DenseI64ArrayAttr>(op->getAttr("stride"));
   const int64_t strideY = strides[0];
@@ -106,12 +127,6 @@ LogicalResult verifyCustomOp(tosa::CustomOp op) {
         return failure();
     }
   }
-
-  // Rest of the checks depend on the output type being a RankedTensorType
-  const auto outputType =
-      llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
-  if (!outputType)
-    return success();
 
   // Fetch pad & dilation;
   SmallVector<int64_t, 2> dilation = {1, 1};
@@ -229,17 +244,7 @@ public:
   using OpRewritePattern<tosa::CustomOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tosa::CustomOp op,
                                 PatternRewriter &rewriter) const final {
-    // Make sure this is a transpose conv op.
-    if (op.getDomainName() != ROCK_CUSTOMOP_DOMAIN_NAME)
-      return rewriter.notifyMatchFailure(op, "domain isn't rocmlir");
-    if (op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_DATA)
-      return rewriter.notifyMatchFailure(op, "isn't a conv_bwd_data");
-    if (op.getNumOperands() < 5)
-      return rewriter.notifyMatchFailure(op, "should have 5 or more operands");
-    if (op.getNumResults() != 1)
-      return rewriter.notifyMatchFailure(op, "should have 1 result");
-
-    if (failed(verifyCustomOp(op)))
+    if (failed(verifyConvTranspose(op, rewriter)))
       return failure();
 
     Location loc = op->getLoc();
@@ -412,17 +417,7 @@ public:
   using OpRewritePattern<tosa::CustomOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tosa::CustomOp op,
                                 PatternRewriter &rewriter) const final {
-    // Make sure this is a transpose conv op.
-    if (op.getDomainName() != ROCK_CUSTOMOP_DOMAIN_NAME)
-      return rewriter.notifyMatchFailure(op, "domain isn't rocmlir");
-    if (op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_DATA)
-      return rewriter.notifyMatchFailure(op, "isn't a conv_bwd_data");
-    if (op.getNumOperands() < 5)
-      return rewriter.notifyMatchFailure(op, "should have 5 or more operands");
-    if (op.getNumResults() != 1)
-      return rewriter.notifyMatchFailure(op, "should have 1 result");
-
-    if (failed(verifyCustomOp(op)))
+    if (failed(verifyConvTranspose(op, rewriter)))
       return failure();
 
     Location loc = op->getLoc();

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -45,6 +45,34 @@ struct RocmlirCustomTosaDecomposePass
   void runOnOperation() override;
 };
 
+// If this is a backward-data (transpose) conv lowered from MIGraphX, its
+// filter logical in/out channels are reversed relative to forward Conv2D.
+FailureOr<std::tuple<Value, ShapedType>>
+swapInputOutputDimensions(OpBuilder &rewriter, tosa::CustomOp op,
+                          Value weight, ShapedType weightTy) {
+  if (op.getOperatorName() == ROCK_CUSTOMOP_CONV_BWD_DATA) {
+    // Expected current shape: [K, H, W, C] but Conv2D expects [O, H, W, I]
+    // Swap K<->C => permutation {3,1,2,0}.
+    auto wShape = weightTy.getShape();
+    SmallVector<int64_t, 4> swappedShape{
+        wShape[3], // C becomes O
+        wShape[1],
+        wShape[2],
+        wShape[0]  // K becomes I
+    };
+    auto swappedTy =
+        RankedTensorType::get(swappedShape, weightTy.getElementType());
+    weight = rewriter.create<tosa::TransposeOp>(
+        op.getLoc(), swappedTy, weight,
+        rewriter.getDenseI32ArrayAttr({3, 1, 2, 0}));
+    weightTy = cast<ShapedType>(weight.getType());
+
+    return std::make_tuple(weight, weightTy);
+  }
+
+  return failure();
+}
+
 class TransposeConvNonStridedConverter
     : public OpRewritePattern<tosa::CustomOp> {
 public:
@@ -72,7 +100,7 @@ public:
     ShapedType resultTy = cast<ShapedType>(op->getResult(0).getType());
 
     // Translate acc_type, padding and stride attributes.
-    llvm::ArrayRef<int64_t> pad = cast<DenseI64ArrayAttr>(op->getAttr("pad"));
+    llvm::ArrayRef<int64_t> pad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
     llvm::ArrayRef<int64_t> stride =
         cast<DenseI64ArrayAttr>(op->getAttr("stride"));
     auto accTypeAttr = cast<TypeAttr>(op->getAttr("acc_type"));
@@ -81,6 +109,28 @@ public:
     int convDims = stride.size();
     if (convDims != 2 && convDims != 3)
       return rewriter.notifyMatchFailure(op, "conv op must be 2D or 3D");
+
+    // Fetch dilation (default all ones)
+    SmallVector<int64_t> dilationVals(ConvDims, 1);
+    if (auto dilOpt = cast<DenseI64ArrayAttr>(op->getAttr("dilation"))) {
+      dilationVals[0] = (dilOpt)[0];
+      dilationVals[1] = (dilOpt)[1];
+      if (convDims == 3)
+        dilationVals[2] = (dilOpt)[2];
+    }
+
+    // Fetch input pads (default zeros)
+    SmallVector<int64_t, 4> inPadVals(convDims * 2, 0);
+    if (auto padOpt = cast<DenseI64ArrayAttr>(op->getAttr("pad"))) {
+      inPadVals[0] = (padOpt)[0];
+      inPadVals[1] = (padOpt)[1];
+      inPadVals[2] = (padOpt)[2];
+      inPadVals[3] = (padOpt)[3];
+      if (convDims == 3) {
+        inPadVals[4] = (padOpt)[4];
+        inPadVals[5] = (padOpt)[5];
+      }
+    }
 
     // Get inputZp and weightZp operands.
     Value inputZp = op.getOperands()[3];
@@ -96,18 +146,48 @@ public:
         !biasTy.hasStaticShape() || !resultTy.hasStaticShape())
       return failure();
 
+    // Swap dimensions if needed
+    auto swapOr = swapInputOutputDimensions(rewriter, op, weight, weightTy);
+    if (succeeded(swapOr)) {
+      weight = std::get<0>(swapOr.value());
+      weightTy = std::get<1>(swapOr.value());
+    }
+
     int64_t kernelHeight = weightTy.getDimSize(1);
     int64_t kernelWidth = weightTy.getDimSize(2);
-
-    llvm::SmallVector<int64_t> convPad(convDims * 2, 0);
-    convPad[0] = kernelHeight - 1 + pad[0];
-    convPad[1] = kernelHeight - 1 + pad[1];
-    convPad[2] = kernelWidth - 1 + pad[2];
-    convPad[3] = kernelWidth - 1 + pad[3];
+    int64_t effKHm1 = (kernelHeight - 1) * dilationVals[0];
+    int64_t effKWm1 = (kernelWidth - 1) * dilationVals[1];
+    int64_t effKDm1 = 0;
     if (convDims == 3) {
-      convPad[4] = kernelWidth - 1 + pad[4];
-      convPad[5] = kernelWidth - 1 + pad[5];
+      int64_t kernelDepth = weightTy.getDimSize(3);
+      effKDm1 = (kernelDepth - 1) * dilationVals[2];
     }
+
+    // Conv2D/Conv3D padding derived from ConvTranspose (ONNX/PyTorch style)
+    // convPad = effK - inPad + outPad
+    SmallVector<int64_t, 4> convPad(convDims * 2, 0);
+    convPad[0] = effKHm1 - inPadVals[0] + pad[0];
+    convPad[1] = effKHm1 - inPadVals[1] + pad[1];
+    convPad[2] = effKWm1 - inPadVals[2] + pad[2];
+    convPad[3] = effKWm1 - inPadVals[3] + pad[3];
+    if (convDims == 3) {
+      convPad[4] = effKDm1 - inPadVals[4] + pad[4];
+      convPad[5] = effKDm1 - inPadVals[5] + pad[5];
+    }
+
+    bool needSlice = false;
+    SmallVector<int64_t,4> negExcess(convDims * 2, 0);
+    for (int i = 0; i < convDims * 2; ++i) {
+      if (convPad[i] < 0) {
+        negExcess[i] = -convPad[i];
+        convPad[i] = 0;
+        needSlice = true;
+      }
+    }
+
+    if (needSlice)
+      return rewriter.notifyMatchFailure(op, "Cannot currently handle negative "
+                                             "padding values.");
 
     Value convOp;
     Value reverse1 =
@@ -122,8 +202,9 @@ public:
           rewriter, loc, resultTy, input, reverse2, bias, inputZp, weightZp,
           rewriter.getDenseI64ArrayAttr(convPad),
           rewriter.getDenseI64ArrayAttr(stride),
-          rewriter.getDenseI64ArrayAttr({1, 1}),
-          /* acc_type = */ accType, /*group=*/nullptr);
+          rewriter.getDenseI64ArrayAttr(dilationVals),
+          /* acc_type = */ accType,
+          op->getAttrOfType<IntegerAttr>("group"));
     } else {
       Value reverse3 =
           tosa::ReverseOp::create(rewriter, loc, weightTy, reverse2,
@@ -132,8 +213,9 @@ public:
                                       bias, inputZp, weightZp,
                                       rewriter.getDenseI64ArrayAttr(convPad),
                                       rewriter.getDenseI64ArrayAttr(stride),
-                                      rewriter.getDenseI64ArrayAttr({1, 1, 1}),
-                                      /* acc_type = */ accType);
+                                      rewriter.getDenseI64ArrayAttr(dilationVals),
+                                      /* acc_type = */ accType,
+                                      op->getAttrOfType<IntegerAttr>("group"));
     }
 
     rewriter.replaceOp(op, convOp);
@@ -200,7 +282,7 @@ public:
     Type resultETy = resultTy.getElementType();
 
     // Translate acc_type, padding and stride attributes.
-    llvm::ArrayRef<int64_t> pad = cast<DenseI64ArrayAttr>(op->getAttr("pad"));
+    llvm::ArrayRef<int64_t> pad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
     llvm::ArrayRef<int64_t> stride =
         cast<DenseI64ArrayAttr>(op->getAttr("stride"));
     auto accTypeAttr = cast<TypeAttr>(op->getAttr("acc_type"));
@@ -210,9 +292,28 @@ public:
     Value inputZpOperand = op.getOperands()[3];
     Value weightZpOperand = op.getOperands()[4];
 
-    // If striding is all 1 we can modify padding and reverse the kernel along
-    // the x/y direction to make it a regular convolution. This is much simpler
-    // then handling striding....
+    // Swap dimensions if needed
+    auto swapOr = swapInputOutputDimensions(rewriter, op, weight, weightTy);
+    if (succeeded(swapOr)) {
+      weight = std::get<0>(swapOr.value());
+      weightTy = std::get<1>(swapOr.value());
+    }
+
+    // Fetch dilation (default {1,1})
+    SmallVector<int64_t, 2> dilationVals = {1, 1};
+    if (auto dilOpt = cast<DenseI64ArrayAttr>(op->getAttr("dilation"))) {
+      dilationVals[0] = (dilOpt)[0];
+      dilationVals[1] = (dilOpt)[1];
+    }
+
+    // Fetch input padding (default {0, 0, 0, 0})
+    SmallVector<int64_t, 4> inPadVals = {0, 0, 0, 0};
+    if (auto inPadOpt = cast<DenseI64ArrayAttr>(op->getAttr("pad"))) {
+      inPadVals[0] = (inPadOpt)[0];
+      inPadVals[1] = (inPadOpt)[1];
+      inPadVals[2] = (inPadOpt)[2];
+      inPadVals[3] = (inPadOpt)[3];
+    }
 
     // If strides are all 1 we dont need to use this one.
     if (llvm::all_of(stride, [](int64_t v) { return v == 1; }))
@@ -228,16 +329,6 @@ public:
     int64_t weightHeight = weightTy.getDimSize(1);
     int64_t weightWidth = weightTy.getDimSize(2);
     int64_t inputChannels = weightTy.getDimSize(3);
-
-    // Pad the weight so that it is modulo of the striding.
-    llvm::SmallVector<int64_t, 8> weightPadding = {0, 0, 0, 0, 0, 0, 0, 0};
-    weightPadding[3] =
-        (weightHeight % stride[0]) ? (stride[0] - weightHeight % stride[0]) : 0;
-    weightPadding[5] =
-        (weightWidth % stride[1]) ? (stride[1] - weightWidth % stride[1]) : 0;
-
-    Value weightPaddingVal =
-        getTosaConstShape(rewriter, op->getLoc(), weightPadding);
 
     // Get and verify zero points.
     FailureOr<int64_t> maybeIZp = getZeroPoint(inputZpOperand, false);
@@ -262,6 +353,109 @@ public:
         createPadConstTensor(builder, op->getLoc(), input, inputZpVal);
     const Value weightPadConst =
         createPadConstTensor(builder, op->getLoc(), input, weightZpVal);
+
+    // Helper to create a scalar pad value (weight zero-point)
+    auto createWeightPadConst = [&](Value like) -> Value {
+      return createPadConstTensor(builder, loc, like, weightZpVal);
+    };
+
+    // Explicitly materialize dilation in the weight tensor by inserting
+    // (d-1) rows / columns of zero between the original kernel rows and
+    // columns. After this expansion we can treat dilation as 1
+    // for the remainder of the lowering.
+    if (dilationVals[0] > 1 || dilationVals[1] > 1) {
+      int64_t dH = dilationVals[0];
+      int64_t dW = dilationVals[1];
+
+      // Expand height: iterate original over original rows, slice each 1-row
+      // slab, and (except for the final row) pad (dH-1) zero rows below it.
+      SmallVector<Value> heightPieces;
+      for (int64_t h = 0; h < weightHeight; ++h) {
+        llvm::SmallVector<int64_t, 4> begin = {0, h, 0, 0};
+        llvm::SmallVector<int64_t, 4> size = {outputChannels, 1, weightWidth,
+                                              inputChannels};
+        Value beginVal = getTosaConstShape(rewriter, loc, begin);
+        Value sizeVal = getTosaConstShape(rewriter, loc, size);
+        Value slice = CreateOpAndInferShape<tosa::SliceOp>(
+                          rewriter, loc, UnrankedTensorType::get(weightETy),
+                          weight, beginVal, sizeVal)
+                          .getResult();
+        int64_t padRows = (h == weightHeight - 1) ? 0 : (dH - 1);
+        if (padRows > 0) {
+          llvm::SmallVector<int64_t, 8> padSpec =
+                            {0, 0, 0, padRows, 0, 0, 0, 0};
+          Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
+          slice = CreateOpAndInferShape<tosa::PadOp>(
+                      rewriter, loc, UnrankedTensorType::get(weightETy), slice,
+                      padSpecVal, createWeightPadConst(weight))
+                      .getResult();
+        }
+        heightPieces.push_back(slice);
+      }
+      weight = CreateOpAndInferShape<tosa::ConcatOp>(
+                   rewriter, loc, UnrankedTensorType::get(weightETy),
+                   SmallVector<Value>(heightPieces.begin(), heightPieces.end()),
+                   rewriter.getI32IntegerAttr(1))
+                   .getResult();
+
+      // Update dims after height expansion
+      weightTy = cast<ShapedType>(weight.getType());
+      weightHeight = weightTy.getDimSize(1); // now (origH-1)*dH + 1
+
+      // Expand width similarly if horizontal dilation > 1.
+      if (dW > 1) {
+        SmallVector<Value> widthPieces;
+        for (int64_t w = 0; w < weightWidth; ++w) {
+          llvm::SmallVector<int64_t, 4> begin = {0, 0, w, 0};
+          llvm::SmallVector<int64_t, 4> size = {outputChannels, weightHeight,
+                                                1, inputChannels};
+          Value beginVal = getTosaConstShape(rewriter, loc, begin);
+          Value sizeVal = getTosaConstShape(rewriter, loc, size);
+          Value slice = CreateOpAndInferShape<tosa::SliceOp>(
+                            rewriter, loc, UnrankedTensorType::get(weightETy),
+                            weight, beginVal, sizeVal)
+                            .getResult();
+          int64_t padCols = (w == weightWidth - 1) ? 0 : (dW - 1);
+          if (padCols > 0) {
+            llvm::SmallVector<int64_t, 8> padSpec =
+                              {0, 0, 0, 0, 0, padCols, 0, 0};
+            Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
+            slice = CreateOpAndInferShape<tosa::PadOp>(
+                        rewriter, loc, UnrankedTensorType::get(weightETy),
+                        slice, padSpecVal, createWeightPadConst(weight))
+                        .getResult();
+          }
+          widthPieces.push_back(slice);
+        }
+        weight = CreateOpAndInferShape<tosa::ConcatOp>(
+                     rewriter, loc, UnrankedTensorType::get(weightETy),
+                     SmallVector<Value>(widthPieces.begin(), widthPieces.end()),
+                     rewriter.getI32IntegerAttr(2))
+                     .getResult();
+      }
+
+      // Update type/dims post width expansion.
+      weightTy = cast<ShapedType>(weight.getType());
+      weightWidth = weightTy.getDimSize(2);
+
+      // After explicit expansion, treat dilation as 1 for the remainder.
+      dilationVals = {1, 1};
+    }
+
+    // We want to capture the height and width values after dilation expansion,
+    // but before padding is added later on.
+    int64_t origWeightHeight = weightHeight;
+    int64_t origWeightWidth  = weightWidth;
+
+    // Pad the weight so that it is modulo of the striding.
+    llvm::SmallVector<int64_t, 8> weightPadding = {0, 0, 0, 0, 0, 0, 0, 0};
+    weightPadding[3] =
+        (weightHeight % stride[0]) ? (stride[0] - weightHeight % stride[0]) : 0;
+    weightPadding[5] =
+        (weightWidth % stride[1]) ? (stride[1] - weightWidth % stride[1]) : 0;
+
+    Value weightPaddingVal =
+        getTosaConstShape(rewriter, op->getLoc(), weightPadding);
 
     weight = CreateOpAndInferShape<tosa::PadOp>(
         rewriter, loc, UnrankedTensorType::get(weightETy), weight,
@@ -305,10 +499,19 @@ public:
 
     // We need to pad the input far enough that we can pull all values.
     llvm::SmallVector<int64_t, 8> inputPadding = {0, 0, 0, 0, 0, 0, 0, 0};
-    inputPadding[2] += restridedWeightTy.getDimSize(1) - 1;
-    inputPadding[3] += restridedWeightTy.getDimSize(1) - 1;
-    inputPadding[4] += restridedWeightTy.getDimSize(2) - 1;
-    inputPadding[5] += restridedWeightTy.getDimSize(2) - 1;
+    // If the op has input padding, make sure to use that. If not, default back
+    // to using the legacy logic.
+    if (op->hasAttr("pad")) {
+      inputPadding[2] = inPadVals[0];
+      inputPadding[3] = inPadVals[1];
+      inputPadding[4] = inPadVals[2];
+      inputPadding[5] = inPadVals[3];
+    } else {
+      inputPadding[2] += restridedWeightTy.getDimSize(1) - 1;
+      inputPadding[3] += restridedWeightTy.getDimSize(1) - 1;
+      inputPadding[4] += restridedWeightTy.getDimSize(2) - 1;
+      inputPadding[5] += restridedWeightTy.getDimSize(2) - 1;
+    }
 
     Value inputPaddingVal =
         getTosaConstShape(rewriter, op->getLoc(), inputPadding);
@@ -344,7 +547,8 @@ public:
                        /*pad=*/rewriter.getDenseI64ArrayAttr({0, 0, 0, 0}),
                        /*stride=*/rewriter.getDenseI64ArrayAttr({1, 1}),
                        /*dilation=*/rewriter.getDenseI64ArrayAttr({1, 1}),
-                       /* acc_type = */ accType, /*group=*/nullptr)
+                       /* acc_type = */ accType,
+                       op->getAttrOfType<IntegerAttr>("group"))
                        .getResult();
 
     // Factor the resulting width / height.
@@ -381,11 +585,51 @@ public:
         rewriter, loc, UnrankedTensorType::get(resultETy), conv2d,
         convReshapeDims1Value);
 
-    // Determine the amount to slice / pad from the result start.
-    int64_t resultSliceTop = std::max<int64_t>(0, -pad[0]);
-    int64_t resultSliceLeft = std::max<int64_t>(0, -pad[2]);
-    int64_t resultPadTop = std::max<int64_t>(0, pad[0]);
-    int64_t resultPadLeft = std::max<int64_t>(0, pad[2]);
+    // Effective pad = outPad + (k - 1) - (inPad * stride)
+    // Each input padded row/col expands to stride rows/cols in the upsampled
+    // domain.
+    int64_t effPadTop  = pad[0] + (origWeightHeight - stride[0]) - inPadVals[0]*stride[0];
+    int64_t effPadLeft = pad[2] + (origWeightWidth  - stride[1]) - inPadVals[2]*stride[1];
+
+    // When we shrink from the orignal size to kPrime by grouping stride phases,
+    // we discard some positions that existed in the conceptual upsampled view.
+    // The total span of the original field is kOrig -1, and the span
+    // represented after factoring is kPrime - 1. The difference is the values
+    // that have been lost
+    int64_t kHPrime = restridedWeightTy.getDimSize(1);
+    int64_t kWPrime = restridedWeightTy.getDimSize(2);
+    auto lost = [](int64_t Korig, int64_t kPrime, int64_t S) {
+      return (Korig - 1) - (kPrime - 1)*S;
+    };
+    int64_t lostH = lost(origWeightHeight, kHPrime, stride[0]);
+    int64_t lostW = lost(origWeightWidth,  kWPrime, stride[1]);
+
+    // If stride factoring compresses a dimension to a single spatial position,
+    // i.e., kPrime == 1, then we dropped a ring of values around that position.
+    // To keep the result centered, update effPad by the half the lost distance.
+    if (kHPrime == 1 && lostH > 0)
+      effPadTop += lostH / 2;
+    if (kWPrime == 1 && lostW > 0)
+      effPadLeft += lostW / 2;
+
+    int64_t resultSliceTop;
+    int64_t resultSliceLeft;
+    int64_t resultPadTop;
+    int64_t resultPadLeft;
+    // Convert effective padding into slice (crop) and post-pad just like the
+    // prior logic but now using effPad*.
+    if (op->hasAttr("pad")) {
+      resultSliceTop = std::max<int64_t>(0, -effPadTop);
+      resultSliceLeft = std::max<int64_t>(0, -effPadLeft);
+      resultPadTop = std::max<int64_t>(0, effPadTop);
+      resultPadLeft = std::max<int64_t>(0, effPadLeft);
+    } else {
+      // Default to using legacy logic if input padding is not present
+      resultSliceTop = std::max<int64_t>(0, -pad[0]);
+      resultSliceLeft = std::max<int64_t>(0, -pad[2]);
+      resultPadTop = std::max<int64_t>(0, pad[0]);
+      resultPadLeft = std::max<int64_t>(0, pad[2]);
+    }
 
     // Try to slice the targetted result size, cap to the convolutions width.
     int64_t resultSliceHeight =

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -48,17 +48,16 @@ struct RocmlirCustomTosaDecomposePass
 // If this is a backward-data (transpose) conv lowered from MIGraphX, its
 // filter logical in/out channels are reversed relative to forward Conv2D.
 FailureOr<std::tuple<Value, ShapedType>>
-swapInputOutputDimensions(OpBuilder &rewriter, tosa::CustomOp op,
-                          Value weight, ShapedType weightTy) {
+swapInputOutputDimensions(OpBuilder &rewriter, tosa::CustomOp op, Value weight,
+                          ShapedType weightTy) {
   if (op.getOperatorName() == ROCK_CUSTOMOP_CONV_BWD_DATA) {
     // Expected current shape: [K, H, W, C] but Conv2D expects [O, H, W, I]
     // Swap K<->C => permutation {3,1,2,0}.
     auto wShape = weightTy.getShape();
     SmallVector<int64_t, 4> swappedShape{
         wShape[3], // C becomes O
-        wShape[1],
-        wShape[2],
-        wShape[0]  // K becomes I
+        wShape[1], wShape[2],
+        wShape[0] // K becomes I
     };
     auto swappedTy =
         RankedTensorType::get(swappedShape, weightTy.getElementType());
@@ -100,7 +99,8 @@ public:
     ShapedType resultTy = cast<ShapedType>(op->getResult(0).getType());
 
     // Translate acc_type, padding and stride attributes.
-    llvm::ArrayRef<int64_t> outPad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
+    llvm::ArrayRef<int64_t> outPad =
+        cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
     llvm::ArrayRef<int64_t> stride =
         cast<DenseI64ArrayAttr>(op->getAttr("stride"));
     auto accTypeAttr = cast<TypeAttr>(op->getAttr("acc_type"));
@@ -284,7 +284,8 @@ public:
     Type resultETy = resultTy.getElementType();
 
     // Translate acc_type, padding and stride attributes.
-    llvm::ArrayRef<int64_t> outPad = cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
+    llvm::ArrayRef<int64_t> outPad =
+        cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
     llvm::ArrayRef<int64_t> stride =
         cast<DenseI64ArrayAttr>(op->getAttr("stride"));
     auto accTypeAttr = cast<TypeAttr>(op->getAttr("acc_type"));
@@ -384,8 +385,8 @@ public:
                           .getResult();
         int64_t padRows = (h == weightHeight - 1) ? 0 : (dH - 1);
         if (padRows > 0) {
-          llvm::SmallVector<int64_t, 8> padSpec =
-                            {0, 0, 0, padRows, 0, 0, 0, 0};
+          llvm::SmallVector<int64_t, 8> padSpec = {0, 0, 0, padRows,
+                                                   0, 0, 0, 0};
           Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
           slice = CreateOpAndInferShape<tosa::PadOp>(
                       rewriter, loc, UnrankedTensorType::get(weightETy), slice,
@@ -409,8 +410,8 @@ public:
         SmallVector<Value> widthPieces;
         for (int64_t w = 0; w < weightWidth; ++w) {
           llvm::SmallVector<int64_t, 4> begin = {0, 0, w, 0};
-          llvm::SmallVector<int64_t, 4> size = {outputChannels, weightHeight,
-                                                1, inputChannels};
+          llvm::SmallVector<int64_t, 4> size = {outputChannels, weightHeight, 1,
+                                                inputChannels};
           Value beginVal = getTosaConstShape(rewriter, loc, begin);
           Value sizeVal = getTosaConstShape(rewriter, loc, size);
           Value slice = CreateOpAndInferShape<tosa::SliceOp>(
@@ -419,8 +420,8 @@ public:
                             .getResult();
           int64_t padCols = (w == weightWidth - 1) ? 0 : (dW - 1);
           if (padCols > 0) {
-            llvm::SmallVector<int64_t, 8> padSpec =
-                              {0, 0, 0, 0, 0, padCols, 0, 0};
+            llvm::SmallVector<int64_t, 8> padSpec = {0, 0,       0, 0,
+                                                     0, padCols, 0, 0};
             Value padSpecVal = getTosaConstShape(rewriter, loc, padSpec);
             slice = CreateOpAndInferShape<tosa::PadOp>(
                         rewriter, loc, UnrankedTensorType::get(weightETy),
@@ -447,7 +448,7 @@ public:
     // We want to capture the height and width values after dilation expansion,
     // but before padding is added later on.
     int64_t origWeightHeight = weightHeight;
-    int64_t origWeightWidth  = weightWidth;
+    int64_t origWeightWidth = weightWidth;
 
     // Pad the weight so that it is modulo of the striding.
     llvm::SmallVector<int64_t, 8> weightPadding = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -543,15 +544,15 @@ public:
     }
 
     // Perform the convolution using the zero bias.
-    Value conv2d = CreateOpAndInferShape<tosa::Conv2DOp>(
-                       rewriter, loc, UnrankedTensorType::get(resultETy), input,
-                       weight, zeroBias, inputZp.value(), weightZp.value(),
-                       /*pad=*/rewriter.getDenseI64ArrayAttr({0, 0, 0, 0}),
-                       /*stride=*/rewriter.getDenseI64ArrayAttr({1, 1}),
-                       /*dilation=*/rewriter.getDenseI64ArrayAttr({1, 1}),
-                       /* acc_type = */ accType,
-                       op->getAttrOfType<IntegerAttr>("group"))
-                       .getResult();
+    Value conv2d =
+        CreateOpAndInferShape<tosa::Conv2DOp>(
+            rewriter, loc, UnrankedTensorType::get(resultETy), input, weight,
+            zeroBias, inputZp.value(), weightZp.value(),
+            /*pad=*/rewriter.getDenseI64ArrayAttr({0, 0, 0, 0}),
+            /*stride=*/rewriter.getDenseI64ArrayAttr({1, 1}),
+            /*dilation=*/rewriter.getDenseI64ArrayAttr({1, 1}),
+            /* acc_type = */ accType, op->getAttrOfType<IntegerAttr>("group"))
+            .getResult();
 
     // Factor the resulting width / height.
     ShapedType convTy = cast<ShapedType>(conv2d.getType());
@@ -590,8 +591,10 @@ public:
     // Effective pad = outPad + (k - 1) - (inPad * stride)
     // Each input padded row/col expands to stride rows/cols in the upsampled
     // domain.
-    int64_t effPadTop  = outPad[0] + (origWeightHeight - stride[0]) - inPadVals[0]*stride[0];
-    int64_t effPadLeft = outPad[2] + (origWeightWidth  - stride[1]) - inPadVals[2]*stride[1];
+    int64_t effPadTop =
+        outPad[0] + (origWeightHeight - stride[0]) - inPadVals[0] * stride[0];
+    int64_t effPadLeft =
+        outPad[2] + (origWeightWidth - stride[1]) - inPadVals[2] * stride[1];
 
     // When we shrink from the orignal size to kPrime by grouping stride phases,
     // we discard some positions that existed in the conceptual upsampled view.
@@ -601,10 +604,10 @@ public:
     int64_t kHPrime = restridedWeightTy.getDimSize(1);
     int64_t kWPrime = restridedWeightTy.getDimSize(2);
     auto lost = [](int64_t Korig, int64_t kPrime, int64_t S) {
-      return (Korig - 1) - (kPrime - 1)*S;
+      return (Korig - 1) - (kPrime - 1) * S;
     };
     int64_t lostH = lost(origWeightHeight, kHPrime, stride[0]);
-    int64_t lostW = lost(origWeightWidth,  kWPrime, stride[1]);
+    int64_t lostW = lost(origWeightWidth, kWPrime, stride[1]);
 
     // If stride factoring compresses a dimension to a single spatial position,
     // i.e., kPrime == 1, then we dropped a ring of values around that position.

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -73,7 +73,7 @@ LogicalResult verifyConvTranspose(tosa::CustomOp op,
     return failure();
 
   llvm::ArrayRef<int64_t> strides =
-        cast<DenseI64ArrayAttr>(op->getAttr("stride"));
+      cast<DenseI64ArrayAttr>(op->getAttr("stride"));
   const int64_t strideY = strides[0];
   const int64_t strideX = strides[1];
 
@@ -82,9 +82,8 @@ LogicalResult verifyConvTranspose(tosa::CustomOp op,
            << strides << "]";
 
   const auto checkPadAgainstKernelDim =
-      [&](int64_t pad_value, int64_t kernel_dim_size,
-             llvm::StringRef pad_name,
-             llvm::StringRef kernel_dim_name) -> LogicalResult {
+      [&](int64_t pad_value, int64_t kernel_dim_size, llvm::StringRef pad_name,
+          llvm::StringRef kernel_dim_name) -> LogicalResult {
     if (pad_value <= -kernel_dim_size)
       return op.emitOpError("expected ")
              << pad_name << " > -" << kernel_dim_name
@@ -94,15 +93,14 @@ LogicalResult verifyConvTranspose(tosa::CustomOp op,
   };
 
   llvm::ArrayRef<int64_t> outPad =
-        cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
+      cast<DenseI64ArrayAttr>(op->getAttr("out_pad"));
   const int64_t outPadTop = outPad[0];
   const int64_t outPadBottom = outPad[1];
   const int64_t outPadLeft = outPad[2];
   const int64_t outPadRight = outPad[3];
 
   Value weight = op->getOperand(1);
-  const auto weightType =
-      llvm::dyn_cast<RankedTensorType>(weight.getType());
+  const auto weightType = llvm::dyn_cast<RankedTensorType>(weight.getType());
 
   if (weightType) {
     const int64_t kernelHeight = weightType.getDimSize(1);
@@ -153,19 +151,18 @@ LogicalResult verifyConvTranspose(tosa::CustomOp op,
 
     if (!ShapedType::isDynamic(inputHeight) &&
         !ShapedType::isDynamic(outputHeight)) {
-      if (outputHeight != (inputHeight - 1) * strideY + outPadTop +
-                          outPadBottom + ((kernelHeight - 1) * dilation[0]) +
-                          1 - inPad[0] - inPad[1]) {
+      if (outputHeight !=
+          (inputHeight - 1) * strideY + outPadTop + outPadBottom +
+              ((kernelHeight - 1) * dilation[0]) + 1 - inPad[0] - inPad[1]) {
         return op.emitOpError(
-                    "dimension mismatch: expected OH = (IH - 1) * "
-                    "stride_y + out_pad_top + out_pad_bottom + ((KH - 1) * "
-                    "dilation_y + 1) - pad_top - pad_bottom, but got: ")
-                << outputHeight << " != (" << inputHeight << " - 1) * "
-                << strideY << " + " << outPadTop << " + "
-                << outPadBottom << " + ((" << kernelHeight
-                << " - 1) * " << dilation[0] << " + 1) - "
-                << inPad[0] << " - " << inPad[1];
-      } 
+                   "dimension mismatch: expected OH = (IH - 1) * "
+                   "stride_y + out_pad_top + out_pad_bottom + ((KH - 1) * "
+                   "dilation_y + 1) - pad_top - pad_bottom, but got: ")
+               << outputHeight << " != (" << inputHeight << " - 1) * "
+               << strideY << " + " << outPadTop << " + " << outPadBottom
+               << " + ((" << kernelHeight << " - 1) * " << dilation[0]
+               << " + 1) - " << inPad[0] << " - " << inPad[1];
+      }
     }
 
     const int64_t inputWidth = inputType.getDimSize(2);
@@ -174,17 +171,17 @@ LogicalResult verifyConvTranspose(tosa::CustomOp op,
 
     if (!ShapedType::isDynamic(inputWidth) &&
         !ShapedType::isDynamic(outputWidth)) {
-      if (outputWidth != (inputWidth - 1) * strideX + outPadLeft + outPadRight + 
-                              ((kernelWidth - 1) * dilation[1] + 1) -
-                              inPad[2] - inPad[3]) {
+      if (outputWidth != (inputWidth - 1) * strideX + outPadLeft + outPadRight +
+                             ((kernelWidth - 1) * dilation[1] + 1) - inPad[2] -
+                             inPad[3]) {
         return op.emitOpError(
-                    "dimension mismatch: expected OW = (IW - 1) * "
-                    "stride_x + out_pad_left + out_pad_right + (KW - 1) * "
-                    "dilation_x + 1 - pad_left - pad_right, but got: ")
-                << outputWidth << " != (" << inputWidth << " - 1) * "
-                << strideX << " + " << outPadLeft << " + " << outPadRight
-                << " + ((" << kernelWidth << " - 1) * " << dilation[1]
-                << " + 1) - " << inPad[2] - inPad[3];
+                   "dimension mismatch: expected OW = (IW - 1) * "
+                   "stride_x + out_pad_left + out_pad_right + (KW - 1) * "
+                   "dilation_x + 1 - pad_left - pad_right, but got: ")
+               << outputWidth << " != (" << inputWidth << " - 1) * " << strideX
+               << " + " << outPadLeft << " + " << outPadRight << " + (("
+               << kernelWidth << " - 1) * " << dilation[1] << " + 1) - "
+               << inPad[2] - inPad[3];
       }
     }
   }
@@ -840,7 +837,7 @@ void mlir::rock::populateRocmlirCustomTosaDecomposeTarget(
   target.addLegalDialect<tosa::TosaDialect>();
   target.addDynamicallyLegalOp<tosa::CustomOp>([](tosa::CustomOp op) {
     return op.getDomainName() != ROCK_CUSTOMOP_DOMAIN_NAME ||
-            (op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_DATA &&
+           (op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_DATA &&
             op.getOperatorName() != ROCK_CUSTOMOP_CONV_BWD_WEIGHT);
   });
 }

--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -67,17 +67,21 @@ LogicalResult verifyConvTranspose(tosa::CustomOp op,
   if (!outputType)
     return failure();
 
-  // Currently, we cannot handle supporting arbitrary Conv3D transpose ops, so
-  // for now we return failure().
-  if (outputType.getRank() == 5)
-    return failure();
-
   llvm::ArrayRef<int64_t> strides =
       cast<DenseI64ArrayAttr>(op->getAttr("stride"));
+  int convDims = strides.size();
+
+  // Right now we can only support 2D values
+  if (convDims == 3)
+    return failure();
+
   const int64_t strideY = strides[0];
   const int64_t strideX = strides[1];
-
-  if (strideY < 1 || strideX < 1)
+  int64_t strideZ = 1;
+  if (convDims == 3)
+    strideZ = strides[2];
+                                    
+  if (strideY < 1 || strideX < 1 || strideZ < 1)
     return op.emitOpError("expect all stride values to be >= 1, got [")
            << strides << "]";
 
@@ -267,7 +271,7 @@ public:
       return rewriter.notifyMatchFailure(op, "conv op must be 2D or 3D");
 
     // Fetch dilation (default all ones)
-    SmallVector<int64_t> dilationVals(ConvDims, 1);
+    SmallVector<int64_t> dilationVals(convDims, 1);
     if (auto dilOpt = cast<DenseI64ArrayAttr>(op->getAttr("dilation"))) {
       dilationVals[0] = (dilOpt)[0];
       dilationVals[1] = (dilOpt)[1];
@@ -372,8 +376,7 @@ public:
                                       rewriter.getDenseI64ArrayAttr(convPad),
                                       rewriter.getDenseI64ArrayAttr(stride),
                                       rewriter.getDenseI64ArrayAttr(dilationVals),
-                                      /* acc_type = */ accType,
-                                      op->getAttrOfType<IntegerAttr>("group"));
+                                      /* acc_type = */ accType);
     }
 
     rewriter.replaceOp(op, convOp);

--- a/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
@@ -19,6 +19,7 @@ add_rocmlir_dialect_library(MLIRRockPipeline
   MLIRRockTransforms
   MLIRRockUtility
   MLIRUBToLLVM
+  RocmlirCustomTosaDecompose
   RocmlirCustomTosaToLinalg
   RocmlirEmulateFp8ExtTrunc
 

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -69,6 +69,7 @@ void rock::buildBufferizePipeline(OpPassManager &pm,
     funcPm.addPass(rock::createRockViewToTransformPass());
   }
 
+  funcPm.addPass(createRocmlirCustomTosaDecomposePass());
   funcPm.addPass(createRocmlirCustomTosaToLinalgPass());
   // use tosa conversion pipeline
   // (see mlir/lib/Conversion/TosaToLinalg/TosaToLinalgPass.cpp)

--- a/mlir/test/Conversion/RocmlirCustomTosaDecompose/rocmlir-custom-tosa-decompose.mlir
+++ b/mlir/test/Conversion/RocmlirCustomTosaDecompose/rocmlir-custom-tosa-decompose.mlir
@@ -3,7 +3,7 @@
 // CHECK: @bwd_data_conv2d
 // CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
 // CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 4, 4, 4, 4>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 2, 2, 2, 2>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
 func.func @bwd_data_conv2d(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>) -> tensor<524288xf32> {
   %0 = tosa.const_shape  {values = dense<[512, 512, 4, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
   %1 = tosa.reshape %arg1, %0 : (tensor<4194304xf32>, !tosa.shape<4>) -> tensor<512x512x4x4xf32>
@@ -25,7 +25,7 @@ func.func @bwd_data_conv2d(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>
 // CHECK: @bwd_data_conv2d_stride
 // CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<2048x2x2x512xf32>) -> tensor<2048x2x2x512xf32>
 // CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<2048x2x2x512xf32>) -> tensor<2048x2x2x512xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x18x18x512xf32>, tensor<2048x2x2x512xf32>, tensor<2048xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x17x17x2048xf32>
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x18x18x512xf32>, tensor<2048x2x2x512xf32>, tensor<2048xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x17x17x2048xf32>
 func.func @bwd_data_conv2d_stride(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>) -> tensor<524288xf32> {
   %0 = tosa.const_shape  {values = dense<[512, 512, 4, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
   %1 = tosa.reshape %arg1, %0 : (tensor<4194304xf32>, !tosa.shape<4>) -> tensor<512x512x4x4xf32>
@@ -47,7 +47,7 @@ func.func @bwd_data_conv2d_stride(%arg0: tensor<131072xf32>, %arg1: tensor<41943
 // CHECK: func @bwd_data_conv2d_group
 // CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
 // CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 4, 4, 4, 4>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 2 : i64, pad = array<i64: 2, 2, 2, 2>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
 func.func @bwd_data_conv2d_group(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>) -> tensor<524288xf32> {
   %0 = tosa.const_shape  {values = dense<[512, 512, 4, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
   %1 = tosa.reshape %arg1, %0 : (tensor<4194304xf32>, !tosa.shape<4>) -> tensor<512x512x4x4xf32>
@@ -69,7 +69,7 @@ func.func @bwd_data_conv2d_group(%arg0: tensor<131072xf32>, %arg1: tensor<419430
 // CHECK: func @bwd_data_conv2d_dilation
 // CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
 // CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 4, 4, 4, 4>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 2, 2>, group = 1 : i64, pad = array<i64: 5, 5, 5, 5>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
 func.func @bwd_data_conv2d_dilation(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>) -> tensor<524288xf32> {
   %0 = tosa.const_shape  {values = dense<[512, 512, 4, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
   %1 = tosa.reshape %arg1, %0 : (tensor<4194304xf32>, !tosa.shape<4>) -> tensor<512x512x4x4xf32>
@@ -89,9 +89,9 @@ func.func @bwd_data_conv2d_dilation(%arg0: tensor<131072xf32>, %arg1: tensor<419
 
 // -----
 // CHECK: func @bwd_data_conv1d
-// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<64x1x1x3xf32>) -> tensor<64x1x1x3xf32>
-// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<64x1x1x3xf32>) -> tensor<64x1x1x3xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x224x1x3xf32>, tensor<64x1x1x3xf32>, tensor<64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x224x1x64xf32>
+// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<3x1x1x64xf32>) -> tensor<3x1x1x64xf32>
+// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<3x1x1x64xf32>) -> tensor<3x1x1x64xf32>
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x224x1x3xf32>, tensor<3x1x1x64xf32>, tensor<64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x224x1x64xf32>
 func.func @bwd_data_conv1d(%arg0: tensor<64xf32>, %arg1: tensor<672xf32>, %arg2: tensor<192xf32>) -> tensor<14336xf32> {
   %0 = tosa.const_shape  {values = dense<14336> : tensor<1xindex>} : () -> !tosa.shape<1>
   %1 = tosa.const_shape  {values = dense<[1, 224, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>

--- a/mlir/test/Conversion/RocmlirCustomTosaDecompose/rocmlir-custom-tosa-decompose.mlir
+++ b/mlir/test/Conversion/RocmlirCustomTosaDecompose/rocmlir-custom-tosa-decompose.mlir
@@ -1,24 +1,21 @@
 // RUN: rocmlir-opt --rocmlir-custom-tosa-decompose --split-input-file %s | FileCheck %s
 
 // CHECK: @bwd_data_conv2d
-// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 2, 2, 2, 2>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
-func.func @bwd_data_conv2d(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>) -> tensor<524288xf32> {
-  %0 = tosa.const_shape  {values = dense<[512, 512, 4, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  %1 = tosa.reshape %arg1, %0 : (tensor<4194304xf32>, !tosa.shape<4>) -> tensor<512x512x4x4xf32>
-  %2 = tosa.const_shape  {values = dense<[1, 512, 16, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  %3 = tosa.reshape %arg0, %2 : (tensor<131072xf32>, !tosa.shape<4>) -> tensor<1x512x16x16xf32>
-  %4 = tosa.transpose %3 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x512x16x16xf32>) -> tensor<1x16x16x512xf32>
-  %5 = tosa.transpose %1 {perms = array<i32: 0, 2, 3, 1>} : (tensor<512x512x4x4xf32>) -> tensor<512x4x4x512xf32>
-  %6 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %7 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %8 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<512xf32>}> : () -> tensor<512xf32>
-  %9 = tosa.custom %4, %5, %8, %6, %7 {acc_type = f32, dilation = array<i64: 1, 1>, domain_name = "rocmlir", group = 1 : i64, implementation_attrs = "", operator_name = "conv_bwd_data", out_pad = array<i64: 0, 0, 0, 0>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
-  %10 = tosa.transpose %9 {perms = array<i32: 0, 3, 1, 2>} : (tensor<1x32x32x512xf32>) -> tensor<1x512x32x32xf32>
-  %11 = tosa.const_shape  {values = dense<524288> : tensor<1xindex>} : () -> !tosa.shape<1>
-  %12 = tosa.reshape %10, %11 : (tensor<1x512x32x32xf32>, !tosa.shape<1>) -> tensor<524288xf32>
-  return %12 : tensor<524288xf32>
+// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<1x3x3x1xf32>) -> tensor<1x3x3x1xf32>
+// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<1x3x3x1xf32>) -> tensor<1x3x3x1xf32>
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 1 : i64, pad = array<i64: 2, 2, 2, 2>, stride = array<i64: 1, 1>} : (tensor<1x3x3x1xf32>, tensor<1x3x3x1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x5x5x1xf32> 
+func.func @bwd_data_conv2d(%arg0: tensor<9xf32> {mhal.read_access}, %arg1: tensor<9xf32> {mhal.read_access}) -> (tensor<25xf32> {mhal.write_access}) {
+  %0 = tosa.const_shape  {values = dense<25> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %1 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %2 = tosa.const_shape  {values = dense<[1, 1, 3, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %3 = tosa.reshape %arg0, %2 : (tensor<9xf32>, !tosa.shape<4>) -> tensor<1x1x3x3xf32>
+  %4 = tosa.reshape %arg1, %2 : (tensor<9xf32>, !tosa.shape<4>) -> tensor<1x1x3x3xf32>
+  %5 = tosa.transpose %4 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x1x3x3xf32>) -> tensor<1x3x3x1xf32>
+  %6 = tosa.transpose %3 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x1x3x3xf32>) -> tensor<1x3x3x1xf32>
+  %7 = tosa.custom %5, %6, %1, %1, %1 {acc_type = f32, dilation = array<i64: 1, 1>, domain_name = "rocmlir", group = 1 : i64, implementation_attrs = "", operator_name = "conv_bwd_data", out_pad = array<i64: 0, 0, 0, 0>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x3x3x1xf32>, tensor<1x3x3x1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x5x5x1xf32>
+  %8 = tosa.transpose %7 {perms = array<i32: 0, 3, 1, 2>} : (tensor<1x5x5x1xf32>) -> tensor<1x1x5x5xf32>
+  %9 = tosa.reshape %8, %0 : (tensor<1x1x5x5xf32>, !tosa.shape<1>) -> tensor<25xf32>
+  return %9 : tensor<25xf32>
 }
 
 // -----
@@ -45,46 +42,40 @@ func.func @bwd_data_conv2d_stride(%arg0: tensor<131072xf32>, %arg1: tensor<41943
 
 // -----
 // CHECK: func @bwd_data_conv2d_group
-// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 2 : i64, pad = array<i64: 2, 2, 2, 2>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
-func.func @bwd_data_conv2d_group(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>) -> tensor<524288xf32> {
-  %0 = tosa.const_shape  {values = dense<[512, 512, 4, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  %1 = tosa.reshape %arg1, %0 : (tensor<4194304xf32>, !tosa.shape<4>) -> tensor<512x512x4x4xf32>
-  %2 = tosa.const_shape  {values = dense<[1, 512, 16, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  %3 = tosa.reshape %arg0, %2 : (tensor<131072xf32>, !tosa.shape<4>) -> tensor<1x512x16x16xf32>
-  %4 = tosa.transpose %3 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x512x16x16xf32>) -> tensor<1x16x16x512xf32>
-  %5 = tosa.transpose %1 {perms = array<i32: 0, 2, 3, 1>} : (tensor<512x512x4x4xf32>) -> tensor<512x4x4x512xf32>
-  %6 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %7 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %8 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<512xf32>}> : () -> tensor<512xf32>
-  %9 = tosa.custom %4, %5, %8, %6, %7 {acc_type = f32, dilation = array<i64: 1, 1>, domain_name = "rocmlir", group = 2 : i64, implementation_attrs = "", operator_name = "conv_bwd_data", out_pad = array<i64: 0, 0, 0, 0>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
-  %10 = tosa.transpose %9 {perms = array<i32: 0, 3, 1, 2>} : (tensor<1x32x32x512xf32>) -> tensor<1x512x32x32xf32>
-  %11 = tosa.const_shape  {values = dense<524288> : tensor<1xindex>} : () -> !tosa.shape<1>
-  %12 = tosa.reshape %10, %11 : (tensor<1x512x32x32xf32>, !tosa.shape<1>) -> tensor<524288xf32>
-  return %12 : tensor<524288xf32>
+// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<1x3x3x1xf32>) -> tensor<1x3x3x1xf32>
+// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<1x3x3x1xf32>) -> tensor<1x3x3x1xf32>
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1>, group = 2 : i64, pad = array<i64: 2, 2, 2, 2>, stride = array<i64: 1, 1>} : (tensor<1x3x3x1xf32>, tensor<1x3x3x1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x5x5x1xf32> 
+func.func @bwd_data_conv2d_group(%arg0: tensor<9xf32> {mhal.read_access}, %arg1: tensor<9xf32> {mhal.read_access}) -> (tensor<25xf32> {mhal.write_access}) {
+  %0 = tosa.const_shape  {values = dense<25> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %1 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %2 = tosa.const_shape  {values = dense<[1, 1, 3, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %3 = tosa.reshape %arg0, %2 : (tensor<9xf32>, !tosa.shape<4>) -> tensor<1x1x3x3xf32>
+  %4 = tosa.reshape %arg1, %2 : (tensor<9xf32>, !tosa.shape<4>) -> tensor<1x1x3x3xf32>
+  %5 = tosa.transpose %4 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x1x3x3xf32>) -> tensor<1x3x3x1xf32>
+  %6 = tosa.transpose %3 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x1x3x3xf32>) -> tensor<1x3x3x1xf32>
+  %7 = tosa.custom %5, %6, %1, %1, %1 {acc_type = f32, dilation = array<i64: 1, 1>, domain_name = "rocmlir", group = 2 : i64, implementation_attrs = "", operator_name = "conv_bwd_data", out_pad = array<i64: 0, 0, 0, 0>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x3x3x1xf32>, tensor<1x3x3x1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x5x5x1xf32>
+  %8 = tosa.transpose %7 {perms = array<i32: 0, 3, 1, 2>} : (tensor<1x5x5x1xf32>) -> tensor<1x1x5x5xf32>
+  %9 = tosa.reshape %8, %0 : (tensor<1x1x5x5xf32>, !tosa.shape<1>) -> tensor<25xf32>
+  return %9 : tensor<25xf32>
 }
 
 // -----
 // CHECK: func @bwd_data_conv2d_dilation
-// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<512x4x4x512xf32>) -> tensor<512x4x4x512xf32>
-// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 2, 2>, group = 1 : i64, pad = array<i64: 5, 5, 5, 5>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
-func.func @bwd_data_conv2d_dilation(%arg0: tensor<131072xf32>, %arg1: tensor<4194304xf32>) -> tensor<524288xf32> {
-  %0 = tosa.const_shape  {values = dense<[512, 512, 4, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  %1 = tosa.reshape %arg1, %0 : (tensor<4194304xf32>, !tosa.shape<4>) -> tensor<512x512x4x4xf32>
-  %2 = tosa.const_shape  {values = dense<[1, 512, 16, 16]> : tensor<4xindex>} : () -> !tosa.shape<4>
-  %3 = tosa.reshape %arg0, %2 : (tensor<131072xf32>, !tosa.shape<4>) -> tensor<1x512x16x16xf32>
-  %4 = tosa.transpose %3 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x512x16x16xf32>) -> tensor<1x16x16x512xf32>
-  %5 = tosa.transpose %1 {perms = array<i32: 0, 2, 3, 1>} : (tensor<512x512x4x4xf32>) -> tensor<512x4x4x512xf32>
-  %6 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %7 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %8 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<512xf32>}> : () -> tensor<512xf32>
-  %9 = tosa.custom %4, %5, %8, %6, %7 {acc_type = f32, dilation = array<i64: 2, 2>, domain_name = "rocmlir", group = 1 : i64, implementation_attrs = "", operator_name = "conv_bwd_data", out_pad = array<i64: 0, 0, 0, 0>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<1x16x16x512xf32>, tensor<512x4x4x512xf32>, tensor<512xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x32x32x512xf32>
-  %10 = tosa.transpose %9 {perms = array<i32: 0, 3, 1, 2>} : (tensor<1x32x32x512xf32>) -> tensor<1x512x32x32xf32>
-  %11 = tosa.const_shape  {values = dense<524288> : tensor<1xindex>} : () -> !tosa.shape<1>
-  %12 = tosa.reshape %10, %11 : (tensor<1x512x32x32xf32>, !tosa.shape<1>) -> tensor<524288xf32>
-  return %12 : tensor<524288xf32>
+// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<1x3x3x1xf32>) -> tensor<1x3x3x1xf32> 
+// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<1x3x3x1xf32>) -> tensor<1x3x3x1xf32> 
+// CHECK: tosa.conv2d %{{.*}}, %[[reverse2]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 2, 2>, group = 1 : i64, pad = array<i64: 3, 3, 3, 3>, stride = array<i64: 1, 1>} : (tensor<1x3x3x1xf32>, tensor<1x3x3x1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x5x5x1xf32>
+func.func @bwd_data_conv2d_dilation(%arg0: tensor<9xf32> {mhal.read_access}, %arg1: tensor<9xf32> {mhal.read_access}) -> (tensor<25xf32> {mhal.write_access}) {
+  %0 = tosa.const_shape  {values = dense<25> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %1 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %2 = tosa.const_shape  {values = dense<[1, 1, 3, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %3 = tosa.reshape %arg0, %2 : (tensor<9xf32>, !tosa.shape<4>) -> tensor<1x1x3x3xf32>
+  %4 = tosa.reshape %arg1, %2 : (tensor<9xf32>, !tosa.shape<4>) -> tensor<1x1x3x3xf32>
+  %5 = tosa.transpose %4 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x1x3x3xf32>) -> tensor<1x3x3x1xf32>
+  %6 = tosa.transpose %3 {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x1x3x3xf32>) -> tensor<1x3x3x1xf32>
+  %7 = tosa.custom %5, %6, %1, %1, %1 {acc_type = f32, dilation = array<i64: 2, 2>, domain_name = "rocmlir", group = 1 : i64, implementation_attrs = "", operator_name = "conv_bwd_data", out_pad = array<i64: 0, 0, 0, 0>, pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>} : (tensor<1x3x3x1xf32>, tensor<1x3x3x1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x5x5x1xf32>
+  %8 = tosa.transpose %7 {perms = array<i32: 0, 3, 1, 2>} : (tensor<1x5x5x1xf32>) -> tensor<1x1x5x5xf32>
+  %9 = tosa.reshape %8, %0 : (tensor<1x1x5x5xf32>, !tosa.shape<1>) -> tensor<25xf32>
+  return %9 : tensor<25xf32>
 }
 
 // -----

--- a/mlir/test/Conversion/RocmlirCustomTosaDecompose/rocmlir-custom-tosa-decompose.mlir
+++ b/mlir/test/Conversion/RocmlirCustomTosaDecompose/rocmlir-custom-tosa-decompose.mlir
@@ -109,22 +109,3 @@ func.func @bwd_data_conv1d(%arg0: tensor<64xf32>, %arg1: tensor<672xf32>, %arg2:
 
 // -----
 
-// CHECK: func.func @bwd_data_conv3d
-// CHECK: %[[reverse1:.*]] = tosa.reverse %{{.*}} {axis = 1 : i32} : (tensor<1x4x4x4x16xf32>) -> tensor<1x4x4x4x16xf32>
-// CHECK: %[[reverse2:.*]] = tosa.reverse %[[reverse1]] {axis = 2 : i32} : (tensor<1x4x4x4x16xf32>) -> tensor<1x4x4x4x16xf32>
-// CHECK: %[[reverse3:.*]] = tosa.reverse %[[reverse2]] {axis = 3 : i32} : (tensor<1x4x4x4x16xf32>) -> tensor<1x4x4x4x16xf32>
-// CHECK: tosa.conv3d %{{.*}}, %[[reverse3]], %{{.*}}, %{{.*}}, %{{.*}} {acc_type = f32, dilation = array<i64: 1, 1, 1>, pad = array<i64: 3, 3, 3, 3, 3, 3>, stride = array<i64: 1, 1, 1>} : (tensor<16x1x1x1x16xf32>, tensor<1x4x4x4x16xf32>, tensor<16xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x4x4x4x16xf32>
-func.func @bwd_data_conv3d(%arg0: tensor<1024xf32>, %arg1: tensor<256xf32>) -> tensor<1024xf32> {
-  %0 = tosa.const_shape  {values = dense<[16, 1, 1, 1, 16]> : tensor<5xindex>} : () -> !tosa.shape<5>
-  %1 = tosa.const_shape  {values = dense<1024> : tensor<1xindex>} : () -> !tosa.shape<1>
-  %2 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<16xf32>}> : () -> tensor<16xf32>
-  %3 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %4 = tosa.const_shape  {values = dense<[1, 16, 4, 4, 4]> : tensor<5xindex>} : () -> !tosa.shape<5>
-  %5 = tosa.reshape %arg0, %4 : (tensor<1024xf32>, !tosa.shape<5>) -> tensor<1x16x4x4x4xf32>
-  %6 = tosa.reshape %arg1, %0 : (tensor<256xf32>, !tosa.shape<5>) -> tensor<16x1x1x1x16xf32>
-  %7 = tosa.transpose %5 {perms = array<i32: 0, 2, 3, 4, 1>} : (tensor<1x16x4x4x4xf32>) -> tensor<1x4x4x4x16xf32>
-  %8 = tosa.custom %6, %7, %2, %3, %3 {acc_type = f32, conv_kind = "bwd_data", dilation = array<i64: 1, 1, 1>, domain_name = "rocmlir", group = 1 : i64, implementation_attrs = "", operator_name = "conv_bwd_data", out_pad = array<i64: 0, 0, 0, 0, 0, 0>, pad = array<i64: 0, 0, 0, 0, 0, 0>, stride = array<i64: 1, 1, 1>} : (tensor<16x1x1x1x16xf32>, tensor<1x4x4x4x16xf32>, tensor<16xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x4x4x4x16xf32>
-  %9 = tosa.transpose %8 {perms = array<i32: 0, 4, 1, 2, 3>} : (tensor<1x4x4x4x16xf32>) -> tensor<1x16x4x4x4xf32>
-  %10 = tosa.reshape %9, %1 : (tensor<1x16x4x4x4xf32>, !tosa.shape<1>) -> tensor<1024xf32>
-  return %10 : tensor<1024xf32>
-}

--- a/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-asymmetric-stride.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-asymmetric-stride.mlir
@@ -1,19 +1,11 @@
-// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-driver -kernel-pipeline migraphx,highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void
-
-// The CPU lowering pipeline is currently broken for backwards data convolution
-// ops (lowering tosa.transpose_conv2d). As such, we do not currently have a way
-// of verifying the GPU results against the CPU results. For the time being, we
-// want to check that the GPU lowering pipeline can successfully lower the op
-// and produce results (the first RUN command), and then for verification
-// we can use rocmlir-gen to create and test a backwards data convolution op
-// with the exact same shape and attributes as the one in the MIXR example below
-// RUN: rocmlir-gen --operation conv_bwd_data --arch %arch -t f32 --fil_layout gkcyx --in_layout ngchw --out_layout ngkhw --batchsize 1 --groupsize 1 --in_channels 4 --out_channels 3 --in_h 11 --in_w 19 --fil_h 3 --fil_w 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 2 --conv_stride_w 3 --padding_h 1 --padding_w 1 -v4r1 0 -pv | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=GEN
+// RUN: rocmlir-gen -fut mlir_bwd_data_conv --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_bwd_data_conv_wrapper --verifier clone -relDiff_threshold 0.00001 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch  | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void
 
 module {
-  func.func @mlir_bwd_data_conv(%arg0: !migraphx.shaped<1x3x6x7xf32, 126x42x7x1>,
-                                        %arg1: !migraphx.shaped<3x4x3x3xf32, 36x9x3x1>
-                                        ) -> !migraphx.shaped<1x4x11x19xf32, 836x209x19x1> attributes {arch = "##TOKEN_ARCH##", kernel} {
-    // GEN: [1 1 1]
+  func.func @mlir_bwd_data_conv(
+      %arg0: !migraphx.shaped<1x3x6x7xf32, 126x42x7x1>,
+      %arg1: !migraphx.shaped<3x4x3x3xf32, 36x9x3x1>
+  ) -> !migraphx.shaped<1x4x11x19xf32, 836x209x19x1> {
+    // CHECK: [1 1 1]
     %0 = migraphx.backwards_data_convolution %arg0, %arg1 {
       dilation = [1, 1],
       group = 1 : i64,

--- a/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-dilation2-stride1.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-dilation2-stride1.mlir
@@ -1,16 +1,20 @@
 // RUN: rocmlir-gen -fut mlir_bwd_data_conv --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_bwd_data_conv_wrapper --verifier clone -relDiff_threshold 0.00001 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch  | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void
 
 module {
-  func.func @mlir_bwd_data_conv(%arg0: !migraphx.shaped<1x512x32x32xf32, 524288x1024x32x1>,
-                                %arg1: !migraphx.shaped<512x384x4x4xf32, 6144x16x4x1>
-                               ) -> !migraphx.shaped<1x384x64x64xf32, 1572864x4096x64x1> {
-    // CHECK: [1 1 1]
-    %0 = migraphx.backwards_data_convolution %arg0, %arg1 {
-      dilation = [1, 1],
+  // CHECK: [1 1 1]
+  func.func @mlir_bwd_data_conv(
+      %arg0: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>,
+      %arg1: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>
+  ) -> !migraphx.shaped<1x1x5x5xf32, 25x25x5x1> {
+    %0 = migraphx.backwards_data_convolution %arg1, %arg0 {
+      dilation = [2, 2],
       group = 1 : i64,
       padding = [1, 1, 1, 1],
       padding_mode = 0 : i64,
-      stride = [2, 2]} : <1x512x32x32xf32, 524288x1024x32x1>, <512x384x4x4xf32, 6144x16x4x1> -> <1x384x64x64xf32, 1572864x4096x64x1>
-    return %0 : !migraphx.shaped<1x384x64x64xf32, 1572864x4096x64x1>
+      stride = [1, 1]
+    } : <1x1x3x3xf32, 9x9x3x1>, <1x1x3x3xf32, 9x9x3x1>
+        -> <1x1x5x5xf32, 25x25x5x1>
+    return %0 : !migraphx.shaped<1x1x5x5xf32, 25x25x5x1>
   }
 }
+

--- a/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-padding1.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-padding1.mlir
@@ -1,16 +1,20 @@
 // RUN: rocmlir-gen -fut mlir_bwd_data_conv --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_bwd_data_conv_wrapper --verifier clone -relDiff_threshold 0.00001 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch  | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void
 
 module {
-  func.func @mlir_bwd_data_conv(%arg0: !migraphx.shaped<1x512x32x32xf32, 524288x1024x32x1>,
-                                %arg1: !migraphx.shaped<512x384x4x4xf32, 6144x16x4x1>
-                               ) -> !migraphx.shaped<1x384x64x64xf32, 1572864x4096x64x1> {
     // CHECK: [1 1 1]
-    %0 = migraphx.backwards_data_convolution %arg0, %arg1 {
+  func.func @mlir_bwd_data_conv(
+      %arg0: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>,
+      %arg1: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>
+  ) -> !migraphx.shaped<1x1x3x3xf32, 9x9x3x1> {
+    %0 = migraphx.backwards_data_convolution %arg1, %arg0 {
       dilation = [1, 1],
       group = 1 : i64,
       padding = [1, 1, 1, 1],
       padding_mode = 0 : i64,
-      stride = [2, 2]} : <1x512x32x32xf32, 524288x1024x32x1>, <512x384x4x4xf32, 6144x16x4x1> -> <1x384x64x64xf32, 1572864x4096x64x1>
-    return %0 : !migraphx.shaped<1x384x64x64xf32, 1572864x4096x64x1>
+      stride = [1, 1]
+    } : <1x1x3x3xf32, 9x9x3x1>, <1x1x3x3xf32, 9x9x3x1>
+        -> <1x1x3x3xf32, 9x9x3x1>
+    return %0 : !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>
   }
 }
+

--- a/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-stride2-dilation2.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-stride2-dilation2.mlir
@@ -1,20 +1,10 @@
-// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-driver -kernel-pipeline migraphx,highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=MIXR
-
-// The CPU lowering pipeline is currently broken for backwards data convolution
-// ops (lowering tosa.transpose_conv2d). As such, we do not currently have a way
-// of verifying the GPU results against the CPU results. For the time being, we
-// want to check that the GPU lowering pipeline can successfully lower the op
-// and produce results (the first RUN command), and then for verification
-// we can use rocmlir-gen to create and test a backwards data convolution op
-// with the exact same shape and attributes as the one in the MIXR example below
-// RUN: rocmlir-gen --operation conv_bwd_data --arch %arch -t f32 --fil_layout gkcyx --in_layout ngchw --out_layout ngkhw --batchsize 1 --groupsize 1 --in_channels 1 --out_channels 1 --in_h 19 --in_w 19 --fil_h 3 --fil_w 3 --dilation_h 2 --dilation_w 2 --conv_stride_h 2 --conv_stride_w 2 --padding_h 2 --padding_w 2 -v4r1 0 -pv | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=GEN
+// RUN: rocmlir-gen -fut mlir_bwd_data_conv --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_bwd_data_conv_wrapper --verifier clone -relDiff_threshold 0.00001 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch  | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void
 
 module {
-  // MIXR: [4, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 9, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 6, 0, 4]
-  // GEN: [1 1 1]
+  // CHECK: [1 1 1]
   func.func @mlir_bwd_data_conv(%arg0: !migraphx.shaped<1x1x10x10xf32, 100x100x10x1>,
                                 %arg1: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>
-                                ) -> !migraphx.shaped<1x1x19x19xf32, 361x361x19x1> attributes {arch = "##TOKEN_ARCH##", kernel} {
+                                ) -> !migraphx.shaped<1x1x19x19xf32, 361x361x19x1> {
     %0 = migraphx.backwards_data_convolution %arg0, %arg1 {
       dilation = [2, 2],
       group = 1 : i64,

--- a/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-stride32.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv-stride32.mlir
@@ -1,16 +1,20 @@
 // RUN: rocmlir-gen -fut mlir_bwd_data_conv --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_bwd_data_conv_wrapper --verifier clone -relDiff_threshold 0.00001 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch  | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void
 
 module {
-  func.func @mlir_bwd_data_conv(%arg0: !migraphx.shaped<1x512x32x32xf32, 524288x1024x32x1>,
-                                %arg1: !migraphx.shaped<512x384x4x4xf32, 6144x16x4x1>
-                               ) -> !migraphx.shaped<1x384x64x64xf32, 1572864x4096x64x1> {
-    // CHECK: [1 1 1]
-    %0 = migraphx.backwards_data_convolution %arg0, %arg1 {
+  // CHECK: [1 1 1]
+  func.func @mlir_bwd_data_conv(
+      %grad_out: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>,
+      %weights:  !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>
+  ) -> !migraphx.shaped<1x1x5x5xf32, 25x25x5x1> {
+    %res = migraphx.backwards_data_convolution %grad_out, %weights {
       dilation = [1, 1],
       group = 1 : i64,
-      padding = [1, 1, 1, 1],
+      padding = [2, 1, 2, 1],
       padding_mode = 0 : i64,
-      stride = [2, 2]} : <1x512x32x32xf32, 524288x1024x32x1>, <512x384x4x4xf32, 6144x16x4x1> -> <1x384x64x64xf32, 1572864x4096x64x1>
-    return %0 : !migraphx.shaped<1x384x64x64xf32, 1572864x4096x64x1>
+      stride = [3, 2]
+    } : <1x1x3x3xf32, 9x9x3x1>, <1x1x3x3xf32, 9x9x3x1>
+        -> <1x1x5x5xf32, 25x25x5x1>
+    return %res : !migraphx.shaped<1x1x5x5xf32, 25x25x5x1>
   }
 }
+

--- a/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-bwd-data-conv.mlir
@@ -1,21 +1,11 @@
-// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-driver -kernel-pipeline migraphx,highlevel | rocmlir-gen -ph -print-results -rand none - | rocmlir-driver -arch %arch -c  | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=MIXR
-
-// The CPU lowering pipeline is currently broken for backwards data convolution
-// ops (lowering tosa.transpose_conv2d). As such, we do not currently have a way
-// of verifying the GPU results against the CPU results. For the time being, we
-// want to check that the GPU lowering pipeline can successfully lower the op
-// and produce results (the first RUN command), and then for verification
-// we can use rocmlir-gen to create and test a backwards data convolution op
-// with the exact same shape and attributes as the one in the MIXR example below
-// RUN: rocmlir-gen --operation conv_bwd_data --arch %arch -t f32 --fil_layout gkcyx --in_layout ngchw --out_layout ngkhw --batchsize 1 --groupsize 1 --in_channels 1 --out_channels 1 --in_h 5 --in_w 5 --fil_h 3 --fil_w 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 -v4r1 0 -pv | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=GEN
+// RUN: rocmlir-gen -fut mlir_bwd_data_conv --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx | rocmlir-driver -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_bwd_data_conv_wrapper --verifier clone -relDiff_threshold 0.00001 - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch  | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void
 
 module {
-  // MIXR: [1,  2,  3,  2,  1,  2,  4,  6,  4,  2,  3,  6,  9,  6,  3,  2,  4,  6,  4,  2,  1,  2,  3,  2,  1]
-  // GEN: [1 1 1]
+  // CHECK: [1 1 1]
   func.func @mlir_bwd_data_conv(
       %arg0: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>,
       %arg1: !migraphx.shaped<1x1x3x3xf32, 9x9x3x1>
-  ) -> !migraphx.shaped<1x1x5x5xf32, 25x25x5x1> attributes {arch = "##TOKEN_ARCH##", kernel} {
+  ) -> !migraphx.shaped<1x1x5x5xf32, 25x25x5x1> {
     %0 = migraphx.backwards_data_convolution %arg1, %arg0 {
       dilation = [1, 1],
       group = 1 : i64,

--- a/mlir/test/rocmlir-driver/pipelines.mlir
+++ b/mlir/test/rocmlir-driver/pipelines.mlir
@@ -135,6 +135,7 @@
 // HIGHLEVEL-NEXT:builtin.module(func.func(tosa-to-tensor,
 // HIGHLEVEL-NEXT:tosa-to-rock,
 // HIGHLEVEL-NEXT:rock-view-to-transform,
+// HIGHLEVEL-NEXT:rocmlir-custom-tosa-decompose,
 // HIGHLEVEL-NEXT:rocmlir-custom-tosa-to-linalg),
 // HIGHLEVEL-NEXT:func.func(tosa-optional-decompositions),
 // HIGHLEVEL-NEXT:func.func(canonicalize{  max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}),


### PR DESCRIPTION
## Motivation
This PR implements proper CPU lowering for `tosa::customOp` operations (representing 2D transpose convolutions) by adding support for dilation and input padding attributes. This change means that we can now remove the LIT test workaround in the bwd_data_conv e2e tests that were introduced in: https://github.com/ROCm/rocMLIR/pull/1951

Implements: https://github.com/ROCm/rocMLIR-internal/issues/1990

## Technical Details
This PR implements the following key changes:
- Update `TransposeConvNonStridedConverter` and `TransposeConvStridedConverter` to both handle input padding and dilation attributes (see the comments in the new logic for more details on this)
- Updated the bwd_data_conv e2e tests that no longer need a workaround.
- Now that we will no longer be using upstream Tosa for CPU/GPU lowering, I've removed any of the additional changes that were added in the initial work to support lowering from MIGraphX

## Test Plan
- Update existing bwd_conv e2e tests to use the new lowering path
- Add new e2e tests for more edge cases

## Test Result
- [ ] PR CI (with MIGraphX tests enabled)
- [x] All bwd_conv e2e LIT tests are passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
