### PR TITLE
Add support for nested pipelining

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
+++ b/mlir/include/mlir/Dialect/Rock/Transforms/RockMultibuffer.h
@@ -18,21 +18,22 @@ namespace mlir {
 namespace rock {
 LogicalResult multiBuffer(RewriterBase &rewriter, rock::GpuAllocOp allocOp,
                           SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
-                          unsigned multiplier, bool skipOverrideAnalysis);
+                          unsigned multiBufferingFactor,
+                          bool skipOverrideAnalysis);
 
 FailureOr<SmallVector<rock::GpuAllocOp>>
 multiBuffer(rock::GpuAllocOp allocOp,
-            SmallVectorImpl<rock::GpuAllocOp> &newAllocs, unsigned multiplier,
-            bool skipOverrideAnalysis);
+            SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
+            unsigned multiBufferingFactor, bool skipOverrideAnalysis);
 
 LogicalResult updateMultiBuffer(RewriterBase &rewriter, Location loc,
-                                ArrayRef<rock::GpuAllocOp> multiBuffer,
+                                ArrayRef<rock::GpuAllocOp> allocs,
                                 SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
-                                unsigned newMultiplier);
+                                unsigned newMultiBufferingFactor);
 
-LogicalResult updateMultiBuffer(ArrayRef<rock::GpuAllocOp> multiBuffer,
+LogicalResult updateMultiBuffer(ArrayRef<rock::GpuAllocOp> allocs,
                                 SmallVectorImpl<rock::GpuAllocOp> &newAllocs,
-                                unsigned newMultiplier);
+                                unsigned newMultiBufferingFactor);
 
 } // namespace rock
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -193,9 +193,6 @@ FailureOr<rock::GpuAllocOp> findGpuAlloc(Value value);
 // `memref::AllocOp` or fails.
 FailureOr<memref::AllocOp> findMemrefAlloc(Value value);
 
-/// Compute, if possible, the constant different between two values.
-std::optional<int64_t> computeConstDiff(Value l, Value u);
-
 // Get gridSize
 FailureOr<IntegerAttr> getGridSize(Operation *op);
 

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -378,11 +378,6 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
           if (type == WAR && getAddressSpace(res) == AddressSpace::Private)
             continue;
 
-          // The DAG is built using "resources", not multibuffers.
-          // So, it is possible that thisMultiBuffers[res] does not exist
-          if (!thisMultiBuffers.contains(res))
-            thisMultiBuffers[res] = 1;
-
           thisMultiBuffers[res]++;
         }
       }
