### PR TITLE
Fix silent parameterSweeps errors and issues in V4R1 path

### DIFF
--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -89,8 +89,11 @@ class MLIROnlyConfig(ConvConfiguration):
                     '--padding_w_l', str(self.paddingWL),
                     '--padding_w_r', str(self.paddingWR)]
 
+        # Under the hood MIGraphX will use -v4r1 0 (i.e., all the gemms it
+        # creates are in a single kernel), so we want to make sure that this
+        # is the path this is tested.
         if self.direction == 'bwd':
-            result += ['-v4r1 1']
+            result += ['-v4r1 0']
 
         result += rocmlir_gen_flags
 
@@ -475,7 +478,7 @@ async def runConfig(paramIter: Iterable[IterType],
         for c in failures:
             print(' '.join(c.generateMlirDriverCommandLine(options.flags, kernel_repeats=None)))
     print(f"Passed: {n_passes}, Invalid: {n_invalids}, Failed: {len(failures)}")
-    return len(failures) == 0 and len(n_passes) > 0
+    return len(failures) == 0 and n_passes > 0
 
 
 def main() -> bool:

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -93,7 +93,7 @@ class MLIROnlyConfig(ConvConfiguration):
         # creates are in a single kernel), so we want to make sure that this
         # is the path this is tested.
         if self.direction == 'bwd':
-            result += ['-v4r1 0']
+            result += ['-v4r1', '0']
 
         result += rocmlir_gen_flags
 

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -56,12 +56,11 @@ class PerfConfig:
 class MLIROnlyConfig(ConvConfiguration):
     def __repr__(self):
         perf_config_str = str(self.perfConfig) if self.perfConfig else ""
-        v4r1_str = str(self.usesV4R1) if self.usesV4R1 else "1"
         return f"""ConvConfiguration(dtype={self.dataType!r}, direction={self.direction!r}, layout={self.inputLayout.upper()!r},
                 n={self.n!r}, c={self.c!r}, hi={self.hi!r}, wi={self.wi!r}, k={self.k!r}, y={self.y!r}, x={self.x!r},
                 convStrideH={self.convStrideH!r}, convStrideW={self.convStrideW!r}, paddingHL={self.paddingHL!r}, paddingHR={self.paddingHR!r},
                 paddingWL={self.paddingWL!r}, paddingWR={self.paddingWR!r}, dilationH={self.dilationH!r}, dilationW={self.dilationW!r},
-                group={self.group!r}, arch={self.arch!r}, usesV4R1={v4r1_str!r}, perfConfig={perf_config_str!r})"""
+                group={self.group!r}, arch={self.arch!r}, perfConfig={perf_config_str!r})"""
 
     def generateMlirDriverCommandLine(self, rocmlir_gen_flags) -> Sequence[str]:
         direction = {'fwd': 'conv',
@@ -90,8 +89,8 @@ class MLIROnlyConfig(ConvConfiguration):
                     '--padding_w_l', str(self.paddingWL),
                     '--padding_w_r', str(self.paddingWR)]
 
-        if self.direction == 'bwd' and self.usesV4R1 is not None:
-            result += ['-v4r1', str(self.usesV4R1)]
+        if self.direction == 'bwd':
+            result += ['-v4r1 1']
 
         result += rocmlir_gen_flags
 
@@ -106,7 +105,6 @@ class MLIROnlyConfig(ConvConfiguration):
                     convStrideH: int, convStrideW: int,
                     paddingHL: int, paddingHR: int, paddingWL: int, paddingWR: int,
                     dilationH: int, dilationW: int, group: int, arch: str,
-                    usesV4R1: Optional[int]=None,
                     perfConfig: Optional[PerfConfig]=None):
         if dtype not in {"f16", "f32", "bf16", "i8"}:
             raise ValueError(f"Invalid datatype: {dtype}")
@@ -140,7 +138,6 @@ class MLIROnlyConfig(ConvConfiguration):
         self.group = group
         self.arch = arch
         self.perfConfig = perfConfig
-        self.usesV4R1 = usesV4R1
         self.ho = math.floor((self.hi + self.paddingHL + self.paddingHR - (self.y - 1) * self.dilationH - 1 ) / self.convStrideH) + 1
         self.wo = math.floor((self.wi + self.paddingWL + self.paddingWR * 2 - (self.x - 1) * self.dilationW - 1 ) / self.convStrideW) + 1
 
@@ -335,44 +332,32 @@ async def sweepParameters(paramIter: Iterable[IterType],
 
     return (passed, invalid, failingConfigs)
 
-def filtered_conv_structure():
-    for size, op, layout, dtype, phl, phr, pwl, pwr, sh, sw, dh, dw, usesV4R1 in itertools.product(
-        # Small/large - that is, do we have padding
-        [False, True],
-        # op
-        ['fwd', 'wrw', 'bwd'],
-        # layout
-        ['NCHW', 'NHWC'],
-        # dtype
-        # TODO(kdrewnia): add bf16 once we're confident in that support
-        # and add int8 for fwd only
-        ['f32', 'f16'],
-        # Padding - hl, hr, wl, wr in [0, 3]
-        # [0, 3] hits the cases 0, < y/x, == y/x, > y/x
-        range(0, 4),
-        range(0, 4),
-        range(0, 4),
-        range(0, 4),
-        # Stride - 1 or 2 - all meaningful strides before breaking past h/w=4
-        range(1, 3),
-        range(1, 3),
-        # Dilation in [1, 2] - all meaningful dilations before breaking past h/w=4
-        range(1, 3),
-        range(1, 3),
-        # UsesV4R1
-        # Note: This only applies to bwd_data ops, it will be a no-op for all others
-        range(0, 1)
-    ):
-        # Only include usesV4R1 for bwd ops, otherwise set to None
-        if op == 'bwd':
-            yield (size, op, layout, dtype, phl, phr, pwl, pwr, sh, sw, dh, dw, usesV4R1)
-        else:
-            yield (size, op, layout, dtype, phl, phr, pwl, pwr, sh, sw, dh, dw, None)
-
-CONV_STRUCTURE = filtered_conv_structure()
+CONV_STRUCTURE = itertools.product(
+    # Small/large - that is, do we have padding
+    [False, True],
+    # op
+    ['fwd', 'wrw', 'bwd'],
+    # layout
+    ['NCHW', 'NHWC'],
+    # dtype
+    # TODO(kdrewnia): add bf16 once we're confident in that support
+    # and add int8 for fwd only
+    ['f32', 'f16'],
+    # Padding - hl, hr, wl, wr in [0, 3]
+    # [0, 3] hits the cases 0, < y/x, == y/x, > y/x
+    range(0, 4),
+    range(0, 4),
+    range(0, 4),
+    range(0, 4),
+    # Stride - 1 or 2 - all meaningful strides before breaking past h/w=4
+    range(1, 3),
+    range(1, 3),
+    # Dilation in [1, 2] - all meaningful dilations befor breaking past h/w=4
+    range(1, 3),
+    range(1, 3))
 
 def to_conv_structure_type_test(params, options: Options) -> MLIROnlyConfig:
-    size, op, layout, dtype, phl, phr, pwl, pwr, sh, sw, dh, dw, usesV4R1 = params
+    size, op, layout, dtype, phl, phr, pwl, pwr, sh, sw, dh, dw = params
     # Fixed parameters, y = x = 2, hi = wi = 4, g = 1
     g, hi, wi, y, x = 1, 4, 4, 2, 2
     if size:
@@ -382,7 +367,7 @@ def to_conv_structure_type_test(params, options: Options) -> MLIROnlyConfig:
         # Values of n, c, k, meant to be small and to hit the padding kernel
         n, c, k = 1, 7, 7
     return MLIROnlyConfig(dtype, op, layout, n, c, hi, wi, k, y, x, sh, sw,
-        phl, phr, pwl, pwr, dh, dw, g, options.arch, usesV4R1)
+        phl, phr, pwl, pwr, dh, dw, g, options.arch)
 
 WMMA_PERF_CONFIG = itertools.product(
     # op
@@ -490,7 +475,7 @@ async def runConfig(paramIter: Iterable[IterType],
         for c in failures:
             print(' '.join(c.generateMlirDriverCommandLine(options.flags, kernel_repeats=None)))
     print(f"Passed: {n_passes}, Invalid: {n_invalids}, Failed: {len(failures)}")
-    return len(failures) == 0
+    return len(failures) == 0 or len(n_passes) == 0
 
 
 def main() -> bool:

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -475,7 +475,7 @@ async def runConfig(paramIter: Iterable[IterType],
         for c in failures:
             print(' '.join(c.generateMlirDriverCommandLine(options.flags, kernel_repeats=None)))
     print(f"Passed: {n_passes}, Invalid: {n_invalids}, Failed: {len(failures)}")
-    return len(failures) == 0 or len(n_passes) == 0
+    return len(failures) == 0 and !(len(n_passes) == 0)
 
 
 def main() -> bool:

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -475,7 +475,7 @@ async def runConfig(paramIter: Iterable[IterType],
         for c in failures:
             print(' '.join(c.generateMlirDriverCommandLine(options.flags, kernel_repeats=None)))
     print(f"Passed: {n_passes}, Invalid: {n_invalids}, Failed: {len(failures)}")
-    return len(failures) == 0 and !(len(n_passes) == 0)
+    return len(failures) == 0 and len(n_passes) > 0
 
 
 def main() -> bool:


### PR DESCRIPTION
## Motivation

This PR fixes silent issues with parameterSweeps that is affecting the weekly CI.

Fixes https://github.com/ROCm/rocMLIR-internal/issues/2015#event-20061683474

## Technical Details

This change does the following:
- Updates the exit check to also check and see if we have some passing configs (catches case where none are failing, but all are invalid)
- Removes conditional V4R1 checks, and replaces with hardcoded `-v4r1 0` logic for backwards data convolution.
  - Right now MIGraphX will only use `-v4r1 0`, so we want to test that
  - This also saves quite a bit of time in running the parameterSweeps.

## Test Plan

- Weekly CI

## Test Result

- [ ] Weekly CI

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
