### PR TITLE
Async load support for gfx1250 (no full support due to missing WMMA)

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -1086,6 +1086,27 @@ def AMDGPU_GatherToLDSOp :
   let hasCanonicalizer = 1;
 }
 
+def AMDGPU_AsyncLoadToLDSOp
+    : AMDGPU_Op<"async_load_to_lds", [AttrSizedOperandSegments]>,
+      Arguments<(ins Arg<AnyMemRef, "buffer to load from", [MemRead]>:$src,
+          Variadic<Index>:$srcIndices,
+          Arg<AnyMemRef, "buffer to write to", [MemWrite]>:$dst,
+          Variadic<Index>:$dstIndices, TypeAttr:$transferType)>,
+      Results<(outs)> {
+  let summary = "MLIR wrapper for gfx1250+ async load to LDS instructions";
+  let description = [{
+    The `amdgpu.async_load_to_lds` op is a wrapper around the `global_load_async_to_lds` instructions.
+    Compared to the `gather_to_lds` instruction, this instruction is asynchronous and also does not
+    behave like a gather, since each thread can have its own LDS address.
+
+    Note: only supported on gfx1250+
+  }];
+  let assemblyFormat = [{
+    $src `[` $srcIndices `]` `,` $dst `[` $dstIndices `]` attr-dict `:` $transferType `,` type($src) `,` type($dst)
+  }];
+  let hasVerifier = 1;
+}
+
 def AMDGPU_TransposeLoadOp :
     AMDGPU_Op<"transpose_load", [SameVariadicOperandSize]>,
     Arguments<(ins Arg<AnyMemRef, "buffer to transpose load from", [MemRead]>:$src, Variadic<Index>:$srcIndices)>,

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -43,6 +43,7 @@ constexpr Chipset kGfx908 = Chipset(9, 0, 8);
 constexpr Chipset kGfx90a = Chipset(9, 0, 0xa);
 constexpr Chipset kGfx942 = Chipset(9, 4, 2);
 constexpr Chipset kGfx950 = Chipset(9, 5, 0);
+constexpr Chipset kGfx1250 = Chipset(12, 5, 0);
 
 /// Convert an unsigned number `val` to i32.
 static Value convertUnsignedToI32(ConversionPatternRewriter &rewriter,
@@ -1440,6 +1441,23 @@ struct TransposeLoadOpLowering
   }
 };
 
+static int getLoadWidth(Type transferType) {
+  // TODO: instead of only transfering one element per thread, we could
+  // augment it to transfer multiple elements per thread by issuing multiple
+  // `global_load_lds` instructions.
+  if (auto transferVectorType = dyn_cast<VectorType>(transferType)) {
+    assert((transferVectorType.getNumElements() *
+            transferVectorType.getElementTypeBitWidth()) >= 8 &&
+           "transfer vector type must have at least 8 bits");
+    return (transferVectorType.getNumElements() *
+            transferVectorType.getElementTypeBitWidth()) /
+           8;
+  }
+  assert(transferType.getIntOrFloatBitWidth() >= 8 &&
+         "transfer type must have at least 8 bits");
+  return transferType.getIntOrFloatBitWidth() / 8;
+}
+
 struct GatherToLDSOpLowering : public ConvertOpToLLVMPattern<GatherToLDSOp> {
   GatherToLDSOpLowering(const LLVMTypeConverter &converter, Chipset chipset)
       : ConvertOpToLLVMPattern<GatherToLDSOp>(converter), chipset(chipset) {}
@@ -1456,19 +1474,7 @@ struct GatherToLDSOpLowering : public ConvertOpToLLVMPattern<GatherToLDSOp> {
 
     auto srcMemRefType = cast<MemRefType>(op.getSrc().getType());
     auto dstMemRefType = cast<MemRefType>(op.getDst().getType());
-
-    // TODO: instead of only transfering one element per thread, we could
-    // augment it to transfer multiple elements per thread by issuing multiple
-    // `global_load_lds` instructions.
-    Type transferType = op.getTransferType();
-    int loadWidth = [&]() -> int {
-      if (auto transferVectorType = dyn_cast<VectorType>(transferType)) {
-        return (transferVectorType.getNumElements() *
-                transferVectorType.getElementTypeBitWidth()) /
-               8;
-      }
-      return transferType.getIntOrFloatBitWidth() / 8;
-    }();
+    int loadWidth = getLoadWidth(op.getTransferType());
 
     // Currently only 1, 2, 4, 12 and 16 byte loads are supported.
     if (!llvm::is_contained({1, 2, 4, 12, 16}, loadWidth))
@@ -1491,6 +1497,66 @@ struct GatherToLDSOpLowering : public ConvertOpToLLVMPattern<GatherToLDSOp> {
         /*aux=*/rewriter.getI32IntegerAttr(0), ArrayAttr{}, ArrayAttr{},
         ArrayAttr{});
 
+    return success();
+  }
+};
+
+struct AsyncLoadToLDSOpLowering
+    : public ConvertOpToLLVMPattern<AsyncLoadToLDSOp> {
+  AsyncLoadToLDSOpLowering(const LLVMTypeConverter &converter, Chipset chipset)
+      : ConvertOpToLLVMPattern<AsyncLoadToLDSOp>(converter), chipset(chipset) {}
+
+  Chipset chipset;
+
+  template <typename OpTy>
+  static void emitLoadOp(mlir::PatternRewriter &rewriter, mlir::Operation *op,
+                         mlir::Value srcPtr, mlir::Value dstPtr) {
+    auto zero = rewriter.getI32IntegerAttr(0);
+    rewriter.replaceOpWithNewOp<OpTy>(op, srcPtr, dstPtr, zero, zero,
+                                      mlir::ArrayAttr{}, mlir::ArrayAttr{},
+                                      mlir::ArrayAttr{});
+  }
+
+  LogicalResult
+  matchAndRewrite(AsyncLoadToLDSOp op, AsyncLoadToLDSOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (chipset != kGfx1250)
+      return op.emitOpError("only gfx1250 is supported");
+
+    Location loc = op.getLoc();
+
+    auto srcMemRefType = cast<MemRefType>(op.getSrc().getType());
+    auto dstMemRefType = cast<MemRefType>(op.getDst().getType());
+    int loadWidth = getLoadWidth(op.getTransferType());
+
+    // Currently only 1, 4, 8 and 16 byte loads are supported.
+    if (!llvm::is_contained({1, 4, 8, 16}, loadWidth))
+      return op.emitOpError("unsupported element size: ") << loadWidth;
+
+    Value srcPtr =
+        getStridedElementPtr(rewriter, loc, srcMemRefType, adaptor.getSrc(),
+                             (adaptor.getSrcIndices()));
+    Value dstPtr =
+        getStridedElementPtr(rewriter, loc, dstMemRefType, adaptor.getDst(),
+                             (adaptor.getDstIndices()));
+
+    switch (loadWidth) {
+    case 1:
+      emitLoadOp<ROCDL::GlobalLoadAsyncToLDSB8Op>(rewriter, op, srcPtr, dstPtr);
+      break;
+    case 4:
+      emitLoadOp<ROCDL::GlobalLoadAsyncToLDSB32Op>(rewriter, op, srcPtr,
+                                                   dstPtr);
+      break;
+    case 8:
+      emitLoadOp<ROCDL::GlobalLoadAsyncToLDSB64Op>(rewriter, op, srcPtr,
+                                                   dstPtr);
+      break;
+    case 16:
+      emitLoadOp<ROCDL::GlobalLoadAsyncToLDSB128Op>(rewriter, op, srcPtr,
+                                                    dstPtr);
+      break;
+    }
     return success();
   }
 };
