### PR TITLE
Add prefetch functionality for gfx1250

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/AmdArchDb.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/AmdArchDb.h
@@ -59,6 +59,7 @@ struct AmdArchInfo {
 
 AmdArchInfo lookupArchInfo(StringRef arch);
 bool isDirectToLDSSupported(GemmFeatures features);
+bool isGlobalPrefetchSupported(StringRef arch);
 } // namespace rock
 } // namespace mlir
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1059,6 +1059,26 @@ def Rock_InBoundsStoreOp
   let hasVerifier = 1;
 }
 
+// global_prefetch
+def Rock_GlobalPrefetchOp
+    : Rock_Op<"global_prefetch">,
+      Arguments<(
+          ins Arg<MemRefOf<SupportedMemoryElems>, "source memory">:$source,
+          Variadic<Index>:$sourceCoord)> {
+  let summary = "Prefetch from global memory";
+  let description = [{
+    `global_prefetch` prefetches an item from the provided memref
+    (applying no coordinate transformations), starting at `sourceCoord`. 
+
+    Note that it's ok if `sourceCoord` are out of bounds because we use Speculative Prefetch.
+  }];
+  let assemblyFormat = [{
+    $source `[` $sourceCoord `]` attr-dict
+    `:` type($source)
+  }];
+  let hasVerifier = 1;
+}
+
 // global_load
 def Rock_GlobalLoadOp
     : Rock_Op<
@@ -1263,7 +1283,7 @@ def Rock_ThreadwiseReadIntoOp
     L is the length of `%dest`, V is the maximum vectorization computed
     for MAPS.
 
-    The input to extraViews ; (the transforms on %source) must have the form
+    The input to extraViews: (the transforms on %source) must have the form
     (extraIdx0, ... , extraIdxN, iteration_number)
 
     Primarily, extraIndices would be used to pass in tid and bid. This would need
@@ -1322,6 +1342,59 @@ def Rock_ThreadwiseReadIntoOp
     attr-dict $extraViews `(` $source `)` (`[` $extraIndices^ `]`)? `->` $dest
     (`if` ` ` `[` $dynamicValidities^ `]`)?
     `:` type($source) `->` type($dest) (`,` type($validityRecord)^)?
+  }];
+  let hasVerifier = 1;
+}
+
+// threadwise_prefetch
+def Rock_ThreadwisePrefetchOp
+    : Rock_Op<"threadwise_prefetch", [DeclareOpInterfaceMethods<
+                                         RockAcceptingViewOpInterface>]>,
+      Arguments<(ins Arg<MemRefOf<SupportedMemoryElems>, "source view">:$source,
+          TransformMapArrayAttr:$extraViews, Variadic<Index>:$extraIndices,
+          UnitAttr:$forceUnroll, UnitAttr:$useIndexDiffs)> {
+  let summary = "Prefetch values from transformed source";
+
+  let description = [{
+    A high-level representation of a global prefetch loop that
+    accounts for coordinate transformations.
+
+    If `%source = rock.transform #transform_mapN %buffer`
+    (with the one transformation representing an entire sequence),
+    the operation
+
+    ```mlir
+    rock.threadwise_prefetch [#transform_mapM](%source)
+    ```
+
+    will lower to
+    ```mlir
+    %bid = rock.workgroup_id
+    %tid = rock.workitem_id
+    rock.transforming_for
+      (%args, ...) = MAPS(%bid, %tid, %c0)
+      (%_, %_, %i) = [](%c0, %c0, %c0)
+      bounds = [1, 1, L], strides = [1, 1, 1] {
+        rock.global_prefetch %buffer[%args]
+    }
+    ```
+
+    where MAPS is `[#transform_mapM, #transform_mapN]`,
+    L is the length of the upper view last dimension (number of elements).
+
+    The input to extraViews ; (the transforms on %source) must have the form
+    (extraIdx0, ... , extraIdxN, iteration_number)
+
+    Primarily, extraIndices would be used to pass in tid and bid. This would need
+    to have a matching view in [extraViews]source. The extraIndices could be used
+    to integrate loop induction vars that is outside of the op.
+    If extraIndices are used, the [extraViews]source must have the form
+    (extraIdx0, ... , extraIdxN, iteration_number).
+  }];
+
+  let assemblyFormat = [{
+    attr-dict $extraViews `(` $source `)` (`[` $extraIndices^ `]`)?
+    `:` type($source)
   }];
   let hasVerifier = 1;
 }

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -453,5 +453,5 @@ mlir::rock::AmdArchInfo::getMaxLDSVectorLength(int64_t elementBitWidth) {
 }
 
 bool mlir::rock::isGlobalPrefetchSupported(StringRef arch) {
-  return arch == "gfx1250";
+  return arch.contains("gfx1250");
 }

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -112,7 +112,18 @@ static constexpr AmdArchInfo
               /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/12,
               /*hasFp8ConversionInstrs=*/false,
               /*hasOcpFp8ConversionInstrs=*/true, /*hasScaledGemm=*/false,
