### PR TITLE
Applicability refactor

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Pipelines/Pipelines.h
+++ b/mlir/include/mlir/Dialect/Rock/Pipelines/Pipelines.h
@@ -38,16 +38,19 @@ struct BufferizeOptions : public PassPipelineOptions<BufferizeOptions> {
 void buildBufferizePipeline(OpPassManager &pm,
                             const BufferizeOptions &options = {});
 
+enum class ApplicabilityMode {
+  Full,             // run full pipeline
+  Applicability,    // run applicability only
+  NonApplicability, // run non-applicability passes only
+};
+
 //===--- Kernel Pipeline --------------------------------------------------===//
 struct KernelOptions : public PassPipelineOptions<KernelOptions> {
 
-  PassOptions::Option<bool> enableApplicability{
-      *this, "enable-applicability", desc("Only test for applicability"),
-      init(false)};
-  PassOptions::Option<bool> enableFusion{
-      *this, "enable-fusion",
-      desc("Enable fusion alignment between anchor op and peripheral ops"),
-      init(true)};
+  PassOptions::Option<ApplicabilityMode> applicabilityMode{
+      *this, "applicability",
+      desc("Whether to run (non-)applicability or the full pipeline"),
+      init(ApplicabilityMode::Full)};
   PassOptions::Option<bool> tuningFallback{
       *this, "tuningFallback",
       desc("Falls back default if invalid config is given"), init(false)};

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -152,12 +152,12 @@ struct InitParamsNonAccel : InitParams, Serializable<InitParamsNonAccel> {
 struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   constexpr InitParamsAccel(int64_t mPerBlock, int64_t nPerBlock,
                             int64_t kPerBlock, int64_t mPerWave,
-                            int64_t nPerWave, int64_t mnPerXdl, int64_t kPack,
+                            int64_t nPerWaveOrMnPerXdl, int64_t kPack,
                             int64_t splitKFactor, int64_t scheduleVersion,
                             int64_t outputSwizzle, bool aThreadCopyMoreGemmK,
                             bool bThreadCopyMoreGemmKPack)
       : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerWave(mPerWave),
-        gemmNPerWave(nPerWave), gemmMnPerXdl(mnPerXdl), gemmKPack(kPack),
+        gemmNPerWaveOrMnPerXdl(nPerWaveOrMnPerXdl), gemmKPack(kPack),
         splitKFactor(splitKFactor), gemmScheduleVersion(scheduleVersion),
         outputSwizzle(outputSwizzle),
         gemmAThreadCopyMoreGemmK(aThreadCopyMoreGemmK),
@@ -167,11 +167,11 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
       : InitParamsAccel(0LL, 0LL, 0LL, 0LL, 0LL, 0LL, 1LL, 1LL, 2LL, false,
                         false) {}
 
-  InitParamsAccel(MfmaGemmParamsAttr attr)
+  InitParamsAccel(XdlopsGemmParamsAttr attr)
       : InitParams{attr.getMPerBlock(), attr.getNPerBlock(),
                    attr.getKpackPerBlock()},
-        gemmMPerWave(attr.getMPerWave()), gemmNPerWave(attr.getNPerWave()),
-        gemmMnPerXdl(attr.getMnPerXdl()), gemmKPack(attr.getKpack()),
+        gemmMPerWave(attr.getMPerWave()),
+        gemmNPerWaveOrMnPerXdl(attr.getMnPerXdl()), gemmKPack(attr.getKpack()),
         splitKFactor(attr.getSplitKFactor()),
         gemmScheduleVersion(attr.getScheduleVersion()),
         outputSwizzle(attr.getOutputSwizzle()),
@@ -181,8 +181,8 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   InitParamsAccel(WmmaGemmParamsAttr attr)
       : InitParams{attr.getMPerBlock(), attr.getNPerBlock(),
                    attr.getKpackPerBlock()},
-        gemmMPerWave(attr.getMPerWave()), gemmNPerWave(attr.getNPerWave()),
-        gemmMnPerXdl(0), gemmKPack(attr.getKpack()),
+        gemmMPerWave(attr.getMPerWave()),
+        gemmNPerWaveOrMnPerXdl(attr.getNPerWave()), gemmKPack(attr.getKpack()),
         splitKFactor(attr.getSplitKFactor()),
         gemmScheduleVersion(attr.getScheduleVersion()),
         outputSwizzle(attr.getOutputSwizzle()),
@@ -192,8 +192,7 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   int64_t getKPack() { return gemmKPack; }
 
   int64_t gemmMPerWave;
-  int64_t gemmNPerWave;
-  int64_t gemmMnPerXdl;
+  int64_t gemmNPerWaveOrMnPerXdl;
   int64_t gemmKPack;
   int64_t splitKFactor;
   int64_t gemmScheduleVersion;
@@ -207,8 +206,7 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
     f(self.gemmNPerBlock);
     f(self.gemmKPerBlock);
     f(self.gemmMPerWave);
-    f(self.gemmNPerWave);
-    f(self.gemmMnPerXdl);
+    f(self.gemmNPerWaveOrMnPerXdl);
     f(self.gemmKPack);
     if (self.version >= Version::V2) {
       f(self.splitKFactor);

--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -152,12 +152,12 @@ struct InitParamsNonAccel : InitParams, Serializable<InitParamsNonAccel> {
 struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   constexpr InitParamsAccel(int64_t mPerBlock, int64_t nPerBlock,
                             int64_t kPerBlock, int64_t mPerWave,
-                            int64_t nPerWaveOrMnPerXdl, int64_t kPack,
+                            int64_t nPerWave, int64_t mnPerXdl, int64_t kPack,
                             int64_t splitKFactor, int64_t scheduleVersion,
                             int64_t outputSwizzle, bool aThreadCopyMoreGemmK,
                             bool bThreadCopyMoreGemmKPack)
       : InitParams{mPerBlock, nPerBlock, kPerBlock}, gemmMPerWave(mPerWave),
-        gemmNPerWaveOrMnPerXdl(nPerWaveOrMnPerXdl), gemmKPack(kPack),
+        gemmNPerWave(nPerWave), gemmMnPerXdl(mnPerXdl), gemmKPack(kPack),
         splitKFactor(splitKFactor), gemmScheduleVersion(scheduleVersion),
         outputSwizzle(outputSwizzle),
         gemmAThreadCopyMoreGemmK(aThreadCopyMoreGemmK),
@@ -167,11 +167,11 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
       : InitParamsAccel(0LL, 0LL, 0LL, 0LL, 0LL, 0LL, 1LL, 1LL, 2LL, false,
                         false) {}
 
-  InitParamsAccel(XdlopsGemmParamsAttr attr)
+  InitParamsAccel(MfmaGemmParamsAttr attr)
       : InitParams{attr.getMPerBlock(), attr.getNPerBlock(),
                    attr.getKpackPerBlock()},
-        gemmMPerWave(attr.getMPerWave()),
-        gemmNPerWaveOrMnPerXdl(attr.getMnPerXdl()), gemmKPack(attr.getKpack()),
+        gemmMPerWave(attr.getMPerWave()), gemmNPerWave(attr.getNPerWave()),
+        gemmMnPerXdl(attr.getMnPerXdl()), gemmKPack(attr.getKpack()),
         splitKFactor(attr.getSplitKFactor()),
         gemmScheduleVersion(attr.getScheduleVersion()),
         outputSwizzle(attr.getOutputSwizzle()),
@@ -181,8 +181,8 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   InitParamsAccel(WmmaGemmParamsAttr attr)
       : InitParams{attr.getMPerBlock(), attr.getNPerBlock(),
                    attr.getKpackPerBlock()},
-        gemmMPerWave(attr.getMPerWave()),
-        gemmNPerWaveOrMnPerXdl(attr.getNPerWave()), gemmKPack(attr.getKpack()),
+        gemmMPerWave(attr.getMPerWave()), gemmNPerWave(attr.getNPerWave()),
+        gemmMnPerXdl(0), gemmKPack(attr.getKpack()),
         splitKFactor(attr.getSplitKFactor()),
         gemmScheduleVersion(attr.getScheduleVersion()),
         outputSwizzle(attr.getOutputSwizzle()),
@@ -192,7 +192,8 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
   int64_t getKPack() { return gemmKPack; }
 
   int64_t gemmMPerWave;
-  int64_t gemmNPerWaveOrMnPerXdl;
+  int64_t gemmNPerWave;
+  int64_t gemmMnPerXdl;
   int64_t gemmKPack;
   int64_t splitKFactor;
   int64_t gemmScheduleVersion;
@@ -206,7 +207,8 @@ struct InitParamsAccel : InitParams, Serializable<InitParamsAccel> {
     f(self.gemmNPerBlock);
     f(self.gemmKPerBlock);
     f(self.gemmMPerWave);
-    f(self.gemmNPerWaveOrMnPerXdl);
+    f(self.gemmNPerWave);
+    f(self.gemmMnPerXdl);
     f(self.gemmKPack);
     if (self.version >= Version::V2) {
       f(self.splitKFactor);

--- a/mlir/lib/CAPI/Dialect/MIGraphX.cpp
+++ b/mlir/lib/CAPI/Dialect/MIGraphX.cpp
@@ -148,7 +148,7 @@ mlirMIGraphXAddApplicabilityPipeline(MlirPassManager pm) {
   auto *passMan = unwrap(pm);
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::rock::KernelOptions opts;
-  opts.enableApplicability = true;
+  opts.applicabilityMode = mlir::rock::ApplicabilityMode::Applicability;
   // This is the default, but we set it paranoidly.
   opts.tuningFallback = false;
   mlir::rock::buildKernelPipeline(*passMan, opts);
@@ -161,6 +161,7 @@ MLIR_CAPI_EXPORTED bool mlirMIGraphXAddBackendPipeline(MlirPassManager pm,
     return false;
   passMan->setNesting(mlir::PassManager::Nesting::Implicit);
   mlir::rock::KernelOptions kOpts;
+  kOpts.applicabilityMode = mlir::rock::ApplicabilityMode::Full;
   kOpts.tuningFallback = false;
   mlir::rock::buildKernelPipeline(*passMan, kOpts);
   llvm::StringRef archStr(arch);

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -155,24 +155,19 @@ void rock::buildKernelPipeline(OpPassManager &pm,
    * --rock-blockwise-load-tile-to-threadwise
    */
   auto &funcPm = pm.nest<func::FuncOp>();
-  funcPm.addPass(rock::createRockAffixTuningParametersPass(
-      rock::RockAffixTuningParametersPassOptions{options.tuningFallback}));
-  funcPm.addPass(rock::createRockConvToGemmPass());
-  funcPm.addPass(rock::createRockGemmLinalgSplitkNormalizationPass());
-  funcPm.addPass(rock::createRockGemmToGridwisePass());
-  funcPm.addPass(rock::createRockRegularizePass());
-  funcPm.addPass(rock::createRockShuffleGemmForReductions());
-  funcPm.addPass(rock::createRockGridwiseGemmToBlockwisePass());
-  funcPm.addPass(rock::createRockBlockwiseLoadTileToThreadwisePass());
 
-  // We want to delay blockwise lowering in the fusion cases
-  // until after linalg align pass because with reduction fusion
-  // it may introduce blockwise_reductions.
-  if (!options.enableFusion) {
-    funcPm.addPass(rock::createRockBlockwiseGemmToThreadwisePass());
-  }
+  if (options.applicabilityMode == rock::ApplicabilityMode::Applicability ||
+      options.applicabilityMode == rock::ApplicabilityMode::Full) {
+    funcPm.addPass(rock::createRockAffixTuningParametersPass(
+        rock::RockAffixTuningParametersPassOptions{options.tuningFallback}));
+    funcPm.addPass(rock::createRockConvToGemmPass());
+    funcPm.addPass(rock::createRockGemmLinalgSplitkNormalizationPass());
+    funcPm.addPass(rock::createRockGemmToGridwisePass());
+    funcPm.addPass(rock::createRockRegularizePass());
+    funcPm.addPass(rock::createRockShuffleGemmForReductions());
+    funcPm.addPass(rock::createRockGridwiseGemmToBlockwisePass());
+    funcPm.addPass(rock::createRockBlockwiseLoadTileToThreadwisePass());
 
-  if (options.enableFusion) {
     // align linalg tiling
     /* rocmlir-opt --rock-linalg-align --canonicalize
      * --convert-linalg-to-affine-loops
@@ -183,18 +178,21 @@ void rock::buildKernelPipeline(OpPassManager &pm,
     funcPm.addPass(createCanonicalizerPass());
     funcPm.addPass(createConvertLinalgToAffineLoopsPass());
     funcPm.addPass(rock::createRockVectorizeFusionsPass());
-  }
-  // We run reuse LDS before the output swizzle pass because it uses a heuristic
-  // to determine whether to swizzle or not, and that heuristic needs the actual
-  // LDS usage. After running output swizzle, we'll create a new LDS buffer and
-  // we need to run reuse LDS again to be able to reuse LDS memory.
-  funcPm.addPass(rock::createRockAnnotateLivenessPass());
-  funcPm.addPass(rock::createRockReuseLDSPass());
-  funcPm.addPass(rock::createRockOutputSwizzlePass());
-  funcPm.addPass(rock::createRockAnnotateLivenessPass());
-  funcPm.addPass(rock::createRockReuseLDSPass());
 
-  if (!options.enableApplicability) {
+    // We run reuse LDS before the output swizzle pass because it uses a
+    // heuristic to determine whether to swizzle or not, and that heuristic
+    // needs the actual LDS usage. After running output swizzle, we'll create a
+    // new LDS buffer and we need to run reuse LDS again to be able to reuse LDS
+    // memory.
+    funcPm.addPass(rock::createRockAnnotateLivenessPass());
+    funcPm.addPass(rock::createRockReuseLDSPass());
+    funcPm.addPass(rock::createRockOutputSwizzlePass());
+    funcPm.addPass(rock::createRockAnnotateLivenessPass());
+    funcPm.addPass(rock::createRockReuseLDSPass());
+  }
+
+  if (options.applicabilityMode == rock::ApplicabilityMode::NonApplicability ||
+      options.applicabilityMode == rock::ApplicabilityMode::Full) {
     // rock lowering for reductions
     /* rocmlir-opt --rock-lower-reduce
      */

--- a/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
+++ b/mlir/tools/rocmlir-driver/rocmlir-driver.cpp
@@ -188,7 +188,7 @@ runKernelPipeline(StringRef arch, ModuleOp m,
   // Set up lowering pipeline.
   if (kernelPipelineSet.contains("applicability")) {
     rock::KernelOptions opts;
-    opts.enableApplicability = true;
+    opts.applicabilityMode = mlir::rock::ApplicabilityMode::Applicability;
     rock::buildKernelPipeline(pm, opts);
   }
   if (kernelPipelineSet.contains("gpu")) {

--- a/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
+++ b/mlir/tools/rocmlir-lib/rocmlir-lib.cpp
@@ -257,7 +257,7 @@ extern "C" MiirStatus miirLowerTuningParams(MiirHandle mlirHandle) {
   PassManager pm(module->getName(), PassManager::Nesting::Implicit);
 
   rock::KernelOptions opts;
-  opts.enableApplicability = true;
+  opts.applicabilityMode = mlir::rock::ApplicabilityMode::Applicability;
   rock::buildKernelPipeline(pm, opts);
 
   auto status = pm.run(module);

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -474,13 +474,13 @@ static LogicalResult runTuningLoop(ModuleOp source) {
 
   // 2. Set up compilation options (shared across all threads)
   rock::KernelOptions applicabilityOpts;
-  applicabilityOpts.enableApplicability = true;
-  applicabilityOpts.enableFusion = true;
+  applicabilityOpts.applicabilityMode =
+      mlir::rock::ApplicabilityMode::Applicability;
   applicabilityOpts.tuningFallback = false;
 
   rock::KernelOptions compilationKernOpts;
-  compilationKernOpts.enableApplicability = false;
-  compilationKernOpts.enableFusion = true;
+  compilationKernOpts.applicabilityMode =
+      mlir::rock::ApplicabilityMode::NonApplicability;
   compilationKernOpts.tuningFallback = false;
 
   RocmDeviceName deviceName;
@@ -603,21 +603,21 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     };
 
     // Applicability check
-    OwningOpRef<ModuleOp> applicabilityCopy =
+    OwningOpRef<ModuleOp> sourceCopy =
         copyIRThread(threadSource.get(), perfConfigAttr);
-    if (!rock::isModuleFusible(applicabilityCopy.get(), result.perfConfig)) {
+    if (!rock::isModuleFusible(sourceCopy.get(), result.perfConfig)) {
       result.status = CompilationStatus::NotApplicable;
       return result;
     }
 
-    if (failed(threadApplicability.run(applicabilityCopy.get()))) {
+    if (failed(threadApplicability.run(sourceCopy.get()))) {
       result.status = CompilationStatus::NotApplicable;
       return result;
     }
 
     // Extract block and grid sizes
     for (auto &fnName : kernelFuncNames) {
-      auto tunedFunc = applicabilityCopy->lookupSymbol<func::FuncOp>(fnName);
+      auto tunedFunc = sourceCopy->lookupSymbol<func::FuncOp>(fnName);
       if (!tunedFunc) {
         result.status = CompilationStatus::CompilationFailed;
         compilationFailed.store(true, std::memory_order_relaxed);
@@ -630,9 +630,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     }
 
     // Compilation
-    OwningOpRef<ModuleOp> compileCopy =
-        copyIRThread(threadSource.get(), perfConfigAttr);
-    if (failed(threadCompilation.run(compileCopy.get()))) {
+    if (failed(threadCompilation.run(sourceCopy.get()))) {
       std::lock_guard<std::mutex> lock(outputMutex);
       llvm::errs() << "Backend pipeline failed for config: "
                    << result.perfConfig << "\n";
@@ -643,8 +641,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
 
     // Extract binaries
     for (const auto &fnName : kernelFuncNames) {
-      auto binary =
-          compileCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
+      auto binary = sourceCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
       if (!binary) {
         result.status = CompilationStatus::CompilationFailed;
         compilationFailed.store(true, std::memory_order_relaxed);

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -50,7 +50,6 @@
 #include <cassert>
 #include <chrono>
 #include <cstdlib>
-#include <future>
 #include <mutex>
 #include <thread>
 
@@ -179,8 +178,8 @@ static benchmark::DataType getDataType(Type inputType) {
     return failure();                                                          \
   }
 
-size_t flushSize = 0;
-void *flushBuffer = nullptr;
+static size_t flushSize = 0;
+static void *flushBuffer = nullptr;
 
 static LogicalResult flushL2Cache(hipStream_t stream) {
   if (flushBuffer == nullptr) {
@@ -682,6 +681,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     };
 
     std::vector<std::thread> threads;
+    threads.reserve(numThreads);
     for (unsigned i = 0; i < numThreads; ++i) {
       threads.emplace_back(worker);
     }


### PR DESCRIPTION
## Motivation

Refactor enableApplicability to applicabilityMode to enable running first applicability then non-applicability passes on tuning driver. Then, we can save some compilation time.

## Technical Details

- Refactor `enableApplicability` to `applicabilityMode` (Full, Applicability and NonApplicability)
- Remove `enableFusion` as nobody was using it
- Minor style changes

## Perf run

Running the following gemm config:
```
-t i8 -out_datatype i32 -transA false -transB false -g 1 -m 1 -n 1001 -k 2048
```

It takes 40 seconds on develop and 38 seconds on this branch (including compilation and running the kernels).

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
