### PR TITLE
Add missing direct to LDS tests

### DIFF
--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -2037,7 +2037,8 @@ LogicalResult BlockwiseLoadTileOp::verify() {
     return emitOpError("destLDS must be set unless loadType is BypassLDS");
 
   if (!destRegisters && !singleBuffer)
-    return emitOpError("destRegisters must be set unless loadType is Default/DirectToLDSDefault");
+    return emitOpError("destRegisters must be set unless loadType is "
+                       "Default/DirectToLDSDefault");
 
   return success();
 }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -2007,16 +2007,20 @@ void BlockwiseLoadTileOp::getEffects(
   auto *read = MemoryEffects::Read::get();
   auto *write = MemoryEffects::Write::get();
   GemmLoadTileType loadType = getLoadType();
+  bool doubleBuffer = loadType == GemmLoadTileType::DoubleBuffer ||
+                      loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
+  bool singleBuffer = loadType == GemmLoadTileType::Default ||
+                      loadType == GemmLoadTileType::DirectToLDSDefault;
 
   effects.emplace_back(read, &getSourceMutable());
   if (loadType != GemmLoadTileType::BypassLDS) {
     assert(getDestLDS() != nullptr);
     effects.emplace_back(write, &getDestLDSMutable()[0]);
     // DoubleBuffer means we write to LDS and then, load from it
-    if (loadType == GemmLoadTileType::DoubleBuffer)
+    if (doubleBuffer)
       effects.emplace_back(read, &getDestLDSMutable()[0]);
   }
-  if (loadType != GemmLoadTileType::Default) {
+  if (!singleBuffer) {
     assert(getDestRegisters() != nullptr);
     effects.emplace_back(write, &getDestRegistersMutable()[0]);
   }
@@ -2026,12 +2030,14 @@ LogicalResult BlockwiseLoadTileOp::verify() {
   Value destLDS = getDestLDS();
   Value destRegisters = getDestRegisters();
   GemmLoadTileType loadType = getLoadType();
+  bool singleBuffer = loadType == GemmLoadTileType::Default ||
+                      loadType == GemmLoadTileType::DirectToLDSDefault;
 
   if (!destLDS && loadType != GemmLoadTileType::BypassLDS)
     return emitOpError("destLDS must be set unless loadType is BypassLDS");
 
-  if (!destRegisters && loadType != GemmLoadTileType::Default)
-    return emitOpError("destRegisters must be set unless loadType is Default");
+  if (!destRegisters && !singleBuffer)
+    return emitOpError("destRegisters must be set unless loadType is Default/DirectToLDSDefault");
 
   return success();
 }

--- a/mlir/test/Dialect/Rock/effects.mlir
+++ b/mlir/test/Dialect/Rock/effects.mlir
@@ -432,7 +432,7 @@ func.func @loadtile_doublebuffer(%arg0: memref<1x384x64xf32>, %lds: memref<4096x
     // expected-remark @below {{found an instance of 'write' on op operand 1, on resource '<Default>'}}
     // expected-remark @below {{found an instance of 'read' on op operand 1, on resource '<Default>'}}
     // expected-remark @below {{found an instance of 'write' on op operand 2, on resource '<Default>'}}
-    rock.blockwise_load_tile %0[%arg1, %c0, %c0, %c0, %c0] LDS -> %lds -> %reg {G = 1 : i64, M = 384 : i64, N = 384 : i64, blockSize = 64 : i32, elementTypeA = f32, elementTypeALoad = f32, elementTypeB = f32, elementTypeBLoad = f32, loadType = #rock<GemmLoadTileType DoubleBuffer>, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>} : memref<1x64x384xf32> LDS -> memref<4096xi8, #gpu.address_space<workgroup>> -> memref<16xf32, #gpu.address_space<private>>
+    rock.blockwise_load_tile %0[%arg1, %c0, %c0, %c0, %c0] LDS -> %lds -> %reg {G = 1 : i64, M = 384 : i64, N = 384 : i64, blockSize = 64 : i32, elementTypeA = f32, elementTypeALoad = f32, elementTypeB = f32, elementTypeBLoad = f32, loadType = #rock<GemmLoadTileType DoubleBuffer>, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 2, outputSwizzle = 2, forceUnroll = true>} : memref<1x64x384xf32> LDS -> memref<4096xi8, #gpu.address_space<workgroup>> -> memref<16xf32, #gpu.address_space<private>>
   }
   return
 }
@@ -461,6 +461,36 @@ func.func @loadtile_bypasslds(%arg0: memref<1x384x64xf32>, %reg: memref<16xf32, 
     // expected-remark @below {{found an instance of 'read' on op operand 0, on resource '<Default>'}}
     // expected-remark @below {{found an instance of 'write' on op operand 1, on resource '<Default>'}}
     rock.blockwise_load_tile %0[%arg1, %c0, %c0, %c0, %c0] -> %reg {G = 1 : i64, M = 384 : i64, N = 384 : i64, blockSize = 64 : i32, elementTypeA = f32, elementTypeALoad = f32, elementTypeB = f32, elementTypeBLoad = f32, loadType = #rock<GemmLoadTileType BypassLDS>, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, forceUnroll = true>} : memref<1x64x384xf32> -> memref<16xf32, #gpu.address_space<private>>
+  }
+  return
+}
+
+func.func @loadtile_doublebuffer_directtolds(%arg0: memref<1x384x64xf32>, %lds: memref<4096xi8, #gpu.address_space<workgroup>>, %reg: memref<16xf32, #gpu.address_space<private>>) attributes {arch = "##TOKEN_ARCH##"} {
+  // expected-remark @below {{operation has no memory effects}}
+  %c0 = arith.constant 0 : index
+  // expected-remark @below {{operation has no memory effects}}
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 384] -> [1, 384, 64]> : memref<1x384x64xf32> to memref<1x64x384xf32>
+
+  affine.for %arg1 = 0 to 2 {
+    // expected-remark @below {{found an instance of 'read' on op operand 0, on resource '<Default>'}}
+    // expected-remark @below {{found an instance of 'write' on op operand 1, on resource '<Default>'}}
+    // expected-remark @below {{found an instance of 'read' on op operand 1, on resource '<Default>'}}
+    // expected-remark @below {{found an instance of 'write' on op operand 2, on resource '<Default>'}}
+    rock.blockwise_load_tile %0[%arg1, %c0, %c0, %c0, %c0] LDS -> %lds -> %reg {G = 1 : i64, M = 384 : i64, N = 384 : i64, blockSize = 64 : i32, elementTypeA = f32, elementTypeALoad = f32, elementTypeB = f32, elementTypeBLoad = f32, loadType = #rock<GemmLoadTileType DirectToLDSDoubleBuffer>, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 4, outputSwizzle = 2, forceUnroll = true>} : memref<1x64x384xf32> LDS -> memref<4096xi8, #gpu.address_space<workgroup>> -> memref<16xf32, #gpu.address_space<private>>
+  }
+  return
+}
+
+func.func @loadtile_default_directtolds(%arg0: memref<1x384x64xf32>, %lds: memref<4096xi8, #gpu.address_space<workgroup>>) attributes {arch = "##TOKEN_ARCH##"} {
+  // expected-remark @below {{operation has no memory effects}}
+  %c0 = arith.constant 0 : index
+  // expected-remark @below {{operation has no memory effects}}
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 384] -> [1, 384, 64]> : memref<1x384x64xf32> to memref<1x64x384xf32>
+
+  affine.for %arg1 = 0 to 2 {
+    // expected-remark @below {{found an instance of 'read' on op operand 0, on resource '<Default>'}}
+    // expected-remark @below {{found an instance of 'write' on op operand 1, on resource '<Default>'}}
+    rock.blockwise_load_tile %0[%arg1, %c0, %c0, %c0, %c0] LDS -> %lds {G = 1 : i64, M = 384 : i64, N = 384 : i64, blockSize = 64 : i32, elementTypeA = f32, elementTypeALoad = f32, elementTypeB = f32, elementTypeBLoad = f32, loadType = #rock<GemmLoadTileType DirectToLDSDefault>, params = #rock.xdlops_gemm_derived_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 3, outputSwizzle = 2, forceUnroll = true>} : memref<1x64x384xf32> LDS -> memref<4096xi8, #gpu.address_space<workgroup>>
   }
   return
 }

--- a/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_gemm_accel.mlir
@@ -175,7 +175,7 @@ func.func @rock_blockwise_gemm_accel_direct_to_lds(%matrixA : memref<256xvector<
       nPerWave = 64,
       mnPerXdl = 32,
       splitKFactor = 1, 
-      scheduleVersion = 1, 
+      scheduleVersion = 4, 
       outputSwizzle = 2,
       forceUnroll = true>
   } : memref<4xvector<16xf32>, #priv> += memref<16xi8, #priv> from memref<256xvector<2xf32>, #wg> * memref<16xi8, #priv> from memref<256xvector<2xf32>, #wg>

--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -46,6 +46,7 @@ if (ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED)
     PrConvElementwiseGemmF16SplitK
     PrConvElementwiseGemmBF16SplitK
     PrGemmDirectToLDS
+    PrConvDirectToLDS
   )
   set(GEN_MODE "")
 endif()
@@ -78,6 +79,7 @@ if (ROCK_E2E_TEST_ENABLED)
   )
   list(APPEND CONFIGS
   GemmDirectToLDS
+  ConvDirectToLDS
   )
 endif()
 # Create a list for dummy files

--- a/mlir/test/e2e/ConvDirectToLDS.cfg
+++ b/mlir/test/e2e/ConvDirectToLDS.cfg
@@ -1,0 +1,2 @@
+if not 'direct_to_lds_32b' in config.features and not 'direct_to_lds_128b' in config.features:
+  config.unsupported = True

--- a/mlir/test/e2e/ConvDirectToLDS.toml
+++ b/mlir/test/e2e/ConvDirectToLDS.toml
@@ -1,0 +1,34 @@
+directory = "ConvDirectToLDS"
+prefix = "rocmlir-gen"
+suffix = "--operation conv --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "layout"
+values = ["-fil_layout=gkcyx -in_layout=ngchw -out_layout=ngkhw", "-fil_layout=gkyxc -in_layout=nhwgc -out_layout=nhwgk"]
+
+# Note: only one fp8 variant is tested as that's enough for a sanity check
+[[axis]]
+name = "data type"
+values = ["f32", "f16", "bf16", "i8", "fp8_fp8"]
+prefix = "-t "
+
+[[axis]]
+name = "schedule_version"
+values = ["v3:64,64,16,32,32,8,1,3,2,1,1", "v3:64,64,8,32,32,8,1,4,2,1,1"]
+prefix = "-perf_config="
+
+## Direct to LDS
+[[suite]]
+name = "conv_direct_to_lds"
+
+[[suite.test]]
+config = "-batchsize=8 -groupsize=1 -in_channels=32 -out_channels=32 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1"
+
+[[suite.test]]
+config = "-batchsize=16 -groupsize=1 -in_channels=8 -out_channels=64 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1"
+
+[[suite.test]]
+config = "-batchsize=5 -groupsize=1 -in_channels=8 -out_channels=64 -in_h=64 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1"
+
+[[suite.test]]
+config = "-batchsize=16 -groupsize=1 -in_channels=8 -out_channels=64 -in_h=64 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1"

--- a/mlir/test/e2e/PrConvDirectToLDS.cfg
+++ b/mlir/test/e2e/PrConvDirectToLDS.cfg
@@ -1,0 +1,2 @@
+if not 'direct_to_lds_32b' in config.features and not 'direct_to_lds_128b' in config.features:
+  config.unsupported = True

--- a/mlir/test/e2e/PrConvDirectToLDS.toml
+++ b/mlir/test/e2e/PrConvDirectToLDS.toml
@@ -1,0 +1,20 @@
+directory = "PrConvDirectToLDS"
+prefix = "rocmlir-gen"
+suffix = "--operation conv --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "data type"
+values = ["f16"]
+prefix = "-t "
+
+[[axis]]
+name = "schedule_version"
+values = ["v3:64,64,16,32,32,8,1,3,2,1,1", "v3:64,64,8,32,32,8,1,4,2,1,1"]
+prefix = "-perf_config="
+
+## Direct to LDS
+[[suite]]
+name = "pr_conv_direct_to_lds"
+
+[[suite.test]]
+config = "-batchsize=8 -groupsize=1 -in_channels=32 -out_channels=32 -in_h=32 -in_w=32 -fil_h=1 -fil_w=1 --dilation_h=1 --dilation_w=1 --padding_h=0 --padding_w=0 --conv_stride_h=1 --conv_stride_w=1"


### PR DESCRIPTION
## Motivation

Add missing direct to LDS tests. Specifically, convolution end to end tests and effects.mlir. And minor fixes for RockDialect.cpp.

## Technical Details

Added new tests.

## Test Plan

Check all tests pass. Especially on direct to LDS enabled GPUs (gfx942 and gfx950).

## Test Result

All tests pass on gfx942 and gfx950.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