@@ -748,26 +743,32 @@ void RockPipeline::runOnOperation() {
     // Cleanup the stages
     {
       if (removeStages) {
-        RewritePatternSet patternsPushBarrier(&getContext());
-        // run PushBarrierDownRewritePattern before RemoveStagesRewritePattern,
-        // because the latter will remove the stages and their terminators
-        patternsPushBarrier.add<PushBarrierDownRewritePattern>(ctx);
-        if (failed(applyPatternsGreedily(func, std::move(patternsPushBarrier))))
+        RewritePatternSet patterns(&getContext());
+        patterns.add<RemoveStagesRewritePattern, PushBarrierDownRewritePattern,
+                     RemoveBackToBackBarriersRewritePattern>(&getContext());
+        if (failed(applyPatternsGreedily(func, std::move(patterns))))
           return signalPassFailure();
 
-        // run RemoveStagesRewritePattern before
-        // RemoveBackToBackBarriersRewritePattern, because the latter expects to
-        // find no stages
-        RewritePatternSet patternsRemoveStages(&getContext());
-        patternsRemoveStages.add<RemoveStagesRewritePattern>(ctx);
-        if (failed(
-                applyPatternsGreedily(func, std::move(patternsRemoveStages))))
-          return signalPassFailure();
+        // RewritePatternSet patternsPushBarrier(&getContext());
+        // // run PushBarrierDownRewritePattern before RemoveStagesRewritePattern,
+        // // because the latter will remove the stages and their terminators
+        // patternsPushBarrier.add<PushBarrierDownRewritePattern>(ctx);
+        // if (failed(applyPatternsGreedily(func, std::move(patternsPushBarrier))))
+        //   return signalPassFailure();
 
-        RewritePatternSet patternsBackToBack(&getContext());
-        patternsBackToBack.add<RemoveBackToBackBarriersRewritePattern>(ctx);
-        if (failed(applyPatternsGreedily(func, std::move(patternsBackToBack))))
-          return signalPassFailure();
+        // // run RemoveStagesRewritePattern before
+        // // RemoveBackToBackBarriersRewritePattern, because the latter expects to
+        // // find no stages
+        // RewritePatternSet patternsRemoveStages(&getContext());
+        // patternsRemoveStages.add<RemoveStagesRewritePattern>(ctx);
+        // if (failed(
+        //         applyPatternsGreedily(func, std::move(patternsRemoveStages))))
+        //   return signalPassFailure();
+
+        // RewritePatternSet patternsBackToBack(&getContext());
+        // patternsBackToBack.add<RemoveBackToBackBarriersRewritePattern>(ctx);
+        // if (failed(applyPatternsGreedily(func, std::move(patternsBackToBack))))
+        //   return signalPassFailure();
       }
     }
   }

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -743,32 +743,26 @@ void RockPipeline::runOnOperation() {
     // Cleanup the stages
     {
       if (removeStages) {
-        RewritePatternSet patterns(&getContext());
-        patterns.add<RemoveStagesRewritePattern, PushBarrierDownRewritePattern,
-                     RemoveBackToBackBarriersRewritePattern>(&getContext());
-        if (failed(applyPatternsGreedily(func, std::move(patterns))))
+        RewritePatternSet patternsPushBarrier(&getContext());
+        // run PushBarrierDownRewritePattern before RemoveStagesRewritePattern,
+        // because the latter will remove the stages and their terminators
+        patternsPushBarrier.add<PushBarrierDownRewritePattern>(ctx);
+        if (failed(applyPatternsGreedily(func, std::move(patternsPushBarrier))))
           return signalPassFailure();
 
-        // RewritePatternSet patternsPushBarrier(&getContext());
-        // // run PushBarrierDownRewritePattern before RemoveStagesRewritePattern,
-        // // because the latter will remove the stages and their terminators
-        // patternsPushBarrier.add<PushBarrierDownRewritePattern>(ctx);
-        // if (failed(applyPatternsGreedily(func, std::move(patternsPushBarrier))))
-        //   return signalPassFailure();
+        // run RemoveStagesRewritePattern before
+        // RemoveBackToBackBarriersRewritePattern, because the latter expects to
+        // find no stages
+        RewritePatternSet patternsRemoveStages(&getContext());
+        patternsRemoveStages.add<RemoveStagesRewritePattern>(ctx);
+        if (failed(
+                applyPatternsGreedily(func, std::move(patternsRemoveStages))))
+          return signalPassFailure();
 
-        // // run RemoveStagesRewritePattern before
-        // // RemoveBackToBackBarriersRewritePattern, because the latter expects to
-        // // find no stages
-        // RewritePatternSet patternsRemoveStages(&getContext());
-        // patternsRemoveStages.add<RemoveStagesRewritePattern>(ctx);
-        // if (failed(
-        //         applyPatternsGreedily(func, std::move(patternsRemoveStages))))
-        //   return signalPassFailure();
-
-        // RewritePatternSet patternsBackToBack(&getContext());
-        // patternsBackToBack.add<RemoveBackToBackBarriersRewritePattern>(ctx);
-        // if (failed(applyPatternsGreedily(func, std::move(patternsBackToBack))))
-        //   return signalPassFailure();
+        RewritePatternSet patternsBackToBack(&getContext());
+        patternsBackToBack.add<RemoveBackToBackBarriersRewritePattern>(ctx);
+        if (failed(applyPatternsGreedily(func, std::move(patternsBackToBack))))
+          return signalPassFailure();
       }
     }
   }

--- a/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RockPipeline.cpp
@@ -377,6 +377,12 @@ void createSchedule(SmallVector<rock::StageOp> &stages,
         for (auto [res, type] : dependencies) {
           if (type == WAR && getAddressSpace(res) == AddressSpace::Private)
             continue;
+
+          // The DAG is built using "resources", not multibuffers.
+          // So, it is possible that thisMultiBuffers[res] does not exist
+          if (!thisMultiBuffers.contains(res))
+            thisMultiBuffers[res] = 1;
+
           thisMultiBuffers[res]++;
         }
       }
