### PR TITLE
Update MI350 quick-tune lists

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -312,26 +312,39 @@ const InitParamsAccel PopulateParamsXDL::initParametersConvGfx942[PopulateParams
 
 // BEGIN_CONV_XDL_f32_gfx950_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersConvGfx950[PopulateParamsXDL::nInitParametersConvGfx950] = {
-    {16,16,8,16,16,8,1,1,2,true,true},
-    {32,32,8,16,16,8,1,2,2,true,true},
-    {64,16,8,16,16,8,1,1,2,true,true},
-    {16,32,8,16,16,8,1,1,2,true,true},
-    {64,16,8,16,16,8,1,2,2,true,true},
-    {16,32,8,16,16,8,1,2,2,true,true},
-    {32,32,4,16,16,8,1,1,2,true,true},
-    {64,32,8,32,16,4,1,2,2,true,true},
-    {16,32,4,16,16,4,1,2,2,true,true},
-    {32,64,8,16,16,8,1,1,2,true,true},
-    {64,64,4,32,16,8,1,1,2,true,true},
-    {32,32,2,32,32,1,1,2,2,true,true},
-    {128,128,4,128,16,1,1,2,2,true,true},
-    {128,32,4,64,16,8,1,1,2,true,true},
-    {64,64,8,16,16,8,1,1,2,true,true},
-    {16,16,8,16,16,1,1,1,2,true,true},
-    {128,32,4,32,32,8,1,2,2,true,true},
     {128,128,4,128,16,1,1,1,2,true,true},
+    {32,64,8,16,16,8,1,1,2,true,true},
+    {64,64,8,16,16,8,1,1,2,true,true},
+    {64,32,8,16,16,4,1,1,2,true,true},
+    {32,32,8,16,16,4,1,2,2,true,true},
+    {64,16,8,16,16,8,1,2,2,true,true},
+    {128,32,4,64,16,8,1,1,2,true,true},
+    {16,32,4,16,16,4,1,2,2,true,true},
+    {256,32,4,128,16,4,1,1,2,true,true},
+    {128,32,8,32,16,4,1,1,2,true,true},
+    {16,16,8,16,16,1,1,1,2,true,true},
+    {16,32,8,16,16,8,1,1,2,true,true},
+    {64,16,8,16,16,4,1,2,2,true,true},
+    {64,64,4,64,16,4,1,2,2,true,true},
+    {32,16,8,16,16,8,1,1,2,true,true},
+    {64,16,8,16,16,8,1,1,2,true,true},
+    {64,16,4,64,16,1,1,1,2,true,true},
+    {128,64,4,128,16,4,1,1,2,true,true},
+    {64,64,4,32,16,8,1,1,2,true,true},
+    {64,32,4,16,16,4,1,2,2,true,true},
+    {16,32,8,16,16,8,1,2,2,true,true},
+    {16,16,8,16,16,8,1,1,2,true,true},
+    {128,128,4,128,16,1,1,2,2,true,true},
+    {32,32,4,16,16,8,1,1,2,true,true},
+    {32,32,2,32,32,1,1,2,2,true,true},
+    {32,32,8,16,16,8,1,2,2,true,true},
+    {128,32,4,32,32,8,1,2,2,true,true},
+    {32,64,8,32,16,8,1,1,2,true,true},
+    {128,256,2,128,32,4,1,2,2,true,true},
+    {64,128,4,64,16,4,1,1,2,true,true},
+    {32,32,8,16,16,4,1,1,2,true,true},
     {64,64,2,64,32,1,1,2,2,true,true},
-    {64,16,4,64,16,1,1,1,2,true,true}
+    {64,32,8,32,16,4,1,2,2,true,true}
 };
 // END_CONV_XDL_f32_gfx950_DEFS
 
