### PR TITLE
Limit the number of LIT workers on gfx950

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -467,8 +467,7 @@ String getLabelFromChip(String chip) {
 int setLitWorkerCount() {
     int limit_lit_workers = 8
     def gpu_arch = get_gpu_architecture()
-    if (gpu_arch.contains('gfx908') || gpu_arch.contains('gfx90a') ||
-        gpu_arch.contains('gfx950')) {
+    if (gpu_arch.contains('gfx908') || gpu_arch.contains('gfx90a')) {
         limit_lit_workers = 20
     } else if (gpu_arch.contains('gfx942')) {
         limit_lit_workers = 64

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -467,9 +467,10 @@ String getLabelFromChip(String chip) {
 int setLitWorkerCount() {
     int limit_lit_workers = 8
     def gpu_arch = get_gpu_architecture()
-    if (gpu_arch.contains('gfx908') || gpu_arch.contains('gfx90a')) {
+    if (gpu_arch.contains('gfx908') || gpu_arch.contains('gfx90a') ||
+        gpu_arch.contains('gfx950')) {
         limit_lit_workers = 20
-    } else if (gpu_arch.contains('gfx942') || gpu_arch.contains('gfx950')) {
+    } else if (gpu_arch.contains('gfx942')) {
         limit_lit_workers = 64
     }
     return limit_lit_workers


### PR DESCRIPTION
## Motivation

With the recent enablement of gfx950 in the CI we are getting intermittent failures on some of the longer E2E tests. This PR addresses that.

Fixes: https://github.com/ROCm/rocMLIR-internal/issues/2118

## Technical Details

Limit the number of LIT_WORKERS on gfx950 from 64 -> 8

## Test Plan

- Multiple runs of the Nightly CI pass with no problems

## Test Result

- [x] Nightly CI
  - I've run twice with 8 runners, and there are no failures. The runtime also still seems quite reasonable, and is similar to gfx90a jobs (e.g., the fixed E2E tests take 23 mins)
  - Link to one of the runs: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2085/3/pipeline-overview/

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