@@ -405,8 +411,8 @@ DagType pruneGraph(const DagType &dag) {
   // dependency concerns two different iteration. In other words, if stageA
   // accesses LDS in iteration i and stageB accesses LDS in iteration j stageA
   // and stageB have no dependencies as long as i!=j
-  for (auto [source, edges] : dag) {
-    for (auto [sink, deps] : edges) {
+  for (const auto &[source, edges] : dag) {
+    for (const auto &[sink, deps] : edges) {
       DenseSet<std::pair<rock::GpuAllocOp, DependencyType>> newDeps;
       for (auto [alloc, type] : deps) {
         if (getAddressSpace(alloc) != gpu::AddressSpace::Workgroup)
@@ -448,6 +454,7 @@ void placeBarriers(IRRewriter &rewriter, Location loc, scf::ForOp forOp,
                    SmallVector<rock::StageOp> &extendedStages,
                    int64_t &initiationInterval, int64_t numIterations) {
   DagType dag = createDependencyGraph(stages, allocs);
+  // prune non-LDS dependencies
   dag = pruneGraph(dag);
 
   // If there is a loop, we probably need a backward barrier, i.e.,
@@ -527,6 +534,7 @@ bool checkIfPipeliningSupported(scf::ForOp forOp) {
     if (parentLoop->hasAttr(rockPipelineAttrName)) {
       return true;
     }
+    forOp = parentLoop;
   }
   return false;
 }
@@ -536,19 +544,24 @@ bool checkIfPipeliningSupported(scf::ForOp forOp) {
 SmallVector<scf::ForOp> collectLoopLevels(mlir::func::FuncOp func) {
   SmallVector<scf::ForOp> loops;
 
-  unsigned curLevelPos = 0;
   unsigned curLevelLen = 0;
   func.walk([&](scf::ForOp forOp) {
-    loops.push_back(forOp);
-    curLevelLen++;
+    if (forOp->getParentOp() == func) {
+      loops.push_back(forOp);
+      curLevelLen++;
+    }
   });
 
+  unsigned curLevelPos = 0;
   while (curLevelLen) {
     unsigned nextLevelLen = 0;
     for (unsigned i = 0; i < curLevelLen; i++) {
-      loops[curLevelPos + i].getBody()->walk([&](scf::ForOp forOp) {
-        loops.push_back(forOp);
-        nextLevelLen++;
+      scf::ForOp currParent = loops[curLevelPos + i];
+      currParent.getBody()->walk([&](scf::ForOp forOp) {
+        if (forOp->getParentOp() == currParent) {
+          loops.push_back(forOp);
+          nextLevelLen++;
+        }
       });
     }
     curLevelPos += curLevelLen;
@@ -609,7 +622,7 @@ void RockPipeline::runOnOperation() {
   for (auto forOp : llvm::reverse(loops)) {
     if (forOp->hasAttr(rockPipelineAttrName)) {
       if (checkIfPipeliningSupported(forOp)) {
-        emitError(loc, "Nested pipelining is not supported yet!\n");
+        forOp.emitError("Nested pipelining is not supported yet");
         return signalPassFailure();
       }
       loopsToPipeline.push_back(forOp);
@@ -623,7 +636,8 @@ void RockPipeline::runOnOperation() {
       // Remove all stages
       RewritePatternSet patterns(&getContext());
       patterns.add<RemoveStagesRewritePattern>(&getContext());
-      (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+        return signalPassFailure();
     }
   } else {
     LLVM_DEBUG(DBGS() << "Found " << loopsToPipeline.size()
@@ -678,24 +692,26 @@ void RockPipeline::runOnOperation() {
       LLVM_DEBUG(DBGS() << "Number of stages: " << stages.size() << "\n");
       LLVM_DEBUG(DBGS() << "Initiation Interval: " << ii << "\n");
       size_t numStages = stages.size();
-      auto maybeNumIterations =
-          rock::computeConstDiff(forOp.getLowerBound(), forOp.getUpperBound());
-      assert(isConstantIntValue(forOp.getStep(), 1) &&
-             "Step size other one is not permitted in rock-pipeline");
+      auto maybeNumIterations = forOp.getStaticTripCount();
       if (!maybeNumIterations.has_value()) {
-        emitError(
-            loc,
-            "Number of iterations are unknown while doing rock-pipeline\n");
+        forOp.emitError(
+            "Number of iterations are unknown while doing rock-pipeline");
         return signalPassFailure();
       }
-      adjustInitiationInterval(maybeNumIterations.value(), numStages, ii);
+      int64_t numIterations = maybeNumIterations.value().getSExtValue();
+      if (!isConstantIntValue(forOp.getStep(), 1)) {
+        forOp.emitError(
+            "Step size other one is not permitted in rock-pipeline");
+        return signalPassFailure();
+      }
+      adjustInitiationInterval(numIterations, numStages, ii);
 
       // Insert the barriers as new stages
       SmallVector<rock::StageOp> extendedStages;
       // use "multiAllocs" to place LDS barriers, no need to explicitly place
       // barriers for registers or globals
       placeBarriers(rewriter, loc, forOp, stages, multiAllocs, extendedStages,
-                    ii, maybeNumIterations.value());
+                    ii, numIterations);
 
       ScheduleType schedule;
       // use all "resources" to generate dependency graph and generate schedule
@@ -710,25 +726,48 @@ void RockPipeline::runOnOperation() {
       };
 
       scf::populateSCFLoopPipeliningPatterns(patterns, options);
-      (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+        return signalPassFailure();
     }
 
     // Remulti-buffer(if needed). Now we know what all the loops need, hence
     // we can safely allocate the right amount of resources in the function
     for (auto [alloc, factor] : multiBufferFactors) {
       SmallVector<rock::GpuAllocOp> newAllocs;
-      if (factor > 1)
-        (void)rock::updateMultiBuffer(rewriter, loc, {alloc}, newAllocs,
-                                      factor);
+      if (factor > 1) {
+        if (failed(rock::updateMultiBuffer(rewriter, loc, {alloc}, newAllocs,
+                                           factor))) {
+
+          alloc.emitError()
+              << "Failed to update multibuffer with factor " << factor << "\n";
+          return signalPassFailure();
+        }
+      }
     }
 
     // Cleanup the stages
     {
       if (removeStages) {
-        RewritePatternSet patterns(&getContext());
-        patterns.add<RemoveStagesRewritePattern, PushBarrierDownRewritePattern,
-                     RemoveBackToBackBarriersRewritePattern>(&getContext());
-        (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+        RewritePatternSet patternsPushBarrier(&getContext());
+        // run PushBarrierDownRewritePattern before RemoveStagesRewritePattern,
+        // because the latter will remove the stages and their terminators
+        patternsPushBarrier.add<PushBarrierDownRewritePattern>(ctx);
+        if (failed(applyPatternsGreedily(func, std::move(patternsPushBarrier))))
+          return signalPassFailure();
+
+        // run RemoveStagesRewritePattern before
+        // RemoveBackToBackBarriersRewritePattern, because the latter expects to
+        // find no stages
+        RewritePatternSet patternsRemoveStages(&getContext());
+        patternsRemoveStages.add<RemoveStagesRewritePattern>(ctx);
+        if (failed(
+                applyPatternsGreedily(func, std::move(patternsRemoveStages))))
+          return signalPassFailure();
+
+        RewritePatternSet patternsBackToBack(&getContext());
+        patternsBackToBack.add<RemoveBackToBackBarriersRewritePattern>(ctx);
+        if (failed(applyPatternsGreedily(func, std::move(patternsBackToBack))))
+          return signalPassFailure();
       }
     }
   }

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -559,7 +559,7 @@ Value mlir::rock::createSliceOfFirstDim(PatternRewriter &rewriter, Location loc,
 }
 
 template <typename AllocType>
-FailureOr<AllocType> findAlloc(Value value) {
+static FailureOr<AllocType> findAlloc(Value value) {
   auto *curOp = value.getDefiningOp();
   auto maybeAllocOp = dyn_cast_or_null<AllocType>(curOp);
   while (!maybeAllocOp) {
@@ -579,7 +579,7 @@ FailureOr<AllocType> findAlloc(Value value) {
       } else if (buffers.size() == 1) {
         curOp = buffers.back().getDefiningOp();
       } else {
-        int64_t index = selectIndex.value();
+        int64_t index = selectIndex.value() % buffers.size();
         curOp = buffers[index].getDefiningOp();
       }
     } else {
@@ -616,16 +616,6 @@ FailureOr<BlockArgument> mlir::rock::findBlockArgument(Value value) {
   }
 
   return maybeBlockArg;
-}
-
-std::optional<int64_t> mlir::rock::computeConstDiff(Value l, Value u) {
-  IntegerAttr clb, cub;
-  if (matchPattern(l, m_Constant(&clb)) && matchPattern(u, m_Constant(&cub))) {
-    llvm::APInt lbValue = clb.getValue();
-    llvm::APInt ubValue = cub.getValue();
-    return (ubValue - lbValue).getSExtValue();
-  }
-  return std::nullopt;
 }
 
 // The rows and columns of subtile view needs to

--- a/mlir/test/Dialect/Rock/test_rock_pipeline_error.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline_error.mlir
@@ -1,0 +1,143 @@
+// RUN: rocmlir-opt --rock-pipeline="rock-pipeline-remove-stages=false" %s -verify-diagnostics
+
+func.func @rock_pipeline_nested_parent_pipeline(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+  
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // expected-error @+1 {{Nested pipelining is not supported yet}}
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }{pipeline = #rock.pipeline<1>}
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+func.func @rock_pipeline_step_nonone(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c2f = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+  
+    scf.for %idx = %c0 to %c4 step %c2 {
+      // expected-error @+1 {{Step size other one is not permitted in rock-pipeline}}
+      scf.for %arg3 = %c0 to %c4 step %c2 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2f : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2f : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+func.func @rock_pipeline_dynamic_count(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>, %dyncount : index){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+  
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // expected-error @+1 {{Number of iterations are unknown while doing rock-pipeline}}
+      scf.for %arg3 = %c0 to %dyncount step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}

--- a/mlir/test/Dialect/Rock/test_rock_pipeline_nested.mlir
+++ b/mlir/test/Dialect/Rock/test_rock_pipeline_nested.mlir
@@ -1,0 +1,995 @@
+// RUN: rocmlir-opt %s --rock-pipeline="rock-pipeline-remove-stages=false" | FileCheck %s
+// RUN: rocmlir-opt %s --rock-pipeline="rock-pipeline-remove-stages=true" | FileCheck %s --check-prefix=REMOVE-STAGES
+
+// REMOVE-STAGES-LABEL: rock_nopipeline
+func.func @rock_nopipeline(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds0  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds1  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds0 = memref.view %rawLds0[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds1 = memref.view %rawLds1[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+
+    // REMOVE-STAGES: rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // REMOVE-STAGES: rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // REMOVE-STAGES-NOT: rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+
+    // REMOVE-STAGES-NOT: rock.stage
+    // REMOVE-STAGES: scf.for
+      // REMOVE-STAGES-NOT: rock.stage
+      // REMOVE-STAGES-NOT: rock.extract_multibuffer
+    // REMOVE-STAGES: scf.for
+    // REMOVE-STAGES-NOT: rock.stage
+    // REMOVE-STAGES: scf.for
+    // REMOVE-STAGES-NOT: rock.stage
+    scf.for %idx = %c0 to %c4 step %c1 {
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds0[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds0[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds1[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds1[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// one loop inside another loop, inner loop has pipeline<1> attribute
+// CHECK-LABEL: rock_pipeline_oneloop
+func.func @rock_pipeline_oneloop(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>){
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+
+    // CHECK: scf.for
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // CHECK: name = "S0" 
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c0]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3" 
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// two loops inside an outer loop, inner loops have pipeline<1> attribute
+// CHECK-LABEL: rock_pipeline_twoloops
+func.func @rock_pipeline_twoloops(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds2  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds2 = memref.view %rawLds2[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds3:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds4:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+    // CHECK: %[[ldsView3:.*]] = memref.view %[[rawLds3]]
+    // CHECK: %[[ldsView4:.*]] = memref.view %[[rawLds4]]
+
+    // CHECK: scf.for
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // CHECK: name = "S0" 
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c0]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3" 
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+      
+      // CHECK: name = "S0" 
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S2"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c0]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3" 
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// two loops inside an outer loop, inner loops have pipeline<2> attribute
+// CHECK-LABEL: rock_pipeline_twoloops_ii2
+func.func @rock_pipeline_twoloops_ii2(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds2  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds2 = memref.view %rawLds2[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+
+    // CHECK: scf.for
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // CHECK: name = "S0" 
+      // CHECK: name = "__bwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]])
+      // CHECK: name = "S1"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c3]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: name = "S0"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]])
+        // CHECK: name = "S2"
+        // CHECK: name = "__bwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S3"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3"
+      scf.for %arg3 = %c0 to %c4 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<2>}
+      
+      // CHECK: name = "S0" 
+      // CHECK: name = "__bwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c3]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: name = "S0"
+        // CHECK: rock.extract_multibuffer(%[[ldsView2]])
+        // CHECK: name = "S2"
+        // CHECK: name = "__bwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView2]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S3"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3"
+      scf.for %arg3 = %c0 to %c4 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<2>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// two loops inside an outer loop (which is inside another outer loop), inner loops have pipeline<1> attribute
+// CHECK-LABEL: rock_pipeline_twoloops_triplenested
+func.func @rock_pipeline_twoloops_triplenested(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds2  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds2 = memref.view %rawLds2[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds3:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds4:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+    // CHECK: %[[ldsView3:.*]] = memref.view %[[rawLds3]]
+    // CHECK: %[[ldsView4:.*]] = memref.view %[[rawLds4]]
+
+    // CHECK: scf.for
+    scf.for %idx = %c0 to %c4 step %c1 {
+      scf.for %idx2 = %c0 to %c4 step %c1 {
+        // CHECK: name = "S0" 
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S2"
+        // CHECK: scf.for 
+        // CHECK-SAME: %[[c0]] to %[[c0]]
+          // CHECK: name = "__fwd_barrier__"
+          // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+          // CHECK: name = "S1"
+          // CHECK: name = "S0"
+          // CHECK: name = "S3"
+          // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+          // CHECK: name = "S2"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S2"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S2"
+        // CHECK: name = "S3" 
+        scf.for %arg3 = %c0 to %c3 step %c1 {
+          rock.stage {
+            %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+            memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            rock.yield
+          }{name="S0"}
+          rock.stage {
+            %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+            rock.yield
+          }{name="S1"}
+          rock.stage {
+            %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+            %comp = arith.addf %tmp, %c2 : f16
+            memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            rock.yield
+          }{name="S2"}
+          rock.stage {
+            %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            %comp = arith.addf %tmp, %c2 : f16
+            memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            rock.yield
+          }{name="S3"}
+        }{pipeline = #rock.pipeline<1>}
+        
+        // CHECK: name = "S0" 
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S2"
+        // CHECK: scf.for 
+        // CHECK-SAME: %[[c0]] to %[[c0]]
+          // CHECK: name = "__fwd_barrier__"
+          // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+          // CHECK: name = "S1"
+          // CHECK: name = "S0"
+          // CHECK: name = "S3"
+          // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+          // CHECK: name = "S2"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S2"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S2"
+        // CHECK: name = "S3" 
+        scf.for %arg3 = %c0 to %c3 step %c1 {
+          rock.stage {
+            %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+            memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            rock.yield
+          }{name="S0"}
+          rock.stage {
+            %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            memref.store %tmp, %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+            rock.yield
+          }{name="S1"}
+          rock.stage {
+            %tmp = memref.load %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+            %comp = arith.addf %tmp, %c2 : f16
+            memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            rock.yield
+          }{name="S2"}
+          rock.stage {
+            %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            %comp = arith.addf %tmp, %c2 : f16
+            memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+            rock.yield
+          }{name="S3"}
+        }{pipeline = #rock.pipeline<1>}
+      }
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// two outer loops that each contain two inner loops, inner loops have pipeline<1> attribute
+// CHECK-LABEL: rock_pipeline_twoloops_twoouterloops
+func.func @rock_pipeline_twoloops_twoouterloops(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds2  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds3  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds4  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds2 = memref.view %rawLds2[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds3 = memref.view %rawLds3[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds4 = memref.view %rawLds4[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds3:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds4:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds5:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds6:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds7:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds8:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg0:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg1:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+    // CHECK: %[[ldsView3:.*]] = memref.view %[[rawLds3]]
+    // CHECK: %[[ldsView4:.*]] = memref.view %[[rawLds4]]
+    // CHECK: %[[ldsView5:.*]] = memref.view %[[rawLds5]]
+    // CHECK: %[[ldsView6:.*]] = memref.view %[[rawLds6]]
+    // CHECK: %[[ldsView7:.*]] = memref.view %[[rawLds7]]
+    // CHECK: %[[ldsView8:.*]] = memref.view %[[rawLds8]]
+
+    // CHECK: scf.for
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // CHECK: name = "S0" 
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c0]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+        // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView1]], %[[ldsView2]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3" 
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+      
+      // CHECK: name = "S0" 
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S2"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c0]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+        // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView3]], %[[ldsView4]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3" 
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }
+    
+    // CHECK: scf.for
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // CHECK: name = "S0" 
+      // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+      // CHECK: name = "S2"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c0]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+        // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+      // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView5]], %[[ldsView6]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3" 
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds3[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds3[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+      
+      // CHECK: name = "S0" 
+      // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S0"
+      // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+      // CHECK: name = "S2"
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c0]]
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+        // CHECK: name = "S1"
+        // CHECK: name = "S0"
+        // CHECK: name = "S3"
+        // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+        // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+      // CHECK: name = "S1"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+      // CHECK: name = "S2"
+      // CHECK: name = "__fwd_barrier__"
+      // CHECK: name = "S3"
+      // CHECK: rock.extract_multibuffer(%[[ldsView7]], %[[ldsView8]])
+      // CHECK: name = "S2"
+      // CHECK: name = "S3" 
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          memref.store %tmp, %lds4[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S1"}
+        rock.stage {
+          %tmp = memref.load %lds4[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %tmp, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S2"}
+        rock.stage {
+          %tmp = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S3"}
+      }{pipeline = #rock.pipeline<1>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// one loop inside a loop, inner loops have pipeline<1> attribute and no rock.stages
+// CHECK-LABEL: rock_pipeline_nestednostages
+func.func @rock_pipeline_nestednostages(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
+    // CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
+    // CHECK-DAG: %[[c4:.*]] = arith.constant 4 : index
+    // CHECK: rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK-NOT: rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+
+    // CHECK-NOT: rock.stage
+    // CHECK: scf.for %{{.*}} = %[[c0]] to %[[c4]] step %[[c1]]
+      // CHECK-NOT: rock.stage
+      // CHECK-NOT: rock.extract_multibuffer
+    // CHECK: scf.for %{{.*}} = %[[c0]] to %[[c3]] step %[[c1]]
+    // CHECK-NOT: rock.stage
+    scf.for %idx = %c0 to %c4 step %c1 {
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        %tmp1 = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+        memref.store %tmp1, %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        %tmp2 = memref.load %reg0[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        rock.lds_barrier
+        memref.store %tmp2, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        rock.lds_barrier
+        %tmp3 = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+        memref.store %tmp3, %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        %tmp4 = memref.load %reg1[%arg3] : memref<16xf16, #gpu.address_space<private>>
+        %comp = arith.addf %tmp4, %c2 : f16
+        memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+      }{pipeline = #rock.pipeline<1>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}
+
+// two loops inside an outer loop, inner loops have pipeline<2> attribute and two rock.stages
+// CHECK-LABEL: rock_pipeline_twoloops_ii_equal_numstages
+func.func @rock_pipeline_twoloops_ii_equal_numstages(%input : memref<16xf16, #gpu.address_space<global>>, %output : memref<16xf16, #gpu.address_space<global>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2.0 : f16
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %rawLds  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %rawLds2  = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    %reg0 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg1 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    %reg2 = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+
+    %lds = memref.view %rawLds[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    %lds2 = memref.view %rawLds2[%c0][] : memref<32xi8, #gpu.address_space<workgroup>> to memref<16xf16, #gpu.address_space<workgroup>>
+    // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+    // CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
+    // CHECK-DAG: %[[c4:.*]] = arith.constant 4 : index
+    // CHECK: %[[rawLds1:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[rawLds2:.*]] = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK-NOT: rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
+    // CHECK: %[[reg2:.*]] = rock.alloc() : memref<16xf16, #gpu.address_space<private>>
+    // CHECK: %[[ldsView1:.*]] = memref.view %[[rawLds1]]
+    // CHECK: %[[ldsView2:.*]] = memref.view %[[rawLds2]]
+
+    // CHECK: scf.for
+    // CHECK-SAME: %[[c0]] to %[[c4]]
+    scf.for %idx = %c0 to %c4 step %c1 {
+      // CHECK-NEXT: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c3]]
+        // CHECK: name = "__bwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]])
+        // CHECK: name = "S0"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView1]])
+        // CHECK: name = "S1"
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %lds[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S1"}
+      }{pipeline = #rock.pipeline<2>}
+      
+      // CHECK: scf.for 
+      // CHECK-SAME: %[[c0]] to %[[c3]]
+        // CHECK: name = "__bwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView2]])
+        // CHECK: name = "S0"
+        // CHECK: name = "__fwd_barrier__"
+        // CHECK: rock.extract_multibuffer(%[[ldsView2]])
+        // CHECK: name = "S1"
+      scf.for %arg3 = %c0 to %c3 step %c1 {
+        rock.stage {
+          %tmp = memref.load %input[%arg3] : memref<16xf16, #gpu.address_space<global>>
+          memref.store %tmp, %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          rock.yield
+        }{name="S0"}
+        rock.stage {
+          %tmp = memref.load %lds2[%arg3] : memref<16xf16, #gpu.address_space<workgroup>>
+          %comp = arith.addf %tmp, %c2 : f16
+          memref.store %comp, %reg2[%arg3] : memref<16xf16, #gpu.address_space<private>>
+          rock.yield
+        }{name="S1"}
+      }{pipeline = #rock.pipeline<2>}
+    }
+
+    %out = memref.load %reg2[%c0] : memref<16xf16, #gpu.address_space<private>>
+    memref.store %out, %output[%c0] : memref<16xf16, #gpu.address_space<global>>
+    return
+}

--- a/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
+++ b/mlir/test/lib/Dialect/Rock/TestRockMultibuffer.cpp
@@ -65,8 +65,9 @@ static LogicalResult testMultiBuffering(func::FuncOp f) {
         rock::multiBuffer(rewriter, alloc.first, mbAllocs, alloc.second, true);
     if (newFactor && succeeded(mb)) {
       SmallVector<rock::GpuAllocOp> newAllocs;
-      (void)rock::updateMultiBuffer(rewriter, loc, mbAllocs, newAllocs,
-                                    newFactor);
+      if (failed(rock::updateMultiBuffer(rewriter, loc, mbAllocs, newAllocs,
+                                         newFactor)))
+        return failure();
     }
   }
 


### PR DESCRIPTION
## Motivation

A reviewer asked to split Attention pipelining ticket into two PRs: https://github.com/ROCm/rocMLIR/pull/1990/files#r2460499275

I have also moved some pipeline related bugs from this PR: https://github.com/ROCm/rocMLIR/pull/2010 The PR is blocked due to a backend compiler bug, so I'm moving relevant bug-fixes that do not trigger the backend bug.

This PR introduces the ability to have nested loops where only the leaf loops have the pipeline attribute:
```
scf.for {
  scf.for {
  } pipeline=2
  scf.for {
  } pipeline=2
} // no pipelined
```

## Technical Details

- RockMultibuffer.h: Make cpp and .h name of variables match
- loweringUtils.h: Removed unused function computeConstDiff()
- RockPipeline.cpp (1): Fix bug due to uninitialized thisMultiBuffers[key], if the key doesn't exist, it's init to 0, instead of 1. 
- RockPipeline.cpp (2): Added some checks to make the pass fail.
- RockPipeline.cpp (3): Enable nested loops (when only leafs have pipeline attribute).
- RockPipeline.cpp (4): Fix order or transforms applied when `removeStages` is enabled.
- loweringUtils.cpp: Fix bug when handling rock.extract_multibuffer, it must do modulo of the index.


## Test Plan

Added new tests as required by reviewer.

## Test Result

Tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
