### PR TITLE
Add fp4 MFMA instruction and selection logic

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/MfmaInsnGroup.h
@@ -27,6 +27,7 @@ enum class MfmaTypeId : uint32_t {
   Fp16TyId,
   Bf16TyId,
   I8TyId,
+  Fp4TyId,
   Fp8Fp8TyId,
   Fp8Bf8TyId,
   Bf8Fp8TyId,

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -957,12 +957,13 @@ def Rock_IndexDiffUpdateOp :
 
 defvar SupportedMemoryElems = [F32, F16, BF16, I1, I<4>, I8, I16, I32,
                                F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN];
-defvar NativeMemoryOpTypes = [F32, F16, BF16, I<4>, I8, I16, I32,
-                           F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN, F4E2M1FN,
-                           VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32, F4E2M1FN]>,
-                           VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
-                           VectorOfLengthAndType<[2, 4, 8, 16],
-                             [I8, F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN]>];
+defvar NativeMemoryOpTypes =
+    [F32, F16, BF16, I<4>, I8, I16, I32, F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2,
+     F8E4M3FN, F4E2M1FN,
+     VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32, F4E2M1FN]>,
+     VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
+     VectorOfLengthAndType<[2, 4, 8, 16], [I8, F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2,
+                                           F8E4M3FN]>];
 
 // in_bounds_load
 def Rock_InBoundsLoadOp

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -958,8 +958,8 @@ def Rock_IndexDiffUpdateOp :
 defvar SupportedMemoryElems = [F32, F16, BF16, I1, I<4>, I8, I16, I32,
                                F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN];
 defvar NativeMemoryOpTypes = [F32, F16, BF16, I<4>, I8, I16, I32,
-                           F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN,
-                           VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32]>,
+                           F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN, F4E2M1FN,
+                           VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32, F4E2M1FN]>,
                            VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
                            VectorOfLengthAndType<[2, 4, 8, 16],
                              [I8, F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2, F8E4M3FN]>];
@@ -1444,6 +1444,7 @@ def Rock_ThreadwiseGemmOp
   }];
   let hasVerifier = 1;
 }
+
 // threadwise_accel_gemm
 def Rock_ThreadwiseAccelGemmOp
     : Rock_Op<"threadwise_accel_gemm",

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/Rock/utility/math.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 
 #include "llvm/Support/Debug.h"
@@ -109,7 +110,13 @@ static auto getMfmaInsnInfoMap = []() -> const llvm::StringMap<MfmaInsnInfo> & {
       {ROCDL::mfma_f32_32x32x16_bf8_bf8::getOperationName(),
        {MfmaTypeId::Bf8Bf8TyId, 32, 16, 1}},
       {ROCDL::mfma_f32_16x16x32_bf8_bf8::getOperationName(),
-       {MfmaTypeId::Bf8Bf8TyId, 16, 32, 1}}};
+       {MfmaTypeId::Bf8Bf8TyId, 16, 32, 1}},
+
+      // fp4
+      {ROCDL::mfma_scale_f32_16x16x128_f8f6f4::getOperationName(),
+       {MfmaTypeId::Fp4TyId, 16, 128, 1}},
+      {ROCDL::mfma_scale_f32_32x32x64_f8f6f4::getOperationName(),
+       {MfmaTypeId::Fp4TyId, 32, 64, 1}}};
   return insnInfo;
 };
 
@@ -435,6 +442,12 @@ static auto getMfmaInsnGroupAttrMapGfx950 = []() {
       {{MfmaTypeId::Bf16TyId, 16, 16},
        {ROCDL::mfma_f32_16x16x32_bf16::getOperationName()}},
 
+      // scaled Fp4 MFMA
+      {{MfmaTypeId::Fp4TyId, 16, 16},
+       {ROCDL::mfma_scale_f32_16x16x128_f8f6f4::getOperationName()}},
+      {{MfmaTypeId::Fp4TyId, 32, 32},
+       {ROCDL::mfma_scale_f32_32x32x64_f8f6f4::getOperationName()}},
+
       // i8 double rate
       {{MfmaTypeId::I8TyId, 32, 32},
        {ROCDL::mfma_i32_32x32x32_i8::getOperationName()}},
@@ -544,6 +557,9 @@ static MfmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
   if (isa<Float8E5M2Type>(dataTypeA) && isa<Float8E5M2Type>(dataTypeB)) {
     return MfmaTypeId::Bf8Bf8TyId;
   }
+  if (isa<Float4E2M1FNType>(dataTypeA) && isa<Float4E2M1FNType>(dataTypeB)) {
+    return MfmaTypeId::Fp4TyId;
+  }
   llvm_unreachable("Unsupported input argument type.");
 }
 
@@ -554,7 +570,9 @@ MfmaInsnGroup::select(Type elementTypeA, Type elementTypeB, StringRef arch,
                           << "elementType A: " << elementTypeA << "\n"
                           << "elementType B: " << elementTypeB << "\n"
                           << "arch: " << arch << "\n"
-                          << "mnPerXdl: " << mnPerXdl << "\n");
+                          << "mnPerXdl: " << mnPerXdl << "\n"
+                          << "kPack: " << kPack << "\n"
+                          << "KPackPerBlock: " << kPackPerBlock << "\n");
 
   // Use 64x64 as base unit in large waves
   int64_t mPerMfmaGroup = getLenPerMfmaGroup(mnPerXdl);
