### PR TITLE
Fix usage of `isModuleFusible` in rocmlir-tuning-driver

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -434,7 +434,7 @@ static bool doesModuleHaveFusions(ModuleOp module) {
     if (isa<linalg::GenericOp>(op) || isa<rock::ReduceOp>(op)) {
       return WalkResult::interrupt();
     }
-    
+
     return WalkResult::advance();
   });
   return result.wasInterrupted();

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -18,6 +18,7 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Rock/IR/GetRockInfo.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
@@ -427,6 +428,18 @@ static LogicalResult extractFuncOps(ModuleOp op,
   return success();
 }
 
+static bool doesModuleHaveFusions(ModuleOp module) {
+  WalkResult result = module.walk([](Operation *op) {
+    // Check for linalg.generic or rock.reduce (standalone fusion ops)
+    if (isa<linalg::GenericOp>(op) || isa<rock::ReduceOp>(op)) {
+      return WalkResult::interrupt();
+    }
+    
+    return WalkResult::advance();
+  });
+  return result.wasInterrupted();
+}
+
 static LogicalResult runTuningLoop(ModuleOp source) {
   // Verify prerequisites
   SmallVector<func::FuncOp> funcs;
@@ -606,14 +619,15 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       return copy;
     };
 
-    // Applicability check
-    OwningOpRef<ModuleOp> sourceCopy =
-        copyIRThread(threadSource.get(), perfConfigAttr);
-    if (!rock::isModuleFusible(sourceCopy.get(), result.perfConfig)) {
+    if (doesModuleHaveFusions(threadSource.get()) &&
+        !rock::isModuleFusible(threadSource.get(), result.perfConfig)) {
       result.status = CompilationStatus::NotApplicable;
       return result;
     }
 
+    // Applicability check
+    OwningOpRef<ModuleOp> sourceCopy =
+        copyIRThread(threadSource.get(), perfConfigAttr);
     if (failed(threadApplicability.run(sourceCopy.get()))) {
       result.status = CompilationStatus::NotApplicable;
       return result;

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1094,7 +1094,7 @@ pipeline {
                                                             if (CHIP.startsWith("gfx1")) {
                                                                 attnConfigToUse = "tier1-attention-configs-nofp32"
                                                                 sh """
-                                                                    grep -v '-t f32' ${attnConfig} > ${attnConfigToUse}
+                                                                    grep -v '\\-t f32' ${attnConfig} > ${attnConfigToUse}
                                                                 """
                                                             }
                                                             sh """../mlir/utils/tuna/tuna-script.sh -o attention \

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1094,7 +1094,7 @@ pipeline {
                                                             if (CHIP.startsWith("gfx1")) {
                                                                 attnConfigToUse = "tier1-attention-configs-nofp32"
                                                                 sh """
-                                                                    grep -v '\\-t f32' ${attnConfig} > ${attnConfigToUse}
+                                                                    grep -v '-t f32' ${attnConfig} > ${attnConfigToUse}
                                                                 """
                                                             }
                                                             sh """../mlir/utils/tuna/tuna-script.sh -o attention \


### PR DESCRIPTION
## Motivation

This PR addresses issues in tuning where backwards data convolution ops were being skipped (marked with N/A).

This fixes https://github.com/ROCm/rocMLIR-internal/issues/2105

## Technical Details

Right now calling `isModuleFusible` from rocmlir-tuning-driver will prohibit any kernels that cannot be fused from running through the tuning driver. What we really want to check is if this kernel already has fusions, then we can run the `isModuleFusible` checks.

See https://github.com/ROCm/rocMLIR/pull/1514 for the initial intent of what this check was trying to do.

This PR also temporarily sets `v4r1=1` in `tuningRunner` to get around a backend issue in https://github.com/ROCm/rocMLIR-internal/issues/2116

## Test Plan

- Manually test bwd_data configs to make sure that we can run them through rocmlir-tuning-driver
- Weekly CI to make sure that we don't introduce any accidental failures

## Test Result

- [x] Manual running
- [x] Weekly CI: 
- [x] PR CI: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2070/43/pipeline-overview/?selected-node=908

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
