### PR TITLE
GQA optimization migraphx integration

### DIFF
--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/Rock/utility/builderUtils.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/Dialect/Rock/utility/tosaUtils.h"
+#include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/Dialect/Tosa/Utils/ConversionUtils.h"
@@ -52,6 +53,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
+#include <tuple>
 #include <utility>
 
 #define DEBUG_TYPE "convert-tosa-to-rock"
@@ -790,7 +792,7 @@ static Value insertBroadcast(Value inp, ArrayRef<int64_t> outShape,
   return rock::TransformOp::create(b, loc, inp, broadcastDims.get());
 }
 
-static FailureOr<Value> mulBroadcast(Value val);
+static FailureOr<Value> mulBroadcast(Value val, bool skipCollapseExpand = true);
 
 static FailureOr<Value> getValueSkipping(Value val,
                                          const DenseSet<StringRef> &opsToSkip) {
@@ -820,9 +822,12 @@ getDefiningOpSkipping(Value val, const DenseSet<StringRef> &opsToSkip) {
   return result;
 }
 
-static FailureOr<Value> mulBroadcast(Value val) {
+static FailureOr<Value> mulBroadcast(Value val, bool skipCollapseExpand) {
   DenseSet<StringRef> opsToSkip{tensor::CollapseShapeOp::getOperationName(),
                                 tensor::ExpandShapeOp::getOperationName()};
+  if (!skipCollapseExpand)
+    opsToSkip.clear();
+
   auto maybeMul = getDefiningOpSkipping<tosa::MulOp>(val, opsToSkip);
   if (succeeded(maybeMul)) {
     auto mul = maybeMul.value();
@@ -2322,6 +2327,216 @@ struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
     return mul.getOutput();
   }
 
+  FailureOr<std::pair<int64_t, int64_t>> getNumHeadsGQA(Value value,
+                                                        bool isQ) const {
+    // this size is = batch*numHeads
+    auto collapse = value.getDefiningOp<tensor::CollapseShapeOp>();
+    if (!collapse)
+      return failure();
+
+    auto reassociationIdx = collapse.getReassociationIndices();
+
+    // expected to reshape to three dimensions (input to tosa.matmul)
+    if (reassociationIdx.size() != 3)
+      return failure();
+    size_t expectedGroupSize = isQ ? 2 : 3;
+    if (reassociationIdx[0].size() != expectedGroupSize ||
+        reassociationIdx[1].size() != 1 || reassociationIdx[2].size() != 1)
+      return failure();
+
+    // group size must match groupSizeQ
+    int64_t count = 0;
+    for (const auto &reassociation : reassociationIdx) {
+      for (auto idx : reassociation) {
+        if (count != idx)
+          return failure();
+        count++;
+      }
+    }
+
+    auto reshapeInputShape =
+        cast<ShapedType>(collapse.getSrc().getType()).getShape();
+    // we expect the input to be batch x num_heads x D x K (or K x D)
+    size_t expectedSize = isQ ? 4 : 5;
+    if (reshapeInputShape.size() != expectedSize)
+      return failure();
+
+    int64_t batch = reshapeInputShape[0];
+    int64_t numHeads = reshapeInputShape[1];
+    return std::make_pair(batch, numHeads);
+  }
+
+  LogicalResult checkBroadcastGQA(Value value, int64_t expectedRepeat) const {
+    auto collapse = value.getDefiningOp<tensor::CollapseShapeOp>();
+    if (!collapse)
+      return failure();
+    Value collapseVal = collapse.getSrc();
+
+    auto maybeNonOne = mulBroadcast(collapseVal, /*skipCollapseExpand=*/false);
+    if (failed(maybeNonOne))
+      return failure();
+
+    // we should be doing batch x num_heads x 1 x D x K -> batch x num_heads x
+    // REPEAT x D x K
+    Value nonOne = maybeNonOne.value();
+    auto shapeBeforeBroadcast = cast<ShapedType>(nonOne.getType()).getShape();
+    auto shapeAfterBroadcast =
+        cast<ShapedType>(
+            collapseVal.getDefiningOp<tosa::MulOp>().getOutput().getType())
+            .getShape();
+    if (shapeBeforeBroadcast.size() != shapeAfterBroadcast.size())
+      return failure();
+
+    // we expect five dimensions
+    if (shapeBeforeBroadcast.size() != 5)
+      return failure();
+
+    // dimension we are broadcasting
+    if (shapeBeforeBroadcast[2] != 1 ||
+        shapeAfterBroadcast[2] != expectedRepeat)
+      return failure();
+
+    // rest of dimensions must be the same
+    for (size_t idx = 0; idx < shapeBeforeBroadcast.size(); idx++) {
+      if (idx != 2 && shapeBeforeBroadcast[idx] != shapeAfterBroadcast[idx])
+        return failure();
+    }
+
+    return success();
+  }
+
+  FailureOr<Value> sliceTensorGQA(PatternRewriter &rewriter, Value value,
+                                  int64_t batch, int64_t numHeads,
+                                  int64_t repeat) const {
+    Location loc = value.getLoc();
+    ArrayRef<int64_t> shape = cast<ShapedType>(value.getType()).getShape();
+    if (shape.size() != 3)
+      return failure();
+
+    if (shape[0] != (batch * numHeads * repeat))
+      return failure();
+
+    // reshape group x D x K -> batch x num_heads x repeat x D x K
+    rock::BottomUpTMBuilder unmergeDims(rewriter, {"group", "dim0", "dim1"},
+                                        shape, loc);
+    unmergeDims.unmerge({"batch", "num_heads", "repeat"}, {0, 1, 2}, "group",
+                        {batch, numHeads, repeat});
+    unmergeDims.passThrough({3, 4}, {1, 2});
+    rock::TransformMapAttr unmergeDimsAttr = unmergeDims.get();
+
+    // slice repeat to 1
+    auto sliceRepeat =
+        rock::BottomUpTMBuilder::above(unmergeDims, unmergeDimsAttr);
+    sliceRepeat.slice({"repeat"}, {"repeat"}, {0}, {1});
+    sliceRepeat.passThrough({"batch", "num_heads", "dim0", "dim1"});
+    rock::TransformMapAttr sliceRepeatAttr = sliceRepeat.get();
+
+    // reshape back to group/repeat x D x K
+    auto finalMerge =
+        rock::BottomUpTMBuilder::above(sliceRepeat, sliceRepeatAttr);
+    finalMerge.merge("group", 0, {"batch", "num_heads", "repeat"});
+    finalMerge.passThrough({"dim0", "dim1"}, {1, 2}, {"dim0", "dim1"});
+    rock::TransformMapAttr finalMergeAttr = finalMerge.get();
+
+    ArrayAttr transformsAttr = rewriter.getArrayAttr(
+        {finalMergeAttr, sliceRepeatAttr, unmergeDimsAttr});
+    return rock::transform(rewriter, value, transformsAttr);
+  }
+
+  /*
+  This tries to identify if GQA is used, and undoes the broadcast. The expected
+  IR is:
+
+  // clang-format off
+  ```
+  %q = tensor.collapse %q [[0, 1], [2], [3]] : tensor<1x32x1x128xf16> into
+  tensor<32x1x128xf16>
+
+  // broadcast from numHeadsK, 1 -> numHeadsK, repeat where
+  numHeadsQ=numHeadsK*repeat %k = tosa.mul %k, constant=1, constant=0 :
+  (tensor<1x8x1x128x64xf16>, tensor<1x8x4x128x64xf16>, tensor<1xi8>) ->
+  tensor<1x8x4x128x64xf16>
+  // collapse batch, numHeadsK and repeat into group dimension,
+  group=batch*numHeadsK*repeat %k = tensor.collapse_shape %k [[0, 1, 2], [3],
+  [4]] : tensor<1x8x4x128x64xf16> into tensor<32x128x64xf16>
+
+  %v = same transforms as %k
+  rock.attention(%q, %k, %v)
+  ```
+  // clang-format on
+
+  Note that if we identify the GQA pattern, we slice the K and V tensors
+  and pass numHeadsQ and numHeadsKV to rock.attention. Otherwise, K and V
+  tensors are left untouched and numHeadsQ=1, numHeadsKV=1.
+  */
+  std::tuple<Value, Value, Value, IntegerAttr, IntegerAttr>
+  getGQAValues(PatternRewriter &rewriter, Value queries, Value keys,
+               Value values) const {
+    // default values in case GQA is not pattern matched
+    IntegerAttr numHeadsQAttr = rewriter.getI32IntegerAttr(1);
+    IntegerAttr numHeadsKVAttr = rewriter.getI32IntegerAttr(1);
+    auto defaultValues =
+        std::make_tuple(queries, keys, values, numHeadsQAttr, numHeadsKVAttr);
+
+    FailureOr<std::pair<int64_t, int64_t>> reshapeQResults =
+        getNumHeadsGQA(queries, true);
+    if (failed(reshapeQResults))
+      return defaultValues;
+    int64_t batchQ = reshapeQResults->first;
+    int64_t numHeadsQ = reshapeQResults->second;
+
+    FailureOr<std::pair<int64_t, int64_t>> reshapeKResults =
+        getNumHeadsGQA(keys, false);
+    if (failed(reshapeKResults))
+      return defaultValues;
+    int64_t batchK = reshapeKResults->first;
+    int64_t numHeadsK = reshapeKResults->second;
+
+    FailureOr<std::pair<int64_t, int64_t>> reshapeVResults =
+        getNumHeadsGQA(values, false);
+    if (failed(reshapeVResults))
+      return defaultValues;
+    int64_t batchV = reshapeVResults->first;
+    int64_t numHeadsV = reshapeVResults->second;
+
+    // batch must be equal for all tensors
+    if (batchQ != batchK || batchQ != batchV)
+      return defaultValues;
+
+    // num heads of K and V must be equal
+    if (numHeadsK != numHeadsV)
+      return defaultValues;
+
+    // numHeadsQ must be divisible by numHeadsKV
+    if (numHeadsQ % numHeadsK != 0)
+      return defaultValues;
+
+    int64_t expectedRepeat = numHeadsQ / numHeadsK;
+    // check we are doing the expected broadcast for K and V
+    LogicalResult kCorrect = checkBroadcastGQA(keys, expectedRepeat);
+    LogicalResult vCorrect = checkBroadcastGQA(values, expectedRepeat);
+    if (failed(kCorrect) || failed(vCorrect))
+      return defaultValues;
+
+    // update keys and values (slicing the repeats)
+    auto maybeKeys =
+        sliceTensorGQA(rewriter, keys, batchK, numHeadsK, expectedRepeat);
+    auto maybeValues =
+        sliceTensorGQA(rewriter, values, batchV, numHeadsV, expectedRepeat);
+    if (failed(maybeKeys) || failed(maybeValues))
+      return defaultValues;
+
+    keys = maybeKeys.value();
+    values = maybeValues.value();
+
+    numHeadsQAttr = rewriter.getI32IntegerAttr(numHeadsQ);
+    numHeadsKVAttr = rewriter.getI32IntegerAttr(numHeadsK);
+    LLVM_DEBUG(llvm::dbgs() << "Found GQA pattern, numHeadsQ=" << numHeadsQ
+                            << " numHeadsKV=" << numHeadsK << "\n");
+    return std::make_tuple(queries, keys, values, numHeadsQAttr,
+                           numHeadsKVAttr);
+  }
+
   FailureOr<AttentionMatcherValues> match(tosa::MatMulOp op) const {
     Value softmaxOutput = op.getA();
     DenseSet<StringRef> expandAndCollapse{
@@ -2517,13 +2732,16 @@ struct AttentionRewritePattern : public OpRewritePattern<tosa::MatMulOp> {
         attentionMatcherValues.preSoftmaxElementwiseFinder;
     int64_t firstGemmBlockIndex = elemwiseRegion.getFirstGemmBlockIndex();
 
-    // TODO: numHeadsQ and numHeadsKV migraphx integration
+    IntegerAttr numHeadsQ, numHeadsKV;
+    Value queries, keys, values;
+    std::tie(queries, keys, values, numHeadsQ, numHeadsKV) = getGQAValues(
+        rewriter, firstMatMulOp.getA(), firstMatMulOp.getB(), op.getB());
+
     rock::AttentionOp attnOp = rock::AttentionOp::create(
-        rewriter, loc, outputType, lseType, firstMatMulOp.getA(),
-        firstMatMulOp.getB(), op.getB(), elementwiseOtherArgs, currentSeqLen,
-        output, lseOut,
-        /*numHeadsQ=*/rewriter.getI32IntegerAttr(1),
-        /*numHeadsKV=*/rewriter.getI32IntegerAttr(1),
+        rewriter, loc, outputType, lseType, queries, keys, values,
+        elementwiseOtherArgs, currentSeqLen, output, lseOut,
+        /*numHeadsQ=*/numHeadsQ,
+        /*numHeadsKV=*/numHeadsKV,
         /*qTransposed=*/nullptr,
         /*kTransposed=*/nullptr,
         /*vTransposed=*/nullptr,

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-attention-gqa.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-attention-gqa.mlir
@@ -1,185 +1,339 @@
 // RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt --tosa-to-rock -verify-diagnostics -o -| FileCheck %s
 
+// CHECK-LABEL: func @attention_gqa_8_32
 // CHECK: rock.attention
-func.func @self_attention_gqa(%arg0: tensor<4096xf32> {mhal.read_access}, %arg1: tensor<8192xf32> {mhal.read_access}, %arg2: tensor<4096xf32> {mhal.read_access}) -> (tensor<8192xf32> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
-  %expanded = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_0 = tensor.expand_shape %arg2 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_1 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_2 = tensor.expand_shape %arg0 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %0 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x2x32x32xf32>}> : () -> tensor<2x2x2x32x32xf32>
-  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-  %1 = tosa.mul %expanded_2, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed = tensor.collapse_shape %1 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %expanded_3 = tensor.expand_shape %arg2 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %2 = tosa.mul %expanded_3, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed_4 = tensor.collapse_shape %2 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %4 = tosa.transpose %collapsed_4 {perms = array<i32: 0, 1, 3, 2>} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %expanded_5 = tensor.expand_shape %arg1 [[0, 1, 2]] output_shape [8, 32, 32] : tensor<8192xf32> into tensor<8x32x32xf32>
-  %collapsed_6 = tensor.collapse_shape %4 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %5 = tosa.matmul %expanded_5, %collapsed_6, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_7 = tensor.expand_shape %5 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %6 = tosa.reduce_max %expanded_7 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %7 = tosa.sub %expanded_7, %6 : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>) -> tensor<2x4x32x32xf32>
-  %8 = tosa.exp %7 : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %9 = tosa.reduce_sum %8 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %10 = tosa.reciprocal %9 : (tensor<2x4x32x1xf32>) -> tensor<2x4x32x1xf32>
-  %11 = tosa.mul %8, %10, %shift : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>, tensor<1xi8>) -> tensor<2x4x32x32xf32>
-  %collapsed_8 = tensor.collapse_shape %11 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %collapsed_9 = tensor.collapse_shape %1 [[0, 1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<8x32x32xf32>
-  %12 = tosa.matmul %collapsed_8, %collapsed_9, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_10 = tensor.expand_shape %12 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %collapsed_11 = tensor.collapse_shape %12 [[0, 1, 2]] : tensor<8x32x32xf32> into tensor<8192xf32>
-  return %collapsed_11 : tensor<8192xf32>
+// CHECK: numHeadsKV = 8 : i32, numHeadsQ = 32 : i32
+func.func @attention_gqa_8_32(%arg0: tensor<6144xf16>, %arg1: tensor<65536xf16>, %arg2: tensor<65536xf16>, %arg3: tensor<1xi32>) -> tensor<4096xf16> attributes {kernel, arch = "##TOKEN_ARCH##"} {
+  %0 = "tosa.const"() <{values = dense<[[[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]]]]> : tensor<1x1x1x64xi32>}> : () -> tensor<1x1x1x64xi32>
+  %1 = tosa.const_shape  {values = dense<4096> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %2 = tosa.const_shape  {values = dense<[32, 64, 128]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %3 = tosa.const_shape  {values = dense<[32, 1, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %4 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<1x32x1x64xf32>}> : () -> tensor<1x32x1x64xf32>
+  %5 = "tosa.const"() <{values = dense<1> : tensor<1x32x1x64xi8>}> : () -> tensor<1x32x1x64xi8>
+  %6 = tosa.const_shape  {values = dense<1> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %7 = "tosa.const"() <{values = dense<8.837890e-02> : tensor<1x32x1x64xf16>}> : () -> tensor<1x32x1x64xf16>
+  %8 = "tosa.const"() <{values = dense<0xFC00> : tensor<1x32x1x64xf16>}> : () -> tensor<1x32x1x64xf16>
+  %9 = tosa.const_shape  {values = dense<[1, 32, 1, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %10 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %11 = tosa.const_shape  {values = dense<[32, 128, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %12 = tosa.const_shape  {values = dense<[32, 1, 128]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %13 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<1x8x4x128x64xf16>}> : () -> tensor<1x8x4x128x64xf16>
+  %14 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<1x8x4x64x128xf16>}> : () -> tensor<1x8x4x64x128xf16>
+  %15 = tosa.const_shape  {values = dense<[1, 8, 1, 64, 128]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %16 = tosa.const_shape  {values = dense<[1, 32, 1, 128]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %17 = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %18 = "tosa.const"() <{values = dense<1> : tensor<1x1x1x64xi32>}> : () -> tensor<1x1x1x64xi32>
+  %19 = tosa.const_shape  {values = dense<[1, 48, 1, 128]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [1, 48, 1, 128] : tensor<6144xf16> into tensor<1x48x1x128xf16>
+  %extracted_slice = tensor.extract_slice %expanded[0, 0, 0, 0] [1, 32, 1, 128] [1, 1, 1, 1] : tensor<1x48x1x128xf16> to tensor<1x32x1x128xf16>
+  %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3, 4]] output_shape [1, 8, 1, 64, 128] : tensor<65536xf16> into tensor<1x8x1x64x128xf16>
+  %expanded_1 = tensor.expand_shape %arg2 [[0, 1, 2, 3, 4]] output_shape [1, 8, 1, 64, 128] : tensor<65536xf16> into tensor<1x8x1x64x128xf16>
+  %20 = tosa.mul %expanded_1, %14, %17 : (tensor<1x8x1x64x128xf16>, tensor<1x8x4x64x128xf16>, tensor<1xi8>) -> tensor<1x8x4x64x128xf16>
+  %21 = tosa.transpose %expanded_0 {perms = array<i32: 0, 1, 2, 4, 3>} : (tensor<1x8x1x64x128xf16>) -> tensor<1x8x1x128x64xf16>
+  %22 = tosa.mul %21, %13, %17 : (tensor<1x8x1x128x64xf16>, tensor<1x8x4x128x64xf16>, tensor<1xi8>) -> tensor<1x8x4x128x64xf16>
+  %collapsed = tensor.collapse_shape %extracted_slice [[0, 1], [2], [3]] : tensor<1x32x1x128xf16> into tensor<32x1x128xf16>
+  %collapsed_2 = tensor.collapse_shape %22 [[0, 1, 2], [3], [4]] : tensor<1x8x4x128x64xf16> into tensor<32x128x64xf16>
+  %23 = tosa.matmul %collapsed, %collapsed_2, %10, %10 {acc_type = f32} : (tensor<32x1x128xf16>, tensor<32x128x64xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<32x1x64xf16>
+  %expanded_3 = tensor.expand_shape %23 [[0, 1], [2], [3]] output_shape [1, 32, 1, 64] : tensor<32x1x64xf16> into tensor<1x32x1x64xf16>
+  %24 = tosa.mul %expanded_3, %7, %17 : (tensor<1x32x1x64xf16>, tensor<1x32x1x64xf16>, tensor<1xi8>) -> tensor<1x32x1x64xf16>
+  %expanded_4 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [1, 1, 1, 1] : tensor<1xi32> into tensor<1x1x1x1xi32>
+  %25 = tosa.mul %expanded_4, %18, %17 : (tensor<1x1x1x1xi32>, tensor<1x1x1x64xi32>, tensor<1xi8>) -> tensor<1x1x1x64xi32>
+  %26 = tosa.greater %0, %25 : (tensor<1x1x1x64xi32>, tensor<1x1x1x64xi32>) -> tensor<1x1x1x64xi1>
+  %27 = tosa.cast %26 : (tensor<1x1x1x64xi1>) -> tensor<1x1x1x64xi32>
+  %28 = tosa.cast %27 : (tensor<1x1x1x64xi32>) -> tensor<1x1x1x64xi8>
+  %29 = tosa.mul %28, %5, %17 : (tensor<1x1x1x64xi8>, tensor<1x32x1x64xi8>, tensor<1xi8>) -> tensor<1x32x1x64xi8>
+  %30 = tosa.cast %29 : (tensor<1x32x1x64xi8>) -> tensor<1x32x1x64xi1>
+  %31 = tosa.select %30, %8, %24 : (tensor<1x32x1x64xi1>, tensor<1x32x1x64xf16>, tensor<1x32x1x64xf16>) -> tensor<1x32x1x64xf16>
+  %32 = tosa.cast %31 : (tensor<1x32x1x64xf16>) -> tensor<1x32x1x64xf32>
+  %33 = tosa.reduce_max %32 {axis = 3 : i32} : (tensor<1x32x1x64xf32>) -> tensor<1x32x1x1xf32>
+  %34 = tosa.mul %33, %4, %17 : (tensor<1x32x1x1xf32>, tensor<1x32x1x64xf32>, tensor<1xi8>) -> tensor<1x32x1x64xf32>
+  %35 = tosa.sub %32, %34 : (tensor<1x32x1x64xf32>, tensor<1x32x1x64xf32>) -> tensor<1x32x1x64xf32>
+  %36 = tosa.exp %35 : (tensor<1x32x1x64xf32>) -> tensor<1x32x1x64xf32>
+  %37 = tosa.reduce_sum %36 {axis = 3 : i32} : (tensor<1x32x1x64xf32>) -> tensor<1x32x1x1xf32>
+  %38 = tosa.mul %37, %4, %17 : (tensor<1x32x1x1xf32>, tensor<1x32x1x64xf32>, tensor<1xi8>) -> tensor<1x32x1x64xf32>
+  %39 = tosa.reciprocal %38 : (tensor<1x32x1x64xf32>) -> tensor<1x32x1x64xf32>
+  %40 = tosa.mul %36, %39, %17 : (tensor<1x32x1x64xf32>, tensor<1x32x1x64xf32>, tensor<1xi8>) -> tensor<1x32x1x64xf32>
+  %41 = tosa.cast %40 : (tensor<1x32x1x64xf32>) -> tensor<1x32x1x64xf16>
+  %collapsed_5 = tensor.collapse_shape %41 [[0, 1], [2], [3]] : tensor<1x32x1x64xf16> into tensor<32x1x64xf16>
+  %collapsed_6 = tensor.collapse_shape %20 [[0, 1, 2], [3], [4]] : tensor<1x8x4x64x128xf16> into tensor<32x64x128xf16>
+  %42 = tosa.matmul %collapsed_5, %collapsed_6, %10, %10 {acc_type = f32} : (tensor<32x1x64xf16>, tensor<32x64x128xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<32x1x128xf16>
+  %expanded_7 = tensor.expand_shape %42 [[0, 1], [2], [3]] output_shape [1, 32, 1, 128] : tensor<32x1x128xf16> into tensor<1x32x1x128xf16>
+  %43 = tosa.transpose %expanded_7 {perms = array<i32: 0, 2, 1, 3>} : (tensor<1x32x1x128xf16>) -> tensor<1x1x32x128xf16>
+  %collapsed_8 = tensor.collapse_shape %43 [[0, 1, 2, 3]] : tensor<1x1x32x128xf16> into tensor<4096xf16>
+  return %collapsed_8 : tensor<4096xf16>
 }
 
 
+// CHECK-LABEL: func @attention_gqa_2_14
 // CHECK: rock.attention
-func.func @self_attention_gqa_bias(%arg0: tensor<4096xf32> {mhal.read_access}, %arg1: tensor<8192xf32> {mhal.read_access}, %arg2: tensor<4096xf32> {mhal.read_access}, %arg3: tensor<8192xf32> {mhal.read_access}) -> (tensor<8192xf32> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
-  %expanded = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_1 = tensor.expand_shape %arg2 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_2 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_3 = tensor.expand_shape %arg0 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %0 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x2x32x32xf32>}> : () -> tensor<2x2x2x32x32xf32>
-  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
-  %1 = tosa.mul %expanded_3, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed = tensor.collapse_shape %1 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %expanded_4 = tensor.expand_shape %arg2 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %2 = tosa.mul %expanded_4, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed_5 = tensor.collapse_shape %2 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %3 = "tosa.const"() <{values = dense<[0, 1, 3, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
-  %4 = tosa.transpose %collapsed_5 {perms = array<i32: 0, 1, 3, 2>} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %expanded_6 = tensor.expand_shape %arg1 [[0, 1, 2]] output_shape [8, 32, 32] : tensor<8192xf32> into tensor<8x32x32xf32>
-  %collapsed_7 = tensor.collapse_shape %4 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %5 = tosa.matmul %expanded_6, %collapsed_7, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_8 = tensor.expand_shape %5 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %6 = tosa.add %expanded_8, %expanded : (tensor<2x4x32x32xf32>, tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %7 = tosa.reduce_max %6 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %8 = tosa.sub %6, %7 : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>) -> tensor<2x4x32x32xf32>
-  %9 = tosa.exp %8 : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %10 = tosa.reduce_sum %9 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %11 = tosa.reciprocal %10 : (tensor<2x4x32x1xf32>) -> tensor<2x4x32x1xf32>
-  %12 = tosa.mul %9, %11, %shift : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>, tensor<1xi8>) -> tensor<2x4x32x32xf32>
-  %collapsed_9 = tensor.collapse_shape %12 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %collapsed_10 = tensor.collapse_shape %1 [[0, 1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<8x32x32xf32>
-  %13 = tosa.matmul %collapsed_9, %collapsed_10, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_11 = tensor.expand_shape %13 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %collapsed_12 = tensor.collapse_shape %13 [[0, 1, 2]] : tensor<8x32x32xf32> into tensor<8192xf32>
-  return %collapsed_12 : tensor<8192xf32>
+// CHECK: numHeadsKV = 2 : i32, numHeadsQ = 14 : i32
+func.func @attention_gqa_2_14(%arg0: tensor<2xi32> {mhal.read_access}, %arg1: tensor<9216xf16> {mhal.read_access}, %arg2: tensor<2048xf16> {mhal.read_access}, %arg3: tensor<2048xf16> {mhal.read_access}) -> (tensor<7168xf16> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
+  %0 = "tosa.const"() <{values = dense<[[[[0, 1, 1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1]]]]> : tensor<1x1x4x8xi8>}> : () -> tensor<1x1x4x8xi8>
+  %1 = "tosa.const"() <{values = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi32>}> : () -> tensor<1x8xi32>
+  %2 = tosa.const_shape  {values = dense<7168> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %3 = tosa.const_shape  {values = dense<[28, 8, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %4 = tosa.const_shape  {values = dense<[28, 4, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %5 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x14x4x8xf32>}> : () -> tensor<2x14x4x8xf32>
+  %6 = "tosa.const"() <{values = dense<0xFC00> : tensor<2x14x4x8xf16>}> : () -> tensor<2x14x4x8xf16>
+  %7 = tosa.const_shape  {values = dense<[2, 14, 4, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %8 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %9 = tosa.const_shape  {values = dense<[28, 64, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %10 = tosa.const_shape  {values = dense<[28, 4, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %11 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x64x8xf16>}> : () -> tensor<2x2x7x64x8xf16>
+  %12 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x8x64xf16>}> : () -> tensor<2x2x7x8x64xf16>
+  %13 = tosa.const_shape  {values = dense<[2, 2, 1, 8, 64]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %14 = tosa.const_shape  {values = dense<[2, 14, 4, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %15 = tosa.const_shape  {values = dense<[2, 1, 1, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %16 = "tosa.const"() <{values = dense<1> : tensor<2x14x4x8xi8>}> : () -> tensor<2x14x4x8xi8>
+  %17 = "tosa.const"() <{values = dense<1.250000e-01> : tensor<2x14x4x8xf16>}> : () -> tensor<2x14x4x8xf16>
+  %18 = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %19 = "tosa.const"() <{values = dense<1> : tensor<2x8xi32>}> : () -> tensor<2x8xi32>
+  %20 = tosa.const_shape  {values = dense<[2, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %21 = tosa.const_shape  {values = dense<[2, 4, 18, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %expanded = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 4, 18, 64] : tensor<9216xf16> into tensor<2x4x18x64xf16>
+  %22 = tosa.transpose %expanded {perms = array<i32: 0, 2, 1, 3>} : (tensor<2x4x18x64xf16>) -> tensor<2x18x4x64xf16>
+  %expanded_0 = tensor.expand_shape %arg0 [[0, 1]] output_shape [2, 1] : tensor<2xi32> into tensor<2x1xi32>
+  %23 = tosa.mul %1, %19, %18 : (tensor<1x8xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %24 = tosa.mul %0, %16, %18 : (tensor<1x1x4x8xi8>, tensor<2x14x4x8xi8>, tensor<1xi8>) -> tensor<2x14x4x8xi8>
+  %25 = tosa.mul %expanded_0, %19, %18 : (tensor<2x1xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %26 = tosa.greater %23, %25 : (tensor<2x8xi32>, tensor<2x8xi32>) -> tensor<2x8xi1>
+  %27 = tosa.cast %26 : (tensor<2x8xi1>) -> tensor<2x8xi32>
+  %28 = tosa.cast %27 : (tensor<2x8xi32>) -> tensor<2x8xi8>
+  %expanded_1 = tensor.expand_shape %28 [[0, 1, 2], [3]] output_shape [2, 1, 1, 8] : tensor<2x8xi8> into tensor<2x1x1x8xi8>
+  %29 = tosa.mul %expanded_1, %16, %18 : (tensor<2x1x1x8xi8>, tensor<2x14x4x8xi8>, tensor<1xi8>) -> tensor<2x14x4x8xi8>
+  %extracted_slice = tensor.extract_slice %22[0, 0, 0, 0] [2, 14, 4, 64] [1, 1, 1, 1] : tensor<2x18x4x64xf16> to tensor<2x14x4x64xf16>
+  %expanded_2 = tensor.expand_shape %arg2 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %30 = tosa.mul %expanded_2, %12, %18 : (tensor<2x2x1x8x64xf16>, tensor<2x2x7x8x64xf16>, tensor<1xi8>) -> tensor<2x2x7x8x64xf16>
+  %expanded_3 = tensor.expand_shape %arg3 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %31 = tosa.transpose %expanded_3 {perms = array<i32: 0, 1, 2, 4, 3>} : (tensor<2x2x1x8x64xf16>) -> tensor<2x2x1x64x8xf16>
+  %32 = tosa.mul %31, %11, %18 : (tensor<2x2x1x64x8xf16>, tensor<2x2x7x64x8xf16>, tensor<1xi8>) -> tensor<2x2x7x64x8xf16>
+  %collapsed = tensor.collapse_shape %extracted_slice [[0, 1], [2], [3]] : tensor<2x14x4x64xf16> into tensor<28x4x64xf16>
+  %collapsed_4 = tensor.collapse_shape %32 [[0, 1, 2], [3], [4]] : tensor<2x2x7x64x8xf16> into tensor<28x64x8xf16>
+  %33 = tosa.matmul %collapsed, %collapsed_4, %8, %8 {acc_type = f32} : (tensor<28x4x64xf16>, tensor<28x64x8xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x4x8xf16>
+  %expanded_5 = tensor.expand_shape %33 [[0, 1], [2], [3]] output_shape [2, 14, 4, 8] : tensor<28x4x8xf16> into tensor<2x14x4x8xf16>
+  %34 = tosa.mul %expanded_5, %17, %18 : (tensor<2x14x4x8xf16>, tensor<2x14x4x8xf16>, tensor<1xi8>) -> tensor<2x14x4x8xf16>
+  %35 = tosa.cast %24 : (tensor<2x14x4x8xi8>) -> tensor<2x14x4x8xi1>
+  %36 = tosa.select %35, %6, %34 : (tensor<2x14x4x8xi1>, tensor<2x14x4x8xf16>, tensor<2x14x4x8xf16>) -> tensor<2x14x4x8xf16>
+  %37 = tosa.cast %29 : (tensor<2x14x4x8xi8>) -> tensor<2x14x4x8xi1>
+  %38 = tosa.select %37, %6, %36 : (tensor<2x14x4x8xi1>, tensor<2x14x4x8xf16>, tensor<2x14x4x8xf16>) -> tensor<2x14x4x8xf16>
+  %39 = tosa.cast %38 : (tensor<2x14x4x8xf16>) -> tensor<2x14x4x8xf32>
+  %40 = tosa.reduce_max %39 {axis = 3 : i32} : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x1xf32>
+  %41 = tosa.mul %40, %5, %18 : (tensor<2x14x4x1xf32>, tensor<2x14x4x8xf32>, tensor<1xi8>) -> tensor<2x14x4x8xf32>
+  %42 = tosa.sub %39, %41 : (tensor<2x14x4x8xf32>, tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf32>
+  %43 = tosa.exp %42 : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf32>
+  %44 = tosa.reduce_sum %43 {axis = 3 : i32} : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x1xf32>
+  %45 = tosa.mul %44, %5, %18 : (tensor<2x14x4x1xf32>, tensor<2x14x4x8xf32>, tensor<1xi8>) -> tensor<2x14x4x8xf32>
+  %46 = tosa.reciprocal %45 : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf32>
+  %47 = tosa.mul %43, %46, %18 : (tensor<2x14x4x8xf32>, tensor<2x14x4x8xf32>, tensor<1xi8>) -> tensor<2x14x4x8xf32>
+  %48 = tosa.cast %47 : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf16>
+  %collapsed_6 = tensor.collapse_shape %48 [[0, 1], [2], [3]] : tensor<2x14x4x8xf16> into tensor<28x4x8xf16>
+  %collapsed_7 = tensor.collapse_shape %30 [[0, 1, 2], [3], [4]] : tensor<2x2x7x8x64xf16> into tensor<28x8x64xf16>
+  %49 = tosa.matmul %collapsed_6, %collapsed_7, %8, %8 {acc_type = f32} : (tensor<28x4x8xf16>, tensor<28x8x64xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x4x64xf16>
+  %expanded_8 = tensor.expand_shape %49 [[0, 1], [2], [3]] output_shape [2, 14, 4, 64] : tensor<28x4x64xf16> into tensor<2x14x4x64xf16>
+  %50 = tosa.transpose %expanded_8 {perms = array<i32: 0, 2, 1, 3>} : (tensor<2x14x4x64xf16>) -> tensor<2x4x14x64xf16>
+  %collapsed_9 = tensor.collapse_shape %50 [[0, 1, 2, 3]] : tensor<2x4x14x64xf16> into tensor<7168xf16>
+  return %collapsed_9 : tensor<7168xf16>
 }
 
+// CHECK-LABEL: func @attention_gqa_2_14_2
 // CHECK: rock.attention
-func.func @self_attention_gqa_scale(%arg0: tensor<4096xf32> {mhal.read_access}, %arg1: tensor<8192xf32> {mhal.read_access}, %arg2: tensor<8192xf32> {mhal.read_access}, %arg3: tensor<4096xf32> {mhal.read_access}) -> (tensor<8192xf32> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
-  %expanded = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_0 = tensor.expand_shape %arg2 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_1 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_2 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_3 = tensor.expand_shape %arg0 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %0 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x2x32x32xf32>}> : () -> tensor<2x2x2x32x32xf32>
-  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
-  %1 = tosa.mul %expanded_3, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed = tensor.collapse_shape %1 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %expanded_4 = tensor.expand_shape %arg3 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %2 = tosa.mul %expanded_4, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed_5 = tensor.collapse_shape %2 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %4 = tosa.transpose %collapsed_5 {perms = array<i32: 0, 1, 3, 2>} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %expanded_6 = tensor.expand_shape %arg2 [[0, 1, 2]] output_shape [8, 32, 32] : tensor<8192xf32> into tensor<8x32x32xf32>
-  %collapsed_7 = tensor.collapse_shape %4 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %5 = tosa.matmul %expanded_6, %collapsed_7, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_8 = tensor.expand_shape %5 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %6 = tosa.mul %expanded_8, %expanded, %shift : (tensor<2x4x32x32xf32>, tensor<2x4x32x32xf32>, tensor<1xi8>) -> tensor<2x4x32x32xf32>
-  %7 = tosa.reduce_max %6 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %8 = tosa.sub %6, %7 : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>) -> tensor<2x4x32x32xf32>
-  %9 = tosa.exp %8 : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %10 = tosa.reduce_sum %9 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %11 = tosa.reciprocal %10 : (tensor<2x4x32x1xf32>) -> tensor<2x4x32x1xf32>
-  %12 = tosa.mul %9, %11, %shift : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>, tensor<1xi8>) -> tensor<2x4x32x32xf32>
-  %collapsed_9 = tensor.collapse_shape %12 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %collapsed_10 = tensor.collapse_shape %1 [[0, 1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<8x32x32xf32>
-  %13 = tosa.matmul %collapsed_9, %collapsed_10, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_11 = tensor.expand_shape %13 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %collapsed_12 = tensor.collapse_shape %13 [[0, 1, 2]] : tensor<8x32x32xf32> into tensor<8192xf32>
-  return %collapsed_12 : tensor<8192xf32>
+// CHECK: numHeadsKV = 2 : i32, numHeadsQ = 14 : i32
+func.func @attention_gqa_2_14_2(%arg0: tensor<9216xf16> {mhal.read_access}, %arg1: tensor<2048xf16> {mhal.read_access}, %arg2: tensor<2048xf16> {mhal.read_access}, %arg3: tensor<2xi32> {mhal.read_access}) -> (tensor<7168xf16> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
+  %0 = "tosa.const"() <{values = dense<[[[[0, 1, 1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1]]]]> : tensor<1x1x4x8xi8>}> : () -> tensor<1x1x4x8xi8>
+  %1 = "tosa.const"() <{values = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi32>}> : () -> tensor<1x8xi32>
+  %2 = tosa.const_shape  {values = dense<7168> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %3 = tosa.const_shape  {values = dense<[28, 8, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %4 = tosa.const_shape  {values = dense<[28, 4, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %5 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x14x4x8xf32>}> : () -> tensor<2x14x4x8xf32>
+  %6 = tosa.const_shape  {values = dense<[2, 1, 1, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %7 = "tosa.const"() <{values = dense<1> : tensor<2x14x4x8xi8>}> : () -> tensor<2x14x4x8xi8>
+  %8 = "tosa.const"() <{values = dense<1.250000e-01> : tensor<2x14x4x8xf16>}> : () -> tensor<2x14x4x8xf16>
+  %9 = "tosa.const"() <{values = dense<0xFC00> : tensor<2x14x4x8xf16>}> : () -> tensor<2x14x4x8xf16>
+  %10 = "tosa.const"() <{values = dense<1> : tensor<2x8xi32>}> : () -> tensor<2x8xi32>
+  %11 = tosa.const_shape  {values = dense<[2, 14, 4, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %12 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %13 = tosa.const_shape  {values = dense<[28, 64, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %14 = tosa.const_shape  {values = dense<[28, 4, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %15 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x64x8xf16>}> : () -> tensor<2x2x7x64x8xf16>
+  %16 = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %17 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x8x64xf16>}> : () -> tensor<2x2x7x8x64xf16>
+  %18 = tosa.const_shape  {values = dense<[2, 2, 1, 8, 64]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %19 = tosa.const_shape  {values = dense<[2, 14, 4, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %20 = tosa.const_shape  {values = dense<[2, 4, 18, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %21 = tosa.const_shape  {values = dense<[2, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %expanded = tensor.expand_shape %arg3 [[0, 1]] output_shape [2, 1] : tensor<2xi32> into tensor<2x1xi32>
+  %expanded_0 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [2, 4, 18, 64] : tensor<9216xf16> into tensor<2x4x18x64xf16>
+  %22 = tosa.transpose %expanded_0 {perms = array<i32: 0, 2, 1, 3>} : (tensor<2x4x18x64xf16>) -> tensor<2x18x4x64xf16>
+  %extracted_slice = tensor.extract_slice %22[0, 0, 0, 0] [2, 14, 4, 64] [1, 1, 1, 1] : tensor<2x18x4x64xf16> to tensor<2x14x4x64xf16>
+  %expanded_1 = tensor.expand_shape %arg1 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %23 = tosa.mul %expanded_1, %17, %16 : (tensor<2x2x1x8x64xf16>, tensor<2x2x7x8x64xf16>, tensor<1xi8>) -> tensor<2x2x7x8x64xf16>
+  %expanded_2 = tensor.expand_shape %arg2 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %24 = tosa.transpose %expanded_2 {perms = array<i32: 0, 1, 2, 4, 3>} : (tensor<2x2x1x8x64xf16>) -> tensor<2x2x1x64x8xf16>
+  %25 = tosa.mul %24, %15, %16 : (tensor<2x2x1x64x8xf16>, tensor<2x2x7x64x8xf16>, tensor<1xi8>) -> tensor<2x2x7x64x8xf16>
+  %collapsed = tensor.collapse_shape %extracted_slice [[0, 1], [2], [3]] : tensor<2x14x4x64xf16> into tensor<28x4x64xf16>
+  %collapsed_3 = tensor.collapse_shape %25 [[0, 1, 2], [3], [4]] : tensor<2x2x7x64x8xf16> into tensor<28x64x8xf16>
+  %26 = tosa.matmul %collapsed, %collapsed_3, %12, %12 {acc_type = f32} : (tensor<28x4x64xf16>, tensor<28x64x8xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x4x8xf16>
+  %expanded_4 = tensor.expand_shape %26 [[0, 1], [2], [3]] output_shape [2, 14, 4, 8] : tensor<28x4x8xf16> into tensor<2x14x4x8xf16>
+  %27 = tosa.mul %1, %10, %16 : (tensor<1x8xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %28 = tosa.mul %expanded_4, %8, %16 : (tensor<2x14x4x8xf16>, tensor<2x14x4x8xf16>, tensor<1xi8>) -> tensor<2x14x4x8xf16>
+  %29 = tosa.mul %0, %7, %16 : (tensor<1x1x4x8xi8>, tensor<2x14x4x8xi8>, tensor<1xi8>) -> tensor<2x14x4x8xi8>
+  %30 = tosa.cast %29 : (tensor<2x14x4x8xi8>) -> tensor<2x14x4x8xi1>
+  %31 = tosa.select %30, %9, %28 : (tensor<2x14x4x8xi1>, tensor<2x14x4x8xf16>, tensor<2x14x4x8xf16>) -> tensor<2x14x4x8xf16>
+  %32 = tosa.mul %expanded, %10, %16 : (tensor<2x1xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %33 = tosa.greater %27, %32 : (tensor<2x8xi32>, tensor<2x8xi32>) -> tensor<2x8xi1>
+  %34 = tosa.cast %33 : (tensor<2x8xi1>) -> tensor<2x8xi32>
+  %35 = tosa.cast %34 : (tensor<2x8xi32>) -> tensor<2x8xi8>
+  %expanded_5 = tensor.expand_shape %35 [[0, 1, 2], [3]] output_shape [2, 1, 1, 8] : tensor<2x8xi8> into tensor<2x1x1x8xi8>
+  %36 = tosa.mul %expanded_5, %7, %16 : (tensor<2x1x1x8xi8>, tensor<2x14x4x8xi8>, tensor<1xi8>) -> tensor<2x14x4x8xi8>
+  %37 = tosa.cast %36 : (tensor<2x14x4x8xi8>) -> tensor<2x14x4x8xi1>
+  %38 = tosa.select %37, %9, %31 : (tensor<2x14x4x8xi1>, tensor<2x14x4x8xf16>, tensor<2x14x4x8xf16>) -> tensor<2x14x4x8xf16>
+  %39 = tosa.cast %38 : (tensor<2x14x4x8xf16>) -> tensor<2x14x4x8xf32>
+  %40 = tosa.reduce_max %39 {axis = 3 : i32} : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x1xf32>
+  %41 = tosa.mul %40, %5, %16 : (tensor<2x14x4x1xf32>, tensor<2x14x4x8xf32>, tensor<1xi8>) -> tensor<2x14x4x8xf32>
+  %42 = tosa.sub %39, %41 : (tensor<2x14x4x8xf32>, tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf32>
+  %43 = tosa.exp %42 : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf32>
+  %44 = tosa.reduce_sum %43 {axis = 3 : i32} : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x1xf32>
+  %45 = tosa.mul %44, %5, %16 : (tensor<2x14x4x1xf32>, tensor<2x14x4x8xf32>, tensor<1xi8>) -> tensor<2x14x4x8xf32>
+  %46 = tosa.reciprocal %45 : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf32>
+  %47 = tosa.mul %43, %46, %16 : (tensor<2x14x4x8xf32>, tensor<2x14x4x8xf32>, tensor<1xi8>) -> tensor<2x14x4x8xf32>
+  %48 = tosa.cast %47 : (tensor<2x14x4x8xf32>) -> tensor<2x14x4x8xf16>
+  %collapsed_6 = tensor.collapse_shape %48 [[0, 1], [2], [3]] : tensor<2x14x4x8xf16> into tensor<28x4x8xf16>
+  %collapsed_7 = tensor.collapse_shape %23 [[0, 1, 2], [3], [4]] : tensor<2x2x7x8x64xf16> into tensor<28x8x64xf16>
+  %49 = tosa.matmul %collapsed_6, %collapsed_7, %12, %12 {acc_type = f32} : (tensor<28x4x8xf16>, tensor<28x8x64xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x4x64xf16>
+  %expanded_8 = tensor.expand_shape %49 [[0, 1], [2], [3]] output_shape [2, 14, 4, 64] : tensor<28x4x64xf16> into tensor<2x14x4x64xf16>
+  %50 = tosa.transpose %expanded_8 {perms = array<i32: 0, 2, 1, 3>} : (tensor<2x14x4x64xf16>) -> tensor<2x4x14x64xf16>
+  %collapsed_9 = tensor.collapse_shape %50 [[0, 1, 2, 3]] : tensor<2x4x14x64xf16> into tensor<7168xf16>
+  return %collapsed_9 : tensor<7168xf16>
 }
 
+// CHECK-LABEL: func @attention_gqa_2_14_3
 // CHECK: rock.attention
-func.func @self_attention_gqa_scale_bias(%arg0: tensor<4096xf32> {mhal.read_access}, %arg1: tensor<8192xf32> {mhal.read_access}, %arg2: tensor<8192xf32> {mhal.read_access}, %arg3: tensor<4096xf32> {mhal.read_access}, %arg4: tensor<8192xf32> {mhal.read_access}) -> (tensor<8192xf32> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
-  %expanded = tensor.expand_shape %arg4 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_1 = tensor.expand_shape %arg2 [[0, 1, 2, 3]] output_shape [2, 4, 32, 32] : tensor<8192xf32> into tensor<2x4x32x32xf32>
-  %expanded_2 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_3 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_4 = tensor.expand_shape %arg0 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %0 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x2x32x32xf32>}> : () -> tensor<2x2x2x32x32xf32>
-  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
-  %1 = tosa.mul %expanded_4, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed = tensor.collapse_shape %1 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %expanded_5 = tensor.expand_shape %arg3 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %2 = tosa.mul %expanded_5, %0, %shift: (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed_6 = tensor.collapse_shape %2 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %4 = tosa.transpose %collapsed_6 {perms = array<i32: 0, 1, 3, 2>} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %expanded_7 = tensor.expand_shape %arg2 [[0, 1, 2]] output_shape [8, 32, 32] : tensor<8192xf32> into tensor<8x32x32xf32>
-  %collapsed_8 = tensor.collapse_shape %4 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %5 = tosa.matmul %expanded_7, %collapsed_8, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_9 = tensor.expand_shape %5 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %6 = tosa.mul %expanded_9, %expanded_0, %shift : (tensor<2x4x32x32xf32>, tensor<2x4x32x32xf32>, tensor<1xi8>) -> tensor<2x4x32x32xf32>
-  %7 = tosa.add %6, %expanded : (tensor<2x4x32x32xf32>, tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %8 = tosa.reduce_max %7 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %9 = tosa.sub %7, %8 : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>) -> tensor<2x4x32x32xf32>
-  %10 = tosa.exp %9 : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %11 = tosa.reduce_sum %10 {axis = 3 : i32} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x1xf32>
-  %12 = tosa.reciprocal %11 : (tensor<2x4x32x1xf32>) -> tensor<2x4x32x1xf32>
-  %13 = tosa.mul %10, %12, %shift : (tensor<2x4x32x32xf32>, tensor<2x4x32x1xf32>, tensor<1xi8>) -> tensor<2x4x32x32xf32>
-  %collapsed_10 = tensor.collapse_shape %13 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %collapsed_11 = tensor.collapse_shape %1 [[0, 1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<8x32x32xf32>
-  %14 = tosa.matmul %collapsed_10, %collapsed_11, %a_zp, %b_zp : (tensor<8x32x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x32x32xf32>
-  %expanded_12 = tensor.expand_shape %14 [[0, 1], [2], [3]] output_shape [2, 4, 32, 32] : tensor<8x32x32xf32> into tensor<2x4x32x32xf32>
-  %collapsed_13 = tensor.collapse_shape %14 [[0, 1, 2]] : tensor<8x32x32xf32> into tensor<8192xf32>
-  return %collapsed_13 : tensor<8192xf32>
+// CHECK: numHeadsKV = 2 : i32, numHeadsQ = 14 : i32
+func.func @attention_gqa_2_14_3(%arg0: tensor<2304xf16> {mhal.read_access}, %arg1: tensor<2048xf16> {mhal.read_access}, %arg2: tensor<2048xf16> {mhal.read_access}, %arg3: tensor<2xi32> {mhal.read_access}) -> (tensor<1792xf16> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
+  %0 = "tosa.const"() <{values = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi32>}> : () -> tensor<1x8xi32>
+  %1 = tosa.const_shape  {values = dense<1792> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %2 = tosa.const_shape  {values = dense<[28, 8, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %3 = tosa.const_shape  {values = dense<[28, 1, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %4 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x14x1x8xf32>}> : () -> tensor<2x14x1x8xf32>
+  %5 = "tosa.const"() <{values = dense<1> : tensor<2x14x1x8xi8>}> : () -> tensor<2x14x1x8xi8>
+  %6 = tosa.const_shape  {values = dense<[2, 1, 1, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %7 = "tosa.const"() <{values = dense<1.250000e-01> : tensor<2x14x1x8xf16>}> : () -> tensor<2x14x1x8xf16>
+  %8 = "tosa.const"() <{values = dense<0xFC00> : tensor<2x14x1x8xf16>}> : () -> tensor<2x14x1x8xf16>
+  %9 = "tosa.const"() <{values = dense<1> : tensor<2x8xi32>}> : () -> tensor<2x8xi32>
+  %10 = tosa.const_shape  {values = dense<[2, 14, 1, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %11 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %12 = tosa.const_shape  {values = dense<[28, 64, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %13 = tosa.const_shape  {values = dense<[28, 1, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %14 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x64x8xf16>}> : () -> tensor<2x2x7x64x8xf16>
+  %15 = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %16 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x8x64xf16>}> : () -> tensor<2x2x7x8x64xf16>
+  %17 = tosa.const_shape  {values = dense<[2, 2, 1, 8, 64]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %18 = tosa.const_shape  {values = dense<[2, 14, 1, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %19 = tosa.const_shape  {values = dense<[2, 18, 1, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %20 = tosa.const_shape  {values = dense<[2, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %expanded = tensor.expand_shape %arg3 [[0, 1]] output_shape [2, 1] : tensor<2xi32> into tensor<2x1xi32>
+  %expanded_0 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [2, 18, 1, 64] : tensor<2304xf16> into tensor<2x18x1x64xf16>
+  %extracted_slice = tensor.extract_slice %expanded_0[0, 0, 0, 0] [2, 14, 1, 64] [1, 1, 1, 1] : tensor<2x18x1x64xf16> to tensor<2x14x1x64xf16>
+  %expanded_1 = tensor.expand_shape %arg1 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %21 = tosa.mul %expanded_1, %16, %15 : (tensor<2x2x1x8x64xf16>, tensor<2x2x7x8x64xf16>, tensor<1xi8>) -> tensor<2x2x7x8x64xf16>
+  %expanded_2 = tensor.expand_shape %arg2 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %22 = tosa.transpose %expanded_2 {perms = array<i32: 0, 1, 2, 4, 3>} : (tensor<2x2x1x8x64xf16>) -> tensor<2x2x1x64x8xf16>
+  %23 = tosa.mul %22, %14, %15 : (tensor<2x2x1x64x8xf16>, tensor<2x2x7x64x8xf16>, tensor<1xi8>) -> tensor<2x2x7x64x8xf16>
+  %collapsed = tensor.collapse_shape %extracted_slice [[0, 1], [2], [3]] : tensor<2x14x1x64xf16> into tensor<28x1x64xf16>
+  %collapsed_3 = tensor.collapse_shape %23 [[0, 1, 2], [3], [4]] : tensor<2x2x7x64x8xf16> into tensor<28x64x8xf16>
+  %24 = tosa.matmul %collapsed, %collapsed_3, %11, %11 {acc_type = f32} : (tensor<28x1x64xf16>, tensor<28x64x8xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x1x8xf16>
+  %expanded_4 = tensor.expand_shape %24 [[0, 1], [2], [3]] output_shape [2, 14, 1, 8] : tensor<28x1x8xf16> into tensor<2x14x1x8xf16>
+  %25 = tosa.mul %0, %9, %15 : (tensor<1x8xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %26 = tosa.mul %expanded_4, %7, %15 : (tensor<2x14x1x8xf16>, tensor<2x14x1x8xf16>, tensor<1xi8>) -> tensor<2x14x1x8xf16>
+  %27 = tosa.mul %expanded, %9, %15 : (tensor<2x1xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %28 = tosa.greater %25, %27 : (tensor<2x8xi32>, tensor<2x8xi32>) -> tensor<2x8xi1>
+  %29 = tosa.cast %28 : (tensor<2x8xi1>) -> tensor<2x8xi32>
+  %30 = tosa.cast %29 : (tensor<2x8xi32>) -> tensor<2x8xi8>
+  %expanded_5 = tensor.expand_shape %30 [[0, 1, 2], [3]] output_shape [2, 1, 1, 8] : tensor<2x8xi8> into tensor<2x1x1x8xi8>
+  %31 = tosa.mul %expanded_5, %5, %15 : (tensor<2x1x1x8xi8>, tensor<2x14x1x8xi8>, tensor<1xi8>) -> tensor<2x14x1x8xi8>
+  %32 = tosa.cast %31 : (tensor<2x14x1x8xi8>) -> tensor<2x14x1x8xi1>
+  %33 = tosa.select %32, %8, %26 : (tensor<2x14x1x8xi1>, tensor<2x14x1x8xf16>, tensor<2x14x1x8xf16>) -> tensor<2x14x1x8xf16>
+  %34 = tosa.cast %33 : (tensor<2x14x1x8xf16>) -> tensor<2x14x1x8xf32>
+  %35 = tosa.reduce_max %34 {axis = 3 : i32} : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x1xf32>
+  %36 = tosa.mul %35, %4, %15 : (tensor<2x14x1x1xf32>, tensor<2x14x1x8xf32>, tensor<1xi8>) -> tensor<2x14x1x8xf32>
+  %37 = tosa.sub %34, %36 : (tensor<2x14x1x8xf32>, tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf32>
+  %38 = tosa.exp %37 : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf32>
+  %39 = tosa.reduce_sum %38 {axis = 3 : i32} : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x1xf32>
+  %40 = tosa.mul %39, %4, %15 : (tensor<2x14x1x1xf32>, tensor<2x14x1x8xf32>, tensor<1xi8>) -> tensor<2x14x1x8xf32>
+  %41 = tosa.reciprocal %40 : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf32>
+  %42 = tosa.mul %38, %41, %15 : (tensor<2x14x1x8xf32>, tensor<2x14x1x8xf32>, tensor<1xi8>) -> tensor<2x14x1x8xf32>
+  %43 = tosa.cast %42 : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf16>
+  %collapsed_6 = tensor.collapse_shape %43 [[0, 1], [2], [3]] : tensor<2x14x1x8xf16> into tensor<28x1x8xf16>
+  %collapsed_7 = tensor.collapse_shape %21 [[0, 1, 2], [3], [4]] : tensor<2x2x7x8x64xf16> into tensor<28x8x64xf16>
+  %44 = tosa.matmul %collapsed_6, %collapsed_7, %11, %11 {acc_type = f32} : (tensor<28x1x8xf16>, tensor<28x8x64xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x1x64xf16>
+  %expanded_8 = tensor.expand_shape %44 [[0, 1], [2], [3]] output_shape [2, 14, 1, 64] : tensor<28x1x64xf16> into tensor<2x14x1x64xf16>
+  %45 = tosa.transpose %expanded_8 {perms = array<i32: 0, 2, 1, 3>} : (tensor<2x14x1x64xf16>) -> tensor<2x1x14x64xf16>
+  %collapsed_9 = tensor.collapse_shape %45 [[0, 1, 2, 3]] : tensor<2x1x14x64xf16> into tensor<1792xf16>
+  return %collapsed_9 : tensor<1792xf16>
 }
 
+// CHECK-LABEL: func @attention_gqa_2_14_4
 // CHECK: rock.attention
-func.func @self_attention_gqa_scale_bias_kvcache(%arg0: tensor<4096xf32> {mhal.read_access}, %arg1: tensor<256xf32> {mhal.read_access}, %arg2: tensor<256xf32> {mhal.read_access}, %arg3: tensor<4096xf32> {mhal.read_access}, %arg4: tensor<256xf32> {mhal.read_access}) -> (tensor<256xf32> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
-  %expanded = tensor.expand_shape %arg4 [[0, 1, 2, 3]] output_shape [2, 4, 1, 32] : tensor<256xf32> into tensor<2x4x1x32xf32>
-  %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 4, 1, 32] : tensor<256xf32> into tensor<2x4x1x32xf32>
-  %expanded_1 = tensor.expand_shape %arg2 [[0, 1, 2, 3]] output_shape [2, 4, 1, 32] : tensor<256xf32> into tensor<2x4x1x32xf32>
-  %expanded_2 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_3 = tensor.expand_shape %arg0 [[0, 1, 2, 3]] output_shape [2, 2, 32, 32] : tensor<4096xf32> into tensor<2x2x32x32xf32>
-  %expanded_4 = tensor.expand_shape %arg0 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %0 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x2x32x32xf32>}> : () -> tensor<2x2x2x32x32xf32>
-  %shift = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8> 
-  %1 = tosa.mul %expanded_4, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed = tensor.collapse_shape %1 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %expanded_5 = tensor.expand_shape %arg3 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 32, 32] : tensor<4096xf32> into tensor<2x2x1x32x32xf32>
-  %2 = tosa.mul %expanded_5, %0, %shift : (tensor<2x2x1x32x32xf32>, tensor<2x2x2x32x32xf32>, tensor<1xi8>) -> tensor<2x2x2x32x32xf32>
-  %collapsed_6 = tensor.collapse_shape %2 [[0], [1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<2x4x32x32xf32>
-  %4 = tosa.transpose %collapsed_6 {perms = array<i32: 0, 1, 3, 2>} : (tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32>
-  %expanded_7 = tensor.expand_shape %arg2 [[0, 1, 2]] output_shape [8, 1, 32] : tensor<256xf32> into tensor<8x1x32xf32>
-  %collapsed_8 = tensor.collapse_shape %4 [[0, 1], [2], [3]] : tensor<2x4x32x32xf32> into tensor<8x32x32xf32>
-  %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
-  %5 = tosa.matmul %expanded_7, %collapsed_8, %a_zp, %b_zp : (tensor<8x1x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x1x32xf32>
-  %expanded_9 = tensor.expand_shape %5 [[0, 1], [2], [3]] output_shape [2, 4, 1, 32] : tensor<8x1x32xf32> into tensor<2x4x1x32xf32>
-  %6 = tosa.mul %expanded_9, %expanded_0, %shift : (tensor<2x4x1x32xf32>, tensor<2x4x1x32xf32>, tensor<1xi8>) -> tensor<2x4x1x32xf32>
-  %7 = tosa.add %6, %expanded : (tensor<2x4x1x32xf32>, tensor<2x4x1x32xf32>) -> tensor<2x4x1x32xf32>
-  %8 = tosa.reduce_max %7 {axis = 3 : i32} : (tensor<2x4x1x32xf32>) -> tensor<2x4x1x1xf32>
-  %9 = tosa.sub %7, %8 : (tensor<2x4x1x32xf32>, tensor<2x4x1x1xf32>) -> tensor<2x4x1x32xf32>
-  %10 = tosa.exp %9 : (tensor<2x4x1x32xf32>) -> tensor<2x4x1x32xf32>
-  %11 = tosa.reduce_sum %10 {axis = 3 : i32} : (tensor<2x4x1x32xf32>) -> tensor<2x4x1x1xf32>
-  %12 = tosa.reciprocal %11 : (tensor<2x4x1x1xf32>) -> tensor<2x4x1x1xf32>
-  %13 = tosa.mul %10, %12, %shift : (tensor<2x4x1x32xf32>, tensor<2x4x1x1xf32>, tensor<1xi8>) -> tensor<2x4x1x32xf32>
-  %collapsed_10 = tensor.collapse_shape %13 [[0, 1], [2], [3]] : tensor<2x4x1x32xf32> into tensor<8x1x32xf32>
-  %collapsed_11 = tensor.collapse_shape %1 [[0, 1, 2], [3], [4]] : tensor<2x2x2x32x32xf32> into tensor<8x32x32xf32>
-  %14 = tosa.matmul %collapsed_10, %collapsed_11, %a_zp, %b_zp : (tensor<8x1x32xf32>, tensor<8x32x32xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8x1x32xf32>
-  %expanded_12 = tensor.expand_shape %14 [[0, 1], [2], [3]] output_shape [2, 4, 1, 32] : tensor<8x1x32xf32> into tensor<2x4x1x32xf32>
-  %collapsed_13 = tensor.collapse_shape %14 [[0, 1, 2]] : tensor<8x1x32xf32> into tensor<256xf32>
-  return %collapsed_13 : tensor<256xf32>
+// CHECK: numHeadsKV = 2 : i32, numHeadsQ = 14 : i32
+func.func @attention_gqa_2_14_4(%arg0: tensor<2xi32> {mhal.read_access}, %arg1: tensor<2304xf16> {mhal.read_access}, %arg2: tensor<2048xf16> {mhal.read_access}, %arg3: tensor<2048xf16> {mhal.read_access}) -> (tensor<1792xf16> {mhal.write_access}) attributes {kernel, arch = "##TOKEN_ARCH##"} {
+  %0 = "tosa.const"() <{values = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi32>}> : () -> tensor<1x8xi32>
+  %1 = tosa.const_shape  {values = dense<1792> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %2 = tosa.const_shape  {values = dense<[28, 8, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %3 = tosa.const_shape  {values = dense<[28, 1, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %4 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x14x1x8xf32>}> : () -> tensor<2x14x1x8xf32>
+  %5 = "tosa.const"() <{values = dense<0xFC00> : tensor<2x14x1x8xf16>}> : () -> tensor<2x14x1x8xf16>
+  %6 = tosa.const_shape  {values = dense<[2, 14, 1, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %7 = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf16>}> : () -> tensor<1xf16>
+  %8 = tosa.const_shape  {values = dense<[28, 64, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %9 = tosa.const_shape  {values = dense<[28, 1, 64]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %10 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x64x8xf16>}> : () -> tensor<2x2x7x64x8xf16>
+  %11 = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x2x7x8x64xf16>}> : () -> tensor<2x2x7x8x64xf16>
+  %12 = tosa.const_shape  {values = dense<[2, 2, 1, 8, 64]> : tensor<5xindex>} : () -> !tosa.shape<5>
+  %13 = tosa.const_shape  {values = dense<[2, 14, 1, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %14 = "tosa.const"() <{values = dense<1> : tensor<2x14x1x8xi8>}> : () -> tensor<2x14x1x8xi8>
+  %15 = tosa.const_shape  {values = dense<[2, 1, 1, 8]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %16 = "tosa.const"() <{values = dense<1.250000e-01> : tensor<2x14x1x8xf16>}> : () -> tensor<2x14x1x8xf16>
+  %17 = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+  %18 = "tosa.const"() <{values = dense<1> : tensor<2x8xi32>}> : () -> tensor<2x8xi32>
+  %19 = tosa.const_shape  {values = dense<[2, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %20 = tosa.const_shape  {values = dense<[2, 18, 1, 64]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %expanded = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 18, 1, 64] : tensor<2304xf16> into tensor<2x18x1x64xf16>
+  %expanded_0 = tensor.expand_shape %arg0 [[0, 1]] output_shape [2, 1] : tensor<2xi32> into tensor<2x1xi32>
+  %21 = tosa.mul %0, %18, %17 : (tensor<1x8xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %22 = tosa.mul %expanded_0, %18, %17 : (tensor<2x1xi32>, tensor<2x8xi32>, tensor<1xi8>) -> tensor<2x8xi32>
+  %23 = tosa.greater %21, %22 : (tensor<2x8xi32>, tensor<2x8xi32>) -> tensor<2x8xi1>
+  %24 = tosa.cast %23 : (tensor<2x8xi1>) -> tensor<2x8xi32>
+  %25 = tosa.cast %24 : (tensor<2x8xi32>) -> tensor<2x8xi8>
+  %expanded_1 = tensor.expand_shape %25 [[0, 1, 2], [3]] output_shape [2, 1, 1, 8] : tensor<2x8xi8> into tensor<2x1x1x8xi8>
+  %26 = tosa.mul %expanded_1, %14, %17 : (tensor<2x1x1x8xi8>, tensor<2x14x1x8xi8>, tensor<1xi8>) -> tensor<2x14x1x8xi8>
+  %extracted_slice = tensor.extract_slice %expanded[0, 0, 0, 0] [2, 14, 1, 64] [1, 1, 1, 1] : tensor<2x18x1x64xf16> to tensor<2x14x1x64xf16>
+  %expanded_2 = tensor.expand_shape %arg2 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %27 = tosa.mul %expanded_2, %11, %17 : (tensor<2x2x1x8x64xf16>, tensor<2x2x7x8x64xf16>, tensor<1xi8>) -> tensor<2x2x7x8x64xf16>
+  %expanded_3 = tensor.expand_shape %arg3 [[0, 1, 2, 3, 4]] output_shape [2, 2, 1, 8, 64] : tensor<2048xf16> into tensor<2x2x1x8x64xf16>
+  %28 = tosa.transpose %expanded_3 {perms = array<i32: 0, 1, 2, 4, 3>} : (tensor<2x2x1x8x64xf16>) -> tensor<2x2x1x64x8xf16>
+  %29 = tosa.mul %28, %10, %17 : (tensor<2x2x1x64x8xf16>, tensor<2x2x7x64x8xf16>, tensor<1xi8>) -> tensor<2x2x7x64x8xf16>
+  %collapsed = tensor.collapse_shape %extracted_slice [[0, 1], [2], [3]] : tensor<2x14x1x64xf16> into tensor<28x1x64xf16>
+  %collapsed_4 = tensor.collapse_shape %29 [[0, 1, 2], [3], [4]] : tensor<2x2x7x64x8xf16> into tensor<28x64x8xf16>
+  %30 = tosa.matmul %collapsed, %collapsed_4, %7, %7 {acc_type = f32} : (tensor<28x1x64xf16>, tensor<28x64x8xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x1x8xf16>
+  %expanded_5 = tensor.expand_shape %30 [[0, 1], [2], [3]] output_shape [2, 14, 1, 8] : tensor<28x1x8xf16> into tensor<2x14x1x8xf16>
+  %31 = tosa.mul %expanded_5, %16, %17 : (tensor<2x14x1x8xf16>, tensor<2x14x1x8xf16>, tensor<1xi8>) -> tensor<2x14x1x8xf16>
+  %32 = tosa.cast %26 : (tensor<2x14x1x8xi8>) -> tensor<2x14x1x8xi1>
+  %33 = tosa.select %32, %5, %31 : (tensor<2x14x1x8xi1>, tensor<2x14x1x8xf16>, tensor<2x14x1x8xf16>) -> tensor<2x14x1x8xf16>
+  %34 = tosa.cast %33 : (tensor<2x14x1x8xf16>) -> tensor<2x14x1x8xf32>
+  %35 = tosa.reduce_max %34 {axis = 3 : i32} : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x1xf32>
+  %36 = tosa.mul %35, %4, %17 : (tensor<2x14x1x1xf32>, tensor<2x14x1x8xf32>, tensor<1xi8>) -> tensor<2x14x1x8xf32>
+  %37 = tosa.sub %34, %36 : (tensor<2x14x1x8xf32>, tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf32>
+  %38 = tosa.exp %37 : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf32>
+  %39 = tosa.reduce_sum %38 {axis = 3 : i32} : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x1xf32>
+  %40 = tosa.mul %39, %4, %17 : (tensor<2x14x1x1xf32>, tensor<2x14x1x8xf32>, tensor<1xi8>) -> tensor<2x14x1x8xf32>
+  %41 = tosa.reciprocal %40 : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf32>
+  %42 = tosa.mul %38, %41, %17 : (tensor<2x14x1x8xf32>, tensor<2x14x1x8xf32>, tensor<1xi8>) -> tensor<2x14x1x8xf32>
+  %43 = tosa.cast %42 : (tensor<2x14x1x8xf32>) -> tensor<2x14x1x8xf16>
+  %collapsed_6 = tensor.collapse_shape %43 [[0, 1], [2], [3]] : tensor<2x14x1x8xf16> into tensor<28x1x8xf16>
+  %collapsed_7 = tensor.collapse_shape %27 [[0, 1, 2], [3], [4]] : tensor<2x2x7x8x64xf16> into tensor<28x8x64xf16>
+  %44 = tosa.matmul %collapsed_6, %collapsed_7, %7, %7 {acc_type = f32} : (tensor<28x1x8xf16>, tensor<28x8x64xf16>, tensor<1xf16>, tensor<1xf16>) -> tensor<28x1x64xf16>
+  %expanded_8 = tensor.expand_shape %44 [[0, 1], [2], [3]] output_shape [2, 14, 1, 64] : tensor<28x1x64xf16> into tensor<2x14x1x64xf16>
+  %45 = tosa.transpose %expanded_8 {perms = array<i32: 0, 2, 1, 3>} : (tensor<2x14x1x64xf16>) -> tensor<2x1x14x64xf16>
+  %collapsed_9 = tensor.collapse_shape %45 [[0, 1, 2, 3]] : tensor<2x1x14x64xf16> into tensor<1792xf16>
+  return %collapsed_9 : tensor<1792xf16>
 }

--- a/mlir/test/fusion/mixr-attention-gqa-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-gqa-problem-key.mlir
@@ -1,0 +1,48 @@
+
+// RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
+// CHECK: gfx942
+// CHECK-SAME: 304
+// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 32 -num_heads_kv 8 -g 1 -seq_len_q 1 -seq_len_k 64 -head_dim_qk 128 -head_dim_v 128
+
+module {
+  func.func @mlir_attention(%arg0: !migraphx.shaped<1x48x1x128xf16, 6144x128x128x1>, %arg1: !migraphx.shaped<1x8x64x128xf16, 65536x8192x128x1>, %arg2: !migraphx.shaped<1x8x64x128xf16, 65536x8192x128x1>, %arg3: !migraphx.shaped<1x1x1xsi32, 1x1x1>) -> !migraphx.shaped<1x1x4096xf16, 4096x4096x1> attributes {kernel, arch = "gfx942", num_cu = 304 : i64} {
+    %0 = migraphx.literal(dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]> : tensor<64xsi32>) : <64xsi32, 1>
+    %1 = migraphx.literal(dense<0xFC00> : tensor<1xf16>) : <1xf16, 1>
+    %2 = migraphx.literal(dense<8.837890e-02> : tensor<1xf16>) : <1xf16, 1>
+    %3 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [1, 1, 1, 64]} : <64xsi32, 1> -> <1x1x1x64xsi32, 0x0x0x1>
+    %4 = migraphx.slice %arg0 {axes = [1], ends = [32], starts = [0]} : <1x48x1x128xf16, 6144x128x128x1> -> <1x32x1x128xf16, 6144x128x128x1>
+    %5 = migraphx.reshape %arg1 {dims = [1, 8, 1, 64, 128]} : <1x8x64x128xf16, 65536x8192x128x1> -> <1x8x1x64x128xf16, 65536x8192x8192x128x1>
+    %6 = migraphx.reshape %arg2 {dims = [1, 8, 1, 64, 128]} : <1x8x64x128xf16, 65536x8192x128x1> -> <1x8x1x64x128xf16, 65536x8192x8192x128x1>
+    %7 = migraphx.multibroadcast %6 {out_dyn_dims = [], out_lens = [1, 8, 4, 64, 128]} : <1x8x1x64x128xf16, 65536x8192x8192x128x1> -> <1x8x4x64x128xf16, 65536x8192x0x128x1>
+    %8 = migraphx.reshape %7 {dims = [1, 32, 64, 128]} : <1x8x4x64x128xf16, 65536x8192x0x128x1> -> <1x32x64x128xf16, 262144x8192x128x1>
+    %9 = migraphx.transpose %5 {permutation = [0, 1, 2, 4, 3]} : <1x8x1x64x128xf16, 65536x8192x8192x128x1> -> <1x8x1x128x64xf16, 65536x8192x8192x1x128>
+    %10 = migraphx.multibroadcast %9 {out_dyn_dims = [], out_lens = [1, 8, 4, 128, 64]} : <1x8x1x128x64xf16, 65536x8192x8192x1x128> -> <1x8x4x128x64xf16, 65536x8192x0x1x128>
+    %11 = migraphx.reshape %10 {dims = [1, 32, 128, 64]} : <1x8x4x128x64xf16, 65536x8192x0x1x128> -> <1x32x128x64xf16, 262144x8192x64x1>
+    %12 = migraphx.dot %4, %11 : <1x32x1x128xf16, 6144x128x128x1>, <1x32x128x64xf16, 262144x8192x64x1> -> <1x32x1x64xf16, 2048x64x64x1>
+    %13 = migraphx.multibroadcast %1 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1xf16, 1> -> <1x32x1x64xf16, 0x0x0x0>
+    %14 = migraphx.multibroadcast %2 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1xf16, 1> -> <1x32x1x64xf16, 0x0x0x0>
+    %15 = migraphx.mul %12, %14 : <1x32x1x64xf16, 2048x64x64x1>, <1x32x1x64xf16, 0x0x0x0> -> <1x32x1x64xf16, 2048x64x64x1>
+    %16 = migraphx.broadcast %arg3 {axis = 0 : i64, out_lens = [1, 1, 1, 64]} : <1x1x1xsi32, 1x1x1> -> <1x1x1x64xsi32, 1x1x1x0>
+    %17 = migraphx.greater %3, %16 : <1x1x1x64xsi32, 0x0x0x1>, <1x1x1x64xsi32, 1x1x1x0> -> <1x1x1x64xsi32, 0x0x0x1>
+    %18 = migraphx.convert %17 {target_type = 0 : i64} : <1x1x1x64xsi32, 0x0x0x1> to <1x1x1x64xsi8, 0x0x0x1>
+    %19 = migraphx.multibroadcast %18 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1x1x1x64xsi8, 0x0x0x1> -> <1x32x1x64xsi8, 0x0x0x1>
+    %20 = migraphx.where %19, %13, %15 : <1x32x1x64xsi8, 0x0x0x1>, <1x32x1x64xf16, 0x0x0x0>, <1x32x1x64xf16, 2048x64x64x1> -> <1x32x1x64xf16, 2048x64x64x1>
+    %21 = migraphx.convert %20 {target_type = 2 : i64} : <1x32x1x64xf16, 2048x64x64x1> to <1x32x1x64xf32, 2048x64x64x1>
+    %22 = migraphx.reshape %21 {dims = [1, 32, 1, 64]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x64xf32, 2048x64x64x1>
+    %23 = migraphx.reduce_max %22 {axes = [3]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %24 = migraphx.reshape %23 {dims = [1, 32, 1, 1]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %25 = migraphx.multibroadcast %24 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x64xf32, 32x1x1x0>
+    %26 = migraphx.sub %21, %25 : <1x32x1x64xf32, 2048x64x64x1>, <1x32x1x64xf32, 32x1x1x0> -> <1x32x1x64xf32, 2048x64x64x1>
+    %27 = migraphx.exp %26 : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x64xf32, 2048x64x64x1>
+    %28 = migraphx.reshape %27 {dims = [1, 32, 1, 64]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x64xf32, 2048x64x64x1>
+    %29 = migraphx.reduce_sum %28 {axes = [3]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %30 = migraphx.reshape %29 {dims = [1, 32, 1, 1]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %31 = migraphx.multibroadcast %30 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x64xf32, 32x1x1x0>
+    %32 = migraphx.div %27, %31 : <1x32x1x64xf32, 2048x64x64x1>, <1x32x1x64xf32, 32x1x1x0> -> <1x32x1x64xf32, 2048x64x64x1>
+    %33 = migraphx.convert %32 {target_type = 1 : i64} : <1x32x1x64xf32, 2048x64x64x1> to <1x32x1x64xf16, 2048x64x64x1>
+    %34 = migraphx.dot %33, %8 : <1x32x1x64xf16, 2048x64x64x1>, <1x32x64x128xf16, 262144x8192x128x1> -> <1x32x1x128xf16, 4096x128x128x1>
+    %35 = migraphx.transpose %34 {permutation = [0, 2, 1, 3]} : <1x32x1x128xf16, 4096x128x128x1> -> <1x1x32x128xf16, 4096x128x128x1>
+    %36 = migraphx.reshape %35 {dims = [1, 1, 4096]} : <1x1x32x128xf16, 4096x128x128x1> -> <1x1x4096xf16, 4096x4096x1>
+    return %36 : !migraphx.shaped<1x1x4096xf16, 4096x4096x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa2.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa2.mlir
@@ -1,0 +1,44 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+module {
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x48x1x128xf16, 6144x128x128x1>, %arg1: !migraphx.shaped<1x8x64x128xf16, 65536x8192x128x1>, %arg2: !migraphx.shaped<1x8x64x128xf16, 65536x8192x128x1>, %arg3: !migraphx.shaped<1x1x1xsi32, 1x1x1>) -> !migraphx.shaped<1x1x4096xf16, 4096x4096x1> {
+    %0 = migraphx.literal(dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]> : tensor<64xsi32>) : <64xsi32, 1>
+    %1 = migraphx.literal(dense<0xFC00> : tensor<1xf16>) : <1xf16, 1>
+    %2 = migraphx.literal(dense<8.837890e-02> : tensor<1xf16>) : <1xf16, 1>
+    %3 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [1, 1, 1, 64]} : <64xsi32, 1> -> <1x1x1x64xsi32, 0x0x0x1>
+    %4 = migraphx.slice %arg0 {axes = [1], ends = [32], starts = [0]} : <1x48x1x128xf16, 6144x128x128x1> -> <1x32x1x128xf16, 6144x128x128x1>
+    %5 = migraphx.reshape %arg1 {dims = [1, 8, 1, 64, 128]} : <1x8x64x128xf16, 65536x8192x128x1> -> <1x8x1x64x128xf16, 65536x8192x8192x128x1>
+    %6 = migraphx.reshape %arg2 {dims = [1, 8, 1, 64, 128]} : <1x8x64x128xf16, 65536x8192x128x1> -> <1x8x1x64x128xf16, 65536x8192x8192x128x1>
+    %7 = migraphx.multibroadcast %6 {out_dyn_dims = [], out_lens = [1, 8, 4, 64, 128]} : <1x8x1x64x128xf16, 65536x8192x8192x128x1> -> <1x8x4x64x128xf16, 65536x8192x0x128x1>
+    %8 = migraphx.reshape %7 {dims = [1, 32, 64, 128]} : <1x8x4x64x128xf16, 65536x8192x0x128x1> -> <1x32x64x128xf16, 262144x8192x128x1>
+    %9 = migraphx.transpose %5 {permutation = [0, 1, 2, 4, 3]} : <1x8x1x64x128xf16, 65536x8192x8192x128x1> -> <1x8x1x128x64xf16, 65536x8192x8192x1x128>
+    %10 = migraphx.multibroadcast %9 {out_dyn_dims = [], out_lens = [1, 8, 4, 128, 64]} : <1x8x1x128x64xf16, 65536x8192x8192x1x128> -> <1x8x4x128x64xf16, 65536x8192x0x1x128>
+    %11 = migraphx.reshape %10 {dims = [1, 32, 128, 64]} : <1x8x4x128x64xf16, 65536x8192x0x1x128> -> <1x32x128x64xf16, 262144x8192x64x1>
+    %12 = migraphx.dot %4, %11 : <1x32x1x128xf16, 6144x128x128x1>, <1x32x128x64xf16, 262144x8192x64x1> -> <1x32x1x64xf16, 2048x64x64x1>
+    %13 = migraphx.multibroadcast %1 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1xf16, 1> -> <1x32x1x64xf16, 0x0x0x0>
+    %14 = migraphx.multibroadcast %2 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1xf16, 1> -> <1x32x1x64xf16, 0x0x0x0>
+    %15 = migraphx.mul %12, %14 : <1x32x1x64xf16, 2048x64x64x1>, <1x32x1x64xf16, 0x0x0x0> -> <1x32x1x64xf16, 2048x64x64x1>
+    %16 = migraphx.broadcast %arg3 {axis = 0 : i64, out_lens = [1, 1, 1, 64]} : <1x1x1xsi32, 1x1x1> -> <1x1x1x64xsi32, 1x1x1x0>
+    %17 = migraphx.greater %3, %16 : <1x1x1x64xsi32, 0x0x0x1>, <1x1x1x64xsi32, 1x1x1x0> -> <1x1x1x64xsi32, 0x0x0x1>
+    %18 = migraphx.convert %17 {target_type = 0 : i64} : <1x1x1x64xsi32, 0x0x0x1> to <1x1x1x64xsi8, 0x0x0x1>
+    %19 = migraphx.multibroadcast %18 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1x1x1x64xsi8, 0x0x0x1> -> <1x32x1x64xsi8, 0x0x0x1>
+    %20 = migraphx.where %19, %13, %15 : <1x32x1x64xsi8, 0x0x0x1>, <1x32x1x64xf16, 0x0x0x0>, <1x32x1x64xf16, 2048x64x64x1> -> <1x32x1x64xf16, 2048x64x64x1>
+    %21 = migraphx.convert %20 {target_type = 2 : i64} : <1x32x1x64xf16, 2048x64x64x1> to <1x32x1x64xf32, 2048x64x64x1>
+    %22 = migraphx.reshape %21 {dims = [1, 32, 1, 64]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x64xf32, 2048x64x64x1>
+    %23 = migraphx.reduce_max %22 {axes = [3]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %24 = migraphx.reshape %23 {dims = [1, 32, 1, 1]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %25 = migraphx.multibroadcast %24 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x64xf32, 32x1x1x0>
+    %26 = migraphx.sub %21, %25 : <1x32x1x64xf32, 2048x64x64x1>, <1x32x1x64xf32, 32x1x1x0> -> <1x32x1x64xf32, 2048x64x64x1>
+    %27 = migraphx.exp %26 : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x64xf32, 2048x64x64x1>
+    %28 = migraphx.reshape %27 {dims = [1, 32, 1, 64]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x64xf32, 2048x64x64x1>
+    %29 = migraphx.reduce_sum %28 {axes = [3]} : <1x32x1x64xf32, 2048x64x64x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %30 = migraphx.reshape %29 {dims = [1, 32, 1, 1]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x1xf32, 32x1x1x1>
+    %31 = migraphx.multibroadcast %30 {out_dyn_dims = [], out_lens = [1, 32, 1, 64]} : <1x32x1x1xf32, 32x1x1x1> -> <1x32x1x64xf32, 32x1x1x0>
+    %32 = migraphx.div %27, %31 : <1x32x1x64xf32, 2048x64x64x1>, <1x32x1x64xf32, 32x1x1x0> -> <1x32x1x64xf32, 2048x64x64x1>
+    %33 = migraphx.convert %32 {target_type = 1 : i64} : <1x32x1x64xf32, 2048x64x64x1> to <1x32x1x64xf16, 2048x64x64x1>
+    %34 = migraphx.dot %33, %8 : <1x32x1x64xf16, 2048x64x64x1>, <1x32x64x128xf16, 262144x8192x128x1> -> <1x32x1x128xf16, 4096x128x128x1>
+    %35 = migraphx.transpose %34 {permutation = [0, 2, 1, 3]} : <1x32x1x128xf16, 4096x128x128x1> -> <1x1x32x128xf16, 4096x128x128x1>
+    %36 = migraphx.reshape %35 {dims = [1, 1, 4096]} : <1x1x32x128xf16, 4096x128x128x1> -> <1x1x4096xf16, 4096x4096x1>
+    return %36 : !migraphx.shaped<1x1x4096xf16, 4096x4096x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa3.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa3.mlir
@@ -1,0 +1,48 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+module {
+  func.func @mlir_attention(%arg0: !migraphx.shaped<2x1xsi32, 1x1>, %arg1: !migraphx.shaped<2x18x4x64xf16, 4608x64x1152x1>, %arg2: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>, %arg3: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>) -> !migraphx.shaped<2x4x896xf16, 3584x896x1> {
+    %0 = migraphx.literal(dense<0xFC00> : tensor<1xf16>) : <1xf16, 1>
+    %1 = migraphx.literal(dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xsi32>) : <8xsi32, 1>
+    %2 = migraphx.literal(dense<1.250000e-01> : tensor<1xf16>) : <1xf16, 1>
+    %3 = migraphx.literal(dense<[[0, 1, 1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1]]> : tensor<4x8xsi8>) : <4x8xsi8, 8x1>
+    %4 = migraphx.broadcast %1 {axis = 1 : i64, out_lens = [2, 8]} : <8xsi32, 1> -> <2x8xsi32, 0x1>
+    %5 = migraphx.multibroadcast %2 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <1xf16, 1> -> <2x14x4x8xf16, 0x0x0x0>
+    %6 = migraphx.multibroadcast %3 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <4x8xsi8, 8x1> -> <2x14x4x8xsi8, 0x0x8x1>
+    %7 = migraphx.multibroadcast %arg0 {out_dyn_dims = [], out_lens = [2, 8]} : <2x1xsi32, 1x1> -> <2x8xsi32, 1x0>
+    %8 = migraphx.greater %4, %7 : <2x8xsi32, 0x1>, <2x8xsi32, 1x0> -> <2x8xsi32, 8x1>
+    %9 = migraphx.convert %8 {target_type = 0 : i64} : <2x8xsi32, 8x1> to <2x8xsi8, 8x1>
+    %10 = migraphx.reshape %9 {dims = [2, 1, 1, 8]} : <2x8xsi8, 8x1> -> <2x1x1x8xsi8, 8x8x8x1>
+    %11 = migraphx.multibroadcast %10 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <2x1x1x8xsi8, 8x8x8x1> -> <2x14x4x8xsi8, 8x0x0x1>
+    %12 = migraphx.slice %arg1 {axes = [1], ends = [14], starts = [0]} : <2x18x4x64xf16, 4608x64x1152x1> -> <2x14x4x64xf16, 4608x64x1152x1>
+    %13 = migraphx.reshape %arg2 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %14 = migraphx.multibroadcast %13 {out_dyn_dims = [], out_lens = [2, 2, 7, 8, 64]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x7x8x64xf16, 1024x512x0x64x1>
+    %15 = migraphx.reshape %14 {dims = [2, 14, 8, 64]} : <2x2x7x8x64xf16, 1024x512x0x64x1> -> <2x14x8x64xf16, 7168x512x64x1>
+    %16 = migraphx.reshape %arg3 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %17 = migraphx.transpose %16 {permutation = [0, 1, 2, 4, 3]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x1x64x8xf16, 1024x512x512x1x64>
+    %18 = migraphx.multibroadcast %17 {out_dyn_dims = [], out_lens = [2, 2, 7, 64, 8]} : <2x2x1x64x8xf16, 1024x512x512x1x64> -> <2x2x7x64x8xf16, 1024x512x0x1x64>
+    %19 = migraphx.reshape %18 {dims = [2, 14, 64, 8]} : <2x2x7x64x8xf16, 1024x512x0x1x64> -> <2x14x64x8xf16, 7168x512x8x1>
+    %20 = migraphx.dot %12, %19 : <2x14x4x64xf16, 4608x64x1152x1>, <2x14x64x8xf16, 7168x512x8x1> -> <2x14x4x8xf16, 448x32x8x1>
+    %21 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <1xf16, 1> -> <2x14x4x8xf16, 0x0x0x0>
+    %22 = migraphx.mul %20, %5 : <2x14x4x8xf16, 448x32x8x1>, <2x14x4x8xf16, 0x0x0x0> -> <2x14x4x8xf16, 448x32x8x1>
+    %23 = migraphx.where %6, %21, %22 : <2x14x4x8xsi8, 0x0x8x1>, <2x14x4x8xf16, 0x0x0x0>, <2x14x4x8xf16, 448x32x8x1> -> <2x14x4x8xf16, 448x32x8x1>
+    %24 = migraphx.where %11, %21, %23 : <2x14x4x8xsi8, 8x0x0x1>, <2x14x4x8xf16, 0x0x0x0>, <2x14x4x8xf16, 448x32x8x1> -> <2x14x4x8xf16, 448x32x8x1>
+    %25 = migraphx.convert %24 {target_type = 2 : i64} : <2x14x4x8xf16, 448x32x8x1> to <2x14x4x8xf32, 448x32x8x1>
+    %26 = migraphx.reshape %25 {dims = [2, 14, 4, 8]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x8xf32, 448x32x8x1>
+    %27 = migraphx.reduce_max %26 {axes = [3]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %28 = migraphx.reshape %27 {dims = [2, 14, 4, 1]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %29 = migraphx.multibroadcast %28 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x8xf32, 56x4x1x0>
+    %30 = migraphx.sub %25, %29 : <2x14x4x8xf32, 448x32x8x1>, <2x14x4x8xf32, 56x4x1x0> -> <2x14x4x8xf32, 448x32x8x1>
+    %31 = migraphx.exp %30 : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x8xf32, 448x32x8x1>
+    %32 = migraphx.reshape %31 {dims = [2, 14, 4, 8]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x8xf32, 448x32x8x1>
+    %33 = migraphx.reduce_sum %32 {axes = [3]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %34 = migraphx.reshape %33 {dims = [2, 14, 4, 1]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %35 = migraphx.multibroadcast %34 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x8xf32, 56x4x1x0>
+    %36 = migraphx.div %31, %35 : <2x14x4x8xf32, 448x32x8x1>, <2x14x4x8xf32, 56x4x1x0> -> <2x14x4x8xf32, 448x32x8x1>
+    %37 = migraphx.convert %36 {target_type = 1 : i64} : <2x14x4x8xf32, 448x32x8x1> to <2x14x4x8xf16, 448x32x8x1>
+    %38 = migraphx.dot %37, %15 : <2x14x4x8xf16, 448x32x8x1>, <2x14x8x64xf16, 7168x512x64x1> -> <2x14x4x64xf16, 3584x256x64x1>
+    %39 = migraphx.transpose %38 {permutation = [0, 2, 1, 3]} : <2x14x4x64xf16, 3584x256x64x1> -> <2x4x14x64xf16, 3584x64x256x1>
+    %40 = migraphx.reshape %39 {dims = [2, 4, 896]} : <2x4x14x64xf16, 3584x64x256x1> -> <2x4x896xf16, 3584x896x1>
+    return %40 : !migraphx.shaped<2x4x896xf16, 3584x896x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa4.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa4.mlir
@@ -1,0 +1,48 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+module {
+  func.func @mlir_attention(%arg0: !migraphx.shaped<2x18x4x64xf16, 4608x64x1152x1>, %arg1: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>, %arg2: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>, %arg3: !migraphx.shaped<2x1xsi32, 1x1>) -> !migraphx.shaped<2x4x896xf16, 3584x896x1> {
+    %0 = migraphx.literal(dense<0xFC00> : tensor<1xf16>) : <1xf16, 1>
+    %1 = migraphx.literal(dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xsi32>) : <8xsi32, 1>
+    %2 = migraphx.literal(dense<1.250000e-01> : tensor<1xf16>) : <1xf16, 1>
+    %3 = migraphx.literal(dense<[[0, 1, 1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1]]> : tensor<4x8xsi8>) : <4x8xsi8, 8x1>
+    %4 = migraphx.slice %arg0 {axes = [1], ends = [14], starts = [0]} : <2x18x4x64xf16, 4608x64x1152x1> -> <2x14x4x64xf16, 4608x64x1152x1>
+    %5 = migraphx.reshape %arg1 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %6 = migraphx.multibroadcast %5 {out_dyn_dims = [], out_lens = [2, 2, 7, 8, 64]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x7x8x64xf16, 1024x512x0x64x1>
+    %7 = migraphx.reshape %6 {dims = [2, 14, 8, 64]} : <2x2x7x8x64xf16, 1024x512x0x64x1> -> <2x14x8x64xf16, 7168x512x64x1>
+    %8 = migraphx.reshape %arg2 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %9 = migraphx.transpose %8 {permutation = [0, 1, 2, 4, 3]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x1x64x8xf16, 1024x512x512x1x64>
+    %10 = migraphx.multibroadcast %9 {out_dyn_dims = [], out_lens = [2, 2, 7, 64, 8]} : <2x2x1x64x8xf16, 1024x512x512x1x64> -> <2x2x7x64x8xf16, 1024x512x0x1x64>
+    %11 = migraphx.reshape %10 {dims = [2, 14, 64, 8]} : <2x2x7x64x8xf16, 1024x512x0x1x64> -> <2x14x64x8xf16, 7168x512x8x1>
+    %12 = migraphx.dot %4, %11 : <2x14x4x64xf16, 4608x64x1152x1>, <2x14x64x8xf16, 7168x512x8x1> -> <2x14x4x8xf16, 448x32x8x1>
+    %13 = migraphx.broadcast %1 {axis = 1 : i64, out_lens = [2, 8]} : <8xsi32, 1> -> <2x8xsi32, 0x1>
+    %14 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <1xf16, 1> -> <2x14x4x8xf16, 0x0x0x0>
+    %15 = migraphx.multibroadcast %2 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <1xf16, 1> -> <2x14x4x8xf16, 0x0x0x0>
+    %16 = migraphx.mul %12, %15 : <2x14x4x8xf16, 448x32x8x1>, <2x14x4x8xf16, 0x0x0x0> -> <2x14x4x8xf16, 448x32x8x1>
+    %17 = migraphx.multibroadcast %3 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <4x8xsi8, 8x1> -> <2x14x4x8xsi8, 0x0x8x1>
+    %18 = migraphx.where %17, %14, %16 : <2x14x4x8xsi8, 0x0x8x1>, <2x14x4x8xf16, 0x0x0x0>, <2x14x4x8xf16, 448x32x8x1> -> <2x14x4x8xf16, 448x32x8x1>
+    %19 = migraphx.multibroadcast %arg3 {out_dyn_dims = [], out_lens = [2, 8]} : <2x1xsi32, 1x1> -> <2x8xsi32, 1x0>
+    %20 = migraphx.greater %13, %19 : <2x8xsi32, 0x1>, <2x8xsi32, 1x0> -> <2x8xsi32, 8x1>
+    %21 = migraphx.convert %20 {target_type = 0 : i64} : <2x8xsi32, 8x1> to <2x8xsi8, 8x1>
+    %22 = migraphx.reshape %21 {dims = [2, 1, 1, 8]} : <2x8xsi8, 8x1> -> <2x1x1x8xsi8, 8x8x8x1>
+    %23 = migraphx.multibroadcast %22 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <2x1x1x8xsi8, 8x8x8x1> -> <2x14x4x8xsi8, 8x0x0x1>
+    %24 = migraphx.where %23, %14, %18 : <2x14x4x8xsi8, 8x0x0x1>, <2x14x4x8xf16, 0x0x0x0>, <2x14x4x8xf16, 448x32x8x1> -> <2x14x4x8xf16, 448x32x8x1>
+    %25 = migraphx.convert %24 {target_type = 2 : i64} : <2x14x4x8xf16, 448x32x8x1> to <2x14x4x8xf32, 448x32x8x1>
+    %26 = migraphx.reshape %25 {dims = [2, 14, 4, 8]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x8xf32, 448x32x8x1>
+    %27 = migraphx.reduce_max %26 {axes = [3]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %28 = migraphx.reshape %27 {dims = [2, 14, 4, 1]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %29 = migraphx.multibroadcast %28 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x8xf32, 56x4x1x0>
+    %30 = migraphx.sub %25, %29 : <2x14x4x8xf32, 448x32x8x1>, <2x14x4x8xf32, 56x4x1x0> -> <2x14x4x8xf32, 448x32x8x1>
+    %31 = migraphx.exp %30 : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x8xf32, 448x32x8x1>
+    %32 = migraphx.reshape %31 {dims = [2, 14, 4, 8]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x8xf32, 448x32x8x1>
+    %33 = migraphx.reduce_sum %32 {axes = [3]} : <2x14x4x8xf32, 448x32x8x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %34 = migraphx.reshape %33 {dims = [2, 14, 4, 1]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x1xf32, 56x4x1x1>
+    %35 = migraphx.multibroadcast %34 {out_dyn_dims = [], out_lens = [2, 14, 4, 8]} : <2x14x4x1xf32, 56x4x1x1> -> <2x14x4x8xf32, 56x4x1x0>
+    %36 = migraphx.div %31, %35 : <2x14x4x8xf32, 448x32x8x1>, <2x14x4x8xf32, 56x4x1x0> -> <2x14x4x8xf32, 448x32x8x1>
+    %37 = migraphx.convert %36 {target_type = 1 : i64} : <2x14x4x8xf32, 448x32x8x1> to <2x14x4x8xf16, 448x32x8x1>
+    %38 = migraphx.dot %37, %7 : <2x14x4x8xf16, 448x32x8x1>, <2x14x8x64xf16, 7168x512x64x1> -> <2x14x4x64xf16, 3584x256x64x1>
+    %39 = migraphx.transpose %38 {permutation = [0, 2, 1, 3]} : <2x14x4x64xf16, 3584x256x64x1> -> <2x4x14x64xf16, 3584x64x256x1>
+    %40 = migraphx.reshape %39 {dims = [2, 4, 896]} : <2x4x14x64xf16, 3584x64x256x1> -> <2x4x896xf16, 3584x896x1>
+    return %40 : !migraphx.shaped<2x4x896xf16, 3584x896x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa5.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa5.mlir
@@ -1,0 +1,45 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+module {
+  func.func @mlir_attention(%arg0: !migraphx.shaped<2x18x1x64xf16, 1152x64x64x1>, %arg1: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>, %arg2: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>, %arg3: !migraphx.shaped<2x1xsi32, 1x1>) -> !migraphx.shaped<2x1x896xf16, 896x896x1> {
+    %0 = migraphx.literal(dense<0xFC00> : tensor<1xf16>) : <1xf16, 1>
+    %1 = migraphx.literal(dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xsi32>) : <8xsi32, 1>
+    %2 = migraphx.literal(dense<1.250000e-01> : tensor<1xf16>) : <1xf16, 1>
+    %3 = migraphx.slice %arg0 {axes = [1], ends = [14], starts = [0]} : <2x18x1x64xf16, 1152x64x64x1> -> <2x14x1x64xf16, 1152x64x64x1>
+    %4 = migraphx.reshape %arg1 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %5 = migraphx.multibroadcast %4 {out_dyn_dims = [], out_lens = [2, 2, 7, 8, 64]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x7x8x64xf16, 1024x512x0x64x1>
+    %6 = migraphx.reshape %5 {dims = [2, 14, 8, 64]} : <2x2x7x8x64xf16, 1024x512x0x64x1> -> <2x14x8x64xf16, 7168x512x64x1>
+    %7 = migraphx.reshape %arg2 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %8 = migraphx.transpose %7 {permutation = [0, 1, 2, 4, 3]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x1x64x8xf16, 1024x512x512x1x64>
+    %9 = migraphx.multibroadcast %8 {out_dyn_dims = [], out_lens = [2, 2, 7, 64, 8]} : <2x2x1x64x8xf16, 1024x512x512x1x64> -> <2x2x7x64x8xf16, 1024x512x0x1x64>
+    %10 = migraphx.reshape %9 {dims = [2, 14, 64, 8]} : <2x2x7x64x8xf16, 1024x512x0x1x64> -> <2x14x64x8xf16, 7168x512x8x1>
+    %11 = migraphx.dot %3, %10 : <2x14x1x64xf16, 1152x64x64x1>, <2x14x64x8xf16, 7168x512x8x1> -> <2x14x1x8xf16, 112x8x8x1>
+    %12 = migraphx.broadcast %1 {axis = 1 : i64, out_lens = [2, 8]} : <8xsi32, 1> -> <2x8xsi32, 0x1>
+    %13 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <1xf16, 1> -> <2x14x1x8xf16, 0x0x0x0>
+    %14 = migraphx.multibroadcast %2 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <1xf16, 1> -> <2x14x1x8xf16, 0x0x0x0>
+    %15 = migraphx.mul %11, %14 : <2x14x1x8xf16, 112x8x8x1>, <2x14x1x8xf16, 0x0x0x0> -> <2x14x1x8xf16, 112x8x8x1>
+    %16 = migraphx.multibroadcast %arg3 {out_dyn_dims = [], out_lens = [2, 8]} : <2x1xsi32, 1x1> -> <2x8xsi32, 1x0>
+    %17 = migraphx.greater %12, %16 : <2x8xsi32, 0x1>, <2x8xsi32, 1x0> -> <2x8xsi32, 8x1>
+    %18 = migraphx.convert %17 {target_type = 0 : i64} : <2x8xsi32, 8x1> to <2x8xsi8, 8x1>
+    %19 = migraphx.reshape %18 {dims = [2, 1, 1, 8]} : <2x8xsi8, 8x1> -> <2x1x1x8xsi8, 8x8x8x1>
+    %20 = migraphx.multibroadcast %19 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <2x1x1x8xsi8, 8x8x8x1> -> <2x14x1x8xsi8, 8x0x8x1>
+    %21 = migraphx.where %20, %13, %15 : <2x14x1x8xsi8, 8x0x8x1>, <2x14x1x8xf16, 0x0x0x0>, <2x14x1x8xf16, 112x8x8x1> -> <2x14x1x8xf16, 112x8x8x1>
+    %22 = migraphx.convert %21 {target_type = 2 : i64} : <2x14x1x8xf16, 112x8x8x1> to <2x14x1x8xf32, 112x8x8x1>
+    %23 = migraphx.reshape %22 {dims = [2, 14, 1, 8]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x8xf32, 112x8x8x1>
+    %24 = migraphx.reduce_max %23 {axes = [3]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %25 = migraphx.reshape %24 {dims = [2, 14, 1, 1]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %26 = migraphx.multibroadcast %25 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x8xf32, 14x1x1x0>
+    %27 = migraphx.sub %22, %26 : <2x14x1x8xf32, 112x8x8x1>, <2x14x1x8xf32, 14x1x1x0> -> <2x14x1x8xf32, 112x8x8x1>
+    %28 = migraphx.exp %27 : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x8xf32, 112x8x8x1>
+    %29 = migraphx.reshape %28 {dims = [2, 14, 1, 8]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x8xf32, 112x8x8x1>
+    %30 = migraphx.reduce_sum %29 {axes = [3]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %31 = migraphx.reshape %30 {dims = [2, 14, 1, 1]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %32 = migraphx.multibroadcast %31 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x8xf32, 14x1x1x0>
+    %33 = migraphx.div %28, %32 : <2x14x1x8xf32, 112x8x8x1>, <2x14x1x8xf32, 14x1x1x0> -> <2x14x1x8xf32, 112x8x8x1>
+    %34 = migraphx.convert %33 {target_type = 1 : i64} : <2x14x1x8xf32, 112x8x8x1> to <2x14x1x8xf16, 112x8x8x1>
+    %35 = migraphx.dot %34, %6 : <2x14x1x8xf16, 112x8x8x1>, <2x14x8x64xf16, 7168x512x64x1> -> <2x14x1x64xf16, 896x64x64x1>
+    %36 = migraphx.transpose %35 {permutation = [0, 2, 1, 3]} : <2x14x1x64xf16, 896x64x64x1> -> <2x1x14x64xf16, 896x64x64x1>
+    %37 = migraphx.reshape %36 {dims = [2, 1, 896]} : <2x1x14x64xf16, 896x64x64x1> -> <2x1x896xf16, 896x896x1>
+    return %37 : !migraphx.shaped<2x1x896xf16, 896x896x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa6.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-gqa6.mlir
@@ -1,0 +1,45 @@
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.000004  --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+module {
+  func.func @mlir_attention(%arg0: !migraphx.shaped<2x1xsi32, 1x1>, %arg1: !migraphx.shaped<2x18x1x64xf16, 1152x64x64x1>, %arg2: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>, %arg3: !migraphx.shaped<2x2x8x64xf16, 1024x512x64x1>) -> !migraphx.shaped<2x1x896xf16, 896x896x1> {
+    %0 = migraphx.literal(dense<0xFC00> : tensor<1xf16>) : <1xf16, 1>
+    %1 = migraphx.literal(dense<[0, 1, 2, 3, 4, 5, 6, 7]> : tensor<8xsi32>) : <8xsi32, 1>
+    %2 = migraphx.literal(dense<1.250000e-01> : tensor<1xf16>) : <1xf16, 1>
+    %3 = migraphx.broadcast %1 {axis = 1 : i64, out_lens = [2, 8]} : <8xsi32, 1> -> <2x8xsi32, 0x1>
+    %4 = migraphx.multibroadcast %2 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <1xf16, 1> -> <2x14x1x8xf16, 0x0x0x0>
+    %5 = migraphx.multibroadcast %arg0 {out_dyn_dims = [], out_lens = [2, 8]} : <2x1xsi32, 1x1> -> <2x8xsi32, 1x0>
+    %6 = migraphx.greater %3, %5 : <2x8xsi32, 0x1>, <2x8xsi32, 1x0> -> <2x8xsi32, 8x1>
+    %7 = migraphx.convert %6 {target_type = 0 : i64} : <2x8xsi32, 8x1> to <2x8xsi8, 8x1>
+    %8 = migraphx.reshape %7 {dims = [2, 1, 1, 8]} : <2x8xsi8, 8x1> -> <2x1x1x8xsi8, 8x8x8x1>
+    %9 = migraphx.multibroadcast %8 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <2x1x1x8xsi8, 8x8x8x1> -> <2x14x1x8xsi8, 8x0x8x1>
+    %10 = migraphx.slice %arg1 {axes = [1], ends = [14], starts = [0]} : <2x18x1x64xf16, 1152x64x64x1> -> <2x14x1x64xf16, 1152x64x64x1>
+    %11 = migraphx.reshape %arg2 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %12 = migraphx.multibroadcast %11 {out_dyn_dims = [], out_lens = [2, 2, 7, 8, 64]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x7x8x64xf16, 1024x512x0x64x1>
+    %13 = migraphx.reshape %12 {dims = [2, 14, 8, 64]} : <2x2x7x8x64xf16, 1024x512x0x64x1> -> <2x14x8x64xf16, 7168x512x64x1>
+    %14 = migraphx.reshape %arg3 {dims = [2, 2, 1, 8, 64]} : <2x2x8x64xf16, 1024x512x64x1> -> <2x2x1x8x64xf16, 1024x512x512x64x1>
+    %15 = migraphx.transpose %14 {permutation = [0, 1, 2, 4, 3]} : <2x2x1x8x64xf16, 1024x512x512x64x1> -> <2x2x1x64x8xf16, 1024x512x512x1x64>
+    %16 = migraphx.multibroadcast %15 {out_dyn_dims = [], out_lens = [2, 2, 7, 64, 8]} : <2x2x1x64x8xf16, 1024x512x512x1x64> -> <2x2x7x64x8xf16, 1024x512x0x1x64>
+    %17 = migraphx.reshape %16 {dims = [2, 14, 64, 8]} : <2x2x7x64x8xf16, 1024x512x0x1x64> -> <2x14x64x8xf16, 7168x512x8x1>
+    %18 = migraphx.dot %10, %17 : <2x14x1x64xf16, 1152x64x64x1>, <2x14x64x8xf16, 7168x512x8x1> -> <2x14x1x8xf16, 112x8x8x1>
+    %19 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <1xf16, 1> -> <2x14x1x8xf16, 0x0x0x0>
+    %20 = migraphx.mul %18, %4 : <2x14x1x8xf16, 112x8x8x1>, <2x14x1x8xf16, 0x0x0x0> -> <2x14x1x8xf16, 112x8x8x1>
+    %21 = migraphx.where %9, %19, %20 : <2x14x1x8xsi8, 8x0x8x1>, <2x14x1x8xf16, 0x0x0x0>, <2x14x1x8xf16, 112x8x8x1> -> <2x14x1x8xf16, 112x8x8x1>
+    %22 = migraphx.convert %21 {target_type = 2 : i64} : <2x14x1x8xf16, 112x8x8x1> to <2x14x1x8xf32, 112x8x8x1>
+    %23 = migraphx.reshape %22 {dims = [2, 14, 1, 8]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x8xf32, 112x8x8x1>
+    %24 = migraphx.reduce_max %23 {axes = [3]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %25 = migraphx.reshape %24 {dims = [2, 14, 1, 1]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %26 = migraphx.multibroadcast %25 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x8xf32, 14x1x1x0>
+    %27 = migraphx.sub %22, %26 : <2x14x1x8xf32, 112x8x8x1>, <2x14x1x8xf32, 14x1x1x0> -> <2x14x1x8xf32, 112x8x8x1>
+    %28 = migraphx.exp %27 : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x8xf32, 112x8x8x1>
+    %29 = migraphx.reshape %28 {dims = [2, 14, 1, 8]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x8xf32, 112x8x8x1>
+    %30 = migraphx.reduce_sum %29 {axes = [3]} : <2x14x1x8xf32, 112x8x8x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %31 = migraphx.reshape %30 {dims = [2, 14, 1, 1]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x1xf32, 14x1x1x1>
+    %32 = migraphx.multibroadcast %31 {out_dyn_dims = [], out_lens = [2, 14, 1, 8]} : <2x14x1x1xf32, 14x1x1x1> -> <2x14x1x8xf32, 14x1x1x0>
+    %33 = migraphx.div %28, %32 : <2x14x1x8xf32, 112x8x8x1>, <2x14x1x8xf32, 14x1x1x0> -> <2x14x1x8xf32, 112x8x8x1>
+    %34 = migraphx.convert %33 {target_type = 1 : i64} : <2x14x1x8xf32, 112x8x8x1> to <2x14x1x8xf16, 112x8x8x1>
+    %35 = migraphx.dot %34, %13 : <2x14x1x8xf16, 112x8x8x1>, <2x14x8x64xf16, 7168x512x64x1> -> <2x14x1x64xf16, 896x64x64x1>
+    %36 = migraphx.transpose %35 {permutation = [0, 2, 1, 3]} : <2x14x1x64xf16, 896x64x64x1> -> <2x1x14x64xf16, 896x64x64x1>
+    %37 = migraphx.reshape %36 {dims = [2, 1, 896]} : <2x1x14x64xf16, 896x64x64x1> -> <2x1x896xf16, 896x896x1>
+    return %37 : !migraphx.shaped<2x1x896xf16, 896x896x1>
+  }
+}


### PR DESCRIPTION
## Motivation

This PR integrates https://github.com/ROCm/rocMLIR/pull/1984 with migraphx. So that they can use our GQA optimization (passing numHeadsQ and numHeadsKV to rock.attention).

## Technical Details

Code changes:
- Added new pattern match code to TosaToRock
- New tests

More details about pattern match:
GQA happens when K and V have smaller number of heads than Q. For example, let's say Q=[B, 32, ...], K=V=[B, 8, ...]. Then, migraphx broadcasts the numHeadsKV dimension to be equal to numHeadsQ. We try to find this broadcast pattern in the IR. 

If we find it, we slice K and V tensors to make them as they were originally and pass numHeadsQ and numHeadsKV to rock.attention.

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
