### PR TITLE
Fix pipeline bugs

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
+++ b/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
@@ -18,21 +18,22 @@ namespace mlir {
 namespace rock {
 LogicalResult multiBuffer(RewriterBase &rewriter, rock::GpuAllocOp allocOp,
                           SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
-                          unsigned multiplier, bool skipOverrideAnalysis);
+                          unsigned multiBufferingFactor,
+                          bool skipOverrideAnalysis);
 
 FailureOr<SmallVector<rock::GpuAllocOp>>
 multiBuffer(rock::GpuAllocOp allocOp,
-            SmallVectorImpl<rock::GpuAllocOp> &newAllocs, unsigned multiplier,
-            bool skipOverrideAnalysis);
+            SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
+            unsigned multiBufferingFactor, bool skipOverrideAnalysis);
 
 LogicalResult updateMultiBuffer(RewriterBase &rewriter, Location loc,
-                                ArrayRef<rock::GpuAllocOp> multiBuffer,
+                                ArrayRef<rock::GpuAllocOp> allocs,
                                 SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
-                                unsigned newMultiplier);
+                                unsigned newMultiBufferingFactor);
 
-LogicalResult updateMultiBuffer(ArrayRef<rock::GpuAllocOp> multiBuffer,
+LogicalResult updateMultiBuffer(ArrayRef<rock::GpuAllocOp> allocs,
                                 SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
-                                unsigned newMultiplier);
+                                unsigned newMultiBufferingFactor);
 
 } // namespace rock
 } // namespace mlir

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1312,16 +1312,17 @@ struct GridwiseAttentionAccelRewritePattern
   template <typename ElementwiseOpType>
   void postProcessFirstGemmSplat(PatternRewriter &rewriter, Location loc,
                                  layout::GridCoordinates gridCoords,
-                                 Value gemm0OutBuffer,
+                                 Value inputBuffer, Value outputBuffer,
                                  RegsAsMatrixSubTiles gemm0OutViews,
                                  TypedAttr splatVal) const {
-    MemRefType bufType = cast<MemRefType>(gemm0OutBuffer.getType());
+    assert(inputBuffer.getType() == outputBuffer.getType());
+    MemRefType bufType = cast<MemRefType>(inputBuffer.getType());
     SmallVector<AffineMap, 2> indexingMaps{
         2, rewriter.getMultiDimIdentityMap(bufType.getRank())};
     SmallVector<utils::IteratorType> iteratorTypes(
         bufType.getRank(), utils::IteratorType::parallel);
     linalg::GenericOp::create(
-        rewriter, loc, ValueRange(gemm0OutBuffer), ValueRange(gemm0OutBuffer),
+        rewriter, loc, ValueRange(inputBuffer), ValueRange(outputBuffer),
         indexingMaps, iteratorTypes,
         [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
           Value splatScalarConst = arith::ConstantOp::create(
@@ -2211,8 +2212,13 @@ struct GridwiseAttentionAccelRewritePattern
 
     Value gemm0OutBuffer = createBufferForGemmOut(loc, gemmOutElemType,
                                                   accelParamsGemm0, rewriter);
-    Value softmaxInputBuffer;
+    Value outputFirstGemm;
     if (fusionOutElemType != elemTypeSoftmax) {
+      outputFirstGemm = createBufferForGemmOut(loc, elemTypeSoftmax,
+                                               accelParamsGemm0, rewriter);
+    }
+    Value softmaxInputBuffer;
+    if (op.getEnableSoftmax()) {
       softmaxInputBuffer = createBufferForGemmOut(loc, elemTypeSoftmax,
                                                   accelParamsGemm0, rewriter);
     }
@@ -2558,14 +2564,14 @@ struct GridwiseAttentionAccelRewritePattern
       }
       gemm0OutBuffer = maybeFusionOutBuffer.value();
       if (fusionOutElemType == elemTypeSoftmax)
-        softmaxInputBuffer = gemm0OutBuffer;
+        outputFirstGemm = gemm0OutBuffer;
 
       // Softmax
       if (op.getEnableSoftmax()) {
         // convert gemm0OutBuffer to elemTypeSoftmax
         if (fusionOutElemType != elemTypeSoftmax) {
           createTypeConversionFlatAndStore(rewriter, loc, gemm0OutBuffer,
-                                           softmaxInputBuffer);
+                                           outputFirstGemm);
         }
         // Scale gemm0 output by (1/ln2)
         // So that we can use exp2 instead of exp.
@@ -2574,7 +2580,7 @@ struct GridwiseAttentionAccelRewritePattern
             elemTypeSoftmax.getIntOrFloatBitWidth() >= 32 ? APFloat::opOK
                                                           : APFloat::opInexact);
         postProcessFirstGemmSplat<ElementwiseMultOp>(
-            rewriter, loc, gridCoordsGemm0, softmaxInputBuffer,
+            rewriter, loc, gridCoordsGemm0, outputFirstGemm, softmaxInputBuffer,
             gemm0OutSubTileViews,
             ln2Recip.getDefiningOp<arith::ConstantOp>().getValue());
 
@@ -2659,7 +2665,7 @@ struct GridwiseAttentionAccelRewritePattern
       // Emit blockwise GEMM 1.
       {
         auto gemm0Out =
-            op.getEnableSoftmax() ? softmaxBufferExp : softmaxInputBuffer;
+            op.getEnableSoftmax() ? softmaxBufferExp : outputFirstGemm;
         if (elemTypeV != elemTypeSoftmax) {
           createTypeConversionFlatAndStore(rewriter, loc, gemm0Out,
                                            gemm1RegBufferB);

--- a/mlir/lib/Dialect/Rock/Transforms/RockMultibuffer.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockMultibuffer.cpp
@@ -199,23 +199,6 @@ mlir::rock::multiBuffer(RewriterBase &rewriter, rock::GpuAllocOp allocOp,
                         unsigned multiBufferingFactor,
                         bool skipOverrideAnalysis) {
   LLVM_DEBUG(DBGS() << "Start multibuffering: " << allocOp << "\n");
-  if (!allocOp.getType().getElementType().isInteger(8)) {
-    LLVM_DEBUG(DBGS() << "-- Not a int8 buffer -> fail\n");
-    return failure();
-  }
-  if (allocOp.getType().getShape().size() != 1) {
-    LLVM_DEBUG(DBGS() << "-- Not a flat buffer -> fail\n");
-    return failure();
-  }
-
-  bool isUsedByViews = llvm::all_of(allocOp->getUsers(), [](Operation *user) {
-    return dyn_cast<memref::ViewOp>(user) != nullptr;
-  });
-  if (!isUsedByViews) {
-    LLVM_DEBUG(DBGS() << "-- Cannot detect the raw i8 buffer alloc followed by "
-                         "a memref.viewOp\n");
-    return failure();
-  }
 
   DominanceInfo dom(allocOp->getParentOp());
   LoopLikeOpInterface candidateLoop;
@@ -279,19 +262,10 @@ mlir::rock::multiBuffer(RewriterBase &rewriter, rock::GpuAllocOp allocOp,
 
   LLVM_DEBUG(DBGS() << "Start multibuffering loop: " << candidateLoop << "\n");
 
-  // 1. Construct the multi-buffered memref type.
+  // Construct the multi-buffered memref type.
   LLVM_DEBUG(DBGS() << "--original type: " << allocOp.getType() << "\n");
 
-  if (!allocOp.getType().getElementType().isInteger(8)) {
-    // We only apply multibuffering on raw bytes allocs
-    return failure();
-  }
-  if (allocOp.getType().getShape().size() > 1) {
-    // We only apply multibuffering on raw bytes allocs
-    return failure();
-  }
-
-  // 2. Create the multiple buffers alloc.
+  // 1. Create the multiple buffers alloc.
   newAllocs.resize(multiBufferingFactor);
   Location loc = allocOp->getLoc();
   OpBuilder::InsertionGuard g(rewriter);
@@ -301,14 +275,14 @@ mlir::rock::multiBuffer(RewriterBase &rewriter, rock::GpuAllocOp allocOp,
                                             ValueRange{}, allocOp->getAttrs());
   }
 
-  // 3. RAUW with the particular slice, taking modular rotation into account.
+  // 2. RAUW with the particular slice, taking modular rotation into account.
   SmallVector<Value> startingValues;
   for (auto alloc : newAllocs)
     startingValues.push_back(alloc);
 
   replaceUsesAndPropagateType(rewriter, loc, allocOp, startingValues,
                               candidateLoop);
-  // 4. Finally, erase the old allocOp.
+  // 3. Finally, erase the old allocOp.
   rewriter.eraseOp(allocOp);
 
   return success();

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -377,6 +377,12 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
         for (auto [res, type] : dependencies) {
           if (type == WAR && getAddressSpace(res) == AddressSpace::Private)
             continue;
+
+          // The DAG is built using "resources", not multibuffers.
+          // So, it is possible that thisMultiBuffers[res] does not exist
+          if (!thisMultiBuffers.contains(res))
+            thisMultiBuffers[res] = 1;
+
           thisMultiBuffers[res]++;
         }
       }
@@ -405,8 +411,8 @@ DagType pruneGraph(const DagType &dag) {
   // dependency concerns two different iteration. In other words, if stageA
   // accesses LDS in iteration i and stageB accesses LDS in iteration j stageA
   // and stageB have no dependencies as long as i!=j
-  for (auto [source, edges] : dag) {
-    for (auto [sink, deps] : edges) {
+  for (const auto &[source, edges] : dag) {
+    for (const auto &[sink, deps] : edges) {
       DenseSet<std::pair<rock::GpuAllocOp, DependencyType>> newDeps;
       for (auto [alloc, type] : deps) {
         if (getAddressSpace(alloc) != gpu::AddressSpace::Workgroup)
@@ -448,6 +454,7 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
                    SmallVector<rock::StageOp> &extendedStages,
                    int64_t &initiationInterval, int64_t numIterations) {
   DagType dag = createDependencyGraph(stages, allocs);
+  // prune non-LDS dependencies
   dag = pruneGraph(dag);
 
   // If there is a loop, we probably need a backward barrier, i.e.,
@@ -527,6 +534,7 @@ bool checkIfPipeliningSupported(scf::ForOp forOp) {
     if (parentLoop->hasAttr(rockPipelineAttrName)) {
       return true;
     }
+    forOp = parentLoop;
   }
   return false;
 }
@@ -536,19 +544,24 @@ bool checkIfPipeliningSupported(scf::ForOp forOp) {
 SmallVector<scf::ForOp> collectLoopLevels(mlir::func::FuncOp func) {
   SmallVector<scf::ForOp> loops;
 
-  unsigned curLevelPos = 0;
   unsigned curLevelLen = 0;
   func.walk([&](scf::ForOp forOp) {
-    loops.push_back(forOp);
-    curLevelLen++;
+    if (forOp->getParentOp() == func) {
+      loops.push_back(forOp);
+      curLevelLen++;
+    }
   });
 
+  unsigned curLevelPos = 0;
   while (curLevelLen) {
     unsigned nextLevelLen = 0;
     for (unsigned i = 0; i < curLevelLen; i++) {
-      loops[curLevelPos + i].getBody()->walk([&](scf::ForOp forOp) {
-        loops.push_back(forOp);
-        nextLevelLen++;
+      scf::ForOp currParent = loops[curLevelPos + i];
+      currParent.getBody()->walk([&](scf::ForOp forOp) {
+        if (forOp->getParentOp() == currParent) {
+          loops.push_back(forOp);
+          nextLevelLen++;
+        }
       });
     }
     curLevelPos += curLevelLen;
@@ -695,15 +708,22 @@ void RockPipeline::runOnOperation() {
     };
 
     scf::populateSCFLoopPipeliningPatterns(patterns, options);
-    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
   }
 
   // Remulti-buffer(if needed). Now we know what all the loops need, hence
   // we can safely allocate the right amount of resources in the function
   for (auto [alloc, factor] : multiBufferFactors) {
     SmallVector<rock::GpuAllocOp> newAllocs;
-    if (factor > 1)
-      (void)rock::updateMultiBuffer(rewriter, loc, {alloc}, newAllocs, factor);
+    if (factor > 1) {
+      if (failed(rock::updateMultiBuffer(rewriter, loc, {alloc}, newAllocs,
+                                         factor))) {
+
+        emitError(loc, "could not update multibuffer\n");
+        return signalPassFailure();
+      }
+    }
   }
 
   // Cleanup the stages
@@ -712,7 +732,8 @@ void RockPipeline::runOnOperation() {
       RewritePatternSet patterns(&getContext());
       patterns.add<RemoveStagesRewritePattern, PushBarrierDownRewritePattern,
                    RemoveBackToBackBarriersRewritePattern>(&getContext());
-      (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+        return signalPassFailure();
     }
   }
 }

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -559,7 +559,7 @@ Value mlir::rock::createSliceOfFirstDim(PatternRewriter &rewriter, Location loc,
 }
 
 template <typename AllocType>
-FailureOr<AllocType> findAlloc(Value value) {
+static FailureOr<AllocType> findAlloc(Value value) {
   auto *curOp = value.getDefiningOp();
   auto maybeAllocOp = dyn_cast_or_null<AllocType>(curOp);
   while (!maybeAllocOp) {
@@ -579,7 +579,7 @@ FailureOr<AllocType> findAlloc(Value value) {
       } else if (buffers.size() == 1) {
         curOp = buffers.back().getDefiningOp();
       } else {
-        int64_t index = selectIndex.value();
+        int64_t index = selectIndex.value() % buffers.size();
         curOp = buffers[index].getDefiningOp();
       }
     } else {

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -88,8 +88,8 @@
 
   // CHECK: rock.transforming_for
     // CHECK: %[[tmp:.+]] =  memref.load %[[gemm0AccBuf]][
-    // CHECK: rock.in_bounds_store %[[tmp]] -> %[[gemm0AccBufScalar:.+]][
-  // CHECK: linalg.generic {{.*}} ins(%[[gemm0AccBufScalar]] {{.*}} outs(%[[gemm0AccBufScalar]]
+    // CHECK: rock.in_bounds_store %[[tmp]] -> %[[gemm0AccBuf:.+]][
+  // CHECK: linalg.generic {{.*}} ins(%[[gemm0AccBuf]] {{.*}} outs(%[[gemm0AccBufScalar:[0-9]+]]
     // CHECK: %[[gemm0Scaled:.+]] = arith.mulf %in, %[[ln2Recip]] : f32
     // CHECK: linalg.yield %[[gemm0Scaled]]
   // CHECK: %[[ldsReductionWS:.+]] = rock.alloc() : memref<256xi8, #gpu.address_space<workgroup>>

--- a/mlir/test/Dialect/Rock/test-fusion-and-pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test-fusion-and-pipeline.mlir
@@ -94,11 +94,19 @@ module {
 }
 
 
-// To test the input argument loads in the prolog and software-pipelined kernel would use the same buffer
-// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.*}}) [{{.*}}] -> %[[BUFFER_0:.+]] : memref<36x1x8x49x64x8xi8> -> memref<8xi8, #gpu.address_space<private>>
-// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.+}}) [{{.*}}] -> %[[BUFFER_1:.+]] : memref<36x1x8x49x64x8xf16> -> memref<8xf16, #gpu.address_space<private>>
-// CHECK: linalg.generic {{{.*}}} ins(%[[BUFFER_0]], %[[BUFFER_1]]
+// To test the input argument loads in the prologue and software-pipelined kernel would use the same buffer
+// CHECK: %[[BUFFER0_EXTRACT:.+]] = rock.extract_multibuffer(%[[BUFFER_0:[0-9]+]])
+// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.*}}) [{{.*}}] -> %[[BUFFER0_EXTRACT]] : memref<36x1x8x49x64x8xi8> -> memref<8xi8, #gpu.address_space<private>>
+// CHECK: %[[BUFFER1_EXTRACT:.+]] = rock.extract_multibuffer(%[[BUFFER_1:[0-9]+]])
+// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.+}}) [{{.*}}] -> %[[BUFFER1_EXTRACT]] : memref<36x1x8x49x64x8xf16> -> memref<8xf16, #gpu.address_space<private>>
+// CHECK-DAG: %[[BUFFER0_EXTRACT2:.+]] = rock.extract_multibuffer(%[[BUFFER_0]])
+// CHECK-DAG: %[[BUFFER1_EXTRACT2:.+]] = rock.extract_multibuffer(%[[BUFFER_1]])
+// CHECK: linalg.generic {{{.*}}} ins(%[[BUFFER0_EXTRACT2]], %[[BUFFER1_EXTRACT2]]
 // CHECK: scf.for
-// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.*}}) [{{.*}}] -> %[[BUFFER_0:.+]] : memref<36x1x8x49x64x8xi8> -> memref<8xi8, #gpu.address_space<private>>
-// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.+}}) [{{.*}}] -> %[[BUFFER_1:.+]] : memref<36x1x8x49x64x8xf16> -> memref<8xf16, #gpu.address_space<private>>
-// CHECK: linalg.generic {{{.*}}} ins(%[[BUFFER_0]], %[[BUFFER_1]]
+// CHECK: %[[BUFFER0_EXTRACT3:.+]] = rock.extract_multibuffer(%[[BUFFER_0]])
+// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.*}}) [{{.*}}] -> %[[BUFFER0_EXTRACT3]] : memref<36x1x8x49x64x8xi8> -> memref<8xi8, #gpu.address_space<private>>
+// CHECK-DAG: %[[BUFFER1_EXTRACT3:.+]] = rock.extract_multibuffer(%[[BUFFER_1]])
+// CHECK: rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%{{.+}}) [{{.*}}] -> %[[BUFFER1_EXTRACT3]] : memref<36x1x8x49x64x8xf16> -> memref<8xf16, #gpu.address_space<private>>
+// CHECK-DAG: %[[BUFFER0_EXTRACT4:.+]] = rock.extract_multibuffer(%[[BUFFER_0]])
+// CHECK-DAG: %[[BUFFER1_EXTRACT4:.+]] = rock.extract_multibuffer(%[[BUFFER_1]])
+// CHECK: linalg.generic {{{.*}}} ins(%[[BUFFER0_EXTRACT4]], %[[BUFFER1_EXTRACT4]]

--- a/mlir/test/Dialect/Rock/test_multi_buffer_noni8_non1D.mlir
+++ b/mlir/test/Dialect/Rock/test_multi_buffer_noni8_non1D.mlir
@@ -1,0 +1,185 @@
+// RUN: rocmlir-opt %s --rock-multibuffer-test | FileCheck %s
+// RUN: rocmlir-opt %s --rock-multibuffer-test --rock-blockwise-gemm-to-threadwise --rock-threadwise-gemm-lowering | FileCheck %s --check-prefix=LOWERING
+// RUN: rocmlir-opt %s --rock-multibuffer-test | grep alloc | wc -l | FileCheck %s --check-prefix=NUM_ALLOCS
+// NUM_ALLOCS: 18
+#map = affine_map<(d0, d1, d2) -> (d0, d2, d1)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d1, (d0 * 8 + d5) * 8 + d7, (d2 * 32 + d4) * 2 + d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4 floordiv 8, d4 mod 8, d5 floordiv 8, d5 mod 8)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d1, (d0 * 8 + d4) * 8 + d6, (d3 * 32 + d5) * 2 + d7)>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4 floordiv 32, d4 mod 32, d5 floordiv 2, d5 mod 2)>
+#map5 = affine_map<(d0, d1) -> (d0 * 8 + d1)>
+#map6 = affine_map<(d0, d1) -> (d1, d0)>
+#map7 = affine_map<(d0, d1, d2) -> ((d0 * 2 + d1) * 8 + d2)>
+#map8 = affine_map<(d0, d1) -> (0, d1, d0)>
+#map9 = affine_map<(d0, d1) -> (d0 * 2 + d1)>
+#map10 = affine_map<(d0, d1) -> (d0, d1)>
+#map11 = affine_map<(d0, d1, d2, d3) -> (d0 * 64 + d1 + d2)>
+#map12 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d3, d4)>
+#map13 = affine_map<(d0, d1, d2, d3) -> (d0, d1 floordiv 64, d1 mod 64, d2, d3)>
+#map14 = affine_map<(d0, d1, d2, d3) -> (d0, d0 + d1, d2, d3)>
+#map15 = affine_map<(d0, d1) -> (d0 floordiv 8, d1, 0, d0 mod 8)>
+#map16 = affine_map<(d0, d1, d2, d3, d4) -> ((d1 + d2) * 8 + d4, d0 * 2 + d3)>
+#map17 = affine_map<(d0, d1) -> (d0 floordiv 8, d0 mod 8, 0, d1 floordiv 8, d1 mod 8)>
+#map18 = affine_map<(d0, d1, d2, d3, d4) -> ((d0 + d2) * 8 + d4, d3 * 32 + d1)>
+#map19 = affine_map<(d0, d1) -> (d0 floordiv 32, d0 mod 32, 0, d1 floordiv 8, d1 mod 8)>
+#xldops_gemm_params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 8, mPerBlock = 64, nPerBlock = 64, kpack = 8, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>
+#transform_map = #rock.transform_map<#map by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemmK", "gemmM"] at [1, 2] -> ["gemmK", "gemmM"] at [2, 1]>] bounds = [1, 1024, 384] -> [1, 384, 1024]>
+#transform_map1 = #rock.transform_map<#map1 by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{16, 8, 8} ["k_loop", "k_thread", "k_iter"] at [0, 5, 7] -> ["k"] at [1]>, <Unmerge{6, 32, 2} ["m_block", "m_thread", "m_iter"] at [2, 4, 6] -> ["m"] at [2]>, <AddDim{16} ["n_block"] at [3] -> [] at []>] bounds = [16, 1, 6, 16, 32, 8, 2, 8] -> [1, 1024, 384]>
+#transform_map2 = #rock.transform_map<#map2 by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{32, 8} ["tid"] at [4] -> ["m_thread", "k_thread"] at [4, 5]>, <Merge{2, 8} ["iter"] at [5] -> ["m_iter", "k_iter"] at [6, 7]>] bounds = [16, 1, 6, 16, 256, 16] -> [16, 1, 6, 16, 32, 8, 2, 8]>
+#transform_map3 = #rock.transform_map<#map3 by [<PassThrough ["g_block"] at [1] -> ["g"] at [0]>, <Unmerge{16, 8, 8} ["k_loop", "k_thread", "k_iter"] at [0, 4, 6] -> ["k"] at [1]>, <Unmerge{16, 32, 2} ["n_block", "n_thread", "n_iter"] at [3, 5, 7] -> ["n"] at [2]>, <AddDim{6} ["m_block"] at [2] -> [] at []>] bounds = [16, 1, 6, 16, 8, 32, 8, 2] -> [1, 1024, 1024]>
+#transform_map4 = #rock.transform_map<#map4 by [<PassThrough ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3] -> ["k_loop", "g_block", "m_block", "n_block"] at [0, 1, 2, 3]>, <Merge{8, 32} ["tid"] at [4] -> ["k_thread", "n_thread"] at [4, 5]>, <Merge{8, 2} ["iter"] at [5] -> ["k_iter", "n_iter"] at [6, 7]>] bounds = [16, 1, 6, 16, 256, 16] -> [16, 1, 6, 16, 8, 32, 8, 2]>
+#transform_map5 = #rock.transform_map<#map5 by [<Unmerge{2, 8} ["m_iter", "k_iter"] at [0, 1] -> ["iter"] at [0]>] bounds = [2, 8] -> [16]>
+#transform_map6 = #rock.transform_map<#map6 by [<Merge{8} ["k"] at [0] -> ["k_iter"] at [1]>, <Merge{2} ["m"] at [1] -> ["m_iter"] at [0]>] bounds = [8, 2] -> [2, 8]>
+#transform_map7 = #rock.transform_map<#map7 by [<Unmerge{1, 2, 8} ["kouterPerThread", "m_iter", "kpackPerThread"] at [0, 1, 2] -> ["iter"] at [0]>] bounds = [1, 2, 8] -> [16]>
+#transform_map8 = #rock.transform_map<#map8 by [<Merge{1, 8} ["k"] at [0] -> ["kouterPerThread", "kpackPerThread"] at [0, 2]>, <Merge{2} ["m"] at [1] -> ["m_iter"] at [1]>] bounds = [8, 2] -> [1, 2, 8]>
+#transform_map9 = #rock.transform_map<#map9 by [<Unmerge{8, 2} ["k_iter", "n_iter"] at [0, 1] -> ["iter"] at [0]>] bounds = [8, 2] -> [16]>
+#transform_map10 = #rock.transform_map<#map10 by [<Merge{8} ["k"] at [0] -> ["k_iter"] at [0]>, <Merge{2} ["n"] at [1] -> ["n_iter"] at [1]>] bounds = [8, 2] -> [8, 2]>
+#transform_map11 = #rock.transform_map<#map7 by [<Unmerge{1, 2, 8} ["kouterPerThread", "n_iter", "kpackPerThread"] at [0, 1, 2] -> ["iter"] at [0]>] bounds = [1, 2, 8] -> [16]>
+#transform_map12 = #rock.transform_map<#map8 by [<Merge{1, 8} ["k"] at [0] -> ["kouterPerThread", "kpackPerThread"] at [0, 2]>, <Merge{2} ["n"] at [1] -> ["n_iter"] at [1]>] bounds = [8, 2] -> [1, 2, 8]>
+#transform_map13 = #rock.transform_map<#map11 by [<Unmerge{8, 64, 1} ["k_outer", "m", "kpack_idx"] at [0, 1, 2] -> ["raw"] at [0]>, <AddDim{8} ["kpack_vec"] at [3] -> [] at []>] bounds = [8, 64, 1, 8] -> [512]>
+#transform_map14 = #rock.transform_map<#map12 by [<PassThrough ["k_outer"] at [0] -> ["k_outer"] at [0]>, <AddDim{8} ["to_discard"] at [1] -> [] at []>, <PassThrough ["m"] at [2] -> ["m"] at [1]>, <PassThrough ["kpack_idx"] at [3] -> ["kpack_idx"] at [2]>, <PassThrough ["kpack_vec"] at [4] -> ["kpack_vec"] at [3]>] bounds = [8, 8, 64, 1, 8] -> [8, 64, 1, 8]>
+#transform_map15 = #rock.transform_map<#map13 by [<PassThrough ["k_outer"] at [0] -> ["k_outer"] at [0]>, <Merge{8, 64} ["m"] at [1] -> ["to_discard", "m"] at [1, 2]>, <PassThrough ["kpack_idx"] at [2] -> ["kpack_idx"] at [3]>, <PassThrough ["kpack_vec"] at [3] -> ["kpack_vec"] at [4]>] bounds = [8, 512, 1, 8] -> [8, 8, 64, 1, 8]>
+#transform_map16 = #rock.transform_map<#map14 by [<PassThrough ["k_outer"] at [0] -> ["k_outer"] at [0]>, <Embed{1, 1} ["k_outer", "m"] at [0, 1] -> ["m"] at [1]>, <PassThrough ["kpack_idx", "kpack_vec"] at [2, 3] -> ["kpack_idx", "kpack_vec"] at [2, 3]>] bounds = [8, 64, 1, 8] -> [8, 512, 1, 8]>
+#transform_map17 = #rock.transform_map<#map15 by [<Merge{8, 1, 8} ["k"] at [0] -> ["k_outer", "kpack_idx", "kpack_vec"] at [0, 2, 3]>, <Merge{64} ["d"] at [1] -> ["m"] at [1]>] bounds = [64, 64] -> [8, 64, 1, 8]>
+#transform_map18 = #rock.transform_map<#map16 by [<Unmerge{8, 1, 8} ["k_thread", "kouterPerThread", "kpackPerThread"] at [1, 2, 4] -> ["k"] at [0]>, <Unmerge{32, 2} ["m_thread", "m_iter"] at [0, 3] -> ["m"] at [1]>] bounds = [32, 8, 1, 2, 8] -> [64, 64]>
+#transform_map19 = #rock.transform_map<#map17 by [<Merge{32, 8} ["tid"] at [0] -> ["m_thread", "k_thread"] at [0, 1]>, <Merge{1, 2, 8} ["iter"] at [1] -> ["kouterPerThread", "m_iter", "kpackPerThread"] at [2, 3, 4]>] bounds = [256, 16] -> [32, 8, 1, 2, 8]>
+#transform_map20 = #rock.transform_map<#map11 by [<Unmerge{8, 64, 1} ["k_outer", "n", "kpack_idx"] at [0, 1, 2] -> ["raw"] at [0]>, <AddDim{8} ["kpack_vec"] at [3] -> [] at []>] bounds = [8, 64, 1, 8] -> [512]>
+#transform_map21 = #rock.transform_map<#map15 by [<Merge{8, 1, 8} ["k"] at [0] -> ["k_outer", "kpack_idx", "kpack_vec"] at [0, 2, 3]>, <Merge{64} ["d"] at [1] -> ["n"] at [1]>] bounds = [64, 64] -> [8, 64, 1, 8]>
+#transform_map22 = #rock.transform_map<#map18 by [<Unmerge{8, 1, 8} ["k_thread", "kouterPerThread", "kpackPerThread"] at [0, 2, 4] -> ["k"] at [0]>, <Unmerge{2, 32} ["n_iter", "n_thread"] at [3, 1] -> ["n"] at [1]>] bounds = [8, 32, 1, 2, 8] -> [64, 64]>
+#transform_map23 = #rock.transform_map<#map19 by [<Merge{8, 32} ["tid"] at [0] -> ["k_thread", "n_thread"] at [0, 1]>, <Merge{1, 2, 8} ["iter"] at [1] -> ["kouterPerThread", "n_iter", "kpackPerThread"] at [2, 3, 4]>] bounds = [256, 16] -> [8, 32, 1, 2, 8]>
+module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx90a"} {
+  func.func @rock_gemm(%arg0: memref<1x384x1024xf16>, %arg1: memref<1x1024x1024xf16>, %arg2: memref<1x384x1024xf16>) attributes {block_size = 256 : i32, grid_size = 96 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a", wave_size = 64 : i32} {
+    %0 = rock.transform %arg0 by #transform_map : memref<1x384x1024xf16> to memref<1x1024x384xf16>
+    %alloc = memref.alloc() : memref<1x384x1024xf32>
+    %1 = rock.transform %0 by #transform_map1 : memref<1x1024x384xf16> to memref<16x1x6x16x32x8x2x8xf16>
+    %2 = rock.transform %1 by #transform_map2 : memref<16x1x6x16x32x8x2x8xf16> to memref<16x1x6x16x256x16xf16>
+    %3 = rock.transform %arg1 by #transform_map3 : memref<1x1024x1024xf16> to memref<16x1x6x16x8x32x8x2xf16>
+    %4 = rock.transform %3 by #transform_map4 : memref<16x1x6x16x8x32x8x2xf16> to memref<16x1x6x16x256x16xf16>
+    %5 = rock.workgroup_id : index
+    %6 = rock.workitem_id : index
+    %7 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %8 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %c0 = arith.constant 0 : index
+    %c22 = arith.constant 22 : index
+    %c352 = arith.constant 352 : index
+    %c6 = arith.constant 6 : index
+    %c96 = arith.constant 96 : index
+    %9 = arith.divui %5, %c96 : index
+    %10 = arith.remui %5, %c96 : index
+    %11 = arith.divui %10, %c352 : index
+    %12 = arith.muli %11, %c22 : index
+    %13 = arith.subi %c6, %12 : index
+    %14 = arith.minui %13, %c22 : index
+    %15 = arith.remui %10, %14 : index
+    %16 = arith.addi %12, %15 : index
+    %17 = arith.remui %10, %c352 : index
+    %18 = arith.divui %17, %14 : index
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%2) [%c0, %9, %16, %18, %6] -> %7 : memref<16x1x6x16x256x16xf16> -> memref<16xf16, #gpu.address_space<private>>
+    rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%c0, %9, %16, %18, %6] -> %8 : memref<16x1x6x16x256x16xf16> -> memref<16xf16, #gpu.address_space<private>>
+    %c0_0 = arith.constant 0 : index
+    // LOWERING: %[[multibuf0:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    // LOWERING: %[[multibuf1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<private>>
+    %raw = rock.alloc(){__multibuffer__=2} : memref<32xi8, #gpu.address_space<private>>
+    // LOWERING: %[[multibuf0_view:.*]] = memref.view %[[multibuf0]][{{.*}}][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
+    // LOWERING: %[[multibuf1_view:.*]] = memref.view %[[multibuf1]][{{.*}}][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
+    %19 = memref.view %raw[%c0_0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
+    %raw1 = rock.alloc(){__multibuffer__=2, __remultibuffer__=1} : memref<32xi8, #gpu.address_space<private>>
+    %20 = memref.view %raw1[%c0_0][] : memref<32xi8, #gpu.address_space<private>> to memref<16xf16, #gpu.address_space<private>>
+    %21 = rock.transform %7 by #transform_map5 : memref<16xf16, #gpu.address_space<private>> to memref<2x8xf16, #gpu.address_space<private>>
+    %22 = rock.transform %21 by #transform_map6 : memref<2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+    %23 = rock.transform %19 by #transform_map7 : memref<16xf16, #gpu.address_space<private>> to memref<1x2x8xf16, #gpu.address_space<private>>
+    %24 = rock.transform %23 by #transform_map8 : memref<1x2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+    %25 = rock.transform %8 by #transform_map9 : memref<16xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+    %26 = rock.transform %25 by #transform_map10 : memref<8x2xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+    %27 = rock.transform %20 by #transform_map11 : memref<16xf16, #gpu.address_space<private>> to memref<1x2x8xf16, #gpu.address_space<private>>
+    %28 = rock.transform %27 by #transform_map12 : memref<1x2x8xf16, #gpu.address_space<private>> to memref<8x2xf16, #gpu.address_space<private>>
+    %c2 = arith.constant 2 : index
+    %c64 = arith.constant 64 : index
+    // CHECK: %[[multibuf2:.*]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[multibuf3:.*]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+    %29 = rock.alloc(){__multibuffer__=2} : memref<8192xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[remultibuf0:.*]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[remultibuf1:.*]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[remultibuf2:.*]] = rock.alloc() : memref<8192xi8, #gpu.address_space<workgroup>>
+    %30 = rock.alloc(){__multibuffer__=2, __remultibuffer__=3} : memref<8192xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[multibuf2_view:.*]] = memref.view %[[multibuf2]][{{.*}}] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    // CHECK: %[[multibuf3_view:.*]] = memref.view %[[multibuf3]][{{.*}}] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    %view = memref.view %29[%c0_0][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    %31 = rock.transform %view by #transform_map13 : memref<512xvector<8xf16>, #gpu.address_space<workgroup>> to memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+    %32 = rock.transform %31 by #transform_map14 : memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>> to memref<8x8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+    %33 = rock.transform %32 by #transform_map15 : memref<8x8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>> to memref<8x512x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+    %34 = rock.transform %33 by #transform_map16 : memref<8x512x1x8xvector<8xf16>, #gpu.address_space<workgroup>> to memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+    %35 = rock.transform %34 by #transform_map17 : memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>> to memref<64x64xvector<8xf16>, #gpu.address_space<workgroup>>
+    %36 = rock.transform %35 by #transform_map18 : memref<64x64xvector<8xf16>, #gpu.address_space<workgroup>> to memref<32x8x1x2x8xvector<8xf16>, #gpu.address_space<workgroup>>
+    %37 = rock.transform %36 by #transform_map19 : memref<32x8x1x2x8xvector<8xf16>, #gpu.address_space<workgroup>> to memref<256x16xvector<8xf16>, #gpu.address_space<workgroup>>
+    %c0_1 = arith.constant 0 : index
+    %view_2 = memref.view %30[%c0_1][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    %38 = rock.transform %view_2 by #transform_map20 : memref<512xvector<8xf16>, #gpu.address_space<workgroup>> to memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+    %39 = rock.transform %38 by #transform_map21 : memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>> to memref<64x64xvector<8xf16>, #gpu.address_space<workgroup>>
+    %40 = rock.transform %39 by #transform_map22 : memref<64x64xvector<8xf16>, #gpu.address_space<workgroup>> to memref<8x32x1x2x8xvector<8xf16>, #gpu.address_space<workgroup>>
+    %41 = rock.transform %40 by #transform_map23 : memref<8x32x1x2x8xvector<8xf16>, #gpu.address_space<workgroup>> to memref<256x16xvector<8xf16>, #gpu.address_space<workgroup>>
+    %c0_3 = arith.constant 0 : index
+    // CHECK: %[[remultibuf0_view:.*]] = memref.view %[[remultibuf0]][{{.*}}] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    // CHECK: %[[remultibuf1_view:.*]] = memref.view %[[remultibuf1]][{{.*}}] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    // CHECK: %[[remultibuf2_view:.*]] = memref.view %[[remultibuf2]][{{.*}}] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    %view_4 = memref.view %29[%c0_3][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    %c0_5 = arith.constant 0 : index
+    %view_6 = memref.view %30[%c0_5][] : memref<8192xi8, #gpu.address_space<workgroup>> to memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+    %42 = arith.divui %6, %c64 : index
+    %43 = arith.divui %42, %c2 : index
+    %44 = arith.remui %42, %c2 : index
+    %c32 = arith.constant 32 : index
+    %c32_7 = arith.constant 32 : index
+    %45 = arith.muli %43, %c32 : index
+    %46 = arith.muli %44, %c32_7 : index
+    // LOWERING: %[[a_multibuf0:.*]] = rock.alloc() : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    // LOWERING: %[[a_multibuf1:.*]] = rock.alloc() : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    // LOWERING: %[[a_multibuf2:.*]] = rock.alloc() : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    // LOWERING: %[[b_multibuf0:.*]] = rock.alloc() : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    // LOWERING: %[[b_multibuf1:.*]] = rock.alloc() : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    // LOWERING: %[[b_multibuf2:.*]] = rock.alloc() : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    %47 = rock.alloc(){__multibuffer__=2, __remultibuffer__=3} : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    %48 = rock.alloc(){__multibuffer__=2, __remultibuffer__=3} : memref<8xvector<4xf16>, #gpu.address_space<private>>
+    %49 = rock.alloc() : memref<1xvector<16xf32>, #gpu.address_space<private>>
+    %cst = arith.constant dense<0.000000e+00> : vector<16xf32>
+    rock.fill(%49, %cst) : memref<1xvector<16xf32>, #gpu.address_space<private>>, vector<16xf32>
+    affine.for %arg3 = 0 to 16 {
+      rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%2) [%arg3, %9, %16, %18, %6] -> %7 : memref<16x1x6x16x256x16xf16> -> memref<16xf16, #gpu.address_space<private>>
+      rock.threadwise_read_into {forceUnroll, useIndexDiffs} [](%4) [%arg3, %9, %16, %18, %6] -> %8 : memref<16x1x6x16x256x16xf16> -> memref<16xf16, #gpu.address_space<private>>
+      // LOWERING: %[[extractView0:.*]] = rock.extract_multibuffer(%[[multibuf0_view]], %[[multibuf1_view]]
+      // LOWERING: rock.transforming_for
+      // LOWERING: strides [8]
+      // LOWERING: rock.in_bounds_store {{.*}} -> %[[extractView0]][{{.*}}]
+      rock.threadwise_copy %22 -> %24 : memref<8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
+      // CHECK: rock.extract_multibuffer({{.*}}) [%arg3]
+      rock.threadwise_copy %26 -> %28 : memref<8x2xf16, #gpu.address_space<private>> -> memref<8x2xf16, #gpu.address_space<private>>
+      // CHECK: %[[extractView1:.*]] = rock.extract_multibuffer(%[[multibuf2_view]], %[[multibuf3_view]]) [%arg3]
+      // CHECK: %[[t1:.*]] = rock.transform %[[extractView1]] by {{.*}} : memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t2:.*]] = rock.transform %[[t1]] by {{.*}} : memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t3:.*]] = rock.transform %[[t2]] by {{.*}} : memref<8x8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t4:.*]] = rock.transform %[[t3]] by {{.*}} : memref<8x512x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t5:.*]] = rock.transform %[[t4]] by {{.*}} : memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t6:.*]] = rock.transform %[[t5]] by {{.*}} : memref<64x64xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t7:.*]] = rock.transform %[[t6]] by {{.*}} : memref<32x8x1x2x8xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: rock.threadwise_write_all {{.*}} -> [](%[[t7]])
+      rock.threadwise_write_all {forceUnroll, useIndexDiffs} %19 -> [](%37) [%6] by  set : memref<16xf16, #gpu.address_space<private>> -> memref<256x16xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[extractView2:.*]] = rock.extract_multibuffer(%[[remultibuf0_view]], %[[remultibuf1_view]], %[[remultibuf2_view]])
+      // CHECK: %[[t8:.*]] = rock.transform %[[extractView2]] by {{.*}} : memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t9:.*]] = rock.transform %[[t8]] by {{.*}} : memref<8x64x1x8xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t10:.*]] = rock.transform %[[t9]] by {{.*}} : memref<64x64xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: %[[t11:.*]] = rock.transform %[[t10]] by {{.*}} : memref<8x32x1x2x8xvector<8xf16>, #gpu.address_space<workgroup>>
+      // CHECK: rock.threadwise_write_all {{.*}} -> [](%[[t11]])
+      rock.threadwise_write_all {forceUnroll, useIndexDiffs} %20 -> [](%41) [%6] by  set : memref<16xf16, #gpu.address_space<private>> -> memref<256x16xvector<8xf16>, #gpu.address_space<workgroup>>
+      rock.lds_barrier
+      // LOWERING: %[[a:.*]] = rock.extract_multibuffer(%[[a_multibuf0]], %[[a_multibuf1]], %[[a_multibuf2]])
+      // LOWERING: %[[b:.*]] = rock.extract_multibuffer(%[[b_multibuf0]], %[[b_multibuf1]], %[[b_multibuf2]])
+      // LOWERING: affine.for %{{.*}} = 0 to 8
+      // LOWERING: %[[aLoaded:.*]] = memref.load %[[a]]
+      // LOWERING: %[[bLoaded:.*]] = memref.load %[[b]]
+      // LOWERING: amdgpu.mfma %[[aLoaded]] * %[[bLoaded]]
+      rock.blockwise_gemm_accel %49 += %47 from %view_4 * %48 from %view_6 {blockSize = 256 : i32, inMPerThread = 2 : i32, inNPerThread = 2 : i32, params = #xldops_gemm_params, rotateMWithK, loadAfromLDS, loadBfromLDS} : memref<1xvector<16xf32>, #gpu.address_space<private>> += memref<8xvector<4xf16>, #gpu.address_space<private>> from memref<512xvector<8xf16>, #gpu.address_space<workgroup>> * memref<8xvector<4xf16>, #gpu.address_space<private>> from memref<512xvector<8xf16>, #gpu.address_space<workgroup>>
+      rock.lds_barrier
+    }
+    return
+  }
+}

--- a/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline.mlir
@@ -635,3 +635,90 @@ func.func @rock_pipeline_4_stages_ii_1_f16_less_iterations_2(%input : memref<16x
     memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
     return
 }
+
+// this test checks that the infinite loop bug for nested loops has been fixed 
+// CHECK-LABEL: rock_pipeline_nested
+func.func @rock_pipeline_nested(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+
+    // CHECK: scf.for
+    // CHECK: name = "S0" 
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S1"
+    // CHECK: name = "S0"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S2"
+    // CHECK: scf.for 
+    // CHECK-SAME: %[[c0]] to %[[c0]]
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S1"
+    // CHECK: name = "S3"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S2"
+    // CHECK: name = "__fwd_barrier__"
+    // CHECK: name = "S3"
+    // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+    // CHECK: name = "S2"
+    // CHECK: name = "S3" 
+    scf.for %idx = %c0 to %c4 step %c1 {
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}

--- a/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
@@ -65,8 +65,9 @@ static LogicalResult testMultiBuffering(func::FuncOp f) {
         rock::multiBuffer(rewriter, alloc.first, mbAllocs, alloc.second, true);
     if (newFactor && succeeded(mb)) {
       SmallVector<rock::GpuAllocOp> newAllocs;
-      (void)rock::updateMultiBuffer(rewriter, loc, mbAllocs, newAllocs,
-                                    newFactor);
+      if (failed(rock::updateMultiBuffer(rewriter, loc, mbAllocs, newAllocs,
+                                         newFactor)))
+        return failure();
     }
   }
 


### PR DESCRIPTION
THIS PR IS BLOCKED BY https://github.com/ROCm/rocMLIR-internal/issues/2036

## Motivation

Fix some bugs related to RockPipeline pass. This will be needed for attention pipelining (outer loop).

## Technical Details

- RockMultibuffer.h: Make cpp and .h name of variables match
- GridwiseGemmToBlockwise.cpp: Use different registers for input and output (postProcessFirstGemmSplat), otherwise multibuffering had some issues.
- RockMultibuffer.cpp: Remove limitation of not multibuffering non-i8 + one dimensions buffers. This was to only let LDS buffers get multibuffered (I guess), because we define LDS buffers in this particular way.
- RockPipeline.cpp: Fix bug due to uninitialized thisMultiBuffers[key], if the key doesn't exist, it's init to 0, instead of 1. Also added some checks to make the pass fail.
- loweringUtils.cpp: Fix bug when handling rock.extract_multibuffer, it must do modulo of the index.

## Test Plan

Tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
