### PR TITLE
[EXTERNAL] si-fold-operand selecting srcidx for v_mov_b16_t16_e64

### DIFF
--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -931,7 +931,8 @@ static MachineOperand *lookUpCopyChain(const SIInstrInfo &TII,
   for (MachineInstr *SubDef = MRI.getVRegDef(SrcReg);
        SubDef && TII.isFoldableCopy(*SubDef);
        SubDef = MRI.getVRegDef(Sub->getReg())) {
-    unsigned SrcIdx = TII.getFoldableCopySrcIdx(*SubDef);
+    const int SrcIdx =
+        (SubDef->getOpcode()) == AMDGPU::V_MOV_B16_t16_e64 ? 2 : 1;
     MachineOperand &SrcOp = SubDef->getOperand(SrcIdx);
 
     if (SrcOp.isImm())

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3454,10 +3454,9 @@ void SIInstrInfo::insertSelect(MachineBasicBlock &MBB,
   }
 }
 
-bool SIInstrInfo::isFoldableCopy(const MachineInstr &MI) {
+bool SIInstrInfo::isFoldableCopy(const MachineInstr &MI) const {
   switch (MI.getOpcode()) {
   case AMDGPU::V_MOV_B16_t16_e32:
-  case AMDGPU::V_MOV_B16_t16_e64:
   case AMDGPU::V_MOV_B32_e32:
   case AMDGPU::V_MOV_B32_e64:
   case AMDGPU::V_MOV_B64_PSEUDO:
@@ -3474,34 +3473,10 @@ bool SIInstrInfo::isFoldableCopy(const MachineInstr &MI) {
   case AMDGPU::AV_MOV_B32_IMM_PSEUDO:
   case AMDGPU::AV_MOV_B64_IMM_PSEUDO:
     return true;
+  case AMDGPU::V_MOV_B16_t16_e64:
+    return !hasAnyModifiersSet(MI);
   default:
     return false;
-  }
-}
-
-unsigned SIInstrInfo::getFoldableCopySrcIdx(const MachineInstr &MI) {
-  switch (MI.getOpcode()) {
-  case AMDGPU::V_MOV_B16_t16_e32:
-  case AMDGPU::V_MOV_B16_t16_e64:
-    return 2;
-  case AMDGPU::V_MOV_B32_e32:
-  case AMDGPU::V_MOV_B32_e64:
-  case AMDGPU::V_MOV_B64_PSEUDO:
-  case AMDGPU::V_MOV_B64_e32:
-  case AMDGPU::V_MOV_B64_e64:
-  case AMDGPU::S_MOV_B32:
-  case AMDGPU::S_MOV_B64:
-  case AMDGPU::S_MOV_B64_IMM_PSEUDO:
-  case AMDGPU::COPY:
-  case AMDGPU::WWM_COPY:
-  case AMDGPU::V_ACCVGPR_WRITE_B32_e64:
-  case AMDGPU::V_ACCVGPR_READ_B32_e64:
-  case AMDGPU::V_ACCVGPR_MOV_B32:
-  case AMDGPU::AV_MOV_B32_IMM_PSEUDO:
-  case AMDGPU::AV_MOV_B64_IMM_PSEUDO:
-    return 1;
-  default:
-    llvm_unreachable("MI is not a foldable copy");
   }
 }
 
@@ -4022,12 +3997,13 @@ bool SIInstrInfo::areMemAccessesTriviallyDisjoint(const MachineInstr &MIa,
   return false;
 }
 
-static bool getFoldableImm(Register Reg, const MachineRegisterInfo &MRI,
-                           int64_t &Imm, MachineInstr **DefMI = nullptr) {
+bool SIInstrInfo::getFoldableImm(Register Reg, const MachineRegisterInfo &MRI,
+                                 int64_t &Imm,
+                                 MachineInstr **DefMI = nullptr) const {
   if (Reg.isPhysical())
     return false;
   auto *Def = MRI.getUniqueVRegDef(Reg);
-  if (Def && SIInstrInfo::isFoldableCopy(*Def) && Def->getOperand(1).isImm()) {
+  if (Def && isFoldableCopy(*Def) && Def->getOperand(1).isImm()) {
     Imm = Def->getOperand(1).getImm();
     if (DefMI)
       *DefMI = Def;
@@ -4036,8 +4012,8 @@ static bool getFoldableImm(Register Reg, const MachineRegisterInfo &MRI,
   return false;
 }
 
-static bool getFoldableImm(const MachineOperand *MO, int64_t &Imm,
-                           MachineInstr **DefMI = nullptr) {
+bool SIInstrInfo::getFoldableImm(const MachineOperand *MO, int64_t &Imm,
+                                 MachineInstr **DefMI = nullptr) const {
   if (!MO->isReg())
     return false;
   const MachineFunction *MF = MO->getParent()->getParent()->getParent();
@@ -10712,10 +10688,11 @@ bool SIInstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
       return false;
 
     int64_t Mask;
-    const auto isMask = [&Mask, SrcSize](const MachineOperand *MO) -> bool {
+    const auto isMask = [&Mask, SrcSize,
+                         this](const MachineOperand *MO) -> bool {
       if (MO->isImm())
         Mask = MO->getImm();
-      else if (!getFoldableImm(MO, Mask))
+      else if (!this->getFoldableImm(MO, Mask))
         return false;
       Mask &= maxUIntN(SrcSize);
       return isPowerOf2_64(Mask);

--- a/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/external/llvm-project/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -432,8 +432,12 @@ public:
   areMemAccessesTriviallyDisjoint(const MachineInstr &MIa,
                                   const MachineInstr &MIb) const override;
 
-  static bool isFoldableCopy(const MachineInstr &MI);
-  static unsigned getFoldableCopySrcIdx(const MachineInstr &MI);
+  bool isFoldableCopy(const MachineInstr &MI) const;
+
+  bool getFoldableImm(Register Reg, const MachineRegisterInfo &MRI,
+                      int64_t &Imm, MachineInstr **DefMI) const;
+  bool getFoldableImm(const MachineOperand *MO, int64_t &Imm,
+                      MachineInstr **DefMI) const;
 
   void removeModOperands(MachineInstr &MI) const;
 


### PR DESCRIPTION
## Motivation

After we pulled https://github.com/llvm/llvm-project/pull/161764 in from upstream to address a failure in the MIGraphX CI, there was some follow up work for the backend failure.

This PR pulls down these changes as well:
https://github.com/llvm/llvm-project/pull/162101

## Technical Details

See the upstream PR for full details of the change

## Test Plan

- Nightly CI

## Test Result

- [ ] Nightly CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