@@ -564,6 +582,7 @@ MfmaInsnGroup::select(Type elementTypeA, Type elementTypeB, StringRef arch,
                                 mPerMfmaGroup, nPerMfmaGroup};
 
   FailureOr<MfmaInsnGroup> result = failure();
+
   auto selectFrom = [&](const MfmaInsnGroupMap &groupMap) {
     // No point in overriding our good work
     if (succeeded(result))
@@ -590,6 +609,7 @@ MfmaInsnGroup::select(Type elementTypeA, Type elementTypeB, StringRef arch,
         LLVM_DEBUG(llvm::dbgs() << "Selected gfx950 double rate instruction\n");
         return;
       }
+      LLVM_DEBUG(llvm::dbgs() << "Incoherent with K for gfx950 double rate instruction\n");
       // else select again
       result = failure();
       return;

--- a/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/MfmaInsnGroup.cpp
@@ -609,7 +609,8 @@ MfmaInsnGroup::select(Type elementTypeA, Type elementTypeB, StringRef arch,
         LLVM_DEBUG(llvm::dbgs() << "Selected gfx950 double rate instruction\n");
         return;
       }
-      LLVM_DEBUG(llvm::dbgs() << "Incoherent with K for gfx950 double rate instruction\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Incoherent with K for gfx950 double rate instruction\n");
       // else select again
       result = failure();
       return;

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
@@ -438,3 +438,121 @@ func.func @accel_gemm_gfx950_i8_16x16x64(%matrixA : memref<1x2xvector<16xi8>, 5>
   } : memref<1x1xvector<4xi32>, 5> += memref<1x2xvector<16xi8>, 5> * memref<1x2xvector<16xi8>, 5>
   return
 }
+
+func.func @accel_gemm_gfx950_f32_16x16x128_fp4(%matrixA : memref<1x1xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixB : memref<1x1xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixC : memref<1x1xvector<4xf32>, 5>) {
+  // CHECK-LABEL: func.func @accel_gemm_gfx950_f32_16x16x128_fp4
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 128 : i32, m = 16 : i32, n = 16 : i32
+  // CHECK-SAME: vector<32xf4E2M1FN>, vector<32xf4E2M1FN>, vector<4xf32>
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
+    arch = "amdgcn-amd-amdhsa:gfx950",
+    params = #rock.xdlops_gemm_derived_params<
+      kpackPerBlock = 32,
+      kpack = 32,
+      mPerWave = 16,
+      nPerWave = 16,
+      mPerBlock = 16,
+      nPerBlock = 16,
+      mnPerXdl = 16,
+      splitKFactor = 1,
+      scheduleVersion = 1,
+      outputSwizzle = 2,
+      forceUnroll = true>
+  } : memref<1x1xvector<4xf32>, 5> += memref<1x1xvector<32xf4E2M1FN>, 5> * memref<1x1xvector<32xf4E2M1FN>, 5>
+  return
+}
+
+func.func @accel_gemm_gfx950_f32_32x32x64_fp4(%matrixA : memref<1x1xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixB : memref<1x1xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixC : memref<1x1xvector<16xf32>, 5>) {
+  // CHECK-LABEL: func.func @accel_gemm_gfx950_f32_32x32x64_fp4
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 64 : i32, m = 32 : i32, n = 32 : i32
+  // CHECK-SAME: vector<32xf4E2M1FN>, vector<32xf4E2M1FN>, vector<16xf32>
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
+    arch = "amdgcn-amd-amdhsa:gfx950",
+    params = #rock.xdlops_gemm_derived_params<
+      kpackPerBlock = 32,
+      kpack = 32,
+      mPerWave = 32,
+      nPerWave = 32,
+      mPerBlock = 32,
+      nPerBlock = 32,
+      mnPerXdl = 32,
+      splitKFactor = 1,
+      scheduleVersion = 1,
+      outputSwizzle = 2,
+      forceUnroll = true>
+  } : memref<1x1xvector<16xf32>, 5> += memref<1x1xvector<32xf4E2M1FN>, 5> * memref<1x1xvector<32xf4E2M1FN>, 5>
+  return
+}
+
+func.func @accel_gemm_gfx950_f32_64x64x512_fp4_1(%matrixA : memref<1x16xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixB : memref<1x16xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixC : memref<1x16xvector<4xf32>, 5>) {
+  // CHECK-LABEL: func.func @accel_gemm_gfx950_f32_64x64x512_fp4_1
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 128 : i32, m = 16 : i32, n = 16 : i32
+  // CHECK-SAME: vector<32xf4E2M1FN>, vector<32xf4E2M1FN>, vector<4xf32>
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
+    arch = "amdgcn-amd-amdhsa:gfx950",
+    params = #rock.xdlops_gemm_derived_params<
+      kpackPerBlock = 512,
+      kpack = 32,
+      mPerWave = 32,
+      nPerWave = 32,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      mnPerXdl = 16,
+      splitKFactor = 1,
+      scheduleVersion = 1,
+      outputSwizzle = 2,
+      forceUnroll = true>
+  } : memref<1x16xvector<4xf32>, 5> += memref<1x16xvector<32xf4E2M1FN>, 5> * memref<1x16xvector<32xf4E2M1FN>, 5>
+  return
+}
+
+// each wave computes 32x32 output tile using 32x32x64 MFMA insn
+// note that kPerBlock is 512. So there will be 8 MFMA instructions per wave
+func.func @accel_gemm_gfx950_f32_64x64x512_fp4_2(%matrixA : memref<1x8xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixB : memref<1x8xvector<32xf4E2M1FN>, 5>,
+                                                 %matrixC : memref<1x1xvector<16xf32>, 5>) {
+  // CHECK-LABEL: func.func @accel_gemm_gfx950_f32_64x64x512_fp4_2
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: amdgpu.mfma
+  // CHECK-SAME: blocks = 1 : i32, k = 64 : i32, m = 32 : i32, n = 32 : i32
+  // CHECK-SAME: vector<32xf4E2M1FN>, vector<32xf4E2M1FN>, vector<16xf32>
+  // CHECK-NOT: amdgpu.mfma
+  %c0 = arith.constant 0 : index
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
+    arch = "amdgcn-amd-amdhsa:gfx950",
+    params = #rock.xdlops_gemm_derived_params<
+      kpackPerBlock = 512,
+      kpack = 32,
+      mPerWave = 32,
+      nPerWave = 32,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      mnPerXdl = 32,
+      splitKFactor = 1,
+      scheduleVersion = 1,
+      outputSwizzle = 2,
+      forceUnroll = true>
+  } : memref<1x1xvector<16xf32>, 5> += memref<1x8xvector<32xf4E2M1FN>, 5> * memref<1x8xvector<32xf4E2M1FN>, 5>
+  return
+}

