### PR TITLE
Check launch configurations in `RockToGPU` pass

### DIFF
--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -159,7 +159,7 @@ void LowerRockOpsToGPUPass::runOnOperation() {
 
   auto processGpuKernelFunc = [&](gpu::GPUModuleOp &gpuMod,
                                   func::FuncOp &theFunc) -> LogicalResult {
-    // Make sure that the function has the neccesary attributes.
+    // Make sure that the function has the necessary attributes.
     auto blockSizeAttr = theFunc->getAttr("block_size");
     auto gridSizeAttr = theFunc->getAttr("grid_size");
     if (!blockSizeAttr) {

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -159,6 +159,16 @@ void LowerRockOpsToGPUPass::runOnOperation() {
 
   auto processGpuKernelFunc = [&](gpu::GPUModuleOp &gpuMod,
                                   func::FuncOp &theFunc) -> LogicalResult {
+    // Make sure that the function has the neccesary attributes.
+    if (!theFunc->hasAttr("block_size")) {
+      return theFunc->emitError()
+             << "kernel func op is missing the block_size attribute";
+    }
+    if (!theFunc->hasAttr("grid_size")) {
+      return theFunc->emitError()
+             << "kernel func op is missing the grid_size attribute";
+    }
+
     // Set up the symbol table for the GPU ModuleOp.
     SymbolTable gpuModuleSymbolTable(gpuMod);
     // Reset builder insertion point to the beginning of the GPU module,
@@ -201,6 +211,17 @@ void LowerRockOpsToGPUPass::runOnOperation() {
     int32_t indexWidth = 32;
     if (theFunc->hasAttr("rock.64bitindex"))
       indexWidth = 64;
+
+    // Check that launch parameters are valid.
+    // We do not want to overcomplicate this pass, so for simplicity we do not
+    // check for hardware specific limit here. Instead, we just check that both
+    // blockSize and gridSize are greater than zero.
+    if (blockSize <= 0) {
+      return theFunc->emitError() << "kernel func op has an invalid block size";
+    }
+    if (gridSize <= 0) {
+      return theFunc->emitError() << "kernel func op has an invalid grid size";
+    }
 
     // move prefill attributes from func::FuncOp to gpu::GPUModuleOp
     llvm::SmallVector<Attribute, 4> prefillAttrs;
@@ -246,27 +267,28 @@ void LowerRockOpsToGPUPass::runOnOperation() {
 
     // Clone in global constants
     llvm::SmallDenseMap<SymbolRefAttr, FlatSymbolRefAttr> clonedConsts;
-    WalkResult result = funcBody.walk([&](memref::GetGlobalOp op)
-                                          -> WalkResult {
-      SymbolRefAttr globalSym = op.getNameAttr();
-      auto toClone = dyn_cast_or_null<memref::GlobalOp>(
-          SymbolTable::lookupNearestSymbolFrom(op, globalSym));
-      if (!toClone)
-        return WalkResult::interrupt();
-      if (toClone->getParentOfType<gpu::GPUModuleOp>() == gpuMod)
-        // Already cloned, continue
-        return WalkResult::advance();
-      auto maybeMapped = clonedConsts.find(globalSym);
-      if (maybeMapped == clonedConsts.end()) {
-        OpBuilder::InsertionGuard guard(b);
-        Operation *cloned = toClone.clone();
-        // There probably shouldn't be any renames, but let's be careful.
-        StringAttr newNameAttr = gpuModuleSymbolTable.insert(cloned);
-        clonedConsts.insert({globalSym, FlatSymbolRefAttr::get(newNameAttr)});
-      }
-      op.setNameAttr(clonedConsts.find(globalSym)->second);
-      return WalkResult::advance();
-    });
+    WalkResult result =
+        funcBody.walk([&](memref::GetGlobalOp op) -> WalkResult {
+          SymbolRefAttr globalSym = op.getNameAttr();
+          auto toClone = dyn_cast_or_null<memref::GlobalOp>(
+              SymbolTable::lookupNearestSymbolFrom(op, globalSym));
+          if (!toClone)
+            return WalkResult::interrupt();
+          if (toClone->getParentOfType<gpu::GPUModuleOp>() == gpuMod)
+            // Already cloned, continue
+            return WalkResult::advance();
+          auto maybeMapped = clonedConsts.find(globalSym);
+          if (maybeMapped == clonedConsts.end()) {
+            OpBuilder::InsertionGuard guard(b);
+            Operation *cloned = toClone.clone();
+            // There probably shouldn't be any renames, but let's be careful.
+            StringAttr newNameAttr = gpuModuleSymbolTable.insert(cloned);
+            clonedConsts.insert(
+                {globalSym, FlatSymbolRefAttr::get(newNameAttr)});
+          }
+          op.setNameAttr(clonedConsts.find(globalSym)->second);
+          return WalkResult::advance();
+        });
     if (result.wasInterrupted())
       return theFunc.emitOpError("failed to clone referenced global constants");
     // copy original_func attribute

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -216,8 +216,9 @@ void LowerRockOpsToGPUPass::runOnOperation() {
     // Check that launch parameters are valid.
     // We do not want to overcomplicate this pass, so for simplicity we do not
     // check for hardware specific limit here. Instead, we just check that both
-    // blockSize and gridSize are greater than zero.
-    if (blockSize <= 0) {
+    // blockSize and gridSize are greater than zero and less than the max
+    // workgroupd size.
+    if (blockSize <= 0 || blockSize > rock::maxHardwareWorkgroupSize) {
       return theFunc->emitError() << "kernel func op has an invalid block size";
     }
     if (gridSize <= 0) {

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -160,11 +160,13 @@ void LowerRockOpsToGPUPass::runOnOperation() {
   auto processGpuKernelFunc = [&](gpu::GPUModuleOp &gpuMod,
                                   func::FuncOp &theFunc) -> LogicalResult {
     // Make sure that the function has the neccesary attributes.
-    if (!theFunc->hasAttr("block_size")) {
+    auto blockSizeAttr = theFunc->getAttr("block_size");
+    auto gridSizeAttr = theFunc->getAttr("grid_size");
+    if (!blockSizeAttr) {
       return theFunc->emitError()
              << "kernel func op is missing the block_size attribute";
     }
-    if (!theFunc->hasAttr("grid_size")) {
+    if (!gridSizeAttr) {
       return theFunc->emitError()
              << "kernel func op is missing the grid_size attribute";
     }
@@ -193,16 +195,15 @@ void LowerRockOpsToGPUPass::runOnOperation() {
       gpuFunc.setAllArgAttrs(*argAttrs);
 
     gpuFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(), b.getUnitAttr());
-    if (auto attr = theFunc->getAttr("block_size")) {
-      gpuFunc->setAttr("block_size", attr);
-      blockSize = cast<IntegerAttr>(attr).getInt();
-      gpuFunc.setKnownBlockSizeAttr(b.getDenseI32ArrayAttr({blockSize, 1, 1}));
-    }
-    if (auto attr = theFunc->getAttr("grid_size")) {
-      gpuFunc->setAttr("grid_size", attr);
-      gridSize = cast<IntegerAttr>(attr).getInt();
-      gpuFunc.setKnownGridSizeAttr(b.getDenseI32ArrayAttr({gridSize, 1, 1}));
-    }
+
+    gpuFunc->setAttr("block_size", blockSizeAttr);
+    blockSize = cast<IntegerAttr>(blockSizeAttr).getInt();
+    gpuFunc.setKnownBlockSizeAttr(b.getDenseI32ArrayAttr({blockSize, 1, 1}));
+
+    gpuFunc->setAttr("grid_size", gridSizeAttr);
+    gridSize = cast<IntegerAttr>(gridSizeAttr).getInt();
+    gpuFunc.setKnownGridSizeAttr(b.getDenseI32ArrayAttr({gridSize, 1, 1}));
+
     FailureOr<StringAttr> maybeArch = rock::getArch(theFunc);
     if (succeeded(maybeArch)) {
       gpuFunc->setAttr("arch", maybeArch.value());

--- a/mlir/test/Conversion/RockToGPU/alloc.mlir
+++ b/mlir/test/Conversion/RockToGPU/alloc.mlir
@@ -4,7 +4,7 @@
 // CHECK-NEXT: gpu.module @allockernel_module
 // CHECK-NEXT: gpu.func @allockernel(%{{.*}}: memref<?x?x?x?xf32>) workgroup(%{{.*}}: memref<16xf32, #gpu.address_space<workgroup>> {llvm.align = 64 : i64}) private(%{{.*}}: memref<16xf32, #gpu.address_space<private>>) kernel
 module {
-  func.func @allockernel(%arg0: memref<?x?x?x?xf32>) attributes {kernel = 0 : i32} {
+  func.func @allockernel(%arg0: memref<?x?x?x?xf32>) attributes {kernel = 0 : i32, grid_size = 1 : i32, block_size = 32 : i32} {
     %cst = arith.constant 0.0 : f32
     %c0 = arith.constant 0 : index
     %buffer_lds = rock.alloc() : memref<16xf32, #gpu.address_space<workgroup>>

--- a/mlir/test/Conversion/RockToGPU/emptykernel.mlir
+++ b/mlir/test/Conversion/RockToGPU/emptykernel.mlir
@@ -4,7 +4,7 @@
 // CHECK-NEXT: gpu.module @emptykernel_module
 // CHECK-NEXT: gpu.func @emptykernel(%{{.*}}: memref<?x?x?x?xf32> {llvm.noalias}) kernel
 module {
-  func.func @emptykernel(%arg0: memref<?x?x?x?xf32> {llvm.noalias}) attributes {kernel = 0 : i32} {
+  func.func @emptykernel(%arg0: memref<?x?x?x?xf32> {llvm.noalias}) attributes {kernel = 0 : i32, block_size = 32 : i32, grid_size = 1 : i32} {
     return
   }
 }
@@ -16,7 +16,7 @@ module {
 // CHECK-NEXT: gpu.func @emptykernel(%{{.*}}: memref<?x?x?x?xf32> {llvm.noalias}) kernel
 // CHECK-SAME: arch = "gfx90a"
 module {
-  func.func @emptykernel(%arg0: memref<?x?x?x?xf32> {llvm.noalias}) attributes {kernel = 0 : i32, arch = "gfx90a"} {
+  func.func @emptykernel(%arg0: memref<?x?x?x?xf32> {llvm.noalias}) attributes {kernel = 0 : i32, block_size = 32 : i32, grid_size = 1 : i32, arch = "gfx90a"} {
     return
   }
 }

--- a/mlir/test/Conversion/RockToGPU/existing_gpu_module.mlir
+++ b/mlir/test/Conversion/RockToGPU/existing_gpu_module.mlir
@@ -6,7 +6,7 @@
 module {
   gpu.module @existing_module {
   }
-  func.func @emptykernel(%arg0: memref<?x?x?x?xf32>) attributes {kernel = 0 : i32} {
+  func.func @emptykernel(%arg0: memref<?x?x?x?xf32>) attributes {kernel = 0 : i32, block_size = 32 : i32, grid_size = 1 : i32} {
     return
   }
 }

--- a/mlir/test/Conversion/RockToGPU/gpu_launch.mlir
+++ b/mlir/test/Conversion/RockToGPU/gpu_launch.mlir
@@ -1,0 +1,46 @@
+// RUN: rocmlir-opt -convert-rock-to-gpu %s -split-input-file -verify-diagnostics
+
+// expected-error@+1 {{kernel func op has an invalid grid size}}
+func.func public @grid_size_invalid() attributes {kernel, block_size = 256 : i32, grid_size = -100 : i32} {
+  return
+}
+func.func @main() {
+  call @grid_size_invalid() : () -> ()
+  return
+}
+
+
+// -----
+
+// expected-error@+1 {{kernel func op has an invalid block size}}
+func.func public @block_size_invalid() attributes {kernel, block_size = 0 : i32, grid_size = 256 : i32} {
+  return
+}
+func.func @main() {
+  call @block_size_invalid() : () -> ()
+  return
+}
+
+// -----
+
+// expected-error@+1 {{kernel func op is missing the block_size attribute}}
+func.func public @block_size_missing() attributes {kernel, grid_size = 256 : i32} {
+  return
+}
+func.func @main() {
+  call @block_size_missing() : () -> ()
+  return
+}
+
+// -----
+
+// expected-error@+1 {{kernel func op is missing the grid_size attribute}}
+func.func public @block_size_missing() attributes {kernel, block_size = 256 : i32} {
+  return
+}
+func.func @main() {
+  call @block_size_missing() : () -> ()
+  return
+}
+
+

--- a/mlir/test/Conversion/RockToGPU/gpu_launch.mlir
+++ b/mlir/test/Conversion/RockToGPU/gpu_launch.mlir
@@ -42,5 +42,3 @@ func.func @main() {
   call @block_size_missing() : () -> ()
   return
 }
-
-

--- a/mlir/test/Conversion/RockToGPU/multiple_kernels.mlir
+++ b/mlir/test/Conversion/RockToGPU/multiple_kernels.mlir
@@ -12,22 +12,22 @@
 // CHECK-LABEL: gpu.func @step1
 
 module  {
-  func.func @step1(%arg0: memref<1x512x16x3x3xf32>, %arg1: memref<512x1x16x32x32xf32>, %arg2: memref<512x1x512x30x30xf32>) attributes {kernel, arch = "amdgcn-amd-amdhsa:gfx906"} {
+  func.func @step1(%arg0: memref<1x512x16x3x3xf32>, %arg1: memref<512x1x16x32x32xf32>, %arg2: memref<512x1x512x30x30xf32>) attributes {kernel, block_size = 32 : i32, grid_size = 1 : i32, arch = "amdgcn-amd-amdhsa:gfx906"} {
     rock.conv(%arg0, %arg1, %arg2) {dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], output_layout = ["no", "go", "ko", "0o", "1o"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]} : memref<1x512x16x3x3xf32>, memref<512x1x16x32x32xf32>, memref<512x1x512x30x30xf32>
     return
   }
 
-  func.func @step2(%arg0: memref<1x64x16x3x3xf32>, %arg1: memref<64x1x16x32x32xf32>, %arg2: memref<64x1x64x30x30xf32>) attributes {kernel, arch = "amdgcn-amd-amdhsa:gfx906"} {
+  func.func @step2(%arg0: memref<1x64x16x3x3xf32>, %arg1: memref<64x1x16x32x32xf32>, %arg2: memref<64x1x64x30x30xf32>) attributes {kernel, block_size = 32 : i32, grid_size = 1 : i32, arch = "amdgcn-amd-amdhsa:gfx906"} {
     rock.conv(%arg0, %arg1, %arg2) {dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], output_layout = ["no", "go", "ko", "0o", "1o"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]} : memref<1x64x16x3x3xf32>, memref<64x1x16x32x32xf32>, memref<64x1x64x30x30xf32>
     return
   }
 
-  func.func @step3(%arg0: memref<1x32x16x3x3xf32>, %arg1: memref<32x1x16x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel, arch = "amdgcn-amd-amdhsa:gfx906"} {
+  func.func @step3(%arg0: memref<1x32x16x3x3xf32>, %arg1: memref<32x1x16x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel, block_size = 32 : i32, grid_size = 1 : i32, arch = "amdgcn-amd-amdhsa:gfx906"} {
     rock.conv(%arg0, %arg1, %arg2) {dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], output_layout = ["no", "go", "ko", "0o", "1o"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]} : memref<1x32x16x3x3xf32>, memref<32x1x16x32x32xf32>, memref<32x1x32x30x30xf32>
     return
   }
 
-  func.func @step4(%arg0: memref<1x32x8x3x3xf32>, %arg1: memref<32x1x8x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel, arch = "amdgcn-amd-amdhsa:gfx906"} {
+  func.func @step4(%arg0: memref<1x32x8x3x3xf32>, %arg1: memref<32x1x8x32x32xf32>, %arg2: memref<32x1x32x30x30xf32>) attributes {kernel, block_size = 32 : i32, grid_size = 1 : i32, arch = "amdgcn-amd-amdhsa:gfx906"} {
     rock.conv(%arg0, %arg1, %arg2) {dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], output_layout = ["no", "go", "ko", "0o", "1o"], padding = [0 : index, 0 : index, 0 : index, 0 : index], strides = [1 : index, 1 : index]} : memref<1x32x8x3x3xf32>, memref<32x1x8x32x32xf32>, memref<32x1x32x30x30xf32>
     return
   }

--- a/mlir/test/rocmlir-driver/buffer_atomic_emulation.mlir
+++ b/mlir/test/rocmlir-driver/buffer_atomic_emulation.mlir
@@ -13,7 +13,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx1030"} {
 // CHECK: %[[res:.+]] = llvm.bitcast %[[resInt]] : i32 to f32
 // CHECK: %[[cond:.+]] = llvm.icmp "eq" %[[resInt]], %[[prevInt]]
 // CHECK: llvm.cond_br %[[cond]], ^{{.*}}, ^[[bb]](%[[res]] : f32)
-func.func @add_scalar(%val: f32, %mem: memref<4xf32>) attributes {kernel} {
+func.func @add_scalar(%val: f32, %mem: memref<4xf32>) attributes {kernel, block_size = 32 : i32, grid_size = 1} {
   %c0 = arith.constant 0 : i32
   amdgpu.raw_buffer_atomic_fadd {boundsCheck = false} %val -> %mem[%c0] : f32 -> memref<4xf32>, i32
   return


### PR DESCRIPTION
## Motivation

A kernel function with no `block_size` and / or `grid_size` will crash at runtime with:

```
'hipModuleLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ, smem, stream, params, extra)' failed with 'hipErrorInvalidValue'
```

because `RockToGPU` will simply put those values to 0 if they don't exist. Futhermore, it does not check what values are being used.

## Technical Details

This PR adds:
- Checks to ensure that both `block_size` and `grid_size` are set at the kernel function.
- Checks to ensure that both both  `block_size` and `grid_size` are greater than 0.

## Test Plan

Added `mlir/test/Conversion/RockToGPU/gpu_launch.mlir` test to check for expected failures.

## Test Result

Tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