@@ -2157,6 +2223,7 @@ void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
            WMMAOpLowering, ExtPackedFp8OpLowering, ScaledExtPackedOpLowering,
            PackedScaledTruncOpLowering, PackedTrunc2xFp8OpLowering,
            PackedStochRoundFp8OpLowering, GatherToLDSOpLowering,
-           TransposeLoadOpLowering, AMDGPUPermlaneLowering>(converter, chipset);
+           AsyncLoadToLDSOpLowering, TransposeLoadOpLowering,
+           AMDGPUPermlaneLowering>(converter, chipset);
   patterns.add<AMDGPUSwizzleBitModeLowering>(converter);
 }

--- a/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -606,6 +606,39 @@ LogicalResult GatherToLDSOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// AsyncLoadToLDSOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AsyncLoadToLDSOp::verify() {
+  MemRefType srcType = cast<MemRefType>(getSrc().getType());
+  MemRefType dstType = cast<MemRefType>(getDst().getType());
+
+  auto elemType = srcType.getElementType();
+  // Check $src and $dst element types are the same.
+  if (elemType != dstType.getElementType())
+    return emitOpError("source and destination element types must match");
+
+  auto transferType = getTransferType();
+  int transferSize;
+  if (auto vectorTransfer = dyn_cast<VectorType>(transferType)) {
+    transferSize = vectorTransfer.getNumElements() *
+                   vectorTransfer.getElementTypeBitWidth();
+  } else {
+    transferSize = transferType.getIntOrFloatBitWidth();
+  }
+  if (!llvm::is_contained({8, 32, 64, 128}, transferSize))
+    return emitOpError("Transfering type size must be 8, 32, 64 or 128 bits");
+
+  if (!hasGlobalMemorySpace(srcType.getMemorySpace()))
+    return emitOpError("source memory address space must be global");
+
+  if (!hasWorkgroupMemorySpace(dstType.getMemorySpace()))
+    return emitOpError("destination memory address space must be Workgroup");
+
+  return success();
+}
+
 namespace {
 /// If the source/target of a GatherToLDSOp is a CastOp that only removes static
 /// information or changes layout, the cast can be skipped.

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/load_lds-gfx1250.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/load_lds-gfx1250.mlir
@@ -1,0 +1,245 @@
+// RUN: mlir-opt %s -convert-amdgpu-to-rocdl=chipset=gfx1250 -split-input-file -verify-diagnostics | FileCheck %s
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+
+// CHECK-LABEL: func.func @global_load_to_rocdl_f32
+// CHECK-SAME: (%[[ARG0:.*]]: memref<128x72xf32, 1>)
+func.func @global_load_to_rocdl_f32(%global : memref<128x72xf32, #gpu_global_addrspace>) {
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c32 = arith.constant 32 : index
+  %alloc = memref.alloc() : memref<64x64xf32, #gpu_lds_addrspace>
+  // CHECK: %[[GLOBAL_DESC:.*]] = builtin.unrealized_conversion_cast %[[ARG0]]
+
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: %[[IC0:.*]] = builtin.unrealized_conversion_cast %c0 : index to i64
+  // CHECK: %[[C12:.*]] = arith.constant 12 : index
+  // CHECK: %[[IC12:.*]] = builtin.unrealized_conversion_cast %[[C12]]
+  // CHECK: %[[C32:.*]] = arith.constant 32 : index
+  // CHECK: %[[IC32:.*]] = builtin.unrealized_conversion_cast %[[C32]]
+
+  // CHECK: %[[ALLOC:.*]] = memref.alloc()
+  // CHECK: %[[LDS_DESC:.*]] = builtin.unrealized_conversion_cast
+  // CHECK: %[[GLOBAL_BASE:.*]] = llvm.extractvalue %[[GLOBAL_DESC]][1]
+
+  // CHECK: %[[C72:.*]] = llvm.mlir.constant(72 : index) : i64
+  // CHECK: %[[MUL:.*]] = llvm.mul %[[IC12]], %[[C72]] : i64
+  // CHECK: %[[SRC_OFFSET:.*]] = llvm.add %[[MUL]], %[[IC0]] : i64
+
+  // CHECK: %[[GLOBAL_PTR:.*]] = llvm.getelementptr %[[GLOBAL_BASE]][%[[SRC_OFFSET]]]
+  // CHECK: %[[LDS_BASE:.*]] = llvm.extractvalue %[[LDS_DESC]][1]
+
+  // CHECK: %[[C64:.*]] = llvm.mlir.constant(64 : index) : i64
+  // CHECK: %[[MUL_2:.*]] = llvm.mul %[[IC32]], %[[C64]] : i64
+  // CHECK: %[[DST_OFFSET:.*]] = llvm.add %[[MUL_2]], %[[IC0]] : i64
+
+  // CHECK: %[[LDS_PTR:.*]] = llvm.getelementptr %[[LDS_BASE]][%[[DST_OFFSET]]]
+  // CHECK: rocdl.global.load.async.to.lds.b32 %[[GLOBAL_PTR]], %[[LDS_PTR]]
+  amdgpu.async_load_to_lds %global[%c12, %c0], %alloc[%c32, %c0]
+    : f32, memref<128x72xf32, #gpu_global_addrspace>, memref<64x64xf32, #gpu_lds_addrspace>
+  func.return
+}
+
+// -----
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+// CHECK-LABEL: func.func @global_load_to_rocdl_i8
+// CHECK-SAME: (%[[ARG0:.*]]: memref<128x72xi8, 1>)
+func.func @global_load_to_rocdl_i8(%global : memref<128x72xi8, #gpu_global_addrspace>) {
+  // CHECK: %[[GLOBAL_DESC:.*]] = builtin.unrealized_conversion_cast %[[ARG0]]
+
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: %[[IC0:.*]] = builtin.unrealized_conversion_cast %c0 : index to i64
+  // CHECK: %[[C12:.*]] = arith.constant 12 : index
+  // CHECK: %[[IC12:.*]] = builtin.unrealized_conversion_cast %[[C12]]
+  // CHECK: %[[C32:.*]] = arith.constant 32 : index
+  // CHECK: %[[IC32:.*]] = builtin.unrealized_conversion_cast %[[C32]]
+
+  // CHECK: %[[ALLOC:.*]] = memref.alloc()
+  // CHECK: %[[LDS_DESC:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]]
+  // CHECK: %[[GLOBAL_BASE:.*]] = llvm.extractvalue %[[GLOBAL_DESC]][1]
+
+  // CHECK: %[[C72:.*]] = llvm.mlir.constant(72 : index) : i64
+  // CHECK: %[[MUL:.*]] = llvm.mul %[[IC12]], %[[C72]] : i64
+  // CHECK: %[[SRC_OFFSET:.*]] = llvm.add %[[MUL]], %[[IC0]] : i64
+
+  // CHECK: %[[GLOBAL_PTR:.*]] = llvm.getelementptr %[[GLOBAL_BASE]][%[[SRC_OFFSET]]]
+  // CHECK: %[[LDS_BASE:.*]] = llvm.extractvalue %[[LDS_DESC]][1]
+
+  // CHECK: %[[C64:.*]] = llvm.mlir.constant(64 : index) : i64
+  // CHECK: %[[MUL_2:.*]] = llvm.mul %[[IC32]], %[[C64]] : i64
+  // CHECK: %[[DST_OFFSET:.*]] = llvm.add %[[MUL_2]], %[[IC0]] : i64
+
+  // CHECK: %[[LDS_PTR:.*]] = llvm.getelementptr %[[LDS_BASE]][%[[DST_OFFSET]]]
+  // CHECK: rocdl.global.load.async.to.lds.b8 %[[GLOBAL_PTR]], %[[LDS_PTR]]
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c32 = arith.constant 32 : index
+  %alloc = memref.alloc() : memref<64x64xi8, #gpu_lds_addrspace>
+  amdgpu.async_load_to_lds %global[%c12, %c0], %alloc[%c32, %c0]
+    : i8, memref<128x72xi8, #gpu_global_addrspace>, memref<64x64xi8, #gpu_lds_addrspace>
+  func.return
+}
+
+// -----
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+// CHECK-LABEL: func.func @global_load_to_rocdl_f64
+// CHECK-SAME: (%[[ARG0:.*]]: memref<128x72xf64, 1>)
+func.func @global_load_to_rocdl_f64(%global : memref<128x72xf64, #gpu_global_addrspace>) {
+  // CHECK: %[[GLOBAL_DESC:.*]] = builtin.unrealized_conversion_cast %[[ARG0]]
+
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: %[[IC0:.*]] = builtin.unrealized_conversion_cast %c0 : index to i64
+  // CHECK: %[[C12:.*]] = arith.constant 12 : index
+  // CHECK: %[[IC12:.*]] = builtin.unrealized_conversion_cast %[[C12]]
+  // CHECK: %[[C32:.*]] = arith.constant 32 : index
+  // CHECK: %[[IC32:.*]] = builtin.unrealized_conversion_cast %[[C32]]
+
+  // CHECK: %[[ALLOC:.*]] = memref.alloc()
+  // CHECK: %[[LDS_DESC:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]]
+  // CHECK: %[[GLOBAL_BASE:.*]] = llvm.extractvalue %[[GLOBAL_DESC]][1]
+
+  // CHECK: %[[C72:.*]] = llvm.mlir.constant(72 : index) : i64
+  // CHECK: %[[MUL:.*]] = llvm.mul %[[IC12]], %[[C72]] : i64
+  // CHECK: %[[SRC_OFFSET:.*]] = llvm.add %[[MUL]], %[[IC0]] : i64
+
+  // CHECK: %[[GLOBAL_PTR:.*]] = llvm.getelementptr %[[GLOBAL_BASE]][%[[SRC_OFFSET]]]
+  // CHECK: %[[LDS_BASE:.*]] = llvm.extractvalue %[[LDS_DESC]][1]
+
+  // CHECK: %[[C64:.*]] = llvm.mlir.constant(64 : index) : i64
+  // CHECK: %[[MUL_2:.*]] = llvm.mul %[[IC32]], %[[C64]] : i64
+  // CHECK: %[[DST_OFFSET:.*]] = llvm.add %[[MUL_2]], %[[IC0]] : i64
+
+  // CHECK: %[[LDS_PTR:.*]] = llvm.getelementptr %[[LDS_BASE]][%[[DST_OFFSET]]]
+  // CHECK: rocdl.global.load.async.to.lds.b64 %[[GLOBAL_PTR]], %[[LDS_PTR]]
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c32 = arith.constant 32 : index
+  %alloc = memref.alloc() : memref<64x64xf64, #gpu_lds_addrspace>
+  amdgpu.async_load_to_lds %global[%c12, %c0], %alloc[%c32, %c0]
+    : f64, memref<128x72xf64, #gpu_global_addrspace>, memref<64x64xf64, #gpu_lds_addrspace>
+  func.return
+}
+
+// -----
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+// CHECK-LABEL: func.func @global_load_to_rocdl_vec
+// CHECK-SAME: (%[[ARG0:.*]]: memref<128x72xi16, 1>)
+func.func @global_load_to_rocdl_vec(%global : memref<128x72xi16, #gpu_global_addrspace>) {
+  // CHECK: %[[GLOBAL_DESC:.*]] = builtin.unrealized_conversion_cast %[[ARG0]]
+
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: %[[IC0:.*]] = builtin.unrealized_conversion_cast %c0 : index to i64
+  // CHECK: %[[C12:.*]] = arith.constant 12 : index
+  // CHECK: %[[IC12:.*]] = builtin.unrealized_conversion_cast %[[C12]]
+  // CHECK: %[[C32:.*]] = arith.constant 32 : index
+  // CHECK: %[[IC32:.*]] = builtin.unrealized_conversion_cast %[[C32]]
+
+  // CHECK: %[[ALLOC:.*]] = memref.alloc()
+  // CHECK: %[[LDS_DESC:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]]
+  // CHECK: %[[GLOBAL_BASE:.*]] = llvm.extractvalue %[[GLOBAL_DESC]][1]
+
+  // CHECK: %[[C72:.*]] = llvm.mlir.constant(72 : index) : i64
+  // CHECK: %[[MUL:.*]] = llvm.mul %[[IC12]], %[[C72]] : i64
+  // CHECK: %[[SRC_OFFSET:.*]] = llvm.add %[[MUL]], %[[IC0]] : i64
+
+  // CHECK: %[[GLOBAL_PTR:.*]] = llvm.getelementptr %[[GLOBAL_BASE]][%[[SRC_OFFSET]]]
+  // CHECK: %[[LDS_BASE:.*]] = llvm.extractvalue %[[LDS_DESC]][1]
+
+  // CHECK: %[[C128:.*]] = llvm.mlir.constant(128 : index) : i64
+  // CHECK: %[[MUL_2:.*]] = llvm.mul %[[IC32]], %[[C128]] : i64
+  // CHECK: %[[DST_OFFSET:.*]] = llvm.add %[[MUL_2]], %[[IC0]] : i64
+
+  // CHECK: %[[LDS_PTR:.*]] = llvm.getelementptr %[[LDS_BASE]][%[[DST_OFFSET]]]
+  // CHECK: rocdl.global.load.async.to.lds.b128 %[[GLOBAL_PTR]], %[[LDS_PTR]]
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c32 = arith.constant 32 : index
+  %alloc = memref.alloc() : memref<64x128xi16, #gpu_lds_addrspace>
+  amdgpu.async_load_to_lds %global[%c12, %c0], %alloc[%c32, %c0]
+    : vector<8 x i16>, memref<128x72xi16, #gpu_global_addrspace>, memref<64x128xi16, #gpu_lds_addrspace>
+  func.return
+}
+
+// -----
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+// CHECK-LABEL: func.func @global_load_to_rocdl_dynamic_indices
+// CHECK-SAME: (%[[ARG0:.*]]: memref<512xi32, 1>, %[[SRC_IDX:.*]]: index, %[[DST_IDX:.*]]: index)
+func.func @global_load_to_rocdl_dynamic_indices(%global : memref<512xi32, #gpu_global_addrspace>, %src_idx : index, %dst_idx : index) {
+  // CHECK: %[[DSTIDX_CAST:.*]] = builtin.unrealized_conversion_cast %[[DST_IDX]]
+  // CHECK: %[[SRCIDX_CAST:.*]] = builtin.unrealized_conversion_cast %[[SRC_IDX]]
+  // CHECK: %[[GLOBAL_DESC:.*]] = builtin.unrealized_conversion_cast %[[ARG0]]
+  // CHECK: %[[ALLOC:.*]] = memref.alloc()
+  // CHECK: %[[LDS_DESC:.*]] = builtin.unrealized_conversion_cast %[[ALLOC]]
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: %[[C0_I64:.*]] = builtin.unrealized_conversion_cast %[[C0]] : index to i64
+  // CHECK: %[[GLOBAL_BASE:.*]] = llvm.extractvalue %[[GLOBAL_DESC]][1]
+  // CHECK: %[[GLOBAL_PTR:.*]] = llvm.getelementptr %[[GLOBAL_BASE]][%[[SRCIDX_CAST]]]
+  // CHECK: %[[LDS_BASE:.*]] = llvm.extractvalue %[[LDS_DESC]][1]
+  // CHECK: %[[C64:.*]] = llvm.mlir.constant(64 : index) : i64
+  // CHECK: %[[DSTIDX:.*]] = llvm.mul %[[DSTIDX_CAST]], %[[C64]] : i64
+  // CHECK: %[[DSTIDX1:.*]] = llvm.add %[[DSTIDX]], %[[C0_I64]] : i64
+  // CHECK: %[[LDS_PTR:.*]] = llvm.getelementptr %[[LDS_BASE]][%[[DSTIDX1]]]
+  // CHECK: rocdl.global.load.async.to.lds.b32 %[[GLOBAL_PTR]], %[[LDS_PTR]]
+  %alloc = memref.alloc() : memref<4x64xi32, #gpu_lds_addrspace>
+  %c0 = arith.constant 0 : index
+  amdgpu.async_load_to_lds %global[%src_idx], %alloc[%dst_idx, %c0]
+    : i32, memref<512xi32, #gpu_global_addrspace>, memref<4x64xi32, #gpu_lds_addrspace>
+  func.return
+}
+
+// -----
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+
+func.func @global_load_to_rocdl_vec_error(%global : memref<128x72xi16, #gpu_global_addrspace>) {
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c32 = arith.constant 32 : index
+  %alloc = memref.alloc() : memref<64x128xi16, #gpu_lds_addrspace>
+  // expected-error@+1 {{'amdgpu.async_load_to_lds' op Transfering type size must be 8, 32, 64 or 128 bits}}
+  amdgpu.async_load_to_lds %global[%c12, %c0], %alloc[%c32, %c0]
+    : vector<16 x i16>, memref<128x72xi16, #gpu_global_addrspace>, memref<64x128xi16, #gpu_lds_addrspace>
+  func.return
+}
+
+// -----
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+
+func.func @global_load_to_rocdl_src_not_global_error(%src : memref<128x72xf32, #gpu_lds_addrspace>) {
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c32 = arith.constant 32 : index
+  %alloc = memref.alloc() : memref<64x64xf32, #gpu_lds_addrspace>
+  // expected-error@+1 {{'amdgpu.async_load_to_lds' op source memory address space must be global}}
+  amdgpu.async_load_to_lds %src[%c12, %c0], %alloc[%c32, %c0]
+    : f32, memref<128x72xf32, #gpu_lds_addrspace>, memref<64x64xf32, #gpu_lds_addrspace>
+  func.return
+}
+
+// -----
+
+#gpu_global_addrspace = 1
+#gpu_lds_addrspace = 3
+
+func.func @global_load_to_rocdl_dst_not_workgroup_error(%global : memref<128x72xf32, #gpu_global_addrspace>) {
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c32 = arith.constant 32 : index
+  %alloc = memref.alloc() : memref<64x64xf32, #gpu_global_addrspace>
+  // expected-error@+1 {{'amdgpu.async_load_to_lds' op destination memory address space must be Workgroup}}
+  amdgpu.async_load_to_lds %global[%c12, %c0], %alloc[%c32, %c0]
+    : f32, memref<128x72xf32, #gpu_global_addrspace>, memref<64x64xf32, #gpu_global_addrspace>
+  func.return
+}

--- a/mlir/include/mlir/Dialect/Rock/IR/AmdArchDb.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/AmdArchDb.h
@@ -60,6 +60,7 @@ struct AmdArchInfo {
 AmdArchInfo lookupArchInfo(StringRef arch);
 bool isDirectToLDSSupported(GemmFeatures features);
 bool isGlobalPrefetchSupported(StringRef arch);
+bool isAsyncDirectToLDSSupported(StringRef arch);
 } // namespace rock
 } // namespace mlir
 

