### PR TITLE
Fix tuningRunner PR CI Error

### DIFF
--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -177,7 +177,7 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
     for test_vector in configs:
         if not test_vector.endswith(".mlir"):
             command_line = test_vector.split(sep=' ')
-            config = conf_class.fromCommandLine(command_line, options.arch, options.num_cu)
+            config = conf_class.from_command_line(command_line, options.arch, options.num_cu)
             test_vector = config.to_command_line()
             print("Tuning:", test_vector, file=sys.stderr)
             command_line_options = config.generate_mlir_driver_commandline(


### PR DESCRIPTION
## Motivation

After https://github.com/ROCm/rocMLIR/pull/1997 was merged in there is now a crash when running `tuningRunner.py` that gets triggered when the PR CI is running. This PR addresses that.

## Technical Details

- Correct type in tuningRunner.py

## Test Plan

- [ ] PR CI

## Test Result

- [ ] PR CI

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