@@ -490,24 +503,32 @@ const InitParamsAccel PopulateParamsXDL::initParametersFp16ConvGfx942[PopulatePa
 
 // BEGIN_CONV_XDL_f16_gfx950_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersFp16ConvGfx950[PopulateParamsXDL::nInitParametersFp16ConvGfx950] = {
-    {64,16,8,16,16,8,1,2,2,true,true},
-    {64,64,8,32,32,8,1,2,2,true,true},
-    {32,16,8,16,16,8,1,2,2,true,true},
-    {32,32,8,16,16,8,1,2,2,true,true},
-    {32,64,8,32,16,8,1,2,2,true,true},
-    {32,32,8,16,16,8,1,1,2,true,true},
-    {64,16,8,16,16,8,1,1,2,true,true},
-    {16,64,8,16,16,8,1,1,2,true,true},
+    {64,128,8,32,16,8,1,1,2,true,true},
     {64,16,8,32,16,8,1,2,2,true,true},
-    {64,64,4,32,32,8,1,2,2,true,true},
-    {32,64,8,32,16,4,1,1,2,true,true},
+    {32,64,8,32,32,1,1,1,2,true,true},
     {128,128,8,64,32,8,1,2,2,true,true},
+    {32,32,8,16,16,8,1,1,2,true,true},
+    {16,64,8,16,16,8,1,1,2,true,true},
+    {32,64,8,32,16,4,1,1,2,true,true},
+    {32,16,8,16,16,8,1,2,2,true,true},
+    {64,16,8,32,16,8,1,1,2,true,true},
+    {64,16,8,16,16,8,1,2,2,true,true},
+    {64,256,8,16,16,4,1,2,2,true,true},
+    {128,128,4,128,16,8,1,1,2,true,true},
+    {64,256,2,64,32,4,1,1,2,true,true},
+    {32,64,8,32,16,8,1,2,2,true,true},
+    {64,256,2,32,32,4,1,1,2,true,true},
+    {64,64,8,64,16,8,1,2,2,true,true},
+    {64,16,8,16,16,8,1,1,2,true,true},
+    {64,64,8,32,32,8,1,2,2,true,true},
+    {64,64,4,32,32,8,1,2,2,true,true},
+    {32,32,8,16,16,8,1,2,2,true,true},
+    {256,32,8,64,32,8,1,2,2,true,true},
     {32,128,4,32,32,8,1,1,2,true,true},
     {128,32,8,32,32,8,1,2,2,true,true},
-    {64,256,2,64,32,4,1,1,2,true,true},
-    {32,32,2,32,32,4,1,1,2,true,true},
-    {32,64,8,32,32,1,1,1,2,true,true},
-    {64,256,2,32,32,4,1,1,2,true,true}
+    {256,128,4,128,32,8,1,2,2,true,true},
+    {256,64,8,64,32,8,1,2,2,true,true},
+    {32,32,2,32,32,4,1,1,2,true,true}
 };
 // END_CONV_XDL_f16_gfx950_DEFS
 
