### PR TITLE
Add support for gfx1250 wmma instructions

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -582,51 +582,148 @@ def ROCDL_smfmac_f32_32x32x32_fp8_fp8 : ROCDL_Mfma_IntrOp<"smfmac.f32.32x32x32.f
 
 //===---------------------------------------------------------------------===//
 // WMMA intrinsics
-class ROCDL_Wmma_IntrOp<string mnemonic, list<int> overloadedOperands,
-                        list<Trait> traits = []> :
-  ROCDL_IntrOp<mnemonic, [0], overloadedOperands, traits, 1>,
-  Arguments<(ins Variadic<LLVM_Type>:$args)> {
-  let assemblyFormat =
-    "$args attr-dict `:` functional-type($args, $res)";
+class ROCDL_WMMA_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
+    [0], [0], [], 1, 0, 0, 0, [], []>,
+  Arguments<(ins 
+             LLVM_ScalarOrVectorOf<AB>:$A, 
+             LLVM_ScalarOrVectorOf<AB>:$B,
+             LLVM_ScalarOrVectorOf<CD>:$C)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+class ROCDL_WMMA_Opsel_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
+    [0], [1], [], 1, 0, 0, 0, [3], ["opsel"]>,
+  Arguments<(ins 
+             LLVM_ScalarOrVectorOf<AB>:$A,
+             LLVM_ScalarOrVectorOf<AB>:$B,
+             LLVM_ScalarOrVectorOf<CD>:$C, 
+             DefaultValuedAttr<I1Attr, "0">:$opsel)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+class ROCDL_WMMA_IU_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
+    [0], [1], [], 1, 0, 0, 0, [0, 2, 5], ["signA", "signB", "clamp"]>,
+  Arguments<(ins 
+             DefaultValuedAttr<I1Attr, "0">:$signA,
+             LLVM_ScalarOrVectorOf<AB>:$A, 
+             DefaultValuedAttr<I1Attr, "0">:$signB,
+             LLVM_ScalarOrVectorOf<AB>:$B,
+             LLVM_ScalarOrVectorOf<CD>:$C, 
+             DefaultValuedAttr<I1Attr, "0">:$clamp)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+class ROCDL_WMMA_ModsAll_Reuse_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
+    [0], [1], [], 1, 0, 0, 0, [0, 2, 4, 6, 7], ["signA", "signB","modC","reuseA","reuseB"]>,
+  Arguments<(ins 
+             DefaultValuedAttr<I1Attr, "0">:$signA,
+             LLVM_ScalarOrVectorOf<AB>:$A, 
+             DefaultValuedAttr<I1Attr, "0">:$signB,
+             LLVM_ScalarOrVectorOf<AB>:$B,
+             DefaultValuedAttr<I16Attr, "0">:$modC, 
+             LLVM_ScalarOrVectorOf<CD>:$C, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseA, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+class ROCDL_WMMA_ModsC_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
+    [0], [0], [], 1, 0, 0, 0, [2, 4, 5], ["modC","reuseA","reuseB"]>,
+  Arguments<(ins 
+             LLVM_ScalarOrVectorOf<AB>:$A, 
+             LLVM_ScalarOrVectorOf<AB>:$B,
+             DefaultValuedAttr<I16Attr, "0">:$modC, 
+             LLVM_ScalarOrVectorOf<CD>:$C, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseA, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+class ROCDL_WMMA_ModsAll_Diff_IntrOp<string mnemonic, Type AB, Type C, Type D> : ROCDL_IntrOp<mnemonic,
+    [0], [1, 5], [], 1, 0, 0, 0, [0, 2, 4, 6, 7], ["signA", "signB","modC","reuseA","reuseB"]>,
+  Arguments<(ins 
+             DefaultValuedAttr<I1Attr, "0">:$signA,
+             LLVM_ScalarOrVectorOf<AB>:$A, 
+             DefaultValuedAttr<I1Attr, "0">:$signB,
+             LLVM_ScalarOrVectorOf<AB>:$B,
+             DefaultValuedAttr<I16Attr, "0">:$modC, 
+             LLVM_ScalarOrVectorOf<C>:$C, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseA, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
+  let results = (outs LLVM_ScalarOrVectorOf<D>:$res);
+  let assemblyFormat = [{
+    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+class ROCDL_WMMA_ModsAB_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
+    [0], [1], [], 1, 0, 0, 0, [0, 2, 5, 6], ["signA", "signB", "reuseA","reuseB"]>,
+  Arguments<(ins 
+             DefaultValuedAttr<I1Attr, "0">:$signA,
+             LLVM_ScalarOrVectorOf<AB>:$A, 
+             DefaultValuedAttr<I1Attr, "0">:$signB,
+             LLVM_ScalarOrVectorOf<AB>:$B,
+             LLVM_ScalarOrVectorOf<CD>:$C, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseA, 
+             DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+  }];
 }
 
 // Available from gfx11
-def ROCDL_wmma_f32_16x16x16_f16 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.f16", [0]>;
-def ROCDL_wmma_f32_16x16x16_bf16 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.bf16", [0]>;
-def ROCDL_wmma_f16_16x16x16_f16 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x16.f16", [0]>;
-def ROCDL_wmma_bf16_16x16x16_bf16 : ROCDL_Wmma_IntrOp<"wmma.bf16.16x16x16.bf16", [0]>;
-def ROCDL_wmma_i32_16x16x16_iu8 : ROCDL_Wmma_IntrOp<"wmma.i32.16x16x16.iu8", [1]>;
-def ROCDL_wmma_i32_16x16x16_iu4 : ROCDL_Wmma_IntrOp<"wmma.i32.16x16x16.iu4", [1]>;
+def ROCDL_wmma_f32_16x16x16_f16 : ROCDL_WMMA_IntrOp<"wmma.f32.16x16x16.f16", /*Type AB=*/F16, /*Type CD=*/F32>;
+def ROCDL_wmma_f32_16x16x16_bf16 : ROCDL_WMMA_IntrOp<"wmma.f32.16x16x16.bf16", AnyInteger, F32>;
+def ROCDL_wmma_f16_16x16x16_f16 : ROCDL_WMMA_Opsel_IntrOp<"wmma.f16.16x16x16.f16", F16, F16>;
+def ROCDL_wmma_bf16_16x16x16_bf16 : ROCDL_WMMA_Opsel_IntrOp<"wmma.bf16.16x16x16.bf16", AnyInteger, AnyInteger>;
+def ROCDL_wmma_i32_16x16x16_iu8 : ROCDL_WMMA_IU_IntrOp<"wmma.i32.16x16x16.iu8", AnyInteger, AnyInteger>;
+def ROCDL_wmma_i32_16x16x16_iu4 : ROCDL_WMMA_IU_IntrOp<"wmma.i32.16x16x16.iu4", AnyInteger, AnyInteger>;
 // Available from gfx12
-def ROCDL_wmma_f32_16x16x16_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.fp8_fp8", [1]>;
-def ROCDL_wmma_f32_16x16x16_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.fp8_bf8", [1]>;
-def ROCDL_wmma_f32_16x16x16_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.bf8_bf8", [1]>;
-def ROCDL_wmma_f32_16x16x16_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.bf8_fp8", [1]>;
-def ROCDL_wmma_i32_16x16x32_iu4 : ROCDL_Wmma_IntrOp<"wmma.i32.16x16x32.iu4", [1]>;
+def ROCDL_wmma_f32_16x16x16_fp8_fp8 : ROCDL_WMMA_IntrOp<"wmma.f32.16x16x16.fp8_fp8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x16_fp8_bf8 : ROCDL_WMMA_IntrOp<"wmma.f32.16x16x16.fp8_bf8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x16_bf8_bf8 : ROCDL_WMMA_IntrOp<"wmma.f32.16x16x16.bf8_bf8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x16_bf8_fp8 : ROCDL_WMMA_IntrOp<"wmma.f32.16x16x16.bf8_fp8", AnyInteger, F32>;
+def ROCDL_wmma_i32_16x16x32_iu4 : ROCDL_WMMA_IU_IntrOp<"wmma.i32.16x16x32.iu4", AnyInteger, AnyInteger>;
 // Available from gfx1250
-def ROCDL_wmma_f32_16x16x4_f32 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x4.f32", [1]>;
-def ROCDL_wmma_f32_16x16x32_bf16 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x32.bf16", [1]>;
-def ROCDL_wmma_f32_16x16x32_f16 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x32.f16", [1]>;
-def ROCDL_wmma_f16_16x16x32_f16 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x32.f16", [1]>;
-def ROCDL_wmma_bf16_16x16x32_bf16 : ROCDL_Wmma_IntrOp<"wmma.bf16.16x16x32.bf16", [1]>;
-def ROCDL_wmma_bf16f32_16x16x32_bf16 : ROCDL_Wmma_IntrOp<"wmma.bf16f32.16x16x32.bf16", [1,5]>;
-def ROCDL_wmma_f32_16x16x64_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.fp8_fp8", [0]>;
-def ROCDL_wmma_f32_16x16x64_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.fp8_bf8", [0]>;
-def ROCDL_wmma_f32_16x16x64_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.bf8_fp8", [0]>;
-def ROCDL_wmma_f32_16x16x64_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.bf8_bf8", [0]>;
-def ROCDL_wmma_f16_16x16x64_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.fp8_fp8", [0]>;
-def ROCDL_wmma_f16_16x16x64_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.fp8_bf8", [0]>;
-def ROCDL_wmma_f16_16x16x64_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.bf8_fp8", [0]>;
-def ROCDL_wmma_f16_16x16x64_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.bf8_bf8", [0]>;
-def ROCDL_wmma_f32_16x16x128_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.fp8_fp8", [0]>;
-def ROCDL_wmma_f32_16x16x128_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.fp8_bf8", [0]>;
-def ROCDL_wmma_f32_16x16x128_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.bf8_fp8", [0]>;
-def ROCDL_wmma_f32_16x16x128_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.bf8_bf8", [0]>;
-def ROCDL_wmma_f16_16x16x128_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.fp8_fp8", [0]>;
-def ROCDL_wmma_f16_16x16x128_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.fp8_bf8", [0]>;
-def ROCDL_wmma_f16_16x16x128_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.bf8_fp8", [0]>;
-def ROCDL_wmma_f16_16x16x128_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.bf8_bf8", [0]>;
-def ROCDL_wmma_i32_16x16x64_iu8 : ROCDL_Wmma_IntrOp<"wmma.i32.16x16x64.iu8", [1]>;
+def ROCDL_wmma_f32_16x16x4_f32 : ROCDL_WMMA_ModsAll_Reuse_IntrOp<"wmma.f32.16x16x4.f32", F32, F32>;
+def ROCDL_wmma_f32_16x16x32_bf16 : ROCDL_WMMA_ModsAll_Reuse_IntrOp<"wmma.f32.16x16x32.bf16", BF16, F32>;
+def ROCDL_wmma_f32_16x16x32_f16 : ROCDL_WMMA_ModsAll_Reuse_IntrOp<"wmma.f32.16x16x32.f16", F16, F32>;
+def ROCDL_wmma_f16_16x16x32_f16 : ROCDL_WMMA_ModsAll_Reuse_IntrOp<"wmma.f16.16x16x32.f16", F16, F16>;
+def ROCDL_wmma_bf16_16x16x32_bf16 : ROCDL_WMMA_ModsAll_Reuse_IntrOp<"wmma.bf16.16x16x32.bf16", BF16, BF16>;
+def ROCDL_wmma_bf16f32_16x16x32_bf16 : ROCDL_WMMA_ModsAll_Diff_IntrOp<"wmma.bf16f32.16x16x32.bf16", BF16, /*Type C=*/F32, /*Type D=*/BF16>;
+def ROCDL_wmma_f32_16x16x64_fp8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x64.fp8_fp8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x64_fp8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x64.fp8_bf8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x64_bf8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x64.bf8_fp8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x64_bf8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x64.bf8_bf8", AnyInteger, F32>;
+def ROCDL_wmma_f16_16x16x64_fp8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x64.fp8_fp8", AnyInteger, F16>;
+def ROCDL_wmma_f16_16x16x64_fp8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x64.fp8_bf8", AnyInteger, F16>;
+def ROCDL_wmma_f16_16x16x64_bf8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x64.bf8_fp8", AnyInteger, F16>;
+def ROCDL_wmma_f16_16x16x64_bf8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x64.bf8_bf8", AnyInteger, F16>;
+def ROCDL_wmma_f32_16x16x128_fp8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x128.fp8_fp8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x128_fp8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x128.fp8_bf8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x128_bf8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x128.bf8_fp8", AnyInteger, F32>;
+def ROCDL_wmma_f32_16x16x128_bf8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f32.16x16x128.bf8_bf8", AnyInteger, F32>;
+def ROCDL_wmma_f16_16x16x128_fp8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x128.fp8_fp8", AnyInteger, F16>;
+def ROCDL_wmma_f16_16x16x128_fp8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x128.fp8_bf8", AnyInteger, F16>;
+def ROCDL_wmma_f16_16x16x128_bf8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x128.bf8_fp8", AnyInteger, F16>;
+def ROCDL_wmma_f16_16x16x128_bf8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x128.bf8_bf8", AnyInteger, F16>;
+def ROCDL_wmma_i32_16x16x64_iu8 : ROCDL_WMMA_ModsAB_IntrOp<"wmma.i32.16x16x64.iu8", AnyInteger, AnyInteger>;
 
 //===---------------------------------------------------------------------===//
 // LDS transpose intrinsics (available in GFX950)

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -77,12 +78,6 @@ static Value convertUnsignedToI64(ConversionPatternRewriter &rewriter,
 static Value createI64Constant(ConversionPatternRewriter &rewriter,
                                Location loc, int64_t value) {
   return LLVM::ConstantOp::create(rewriter, loc, rewriter.getI64Type(), value);
-}
-
-static Value createI1Constant(ConversionPatternRewriter &rewriter, Location loc,
-                              bool value) {
-  Type llvmI1 = rewriter.getI1Type();
-  return LLVM::ConstantOp::create(rewriter, loc, llvmI1, value);
 }
 
 /// Returns the linear index used to access an element in the memref.
@@ -687,12 +682,11 @@ static Value castMFMAScaleOperand(ConversionPatternRewriter &rewriter,
 /// intrinsics having been defined before the AMD backend supported bfloat. We
 /// similarly need to pack 8-bit float types into integers as if they were i8
 /// (which they are for the backend's purposes).
-static void wmmaPushInputOperand(ConversionPatternRewriter &rewriter,
-                                 Location loc,
-                                 const TypeConverter *typeConverter,
-                                 bool isUnsigned, Value llvmInput,
-                                 Value mlirInput,
-                                 SmallVector<Value, 4> &operands) {
+static void wmmaPushInputOperand(
+    ConversionPatternRewriter &rewriter, Location loc,
+    const TypeConverter *typeConverter, bool isUnsigned, Value llvmInput,
+    Value mlirInput, SmallVectorImpl<Value> &operands,
+    SmallVectorImpl<NamedAttribute> &attrs, StringRef attrName) {
   Type inputType = llvmInput.getType();
   auto vectorType = dyn_cast<VectorType>(inputType);
   if (!vectorType) {
@@ -700,10 +694,6 @@ static void wmmaPushInputOperand(ConversionPatternRewriter &rewriter,
     return;
   }
   Type elemType = vectorType.getElementType();
-
-  if (elemType.isBF16())
-    llvmInput = LLVM::BitcastOp::create(
-        rewriter, loc, vectorType.clone(rewriter.getI16Type()), llvmInput);
   if (elemType.getIntOrFloatBitWidth() > 8) {
     operands.push_back(llvmInput);
     return;
@@ -722,8 +712,8 @@ static void wmmaPushInputOperand(ConversionPatternRewriter &rewriter,
     } else if (elemType.isSignedInteger()) {
       localIsUnsigned = false;
     }
-    Value sign = createI1Constant(rewriter, loc, !localIsUnsigned);
-    operands.push_back(sign);
+    attrs.push_back(
+        NamedAttribute(attrName, rewriter.getBoolAttr(!localIsUnsigned)));
   }
 
   int64_t numBits =
@@ -754,18 +744,17 @@ static void wmmaPushOutputOperand(ConversionPatternRewriter &rewriter,
                                   Location loc,
                                   const TypeConverter *typeConverter,
                                   Value output, int32_t subwordOffset,
-                                  bool clamp, SmallVector<Value, 4> &operands) {
+                                  bool clamp, SmallVectorImpl<Value> &operands,
+                                  SmallVectorImpl<NamedAttribute> &attrs) {
   Type inputType = output.getType();
   auto vectorType = dyn_cast<VectorType>(inputType);
   Type elemType = vectorType.getElementType();
-  if (elemType.isBF16())
-    output = LLVM::BitcastOp::create(
-        rewriter, loc, vectorType.clone(rewriter.getI16Type()), output);
   operands.push_back(output);
   if (elemType.isF16() || elemType.isBF16() || elemType.isInteger(16)) {
-    operands.push_back(createI1Constant(rewriter, loc, subwordOffset));
+    attrs.push_back(
+        NamedAttribute("opsel", rewriter.getBoolAttr(subwordOffset)));
   } else if (elemType.isInteger(32)) {
-    operands.push_back(createI1Constant(rewriter, loc, clamp));
+    attrs.push_back(NamedAttribute("clamp", rewriter.getBoolAttr(clamp)));
   }
 }
 
@@ -1314,11 +1303,33 @@ struct WMMAOpLowering : public ConvertOpToLLVMPattern<WMMAOp> {
     if (chipset.majorVersion != 11 && chipset.majorVersion != 12)
       return op->emitOpError("WMMA only supported on gfx11 and gfx12");
 
-    // The WMMA operations represent vectors of bf16s as vectors of i16s, so we
-    // need to bitcast bfloats to i16 and then bitcast them back.
+    bool isGFX1250 = chipset >= Chipset(12, 5, 0);
+
+    // The WMMA operations represent vectors of bf16s as vectors of i16s
+    // (except on gfx1250), so we need to bitcast bfloats to i16 and then
+    // bitcast them back.
+    auto aType = cast<VectorType>(adaptor.getSourceA().getType());
+    auto bType = cast<VectorType>(adaptor.getSourceB().getType());
+    auto destCType = cast<VectorType>(adaptor.getDestC().getType());
+    bool castAToI16 = aType.getElementType().isBF16() && !isGFX1250;
+    bool castBToI16 = bType.getElementType().isBF16() && !isGFX1250;
+    bool castDestCToI16 = destCType.getElementType().isBF16() && !isGFX1250;
+    bool castOutToI16 = outType.getElementType().isBF16() && !isGFX1250;
     VectorType rawOutType = outType;
-    if (outType.getElementType().isBF16())
+    if (castOutToI16)
       rawOutType = outType.clone(rewriter.getI16Type());
+    Value a = adaptor.getSourceA();
+    if (castAToI16)
+      a = LLVM::BitcastOp::create(rewriter, loc,
+                                  aType.clone(rewriter.getI16Type()), a);
+    Value b = adaptor.getSourceB();
+    if (castBToI16)
+      b = LLVM::BitcastOp::create(rewriter, loc,
+                                  bType.clone(rewriter.getI16Type()), b);
+    Value destC = adaptor.getDestC();
+    if (castDestCToI16)
+      destC = LLVM::BitcastOp::create(
+          rewriter, loc, destCType.clone(rewriter.getI16Type()), destC);
 
     std::optional<StringRef> maybeIntrinsic = wmmaOpToIntrinsic(op, chipset);
 
@@ -1328,18 +1339,20 @@ struct WMMAOpLowering : public ConvertOpToLLVMPattern<WMMAOp> {
     if (chipset.majorVersion >= 12 && op.getSubwordOffset() != 0)
       return op.emitOpError("subwordOffset not supported on gfx12+");
 
+    SmallVector<Value, 4> operands;
+    SmallVector<NamedAttribute, 4> attrs;
+    wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedA(), a,
+                         op.getSourceA(), operands, attrs, "signA");
+    wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedB(), b,
+                         op.getSourceB(), operands, attrs, "signB");
+    wmmaPushOutputOperand(rewriter, loc, typeConverter, destC,
+                          op.getSubwordOffset(), op.getClamp(), operands,
+                          attrs);
+
     OperationState loweredOp(loc, *maybeIntrinsic);
     loweredOp.addTypes(rawOutType);
-
-    SmallVector<Value, 4> operands;
-    wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedA(),
-                         adaptor.getSourceA(), op.getSourceA(), operands);
-    wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedB(),
-                         adaptor.getSourceB(), op.getSourceB(), operands);
-    wmmaPushOutputOperand(rewriter, loc, typeConverter, adaptor.getDestC(),
-                          op.getSubwordOffset(), op.getClamp(), operands);
-
     loweredOp.addOperands(operands);
+    loweredOp.addAttributes(attrs);
     Operation *lowered = rewriter.create(loweredOp);
 
     Operation *maybeCastBack = lowered;

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx11.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx11.mlir
@@ -6,30 +6,30 @@ func.func @wmma_to_rocdl(%arg0 : vector<16xf16>, %arg1 : vector<8xf32>, %arg2 : 
                          %arg6 : vector<16xi8>, %arg7 : vector<8xi32>, %arg8 : vector<4xi32>,
                          %arg9 : vector<16xui8>, %arg10 : vector<16xi4>, %arg11 : vector<8xi4>) {
   // CHECK: rocdl.wmma.f32.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 : vector<16xf16>, vector<16xf16>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 {subwordOffset = 0 : i32} : vector<16xf16>, vector<16xf16>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg2 : vector<16xf16>, vector<16xf16>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg2 {subwordOffset = 0 : i32} : vector<16xf16>, vector<16xf16>, vector<4xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg1 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg1 {subwordOffset = 0 : i32} : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg2 : vector<16xbf16>, vector<16xbf16>, vector<4xf32>
-  // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<16xf16>, i1) -> vector<16xf16>
+  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg2 {subwordOffset = 0 : i32} : vector<16xbf16>, vector<16xbf16>, vector<4xf32>
+  // CHECK: rocdl.wmma.f16.16x16x16.f16 {{.*}} {opsel = true} : (vector<16xf16>, vector<16xf16>, vector<16xf16>) -> vector<16xf16>
   amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg0 {subwordOffset = 1 : i32}: vector<16xf16>, vector<16xf16>, vector<16xf16>
-  // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<8xf16>, i1) -> vector<8xf16>
+  // CHECK: rocdl.wmma.f16.16x16x16.f16 {{.*}} : (vector<16xf16>, vector<16xf16>, vector<8xf16>) -> vector<8xf16>
   amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg4 {subwordOffset = 0 : i32}: vector<16xf16>, vector<16xf16>, vector<8xf16>
-  // CHECK: %[[raw_bf16x16:.+]] = rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<16xi16>, i1) -> vector<16xi16>
+  // CHECK: %[[raw_bf16x16:.+]] = rocdl.wmma.bf16.16x16x16.bf16 {{.*}} {opsel = true} : (vector<16xi16>, vector<16xi16>, vector<16xi16>) -> vector<16xi16>
   // CHECK-NEXT: llvm.bitcast %[[raw_bf16x16]] : vector<16xi16> to vector<16xbf16>
   amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg3 {subwordOffset = 1 : i32}: vector<16xbf16>, vector<16xbf16>, vector<16xbf16>
-  // CHECK: %[[raw_bf16x8:.+]] = rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<8xi16>, i1) -> vector<8xi16>
+  // CHECK: %[[raw_bf16x8:.+]] = rocdl.wmma.bf16.16x16x16.bf16 {{.*}} : (vector<16xi16>, vector<16xi16>, vector<8xi16>) -> vector<8xi16>
   // CHECK-NEXT: llvm.bitcast %[[raw_bf16x8]] : vector<8xi16> to vector<8xbf16>
   amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg5 {subwordOffset = 0 : i32}: vector<16xbf16>, vector<16xbf16>, vector<8xbf16>
-  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, vector<4xi32>, i1, vector<4xi32>, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}{clamp = true, signA = true, signB = true} : (vector<4xi32>, vector<4xi32>, vector<8xi32>) -> vector<8xi32>
   amdgpu.wmma 16x16x16 %arg6 * %arg6 + %arg7 {clamp}: vector<16xi8>, vector<16xi8>, vector<8xi32>
-  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, vector<4xi32>, i1, vector<4xi32>, vector<4xi32>, i1) -> vector<4xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}{clamp = true} : (vector<4xi32>, vector<4xi32>, vector<4xi32>) -> vector<4xi32>
   amdgpu.wmma 16x16x16 %arg9 * %arg9 + %arg8 {unsignedA, unsignedB, clamp}: vector<16xui8>, vector<16xui8>, vector<4xi32>
-  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}{clamp = true, signA = true, signB = true} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
   amdgpu.wmma 16x16x16 %arg10 * %arg10 + %arg7 {clamp}: vector<16xi4>, vector<16xi4>, vector<8xi32>
-  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}{clamp = true, signA = true, signB = true} : (i32, i32, vector<4xi32>) -> vector<4xi32>
   amdgpu.wmma 16x16x16 %arg11 * %arg11 + %arg8 {clamp}: vector<8xi4>, vector<8xi4>, vector<4xi32>
 
   return

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx12.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx12.mlir
@@ -20,15 +20,15 @@ func.func @wmma_to_rocdl(%arg0 : vector<8xf16>, %arg1 : vector<4xf16>,
   // CHECK: rocdl.wmma.f32.16x16x16.bf16{{.*}}: (vector<4xi16>, vector<4xi16>, vector<4xf32>) -> vector<4xf32>
   amdgpu.wmma 16x16x16 %arg5 * %arg5 + %arg3 : vector<4xbf16>, vector<4xbf16>, vector<4xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
+  // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<8xf16>, vector<8xf16>, vector<8xf16>) -> vector<8xf16>
   amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg0 : vector<8xf16>, vector<8xf16>, vector<8xf16>
-  // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<4xf16>, vector<4xf16>, vector<4xf16>, i1) -> vector<4xf16>
+  // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<4xf16>, vector<4xf16>, vector<4xf16>) -> vector<4xf16>
   amdgpu.wmma 16x16x16 %arg1 * %arg1 + %arg1 : vector<4xf16>, vector<4xf16>, vector<4xf16>
 
-  // CHECK: %[[raw_bf16x8:.+]] = rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<8xi16>, vector<8xi16>, vector<8xi16>, i1) -> vector<8xi16>
+  // CHECK: %[[raw_bf16x8:.+]] = rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<8xi16>, vector<8xi16>, vector<8xi16>) -> vector<8xi16>
   // CHECK-NEXT: llvm.bitcast %[[raw_bf16x8]] : vector<8xi16> to vector<8xbf16>
   amdgpu.wmma 16x16x16 %arg4 * %arg4 + %arg4 : vector<8xbf16>, vector<8xbf16>, vector<8xbf16>
-  // CHECK: rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<4xi16>, vector<4xi16>, vector<4xi16>, i1) -> vector<4xi16>
+  // CHECK: rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<4xi16>, vector<4xi16>, vector<4xi16>) -> vector<4xi16>
   amdgpu.wmma 16x16x16 %arg5 * %arg5 + %arg5 : vector<4xbf16>, vector<4xbf16>, vector<4xbf16>
 
   // CHECK: rocdl.wmma.f32.16x16x16.fp8_fp8{{.*}}: (vector<2xi32>, vector<2xi32>, vector<8xf32>) -> vector<8xf32>
@@ -51,19 +51,19 @@ func.func @wmma_to_rocdl(%arg0 : vector<8xf16>, %arg1 : vector<4xf16>,
   // CHECK: rocdl.wmma.f32.16x16x16.bf8_fp8{{.*}}: (i32, i32, vector<4xf32>) -> vector<4xf32>
   amdgpu.wmma 16x16x16 %arg9 * %arg7 + %arg3 : vector<4xf8E5M2>, vector<4xf8E4M3FN>, vector<4xf32>
 
-  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}{clamp = true, signA = true, signB = true} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
   amdgpu.wmma 16x16x16 %arg10 * %arg10 + %arg12 {clamp} : vector<8xi8>, vector<8xi8>, vector<8xi32>
-  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}{clamp = true} : (i32, i32, vector<4xi32>) -> vector<4xi32>
   amdgpu.wmma 16x16x16 %arg11 * %arg11 + %arg13 {unsignedA, unsignedB, clamp}: vector<4xi8>, vector<4xi8>, vector<4xi32>
 
-  // CHECK: rocdl.wmma.i32.16x16x32.iu4{{.*}}: (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: rocdl.wmma.i32.16x16x32.iu4{{.*}}{clamp = true, signA = true, signB = true} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
   amdgpu.wmma 16x16x32 %arg14 * %arg14 + %arg12 {clamp} : vector<16xi4>, vector<16xi4>, vector<8xi32>
-  // CHECK: rocdl.wmma.i32.16x16x32.iu4{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
+  // CHECK: rocdl.wmma.i32.16x16x32.iu4{{.*}}{clamp = true, signA = true, signB = true} : (i32, i32, vector<4xi32>) -> vector<4xi32>
   amdgpu.wmma 16x16x32 %arg15 * %arg15 + %arg13 {clamp} : vector<8xi4>, vector<8xi4>, vector<4xi32>
 
-  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, i32, i1, i32, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}{clamp = true, signA = true, signB = true} : (i32, i32, vector<8xi32>) -> vector<8xi32>
   amdgpu.wmma 16x16x16 %arg15 * %arg15 + %arg12 {clamp} : vector<8xi4>, vector<8xi4>, vector<8xi32>
-  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
+  // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}{clamp = true, signA = true, signB = true} : (i32, i32, vector<4xi32>) -> vector<4xi32>
   amdgpu.wmma 16x16x16 %arg16 * %arg16 + %arg13 {clamp} : vector<4xi4>, vector<4xi4>, vector<4xi32>
 
   func.return

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx1250.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx1250.mlir
@@ -14,13 +14,13 @@ func.func @wmma_k32(%arg0 : vector<16xf16>, %arg1 : vector<16xbf16>, %arg2 : vec
   // CHECK: rocdl.wmma.f32.16x16x32.f16 %arg0, %arg0, %arg2
   amdgpu.wmma 16x16x32 %arg0 * %arg0 + %arg2 : vector<16xf16>, vector<16xf16>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x32.f16 %arg0, %arg0, {{.*}} : (vector<16xf16>, vector<16xf16>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x32.f16 %arg0, %arg0, {{.*}} : (vector<16xf16>, vector<16xf16>, vector<8xf16>)
   amdgpu.wmma 16x16x32 %arg0 * %arg0 + %arg3 : vector<16xf16>, vector<16xf16>, vector<8xf16>
 
   // CHECK: rocdl.wmma.f32.16x16x32.bf16 {{.*}}, {{.*}}, %arg2
   amdgpu.wmma 16x16x32 %arg1 * %arg1 + %arg2 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.bf16.16x16x32.bf16 {{.*}}, {{.*}}, {{.*}}, {{.*}} : (vector<16xi16>, vector<16xi16>, vector<8xi16>, i1)
+  // CHECK: rocdl.wmma.bf16.16x16x32.bf16 {{.*}}, {{.*}}, {{.*}} : (vector<16xbf16>, vector<16xbf16>, vector<8xbf16>)
   amdgpu.wmma 16x16x32 %arg1 * %arg1 + %arg4 : vector<16xbf16>, vector<16xbf16>, vector<8xbf16>
 
   return
@@ -29,31 +29,31 @@ func.func @wmma_k32(%arg0 : vector<16xf16>, %arg1 : vector<16xbf16>, %arg2 : vec
 // CHECK-LABEL: @wmma_k64
 func.func @wmma_k64(%arg0 : vector<32xi8>, %arg1 : vector<32xf8E4M3FN>, %arg2 : vector<32xf8E5M2>,
                     %arg3 : vector<8xi32>, %arg4 : vector<8xf32>, %arg5 : vector<8xf16>) {
-  // CHECK: rocdl.wmma.i32.16x16x64.iu8 {{.*}}, {{.*}}, {{.*}}, {{.*}}, %arg3, {{.*}}
+  // CHECK: rocdl.wmma.i32.16x16x64.iu8 {{.*}}, {{.*}}, %arg3 {clamp = true, signA = true, signB = true}
   amdgpu.wmma 16x16x64 %arg0 * %arg0 + %arg3 {clamp} : vector<32xi8>, vector<32xi8>, vector<8xi32>
 
   // CHECK: rocdl.wmma.f32.16x16x64.fp8_fp8 {{.*}}, {{.*}}, %arg4
   amdgpu.wmma 16x16x64 %arg1 * %arg1 + %arg4 : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x64.fp8_fp8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x64.fp8_fp8 {{.*}}, {{.*}}, %arg5 {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x64 %arg1 * %arg1 + %arg5 : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<8xf16>
 
   // CHECK: rocdl.wmma.f32.16x16x64.fp8_bf8 {{.*}}, {{.*}}, %arg4
   amdgpu.wmma 16x16x64 %arg1 * %arg2 + %arg4 : vector<32xf8E4M3FN>, vector<32xf8E5M2>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x64.fp8_bf8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x64.fp8_bf8 {{.*}}, {{.*}}, %arg5 {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x64 %arg1 * %arg2 + %arg5 : vector<32xf8E4M3FN>, vector<32xf8E5M2>, vector<8xf16>
 
   // CHECK: rocdl.wmma.f32.16x16x64.bf8_bf8 {{.*}}, {{.*}}, %arg4
   amdgpu.wmma 16x16x64 %arg2 * %arg2 + %arg4 : vector<32xf8E5M2>, vector<32xf8E5M2>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x64.bf8_bf8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x64.bf8_bf8 {{.*}}, {{.*}}, %arg5 {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x64 %arg2 * %arg2 + %arg5 : vector<32xf8E5M2>, vector<32xf8E5M2>, vector<8xf16>
 
   // CHECK: rocdl.wmma.f32.16x16x64.bf8_fp8 {{.*}}, {{.*}}, %arg4
   amdgpu.wmma 16x16x64 %arg2 * %arg1 + %arg4 : vector<32xf8E5M2>, vector<32xf8E4M3FN>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x64.bf8_fp8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x64.bf8_fp8 {{.*}}, {{.*}}, %arg5 {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x64 %arg2 * %arg1 + %arg5 : vector<32xf8E5M2>, vector<32xf8E4M3FN>, vector<8xf16>
 
   return
@@ -65,25 +65,25 @@ func.func @wmma_k128(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<64xf8E5M2>,
   // CHECK: rocdl.wmma.f32.16x16x128.fp8_fp8 {{.*}}, {{.*}}, %arg2
   amdgpu.wmma 16x16x128 %arg0 * %arg0 + %arg2 : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x128.fp8_fp8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x128.fp8_fp8 {{.*}}, {{.*}}, %arg3 {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x128 %arg0 * %arg0 + %arg3 : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf16>
 
   // CHECK: rocdl.wmma.f32.16x16x128.fp8_bf8 {{.*}}, {{.*}}, %arg2
   amdgpu.wmma 16x16x128 %arg0 * %arg1 + %arg2 : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x128.fp8_bf8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x128.fp8_bf8 {{.*}}, {{.*}}, %arg3 {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x128 %arg0 * %arg1 + %arg3 : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf16>
 
   // CHECK: rocdl.wmma.f32.16x16x128.bf8_bf8 {{.*}}, {{.*}}, %arg2
   amdgpu.wmma 16x16x128 %arg1 * %arg1 + %arg2 : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x128.bf8_bf8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x128.bf8_bf8 {{.*}}, {{.*}}, %arg3 {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x128 %arg1 * %arg1 + %arg3 : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf16>
 
   // CHECK: rocdl.wmma.f32.16x16x128.bf8_fp8 {{.*}}, {{.*}}, %arg2
   amdgpu.wmma 16x16x128 %arg1 * %arg0 + %arg2 : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf32>
 
-  // CHECK: rocdl.wmma.f16.16x16x128.bf8_fp8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  // CHECK: rocdl.wmma.f16.16x16x128.bf8_fp8 {{.*}}, {{.*}}, %arg3 {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>)
   amdgpu.wmma 16x16x128 %arg1 * %arg0 + %arg3 : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf16>
 
   return

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -875,140 +875,138 @@ llvm.func @rocdl.wmma(%arg0 : vector<8xf32>, %arg1 : vector<16 x f16>, %arg2 : v
                       %arg4 : vector<2xi32>, %arg5 : vector<4xi32>, %arg6 : vector<4xf32>, %arg7 : vector<8xf16>, %arg8 : vector<8xi16>,
                       %arg9 : vector<32xf16>, %arg10 : vector<16xf32>, %arg11 : vector<4xf32>, %arg12 : vector<32xf32>, %arg13 : vector<64xf32>, 
                       %arg14 : vector<64xi32>, %arg15 : vector<64xf16>, %arg16 : vector<16xbf16>, %arg17 : vector<32xbf16>) -> vector<8xf32> {
-  %zero = llvm.mlir.constant(false) : i1
-  %zero_i16 = llvm.mlir.constant(0 : i16) : i16
-  // ---- Wave32 -----
 
+  // ---- Wave32 -----
   // f16 -> f32
-  // CHECK: call <8 x float> @llvm.amdgcn.wmma.f32.16x16x16.f16.v8f32.v16f16(<16 x half> %{{.*}}, <16 x half> %{{.*}}, <8 x float> %{{.*}})
+  // CHECK: call <8 x float> @llvm.amdgcn.wmma.f32.16x16x16.f16.v8f32.v16f16(<16 x half> %{{.*}} <16 x half> %{{.*}} <8 x float> %{{.*}})
   %r0 = rocdl.wmma.f32.16x16x16.f16 %arg1, %arg1, %arg0 : (vector<16xf16>, vector<16xf16>, vector<8xf32>) -> vector<8xf32>
 
   // bf16 -> f32
-  // CHECK: call <8 x float> @llvm.amdgcn.wmma.f32.16x16x16.bf16.v8f32.v16i16(<16 x i16> %{{.*}}, <16 x i16> %{{.*}}, <8 x float> %{{.*}})
+  // CHECK: call <8 x float> @llvm.amdgcn.wmma.f32.16x16x16.bf16.v8f32.v16i16(<16 x i16> %{{.*}} <16 x i16> %{{.*}} <8 x float> %{{.*}})
   %r1 = rocdl.wmma.f32.16x16x16.bf16 %arg2, %arg2, %arg0 : (vector<16xi16>, vector<16xi16>, vector<8xf32>) -> vector<8xf32>
 
   // f16 -> f16 (OPSEL = {0,1})
-  // CHECK: call <16 x half> @llvm.amdgcn.wmma.f16.16x16x16.f16.v16f16.v16f16(<16 x half> %{{.*}}, <16 x half> %{{.*}}, <16 x half> %{{.*}}, i1 {{.*}})
-  %r2 = rocdl.wmma.f16.16x16x16.f16 %arg1, %arg1, %arg1, %zero : (vector<16xf16>, vector<16xf16>, vector<16xf16>, i1) -> vector<16xf16>
+  // CHECK: call <16 x half> @llvm.amdgcn.wmma.f16.16x16x16.f16.v16f16.v16f16(<16 x half> %{{.*}} <16 x half> %{{.*}} <16 x half> %{{.*}} i1 false)
+  %r2 = rocdl.wmma.f16.16x16x16.f16 %arg1, %arg1, %arg1 {opsel = false} : (vector<16xf16>, vector<16xf16>, vector<16xf16>) -> vector<16xf16>
 
   // bf16 -> bf16 (OPSEL = {0,1})
-  // CHECK: call <16 x i16> @llvm.amdgcn.wmma.bf16.16x16x16.bf16.v16i16.v16i16(<16 x i16> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}, i1 {{.*}})
-  %r4 = rocdl.wmma.bf16.16x16x16.bf16 %arg2, %arg2, %arg2, %zero : (vector<16xi16>, vector<16xi16>, vector<16xi16>, i1) -> vector<16xi16>
+  // CHECK: call <16 x i16> @llvm.amdgcn.wmma.bf16.16x16x16.bf16.v16i16.v16i16(<16 x i16> %{{.*}} <16 x i16> %{{.*}} <16 x i16> %{{.*}} i1 false)
+  %r4 = rocdl.wmma.bf16.16x16x16.bf16 %arg2, %arg2, %arg2 {opsel = false} : (vector<16xi16>, vector<16xi16>, vector<16xi16>) -> vector<16xi16>
 
   // int8 -> int32 (signA = {0,1}, signB = {0,1}, clamp = {0,1})
-  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu8.v8i32.v4i32(i1 {{.*}}, <4 x i32> %{{.*}}, i1 {{.*}}, <4 x i32> %{{.*}}, <8 x i32> %{{.*}}, i1 {{.*}})
-  %r5 = rocdl.wmma.i32.16x16x16.iu8 %zero, %arg5, %zero, %arg5, %arg3, %zero : (i1, vector<4xi32>, i1, vector<4xi32>, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu8.v8i32.v4i32(i1 false, <4 x i32> %{{.*}} i1 false, <4 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
+  %r5 = rocdl.wmma.i32.16x16x16.iu8 %arg5, %arg5, %arg3 {signA = false, signB = false, clamp = false} : (vector<4xi32>, vector<4xi32>, vector<8xi32>) -> vector<8xi32>
 
   // int4 -> int32 (signA = {0,1}, signB = {0,1}, clamp = {0,1})
-  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu4.v8i32.v2i32(i1 {{.*}}, <2 x i32> %{{.*}}, i1 {{.*}}, <2 x i32> %{{.*}}, <8 x i32> %{{.*}}, i1 {{.*}})
-  %r6 = rocdl.wmma.i32.16x16x16.iu4 %zero, %arg4, %zero, %arg4, %arg3, %zero : (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu4.v8i32.v2i32(i1 false, <2 x i32> %{{.*}} i1 false, <2 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
+  %r6 = rocdl.wmma.i32.16x16x16.iu4 %arg4, %arg4, %arg3 {signA = false, signB = false, clamp = false} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
 
   // int4 -> int32 (signA = {0,1}, signB = {0,1}, clamp = {0,1})
-  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x32.iu4.v8i32.v2i32(i1 {{.*}}, <2 x i32> %{{.*}}, i1 {{.*}}, <2 x i32> %{{.*}}, <8 x i32> %{{.*}}, i1 {{.*}})
-  %r6.gfx12 = rocdl.wmma.i32.16x16x32.iu4 %zero, %arg4, %zero, %arg4, %arg3, %zero : (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x32.iu4.v8i32.v2i32(i1 false, <2 x i32> %{{.*}} i1 false, <2 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
+  %r6.gfx12 = rocdl.wmma.i32.16x16x32.iu4 %arg4, %arg4, %arg3 {signA = false, signB = false, clamp = false} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
 
   // f32 -> f32
-  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x4.f32.v4f32.v16f32(i1 {{.*}}, <16 x float> %{{.*}}, i1 {{.*}}, <16 x float> %{{.*}}, i16 0, <4 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r1.gfx1250 = rocdl.wmma.f32.16x16x4.f32 %zero, %arg10, %zero, %arg10, %zero_i16, %arg11, %zero, %zero : (i1, vector<16xf32>, i1, vector<16xf32>, i16, vector<4xf32>, i1, i1) -> vector<4xf32>
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x4.f32.v4f32.v16f32(i1 false, <16 x float> %{{.*}} i1 false, <16 x float> %{{.*}} i16 0, <4 x float> %{{.*}} i1 false, i1 false)
+  %r1.gfx1250 = rocdl.wmma.f32.16x16x4.f32 %arg10, %arg10, %arg11 {signA = false, signB = false, modC = 0 : i16} : (vector<16xf32>, vector<16xf32>, vector<4xf32>) -> vector<4xf32>
 
   // f16 -> f32
-  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.f16.v32f32.v16f16(i1 {{.*}}, <16 x half> %{{.*}}, i1 {{.*}}, <16 x half> %{{.*}}, i16 0, <32 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r2.gfx1250 = rocdl.wmma.f32.16x16x32.f16 %zero, %arg1, %zero, %arg1, %zero_i16, %arg12, %zero, %zero : (i1, vector<16xf16>, i1, vector<16xf16>, i16, vector<32xf32>, i1, i1) -> vector<32xf32>
+  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.f16.v32f32.v16f16(i1 false, <16 x half> %{{.*}} i1 false, <16 x half> %{{.*}} i16 0, <32 x float> %{{.*}} i1 false, i1 false)
+  %r2.gfx1250 = rocdl.wmma.f32.16x16x32.f16 %arg1, %arg1, %arg12 {signA = false, signB = false, modC = 0 : i16} : (vector<16xf16>, vector<16xf16>, vector<32xf32>) -> vector<32xf32>
 
   // bf16 -> f32
-  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.bf16.v32f32.v16bf16(i1 {{.*}}, <16 x bfloat> %{{.*}}, i1 {{.*}}, <16 x bfloat> %{{.*}}, i16 0, <32 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r3.gfx1250 = rocdl.wmma.f32.16x16x32.bf16 %zero, %arg16, %zero, %arg16, %zero_i16, %arg12, %zero, %zero : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<32xf32>, i1, i1) -> vector<32xf32>
+  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.bf16.v32f32.v16bf16(i1 false, <16 x bfloat> %{{.*}} i1 false, <16 x bfloat> %{{.*}} i16 0, <32 x float> %{{.*}} i1 false, i1 false)
+  %r3.gfx1250 = rocdl.wmma.f32.16x16x32.bf16 %arg16, %arg16, %arg12 {signA = false, signB = false, modC = 0 : i16} : (vector<16xbf16>, vector<16xbf16>, vector<32xf32>) -> vector<32xf32>
 
   // f16 -> f16
-  // CHECK: call <32 x half> @llvm.amdgcn.wmma.f16.16x16x32.f16.v32f16.v16f16(i1 {{.*}}, <16 x half> %{{.*}}, i1 {{.*}}, <16 x half> %{{.*}}, i16 0, <32 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r4.gfx1250 = rocdl.wmma.f16.16x16x32.f16 %zero, %arg1, %zero, %arg1, %zero_i16, %arg9, %zero, %zero : (i1, vector<16xf16>, i1, vector<16xf16>, i16, vector<32xf16>, i1, i1) -> vector<32xf16>
+  // CHECK: call <32 x half> @llvm.amdgcn.wmma.f16.16x16x32.f16.v32f16.v16f16(i1 false, <16 x half> %{{.*}} i1 false, <16 x half> %{{.*}} i16 0, <32 x half> %{{.*}} i1 false, i1 false)
+  %r4.gfx1250 = rocdl.wmma.f16.16x16x32.f16 %arg1, %arg1, %arg9 {signA = false, signB = false, modC = 0 : i16} : (vector<16xf16>, vector<16xf16>, vector<32xf16>) -> vector<32xf16>
 
   // bf16 -> bf16
-  // CHECK: call <32 x bfloat> @llvm.amdgcn.wmma.bf16.16x16x32.bf16.v32bf16.v16bf16(i1 {{.*}}, <16 x bfloat> %{{.*}}, i1 {{.*}}, <16 x bfloat> %{{.*}}, i16 0, <32 x bfloat> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r5.gfx1250 = rocdl.wmma.bf16.16x16x32.bf16 %zero, %arg16, %zero, %arg16, %zero_i16, %arg17, %zero, %zero : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<32xbf16>, i1, i1) -> vector<32xbf16>
+  // CHECK: call <32 x bfloat> @llvm.amdgcn.wmma.bf16.16x16x32.bf16.v32bf16.v16bf16(i1 false, <16 x bfloat> %{{.*}} i1 false, <16 x bfloat> %{{.*}} i16 0, <32 x bfloat> %{{.*}} i1 false, i1 false)
+  %r5.gfx1250 = rocdl.wmma.bf16.16x16x32.bf16 %arg16, %arg16, %arg17 {signA = false, signB = false, modC = 0 : i16} : (vector<16xbf16>, vector<16xbf16>, vector<32xbf16>) -> vector<32xbf16>
 
   // bf16 -> bf16 / f32
-  // CHECK: call <32 x bfloat> @llvm.amdgcn.wmma.bf16f32.16x16x32.bf16.v32bf16.v16bf16.v32f32(i1 {{.*}}, <16 x bfloat> %{{.*}}, i1 {{.*}}, <16 x bfloat> %{{.*}}, i16 0, <32 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r6.gfx1250 = rocdl.wmma.bf16f32.16x16x32.bf16 %zero, %arg16, %zero, %arg16, %zero_i16, %arg12, %zero, %zero : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<32xf32>, i1, i1) -> vector<32xbf16>
+  // CHECK: call <32 x bfloat> @llvm.amdgcn.wmma.bf16f32.16x16x32.bf16.v32bf16.v16bf16.v32f32(i1 false, <16 x bfloat> %{{.*}} i1 false, <16 x bfloat> %{{.*}} i16 0, <32 x float> %{{.*}} i1 false, i1 false)
+  %r6.gfx1250 = rocdl.wmma.bf16f32.16x16x32.bf16 %arg16, %arg16, %arg12 {signA = false, signB = false, modC = 0 : i16} : (vector<16xbf16>, vector<16xbf16>, vector<32xf32>) -> vector<32xbf16>
 
   // f8/bf8 -> f16/f32
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.fp8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r7.gfx1250 = rocdl.wmma.f32.16x16x64.fp8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.fp8.fp8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r7.gfx1250 = rocdl.wmma.f32.16x16x64.fp8_fp8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.fp8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r8.gfx1250 = rocdl.wmma.f32.16x16x64.fp8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.fp8.bf8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r8.gfx1250 = rocdl.wmma.f32.16x16x64.fp8_bf8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.bf8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r9.gfx1250 = rocdl.wmma.f32.16x16x64.bf8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.bf8.fp8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r9.gfx1250 = rocdl.wmma.f32.16x16x64.bf8_fp8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.bf8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r10.gfx1250 = rocdl.wmma.f32.16x16x64.bf8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.bf8.bf8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r10.gfx1250 = rocdl.wmma.f32.16x16x64.bf8_bf8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.fp8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r11.gfx1250 = rocdl.wmma.f16.16x16x64.fp8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.fp8.fp8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r11.gfx1250 = rocdl.wmma.f16.16x16x64.fp8_fp8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.fp8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r12.gfx1250 = rocdl.wmma.f16.16x16x64.fp8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.fp8.bf8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r12.gfx1250 = rocdl.wmma.f16.16x16x64.fp8_bf8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.bf8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r13.gfx1250 = rocdl.wmma.f16.16x16x64.bf8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.bf8.fp8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r13.gfx1250 = rocdl.wmma.f16.16x16x64.bf8_fp8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.bf8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r14.gfx1250 = rocdl.wmma.f16.16x16x64.bf8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.bf8.bf8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r14.gfx1250 = rocdl.wmma.f16.16x16x64.bf8_bf8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.fp8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r15.gfx1250 = rocdl.wmma.f32.16x16x128.fp8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.fp8.fp8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r15.gfx1250 = rocdl.wmma.f32.16x16x128.fp8_fp8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.fp8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r16.gfx1250 = rocdl.wmma.f32.16x16x128.fp8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.fp8.bf8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r16.gfx1250 = rocdl.wmma.f32.16x16x128.fp8_bf8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.bf8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r17.gfx1250 = rocdl.wmma.f32.16x16x128.bf8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.bf8.fp8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r17.gfx1250 = rocdl.wmma.f32.16x16x128.bf8_fp8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.bf8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r18.gfx1250 = rocdl.wmma.f32.16x16x128.bf8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.bf8.bf8.v64f32.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x float> %{{.*}} i1 false, i1 false)
+  %r18.gfx1250 = rocdl.wmma.f32.16x16x128.bf8_bf8 %arg5, %arg5, %arg13 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf32>) -> vector<64xf32>
 
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r19.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.fp8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r19.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_fp8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
+  
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.bf8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r20.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_bf8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r20.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.bf8.fp8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r21.gfx1250 = rocdl.wmma.f16.16x16x128.bf8_fp8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.bf8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r21.gfx1250 = rocdl.wmma.f16.16x16x128.bf8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
-
-  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.bf8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r22.gfx1250 = rocdl.wmma.f16.16x16x128.bf8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.bf8.bf8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
+  %r22.gfx1250 = rocdl.wmma.f16.16x16x128.bf8_bf8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
   // iu8 -> i32
-  // CHECK: call <64 x i32> @llvm.amdgcn.wmma.i32.16x16x64.iu8.v64i32.v4i32(i1 {{.*}}, <4 x i32> %{{.*}}, i1 {{.*}}, <4 x i32> %{{.*}}, <64 x i32> %{{.*}}, i1 {{.*}}, i1 {{.*}})
-  %r23.gfx1250 = rocdl.wmma.i32.16x16x64.iu8 %zero, %arg5, %zero, %arg5, %arg14, %zero, %zero : (i1, vector<4xi32>, i1, vector<4xi32>, vector<64xi32>, i1, i1) -> vector<64xi32>
+  // CHECK: call <64 x i32> @llvm.amdgcn.wmma.i32.16x16x64.iu8.v64i32.v4i32(i1 false, <4 x i32> %{{.*}} i1 false, <4 x i32> %{{.*}} <64 x i32> %{{.*}} i1 false, i1 false)
+  %r23.gfx1250 = rocdl.wmma.i32.16x16x64.iu8 %arg5, %arg5, %arg14 {signA = false, signB = false} : (vector<4xi32>, vector<4xi32>, vector<64xi32>) -> vector<64xi32>
 
   // ---- Wave64 -----
 
   // f16 -> f32
-  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x16.f16.v4f32.v16f16(<16 x half> %{{.*}}, <16 x half> %{{.*}}, <4 x float> %{{.*}})
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x16.f16.v4f32.v16f16(<16 x half> %{{.*}} <16 x half> %{{.*}} <4 x float> %{{.*}})
   %r7 = rocdl.wmma.f32.16x16x16.f16 %arg1, %arg1, %arg6 : (vector<16xf16>, vector<16xf16>, vector<4xf32>) -> vector<4xf32>
 
   // bf16 -> f32
-  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x16.bf16.v4f32.v16i16(<16 x i16> %{{.*}}, <16 x i16> %{{.*}}, <4 x float> %{{.*}})
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x16.bf16.v4f32.v16i16(<16 x i16> %{{.*}} <16 x i16> %{{.*}} <4 x float> %{{.*}})
   %r8 = rocdl.wmma.f32.16x16x16.bf16 %arg2, %arg2, %arg6 : (vector<16xi16>, vector<16xi16>, vector<4xf32>) -> vector<4xf32>
 
   // f16 -> f16 (OPSEL = {0,1})
-  // CHECK: call <8 x half> @llvm.amdgcn.wmma.f16.16x16x16.f16.v8f16.v16f16(<16 x half> %{{.*}}, <16 x half> %{{.*}}, <8 x half> %{{.*}}, i1 {{.*}})
-  %r9 = rocdl.wmma.f16.16x16x16.f16 %arg1, %arg1, %arg7, %zero : (vector<16xf16>, vector<16xf16>, vector<8xf16>, i1) -> vector<8xf16>
+  // CHECK: call <8 x half> @llvm.amdgcn.wmma.f16.16x16x16.f16.v8f16.v16f16(<16 x half> %{{.*}} <16 x half> %{{.*}} <8 x half> %{{.*}} i1 false)
+  %r9 = rocdl.wmma.f16.16x16x16.f16 %arg1, %arg1, %arg7 {opsel = false} : (vector<16xf16>, vector<16xf16>, vector<8xf16>) -> vector<8xf16>
 
   // bf16 -> bf16 (OPSEL = {0,1})
-  // CHECK: call <8 x i16> @llvm.amdgcn.wmma.bf16.16x16x16.bf16.v8i16.v16i16(<16 x i16> %{{.*}}, <16 x i16> %{{.*}}, <8 x i16> %{{.*}}, i1 {{.*}})
-  %r11 = rocdl.wmma.bf16.16x16x16.bf16 %arg2, %arg2, %arg8, %zero : (vector<16xi16>, vector<16xi16>, vector<8xi16>, i1) -> vector<8xi16>
+  // CHECK: call <8 x i16> @llvm.amdgcn.wmma.bf16.16x16x16.bf16.v8i16.v16i16(<16 x i16> %{{.*}} <16 x i16> %{{.*}} <8 x i16> %{{.*}} i1 false)
+  %r11 = rocdl.wmma.bf16.16x16x16.bf16 %arg2, %arg2, %arg8 {opsel = false} : (vector<16xi16>, vector<16xi16>, vector<8xi16>) -> vector<8xi16>
 
   // int8 -> int32 (signA = {0,1}, signB = {0,1}, clamp = {0,1})
-  // CHECK: call <4 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu8.v4i32.v4i32(i1 {{.*}}, <4 x i32> %{{.*}}, i1 {{.*}}, <4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i1 {{.*}})
-  %r12 = rocdl.wmma.i32.16x16x16.iu8 %zero, %arg5, %zero, %arg5, %arg5, %zero : (i1, vector<4xi32>, i1, vector<4xi32>, vector<4xi32>, i1) -> vector<4xi32>
+  // CHECK: call <4 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu8.v4i32.v4i32(i1 false, <4 x i32> %{{.*}} i1 false, <4 x i32> %{{.*}} <4 x i32> %{{.*}} i1 true)
+  %r12 = rocdl.wmma.i32.16x16x16.iu8 %arg5, %arg5, %arg5 {signA = false, signB = false, clamp = true} : (vector<4xi32>, vector<4xi32>, vector<4xi32>) -> vector<4xi32>
 
   // int4 -> int32 (signA = {0,1}, signB = {0,1}, clamp = {0,1})
-  // CHECK: call <4 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu4.v4i32.v2i32(i1 {{.*}}, <2 x i32> %{{.*}}, i1 {{.*}}, <2 x i32> %{{.*}}, <4 x i32> %{{.*}}, i1 {{.*}})
-  %r13 = rocdl.wmma.i32.16x16x16.iu4 %zero, %arg4, %zero, %arg4, %arg5, %zero : (i1, vector<2xi32>, i1, vector<2xi32>, vector<4xi32>, i1) -> vector<4xi32>
+  // CHECK: call <4 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu4.v4i32.v2i32(i1 false, <2 x i32> %{{.*}} i1 false, <2 x i32> %{{.*}} <4 x i32> %{{.*}} i1 true)
+  %r13 = rocdl.wmma.i32.16x16x16.iu4 %arg4, %arg4, %arg5 {signA = false, signB = false, clamp = true} : (vector<2xi32>, vector<2xi32>, vector<4xi32>) -> vector<4xi32>
 
   llvm.return %r0 : vector<8xf32>
 }

--- a/external/llvm-project/mlir/test/python/dialects/rocdl.py
+++ b/external/llvm-project/mlir/test/python/dialects/rocdl.py
@@ -29,13 +29,12 @@ def testSmoke():
     a_frag = arith.constant(v16f32, f32_array)
     b_frag = arith.constant(v16f32, f32_array)
     c_frag = arith.constant(v16f32, f32_array)
-    false = arith.constant(T.bool(), False)
 
-    c_frag = rocdl.wmma_f16_16x16x16_f16(v16f32, [a_frag, b_frag, c_frag, false])
-    # CHECK: %{{.*}} = rocdl.wmma.f16.16x16x16.f16
+    c_frag = rocdl.wmma_f16_16x16x16_f16(v16f32, a_frag, b_frag, c_frag, opsel=False)
+    # CHECK: %{{.*}} = "rocdl.wmma.f16.16x16x16.f16"
     print(c_frag)
     assert isinstance(c_frag, OpView)
-    # CHECK: Value(%{{.*}} = rocdl.wmma.f16.16x16x16.f16
-    c_frag = rocdl.wmma_f16_16x16x16_f16_(v16f32, [a_frag, b_frag, c_frag, false])
+    # CHECK: Value(%{{.*}} = "rocdl.wmma.f16.16x16x16.f16"
+    c_frag = rocdl.wmma_f16_16x16x16_f16_(v16f32, a_frag, b_frag, c_frag, opsel=False)
     print(c_frag)
     assert isinstance(c_frag, Value)

--- a/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
@@ -151,10 +151,10 @@ struct AccelEmitter {
   AccelEmitterParams getParams() const { return accelEmitterParams; }
 
   // Return the accelerator K dimension
-  virtual int64_t getMfmaK() const = 0;
+  virtual int64_t getKDim() const = 0;
 
   // Return the accelerator D dimension (M/N dimension)
-  virtual int64_t getMfmaDDim() const = 0;
+  virtual int64_t getDDim(StringRef dName) const = 0;
 
   virtual ~AccelEmitter() {}
 
@@ -209,10 +209,10 @@ struct MfmaEmitter : public AccelEmitter {
   int64_t getRowGroupSize() const;
 
   // Return the MFMA K dimension
-  int64_t getMfmaK() const override;
+  int64_t getKDim() const override;
 
   // Return the MFMA D dimension (M/N dimension)
-  int64_t getMfmaDDim() const override;
+  int64_t getDDim(StringRef dName = "") const override;
 
   static bool classof(const AccelEmitter *AE) {
     return AE->getKind() == AccelEmitterKind::AEK_MFMAEmitter;
@@ -256,10 +256,10 @@ struct WmmaEmitter : public AccelEmitter {
       bool doSwapThreadIterSubDimsForN = false) override;
 
   // Return the WMMA K dimension
-  int64_t getMfmaK() const override;
+  int64_t getKDim() const override;
 
   // Return the WMMA D dimension (M/N dimension)
-  int64_t getMfmaDDim() const override;
+  int64_t getDDim(StringRef dName = "") const override;
 
   static bool classof(const AccelEmitter *AE) {
     return AE->getKind() == AccelEmitterKind::AEK_WMMAEmitter;

--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -519,8 +519,8 @@ def Rock_LDSTransposeConfigAttr : Rock_Attr<"LDSTransposeConfig", []> {
     rock.lds_transpose_load operations with the correct accelerator geometry
     and tiling parameters.
     
-    - mfmaDDim: Matrix-multiply accelerator instruction D dimension (M or N, typically 16 or 32)
-    - mfmaKDim: Matrix-multiply accelerator instruction K dimension (typically 8, 16, or 32)
+    - DDim: Matrix-multiply accelerator instruction D dimension (M or N, typically 16 or 32)
+    - KDim: Matrix-multiply accelerator instruction K dimension (typically 8, 16, or 32)
     - mPerBlock: M dimension size per block
     - nPerBlock: N dimension size per block
     - kPerBlock: K dimension size per block
@@ -529,10 +529,9 @@ def Rock_LDSTransposeConfigAttr : Rock_Attr<"LDSTransposeConfig", []> {
     - doubleBuffering: Whether double buffering is enabled
     - isOperandA: True if this is operand A, false if operand B
   }];
-  let parameters = (ins "int64_t":$mfmaDDim, "int64_t":$mfmaKDim,
-      "int64_t":$mPerBlock, "int64_t":$nPerBlock, "int64_t":$kPerBlock,
-      "int64_t":$mPerWave, "int64_t":$nPerWave, "bool":$doubleBuffering,
-      "bool":$isOperandA);
+  let parameters = (ins "int64_t":$dDim, "int64_t":$kDim, "int64_t":$mPerBlock,
+      "int64_t":$nPerBlock, "int64_t":$kPerBlock, "int64_t":$mPerWave,
+      "int64_t":$nPerWave, "bool":$doubleBuffering, "bool":$isOperandA);
 
   let assemblyFormat = [{
     `<` struct(params) `>`

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1001,8 +1001,8 @@ defvar NativeMemoryOpTypes =
      F8E4M3FN, F4E2M1FN, F8E8M0FNU,
      VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32, F4E2M1FN, F8E8M0FNU]>,
      VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
-     VectorOfLengthAndType<[2, 4, 8, 16], [I8, F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2,
-                                           F8E4M3FN]>];
+     VectorOfLengthAndType<[2, 4, 8, 16, 32, 64], [I8, F8E5M2FNUZ, F8E4M3FNUZ,
+                                                   F8E5M2, F8E4M3FN]>];
 
 // in_bounds_load
 def Rock_InBoundsLoadOp

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -22,9 +22,51 @@
 namespace mlir {
 namespace rock {
 
+// Type IDs for WMMA instruction selection
+// Naming convention: InputType(s)_To_OutputType_TyId
+enum class WmmaTypeId : uint32_t {
+  // F32 output
+  F32_To_F32_TyId = 0, // F32 x F32 -> F32
+  F16_To_F32_TyId,     // F16 x F16 -> F32
+  Bf16_To_F32_TyId,    // BF16 x BF16 -> F32
+  Fp8Fp8_To_F32_TyId,  // FP8 x FP8 -> F32
+  Fp8Bf8_To_F32_TyId,  // FP8 x BF8 -> F32
+  Bf8Fp8_To_F32_TyId,  // BF8 x FP8 -> F32
+  Bf8Bf8_To_F32_TyId,  // BF8 x BF8 -> F32
+
+  // F16 output
+  F16_To_F16_TyId,    // F16 x F16 -> F16
+  Fp8Fp8_To_F16_TyId, // FP8 x FP8 -> F16
+  Fp8Bf8_To_F16_TyId, // FP8 x BF8 -> F16
+  Bf8Fp8_To_F16_TyId, // BF8 x FP8 -> F16
+  Bf8Bf8_To_F16_TyId, // BF8 x BF8 -> F16
+
+  // BF16 output
+  Bf16_To_Bf16_TyId,    // BF16 x BF16 -> BF16
+  Bf16_To_Bf16F32_TyId, // BF16 x BF16 -> mixed BF16/F32
+
+  // Integer output
+  I8_To_I32_TyId, // I8 x I8 -> I32
+  I4_To_I32_TyId  // I4 x I4 -> I32
+};
+
+// Information needed to create a WMMA instruction
+struct WmmaInsnInfo {
+  StringRef insn;
+  int64_t inputVectorLen;
+  int64_t outputVectorLen;
+  int64_t mPerAccel;
+  int64_t nPerAccel;
+};
+
+// Key type for WMMA instruction maps: (TypeId, K dimension)
+using WmmaInsnKey = std::pair<WmmaTypeId, int64_t>;
+
 struct WmmaInsn {
   StringRef insn;
-  int64_t dPerAccel;
+  int64_t mPerAccel;
+  int64_t nPerAccel;
+  int64_t kDim;
   int64_t outputStride;
   int64_t mRepeats;
   int64_t nRepeats;
@@ -36,7 +78,8 @@ public:
   bool isCoherentWithK(int64_t kpack, int64_t kPerBlock);
   static FailureOr<WmmaInsn> select(Type elementTypeA, Type elementTypeB,
                                     int64_t waveSize, StringRef arch,
-                                    int64_t mPerWave, int64_t nPerWave);
+                                    int64_t mPerWave, int64_t nPerWave,
+                                    int64_t kPack, int64_t kPackPerBlock);
 };
 } // namespace rock
 } // namespace mlir

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -565,36 +565,34 @@ static bool isValidLdsTransposeMfmaGeometry(int64_t dDim, int64_t kDim) {
 }
 
 LogicalResult LDSTransposeConfigAttr::verify(
-    function_ref<InFlightDiagnostic()> emitError, int64_t mfmaDDim,
-    int64_t mfmaKDim, int64_t mPerBlock, int64_t nPerBlock, int64_t kPerBlock,
-    int64_t mPerWave, int64_t nPerWave, bool doubleBuffering, bool isOperandA) {
+    function_ref<InFlightDiagnostic()> emitError, int64_t dDim, int64_t kDim,
+    int64_t mPerBlock, int64_t nPerBlock, int64_t kPerBlock, int64_t mPerWave,
+    int64_t nPerWave, bool doubleBuffering, bool isOperandA) {
 
   // Validate MFMA geometry
-  if (!isValidLdsTransposeMfmaGeometry(mfmaDDim, mfmaKDim)) {
-    return emitError() << "invalid MFMA geometry (" << mfmaDDim << "x"
-                       << mfmaKDim
+  if (!isValidLdsTransposeMfmaGeometry(dDim, kDim)) {
+    return emitError() << "invalid MFMA geometry (" << dDim << "x" << kDim
                        << ") for LDS transpose - valid combinations: "
                           "(16,16), (16,32), (32,8), (32,16)";
   }
 
   // Validate positive dimensions
-  if (mfmaDDim <= 0 || mfmaKDim <= 0 || mPerBlock <= 0 || nPerBlock <= 0 ||
+  if (dDim <= 0 || kDim <= 0 || mPerBlock <= 0 || nPerBlock <= 0 ||
       kPerBlock <= 0 || mPerWave <= 0 || nPerWave <= 0) {
     return emitError() << "all dimensions must be positive";
   }
 
   // Validate that block dimensions are divisible by MFMA dimensions
   int64_t dPerBlock = isOperandA ? mPerBlock : nPerBlock;
-  if (dPerBlock % mfmaDDim != 0) {
+  if (dPerBlock % dDim != 0) {
     return emitError() << (isOperandA ? "mPerBlock" : "nPerBlock") << " ("
-                       << dPerBlock << ") must be divisible by mfmaDDim ("
-                       << mfmaDDim << ")";
+                       << dPerBlock << ") must be divisible by dDim (" << dDim
+                       << ")";
   }
 
-  if (kPerBlock % mfmaKDim != 0) {
+  if (kPerBlock % kDim != 0) {
     return emitError() << "kPerBlock (" << kPerBlock
-                       << ") must be divisible by mfmaKDim (" << mfmaKDim
-                       << ")";
+                       << ") must be divisible by kDim (" << kDim << ")";
   }
 
   return success();
@@ -766,20 +764,44 @@ static LogicalResult verifyGemmTypes(Operation *op, GemmFeatures features,
                                      StringRef arch, Type elemTypeA,
                                      Type elemTypeB, Type elemTypeC) {
   bool isGfx11 = arch.contains("gfx11");
+  bool isGfx1250 = arch.contains("gfx1250");
   if (isa<Float8E8M0FNUType>(elemTypeA) || isa<Float8E8M0FNUType>(elemTypeB)) {
     return op->emitOpError(
         "Matrix A or B is not allowed to have Float8E8M0FNU types");
   }
   if (bitEnumContainsAll(features, GemmFeatures::wmma)) {
-    if (!(elemTypeA.isF16() || elemTypeA.isBF16() || elemTypeA.isInteger(8))) {
+    // Validate input data types based on architecture
+    bool isValidTypeA = elemTypeA.isF16() || elemTypeA.isBF16() ||
+                        elemTypeA.isInteger(8) || isFloat8Type(elemTypeA);
+
+    // gfx1250 additionally supports F32
+    if (isGfx1250)
+      isValidTypeA = isValidTypeA || elemTypeA.isF32();
+
+    // gfx11 doesn't support float8 types
+    if (isGfx11 && isFloat8Type(elemTypeA))
+      isValidTypeA = false;
+
+    if (!isValidTypeA) {
       if (isGfx11)
         return op->emitOpError("Wmma supports only F16/BF16/int8 data types");
-      if (!isFloat8Type(elemTypeA))
+      if (isGfx1250)
         return op->emitOpError(
-            "Wmma supports only F16/BF16/int8/E4M3/E5M2 data types");
+            "Wmma supports only F32/F16/BF16/int8/E4M3/E5M2 data types");
+      return op->emitOpError(
+          "Wmma supports only F16/BF16/int8/E4M3/E5M2 data types");
     }
-    if (elemTypeA != elemTypeB)
-      return op->emitOpError("Wmma does not support mixed types");
+
+    // Validate mixed types
+    if (elemTypeA != elemTypeB) {
+      // gfx1250 allows mixed precision for float8 types only
+      bool allowMixed =
+          isGfx1250 && isFloat8Type(elemTypeA) && isFloat8Type(elemTypeB);
+      if (!allowMixed)
+        return op->emitOpError(isGfx1250 ? "Wmma on gfx1250 supports mixed "
+                                           "types only for FP8/BF8 combinations"
+                                         : "Wmma does not support mixed types");
+    }
   }
   if (bitEnumContainsAll(features, GemmFeatures::mfma)) {
     bool isGfx95 = arch.contains("gfx95");

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -17,81 +17,282 @@
 using namespace mlir;
 using namespace mlir::rock;
 
-static Type getRetType(Type inputType) {
+static Type getRetType(Type inputType, WmmaTypeId typeId) {
   Builder b(inputType.getContext());
-  if (inputType.isInteger(8))
+
+  // Integer types always output I32
+  if (typeId == WmmaTypeId::I8_To_I32_TyId ||
+      typeId == WmmaTypeId::I4_To_I32_TyId)
     return b.getI32Type();
 
+  // F16 output variants
+  if (typeId == WmmaTypeId::F16_To_F16_TyId ||
+      typeId == WmmaTypeId::Fp8Fp8_To_F16_TyId ||
+      typeId == WmmaTypeId::Fp8Bf8_To_F16_TyId ||
+      typeId == WmmaTypeId::Bf8Fp8_To_F16_TyId ||
+      typeId == WmmaTypeId::Bf8Bf8_To_F16_TyId)
+    return b.getF16Type();
+
+  // BF16 output variants
+  if (typeId == WmmaTypeId::Bf16_To_Bf16_TyId ||
+      typeId == WmmaTypeId::Bf16_To_Bf16F32_TyId)
+    return b.getBF16Type();
+
+  // Default: F32 output
   return b.getF32Type();
 }
 
-bool WmmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
-  int64_t inputVectorLen = argTypeA.getNumElements();
-  if (kPerBlock * kpack < inputVectorLen) {
+// Convert input types to type ID. This handles both same-type and mixed-type
+// inputs and always uses F32/I32 outputs
+static WmmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
+  // Same type inputs
+  if (dataTypeA == dataTypeB) {
+    if (dataTypeA.isF32())
+      return WmmaTypeId::F32_To_F32_TyId;
+    if (dataTypeA.isF16())
+      return WmmaTypeId::F16_To_F32_TyId;
+    if (dataTypeA.isBF16())
+      return WmmaTypeId::Bf16_To_F32_TyId;
+    if (dataTypeA.isInteger(8))
+      return WmmaTypeId::I8_To_I32_TyId;
+    if (dataTypeA.isInteger(4))
+      return WmmaTypeId::I4_To_I32_TyId;
+  }
+
+  // Mixed precision FP8/BF8 combinations
+  if (isa<Float8E4M3FNType>(dataTypeA) && isa<Float8E4M3FNType>(dataTypeB))
+    return WmmaTypeId::Fp8Fp8_To_F32_TyId;
+  if (isa<Float8E4M3FNType>(dataTypeA) && isa<Float8E5M2Type>(dataTypeB))
+    return WmmaTypeId::Fp8Bf8_To_F32_TyId;
+  if (isa<Float8E5M2Type>(dataTypeA) && isa<Float8E4M3FNType>(dataTypeB))
+    return WmmaTypeId::Bf8Fp8_To_F32_TyId;
+  if (isa<Float8E5M2Type>(dataTypeA) && isa<Float8E5M2Type>(dataTypeB))
+    return WmmaTypeId::Bf8Bf8_To_F32_TyId;
+
+  llvm_unreachable("Unsupported WMMA input type combination");
+}
+
+// WMMA instructions available on gfx11
+static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx11() {
+  static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
+      {{WmmaTypeId::F16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 16, 8, 16, 16}},
+      {{WmmaTypeId::Bf16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 16, 8, 16, 16}},
+      {{WmmaTypeId::I8_To_I32_TyId, 16},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 16, 8, 16, 16}},
+  };
+  return insnMap;
+}
+
+// WMMA instructions available on gfx12
+static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx12() {
+  static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
+      {{WmmaTypeId::F16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 8, 8, 16, 16}},
+      {{WmmaTypeId::Bf16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 8, 8, 16, 16}},
+      {{WmmaTypeId::I8_To_I32_TyId, 16},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 8, 8, 16, 16}},
+
+      // FP8/BF8
+      {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName(), 8, 8, 16, 16}},
+      {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName(), 8, 8, 16, 16}},
+  };
+  return insnMap;
+}
+
+// WMMA instructions available on gfx1250
+static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &
+getWmmaInsnMapGfx1250() {
+  static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
+      // F32
+      {{WmmaTypeId::F32_To_F32_TyId, 4},
+       {ROCDL::wmma_f32_16x16x4_f32::getOperationName(), 2, 8, 16, 16}},
+
+      // F16/BF16
+      {{WmmaTypeId::F16_To_F32_TyId, 32},
+       {ROCDL::wmma_f32_16x16x32_f16::getOperationName(), 16, 8, 16, 16}},
+      {{WmmaTypeId::Bf16_To_F32_TyId, 32},
+       {ROCDL::wmma_f32_16x16x32_bf16::getOperationName(), 16, 8, 16, 16}},
+
+      // FP8/BF8 (k=64)
+      {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_fp8_fp8::getOperationName(), 32, 8, 16, 16}},
+      {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_fp8_bf8::getOperationName(), 32, 8, 16, 16}},
+      {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_bf8_fp8::getOperationName(), 32, 8, 16, 16}},
+      {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_bf8_bf8::getOperationName(), 32, 8, 16, 16}},
+
+      // FP8/BF8 (k=128)
+      {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_fp8_fp8::getOperationName(), 64, 8, 16, 16}},
+      {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_fp8_bf8::getOperationName(), 64, 8, 16, 16}},
+      {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_bf8_fp8::getOperationName(), 64, 8, 16, 16}},
+      {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_bf8_bf8::getOperationName(), 64, 8, 16, 16}},
+
+      // I8
+      {{WmmaTypeId::I8_To_I32_TyId, 64},
+       {ROCDL::wmma_i32_16x16x64_iu8::getOperationName(), 32, 8, 16, 16}},
+  };
+  return insnMap;
+}
+
+// Helper function to validate K coherence
+// Returns true if kPerBlock * kPack is sufficient for the given inputVectorLen
+static bool isKCoherent(int64_t inputVectorLen, int64_t kPack,
+                        int64_t kPackPerBlock) {
+  if (((kPackPerBlock * kPack) % inputVectorLen) != 0) {
     LLVM_DEBUG(llvm::dbgs()
-               << "kPerBlock*kpack needs to be a multiple of inputLen "
-               << inputVectorLen << "\n");
+               << "kPerBlock*kpack needs to be a multiple of inputLen: "
+               << kPackPerBlock << " * " << kPack << " = "
+               << (kPackPerBlock * kPack) << " % " << inputVectorLen << "\n");
     return false;
   }
   return true;
 }
 
+bool WmmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
+  int64_t inputVectorLen = argTypeA.getNumElements();
+  return isKCoherent(inputVectorLen, kpack, kPerBlock);
+}
+
 FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
                                      mlir::Type elementTypeB, int64_t waveSize,
                                      StringRef arch, int64_t mPerWave,
-                                     int64_t nPerWave) {
-  LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma group selection:\n"
+                                     int64_t nPerWave, int64_t kPack,
+                                     int64_t kPackPerBlock) {
+  LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma instruction selection:\n"
                           << "elementTypeA: " << elementTypeA << "\n"
                           << "elementTypeB: " << elementTypeB << "\n"
+                          << "arch: " << arch << "\n"
                           << "mPerWave: " << mPerWave << "\n"
-                          << "nPerWave: " << nPerWave << "\n");
+                          << "nPerWave: " << nPerWave << "\n"
+                          << "kPack: " << kPack << "\n"
+                          << "kPackPerBlock: " << kPackPerBlock << "\n");
 
-  if (elementTypeA != elementTypeB)
-    return failure();
-
+  // WMMA only supports wave32
   if (waveSize != 32)
     return failure();
 
-  // Length of the input vectors that need to be passed to the WMMA
-  int64_t inputVectorLen = 8;
-  // Length of the ouput vector that needs to be passed to the WMMA
-  int64_t outputVectorLen = 8;
-  // Number of rows/cols a given wmma instruction computes
-  int64_t dPerAccel = 16;
+  // Architecture detection
+  bool isGfx11 = arch.contains("gfx11");
+  bool isGfx1250 = arch.contains("gfx1250");
 
-  int64_t outStride = 2;
-  if (arch.contains("gfx11")) {
-    inputVectorLen = 16;
+  // Convert element types to ID for map lookup. Handles both same-type and
+  // mixed-type inputs
+  WmmaTypeId typeId = convertTypesToId(elementTypeA, elementTypeB);
+
+  // Select instruction based on architecture priority: gfx1250 > gfx12 > gfx11
+  const WmmaInsnInfo *insnInfo = nullptr;
+  int64_t selectedKDim = 0; // Track the selected K dimension from the map key
+
+  if (isGfx1250) {
+    auto &gfx1250Map = getWmmaInsnMapGfx1250();
+
+    // FP8/BF8 types have multiple K options and we need to select the best one.
+    // We will always try to select the largest K value that is coherent with
+    // the KPack and KPackPerBlock, and then fall back to the smaller values
+    // if need be.
+    if (typeId >= WmmaTypeId::Fp8Fp8_To_F32_TyId &&
+        typeId <= WmmaTypeId::Bf8Bf8_To_F32_TyId) {
+      for (int64_t k : {128, 64}) {
+        auto it = gfx1250Map.find({typeId, k});
+        if (it != gfx1250Map.end()) {
+          const WmmaInsnInfo *info = &it->second;
+          if (isKCoherent(info->inputVectorLen, kPack, kPackPerBlock)) {
+            insnInfo = info;
+            selectedKDim = k; // Extract K from the key
+            LLVM_DEBUG(llvm::dbgs() << "Selected gfx1250 instruction: "
+                                    << insnInfo->insn << "\n");
+            break;
+          }
+        }
+      }
+    } else {
+      // All other types have only one K value, so we can just directly look
+      // that up
+      int64_t k;
+      if (typeId == WmmaTypeId::F32_To_F32_TyId) {
+        k = 4;
+      } else if (typeId == WmmaTypeId::I8_To_I32_TyId) {
+        k = 64;
+      } else {
+        // F16/BF16 types
+        k = 32;
+      }
+
+      auto it = gfx1250Map.find({typeId, k});
+      if (it != gfx1250Map.end()) {
+        insnInfo = &it->second;
+        selectedKDim = k;
+        LLVM_DEBUG(llvm::dbgs() << "Selected gfx1250 instruction: "
+                                << insnInfo->insn << "\n");
+      }
+    }
   }
 
-  if (mPerWave % inputVectorLen != 0 || mPerWave % dPerAccel != 0)
-    return failure();
-  if (nPerWave % inputVectorLen != 0 || nPerWave % dPerAccel != 0)
+  // Use gfx12 only if we don't have a selected instruction and not gfx11
+  if (!insnInfo && !isGfx11) {
+    auto &gfx12Map = getWmmaInsnMapGfx12();
+    auto it = gfx12Map.find({typeId, 16});
+    if (it != gfx12Map.end()) {
+      insnInfo = &it->second;
+      selectedKDim = 16;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Selected gfx12 instruction: " << insnInfo->insn << "\n");
+    }
+  }
+
+  // Fall back to gfx11 if we are using gfx12, or if we explicitly ask for gfx11
+  if (!insnInfo && (!isGfx1250 || isGfx11)) {
+    auto &gfx11Map = getWmmaInsnMapGfx11();
+    auto it = gfx11Map.find({typeId, 16});
+    if (it != gfx11Map.end()) {
+      insnInfo = &it->second;
+      selectedKDim = 16;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Selected gfx11 instruction: " << insnInfo->insn << "\n");
+    }
+  }
+
+  if (!insnInfo)
     return failure();
 
-  int64_t mRepeats = mPerWave / dPerAccel;
-  int64_t nRepeats = nPerWave / dPerAccel;
+  // Extract instruction info
+  int64_t inputVectorLen = insnInfo->inputVectorLen;
+  int64_t outputVectorLen = insnInfo->outputVectorLen;
+  int64_t kDim = selectedKDim;
+  StringRef insn = insnInfo->insn;
+  int64_t mPerAccel = insnInfo->mPerAccel;
+  int64_t nPerAccel = insnInfo->nPerAccel;
+
+  // Architecture-specific outStride
+  // gfx11: full-wave K cooperation -> outStride=2
+  // gfx12/gfx1250: half-wave K cooperation -> outStride=outputVectorLen
+  int64_t outStride = isGfx11 ? 2 : outputVectorLen;
+
+  // Validate dimensions
+  if (mPerWave % inputVectorLen != 0 || mPerWave % mPerAccel != 0)
+    return failure();
+  if (nPerWave % inputVectorLen != 0 || nPerWave % nPerAccel != 0)
+    return failure();
+
+  int64_t mRepeats = mPerWave / mPerAccel;
+  int64_t nRepeats = nPerWave / nPerAccel;
 
   VectorType argTypeA = VectorType::get({inputVectorLen}, elementTypeA);
   VectorType argTypeB = VectorType::get({inputVectorLen}, elementTypeB);
   VectorType retType =
-      VectorType::get({outputVectorLen}, getRetType(elementTypeA));
+      VectorType::get({outputVectorLen}, getRetType(elementTypeA, typeId));
 
-  StringRef insn;
-  if (elementTypeA.isF16()) {
-    insn = ROCDL::wmma_f32_16x16x16_f16::getOperationName();
-  } else if (elementTypeA.isBF16()) {
-    insn = ROCDL::wmma_f32_16x16x16_bf16::getOperationName();
-  } else if (elementTypeA.isInteger(8)) {
-    insn = ROCDL::wmma_i32_16x16x16_iu8::getOperationName();
-  } else if (isa<Float8E4M3FNType>(elementTypeA)) {
-    insn = ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName();
-  } else if (isa<Float8E5M2Type>(elementTypeA)) {
-    insn = ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName();
-  } else {
-    return failure();
-  }
-
-  return WmmaInsn{insn,     dPerAccel, outStride, mRepeats,
-                  nRepeats, argTypeA,  argTypeB,  retType};
+  return WmmaInsn{insn,     mPerAccel, nPerAccel, kDim,     outStride,
+                  mRepeats, nRepeats,  argTypeA,  argTypeB, retType};
 }

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -682,9 +682,9 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
   }
 
   // Reject invalid KPACK values.
-  auto maybeWmmaInsn =
-      WmmaInsn::select(dataTypeA, dataTypeB, waveSize, arch,
-                       param.getMPerWave(), param.getNPerWave());
+  auto maybeWmmaInsn = WmmaInsn::select(
+      dataTypeA, dataTypeB, waveSize, arch, param.getMPerWave(),
+      param.getNPerWave(), param.getKpack(), param.getKpackPerBlock());
   if (failed(maybeWmmaInsn)) {
     LLVM_DEBUG(llvm::dbgs() << "Failed to select wmma instruction.\n");
     return failure();
@@ -708,18 +708,18 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
   std::vector<InitParamsAccel> res;
   // Only return valid Wmma params
   const int64_t waveSize = mlir::rock::lookupArchInfo(arch).waveSize;
-  std::copy_if(params.begin(), params.end(), std::back_inserter(res),
-               [&](const InitParamsAccel &param) {
-                 auto maybeWmmaInsn =
-                     WmmaInsn::select(dataTypeA, dataTypeB, waveSize, arch,
-                                      param.gemmMPerWave, param.gemmNPerWave);
-                 if (failed(maybeWmmaInsn)) {
-                   return false;
-                 }
-                 WmmaInsn wmmaInsn = *maybeWmmaInsn;
-                 return wmmaInsn.isCoherentWithK(param.gemmKPack,
-                                                 param.gemmKPerBlock);
-               });
+  std::copy_if(
+      params.begin(), params.end(), std::back_inserter(res),
+      [&](const InitParamsAccel &param) {
+        auto maybeWmmaInsn = WmmaInsn::select(
+            dataTypeA, dataTypeB, waveSize, arch, param.gemmMPerWave,
+            param.gemmNPerWaveOrMnPerXdl, param.gemmKPack, param.gemmKPerBlock);
+        if (failed(maybeWmmaInsn)) {
+          return false;
+        }
+        WmmaInsn wmmaInsn = *maybeWmmaInsn;
+        return wmmaInsn.isCoherentWithK(param.gemmKPack, param.gemmKPerBlock);
+      });
   return res;
 }
 

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -591,12 +591,12 @@ int64_t MfmaEmitter::getRowGroupSize() const {
   return mfmaAttr.rowGroupSize;
 }
 
-int64_t MfmaEmitter::getMfmaK() const {
+int64_t MfmaEmitter::getKDim() const {
   MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
   return mfmaAttr.k;
 }
 
-int64_t MfmaEmitter::getMfmaDDim() const {
+int64_t MfmaEmitter::getDDim(StringRef dName) const {
   MfmaInsnAttr mfmaAttr = mfmaGroup.getInsnAttr();
   return mfmaAttr.mfmaDDim;
 }
@@ -815,8 +815,8 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
   params.nResultVectors = 1;
 
   params.kpackPerThread = kpackPerBlock;
-  params.mPerAccel = wmmaInsn.dPerAccel;
-  params.nPerAccel = wmmaInsn.dPerAccel;
+  params.mPerAccel = wmmaInsn.mPerAccel;
+  params.nPerAccel = wmmaInsn.nPerAccel;
   // Pre-gfx12 each thread in the wave is loading an entire groups
   // of Ks to reduce. So, if there are 32 threads in a wave and
   // and we want to do a(16x16) * b(16x16), 16 threads are loading a vector
@@ -829,7 +829,9 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
     // to reduce. For instance, with the previous example, each
     // thread is loading a vector of 8 Ks. The first 16 threads are
     // loading k=[0:8] the second 16 threads are loading k=[8:16] threads
-    int64_t numReductions = waveSize / wmmaInsn.dPerAccel;
+    assert(wmmaInsn.mPerAccel == wmmaInsn.nPerAccel &&
+           "Currently only supported for equal mPerAccel and nPerAccel");
+    int64_t numReductions = waveSize / wmmaInsn.mPerAccel;
     params.kpackPerThread /= numReductions;
   }
   params.kBasePerThread = (params.kpackPerThread * kPack) / params.kBase;
@@ -840,14 +842,17 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
   return params;
 }
 
-int64_t WmmaEmitter::getMfmaK() const {
+int64_t WmmaEmitter::getKDim() const {
   // K dimension is encoded in the input vector length
-  return wmmaInsn.argTypeA.getNumElements();
+  return wmmaInsn.kDim;
 }
 
-int64_t WmmaEmitter::getMfmaDDim() const {
-  // D dimension (M/N) for WMMA is always dPerAccel
-  return wmmaInsn.dPerAccel;
+int64_t WmmaEmitter::getDDim(StringRef dName) const {
+  if (dName.empty()) {
+    llvm_unreachable("dName must be specified for WMMA");
+  }
+
+  return dName == "m" ? wmmaInsn.mPerAccel : wmmaInsn.nPerAccel;
 }
 
 Value WmmaEmitter::wrapLDSBufferForLoad(
@@ -1122,10 +1127,9 @@ void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
       memref::LoadOp::create(b, loc, vectorType, bufferC, regCOffset);
 
   // WMMAOp requires explicit m, n, k dimensions as IntegerAttrs
-  auto mAttr = b.getI32IntegerAttr(wmmaInsn.dPerAccel);
-  auto nAttr = b.getI32IntegerAttr(wmmaInsn.dPerAccel);
-  // see WmmaInsnGroup.cpp, all current wmma operations have k=16
-  auto kAttr = b.getI32IntegerAttr(16);
+  auto mAttr = b.getI32IntegerAttr(wmmaInsn.mPerAccel);
+  auto nAttr = b.getI32IntegerAttr(wmmaInsn.nPerAccel);
+  auto kAttr = b.getI32IntegerAttr(wmmaInsn.kDim);
   auto subwordOffsetAttr = b.getI32IntegerAttr(0);
 
   // Clamp flag is only valid for integer output types
@@ -1137,11 +1141,6 @@ void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
                                      argA, argB, vectorC, subwordOffsetAttr,
                                      /*unsignedA=*/nullptr,
                                      /*unsignedB=*/nullptr, clampAttr);
-
-  // auto mfma = amdgpu::WMMAOp::create(b, loc, vectorType, argA, argB, vectorC,
-  //                                    /*subwordOffset=*/0,
-  //                                    /*unsignedA=*/false,
-  //                                    /*unsignedB=*/false, /*clamp=*/true);
   auto vectorD = mfma.getDestD();
 
   memref::StoreOp::create(b, loc, vectorD, bufferC, regCOffset);
@@ -1181,8 +1180,8 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
     dimNamesM.push_back(/*4=*/"item_i");
   }
   SmallVector<int64_t, 7> orderedDimStridesM{/*0=*/mPerBlock,
-                                             /*1=*/mWaves * wmmaInsn.dPerAccel,
-                                             /*2=*/wmmaInsn.dPerAccel};
+                                             /*1=*/mWaves * wmmaInsn.mPerAccel,
+                                             /*2=*/wmmaInsn.mPerAccel};
   if (isGfx11) {
     orderedDimStridesM.push_back(/*3=*/wmmaInsn.outputStride);
   } else {
@@ -1198,8 +1197,8 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
                                       /*2=*/"wave_n",
                                       /*3=*/"n_tid"};
   SmallVector<int64_t, 5> orderedDimStridesN{/*0=*/nPerBlock,
-                                             /*1=*/nWaves * wmmaInsn.dPerAccel,
-                                             /*2=*/wmmaInsn.dPerAccel,
+                                             /*1=*/nWaves * wmmaInsn.nPerAccel,
+                                             /*2=*/wmmaInsn.nPerAccel,
                                              /*3=*/1};
   SmallVector<int64_t, 7> dimSizesN;
   convertDimStridestoSizes(orderedDimStridesN, nLen, dimSizesN);
@@ -1213,9 +1212,11 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
          mRepeats * nRepeats * retNumElements},
         loc);
     splitMemoryCoords.passThrough({"g_block", "m_block", "n_block"});
+    assert(wmmaInsn.mPerAccel == wmmaInsn.nPerAccel &&
+           "Currently only supported for equal mPerAccel and nPerAccel");
     splitMemoryCoords.merge(
         {"wave_m", "wave_n", "m_tid", "n_tid"}, {3, 4, 5, 6}, "tid",
-        {mWaves, nWaves, waveSize / wmmaInsn.dPerAccel, wmmaInsn.dPerAccel});
+        {mWaves, nWaves, waveSize / wmmaInsn.mPerAccel, wmmaInsn.mPerAccel});
     splitMemoryCoords.merge({"rep_i", "rep_j", "item_i"}, {7, 8, 9}, "item",
                             {mRepeats, nRepeats, retNumElements});
     TransformMapAttr splitMemoryCoordsAttr = splitMemoryCoords.get();
@@ -1295,10 +1296,12 @@ AccelEmitter::select(GemmFeatures features, Type dataTypeA, Type dataTypeB,
     return std::make_unique<MfmaEmitter>(*maybeMfmaInsnGroup, arch,
                                          tuningParams);
   } else if (isWmma) {
+    WmmaGemmParamsAttr wmmaParams = cast<WmmaGemmParamsAttr>(tuningParams);
     int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
-    auto maybeWmmaInsnGroup = WmmaInsn::select(dataTypeA, dataTypeB, waveSize,
-                                               arch, tuningParams.getMPerWave(),
-                                               tuningParams.getNPerWave());
+    auto maybeWmmaInsnGroup =
+        WmmaInsn::select(dataTypeA, dataTypeB, waveSize, arch,
+                         wmmaParams.getMPerWave(), wmmaParams.getNPerWave(),
+                         wmmaParams.getKpack(), wmmaParams.getKpackPerBlock());
     if (failed(maybeWmmaInsnGroup)) {
       return nullptr;
     }

--- a/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
+++ b/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
@@ -214,8 +214,8 @@ LDSTransposeDecision decideLDSTransposeForOperands(
   }
 
   // Extract MFMA geometry temporarily for decision making
-  int64_t mfmaDDim = mfmaEmitter->getMfmaDDim();
-  int64_t mfmaKDim = mfmaEmitter->getMfmaK();
+  int64_t mfmaDDim = mfmaEmitter->getDDim();
+  int64_t mfmaKDim = mfmaEmitter->getKDim();
 
   LLVM_DEBUG(llvm::dbgs() << "[lds_transpose] MFMA geometry: " << mfmaDDim
                           << "x" << mfmaKDim << "\n");
@@ -1093,8 +1093,8 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
   Value waveId = arith::DivUIOp::create(b, loc, tid, waveSizeVal);
 
   // Read parameters directly from config
-  int64_t dDim = config.getMfmaDDim();
-  int64_t instrK = config.getMfmaKDim();
+  int64_t dDim = config.getDDim();
+  int64_t instrK = config.getKDim();
   int64_t mPerWave = config.getMPerWave();
   int64_t nPerWave = config.getNPerWave();
   int64_t mPerBlock = config.getMPerBlock();

--- a/mlir/test/Dialect/Rock/lds_transpose_attributes.mlir
+++ b/mlir/test/Dialect/Rock/lds_transpose_attributes.mlir
@@ -28,8 +28,8 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
   }
 }
 
-// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 32, mfmaKDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = true>, useIndexDiffs} [](%{{.*}}) [%{{.*}}, %{{.*}}] -> %{{.*}} : memref<256x1x8xf16, #gpu.address_space<workgroup>> -> memref<8xf16, #gpu.address_space<private>>
-// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 32, mfmaKDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>, useIndexDiffs} [](%{{.*}}) [%{{.*}}, %{{.*}}] -> %{{.*}} : memref<256x1x8xf16, #gpu.address_space<workgroup>> -> memref<8xf16, #gpu.address_space<private>>
+// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<dDim = 32, kDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = true>, useIndexDiffs} [](%{{.*}}) [%{{.*}}, %{{.*}}] -> %{{.*}} : memref<256x1x8xf16, #gpu.address_space<workgroup>> -> memref<8xf16, #gpu.address_space<private>>
+// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<dDim = 32, kDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>, useIndexDiffs} [](%{{.*}}) [%{{.*}}, %{{.*}}] -> %{{.*}} : memref<256x1x8xf16, #gpu.address_space<workgroup>> -> memref<8xf16, #gpu.address_space<private>>
 
 // -----
 
@@ -61,7 +61,7 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
   }
 }
 
-// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 16, mfmaKDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>, useIndexDiffs}
+// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<dDim = 16, kDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>, useIndexDiffs}
 // CHECK-SAME: memref<256x8xf16, #gpu.address_space<workgroup>> -> memref<8xf16, #gpu.address_space<private>>
-// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 16, mfmaKDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = false>, useIndexDiffs}
+// CHECK: rock.threadwise_read_into {forceUnroll, ldsTransposeConfig = #rock.lds_transpose_config<dDim = 16, kDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = false>, useIndexDiffs}
 // CHECK-SAME: memref<256x32xf16, #gpu.address_space<workgroup>> -> memref<32xf16, #gpu.address_space<private>>

--- a/mlir/test/Dialect/Rock/lds_transpose_error.mlir
+++ b/mlir/test/Dialect/Rock/lds_transpose_error.mlir
@@ -10,7 +10,7 @@ func.func @threadwise_read_into_invalid_mfma_geometry_16x8(
   rock.threadwise_read_into {
     // expected-error @+1 {{invalid MFMA geometry (16x8) for LDS transpose - valid combinations: (16,16), (16,32), (32,8), (32,16)}}
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 16, mfmaKDim = 8,
+      dDim = 16, kDim = 8,
       mPerBlock = 128, nPerBlock = 128, kPerBlock = 32,
       mPerWave = 64, nPerWave = 64,
       doubleBuffering = false, isOperandA = true
@@ -29,7 +29,7 @@ func.func @threadwise_read_into_invalid_mfma_geometry_32x32(
   rock.threadwise_read_into {
     // expected-error @+1 {{invalid MFMA geometry (32x32) for LDS transpose - valid combinations: (16,16), (16,32), (32,8), (32,16)}}
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 32, mfmaKDim = 32,
+      dDim = 32, kDim = 32,
       mPerBlock = 128, nPerBlock = 128, kPerBlock = 32,
       mPerWave = 64, nPerWave = 64,
       doubleBuffering = false, isOperandA = true
@@ -48,7 +48,7 @@ func.func @threadwise_read_into_invalid_mfma_geometry_8x8(
   rock.threadwise_read_into {
     // expected-error @+1 {{invalid MFMA geometry (8x8) for LDS transpose - valid combinations: (16,16), (16,32), (32,8), (32,16)}}
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 8, mfmaKDim = 8,
+      dDim = 8, kDim = 8,
       mPerBlock = 128, nPerBlock = 128, kPerBlock = 32,
       mPerWave = 64, nPerWave = 64,
       doubleBuffering = false, isOperandA = true
@@ -59,15 +59,15 @@ func.func @threadwise_read_into_invalid_mfma_geometry_8x8(
 
 // -----
 
-// Error case: kPerBlock not divisible by mfmaKDim
+// Error case: kPerBlock not divisible by kDim
 func.func @threadwise_read_into_kperblock_not_divisible(
     %source: memref<128xf16, #gpu.address_space<workgroup>>,
     %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
-    // expected-error @+1 {{kPerBlock (30) must be divisible by mfmaKDim (16)}}
+    // expected-error @+1 {{kPerBlock (30) must be divisible by kDim (16)}}
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 16, mfmaKDim = 16,
+      dDim = 16, kDim = 16,
       mPerBlock = 128, nPerBlock = 128, kPerBlock = 30,
       mPerWave = 64, nPerWave = 64,
       doubleBuffering = false, isOperandA = true

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
@@ -11,7 +11,7 @@ func.func @rock_accel_gemm_wmma(%matrixA : memref<1x4xvector<16xf16>, 5>,
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
-  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] : vector<16xf16>, vector<16xf16>, vector<8xf32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
   rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
@@ -41,7 +41,7 @@ func.func @rock_accel_gemm_wmma_gfx12(%matrixA : memref<1x4xvector<8xf16>, 5>,
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<8xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<8xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
-  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] : vector<8xf16>, vector<8xf16>, vector<8xf32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
   rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1200",
@@ -72,7 +72,7 @@ func.func @rock_accel_gemm_wmma_repeats(%matrixA : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xf32>, 5>
-  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] : vector<16xf16>, vector<16xf16>, vector<8xf32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xf32>, 5>
   %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xf32>, 5> to memref<2x2xvector<8xf32>, 5>
   rock.threadwise_gemm_accel %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
@@ -104,7 +104,7 @@ func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<1x4xvector<16xi8>
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
-  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] {clamp} : vector<16xi8>, vector<16xi8>, vector<8xi32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
   %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2xvector<8xi32>, 5>
   rock.threadwise_gemm_accel %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
@@ -136,7 +136,7 @@ func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<1x2xvecto
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
-  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] {clamp} : vector<16xi8>, vector<16xi8>, vector<8xi32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
   %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2xvector<8xi32>, 5>
   rock.threadwise_gemm_accel %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
@@ -154,5 +154,395 @@ func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<1x2xvecto
        outputSwizzle = 2,
        forceUnroll = true>
      } : memref<2x2xvector<8xi32>, 5> += memref<1x2xvector<16xi8>, 5> * memref<1x2xvector<16xi8>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_f32
+func.func @rock_accel_gemm_wmma_gfx1250_f32(%matrixA : memref<1x1xvector<2xf32>, 5>,
+                                             %matrixB : memref<1x1xvector<2xf32>, 5>,
+                                             %matrixC : memref<1x1xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x1xvector<2xf32>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x1xvector<2xf32>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x4 %[[a]] * %[[b]] + %[[c]] : vector<2xf32>, vector<2xf32>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 1,
+       mPerWave = 16,
+       nPerWave = 16,
+       mnPerXdl = 16,
+       kpack = 4,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x1xvector<2xf32>, 5> * memref<1x1xvector<2xf32>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_f16_k32
+func.func @rock_accel_gemm_wmma_gfx1250_f16_k32(%matrixA : memref<1x2xvector<16xf16>, 5>,
+                                                 %matrixB : memref<1x2xvector<16xf16>, 5>,
+                                                 %matrixC : memref<1x1xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xf16>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x32 %[[a]] * %[[b]] + %[[c]] : vector<16xf16>, vector<16xf16>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 2,
+       mPerWave = 16,
+       nPerWave = 16,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x2xvector<16xf16>, 5> * memref<1x2xvector<16xf16>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf16_k32
+func.func @rock_accel_gemm_wmma_gfx1250_bf16_k32(%matrixA : memref<1x2xvector<16xbf16>, 5>,
+                                                  %matrixB : memref<1x2xvector<16xbf16>, 5>,
+                                                  %matrixC : memref<1x1xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xbf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xbf16>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x32 %[[a]] * %[[b]] + %[[c]] : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 2,
+       mPerWave = 16,
+       nPerWave = 16,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x2xvector<16xbf16>, 5> * memref<1x2xvector<16xbf16>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k64(%matrixA : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E4M3FN>, 5> * memref<4x4xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k64(%matrixA : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E4M3FN>, 5> * memref<4x4xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k64(%matrixA : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E5M2>, 5> * memref<4x4xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k64(%matrixA : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E5M2>, 5> * memref<4x4xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k128(%matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> * memref<4x8xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k128(%matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> * memref<4x8xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k128(%matrixA : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E5M2>, 5> * memref<4x8xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k128(%matrixA : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E5M2>, 5> * memref<4x8xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_i8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_i8_k64(%matrixA : memref<4x4xvector<32xi8>, 5>,
+                                               %matrixB : memref<4x4xvector<32xi8>, 5>,
+                                               %matrixC : memref<4x4xvector<8xi32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<32xi8>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<32xi8>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xi32>, 5>
+  // CHECK: amdgpu.wmma 16x16x64 %[[a]] * %[[b]] + %[[c]] {clamp} : vector<32xi8>, vector<32xi8>, vector<8xi32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xi32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xi32>, 5> += memref<4x4xvector<32xi8>, 5> * memref<4x4xvector<32xi8>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_k_selection
+func.func @rock_accel_gemm_wmma_gfx1250_k_selection(%matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> * memref<4x8xvector<64xf8E5M2>, 5>
   return
 }

--- a/mlir/test/Dialect/Rock/ops.mlir
+++ b/mlir/test/Dialect/Rock/ops.mlir
@@ -434,15 +434,15 @@ func.func @rock_lds_transpose_load_full_arch(%lds_buffer: memref<128x64xf16, #gp
 }
 
 // CHECK-LABEL: func.func @test_lds_transpose_config_attr_16x32
-// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 16, mfmaKDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 16, kDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>
 func.func @test_lds_transpose_config_attr_16x32(%src: memref<8192xf16, #gpu.address_space<workgroup>>, 
                                                  %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
     forceUnroll, 
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 16, 
-      mfmaKDim = 32, 
+      dDim = 16, 
+      kDim = 32, 
       mPerBlock = 64, 
       nPerBlock = 64, 
       kPerBlock = 32, 
@@ -457,15 +457,15 @@ func.func @test_lds_transpose_config_attr_16x32(%src: memref<8192xf16, #gpu.addr
 }
 
 // CHECK-LABEL: func.func @test_lds_transpose_config_attr_32x16
-// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 32, mfmaKDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 32, kDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>
 func.func @test_lds_transpose_config_attr_32x16(%src: memref<1024xf16, #gpu.address_space<workgroup>>, 
                                                  %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
     forceUnroll, 
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 32, 
-      mfmaKDim = 16, 
+      dDim = 32, 
+      kDim = 16, 
       mPerBlock = 64, 
       nPerBlock = 64, 
       kPerBlock = 16, 
@@ -480,15 +480,15 @@ func.func @test_lds_transpose_config_attr_32x16(%src: memref<1024xf16, #gpu.addr
 }
 
 // CHECK-LABEL: func.func @test_lds_transpose_config_attr_16x16
-// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 16, mfmaKDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 16, kDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>
 func.func @test_lds_transpose_config_attr_16x16(%src: memref<4096xf16, #gpu.address_space<workgroup>>, 
                                                  %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
     forceUnroll, 
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 16, 
-      mfmaKDim = 16, 
+      dDim = 16, 
+      kDim = 16, 
       mPerBlock = 64, 
       nPerBlock = 64, 
       kPerBlock = 16, 
@@ -503,15 +503,15 @@ func.func @test_lds_transpose_config_attr_16x16(%src: memref<4096xf16, #gpu.addr
 }
 
 // CHECK-LABEL: func.func @test_lds_transpose_config_attr_32x8
-// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<mfmaDDim = 32, mfmaKDim = 8, mPerBlock = 64, nPerBlock = 64, kPerBlock = 8, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 32, kDim = 8, mPerBlock = 64, nPerBlock = 64, kPerBlock = 8, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>
 func.func @test_lds_transpose_config_attr_32x8(%src: memref<2048xf16, #gpu.address_space<workgroup>>, 
                                                 %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
     forceUnroll, 
     ldsTransposeConfig = #rock.lds_transpose_config<
-      mfmaDDim = 32, 
-      mfmaKDim = 8, 
+      dDim = 32, 
+      kDim = 8, 
       mPerBlock = 64, 
       nPerBlock = 64, 
       kPerBlock = 8, 


### PR DESCRIPTION
## Motivation

This PR adds in new wmma instructions that are available on gfx1250. This implements https://github.com/ROCm/rocMLIR-internal/issues/2045

## Technical Details

Before we can make any rocMLIR changes we need to pull in the corresponding upstream wmma changes:
- https://github.com/llvm/llvm-project/pull/167041

### rocMLIR Changes:
- Update instances of `amdgpu::WMMAOp::create` to only set clamp for integer data types (needed after upstream changes)
- Refactored `WmmaInsnGroup`
  - The previous logic was not very robust and would make adding in additional archs in the future more difficult
  - We now use a map approach that is more similar to what is done in `MfmaInsnGroup`, with much simpler `select` logic
 - Added in new gfx1250 wmma instructions

## Test Plan

- Nightly CI

## Test Result

- [x] Nightly CI: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2094/10/pipeline-overview

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
