### PR TITLE
add multi threaded compilation for rocmlir-tuning-driver

### DIFF
--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -1519,16 +1519,14 @@ static func::FuncOp createGPUWrapper(ModuleOp module,
             cpuMem[cpuMem.size() - 1].getType()),
         cpuMem[cpuMem.size() - 1], true, false);
     Value lseTensor = bufferization::ToTensorOp::create(
-        b,
-        loc,
+        b, loc,
         memref::getTensorTypeFromMemRefType(
             cpuMem[cpuMem.size() - 2].getType()),
         cpuMem[cpuMem.size() - 2], true, false);
     auto out = computeFinalAttentionStage(b, loc, resultTensor, lseTensor,
                                           validSplitKV);
     Value outMemref = bufferization::ToBufferOp::create(
-        b,
-        loc,
+        b, loc,
         cast<mlir::bufferization::BufferLikeType>(
             cpuMem[cpuMem.size() - 1].getType()),
         out);
@@ -3050,8 +3048,8 @@ static func::FuncOp createGpuAttentionKernel(ModuleOp module,
 
   auto softmaxType =
       TypeAttr::get(typeFromString(softmaxDataType.getValue(), ctx));
-  auto attention = rock::AttentionOp::create(builder,
-      loc, TypeRange{}, queries, keys, values, elemwiseInputs,
+  auto attention = rock::AttentionOp::create(
+      builder, loc, TypeRange{}, queries, keys, values, elemwiseInputs,
       currentSeqLenTensor, output, lse, numHeadsQ, numHeadsKV, transposeQ,
       transposeK, transposeV, transposeO, causalMasking, splitKV,
       rock::GemmFeaturesAttr::get(builder.getContext(), params.features),
@@ -4212,9 +4210,8 @@ static func::FuncOp createVerifierFunc(ModuleOp module, const KernelIF &kernel,
                                   {mr1DUnkTestType, mr1DUnkValType, floatType,
                                    floatType, floatType, charType, boolType});
     func::CallOp::create(b, loc, verifyFuncDecl,
-                           ValueRange{testResult, valResult, thr_RMS,
-                                      thr_absDiff, thr_relDiff, printDebugVal,
-                                      isFP32Val});
+                         ValueRange{testResult, valResult, thr_RMS, thr_absDiff,
+                                    thr_relDiff, printDebugVal, isFP32Val});
   } else {
     verifyFuncDecl = makeFuncDecl(module, verifyFuncName,
                                   {mr1DUnkTestType, mr1DUnkValType, charType});

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -46,8 +46,11 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
+#include <future>
+#include <mutex>
 #include <thread>
 
 // Utilities to allocate buffers
@@ -128,6 +131,11 @@ static llvm::cl::opt<std::string> benchmarkConfig(
     llvm::cl::desc(
         "Run benchmark with specific perf config only (skip tuning)"),
     llvm::cl::value_desc("perf config string"), llvm::cl::init(""));
+
+static llvm::cl::opt<unsigned> numCompileThreads(
+    "num-compile-threads",
+    llvm::cl::desc("Number of parallel compilation threads (0 = auto)"),
+    llvm::cl::value_desc("thread count"), llvm::cl::init(0));
 
 // Ripped out of JitRunner.cpp
 static OwningOpRef<ModuleOp> parseMLIRInput(StringRef inputFilename,
@@ -253,6 +261,15 @@ struct BenchmarkParams {
   unsigned trimPercent;
   unsigned sleepUs;
   bool showStats;
+};
+
+struct CompilationResult {
+  SmallString<64> perfConfig;
+  bool isApplicable = false;
+  bool compilationSucceeded = false;
+  SmallVector<std::string> hipModules;
+  SmallVector<uint32_t> blockSizes;
+  SmallVector<uint32_t> gridSizes;
 };
 
 // In order to match rocprof, returns time in nanoseconds
@@ -449,22 +466,16 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     bufferLengths.push_back(sizeInBits / 8);
   }
 
-  // 2. Set up pipelines. Do this only once to save on construction cost.
-  MLIRContext *ctx = source->getContext();
-  PassManager applicability(source->getName(), PassManager::Nesting::Implicit);
-  PassManager compilation(source->getName(), PassManager::Nesting::Implicit);
-
+  // 2. Set up compilation options (shared across all threads)
   rock::KernelOptions applicabilityOpts;
   applicabilityOpts.enableApplicability = true;
   applicabilityOpts.enableFusion = true;
   applicabilityOpts.tuningFallback = false;
-  rock::buildKernelPipeline(applicability, applicabilityOpts);
 
   rock::KernelOptions compilationKernOpts;
   compilationKernOpts.enableApplicability = false;
   compilationKernOpts.enableFusion = true;
   compilationKernOpts.tuningFallback = false;
-  rock::buildKernelPipeline(compilation, compilationKernOpts);
 
   RocmDeviceName deviceName;
   StringRef archName =
@@ -478,12 +489,6 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   backendOpts.features = backendFeatures;
   backendOpts.optLevel = 3;
   backendOpts.suppressDiagnostic = true;
-  rock::buildBackendPipeline(compilation, backendOpts);
-
-  // Now that we're in the kernel execution zone, turn off error messages
-  // Register a handler that swallows all diagnostic print
-  DiagnosticEngine &engine = ctx->getDiagEngine();
-  engine.registerHandler([](Diagnostic &diag) {});
 
   // 3. Initialize host buffers and allocate device buffers
   std::vector<void *> hostBuffers;
@@ -498,20 +503,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     gpuBuffers.push_back(gpuBuffer);
   }
 
-  auto copyIR = [&](ModuleOp source,
-                    StringAttr perfConfigAttr) -> OwningOpRef<ModuleOp> {
-    OwningOpRef<ModuleOp> copy = cast<ModuleOp>(source->clone());
-
-    copy->walk([&perfConfigAttr](rock::RockGemmWrapperInterface op) {
-      op->setAttr("perf_config", perfConfigAttr);
-    });
-    copy->walk([&perfConfigAttr](rock::RockGemmGemmWrapperInterface op) {
-      op->setAttr("perf_config", perfConfigAttr);
-    });
-    return copy;
-  };
-
-  // 4. Actually tune
+  // 4. Collect perf configs to compile
   std::vector<SmallString<64>> configs;
   if (!benchmarkConfig.empty()) {
     // Benchmark mode - just one config
@@ -540,65 +532,152 @@ static LogicalResult runTuningLoop(ModuleOp source) {
                                            useMedian,     trimPercent,
                                            sleepUs,       showStats};
 
-  for (const auto &perfConfig : configs) {
-    llvm::outs() << perfConfig << "\t";
-    OwningOpRef<ModuleOp> tuneCopy = cast<ModuleOp>(source->clone());
-    StringAttr perfConfigAttr = StringAttr::get(ctx, perfConfig);
+  // Determine number of parallel threads
+  unsigned numThreads = (numCompileThreads > 0) ? numCompileThreads 
+                                                 : std::thread::hardware_concurrency();
+  if (numThreads == 0) numThreads = 4; // fallback
 
-    OwningOpRef<ModuleOp> applicabilityCopy = copyIR(source, perfConfigAttr);
-    if (!rock::isModuleFusible(applicabilityCopy.get(), perfConfig)) {
-      llvm::outs() << "N/A\n";
-      continue;
+  // Serialize source module once (shared by all threads for cloning)
+  std::string sourceModuleStr;
+  llvm::raw_string_ostream sourceOs(sourceModuleStr);
+  source->print(sourceOs);
+  sourceOs.flush();
+
+  // Parallel compilation phase
+  std::vector<CompilationResult> compilationResults(configs.size());
+  std::mutex outputMutex; // For thread-safe console output
+
+  auto compileConfig = [&](size_t idx) -> CompilationResult {
+    CompilationResult result;
+    result.perfConfig = configs[idx];
+    
+    // Each thread needs its own context and pass managers for thread-safety
+    DialectRegistry threadRegistry;
+    registerRocMLIRDialects(threadRegistry);
+    MLIRContext threadCtx(threadRegistry);
+    threadCtx.getDiagEngine().registerHandler([](Diagnostic &diag) {});
+    
+    // Parse the serialized module in this thread's context
+    OwningOpRef<ModuleOp> threadSource = 
+        parseSourceString<ModuleOp>(sourceModuleStr, &threadCtx);
+    if (!threadSource) return result;
+    
+    // Set up pipelines for this thread
+    PassManager threadApplicability(&threadCtx, 
+                                    PassManager::getAnyOpAnchorName(),
+                                    PassManager::Nesting::Implicit);
+    PassManager threadCompilation(&threadCtx, 
+                                  PassManager::getAnyOpAnchorName(),
+                                  PassManager::Nesting::Implicit);
+    
+    rock::buildKernelPipeline(threadApplicability, applicabilityOpts);
+    rock::buildKernelPipeline(threadCompilation, compilationKernOpts);
+    rock::buildBackendPipeline(threadCompilation, backendOpts);
+    
+    StringAttr perfConfigAttr = StringAttr::get(&threadCtx, result.perfConfig);
+    
+    // Helper to copy IR with perf config set
+    auto copyIRThread = [&](ModuleOp src, StringAttr attr) -> OwningOpRef<ModuleOp> {
+      OwningOpRef<ModuleOp> copy = cast<ModuleOp>(src->clone());
+      copy->walk([&attr](rock::RockGemmWrapperInterface op) {
+        op->setAttr("perf_config", attr);
+      });
+      copy->walk([&attr](rock::RockGemmGemmWrapperInterface op) {
+        op->setAttr("perf_config", attr);
+      });
+      return copy;
+    };
+    
+    // Applicability check
+    OwningOpRef<ModuleOp> applicabilityCopy = 
+        copyIRThread(threadSource.get(), perfConfigAttr);
+    if (!rock::isModuleFusible(applicabilityCopy.get(), result.perfConfig)) {
+      return result; // Not applicable
     }
-
-    if (failed(applicability.run(applicabilityCopy.get()))) {
-      llvm::outs() << "N/A\n";
-      continue;
+    
+    if (failed(threadApplicability.run(applicabilityCopy.get()))) {
+      return result; // Not applicable
     }
-
-    // We have to get these now, they disappear later. Also, if these attributes
-    // aren't set the contract of the applicability pipeline changed and that's
-    // a problem.
-    SmallVector<uint32_t> blockSizes;
-    SmallVector<uint32_t> gridSizes;
+    
+    result.isApplicable = true;
+    
+    // Extract block and grid sizes
     for (auto &fnName : kernelFuncNames) {
       auto tunedFunc = applicabilityCopy->lookupSymbol<func::FuncOp>(fnName);
-      if (!tunedFunc) {
-        llvm::errs() << "Tuned copy somehow missing kernel function\n";
-        return failure();
-      }
-      blockSizes.push_back(
+      if (!tunedFunc) return result;
+      result.blockSizes.push_back(
           tunedFunc->getAttrOfType<IntegerAttr>("block_size").getInt());
-      gridSizes.push_back(
+      result.gridSizes.push_back(
           tunedFunc->getAttrOfType<IntegerAttr>("grid_size").getInt());
     }
-
-    OwningOpRef<ModuleOp> compileCopy = copyIR(source, perfConfigAttr);
-
-    // NOTE: Call to run() resets the cl opts
-    if (failed(compilation.run(compileCopy.get()))) {
-      llvm::errs() << "Backend pipeline failed for config: " << perfConfig
-                   << "\n";
-      return failure();
+    
+    // Compilation
+    OwningOpRef<ModuleOp> compileCopy = 
+        copyIRThread(threadSource.get(), perfConfigAttr);
+    if (failed(threadCompilation.run(compileCopy.get()))) {
+      std::lock_guard<std::mutex> lock(outputMutex);
+      llvm::errs() << "Backend pipeline failed for config: " 
+                   << result.perfConfig << "\n";
+      return result;
     }
-
-    // Extract binary and benchmark
-    SmallVector<std::string> hipModules;
+    
+    result.compilationSucceeded = true;
+    
+    // Extract binaries
     for (const auto &fnName : kernelFuncNames) {
-      auto binary =
-          compileCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
-      if (!binary) {
-        llvm::errs() << "could not find the GPU binary\n";
-      }
-      hipModules.push_back(cast<gpu::ObjectAttr>(binary.getObjects()[0])
-                               .getObject()
-                               .getValue()
-                               .str());
+      auto binary = compileCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
+      if (!binary) return result;
+      result.hipModules.push_back(
+          cast<gpu::ObjectAttr>(binary.getObjects()[0])
+              .getObject()
+              .getValue()
+              .str());
     }
+    
+    return result;
+  };
 
+  // Launch parallel compilation tasks
+  {
+    std::atomic<size_t> nextIdx{0};
+    
+    // Thread pool pattern
+    auto worker = [&]() {
+      while (true) {
+        size_t idx = nextIdx.fetch_add(1);
+        if (idx >= configs.size()) break;
+        compilationResults[idx] = compileConfig(idx);
+      }
+    };
+    
+    std::vector<std::thread> threads;
+    for (unsigned i = 0; i < numThreads; ++i) {
+      threads.emplace_back(worker);
+    }
+    
+    for (auto &t : threads) {
+      t.join();
+    }
+  }
+
+  // Sequential benchmarking phase (must be sequential for accurate timing)
+  for (const auto &result : compilationResults) {
+    llvm::outs() << result.perfConfig << "\t";
+    
+    if (!result.isApplicable) {
+      llvm::outs() << "N/A\n";
+      continue;
+    }
+    
+    if (!result.compilationSucceeded) {
+      llvm::outs() << "COMPILE_FAILED\n";
+      continue;
+    }
+    
     FailureOr<double> timing = benchmarkKernels(
-        hipModules, kernelFuncNames, blockSizes, gridSizes, dataType,
-        hostBuffers, gpuBuffers, bufferLengths, benchmarkParams);
+        result.hipModules, kernelFuncNames, result.blockSizes, result.gridSizes,
+        dataType, hostBuffers, gpuBuffers, bufferLengths, benchmarkParams);
+    
     if (failed(timing)) {
       llvm::errs() << "Kernel execution failed\n";
       return failure();

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -265,9 +265,9 @@ struct BenchmarkParams {
 };
 
 enum class CompilationStatus {
-  NotApplicable,      // Config not applicable for this kernel
-  CompilationFailed,  // Config applicable but compilation failed
-  Success             // Successfully compiled
+  NotApplicable,     // Config not applicable for this kernel
+  CompilationFailed, // Config applicable but compilation failed
+  Success            // Successfully compiled
 };
 
 struct CompilationResult {
@@ -544,7 +544,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
                             : std::thread::hardware_concurrency();
   if (numThreads == 0)
     numThreads = 4; // fallback
-  
+
   // Don't create more threads than configs to compile
   numThreads = std::min(numThreads, static_cast<unsigned>(configs.size()));
 
@@ -557,7 +557,8 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   // Parallel compilation phase
   std::vector<CompilationResult> compilationResults(configs.size());
   std::mutex outputMutex; // For thread-safe console output
-  std::atomic<bool> compilationFailed{false}; // Flag to signal early termination
+  std::atomic<bool> compilationFailed{
+      false}; // Flag to signal early termination
 
   auto compileConfig = [&](size_t idx) -> CompilationResult {
     CompilationResult result;
@@ -669,11 +670,11 @@ static LogicalResult runTuningLoop(ModuleOp source) {
         // Check if any compilation has failed
         if (compilationFailed.load())
           break;
-        
+
         size_t idx = nextIdx.fetch_add(1);
         if (idx >= configs.size())
           break;
-        
+
         compilationResults[idx] = compileConfig(idx);
       }
     };
@@ -690,7 +691,8 @@ static LogicalResult runTuningLoop(ModuleOp source) {
 
   // Check if any compilation failed and terminate early
   if (compilationFailed.load()) {
-    llvm::errs() << "Compilation failed for one or more configs. Terminating.\n";
+    llvm::errs()
+        << "Compilation failed for one or more configs. Terminating.\n";
     return failure();
   }
 

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -620,7 +620,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       auto tunedFunc = applicabilityCopy->lookupSymbol<func::FuncOp>(fnName);
       if (!tunedFunc) {
         result.status = CompilationStatus::CompilationFailed;
-        compilationFailed.store(true);
+        compilationFailed.store(true, std::memory_order_relaxed);
         return result;
       }
       result.blockSizes.push_back(
@@ -637,7 +637,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       llvm::errs() << "Backend pipeline failed for config: "
                    << result.perfConfig << "\n";
       result.status = CompilationStatus::CompilationFailed;
-      compilationFailed.store(true);
+      compilationFailed.store(true, std::memory_order_relaxed);
       return result;
     }
 
@@ -647,7 +647,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
           compileCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
       if (!binary) {
         result.status = CompilationStatus::CompilationFailed;
-        compilationFailed.store(true);
+        compilationFailed.store(true, std::memory_order_relaxed);
         return result;
       }
       result.hipModules.push_back(cast<gpu::ObjectAttr>(binary.getObjects()[0])
@@ -660,18 +660,22 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     return result;
   };
 
-  // Launch parallel compilation tasks
+  // Launch parallel compilation tasks with dynamic work stealing
+  // Note: We use atomic counter instead of static partitioning because
+  // compilation times vary dramatically between configs (NotApplicable is fast,
+  // full compilation is slow). Dynamic work stealing provides better load
+  // balancing by allowing fast threads to pick up more work.
   {
     std::atomic<size_t> nextIdx{0};
 
-    // Thread pool pattern
+    // Thread pool with work stealing pattern
     auto worker = [&]() {
       while (true) {
-        // Check if any compilation has failed
-        if (compilationFailed.load())
+        // Check if any compilation has failed (relaxed: just an optimization hint)
+        if (compilationFailed.load(std::memory_order_relaxed))
           break;
 
-        size_t idx = nextIdx.fetch_add(1);
+        size_t idx = nextIdx.fetch_add(1, std::memory_order_relaxed);
         if (idx >= configs.size())
           break;
 
@@ -690,7 +694,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   }
 
   // Check if any compilation failed and terminate early
-  if (compilationFailed.load()) {
+  if (compilationFailed.load(std::memory_order_relaxed)) {
     llvm::errs()
         << "Compilation failed for one or more configs. Terminating.\n";
     return failure();

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -533,9 +533,11 @@ static LogicalResult runTuningLoop(ModuleOp source) {
                                            sleepUs,       showStats};
 
   // Determine number of parallel threads
-  unsigned numThreads = (numCompileThreads > 0) ? numCompileThreads 
-                                                 : std::thread::hardware_concurrency();
-  if (numThreads == 0) numThreads = 4; // fallback
+  unsigned numThreads = (numCompileThreads > 0)
+                            ? numCompileThreads
+                            : std::thread::hardware_concurrency();
+  if (numThreads == 0)
+    numThreads = 4; // fallback
 
   // Serialize source module once (shared by all threads for cloning)
   std::string sourceModuleStr;
@@ -550,34 +552,35 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   auto compileConfig = [&](size_t idx) -> CompilationResult {
     CompilationResult result;
     result.perfConfig = configs[idx];
-    
+
     // Each thread needs its own context and pass managers for thread-safety
     DialectRegistry threadRegistry;
     registerRocMLIRDialects(threadRegistry);
     MLIRContext threadCtx(threadRegistry);
     threadCtx.getDiagEngine().registerHandler([](Diagnostic &diag) {});
-    
+
     // Parse the serialized module in this thread's context
-    OwningOpRef<ModuleOp> threadSource = 
+    OwningOpRef<ModuleOp> threadSource =
         parseSourceString<ModuleOp>(sourceModuleStr, &threadCtx);
-    if (!threadSource) return result;
-    
+    if (!threadSource)
+      return result;
+
     // Set up pipelines for this thread
-    PassManager threadApplicability(&threadCtx, 
+    PassManager threadApplicability(&threadCtx,
                                     PassManager::getAnyOpAnchorName(),
                                     PassManager::Nesting::Implicit);
-    PassManager threadCompilation(&threadCtx, 
-                                  PassManager::getAnyOpAnchorName(),
+    PassManager threadCompilation(&threadCtx, PassManager::getAnyOpAnchorName(),
                                   PassManager::Nesting::Implicit);
-    
+
     rock::buildKernelPipeline(threadApplicability, applicabilityOpts);
     rock::buildKernelPipeline(threadCompilation, compilationKernOpts);
     rock::buildBackendPipeline(threadCompilation, backendOpts);
-    
+
     StringAttr perfConfigAttr = StringAttr::get(&threadCtx, result.perfConfig);
-    
+
     // Helper to copy IR with perf config set
-    auto copyIRThread = [&](ModuleOp src, StringAttr attr) -> OwningOpRef<ModuleOp> {
+    auto copyIRThread = [&](ModuleOp src,
+                            StringAttr attr) -> OwningOpRef<ModuleOp> {
       OwningOpRef<ModuleOp> copy = cast<ModuleOp>(src->clone());
       copy->walk([&attr](rock::RockGemmWrapperInterface op) {
         op->setAttr("perf_config", attr);
@@ -587,74 +590,77 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       });
       return copy;
     };
-    
+
     // Applicability check
-    OwningOpRef<ModuleOp> applicabilityCopy = 
+    OwningOpRef<ModuleOp> applicabilityCopy =
         copyIRThread(threadSource.get(), perfConfigAttr);
     if (!rock::isModuleFusible(applicabilityCopy.get(), result.perfConfig)) {
       return result; // Not applicable
     }
-    
+
     if (failed(threadApplicability.run(applicabilityCopy.get()))) {
       return result; // Not applicable
     }
-    
+
     result.isApplicable = true;
-    
+
     // Extract block and grid sizes
     for (auto &fnName : kernelFuncNames) {
       auto tunedFunc = applicabilityCopy->lookupSymbol<func::FuncOp>(fnName);
-      if (!tunedFunc) return result;
+      if (!tunedFunc)
+        return result;
       result.blockSizes.push_back(
           tunedFunc->getAttrOfType<IntegerAttr>("block_size").getInt());
       result.gridSizes.push_back(
           tunedFunc->getAttrOfType<IntegerAttr>("grid_size").getInt());
     }
-    
+
     // Compilation
-    OwningOpRef<ModuleOp> compileCopy = 
+    OwningOpRef<ModuleOp> compileCopy =
         copyIRThread(threadSource.get(), perfConfigAttr);
     if (failed(threadCompilation.run(compileCopy.get()))) {
       std::lock_guard<std::mutex> lock(outputMutex);
-      llvm::errs() << "Backend pipeline failed for config: " 
+      llvm::errs() << "Backend pipeline failed for config: "
                    << result.perfConfig << "\n";
       return result;
     }
-    
+
     result.compilationSucceeded = true;
-    
+
     // Extract binaries
     for (const auto &fnName : kernelFuncNames) {
-      auto binary = compileCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
-      if (!binary) return result;
-      result.hipModules.push_back(
-          cast<gpu::ObjectAttr>(binary.getObjects()[0])
-              .getObject()
-              .getValue()
-              .str());
+      auto binary =
+          compileCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
+      if (!binary)
+        return result;
+      result.hipModules.push_back(cast<gpu::ObjectAttr>(binary.getObjects()[0])
+                                      .getObject()
+                                      .getValue()
+                                      .str());
     }
-    
+
     return result;
   };
 
   // Launch parallel compilation tasks
   {
     std::atomic<size_t> nextIdx{0};
-    
+
     // Thread pool pattern
     auto worker = [&]() {
       while (true) {
         size_t idx = nextIdx.fetch_add(1);
-        if (idx >= configs.size()) break;
+        if (idx >= configs.size())
+          break;
         compilationResults[idx] = compileConfig(idx);
       }
     };
-    
+
     std::vector<std::thread> threads;
     for (unsigned i = 0; i < numThreads; ++i) {
       threads.emplace_back(worker);
     }
-    
+
     for (auto &t : threads) {
       t.join();
     }
@@ -663,21 +669,21 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   // Sequential benchmarking phase (must be sequential for accurate timing)
   for (const auto &result : compilationResults) {
     llvm::outs() << result.perfConfig << "\t";
-    
+
     if (!result.isApplicable) {
       llvm::outs() << "N/A\n";
       continue;
     }
-    
+
     if (!result.compilationSucceeded) {
       llvm::outs() << "COMPILE_FAILED\n";
       continue;
     }
-    
+
     FailureOr<double> timing = benchmarkKernels(
         result.hipModules, kernelFuncNames, result.blockSizes, result.gridSizes,
         dataType, hostBuffers, gpuBuffers, bufferLengths, benchmarkParams);
-    
+
     if (failed(timing)) {
       llvm::errs() << "Kernel execution failed\n";
       return failure();

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -671,7 +671,8 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     // Thread pool with work stealing pattern
     auto worker = [&]() {
       while (true) {
-        // Check if any compilation has failed (relaxed: just an optimization hint)
+        // Check if any compilation has failed (relaxed: just an optimization
+        // hint)
         if (compilationFailed.load(std::memory_order_relaxed))
           break;
 

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Support/SourceMgr.h"
 
 #include <atomic>
+#include <cassert>
 #include <chrono>
 #include <cstdlib>
 #include <future>
@@ -263,10 +264,15 @@ struct BenchmarkParams {
   bool showStats;
 };
 
+enum class CompilationStatus {
+  NotApplicable,      // Config not applicable for this kernel
+  CompilationFailed,  // Config applicable but compilation failed
+  Success             // Successfully compiled
+};
+
 struct CompilationResult {
   SmallString<64> perfConfig;
-  bool isApplicable = false;
-  bool compilationSucceeded = false;
+  CompilationStatus status = CompilationStatus::NotApplicable;
   SmallVector<std::string> hipModules;
   SmallVector<uint32_t> blockSizes;
   SmallVector<uint32_t> gridSizes;
@@ -538,6 +544,9 @@ static LogicalResult runTuningLoop(ModuleOp source) {
                             : std::thread::hardware_concurrency();
   if (numThreads == 0)
     numThreads = 4; // fallback
+  
+  // Don't create more threads than configs to compile
+  numThreads = std::min(numThreads, static_cast<unsigned>(configs.size()));
 
   // Serialize source module once (shared by all threads for cloning)
   std::string sourceModuleStr;
@@ -548,6 +557,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   // Parallel compilation phase
   std::vector<CompilationResult> compilationResults(configs.size());
   std::mutex outputMutex; // For thread-safe console output
+  std::atomic<bool> compilationFailed{false}; // Flag to signal early termination
 
   auto compileConfig = [&](size_t idx) -> CompilationResult {
     CompilationResult result;
@@ -595,20 +605,23 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     OwningOpRef<ModuleOp> applicabilityCopy =
         copyIRThread(threadSource.get(), perfConfigAttr);
     if (!rock::isModuleFusible(applicabilityCopy.get(), result.perfConfig)) {
-      return result; // Not applicable
+      result.status = CompilationStatus::NotApplicable;
+      return result;
     }
 
     if (failed(threadApplicability.run(applicabilityCopy.get()))) {
-      return result; // Not applicable
+      result.status = CompilationStatus::NotApplicable;
+      return result;
     }
-
-    result.isApplicable = true;
 
     // Extract block and grid sizes
     for (auto &fnName : kernelFuncNames) {
       auto tunedFunc = applicabilityCopy->lookupSymbol<func::FuncOp>(fnName);
-      if (!tunedFunc)
+      if (!tunedFunc) {
+        result.status = CompilationStatus::CompilationFailed;
+        compilationFailed.store(true);
         return result;
+      }
       result.blockSizes.push_back(
           tunedFunc->getAttrOfType<IntegerAttr>("block_size").getInt());
       result.gridSizes.push_back(
@@ -622,23 +635,27 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       std::lock_guard<std::mutex> lock(outputMutex);
       llvm::errs() << "Backend pipeline failed for config: "
                    << result.perfConfig << "\n";
+      result.status = CompilationStatus::CompilationFailed;
+      compilationFailed.store(true);
       return result;
     }
-
-    result.compilationSucceeded = true;
 
     // Extract binaries
     for (const auto &fnName : kernelFuncNames) {
       auto binary =
           compileCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
-      if (!binary)
+      if (!binary) {
+        result.status = CompilationStatus::CompilationFailed;
+        compilationFailed.store(true);
         return result;
+      }
       result.hipModules.push_back(cast<gpu::ObjectAttr>(binary.getObjects()[0])
                                       .getObject()
                                       .getValue()
                                       .str());
     }
 
+    result.status = CompilationStatus::Success;
     return result;
   };
 
@@ -649,9 +666,14 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     // Thread pool pattern
     auto worker = [&]() {
       while (true) {
+        // Check if any compilation has failed
+        if (compilationFailed.load())
+          break;
+        
         size_t idx = nextIdx.fetch_add(1);
         if (idx >= configs.size())
           break;
+        
         compilationResults[idx] = compileConfig(idx);
       }
     };
@@ -666,19 +688,26 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     }
   }
 
+  // Check if any compilation failed and terminate early
+  if (compilationFailed.load()) {
+    llvm::errs() << "Compilation failed for one or more configs. Terminating.\n";
+    return failure();
+  }
+
   // Sequential benchmarking phase (must be sequential for accurate timing)
+  // Note: Due to early exit on compilation failures, only NotApplicable and
+  // Success statuses are possible here.
   for (const auto &result : compilationResults) {
     llvm::outs() << result.perfConfig << "\t";
 
-    if (!result.isApplicable) {
+    if (result.status == CompilationStatus::NotApplicable) {
       llvm::outs() << "N/A\n";
       continue;
     }
 
-    if (!result.compilationSucceeded) {
-      llvm::outs() << "COMPILE_FAILED\n";
-      continue;
-    }
+    // At this point, status must be Success (we exited early on any failures)
+    assert(result.status == CompilationStatus::Success &&
+           "Unexpected compilation status in benchmarking phase");
 
     FailureOr<double> timing = benchmarkKernels(
         result.hipModules, kernelFuncNames, result.blockSizes, result.gridSizes,


### PR DESCRIPTION
## Motivation

Compile all perf configs all at once using multiple threads to speed up tuning
Fixes https://github.com/ROCm/rocMLIR-internal/issues/2104

## Technical Details

LLVM/MLIR does have support for parallelFor 

https://github.com/ROCm/rocMLIR/blob/develop/external/llvm-project/mlir/include/mlir/IR/Threading.h 

But for some reason it wasn't playing nice with MLIRContext. MLIRContext.cpp has some weird logic that disables multi-threading globally. 

e.g. here it should be `LLVM_ENABLE_THREADS` . There is no definition for `MLIR_ENABLE_THREADS` anywhere.

https://github.com/ROCm/rocMLIR/blob/71f73a70a054019ca44975908a4273b09ada2930/external/llvm-project/mlir/lib/IR/MLIRContext.cpp#L79 

Upstream MLIR has that change. But for some reason we don't. 

Even after making that change MLIRContext seems to statically disabling multi-threading globally. 
https://github.com/ROCm/rocMLIR/blob/71f73a70a054019ca44975908a4273b09ada2930/external/llvm-project/mlir/lib/IR/MLIRContext.cpp#L80


Therefore i had to implement parallelFor manually. 

## Test Plan

compare tuning time on CI 

## Selected-gemm-configs

| Selected-gemm-configs | Develop | This PR | speed up |
|----------------------|---------|---------|----------|
| 8xGfx90a | 3m29s | 31s | 6.741935 |
| Navi3x | 3m19s | 27s | 7.37037 |
| Navi4x | 6m30s | 40s | 9.75 |

## Selected-Conv-configs

| Selected-Conv-configs | Develop | This PR | Speed Up |
|----------------------|---------|---------|----------|
| 8xGfx90a | 3m52s | 28s | 8.285714 |
| Navi3x | 4m35s | 26s | 10.57692 |
| Navi4x | 7m28s | 41s | 10.92683 |

## Selected-attention-configs

| Selected-attention-configs | Develop | This PR | Speed Up |
|---------------------------|---------|---------|----------|
| 8xGfx90a | 10m7s | 2m7s | 4.779528 |
| Navi3x | 5m1s | 1m55s | 2.617391 |
| Navi4x | 3m10s | 51s | 3.72549 |

## Test Result
Here are the measurements on MI355X server with 384 threads on `selected-{.*}-configs` used in PR CI. 

| Config | Develop (seconds) | This PR  | Speed up |
|---|---|---|---| 
| Selected-gemm-configs |34m56s | 34.044s | > 50 |
| Selected-conv-configs | 39m40s| 35.846s | > 50 | 
| Selected-attention-configs |199m | 4m0.156s | ~ 50 | 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