-              /*maxNumXCC=*/1, /*hasLdsTransposeLoad=*/false);
+              /*maxNumXCC=*/1, /*hasLdsTransposeLoad=*/false),
+    // TODO: update with right information
+    gfx1250Info(GemmFeatures::dot | GemmFeatures::atomic_add |
+                    GemmFeatures::atomic_fmax_f32 | GemmFeatures::wmma |
+                    GemmFeatures::atomic_add_f16 |
+                    GemmFeatures::atomic_add_bf16,
+                /*waveSize=*/32, /*maxWavesPerEU*/ 16, /*totalSGPRPerEU*/ 800,
+                /*totalVGPRPerEU*/ 1536, /*totalSharedMemPerCU*/ 131072,
+                /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/12,
+                /*hasFp8ConversionInstrs=*/false,
+                /*hasOcpFp8ConversionInstrs=*/true, /*hasScaledGemm=*/false,
+                /*maxNumXCC=*/1, /*hasLdsTransposeLoad=*/false);
 
 static std::tuple<StringRef, unsigned> parseArchString(StringRef arch) {
   std::tuple<StringRef, unsigned> ret("", 0);
@@ -373,7 +384,9 @@ AmdArchInfo mlir::rock::lookupArchInfo(StringRef arch) {
     return rdna3Info;
   }
   if (major == "gfx12") {
-    return rdna4Info;
+    return llvm::StringSwitch<AmdArchInfo>(minor)
+        .Case("50", gfx1250Info)
+        .Default(rdna4Info);
   }
   auto msg = "Unsupported architecture: " + arch.str();
   llvm_unreachable(msg.c_str());
@@ -437,4 +450,8 @@ mlir::rock::AmdArchInfo::getMaxLDSVectorLength(int64_t elementBitWidth) {
   }
 
   return maxGlobalToLDSVectorLen;
+}
+
+bool mlir::rock::isGlobalPrefetchSupported(StringRef arch) {
+  return arch == "gfx1250";
 }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1916,21 +1916,40 @@ LogicalResult IndexDiffUpdateOp::verify() {
   return success();
 }
 
