### PR TITLE
Allow tile size of 16 (m or n) for decoding phase

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -82,20 +82,20 @@ static void createAttnTuningRangeBF(TuningParamSet *newSpace,
                                     bool isSplitKFusible,
                                     TuningParamSetKind kind) {
   static const std::vector<std::vector<uint32_t>> validRangeAttnParamsMFMA = {
-      /*gemm0MPerBlock=*/{32, 64, 128, 256},
-      /*gemm1MPerBlock=*/{32, 64, 128, 256},
-      /*gemm0NPerBlock=*/{32, 64, 128, 256},
+      /*gemm0MPerBlock=*/{16, 32, 64, 128, 256},
+      /*gemm1MPerBlock=*/{16, 32, 64, 128, 256},
+      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
       /*kPackPerBlock=*/{8, 16, 32, 64},
-      /*mPerWave=*/{32, 64, 128, 256},
+      /*mPerWave=*/{16, 32, 64, 128, 256},
       /*mnPerXdl=*/{4, 16, 32},
       /*kPack=*/{4, 8, 16}};
   static const std::vector<std::vector<uint32_t>> validRangeAttnParamsWMMA = {
-      /*gemm0MPerBlock=*/{32, 64, 128},
-      /*gemm1MPerBlock=*/{32, 64, 128},
-      /*gemm0NPerBlock=*/{32, 64, 128, 256},
+      /*gemm0MPerBlock=*/{16, 32, 64, 128},
+      /*gemm1MPerBlock=*/{16, 32, 64, 128},
+      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
       /*kPackPerBlock=*/{8, 16, 32, 64},
-      /*mPerWave=*/{32, 64},
-      /*nPerWave=*/{32, 64},
+      /*mPerWave=*/{16, 32, 64},
+      /*nPerWave=*/{16, 32, 64},
       /*kPack=*/{4, 8, 16}};
   GemmFeatures features = rock::getFeatures(gemmGemmOp);
   int64_t numEUPerCU =

--- a/mlir/utils/performance/attentionSweeps.py
+++ b/mlir/utils/performance/attentionSweeps.py
@@ -142,11 +142,11 @@ def sample_attn_shape():
 # Keep in sync with RockTuningImpl.cpp
 perfconfig_space_mfma = list(
     itertools.product(  # MFMA perfConfig space
-        [32, 64, 128, 256],  # M/block G0
-        [32, 64, 128, 256],  # M/block G1
-        [32, 64, 128, 256],  # N/block G0
+        [16, 32, 64, 128, 256],  # M/block G0
+        [16, 32, 64, 128, 256],  # M/block G1
+        [16, 32, 64, 128, 256],  # N/block G0
         [8, 16, 32, 64],  # Kpack/Block
-        [32, 64, 128, 256],  # M/Wave
+        [16, 32, 64, 128, 256],  # M/Wave
         [4, 16, 32],  # MN/Xdl
         [4, 8, 16],  # kPack
         [1],  # splitKFactor
@@ -157,12 +157,12 @@ perfconfig_space_mfma = list(
 
 perfconfig_space_wmma = list(
     itertools.product(  # WMMA perfConfig space
-        [32, 64, 128],  # M/block G0
-        [32, 64, 128],  # M/block G1
-        [32, 64, 128, 256],  # N/block G0
+        [16, 32, 64, 128],  # M/block G0
+        [16, 32, 64, 128],  # M/block G1
+        [16, 32, 64, 128, 256],  # N/block G0
         [8, 16, 32, 64],  # Kpack/Block
-        [32, 64],  # M/Wave
-        [32, 64],  # N/Wave
+        [16, 32, 64],  # M/Wave
+        [16, 32, 64],  # N/Wave
         [4, 8, 16],  # kPack
         [1],  # splitKFactor
         [1],  # scheduleVersion


### PR DESCRIPTION
## Motivation

For the decoding phase, we can have seqLenQ=1, so, we'd like to have nPerBlock=16 (or the minimum possible). We simply add 16 to both wmma and mfma attention tuning parameters.

closes: https://github.com/ROCm/rocMLIR-internal/issues/1988

## Technical Details

- Add 16 to m/nPerBlock and m/nPerWave to allow the smallest tile size possible (given mfma/wmma sizes)

## Perf results

The problem config is the following:
```
-t f16 -transQ false -transK true -transV false -transO false -causal false -num_heads_q 64 -num_heads_kv 8 -g 1 -seq_len_q 1 -seq_len_k 8192 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale false -with-attn-bias false

```

We change split_kv to values 1, 2, 4, 8, 16. Results for gfx1100:

| SplitKV | PerfConfig develop                    | PerfConfig PR                         | Tflops develop | Tflops PR | Speed up |
| ------- | ------------------------------------- | ------------------------------------- | -------------- | --------- | -------- |
| 1       | attn:v2:128,128,32,16,32,32,8,1,1,2,1 | attn:v2:128,128,16,16,16,16,8,1,1,2,1 | 1.28           | 1.61      | 1.26     |
| 2       | attn:v2:128,128,32,16,32,32,8,1,1,2,1 | attn:v2:128,128,16,16,16,16,8,1,1,2,1 | 2.53           | 3.13      | 1.24     |
| 4       | attn:v2:128,128,32,16,32,32,8,1,1,2,1 | attn:v2:128,128,16,16,16,16,8,1,1,2,1 | 4.87           | 6.09      | 1.25     |
| 8       | attn:v2:128,128,32,16,32,32,8,1,1,2,1 | attn:v2:128,128,16,8,32,16,8,1,1,2,1  | 7.00           | 8.28      | 1.18     |
| 16      | attn:v2:128,128,32,16,32,32,8,1,1,2,1 | attn:v2:128,128,16,8,32,16,8,1,1,2,1  | 9.29           | 11.44     | 1.23     |

Results for gfx942:

| SplitKV | PerfConfig develop                    | PerfConfig PR                         | Tflops develop | Tflops PR | Speed up |
| ------- | ------------------------------------- | ------------------------------------- | -------------- | --------- | -------- |
| 1       | attn:v2:128,128,32,8,32,32,16,1,1,2,1 | attn:v2:128,128,16,8,16,16,16,1,1,2,1 | 1.09           | 1.19      | 1.09     |
| 2       | attn:v2:128,128,32,8,32,32,16,1,1,2,1 | attn:v2:128,128,16,8,16,16,16,1,1,2,1 | 2.08           | 2.27      | 1.09     |
| 4       | attn:v2:128,128,32,8,32,32,16,1,1,2,1 | attn:v2:128,128,16,8,16,16,16,1,1,2,1 | 3.84           | 4.28      | 1.11     |
| 8       | attn:v2:128,128,32,8,32,32,16,1,1,2,1 | attn:v2:128,128,16,8,16,16,16,1,1,2,1 | 7.60           | 8.55      | 1.13     |
| 16      | attn:v2:128,128,32,8,32,32,16,1,1,2,1 | attn:v2:128,128,16,8,32,16,16,1,1,2,1 | 12.46          | 14.28     | 1.15     |

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