--- a/mlir/include/mlir/Dialect/Rock/IR/GetRockInfo.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/GetRockInfo.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -51,6 +52,10 @@ inline rock::GemmFeatures intersectGemmFeatures(rock::GemmFeatures a,
 // Get the features enabled for the specified op. These will be dependent on
 // the architecture being used, and the type of the op.
 rock::GemmFeatures getFeatures(Operation *op);
+
+// Check if a schedule version is supported by the hardware
+LogicalResult isScheduleVersionSupported(int64_t scheduleVersion,
+                                         GemmFeatures features, StringRef arch);
 
 } // End namespace rock
 } // End namespace mlir

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/Rock/IR/AmdArchDb.h"
 
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -436,6 +437,10 @@ GemmFeatures mlir::rock::AmdArchInfo::getDefaultFeatures(Type dataType) {
 bool mlir::rock::isDirectToLDSSupported(GemmFeatures features) {
   return bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b) ||
          bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
+}
+
+bool mlir::rock::isAsyncDirectToLDSSupported(StringRef arch) {
+  return arch.contains("gfx1250");
 }
 
 int64_t

--- a/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
+++ b/mlir/lib/Dialect/Rock/IR/GetRockInfo.cpp
@@ -184,3 +184,26 @@ mlir::rock::GemmFeatures mlir::rock::getFeatures(Operation *op) {
 
   return features.value();
 }