--- a/mlir/test/Dialect/Rock/ops_2.mlir
+++ b/mlir/test/Dialect/Rock/ops_2.mlir
@@ -160,6 +160,33 @@ func.func @rock_accel_gemm_one_result(%matrixA : memref<1x16xf32, 5>,
 
 // ----
 
+func.func @rock_accel_gemm_one_result_f4(%matrixA : memref<1x1xvector<32xf4E2M1FN>, 5>,
+                                            %matrixB : memref<1x1xvector<32xf4E2M1FN>, 5>,
+                                            %matrixC : memref<1x1xvector<4xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  rock.threadwise_accel_gemm %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = mfma {
+    arch = "amdgcn-amd-amdhsa:gfx90a",
+    params = #rock.xdlops_gemm_derived_params<
+      mPerBlock = 256,
+      nPerBlock = 256,
+      kpackPerBlock = 32,
+      mPerWave = 16,
+      nPerWave = 16,
+      mnPerXdl = 16,
+      kpack = 1,
+      splitKFactor = 1, 
+      scheduleVersion = 1, 
+      outputSwizzle = 2,
+      forceUnroll = true>
+  } : memref<1x1xvector<4xf32>, 5> += memref<1x1xvector<32xf4E2M1FN>, 5> * memref<1x1xvector<32xf4E2M1FN>, 5>
+  return
+}
+
+// CHECK-LABEL: func.func @rock_accel_gemm_one_result_f4
+// CHECK: rock.threadwise_accel_gemm
+
+// ----
+
 #transform_map0 = #rock.transform_map<affine_map<(d0, d1) -> (2*d0 + d1)> by [<Unmerge{2, 2} ["ci", "cj"] at [0, 1] -> ["offset"] at [0]>] bounds = [2, 2] -> [4]>
 
 func.func @rock_accel_gemm_two_results(%matrixA : memref<1x16xf32, 5>,


### PR DESCRIPTION
## Motivation

Adds MFMA instructions for Fp4 and mfma instruction selection logic for the FP4. 

## Technical Details

Adds MFMA instruction selection logic for fp4. 

On MI355X there are two versions of Fp4 MFMAs. 
1. `v_mfma_scale` which takes additional scale parameters
2. `v_mfma` which doesn't take any scale parameters. 

Both versions have two MFMA sizes 
1. `16x16x128` 
2. `32x32x64`

We mostly care about the `v_mfma_scale` for accuracy reasons during inference. 

This PR is only adding `v_mfma_scale` in `mfmainsngroup.cpp`. But because both non-scaled and scale share same `m/n/k` sizes, scaled mfma instruction selection logic also works to lower to non-scaled one. 

Please see the tests which lowers to `amdgpu.mfma` and not `amdgpu.scaled_mfma`. 
Reason for that is that we don't have lowering to scaled one yet.  Once i have threadwise lowering to scaled one, i can add tests which lowers to `amdgpu.scaled_mfma` later. 

This would require some changes in tuning params logic as it requires kPack = 32. I plan to do tuning related changes later once i have everything in place for lowering. 

## Test Plan


## Test Result


## Submission Checklist