-template <typename Load>
-static LogicalResult verifyGlobalLoad(Load op) {
+template <typename LoadOrPrefetch>
+static LogicalResult verifyGlobalLoadAndPrefetch(LoadOrPrefetch op) {
   MemRefType sourceType = op.getSource().getType();
   size_t nDims = sourceType.getRank();
 
   if (op.getSourceCoord().size() != nDims)
-    return op.emitOpError("Expected " + Twine(nDims) + " coordinates for load");
-  if (op.getCanReadOffEnd() && nDims != 1)
-    return op.emitOpError("can only have one dimension in canReadOffEnd loads");
+    return op.emitOpError("Expected " + Twine(nDims) + " coordinates");
   Attribute memSpaceAttr = sourceType.getMemorySpace();
   auto gpuMemSpaceAttr = dyn_cast_or_null<gpu::AddressSpaceAttr>(memSpaceAttr);
   if (memSpaceAttr && (!gpuMemSpaceAttr ||
                        gpuMemSpaceAttr.getValue() != gpu::AddressSpace::Global))
     return op.emitOpError("Source memref must live in global memory");
   return success();
+}
+
+template <typename Load>
+static LogicalResult verifyGlobalLoad(Load op) {
+  if (failed(verifyGlobalLoadAndPrefetch(op)))
+    return failure();
+
+  MemRefType sourceType = op.getSource().getType();
+  size_t nDims = sourceType.getRank();
+
+  if (op.getCanReadOffEnd() && nDims != 1)
+    return op.emitOpError("can only have one dimension in canReadOffEnd loads");
+  return success();
+}
+
+//===-----------------------------------------------------===//
+// GlobalPrefetchOp
+//===-----------------------------------------------------===//
+
+LogicalResult GlobalPrefetchOp::verify() {
+  return verifyGlobalLoadAndPrefetch(*this);
 }
 
 //===-----------------------------------------------------===//
@@ -2120,6 +2139,70 @@ LogicalResult LDSTransposeLoadOp::verify() {
   for (Value idx : getIndices()) {
     if (!idx.getType().isIndex())
       return emitOpError("indices must be of index type");
+  }
+
+  return success();
+}
+
+//===-----------------------------------------------------===//
+// ThreadwisePrefetchOp
+//===-----------------------------------------------------===//
+
+SmallPtrSet<OpOperand *, 2> ThreadwisePrefetchOp::getAcceptingViewOperands() {
+  auto operands = getOperation()->getOpOperands();
+  return {operands.begin()};
+}
+
+std::optional<OperandRange>
+ThreadwisePrefetchOp::getExtraIndices(OpOperand &operand) {
+  if (!getAcceptingViewOperands().contains(&operand)) {
+    return std::nullopt;
+  }
+  // Only one operand supports view
+  return getExtraIndices();
+}
+
+Operation *
+ThreadwisePrefetchOp::cloneWithExtraIndices(OpBuilder &builder,
+                                            OpOperand &operand, Value view,
+                                            ArrayRef<Value> newExtraIndices) {
+  if (!getAcceptingViewOperands().contains(&operand)) {
+    return getOperation();
+  }
+
+  // Only one operand supports view
+  auto newOp = ThreadwisePrefetchOp::create(
+      builder, getLoc(), view, getExtraViews(), newExtraIndices,
+      getForceUnroll(), getUseIndexDiffs());
+  return newOp.getOperation();
+}
+
+LogicalResult ThreadwisePrefetchOp::verify() {
+  MemRefType srcType = getSource().getType();
+  Attribute srcMemSpaceAttr = srcType.getMemorySpace();
+  auto gpuSrcMemSpaceAttr =
+      dyn_cast_or_null<gpu::AddressSpaceAttr>(srcMemSpaceAttr);
+  if (srcMemSpaceAttr &&
+      (!gpuSrcMemSpaceAttr ||
+       gpuSrcMemSpaceAttr.getValue() != gpu::AddressSpace::Global))
+    return emitOpError("prefetching only works for global");
+
+  // we are checking below if extra indices match the upper view bounds.
+  // we should expect zero extra indices if we are prefetching a scalar.
+  // And upperBounds.size() + 1 otherwise.
+  ArrayAttr extraViews = getExtraViews();
+  ArrayRef<int64_t> inputShape;
+  if (extraViews.empty())
+    inputShape = srcType.getShape();
+  else
+    inputShape = cast<TransformMapAttr>(extraViews[0]).getUpperBounds();
+
+  size_t extraIdxCount = getExtraIndices().size();
+  if (inputShape.empty()) {
+    if (extraIdxCount != 0)
+      return emitOpError("read from a scalar value cannot have coordinates");
+  } else if (inputShape.size() != extraIdxCount + 1) {
+    return emitOpError("source view must be extraIndices + 1");
   }
 
   return success();

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1916,6 +1916,7 @@ LogicalResult IndexDiffUpdateOp::verify() {
   return success();
 }
 
+// Common verification code for load and prefetch
 template <typename LoadOrPrefetch>
 static LogicalResult verifyGlobalLoadAndPrefetch(LoadOrPrefetch op) {
   MemRefType sourceType = op.getSource().getType();

--- a/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AlignTiling.cpp
@@ -474,6 +474,8 @@ traceToNonViewReaders(Operation *op, Value parentVal,
     if (hasEffect<MemoryEffects::Read>(memEffectOp, parentVal)) {
       nonViewReaders.push_back(op);
     }
+  } else if (isa<ThreadwisePrefetchOp>(op)) {
+    // ignore because ThreadwisePrefetchOp is not a reader.
   } else {
     return op->emitError() << "Found an unsupported operator that needs to "
                               "be added reader checks \n"

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
@@ -18,9 +18,11 @@
 
 #include "GridLayoutEmitter.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Rock/IR/AccelEmitter.h"
+#include "mlir/Dialect/Rock/IR/AmdArchDb.h"
 #include "mlir/Dialect/Rock/IR/GetRockInfo.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockGemmGemmWrapperInterface.h"
@@ -294,6 +296,22 @@ class LoweringBlockwiseLoadTileOp final
                                    /*extraViews=*/b.getArrayAttr({}),
                                    /*extraIndices=*/indices, forceUnroll, true,
                                    /*ldsTransposeConfig=*/nullptr);
+
+      if (rock::isGlobalPrefetchSupported(arch)) {
+        // add one to k_loop to prefetch next iteration
+        SmallVector<Value> indicesNext(indices.begin(), indices.end());
+        Value one = b.createOrFold<arith::ConstantIndexOp>(loc, 1);
+        indicesNext[0] =
+            arith::AddIOp::create(b, loc, indicesNext[0], one).getResult();
+
+        // it's acceptable if the indices are out of bounds because we use
+        // GLOBAL_PREFETCH_B8 with Speculative Prefetch. See llvm.prefetch
+        // documentation in AMDGPUUsage.rst
+        rock::ThreadwisePrefetchOp::create(b, loc, wrappedSource,
+                                           /*extraViews=*/b.getArrayAttr({}),
+                                           /*extraIndices=*/indicesNext,
+                                           forceUnroll, true);
+      }
       if (stageGlobalReadNew)
         rock::YieldOp::create(b, loc);
     }

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1172,6 +1172,26 @@ Value selectDataIf4b(Location loc, PatternRewriter &b,
   return b.createOrFold<vector::ExtractOp>(loc, loadedVec, lsb);
 }
 
+struct GlobalPrefetchRewritePattern
+    : public OpRewritePattern<GlobalPrefetchOp> {
+  using OpRewritePattern<GlobalPrefetchOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(GlobalPrefetchOp op,
+                                PatternRewriter &b) const override {
+    Value source = op.getSource();
+
+    source = asGlobal(b, source);
+
+    // it's acceptable if the indices are out of bounds because we use
+    // GLOBAL_PREFETCH_B8 with Speculative Prefetch. See llvm.prefetch
+    // documentation in AMDGPUUsage.rst localityHint=3 is translated to memory
+    // scope SCOPE_SE.
+    b.replaceOpWithNewOp<memref::PrefetchOp>(
+        op, source, op.getSourceCoord(), /*isWrite=*/false, /*localityHint=*/3,
+        /*isDataCache=*/true);
+    return success();
+  }
+};
+
 struct GlobalLoadRewritePattern : public OpRewritePattern<GlobalLoadOp> {
   using OpRewritePattern<GlobalLoadOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(GlobalLoadOp op,
@@ -1650,8 +1670,9 @@ void RockSugarToLoopsPass::runOnOperation() {
   RewritePatternSet patterns(ctx);
   patterns.add<ExtractSliceRewritePattern, InsertSliceRewritePattern,
                GlobalLoadRewritePattern, GlobalLoadToLDSRewritePattern,
-               GlobalStoreRewritePattern, LDSTransposeLoadRewritePattern,
-               InBoundsLoadRewritePattern, InBoundsStoreRewritePattern>(ctx);
+               GlobalPrefetchRewritePattern, GlobalStoreRewritePattern,
+               LDSTransposeLoadRewritePattern, InBoundsLoadRewritePattern,
+               InBoundsStoreRewritePattern>(ctx);
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
     signalPassFailure();
 

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -95,6 +95,14 @@ struct ThreadwiseReadIntoRewritePattern
                                 ConversionPatternRewriter &b) const final;
 };
 
+struct ThreadwisePrefetchRewritePattern
+    : public OpConversionPattern<ThreadwisePrefetchOp> {
+  using OpConversionPattern<ThreadwisePrefetchOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(ThreadwisePrefetchOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &b) const final;
+};
+
 //===----------------------------------------------------------------------===//
 // ThreadwiseGemm lowering.
 //===----------------------------------------------------------------------===//
@@ -990,6 +998,54 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
   return success();
 }
 
+LogicalResult ThreadwisePrefetchRewritePattern::matchAndRewrite(
+    ThreadwisePrefetchOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &b) const {
+  Location loc = op.getLoc();
+  Value sourceView = adaptor.getSource();
+  ArrayAttr extraViews = op.getExtraViews();
+  sourceView =
+      cast<TypedValue<MemRefType>>(transform(b, sourceView, extraViews));
+  sourceView = addIterationIndexIfScalar(b, loc, sourceView);
+  sourceView = isolateTransforms(b, sourceView);
+
+  auto [buffer, transforms, _] = untransform(b, sourceView);
+
+  size_t extraIdxCount = op.getExtraIndices().size();
+  auto upperType = cast<ShapedType>(sourceView.getType());
+  int64_t numValues = upperType.getShape()[extraIdxCount];
+
+  bool forceUnroll = op.getForceUnroll();
+  bool useIndexDiffs = op.getUseIndexDiffs();
+
+  Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
+  SmallVector<Value, 3> readStartCoords =
+      llvm::to_vector<3>(op.getExtraIndices());
+  readStartCoords.push_back(zero);
+  SmallVector<int64_t, 3> bounds(readStartCoords.size() - 1, 1);
+  bounds.push_back(numValues);
+  SmallVector<int64_t, 3> strides(readStartCoords.size() - 1, 1);
+  strides.push_back(1);
+
+  SmallVector<Attribute> transformAttrs;
+
+  SmallVector<ValueRange> inits{readStartCoords};
+  SmallVector<Attribute> loopTransforms{transforms};
+
+  auto prefetchLoop =
+      TransformingForOp::create(b, loc, inits, loopTransforms, bounds, strides,
+                                forceUnroll, useIndexDiffs, ValueRange{});
+  {
+    OpBuilder::InsertionGuard guard(b);
+    b.setInsertionPointToStart(prefetchLoop.getBody());
+
+    rock::GlobalPrefetchOp::create(b, loc, buffer,
+                                   prefetchLoop.getLowerCoords(/*domain=*/0));
+  }
+  b.replaceOp(op, prefetchLoop.getResults());
+  return success();
+}
+
 LogicalResult ThreadwiseWriteAllRewritePattern::matchAndRewrite(
     ThreadwiseWriteAllOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &b) const {
@@ -1103,7 +1159,7 @@ void RockThreadwiseGemmLoweringPass::runOnOperation() {
   {
     ConversionTarget writeAllTarget(*ctx);
     writeAllTarget.addIllegalOp<ThreadwiseReadIntoOp, ThreadwiseWriteAllOp,
-                                ThreadwiseCopyOp>();
+                                ThreadwiseCopyOp, ThreadwisePrefetchOp>();
     writeAllTarget.addLegalDialect<
         arith::ArithDialect, rock::RockDialect, memref::MemRefDialect,
         scf::SCFDialect, vector::VectorDialect, affine::AffineDialect>();
@@ -1111,7 +1167,8 @@ void RockThreadwiseGemmLoweringPass::runOnOperation() {
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns
         .add<ThreadwiseReadIntoRewritePattern, ThreadwiseWriteAllRewritePattern,
-             ThreadwiseCopyRewritePattern>(ctx);
+             ThreadwiseCopyRewritePattern, ThreadwisePrefetchRewritePattern>(
+            ctx);
     if (failed(applyPartialConversion(getOperation(), writeAllTarget,
                                       std::move(writeAllPatterns))))
       signalPassFailure();

--- a/mlir/test/Dialect/Rock/loadtile_to_threadwise_lowering.mlir
+++ b/mlir/test/Dialect/Rock/loadtile_to_threadwise_lowering.mlir
@@ -40,6 +40,7 @@ func.func @default(%arg0: memref<1x384x64xf32>) attributes {block_size = 256 : i
   // CHECK: affine.for %[[arg1:.+]] = 0 to 2
     // CHECK: rock.stage
     // CHECK: rock.threadwise_read_into
+    // CHECK-NOT: rock.threadwise_prefetch
     // CHECK-NEXT: rock.yield
     // CHECK: {name = "GlobalRead"}
 
@@ -63,6 +64,7 @@ func.func @bypasslds(%arg0: memref<1x384x64xf32>) attributes {block_size = 256 :
   // CHECK: affine.for %[[arg1:.+]] = 0 to 2
     // CHECK: rock.stage
     // CHECK: rock.threadwise_read_into
+    // CHECK-NOT: rock.threadwise_prefetch
     // CHECK-NEXT: rock.yield
     // CHECK: {name = "GlobalRead"}
 
@@ -76,3 +78,5 @@ func.func @bypasslds(%arg0: memref<1x384x64xf32>) attributes {block_size = 256 :
   }
   return
 }
+
+// TODO(gfx1250): add _prefetch version of all

--- a/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
@@ -56,10 +56,9 @@ func.func @load_vector_oob(%mem: memref<1x2x3x4x8xf32>, %idx: index, %valid: i1)
 }
 
 // CHECK-LABEL: func.func @load_scalar
-// CHECK-SAME: (%[[mem:.*]]: memref<f32>, %[[idx:.*]]: index)
-func.func @load_scalar_empty_mem(%mem: memref<f32>, %idx: index) -> f32 {
+// CHECK-SAME: (%[[mem:.*]]: memref<f32>)
+func.func @load_scalar(%mem: memref<f32>) -> f32 {
     %true = arith.constant true
-    %c0 = arith.constant 0 : index
     // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
     // CHECK-SAME: #gpu.address_space<global>
     // CHECK: %[[ret:.*]] = memref.load %[[cast]][] : memref<f32, #gpu.address_space<global>>

--- a/mlir/test/Dialect/Rock/lowering_global_prefetch.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_prefetch.mlir
@@ -1,0 +1,50 @@
+// RUN: rocmlir-opt --rock-sugar-to-loops %s | FileCheck %s
+
+module {
+// CHECK-LABEL: func.func @prefetch_scalar_in_bounds
+// CHECK-SAME: (%[[mem:.*]]: memref<1x2x3x4x8xf32>)
+func.func @prefetch_scalar_in_bounds(%mem: memref<1x2x3x4x8xf32>) {
+    %c0 = arith.constant 0 : index
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: memref.prefetch %[[cast]]
+    // CHECK-SAME: read, locality<3>, data : memref<1x2x3x4x8xf32, #gpu.address_space<global>>
+    rock.global_prefetch %mem[%c0, %c0, %c0, %c0, %c0] : memref<1x2x3x4x8xf32>
+    return
+}
+
+// CHECK-LABEL: func.func @prefetch_scalar_in_bounds_oob
+// CHECK-SAME: (%[[mem:.*]]: memref<8xf32>)
+func.func @prefetch_scalar_in_bounds_oob(%mem: memref<8xf32>) {
+    %c9 = arith.constant 9 : index
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: memref.prefetch %[[cast]]
+    // CHECK-SAME: read, locality<3>, data : memref<8xf32, #gpu.address_space<global>>
+    rock.global_prefetch %mem[%c9] : memref<8xf32> 
+    return
+}
+
+// CHECK-LABEL: func.func @prefetch_scalar_large_i4
+// CHECK-SAME: (%[[mem:.*]]: memref<1073741825xi4>)
+func.func @prefetch_scalar_large_i4(%mem: memref<1073741825xi4>) {
+    %c0 = arith.constant 0 : index
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: memref.prefetch %[[cast]]
+    // CHECK-SAME: read, locality<3>, data : memref<1073741825xi4, #gpu.address_space<global>>
+    rock.global_prefetch %mem[%c0] : memref<1073741825xi4>
+    return
+}
+
+// CHECK-LABEL: func.func @prefetch_scalar
+// CHECK-SAME: (%[[mem:.*]]: memref<f32>)
+func.func @prefetch_scalar(%mem: memref<f32>) {
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // CHECK: memref.prefetch %[[cast]][]
+    // CHECK-SAME: read, locality<3>, data : memref<f32, #gpu.address_space<global>>
+    rock.global_prefetch %mem[] : memref<f32>
+    return
+}
+}

--- a/mlir/test/Dialect/Rock/lowering_threadwise_prefetch.mlir
+++ b/mlir/test/Dialect/Rock/lowering_threadwise_prefetch.mlir
@@ -1,0 +1,81 @@
+// Note: this should be in a post-fusion pass
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt -rock-blockwise-gemm-to-threadwise -rock-threadwise-gemm-lowering --canonicalize | FileCheck --enable-var-scope %s
+
+// CHECK-DAG: #[[$ON_OP:transform_map[0-9]*]] = #rock.transform_map{{.*}}PassThrough{{.*}}[0, 1, 2]{{.*}}[0, 1, 2]
+#transform_map0 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+  by [<PassThrough ["1", "0", "z"] at [0, 1, 2] -> ["1", "0", "z"] at [0, 1, 2]>]
+  bounds = [2, 64, 32] -> [2, 64, 32]>
+// CHECK-DAG: #[[$IN_FUNC:transform_map[0-9]*]] = #rock.transform_map{{.*}}PassThrough{{.*}}[0, 1]{{.*}}[0, 1]{{.*}}Pad{2, 0}
+#transform_map1 = #rock.transform_map<affine_map<(d0, d1, d2) -> (d0, d1, d2 - 2)>
+  by [<PassThrough ["1", "0"] at [0, 1]  -> ["1", "0"] at [0, 1]>,
+    <Pad{2, 0} ["z"] at [2] -> ["z"] at [2]>]
+  bounds = [2, 64, 32] -> [2, 64, 30]>
+
+// CHECK-DAG: #[[$ON_OP_IDX:transform_map[0-9]*]] = #rock.transform_map{{.*}}PassThrough{{.*}}[0, 1, 2, 3]{{.*}}[0, 1, 2, 3]
+#transform_map2 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+  by [<PassThrough ["1", "1", "0", "z"] at [0, 1, 2, 3] -> ["1", "1", "0", "z"] at [0, 1, 2, 3]>]
+  bounds = [3, 2, 64, 32] -> [3, 2, 64, 32]>
+// CHECK-DAG: #[[$IN_FUNC_IDX:transform_map[0-9]*]] = #rock.transform_map{{.*}}PassThrough{{.*}}[0, 1, 2]{{.*}}[0, 1, 2]{{.*}}Pad{2, 0}
+#transform_map3 = #rock.transform_map<affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3 - 2)>
+  by [<PassThrough ["1", "1", "0"] at [0, 1, 2]  -> ["1", "1", "0"] at [0, 1, 2]>,
+    <Pad{2, 0} ["z"] at [3] -> ["z"] at [3]>]
+  bounds = [3, 2, 64, 32] -> [3, 2, 64, 30]>
+
+// CHECK-LABEL: func @threadwise_prefetch
+// CHECK-SAME: [[source:%.+]]: memref<2x64x30xf32>
+func.func @threadwise_prefetch(%source: memref<2x64x30xf32>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
+  // CHECK-DAG: [[zero:%.+]] = arith.constant 0
+  // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
+  // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
+  // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
+  // CHECK-SAME: ([[args:%.+, %.+, %.+]]) = [#[[$ON_OP]], #[[$IN_FUNC]]]([[bid]], [[tid]], [[zero]])
+  // CHECK-SAME: bounds [1, 1, 32]
+  // CHECK-SAME: strides [1, 1, 1]
+  // CHECK-NEXT: rock.global_prefetch [[source]][[[args]]]
+
+  %view = rock.transform %source by #transform_map1 : memref<2x64x30xf32> to memref<2x64x32xf32>
+  %bid = rock.workgroup_id : index
+  %tid = rock.workitem_id : index
+  rock.threadwise_prefetch {forceUnroll, useIndexDiffs}
+    [#transform_map0](%view)[%bid, %tid] : memref<2x64x32xf32>
+  func.return
+}
+
+// CHECK-LABEL: func @threadwise_prefetch_scalar
+// CHECK-SAME: [[source:%.+]]: memref<f32>
+func.func @threadwise_prefetch_scalar(%source: memref<f32>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
+  // CHECK-DAG: [[zero:%.+]] = arith.constant 0
+  // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
+  // CHECK-SAME: () = [#transform_map{{[0-9]*}}]([[zero]])
+  // CHECK-SAME: bounds [1]
+  // CHECK-SAME: strides [1]
+  // CHECK-NEXT: rock.global_prefetch [[source]][]
+  rock.threadwise_prefetch {forceUnroll, useIndexDiffs}
+    [](%source)[]
+    : memref<f32>
+  func.return
+}
+
+
+// CHECK-LABEL: func @threadwise_prefetch_extra_idx
+// CHECK-SAME: [[source:%.+]]: memref<3x2x64x30xf32>
+func.func @threadwise_prefetch_extra_idx(%source: memref<3x2x64x30xf32>) attributes {block_size = 128 : i32, arch = "##TOKEN_ARCH##"} {
+  // CHECK-DAG: [[zero:%.+]] = arith.constant 0
+  // CHECK-DAG: [[extra_idx:%.+]] = arith.constant 1
+  // CHECK-DAG: [[bid:%.+]] = rock.workgroup_id
+  // CHECK-DAG: [[tid:%.+]] = rock.workitem_id
+  // CHECK: rock.transforming_for {forceUnroll, useIndexDiffs}
+  // CHECK-SAME: ([[args:%.+, %.+, %.+]]) = [#[[$ON_OP_IDX]], #[[$IN_FUNC_IDX]]]([[extra_idx]], [[bid]], [[tid]], [[zero]])
+  // CHECK-SAME: bounds [1, 1, 1, 32]
+  // CHECK-SAME: strides [1, 1, 1, 1]
+  // CHECK-NEXT: rock.global_prefetch [[source]][[[args]]]
+
+  %view = rock.transform %source by #transform_map3 : memref<3x2x64x30xf32> to memref<3x2x64x32xf32>
+  %extra_idx = arith.constant 1 : index
+  %bid = rock.workgroup_id : index
+  %tid = rock.workitem_id : index
+  rock.threadwise_prefetch {forceUnroll, useIndexDiffs}
+    [#transform_map2](%view)[%extra_idx, %bid, %tid]
+    : memref<3x2x64x32xf32>
+  func.return
+}

--- a/mlir/test/rocmlir-driver/prefetch_assembly.mlir
+++ b/mlir/test/rocmlir-driver/prefetch_assembly.mlir
@@ -1,0 +1,11 @@
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX942
+// RUN: rocmlir-gen --arch gfx950 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX950
+// RUN: rocmlir-gen --arch gfx1200 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX1200
+// RUN: rocmlir-gen --arch gfx1100 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX1100
+
+// GFX942-NOT: global_prefetch_b8
+// GFX950-NOT: global_prefetch_b8
+// GFX1100-NOT: global_prefetch_b8
+// GFX1200-NOT: global_prefetch_b8
+
+// TODO(gfx1250): add gfx1250 when it doesn't fail compilation

--- a/mlir/test/rocmlir-driver/prefetch_assembly.mlir
+++ b/mlir/test/rocmlir-driver/prefetch_assembly.mlir
@@ -2,10 +2,12 @@
 // RUN: rocmlir-gen --arch gfx950 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX950
 // RUN: rocmlir-gen --arch gfx1200 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX1200
 // RUN: rocmlir-gen --arch gfx1100 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX1100
+// RUN: rocmlir-gen --arch gfx1250 --operation gemm -t f16 -p | rocmlir-driver -c --debug-only=serialize-to-isa 2>&1 | FileCheck %s --check-prefix=GFX1250
+
+// Only gfx1250 supports global_prefetch_b8 instruction
 
 // GFX942-NOT: global_prefetch_b8
 // GFX950-NOT: global_prefetch_b8
 // GFX1100-NOT: global_prefetch_b8
 // GFX1200-NOT: global_prefetch_b8
-
-// TODO(gfx1250): add gfx1250 when it doesn't fail compilation
+// GFX1250: global_prefetch_b8


### PR DESCRIPTION
## Motivation

Add prefetch functionality for gfx1250.

## Technical Details

- Added rock.threadwise_prefetch (similar to threadwise_read_into)
- Added rock.global_prefetch (similar to global load), it lowers into memref.prefetch, which correctly uses global_prefetch_b8 on gfx1250
- Added rock.threadwise_prefetch call in load_tile, just after loading the current tile, we start prefetching the next tile.

Note there's no need to conditionally call prefetch, as memref.prefetch operation is lowered to a no-op on targets that do not support hardware prefetching.

There are some pending things that will need to be done once we can measure performance:
- measure if prefetching improves performance
- what happens if we move prefetch to happen later

Our compilation fails for gfx1250 currently, so one test has a TODO until that is solved.

## Test Plan

Added tests for rock.threadwise_prefetch and rock.threadwise_prefetch

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