+
+LogicalResult mlir::rock::isScheduleVersionSupported(int64_t scheduleVersion,
+                                                     GemmFeatures features,
+                                                     StringRef arch) {
+  std::optional<GemmLoadTileType> maybeLoadType =
+      rock::symbolizeGemmLoadTileType(scheduleVersion);
+  if (!maybeLoadType.has_value()) {
+    LLVM_DEBUG(llvm::dbgs() << "Schedule version value is incorrect\n");
+    return failure();
+  }
+
+  auto loadType = maybeLoadType.value();
+  bool directToLDS = loadType == GemmLoadTileType::DirectToLDSDefault ||
+                     loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
+  if (directToLDS && !isDirectToLDSSupported(features) &&
+      !isAsyncDirectToLDSSupported(arch)) {
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "Requested direct to LDS but not supported by the hardware\n");
+    return failure();
+  }
+  return success();
+}

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -167,22 +167,6 @@ void AffixTuningParameters::setUtilityKernelSizes(Value arg, T utilityOp) {
   funcOp->setAttr("grid_size", gridSizeAttr);
 }
 
-static LogicalResult isScheduleVersionSupported(int64_t scheduleVersion,
-                                                GemmFeatures features) {
-  std::optional<GemmLoadTileType> maybeLoadType =
-      rock::symbolizeGemmLoadTileType(scheduleVersion);
-  if (!maybeLoadType.has_value())
-    return failure();
-
-  auto loadType = maybeLoadType.value();
-  bool directToLDS = loadType == GemmLoadTileType::DirectToLDSDefault ||
-                     loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
-  if (directToLDS && !isDirectToLDSSupported(features))
-    return failure();
-
-  return success();
-}
-
 void AffixTuningParameters::affixTuningParametersImpl(
     RockGemmWrapperInterface op) {
   OpBuilder b(op.getContext());
@@ -199,6 +183,7 @@ void AffixTuningParameters::affixTuningParametersImpl(
 
   std::optional<int64_t> scheduleVersion = maybeScheduleVersion.value();
 
+  StringRef arch = rock::getArchValue(op);
   GemmFeatures features = rock::getFeatures(op);
   if (isAccel(features)) {
     auto populateParamsAccelPtr = PopulateParamsAccel::select(features);
@@ -212,7 +197,7 @@ void AffixTuningParameters::affixTuningParametersImpl(
       validParams.gemmScheduleVersion = scheduleVersion.value();
 
     if (failed(isScheduleVersionSupported(validParams.gemmScheduleVersion,
-                                          features))) {
+                                          features, arch))) {
       op->emitError("schedule version not supported\n");
       return signalPassFailure();
     }
@@ -340,7 +325,8 @@ void AffixTuningParameters::affixTuningParametersImpl(
         attnPerfConfig.withScheduleVersion(scheduleVersion.value());
 
   if (failed(isScheduleVersionSupported(attnPerfConfig.getScheduleVersion(),
-                                        rock::getFeatures(op)))) {
+                                        rock::getFeatures(op),
+                                        rock::getArchValue(op)))) {
     op->emitError("schedule version not supported\n");
     return signalPassFailure();
   }

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -2064,6 +2064,11 @@ struct GridwiseAttentionAccelRewritePattern
     int64_t scheduleVersion = gemm0TuningParams.getScheduleVersion();
     int64_t scheduleVersionG1 = gemm1TuningParams.getScheduleVersion();
     assert(scheduleVersion == scheduleVersionG1);
+
+    // Check if the schedule version is supported by the hardware
+    if (failed(isScheduleVersionSupported(scheduleVersion, features, arch)))
+      return op.emitOpError("schedule version not supported");
+
     std::optional<GemmLoadTileType> maybeLoadType =
         symbolizeGemmLoadTileType(scheduleVersion);
     if (!maybeLoadType.has_value())
@@ -2072,11 +2077,6 @@ struct GridwiseAttentionAccelRewritePattern
     GemmLoadTileType loadType = maybeLoadType.value();
     bool directToLDS = loadType == GemmLoadTileType::DirectToLDSDefault ||
                        loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
-
-    // If we are using direct to LDS, we need to ensure that the
-    // hardware supports it.
-    if (directToLDS && !isDirectToLDSSupported(features))
-      return op.emitOpError("Direct to LDS is not supported by the hardware");
 
     auto accelEmitterPtrGemm0 = accel::AccelEmitter::select(
         features, elemTypeQ, elemTypeK, arch, gemm0TuningParams);
@@ -3146,6 +3146,11 @@ struct GridwiseGemmAccelRewritePattern
         math_util::integer_divide_ceil(bCopyPerThread, kpack);
 
     int64_t scheduleVersion = tuningParams.getScheduleVersion();
+
+    // Check if the schedule version is supported by the hardware
+    if (failed(isScheduleVersionSupported(scheduleVersion, features, arch)))
+      return op.emitOpError("schedule version not supported");
+
     std::optional<GemmLoadTileType> maybeLoadType =
         symbolizeGemmLoadTileType(scheduleVersion);
     if (!maybeLoadType.has_value())
@@ -3154,11 +3159,6 @@ struct GridwiseGemmAccelRewritePattern
     auto loadType = maybeLoadType.value();
     bool directToLDS = loadType == GemmLoadTileType::DirectToLDSDefault ||
                        loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
-
-    // If we are using direct to LDS, we need to ensure that the
-    // hardware supports it.
-    if (directToLDS && !isDirectToLDSSupported(features))
-      return op.emitOpError("Direct to LDS is not supported by the hardware");
 
     // Get the vector copy layout for A and B
     FailureOr<VectorDimInfo> maybeVecDimInfoA =

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -15,6 +15,8 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Rock/IR/AmdArchDb.h"
+#include "mlir/Dialect/Rock/IR/GetRockInfo.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Rock/Passes.h"
@@ -1332,6 +1334,9 @@ struct GlobalLoadToLDSRewritePattern
     bool emitOobChecks =
         !isStaticSize || !isAlwaysValid || (hasI64Idx && op.getCanReadOffEnd());
 
+    StringRef arch = rock::getArchValue(op);
+    bool asyncDirectToLDS = rock::isAsyncDirectToLDSSupported(arch);
+
     unsigned bitWidth =
         cast<ShapedType>(source.getType()).getElementTypeBitWidth();
     APInt numBits = numElemsConst * bitWidth;
@@ -1340,8 +1345,11 @@ struct GlobalLoadToLDSRewritePattern
     // using 32-bit indexing, we'll need to use buffer operations. In the
     // dynamic shape case, we'll already be in the i64 case, so we don't set
     // this.
-    bool useBufferOps = !hasI64Idx && (numBytes.trunc(32).isNegative() ||
-                                       emitOobChecks || op.getCanReadOffEnd());
+    // gfx1250 only supports global async load to LDS, so we will use buffer
+    // load only if asyncDirectToLDS is false.
+    bool useBufferOps = !asyncDirectToLDS && !hasI64Idx &&
+                        (numBytes.trunc(32).isNegative() || emitOobChecks ||
+                         op.getCanReadOffEnd());
 
     if (emitOobChecks && !useBufferOps) {
       return op->emitError(
@@ -1374,9 +1382,14 @@ struct GlobalLoadToLDSRewritePattern
           /*resetOffset=*/false);
     }
 
-    auto gaterToLDS = amdgpu::GatherToLDSOp::create(
-        b, loc, source, coords, dest, destCoords, op.getTransferType());
-    b.replaceOp(op, gaterToLDS);
+    Operation *toLDSOp =
+        asyncDirectToLDS
+            ? amdgpu::AsyncLoadToLDSOp::create(b, loc, source, coords, dest,
+                                               destCoords, op.getTransferType())
+            : amdgpu::GatherToLDSOp::create(b, loc, source, coords, dest,
+                                            destCoords, op.getTransferType());
+
+    b.replaceOp(op, toLDSOp);
     return success();
   }
 };

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -1174,6 +1174,11 @@ mlir::rock::getVectorDim(Location loc, Value matrix, Type elemType,
     auto arch = getArch(matrix.getDefiningOp());
     if (failed(arch))
       return emitError(loc) << "can't get arch\n";
+    // TODO: Implement this for WMMA.
+    StringRef archValue = rock::getArchValue(matrix.getDefiningOp());
+    if (archValue.contains("gfx1250")) {
+      return emitError(loc) << "AsyncDirectToLDS is not implemented for WMMA";
+    }
     auto features = rock::lookupArchInfo(arch.value()).defaultFeatures;
     bool directToLDS128b =
         bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b);

