### PR TITLE
fix PrGemmSplitK test to actually use split-k > 1

### DIFF
--- a/mlir/test/e2e/PrGemmSplitK.toml
+++ b/mlir/test/e2e/PrGemmSplitK.toml
@@ -4,7 +4,7 @@ suffix = "--operation gemm --arch %arch %pv %random_data %rocmlir_gen_flags | ro
 
 [[axis]]
 name = "splitKFactor"
-values = ["v3:64,64,16,32,32,4,1,1,2,1,1", "v3:64,64,16,32,32,4,1,2,2,1,1"]
+values = ["v3:64,64,16,32,32,4,3,1,2,1,1", "v3:64,64,16,32,32,4,4,2,2,1,1"]
 prefix = "-perf_config="
 
 [[axis]]


### PR DESCRIPTION
## Motivation

PrGemmSplitK is not running split-k.

## Technical Details

change perf config to split-k > 1.

## Test Plan

Tests pass.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