@@ -835,16 +856,27 @@ const InitParamsAccel PopulateParamsXDL::initParametersForwardI8ConvGfx942[Popul
 
 // BEGIN_CONV_XDL_i8_gfx950_DEFS
 const InitParamsAccel PopulateParamsXDL::initParametersForwardI8ConvGfx950[PopulateParamsXDL::nInitParametersForwardI8ConvGfx950] = {
-    {16,32,32,16,16,16,1,2,2,true,true},
-    {32,16,32,16,16,16,1,2,2,true,true},
-    {32,16,16,16,16,16,1,1,2,true,true},
-    {64,16,16,16,16,16,1,2,2,true,true},
-    {64,16,8,32,16,16,1,2,2,true,true},
-    {32,32,8,16,16,16,1,1,2,true,true},
-    {64,64,4,64,16,16,1,1,2,true,true},
+    {64,32,8,16,16,8,1,1,2,true,true},
     {32,32,16,32,32,1,1,1,2,true,true},
+    {64,128,16,64,32,1,1,2,2,true,true},
+    {128,16,8,64,16,16,1,2,2,true,true},
+    {256,32,8,64,16,16,1,2,2,true,true},
+    {64,64,32,32,16,1,1,1,2,true,true},
+    {64,16,16,16,16,16,1,2,2,true,true},
+    {32,16,32,16,16,16,1,2,2,true,true},
+    {128,128,4,64,32,16,1,1,2,true,true},
+    {256,64,4,128,32,16,1,2,2,true,true},
+    {64,16,8,32,16,16,1,2,2,true,true},
+    {64,256,4,64,32,8,1,2,2,true,true},
+    {64,64,4,64,16,16,1,1,2,true,true},
+    {64,32,4,32,16,16,1,2,2,true,true},
     {64,64,16,64,32,1,1,2,2,true,true},
-    {64,128,16,64,32,1,1,2,2,true,true}
+    {16,32,32,16,16,16,1,2,2,true,true},
+    {32,16,16,16,16,16,1,1,2,true,true},
+    {32,16,16,16,16,8,1,2,2,true,true},
+    {256,128,8,64,32,16,1,1,2,true,true},
+    {64,256,4,64,32,8,1,1,2,true,true},
+    {32,32,8,16,16,16,1,1,2,true,true}
 };
 // END_CONV_XDL_i8_gfx950_DEFS
 
@@ -888,7 +920,7 @@ static const InitParamsAccel initParametersConvGfx942[nInitParametersConvGfx942]
 // END_CONV_XDL_f32_gfx942_DECS
 
 // BEGIN_CONV_XDL_f32_gfx950_DECS
-static constexpr size_t nInitParametersConvGfx950 = 20;
+static constexpr size_t nInitParametersConvGfx950 = 33;
 static const InitParamsAccel initParametersConvGfx950[nInitParametersConvGfx950];
 // END_CONV_XDL_f32_gfx950_DECS
 
@@ -928,7 +960,7 @@ static const InitParamsAccel initParametersFp16ConvGfx942[nInitParametersFp16Con
 // END_CONV_XDL_f16_gfx942_DECS
 
 // BEGIN_CONV_XDL_f16_gfx950_DECS
-static constexpr size_t nInitParametersFp16ConvGfx950 = 18;
+static constexpr size_t nInitParametersFp16ConvGfx950 = 26;
 static const InitParamsAccel initParametersFp16ConvGfx950[nInitParametersFp16ConvGfx950];
 // END_CONV_XDL_f16_gfx950_DECS
 
@@ -1008,7 +1040,7 @@ static const InitParamsAccel initParametersForwardI8ConvGfx942[nInitParametersFo
 // END_CONV_XDL_i8_gfx942_DECS
 
 // BEGIN_CONV_XDL_i8_gfx950_DECS
-static constexpr size_t nInitParametersForwardI8ConvGfx950 = 10;
+static constexpr size_t nInitParametersForwardI8ConvGfx950 = 21;
 static const InitParamsAccel initParametersForwardI8ConvGfx950[nInitParametersForwardI8ConvGfx950];
 // END_CONV_XDL_i8_gfx950_DECS
 

--- a/mlir/test/Dialect/Rock/affix_tuning_params.mlir
+++ b/mlir/test/Dialect/Rock/affix_tuning_params.mlir
@@ -260,7 +260,7 @@ func.func @rock_conv_7x7_tuning(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256
 func.func @rock_conv_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x230x230xf32>, %arg2: memref<256x1x64x112x112xf32>) attributes {arch = "amdgcn-amd-amdhsa:gfx906"} {
   // CHECK: rock.conv
   // CHECK-SAME: derivedBlockSize = 64
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 2, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 16, kpack = 1, mPerWave = 64, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
   // GRID: rock.gridwise_gemm
   // GRID-SAME: gridSize = 200704
   rock.conv(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add|atomic_add_f16 {
@@ -278,10 +278,10 @@ func.func @rock_conv_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x23
 // GRID-LABEL: @rock_conv_bwd_weight_7x7
 func.func @rock_conv_bwd_weight_7x7(%arg0: memref<1x64x3x7x7xf32>, %arg1: memref<256x1x3x230x230xf32>, %arg2: memref<256x1x64x112x112xf32>) attributes {kernel = 0 : i32, arch = "amdgcn-amd-amdhsa:gfx906", numCU = 120 : i32} {
   // CHECK: rock.conv_bwd_weight
-  // CHECK-SAME: derivedBlockSize = 64
-  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 16, nPerBlock = 16, kpack = 8, mPerWave = 16, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+  // CHECK-SAME: derivedBlockSize = 256
+  // CHECK-SAME: params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 64, nPerBlock = 32, kpack = 4, mPerWave = 16, nPerWave = 32, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
   // GRID: rock.gridwise_gemm
-  // GRID-SAME: gridSize = 40
+  // GRID-SAME: gridSize = 5
   rock.conv_bwd_weight(%arg0, %arg1, %arg2) features =  mfma|dot|atomic_add|atomic_add_f16 {
     dilations = [1 : index, 1 : index],
     filter_layout = ["g", "k", "c", "0", "1"],


### PR DESCRIPTION
## Motivation

Extend the quick-tune lists for MI350 in order to recover performance.

## Technical Details

Exhaustive tune has been done on MI350 using the problem configs provided in https://github.com/ROCm/rocMLIR/pull/2001. The resulting quick-tune list has been merged with the existing one.

Resolves https://github.com/ROCm/rocMLIR-internal/issues/1995

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