--- a/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
@@ -1,48 +1,55 @@
-// RUN: rocmlir-opt --rock-sugar-to-loops %s | FileCheck %s
+// RUN: sed s/##TOKEN_ARCH##/gfx942/g %s | rocmlir-opt --rock-sugar-to-loops | FileCheck %s --check-prefixes=CHECK,GFX942
+// RUN: sed s/##TOKEN_ARCH##/gfx1250/g %s | rocmlir-opt --rock-sugar-to-loops | FileCheck %s --check-prefixes=CHECK,GFX1250
 
 module {
 // CHECK-LABEL: func.func @load_scalar_in_bounds
 // CHECK-SAME: (%[[mem:.*]]: memref<192xf32>)
-func.func @load_scalar_in_bounds(%mem: memref<192xf32>) {
+func.func @load_scalar_in_bounds(%mem: memref<192xf32>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
     %c0 = arith.constant 0 : index
     %true = arith.constant true
     %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
     %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
-    // CHECK: amdgpu.gather_to_lds %[[cast]]
-    // CHECK-SAME: f32, memref<192xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX942: amdgpu.gather_to_lds %[[cast]]
+    // GFX942-SAME: f32, memref<192xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX1250: amdgpu.async_load_to_lds %[[cast]]
+    // GFX1250-SAME: f32, memref<192xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
     rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0]  if %true {transferType = f32} : memref<192xf32> -> memref<4xf32, #gpu.address_space<workgroup>>
     return
 }
 
 // CHECK-LABEL: func.func @load_scalar_in_bounds_force_oob
 // CHECK-SAME: (%[[mem:.*]]: memref<192xf32>)
-func.func @load_scalar_in_bounds_force_oob(%mem: memref<192xf32>) {
+func.func @load_scalar_in_bounds_force_oob(%mem: memref<192xf32>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
     %c0 = arith.constant 0 : index
     %true = arith.constant true
     %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
     %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
-    // CHECK: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]] : memref<192xf32, #gpu.address_space<global>> to memref<192xf32, #amdgpu.address_space<fat_raw_buffer>>
-    // CHECK: amdgpu.gather_to_lds %[[fatBuff]]
-    // CHECK-SAME: f32, memref<192xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX942: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]] : memref<192xf32, #gpu.address_space<global>> to memref<192xf32, #amdgpu.address_space<fat_raw_buffer>>
+    // GFX942: amdgpu.gather_to_lds %[[fatBuff]]
+    // GFX942-SAME: f32, memref<192xf32, #amdgpu.address_space<fat_raw_buffer>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX1250: amdgpu.async_load_to_lds %[[cast]]
+    // GFX1250-SAME: f32, memref<192xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
     rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0]  if %true {transferType = f32, canReadOffEnd} : memref<192xf32> -> memref<4xf32, #gpu.address_space<workgroup>>
     return
 }
 
 // CHECK-LABEL: func.func @load_scalar
 // CHECK-SAME: (%[[mem:.*]]: memref<f32>, %[[idx:.*]]: index)
-func.func @load_scalar_empty_mem(%mem: memref<f32>, %idx: index) {
+func.func @load_scalar_empty_mem(%mem: memref<f32>, %idx: index) attributes {kernel, arch = "##TOKEN_ARCH##"} {
     %true = arith.constant true
     %c0 = arith.constant 0 : index
     %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
     %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
-    // CHECK: amdgpu.gather_to_lds %[[cast]]
-    // CHECK-SAME: f32, memref<f32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX942: amdgpu.gather_to_lds %[[cast]]
+    // GFX942-SAME: f32, memref<f32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX1250: amdgpu.async_load_to_lds %[[cast]]
+    // GFX1250-SAME: f32, memref<f32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
     rock.global_load_to_lds %mem[] -> %lds_view[%c0] if %true {transferType = f32} 
         : memref<f32> -> memref<4xf32, #gpu.address_space<workgroup>>
     return
@@ -50,15 +57,17 @@ func.func @load_scalar_empty_mem(%mem: memref<f32>, %idx: index) {
 
 // CHECK-LABEL: func.func @load_scalar_in_bounds_large
 // CHECK-SAME: (%[[mem:.*]]: memref<1073741825xf32>)
-func.func @load_scalar_in_bounds_large(%mem: memref<1073741825xf32>) {
+func.func @load_scalar_in_bounds_large(%mem: memref<1073741825xf32>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
     %c0 = arith.constant 0 : index
     %true = arith.constant true
     %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
     %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<4xf32, #gpu.address_space<workgroup>>
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
-    // CHECK: amdgpu.gather_to_lds %[[cast]][%c0] 
-    // CHECK-SAME: f32, memref<1073741825xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX942: amdgpu.gather_to_lds %[[cast]][%c0] 
+    // GFX942-SAME: f32, memref<1073741825xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
+    // GFX1250: amdgpu.async_load_to_lds %[[cast]][%c0]
+    // GFX1250-SAME: f32, memref<1073741825xf32, #gpu.address_space<global>>, memref<4xf32, #gpu.address_space<workgroup>>
     rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0] if %true {transferType = f32, needs64BitIdx}
         : memref<1073741825xf32> -> memref<4xf32, #gpu.address_space<workgroup>>
     return
@@ -66,7 +75,7 @@ func.func @load_scalar_in_bounds_large(%mem: memref<1073741825xf32>) {
 
 // CHECK-LABEL: func.func @load_4bit_boundary_case_to_lds
 // CHECK-SAME: (%[[mem:.*]]: memref<4294967295xi4>)
-func.func @load_4bit_boundary_case_to_lds(%mem: memref<4294967295xi4>) {
+func.func @load_4bit_boundary_case_to_lds(%mem: memref<4294967295xi4>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
     %c0 = arith.constant 0 : index
     %true = arith.constant true
     %lds = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
@@ -77,10 +86,12 @@ func.func @load_4bit_boundary_case_to_lds(%mem: memref<4294967295xi4>) {
     // Forces buffer operations due to size exceeding 2GB threshold
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
-    // CHECK: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]]
-    // CHECK-SAME: memref<4294967295xi4, #gpu.address_space<global>> to memref<4294967295xi4, #amdgpu.address_space<fat_raw_buffer>>
-    // CHECK: amdgpu.gather_to_lds %[[fatBuff]]
-    // CHECK-SAME: i32, memref<4294967295xi4, #amdgpu.address_space<fat_raw_buffer>>, memref<8xi4, #gpu.address_space<workgroup>>
+    // GFX942: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]]
+    // GFX942-SAME: memref<4294967295xi4, #gpu.address_space<global>> to memref<4294967295xi4, #amdgpu.address_space<fat_raw_buffer>>
+    // GFX942: amdgpu.gather_to_lds %[[fatBuff]]
+    // GFX942-SAME: i32, memref<4294967295xi4, #amdgpu.address_space<fat_raw_buffer>>, memref<8xi4, #gpu.address_space<workgroup>>
+    // GFX1250: amdgpu.async_load_to_lds %[[cast]]
+    // GFX1250-SAME: i32, memref<4294967295xi4, #gpu.address_space<global>>, memref<8xi4, #gpu.address_space<workgroup>>
     rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0] if %true {transferType = i32}
         : memref<4294967295xi4> -> memref<8xi4, #gpu.address_space<workgroup>>
     return
@@ -88,7 +99,7 @@ func.func @load_4bit_boundary_case_to_lds(%mem: memref<4294967295xi4>) {
 
 // CHECK-LABEL: func.func @load_4bit_boundary_case_to_lds_f4E2M1FN
 // CHECK-SAME: (%[[mem:.*]]: memref<4294967295xf4E2M1FN>)
-func.func @load_4bit_boundary_case_to_lds_f4E2M1FN(%mem: memref<4294967295xf4E2M1FN>) {
+func.func @load_4bit_boundary_case_to_lds_f4E2M1FN(%mem: memref<4294967295xf4E2M1FN>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
     %c0 = arith.constant 0 : index
     %true = arith.constant true
     %lds = rock.alloc() : memref<32xi8, #gpu.address_space<workgroup>>
@@ -97,10 +108,12 @@ func.func @load_4bit_boundary_case_to_lds_f4E2M1FN(%mem: memref<4294967295xf4E2M
     // 4294967295 elements * 4 bits = 2147483648 bytes after ceiling division
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
-    // CHECK: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]]
-    // CHECK-SAME: memref<4294967295xf4E2M1FN, #gpu.address_space<global>> to memref<4294967295xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
-    // CHECK: amdgpu.gather_to_lds %[[fatBuff]]
-    // CHECK-SAME: f32, memref<4294967295xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>, memref<8xf4E2M1FN, #gpu.address_space<workgroup>>
+    // GFX942: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]]
+    // GFX942-SAME: memref<4294967295xf4E2M1FN, #gpu.address_space<global>> to memref<4294967295xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+    // GFX942: amdgpu.gather_to_lds %[[fatBuff]]
+    // GFX942-SAME: f32, memref<4294967295xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>, memref<8xf4E2M1FN, #gpu.address_space<workgroup>>
+    // GFX1250: amdgpu.async_load_to_lds %[[cast]]
+    // GFX1250-SAME: f32, memref<4294967295xf4E2M1FN, #gpu.address_space<global>>, memref<8xf4E2M1FN, #gpu.address_space<workgroup>>
     rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0] if %true {transferType = f32}
         : memref<4294967295xf4E2M1FN> -> memref<8xf4E2M1FN, #gpu.address_space<workgroup>>
     return


### PR DESCRIPTION
## Motivation

Implements https://github.com/ROCm/rocMLIR-internal/issues/2049

Note that this PR adds basic support for async loads, but because we do not support DirecToLDS on WMMA, E2E tests does not work yet. This will be addressed in https://github.com/ROCm/rocMLIR-internal/issues/2187

## Technical Details

### Flow:
For some context, the DirectToLDS flow is:

`rock.global_load_to_lds` -> `amd.gather_to_lds` -> `rocdl.load.to.lds` -> `@llvm.amdgcn.load.to.lds`

the proposed flow for async loads (gfx1250) is:

`rock.global_load_to_lds` -> `amd.async_load_to_lds` -> `rocdl.global.load.async.to.lds` -> `@llvm.amdgcn.global.load.async.to.lds`

**NOTE**: The async load in gfx1250 does not seem to behave as a gather anymore (this was the case of global load in gfx942/gfx950). 

In this PR we add `amdgpu.async_load_to_lds` with a identical functionality to `amdgpu.gather_to_lds` (i.e., gather). In a future ticket (https://github.com/ROCm/rocMLIR-internal/issues/2089) we will extend `amdgpu.async_load_to_lds` to make it behave like a normal load instead of a gather (you can check the ticket description for more details).

### Upstream PRs
Because some of them are not in external yet, I had to cherry-pick some of them:
- Async Load:
  - LLVM intrinsics: https://github.com/llvm/llvm-project/pull/151058
  - `rocdl` support: https://github.com/llvm/llvm-project/pull/165374
- Wait asynccnt:
  -  `rocdl` support (added, but not used!): https://github.com/llvm/llvm-project/pull/163533

### PR organization
This PR has 4 parts:
1. ~~`rocdl` support: Cherry-picked https://github.com/llvm/llvm-project/pull/165374 to external~~ After upstream merge we already have this in external.
2. `amdgpu` support: Added support in external, will upstream later.
3. rocMLIR support: Lower `global_load_to_lds` to `async_load_to_lds` if arch is `gfx1250`.
4. Barrier support (asynccnt wait): 
    1. ~~Cherry-picked https://github.com/llvm/llvm-project/pull/163533 to external~~ After upstream merge we already have this in external.
    2. Added support for gfx1250 in `AMDGPUToROCDL.cpp`

### DirectToLDS vs AsyncDirectToLDS
gfx1250 supports only AsyncDirectToLDS, so we now use scheduleversion=3/4 for both DirectToLDS and AsyncDirectToLDS:
- On gfx9* it implicitly means DirectToLDS
- On gfx1250 it implicitly means AsyncDirectToLDS

## Test Plan
LIT test pass, but E2E does not work yet as we do not support DirecToLDS on WMMA yet. This will be addressed in https://github.com/ROCm/rocMLIR-internal/issues/2187

## Test Result

Running on FFM succeeds:
```
$ LIT_FILTER="async_load_lds|ldsbarrier-hack-async|LLVMIR/rocdl" ninja check-mlir; LIT_FILTER="lowering_global_load_to_lds" ninja check-rocmlir
[0/1] Running the MLIR regression tests

Testing Time: 0.54s

Total Discovered Tests: 2748
  Excluded: 2744 (99.85%)
  Passed  :    4 (0.15%)

...

Testing Time: 0.27s

Total Discovered Tests: 958
  Excluded: 957 (99.90%)
  Passed  :   1 (0.10%)
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
