### PR TITLE
Enable f32 wmma tests gfx1250

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -821,12 +821,10 @@ def ScaledMFMAInTypes : AnyTypeOf<[VectorOfLengthAndType<[32], [F8E5M2, F8E4M3FN
                                    VectorOfLengthAndType<[32], [F6E2M3FN, F6E3M2FN, F4E2M1FN]>]>;
 def ScaledMFMAOutTypes : AnyTypeOf<[VectorOfLengthAndType<[4, 16], [F32]>]>;
 // wmma
-def WMMAInTypes : AnyTypeOf<[VectorOfLengthAndType<
-                             [4, 8, 16],
-                             [F16, BF16,
-                              I8, SI8, UI8,
-                              I<4>, SI<4>, UI<4>,
-                              F8E4M3FN, F8E5M2]>]>;
+def WMMAInTypes : AnyTypeOf<[VectorOfLengthAndType<[4, 8, 16], [F16, BF16]>,
+                             VectorOfLengthAndType<[4, 8, 16], [I8, SI8, UI8]>,
+                             VectorOfLengthAndType<[4, 8], [F8E4M3FN, F8E5M2]>,
+                             VectorOfLengthAndType<[4, 8, 16], [I<4>, SI<4>, UI<4>]>]>;
 def WMMAOutTypes : AnyTypeOf<[VectorOfLengthAndType<[4, 8], [F32, I32]>,
                               VectorOfLengthAndType<[4, 8, 16], [F16, BF16]>]>;
 
@@ -877,6 +875,14 @@ def AMDGPU_MFMAOp :
 
     The negateA, negateB, and negateC flags are only supported for double-precision
     operations on gfx94x.
+
+    Example:
+    ```mlir
+      %0 = amdgpu.mfma %matA * %matB + %matC
+        { abid = 1 : i32, cbsz = 1 : i32,
+          m = 32 : i32, n = 32 : i32, k = 1 : i32, blocks = 2 : i32 }
+        blgp = bcast_second_32 : f32, f32, vector<32xf32>
+    ```
   }];
   let assemblyFormat = [{
     $sourceA `*` $sourceB `+` $destC
@@ -891,36 +897,43 @@ def AMDGPU_WMMAOp :
     AMDGPU_Op<"wmma", [AllTypesMatch<["destC", "destD"]>,
                        Pure]>,
     Arguments<(ins
+                   ConfinedAttr<I32Attr, [IntIsOneOf<[16]>]>:$m,
+                   ConfinedAttr<I32Attr, [IntIsOneOf<[16]>]>:$n,
+                   ConfinedAttr<I32Attr, [IntIsOneOf<[16, 32]>]>:$k,
                    WMMAInTypes:$sourceA,
                    WMMAInTypes:$sourceB,
                    WMMAOutTypes:$destC,
-                   DefaultValuedAttr<ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<1>]>, "0">:$subwordOffset,
+                   DefaultValuedAttr<ConfinedAttr<I32Attr, [IntIsOneOf<[0, 1]>]>, "0">:$subwordOffset,
                    UnitAttr:$unsignedA,
                    UnitAttr:$unsignedB,
                    UnitAttr:$clamp)>,
     Results<(outs WMMAOutTypes: $destD)> {
-  let summary = "MLIR wrapper for RDNA3 wmma instructions";
+  let summary = "MLIR wrapper for wmma instructions";
   let description = [{
-    The `amdgpu.wmma` op is an MLIR wrapper around intrinsics
-    for various `wmma` instructions in the RDNA3 or RDNA4 architecture, which
-    perform a 16x16 * 16x16 matrix multiplication for different data types.
-    Note that in gfx12/RDNA4, there is also a 16x32 * 32x16 instruction for 4-bit
-    integer inputs.
+    The `amdgpu.wmma` op is an MLIR wrapper around intrinsics for various `wmma`
+    instructions in the AMDGPU architecture, which perform matrix multiplication.
+    Note that all wmma intrinsics have M=N=16 dimensions but vary by in allowed K
+    dimensions.
 
     On gfx11/RDNA3, emitting f16->f16 (or bf16->bf16) wmma the output is a 16xf16
     (or 16xbf16) vector containing only 8 valid values:
       - If `subwordOffset` is 0, then the output is stored at indices 0, 2, 4, ..., 14.
       - If `subwordOffset` is 1, then the output is stored at indices 1, 3, 5, ..., 15.
-    On gfx12/RDNA4, the result is instead returned as a vector<8 x f16/bf16> where
-    all values are valid and the `subwordOffset` must be `0`, as it cannot be used.
+    On gfx12/RDNA4 and gfx1250, the result is instead returned as vector where all
+    the values are valid and the `subwordOffset` must be `0`, as it cannot be used.
 
     `unsignedA` and `unsignedB` flag that the `int8` LLVM inputs are unsigned.
 
-    The `clamp` flag is used to saturate the output of type T to numeric_limits<T>::max()
+    The `clamp` flag is used to saturate the output of type T to `numeric_limits<T>::max()`
     in case of overflow.
+
+    Example:
+    ```mlir
+      %0 = amdgpu.wmma 16x16x16 %matA * %matB + %matC : vector<16xf16>, vector<16xf16>, vector<8xf16>
+    ```
   }];
   let assemblyFormat = [{
-    $sourceA `*` $sourceB `+` $destC
+    custom<MNKDimensionList>($m, $n, $k) $sourceA `*` $sourceB `+` $destC
     attr-dict
     `:` type($sourceA) `,` type($sourceB) `,` type($destC)
   }];

--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -821,9 +821,10 @@ def ScaledMFMAInTypes : AnyTypeOf<[VectorOfLengthAndType<[32], [F8E5M2, F8E4M3FN
                                    VectorOfLengthAndType<[32], [F6E2M3FN, F6E3M2FN, F4E2M1FN]>]>;
 def ScaledMFMAOutTypes : AnyTypeOf<[VectorOfLengthAndType<[4, 16], [F32]>]>;
 // wmma
-def WMMAInTypes : AnyTypeOf<[VectorOfLengthAndType<[4, 8, 16], [F16, BF16]>,
-                             VectorOfLengthAndType<[4, 8, 16], [I8, SI8, UI8]>,
-                             VectorOfLengthAndType<[4, 8], [F8E4M3FN, F8E5M2]>,
+def WMMAInTypes : AnyTypeOf<[VectorOfLengthAndType<[2], [F32]>,
+                             VectorOfLengthAndType<[4, 8, 16], [F16, BF16]>,
+                             VectorOfLengthAndType<[4, 8, 16, 32], [I8, SI8, UI8]>,
+                             VectorOfLengthAndType<[4, 8, 32, 64], [F8E4M3FN, F8E5M2]>,
                              VectorOfLengthAndType<[4, 8, 16], [I<4>, SI<4>, UI<4>]>]>;
 def WMMAOutTypes : AnyTypeOf<[VectorOfLengthAndType<[4, 8], [F32, I32]>,
                               VectorOfLengthAndType<[4, 8, 16], [F16, BF16]>]>;
@@ -899,7 +900,7 @@ def AMDGPU_WMMAOp :
     Arguments<(ins
                    ConfinedAttr<I32Attr, [IntIsOneOf<[16]>]>:$m,
                    ConfinedAttr<I32Attr, [IntIsOneOf<[16]>]>:$n,
-                   ConfinedAttr<I32Attr, [IntIsOneOf<[16, 32]>]>:$k,
+                   ConfinedAttr<I32Attr, [IntIsOneOf<[4, 16, 32, 64, 128]>]>:$k,
                    WMMAInTypes:$sourceA,
                    WMMAInTypes:$sourceB,
                    WMMAOutTypes:$destC,
@@ -912,8 +913,14 @@ def AMDGPU_WMMAOp :
   let description = [{
     The `amdgpu.wmma` op is an MLIR wrapper around intrinsics for various `wmma`
     instructions in the AMDGPU architecture, which perform matrix multiplication.
-    Note that all wmma intrinsics have M=N=16 dimensions but vary by in allowed K
-    dimensions.
+
+    On gfx11/RDNA3, wmma intrinsics have M=N=K=16 dimensions.
+
+    On gfx12/RDNA4, wmma intrinsics have M=N=16 dimensions and support K=16 for
+    all element types, and K=32 for i4 sources.
+
+    On gfx1250, wmma intrinsics have M=N=16 and K dimensions of 4, 32, 64, or 128,
+    depending on the element types.
 
     On gfx11/RDNA3, emitting f16->f16 (or bf16->bf16) wmma the output is a 16xf16
     (or 16xbf16) vector containing only 8 valid values:
@@ -929,7 +936,13 @@ def AMDGPU_WMMAOp :
 
     Example:
     ```mlir
-      %0 = amdgpu.wmma 16x16x16 %matA * %matB + %matC : vector<16xf16>, vector<16xf16>, vector<8xf16>
+      %0 = amdgpu.wmma 16x16x16 %matA * %matB + %matC : vector<8xf16>, vector<8xf16>, vector<8xf16>
+
+      %1 = amdgpu.wmma 16x16x64 %matD * %matE + %matF : vector<32xi8>, vector<8xf32>, vector<8xf32>
+
+      %2 = amdgpu.wmma 16x16x128 %matG * %matH + %matI : vector<64xf4E2M1FN>, vector<64xf4E2M1FN>, vector<8xf32>
+
+      %3 = amdgpu.wmma 16x16x4 %matJ * %matK + %matL : vector<2xf32>, vector<2xf32>, vector<8xf32>
     ```
   }];
   let assemblyFormat = [{

--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file declares a dialect for MLIR wrappers around AMDGPU-specific
-// intrinssics and for other AMD GPU-specific functionality.
+// intrinsics and for other AMD GPU-specific functionality.
 //
 //===----------------------------------------------------------------------===//
 
@@ -25,6 +25,29 @@
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h.inc"
 
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUEnums.h.inc"
+
+namespace mlir::amdgpu {
+/// Parser for the `custom<MNKDimensionList>` custom assembly format used by
+/// WMMAOp.
+ParseResult parseMNKDimensionList(OpAsmParser &parser, IntegerAttr &m,
+                                  IntegerAttr &n, IntegerAttr &k);
+inline ParseResult parseMNKDimensionList(OpAsmParser &parser, Operation *,
+                                         IntegerAttr &m, IntegerAttr &n,
+                                         IntegerAttr &k) {
+  return parseMNKDimensionList(parser, m, n, k);
+}
+
+/// Printer for the `custom<MNKDimensionList>` custom assembly format used by
+/// WMMAOp.
+inline void printMNKDimensionList(OpAsmPrinter &printer, IntegerAttr m,
+                                  IntegerAttr n, IntegerAttr k) {
+  printer.printDimensionList(ArrayRef{m.getInt(), n.getInt(), k.getInt()});
+}
+inline void printMNKDimensionList(OpAsmPrinter &printer, Operation *,
+                                  IntegerAttr m, IntegerAttr n, IntegerAttr k) {
+  printMNKDimensionList(printer, m, n, k);
+}
+} // namespace mlir::amdgpu
 
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUAttributes.h.inc"

--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -492,6 +492,30 @@ def ROCDL_wmma_f32_16x16x16_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.fp8_b
 def ROCDL_wmma_f32_16x16x16_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.bf8_bf8", [1]>;
 def ROCDL_wmma_f32_16x16x16_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x16.bf8_fp8", [1]>;
 def ROCDL_wmma_i32_16x16x32_iu4 : ROCDL_Wmma_IntrOp<"wmma.i32.16x16x32.iu4", [1]>;
+// Available from gfx1250
+def ROCDL_wmma_f32_16x16x4_f32 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x4.f32", [1]>;
+def ROCDL_wmma_f32_16x16x32_bf16 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x32.bf16", [1]>;
+def ROCDL_wmma_f32_16x16x32_f16 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x32.f16", [1]>;
+def ROCDL_wmma_f16_16x16x32_f16 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x32.f16", [1]>;
+def ROCDL_wmma_bf16_16x16x32_bf16 : ROCDL_Wmma_IntrOp<"wmma.bf16.16x16x32.bf16", [1]>;
+def ROCDL_wmma_bf16f32_16x16x32_bf16 : ROCDL_Wmma_IntrOp<"wmma.bf16f32.16x16x32.bf16", [1,5]>;
+def ROCDL_wmma_f32_16x16x64_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.fp8_fp8", [0]>;
+def ROCDL_wmma_f32_16x16x64_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.fp8_bf8", [0]>;
+def ROCDL_wmma_f32_16x16x64_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.bf8_fp8", [0]>;
+def ROCDL_wmma_f32_16x16x64_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x64.bf8_bf8", [0]>;
+def ROCDL_wmma_f16_16x16x64_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.fp8_fp8", [0]>;
+def ROCDL_wmma_f16_16x16x64_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.fp8_bf8", [0]>;
+def ROCDL_wmma_f16_16x16x64_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.bf8_fp8", [0]>;
+def ROCDL_wmma_f16_16x16x64_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x64.bf8_bf8", [0]>;
+def ROCDL_wmma_f32_16x16x128_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.fp8_fp8", [0]>;
+def ROCDL_wmma_f32_16x16x128_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.fp8_bf8", [0]>;
+def ROCDL_wmma_f32_16x16x128_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.bf8_fp8", [0]>;
+def ROCDL_wmma_f32_16x16x128_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f32.16x16x128.bf8_bf8", [0]>;
+def ROCDL_wmma_f16_16x16x128_fp8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.fp8_fp8", [0]>;
+def ROCDL_wmma_f16_16x16x128_fp8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.fp8_bf8", [0]>;
+def ROCDL_wmma_f16_16x16x128_bf8_fp8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.bf8_fp8", [0]>;
+def ROCDL_wmma_f16_16x16x128_bf8_bf8 : ROCDL_Wmma_IntrOp<"wmma.f16.16x16x128.bf8_bf8", [0]>;
+def ROCDL_wmma_i32_16x16x64_iu8 : ROCDL_Wmma_IntrOp<"wmma.i32.16x16x64.iu8", [1]>;
 
 //===---------------------------------------------------------------------===//
 // LDS transpose intrinsics (available in GFX950)

--- a/external/llvm-project/mlir/include/mlir/IR/CommonAttrConstraints.td
+++ b/external/llvm-project/mlir/include/mlir/IR/CommonAttrConstraints.td
@@ -804,6 +804,11 @@ def IntPositivePowerOf2 : AllAttrOf<[IntPositive, IntPowerOf2]>;
 
 class IntValidAlignment<Attr attr>: ConfinedAttr<attr, [IntPositivePowerOf2]>;
 
+class IntIsOneOf<list<int> values> : AttrConstraint<
+    CPred<"::llvm::is_contained({" # !interleave(!foreach(val, values, val), ", ") #
+                                "}, ::llvm::cast<::mlir::IntegerAttr>($_self).getInt())">,
+    "whose value is one of {" # !interleave(!foreach(val, values, val), ", ") # "}">;
+
 class ArrayMaxCount<int n> : AttrConstraint<
     CPred<"::llvm::cast<::mlir::ArrayAttr>($_self).size() <= " # n>,
     "with at most " # n # " elements">;

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Pass/Pass.h"
@@ -1025,28 +1026,36 @@ mfmaOpToScaledIntrinsic(ScaledMFMAOp smfma, Chipset chipset) {
 /// on the architecture you are compiling for.
 static std::optional<StringRef> wmmaOpToIntrinsic(WMMAOp wmma,
                                                   Chipset chipset) {
-  auto sourceVectorType = dyn_cast<VectorType>(wmma.getSourceA().getType());
-  auto sourceBVectorType = dyn_cast<VectorType>(wmma.getSourceB().getType());
-  auto destVectorType = dyn_cast<VectorType>(wmma.getDestC().getType());
-  auto elemSourceType = sourceVectorType.getElementType();
-  auto elemBSourceType = sourceBVectorType.getElementType();
-  auto elemDestType = destVectorType.getElementType();
+  auto sourceVectorType = cast<VectorType>(wmma.getSourceA().getType());
+  auto sourceBVectorType = cast<VectorType>(wmma.getSourceB().getType());
+  auto destVectorType = cast<VectorType>(wmma.getDestC().getType());
+  Type elemSourceType = sourceVectorType.getElementType();
+  Type elemBSourceType = sourceBVectorType.getElementType();
+  Type elemDestType = destVectorType.getElementType();
 
-  if (elemSourceType.isF16() && elemDestType.isF32())
-    return ROCDL::wmma_f32_16x16x16_f16::getOperationName();
-  if (elemSourceType.isBF16() && elemDestType.isF32())
-    return ROCDL::wmma_f32_16x16x16_bf16::getOperationName();
-  if (elemSourceType.isF16() && elemDestType.isF16())
-    return ROCDL::wmma_f16_16x16x16_f16::getOperationName();
-  if (elemSourceType.isBF16() && elemDestType.isBF16())
-    return ROCDL::wmma_bf16_16x16x16_bf16::getOperationName();
-  if (elemSourceType.isInteger(8) && elemDestType.isInteger(32))
-    return ROCDL::wmma_i32_16x16x16_iu8::getOperationName();
-  if (chipset.majorVersion == 11) {
-    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
-      return ROCDL::wmma_i32_16x16x16_iu4::getOperationName();
+  const uint32_t k = wmma.getK();
+
+  if (k == 16) {
+    if (elemSourceType.isF16() && elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_f16::getOperationName();
+    if (elemSourceType.isBF16() && elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_bf16::getOperationName();
+    if (elemSourceType.isF16() && elemDestType.isF16())
+      return ROCDL::wmma_f16_16x16x16_f16::getOperationName();
+    if (elemSourceType.isBF16() && elemDestType.isBF16())
+      return ROCDL::wmma_bf16_16x16x16_bf16::getOperationName();
+    if (elemSourceType.isInteger(8) && elemDestType.isInteger(32))
+      return ROCDL::wmma_i32_16x16x16_iu8::getOperationName();
+    if (chipset.majorVersion == 11) {
+      if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
+        return ROCDL::wmma_i32_16x16x16_iu4::getOperationName();
+    }
   }
-  if (chipset.majorVersion >= 12) {
+  if (chipset.majorVersion < 12)
+    return std::nullopt;
+
+  // gfx12+
+  if (k == 16) {
     if (isa<Float8E4M3FNType>(elemSourceType) &&
         isa<Float8E4M3FNType>(elemBSourceType) && elemDestType.isF32())
       return ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName();
@@ -1059,17 +1068,18 @@ static std::optional<StringRef> wmmaOpToIntrinsic(WMMAOp wmma,
     if (isa<Float8E5M2Type>(elemSourceType) &&
         isa<Float8E4M3FNType>(elemBSourceType) && elemDestType.isF32())
       return ROCDL::wmma_f32_16x16x16_bf8_fp8::getOperationName();
-    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32)) {
-      bool isWave64 = destVectorType.getNumElements() == 4;
-      // This is the ambiguous case. 8 inputs to the wave64 version means that
-      // we want the 16x16x32 version, but for wave32 they mean the short form.
-      bool has8Inputs = sourceVectorType.getNumElements() == 8;
-      if ((isWave64 && has8Inputs) || (!isWave64 && !has8Inputs))
-        return ROCDL::wmma_i32_16x16x32_iu4::getOperationName();
+    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
       return ROCDL::wmma_i32_16x16x16_iu4::getOperationName();
-    }
+
+    return std::nullopt;
   }
-  return std::nullopt;
+  if (k == 32) {
+    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
+      return ROCDL::wmma_i32_16x16x32_iu4::getOperationName();
+    return std::nullopt;
+  }
+
+  llvm_unreachable("unhandled WMMA case");
 }
 
 namespace {

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -1021,7 +1021,156 @@ mfmaOpToScaledIntrinsic(ScaledMFMAOp smfma, Chipset chipset) {
                                  smfma.getN(), smfma.getK(), 1u, chipset);
 }
 
+/// Returns the `rocdl` intrinsic corresponding to a WMMA operation `wmma`
+/// for RDNA3/4 architectures.
+static std::optional<StringRef>
+wmmaOpToIntrinsicRDNA(Type elemSourceType, Type elemBSourceType,
+                      Type elemDestType, uint32_t k, bool isRDNA3) {
+  using fp8 = Float8E4M3FNType;
+  using bf8 = Float8E5M2Type;
+
+  // Handle k == 16 for RDNA3/4.
+  if (k == 16) {
+    // Common patterns for RDNA3 and RDNA4.
+    if (elemSourceType.isF16() && elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_f16::getOperationName();
+    if (elemSourceType.isBF16() && elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_bf16::getOperationName();
+    if (elemSourceType.isF16() && elemDestType.isF16())
+      return ROCDL::wmma_f16_16x16x16_f16::getOperationName();
+    if (elemSourceType.isBF16() && elemDestType.isBF16())
+      return ROCDL::wmma_bf16_16x16x16_bf16::getOperationName();
+    if (elemSourceType.isInteger(8) && elemDestType.isInteger(32))
+      return ROCDL::wmma_i32_16x16x16_iu8::getOperationName();
+
+    // RDNA3 specific patterns.
+    if (isRDNA3) {
+      if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
+        return ROCDL::wmma_i32_16x16x16_iu4::getOperationName();
+      return std::nullopt;
+    }
+
+    // RDNA4 specific patterns (fp8/bf8).
+    if (isa<fp8>(elemSourceType) && isa<fp8>(elemBSourceType) &&
+        elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName();
+    if (isa<fp8>(elemSourceType) && isa<bf8>(elemBSourceType) &&
+        elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_fp8_bf8::getOperationName();
+    if (isa<bf8>(elemSourceType) && isa<bf8>(elemBSourceType) &&
+        elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName();
+    if (isa<bf8>(elemSourceType) && isa<fp8>(elemBSourceType) &&
+        elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x16_bf8_fp8::getOperationName();
+    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
+      return ROCDL::wmma_i32_16x16x16_iu4::getOperationName();
+
+    return std::nullopt;
+  }
+
+  // Handle k == 32 for RDNA4.
+  if (k == 32 && !isRDNA3) {
+    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
+      return ROCDL::wmma_i32_16x16x32_iu4::getOperationName();
+  }
+
+  llvm_unreachable("Unsupported k value");
+}
+
 /// Return the `rocdl` intrinsic corresponding to a WMMA operation `wmma`
+/// for the gfx1250 architecture.
+static std::optional<StringRef> wmmaOpToIntrinsicGfx1250(Type elemSourceType,
+                                                         Type elemBSourceType,
+                                                         Type elemDestType,
+                                                         uint32_t k) {
+  using fp8 = Float8E4M3FNType;
+  using bf8 = Float8E5M2Type;
+
+  if (k == 4) {
+    if (elemSourceType.isF32() && elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x4_f32::getOperationName();
+
+    return std::nullopt;
+  }
+
+  if (k == 32) {
+    if (elemSourceType.isF16() && elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x32_f16::getOperationName();
+    if (elemSourceType.isBF16() && elemDestType.isF32())
+      return ROCDL::wmma_f32_16x16x32_bf16::getOperationName();
+    if (elemSourceType.isF16() && elemDestType.isF16())
+      return ROCDL::wmma_f16_16x16x32_f16::getOperationName();
+    if (elemSourceType.isBF16() && elemDestType.isBF16())
+      return ROCDL::wmma_bf16_16x16x32_bf16::getOperationName();
+
+    return std::nullopt;
+  }
+
+  if (k == 64) {
+    if (isa<fp8>(elemSourceType) && isa<fp8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x64_fp8_fp8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x64_fp8_fp8::getOperationName();
+    }
+    if (isa<fp8>(elemSourceType) && isa<bf8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x64_fp8_bf8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x64_fp8_bf8::getOperationName();
+    }
+    if (isa<bf8>(elemSourceType) && isa<bf8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x64_bf8_bf8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x64_bf8_bf8::getOperationName();
+    }
+    if (isa<bf8>(elemSourceType) && isa<fp8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x64_bf8_fp8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x64_bf8_fp8::getOperationName();
+    }
+    if (elemSourceType.isInteger(8) && elemDestType.isInteger(32))
+      return ROCDL::wmma_i32_16x16x64_iu8::getOperationName();
+
+    return std::nullopt;
+  }
+
+  if (k == 128) {
+    if (isa<fp8>(elemSourceType) && isa<fp8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x128_fp8_fp8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x128_fp8_fp8::getOperationName();
+    }
+    if (isa<fp8>(elemSourceType) && isa<bf8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x128_fp8_bf8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x128_fp8_bf8::getOperationName();
+    }
+    if (isa<bf8>(elemSourceType) && isa<bf8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x128_bf8_bf8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x128_bf8_bf8::getOperationName();
+    }
+    if (isa<bf8>(elemSourceType) && isa<fp8>(elemBSourceType)) {
+      if (elemDestType.isF32())
+        return ROCDL::wmma_f32_16x16x128_bf8_fp8::getOperationName();
+      if (elemDestType.isF16())
+        return ROCDL::wmma_f16_16x16x128_bf8_fp8::getOperationName();
+    }
+
+    return std::nullopt;
+  }
+
+  llvm_unreachable("Unsupported k value");
+}
+
+/// Returns the `rocdl` intrinsic corresponding to a WMMA operation `wmma`
 /// if one exists. This includes checking to ensure the intrinsic is supported
 /// on the architecture you are compiling for.
 static std::optional<StringRef> wmmaOpToIntrinsic(WMMAOp wmma,
@@ -1034,50 +1183,18 @@ static std::optional<StringRef> wmmaOpToIntrinsic(WMMAOp wmma,
   Type elemDestType = destVectorType.getElementType();
 
   const uint32_t k = wmma.getK();
+  const bool isRDNA3 = chipset.majorVersion == 11;
+  const bool isRDNA4 = chipset.majorVersion == 12 && chipset.minorVersion == 0;
 
-  if (k == 16) {
-    if (elemSourceType.isF16() && elemDestType.isF32())
-      return ROCDL::wmma_f32_16x16x16_f16::getOperationName();
-    if (elemSourceType.isBF16() && elemDestType.isF32())
-      return ROCDL::wmma_f32_16x16x16_bf16::getOperationName();
-    if (elemSourceType.isF16() && elemDestType.isF16())
-      return ROCDL::wmma_f16_16x16x16_f16::getOperationName();
-    if (elemSourceType.isBF16() && elemDestType.isBF16())
-      return ROCDL::wmma_bf16_16x16x16_bf16::getOperationName();
-    if (elemSourceType.isInteger(8) && elemDestType.isInteger(32))
-      return ROCDL::wmma_i32_16x16x16_iu8::getOperationName();
-    if (chipset.majorVersion == 11) {
-      if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
-        return ROCDL::wmma_i32_16x16x16_iu4::getOperationName();
-    }
-  }
-  if (chipset.majorVersion < 12)
-    return std::nullopt;
+  // Handle RDNA3 and RDNA4.
+  if (isRDNA3 || isRDNA4)
+    return wmmaOpToIntrinsicRDNA(elemSourceType, elemBSourceType, elemDestType,
+                                 k, isRDNA3);
 
-  // gfx12+
-  if (k == 16) {
-    if (isa<Float8E4M3FNType>(elemSourceType) &&
-        isa<Float8E4M3FNType>(elemBSourceType) && elemDestType.isF32())
-      return ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName();
-    if (isa<Float8E4M3FNType>(elemSourceType) &&
-        isa<Float8E5M2Type>(elemBSourceType) && elemDestType.isF32())
-      return ROCDL::wmma_f32_16x16x16_fp8_bf8::getOperationName();
-    if (isa<Float8E5M2Type>(elemSourceType) &&
-        isa<Float8E5M2Type>(elemBSourceType) && elemDestType.isF32())
-      return ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName();
-    if (isa<Float8E5M2Type>(elemSourceType) &&
-        isa<Float8E4M3FNType>(elemBSourceType) && elemDestType.isF32())
-      return ROCDL::wmma_f32_16x16x16_bf8_fp8::getOperationName();
-    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
-      return ROCDL::wmma_i32_16x16x16_iu4::getOperationName();
-
-    return std::nullopt;
-  }
-  if (k == 32) {
-    if (elemSourceType.isInteger(4) && elemDestType.isInteger(32))
-      return ROCDL::wmma_i32_16x16x32_iu4::getOperationName();
-    return std::nullopt;
-  }
+  // Handle gfx1250.
+  if (chipset == Chipset{12, 5, 0})
+    return wmmaOpToIntrinsicGfx1250(elemSourceType, elemBSourceType,
+                                    elemDestType, k);
 
   llvm_unreachable("unhandled WMMA case");
 }

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -1361,12 +1361,99 @@ struct WMMAOpLowering : public ConvertOpToLLVMPattern<WMMAOp> {
     loweredOp.addTypes(rawOutType);
 
     SmallVector<Value, 4> operands;
-    wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedA(),
-                         adaptor.getSourceA(), op.getSourceA(), operands);
-    wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedB(),
-                         adaptor.getSourceB(), op.getSourceB(), operands);
-    wmmaPushOutputOperand(rewriter, loc, typeConverter, adaptor.getDestC(),
-                          op.getSubwordOffset(), op.getClamp(), operands);
+    
+    // gfx1250 has different intrinsic signatures with modifier arguments
+    bool isGfx1250 = (chipset == Chipset{12, 5, 0});
+    
+    if (isGfx1250) {
+      // gfx1250 has three different intrinsic signature patterns:
+      // 1. ModsAllReuse (f16/bf16/f32): (A_mod, A, B_mod, B, C_mod, C, A_reuse, B_reuse)
+      // 2. ModsC (fp8/bf8): (A, B, C_mod, C, A_reuse, B_reuse)
+      // 3. ModsAB (integers): (A_mod, A, B_mod, B, C, A_reuse, B_reuse)
+      
+      Value falseVal = createI1Constant(rewriter, loc, false);
+      Value zeroI16 = rewriter.create<LLVM::ConstantOp>(
+          loc, rewriter.getI16Type(), rewriter.getI16IntegerAttr(0));
+      
+      auto sourceAVecType = cast<VectorType>(op.getSourceA().getType());
+      Type elemSourceA = sourceAVecType.getElementType();
+      Type elemDestC = cast<VectorType>(op.getDestC().getType()).getElementType();
+      
+      using fp8 = Float8E4M3FNType;
+      using bf8 = Float8E5M2Type;
+      
+      bool isFp8Input = isa<fp8, bf8>(elemSourceA);
+      bool isIntOutput = elemDestC.isInteger(32);
+      
+      Value sourceA = adaptor.getSourceA();
+      Value sourceB = adaptor.getSourceB();
+      Value destC = adaptor.getDestC();
+      
+      // Handle BF16 and FP8/BF8 bitcasting
+      if (auto vecType = dyn_cast<VectorType>(sourceA.getType())) {
+        if (vecType.getElementType().isBF16()) {
+          sourceA = LLVM::BitcastOp::create(
+              rewriter, loc, vecType.clone(rewriter.getI16Type()), sourceA);
+        } else if (vecType.getElementType().getIntOrFloatBitWidth() == 8) {
+          // Pack 8-bit FP8/BF8 elements into 32-bit integers (v32i8 -> v8i32)
+          int64_t numBits = vecType.getNumElements() * 8;
+          Type i32 = rewriter.getI32Type();
+          Type packedType = VectorType::get(numBits / 32, i32);
+          sourceA = rewriter.createOrFold<LLVM::BitcastOp>(loc, packedType, sourceA);
+        }
+      }
+      if (auto vecType = dyn_cast<VectorType>(sourceB.getType())) {
+        if (vecType.getElementType().isBF16()) {
+          sourceB = LLVM::BitcastOp::create(
+              rewriter, loc, vecType.clone(rewriter.getI16Type()), sourceB);
+        } else if (vecType.getElementType().getIntOrFloatBitWidth() == 8) {
+          // Pack 8-bit FP8/BF8 elements into 32-bit integers (v32i8 -> v8i32)
+          int64_t numBits = vecType.getNumElements() * 8;
+          Type i32 = rewriter.getI32Type();
+          Type packedType = VectorType::get(numBits / 32, i32);
+          sourceB = rewriter.createOrFold<LLVM::BitcastOp>(loc, packedType, sourceB);
+        }
+      }
+      
+      if (isFp8Input) {
+        // FP8/BF8 path (ModsC): (A, B, C_mod, C, A_reuse, B_reuse)
+        operands.push_back(sourceA);
+        operands.push_back(sourceB);
+        operands.push_back(zeroI16);  // C_mod
+        operands.push_back(destC);
+        operands.push_back(falseVal);  // matrix_a_reuse
+        operands.push_back(falseVal);  // matrix_b_reuse
+      } else if (isIntOutput) {
+        // Integer path (ModsAB): (A_mod, A, B_mod, B, C, A_reuse, B_reuse)
+        operands.push_back(falseVal);  // A_mod
+        wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedA(),
+                             sourceA, op.getSourceA(), operands);
+        operands.push_back(falseVal);  // B_mod
+        wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedB(),
+                             sourceB, op.getSourceB(), operands);
+        operands.push_back(destC);
+        operands.push_back(falseVal);  // matrix_a_reuse
+        operands.push_back(falseVal);  // matrix_b_reuse
+      } else {
+        // Float path (ModsAllReuse): (A_mod, A, B_mod, B, C_mod, C, A_reuse, B_reuse)
+        operands.push_back(falseVal);  // A_mod
+        operands.push_back(sourceA);
+        operands.push_back(falseVal);  // B_mod
+        operands.push_back(sourceB);
+        operands.push_back(zeroI16);   // C_mod
+        operands.push_back(destC);
+        operands.push_back(falseVal);  // matrix_a_reuse
+        operands.push_back(falseVal);  // matrix_b_reuse
+      }
+    } else {
+      // Original gfx11/gfx12 path
+      wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedA(),
+                           adaptor.getSourceA(), op.getSourceA(), operands);
+      wmmaPushInputOperand(rewriter, loc, typeConverter, op.getUnsignedB(),
+                           adaptor.getSourceB(), op.getSourceB(), operands);
+      wmmaPushOutputOperand(rewriter, loc, typeConverter, adaptor.getDestC(),
+                            op.getSubwordOffset(), op.getClamp(), operands);
+    }
 
     loweredOp.addOperands(operands);
     Operation *lowered = rewriter.create(loweredOp);

--- a/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -369,13 +369,15 @@ LogicalResult WMMAOp::verify() {
 
   if (!sourceAElemType.isFloat(8) && sourceAElemType != sourceBElemType) {
     return emitOpError(
-               "source element types much match (except for fp8) but have ")
+               "source element types must match (except for fp8/bf8) but have ")
            << sourceAType << " and " << sourceBType;
   }
 
-  if (!sourceAElemType.isInteger(4) && getK() != 16) {
-    return emitOpError("K dimension must be 16 for source element type ")
-           << sourceAElemType;
+  if (isSrcFloat) {
+    if (getClamp())
+      return emitOpError("clamp flag is not supported for float types");
+    if (getUnsignedA() || getUnsignedB())
+      return emitOpError("unsigned flags are not supported for float types");
   }
   return success();
 }

--- a/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -330,44 +330,52 @@ void RawBufferAtomicCmpswapOp::getCanonicalizationPatterns(
 //===----------------------------------------------------------------------===//
 // WMMAOp
 //===----------------------------------------------------------------------===//
+
+ParseResult mlir::amdgpu::parseMNKDimensionList(OpAsmParser &parser,
+                                                IntegerAttr &m, IntegerAttr &n,
+                                                IntegerAttr &k) {
+  SmallVector<int64_t, 3> dimensions;
+  if (parser.parseDimensionList(dimensions, false, false))
+    return failure();
+  if (dimensions.size() != 3)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected 3 dimensions in MNK dimension list";
+
+  m = parser.getBuilder().getI32IntegerAttr(dimensions[0]);
+  n = parser.getBuilder().getI32IntegerAttr(dimensions[1]);
+  k = parser.getBuilder().getI32IntegerAttr(dimensions[2]);
+  return success();
+}
+
 LogicalResult WMMAOp::verify() {
-  Type sourceAType = getSourceA().getType();
-  Type sourceBType = getSourceB().getType();
-  Type destType = getDestC().getType();
+  auto sourceAType = cast<VectorType>(getSourceA().getType());
+  auto sourceBType = cast<VectorType>(getSourceB().getType());
+  auto destType = cast<VectorType>(getDestC().getType());
 
-  VectorType sourceVectorAType = dyn_cast<VectorType>(sourceAType);
-  VectorType sourceVectorBType = dyn_cast<VectorType>(sourceBType);
-  VectorType destVectorType = dyn_cast<VectorType>(destType);
-
-  Type sourceAElemType = sourceVectorAType.getElementType();
-  Type sourceBElemType = sourceVectorBType.getElementType();
-  Type destElemType = destVectorType.getElementType();
-
-  if (sourceVectorAType.getNumElements() !=
-      sourceVectorBType.getNumElements()) {
+  Type sourceAElemType = sourceAType.getElementType();
+  Type sourceBElemType = sourceBType.getElementType();
+  if (sourceAType.getNumElements() != sourceBType.getNumElements()) {
     return emitOpError("source vectors have different lengths: ")
-           << sourceVectorAType << " vs. " << sourceVectorBType;
+           << sourceAType << " vs. " << sourceBType;
   }
 
-  bool isDestFloat = isa<Float32Type, Float16Type, BFloat16Type>(destElemType);
-  bool isSrcFloat =
-      isa<Float16Type, BFloat16Type, Float8E4M3FNType, Float8E5M2Type>(
-          sourceAElemType);
+  bool isDestFloat = destType.getElementType().isFloat();
+  bool isSrcFloat = sourceAElemType.isFloat();
 
-  if (isDestFloat && !isSrcFloat) {
-    return emitOpError("Expected float sources with float destination");
-  }
+  if (isDestFloat && !isSrcFloat)
+    return emitOpError("expected float sources with float destination");
+  if (!isDestFloat && isSrcFloat)
+    return emitOpError("expected int sources with int destination");
 
-  if (!isDestFloat && isSrcFloat) {
-    return emitOpError("Expected int sources with int destination");
-  }
-
-  if (sourceAElemType != sourceBElemType &&
-      !(isa<Float8E5M2Type, Float8E4M3FNType>(sourceAElemType) &&
-        isa<Float8E5M2Type, Float8E4M3FNType>(sourceBElemType))) {
+  if (!sourceAElemType.isFloat(8) && sourceAElemType != sourceBElemType) {
     return emitOpError(
                "source element types much match (except for fp8) but have ")
            << sourceAType << " and " << sourceBType;
+  }
+
+  if (!sourceAElemType.isInteger(4) && getK() != 16) {
+    return emitOpError("K dimension must be 16 for source element type ")
+           << sourceAElemType;
   }
   return success();
 }

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx11.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx11.mlir
@@ -1,35 +1,36 @@
-// RUN: mlir-opt %s -convert-amdgpu-to-rocdl=chipset=gfx1100 --allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt %s --convert-amdgpu-to-rocdl=chipset=gfx1100 --allow-unregistered-dialect | FileCheck %s
+
 // CHECK-LABEL: @wmma_to_rocdl
 func.func @wmma_to_rocdl(%arg0 : vector<16xf16>, %arg1 : vector<8xf32>, %arg2 : vector<4xf32>,
                          %arg3 : vector<16xbf16>, %arg4 : vector<8xf16>, %arg5 : vector<8xbf16>,
                          %arg6 : vector<16xi8>, %arg7 : vector<8xi32>, %arg8 : vector<4xi32>,
                          %arg9 : vector<16xui8>, %arg10 : vector<16xi4>, %arg11 : vector<8xi4>) {
   // CHECK: rocdl.wmma.f32.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg0 * %arg0 + %arg1 : vector<16xf16>, vector<16xf16>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 : vector<16xf16>, vector<16xf16>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg0 * %arg0 + %arg2 : vector<16xf16>, vector<16xf16>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg2 : vector<16xf16>, vector<16xf16>, vector<4xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg3 * %arg3 + %arg1 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg1 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg3 * %arg3 + %arg2 : vector<16xbf16>, vector<16xbf16>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg2 : vector<16xbf16>, vector<16xbf16>, vector<4xf32>
   // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<16xf16>, i1) -> vector<16xf16>
-  amdgpu.wmma %arg0 * %arg0 + %arg0 {subwordOffset = 1 : i32}: vector<16xf16>, vector<16xf16>, vector<16xf16>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg0 {subwordOffset = 1 : i32}: vector<16xf16>, vector<16xf16>, vector<16xf16>
   // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<16xf16>, vector<16xf16>, vector<8xf16>, i1) -> vector<8xf16>
-  amdgpu.wmma %arg0 * %arg0 + %arg4 {subwordOffset = 0 : i32}: vector<16xf16>, vector<16xf16>, vector<8xf16>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg4 {subwordOffset = 0 : i32}: vector<16xf16>, vector<16xf16>, vector<8xf16>
   // CHECK: %[[raw_bf16x16:.+]] = rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<16xi16>, i1) -> vector<16xi16>
   // CHECK-NEXT: llvm.bitcast %[[raw_bf16x16]] : vector<16xi16> to vector<16xbf16>
-  amdgpu.wmma %arg3 * %arg3 + %arg3 {subwordOffset = 1 : i32}: vector<16xbf16>, vector<16xbf16>, vector<16xbf16>
+  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg3 {subwordOffset = 1 : i32}: vector<16xbf16>, vector<16xbf16>, vector<16xbf16>
   // CHECK: %[[raw_bf16x8:.+]] = rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<16xi16>, vector<16xi16>, vector<8xi16>, i1) -> vector<8xi16>
   // CHECK-NEXT: llvm.bitcast %[[raw_bf16x8]] : vector<8xi16> to vector<8xbf16>
-  amdgpu.wmma %arg3 * %arg3 + %arg5 {subwordOffset = 0 : i32}: vector<16xbf16>, vector<16xbf16>, vector<8xbf16>
+  amdgpu.wmma 16x16x16 %arg3 * %arg3 + %arg5 {subwordOffset = 0 : i32}: vector<16xbf16>, vector<16xbf16>, vector<8xbf16>
   // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, vector<4xi32>, i1, vector<4xi32>, vector<8xi32>, i1) -> vector<8xi32>
-  amdgpu.wmma %arg6 * %arg6 + %arg7 {clamp}: vector<16xi8>, vector<16xi8>, vector<8xi32>
+  amdgpu.wmma 16x16x16 %arg6 * %arg6 + %arg7 {clamp}: vector<16xi8>, vector<16xi8>, vector<8xi32>
   // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, vector<4xi32>, i1, vector<4xi32>, vector<4xi32>, i1) -> vector<4xi32>
-  amdgpu.wmma %arg9 * %arg9 + %arg8 {unsignedA, unsignedB, clamp}: vector<16xui8>, vector<16xui8>, vector<4xi32>
+  amdgpu.wmma 16x16x16 %arg9 * %arg9 + %arg8 {unsignedA, unsignedB, clamp}: vector<16xui8>, vector<16xui8>, vector<4xi32>
   // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
-  amdgpu.wmma %arg10 * %arg10 + %arg7 {clamp}: vector<16xi4>, vector<16xi4>, vector<8xi32>
+  amdgpu.wmma 16x16x16 %arg10 * %arg10 + %arg7 {clamp}: vector<16xi4>, vector<16xi4>, vector<8xi32>
   // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
-  amdgpu.wmma %arg11 * %arg11 + %arg8 {clamp}: vector<8xi4>, vector<8xi4>, vector<4xi32>
+  amdgpu.wmma 16x16x16 %arg11 * %arg11 + %arg8 {clamp}: vector<8xi4>, vector<8xi4>, vector<4xi32>
 
   func.return
 }

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx12.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx12.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -convert-amdgpu-to-rocdl=chipset=gfx1200 --allow-unregistered-dialect | FileCheck %s
+// RUN: mlir-opt %s --convert-amdgpu-to-rocdl=chipset=gfx1200 --allow-unregistered-dialect | FileCheck %s
 // CHECK-LABEL: @wmma_to_rocdl
 func.func @wmma_to_rocdl(%arg0 : vector<8xf16>, %arg1 : vector<4xf16>,
                          %arg2 : vector<8xf32>, %arg3 : vector<4xf32>,
@@ -9,60 +9,60 @@ func.func @wmma_to_rocdl(%arg0 : vector<8xf16>, %arg1 : vector<4xf16>,
                          %arg12 : vector<8xi32>, %arg13 : vector<4xi32>,
                          %arg14 : vector<16xi4>, %arg15 : vector<8xi4>, %arg16 : vector<4xi4>) {
   // CHECK: rocdl.wmma.f32.16x16x16.f16{{.*}}: (vector<8xf16>, vector<8xf16>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg0 * %arg0 + %arg2 : vector<8xf16>, vector<8xf16>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg2 : vector<8xf16>, vector<8xf16>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.f16{{.*}}: (vector<4xf16>, vector<4xf16>, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg1 * %arg1 + %arg3 : vector<4xf16>, vector<4xf16>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg1 * %arg1 + %arg3 : vector<4xf16>, vector<4xf16>, vector<4xf32>
 
   // CHECK: rocdl.wmma.f32.16x16x16.bf16{{.*}}: (vector<8xi16>, vector<8xi16>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg4 * %arg4 + %arg2 : vector<8xbf16>, vector<8xbf16>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg4 * %arg4 + %arg2 : vector<8xbf16>, vector<8xbf16>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.bf16{{.*}}: (vector<4xi16>, vector<4xi16>, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg5 * %arg5 + %arg3 : vector<4xbf16>, vector<4xbf16>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg5 * %arg5 + %arg3 : vector<4xbf16>, vector<4xbf16>, vector<4xf32>
 
   // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
-  amdgpu.wmma %arg0 * %arg0 + %arg0 : vector<8xf16>, vector<8xf16>, vector<8xf16>
+  amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg0 : vector<8xf16>, vector<8xf16>, vector<8xf16>
   // CHECK: rocdl.wmma.f16.16x16x16.f16{{.*}}: (vector<4xf16>, vector<4xf16>, vector<4xf16>, i1) -> vector<4xf16>
-  amdgpu.wmma %arg1 * %arg1 + %arg1 : vector<4xf16>, vector<4xf16>, vector<4xf16>
+  amdgpu.wmma 16x16x16 %arg1 * %arg1 + %arg1 : vector<4xf16>, vector<4xf16>, vector<4xf16>
 
   // CHECK: %[[raw_bf16x8:.+]] = rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<8xi16>, vector<8xi16>, vector<8xi16>, i1) -> vector<8xi16>
   // CHECK-NEXT: llvm.bitcast %[[raw_bf16x8]] : vector<8xi16> to vector<8xbf16>
-  amdgpu.wmma %arg4 * %arg4 + %arg4 : vector<8xbf16>, vector<8xbf16>, vector<8xbf16>
+  amdgpu.wmma 16x16x16 %arg4 * %arg4 + %arg4 : vector<8xbf16>, vector<8xbf16>, vector<8xbf16>
   // CHECK: rocdl.wmma.bf16.16x16x16.bf16{{.*}}: (vector<4xi16>, vector<4xi16>, vector<4xi16>, i1) -> vector<4xi16>
-  amdgpu.wmma %arg5 * %arg5 + %arg5 : vector<4xbf16>, vector<4xbf16>, vector<4xbf16>
+  amdgpu.wmma 16x16x16 %arg5 * %arg5 + %arg5 : vector<4xbf16>, vector<4xbf16>, vector<4xbf16>
 
   // CHECK: rocdl.wmma.f32.16x16x16.fp8_fp8{{.*}}: (vector<2xi32>, vector<2xi32>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg6 * %arg6 + %arg2 : vector<8xf8E4M3FN>, vector<8xf8E4M3FN>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg6 * %arg6 + %arg2 : vector<8xf8E4M3FN>, vector<8xf8E4M3FN>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.fp8_fp8{{.*}}: (i32, i32, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg7 * %arg7 + %arg3 : vector<4xf8E4M3FN>, vector<4xf8E4M3FN>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg7 * %arg7 + %arg3 : vector<4xf8E4M3FN>, vector<4xf8E4M3FN>, vector<4xf32>
 
   // CHECK: rocdl.wmma.f32.16x16x16.fp8_bf8{{.*}}: (vector<2xi32>, vector<2xi32>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg6 * %arg8 + %arg2 : vector<8xf8E4M3FN>, vector<8xf8E5M2>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg6 * %arg8 + %arg2 : vector<8xf8E4M3FN>, vector<8xf8E5M2>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.fp8_bf8{{.*}}: (i32, i32, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg7 * %arg9 + %arg3 : vector<4xf8E4M3FN>, vector<4xf8E5M2>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg7 * %arg9 + %arg3 : vector<4xf8E4M3FN>, vector<4xf8E5M2>, vector<4xf32>
 
   // CHECK: rocdl.wmma.f32.16x16x16.bf8_bf8{{.*}}: (vector<2xi32>, vector<2xi32>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg8 * %arg8 + %arg2 : vector<8xf8E5M2>, vector<8xf8E5M2>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg8 * %arg8 + %arg2 : vector<8xf8E5M2>, vector<8xf8E5M2>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.bf8_bf8{{.*}}: (i32, i32, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg9 * %arg9 + %arg3 : vector<4xf8E5M2>, vector<4xf8E5M2>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg9 * %arg9 + %arg3 : vector<4xf8E5M2>, vector<4xf8E5M2>, vector<4xf32>
 
   // CHECK: rocdl.wmma.f32.16x16x16.bf8_fp8{{.*}}: (vector<2xi32>, vector<2xi32>, vector<8xf32>) -> vector<8xf32>
-  amdgpu.wmma %arg8 * %arg6 + %arg2 : vector<8xf8E5M2>, vector<8xf8E4M3FN>, vector<8xf32>
+  amdgpu.wmma 16x16x16 %arg8 * %arg6 + %arg2 : vector<8xf8E5M2>, vector<8xf8E4M3FN>, vector<8xf32>
   // CHECK: rocdl.wmma.f32.16x16x16.bf8_fp8{{.*}}: (i32, i32, vector<4xf32>) -> vector<4xf32>
-  amdgpu.wmma %arg9 * %arg7 + %arg3 : vector<4xf8E5M2>, vector<4xf8E4M3FN>, vector<4xf32>
+  amdgpu.wmma 16x16x16 %arg9 * %arg7 + %arg3 : vector<4xf8E5M2>, vector<4xf8E4M3FN>, vector<4xf32>
 
   // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
-  amdgpu.wmma %arg10 * %arg10 + %arg12 {clamp} : vector<8xi8>, vector<8xi8>, vector<8xi32>
+  amdgpu.wmma 16x16x16 %arg10 * %arg10 + %arg12 {clamp} : vector<8xi8>, vector<8xi8>, vector<8xi32>
   // CHECK: rocdl.wmma.i32.16x16x16.iu8{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
-  amdgpu.wmma %arg11 * %arg11 + %arg13 {unsignedA, unsignedB, clamp}: vector<4xi8>, vector<4xi8>, vector<4xi32>
+  amdgpu.wmma 16x16x16 %arg11 * %arg11 + %arg13 {unsignedA, unsignedB, clamp}: vector<4xi8>, vector<4xi8>, vector<4xi32>
 
   // CHECK: rocdl.wmma.i32.16x16x32.iu4{{.*}}: (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
-  amdgpu.wmma %arg14 * %arg14 + %arg12 {clamp} : vector<16xi4>, vector<16xi4>, vector<8xi32>
+  amdgpu.wmma 16x16x32 %arg14 * %arg14 + %arg12 {clamp} : vector<16xi4>, vector<16xi4>, vector<8xi32>
   // CHECK: rocdl.wmma.i32.16x16x32.iu4{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
-  amdgpu.wmma %arg15 * %arg15 + %arg13 {clamp} : vector<8xi4>, vector<8xi4>, vector<4xi32>
+  amdgpu.wmma 16x16x32 %arg15 * %arg15 + %arg13 {clamp} : vector<8xi4>, vector<8xi4>, vector<4xi32>
 
   // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, i32, i1, i32, vector<8xi32>, i1) -> vector<8xi32>
-  amdgpu.wmma %arg15 * %arg15 + %arg12 {clamp} : vector<8xi4>, vector<8xi4>, vector<8xi32>
+  amdgpu.wmma 16x16x16 %arg15 * %arg15 + %arg12 {clamp} : vector<8xi4>, vector<8xi4>, vector<8xi32>
   // CHECK: rocdl.wmma.i32.16x16x16.iu4{{.*}}: (i1, i32, i1, i32, vector<4xi32>, i1) -> vector<4xi32>
-  amdgpu.wmma %arg16 * %arg16 + %arg13 {clamp} : vector<4xi4>, vector<4xi4>, vector<4xi32>
+  amdgpu.wmma 16x16x16 %arg16 * %arg16 + %arg13 {clamp} : vector<4xi4>, vector<4xi4>, vector<4xi32>
 
   func.return
 }

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx1250.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx1250.mlir
@@ -1,0 +1,89 @@
+// RUN: mlir-opt %s --convert-amdgpu-to-rocdl=chipset=gfx1250 --allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: @wmma_k4
+func.func @wmma_k4(%arg0 : vector<2xf32>, %arg1 : vector<8xf32>) {
+  // CHECK: rocdl.wmma.f32.16x16x4.f32 %arg0, %arg0, %arg1
+  amdgpu.wmma 16x16x4 %arg0 * %arg0 + %arg1 : vector<2xf32>, vector<2xf32>, vector<8xf32>
+  func.return
+}
+
+// CHECK-LABEL: @wmma_k32
+func.func @wmma_k32(%arg0 : vector<16xf16>, %arg1 : vector<16xbf16>, %arg2 : vector<8xf32>,
+                    %arg3 : vector<8xf16>, %arg4 : vector<8xbf16>) {
+  // CHECK: rocdl.wmma.f32.16x16x32.f16 %arg0, %arg0, %arg2
+  amdgpu.wmma 16x16x32 %arg0 * %arg0 + %arg2 : vector<16xf16>, vector<16xf16>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x32.f16 %arg0, %arg0, {{.*}} : (vector<16xf16>, vector<16xf16>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x32 %arg0 * %arg0 + %arg3 : vector<16xf16>, vector<16xf16>, vector<8xf16>
+
+  // CHECK: rocdl.wmma.f32.16x16x32.bf16 {{.*}}, {{.*}}, %arg2
+  amdgpu.wmma 16x16x32 %arg1 * %arg1 + %arg2 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.bf16.16x16x32.bf16 {{.*}}, {{.*}}, {{.*}}, {{.*}} : (vector<16xi16>, vector<16xi16>, vector<8xi16>, i1)
+  amdgpu.wmma 16x16x32 %arg1 * %arg1 + %arg4 : vector<16xbf16>, vector<16xbf16>, vector<8xbf16>
+
+  func.return
+}
+
+// CHECK-LABEL: @wmma_k64
+func.func @wmma_k64(%arg0 : vector<32xi8>, %arg1 : vector<32xf8E4M3FN>, %arg2 : vector<32xf8E5M2>,
+                    %arg3 : vector<8xi32>, %arg4 : vector<8xf32>, %arg5 : vector<8xf16>) {
+  // CHECK: rocdl.wmma.i32.16x16x64.iu8 {{.*}}, {{.*}}, {{.*}}, {{.*}}, %arg3, {{.*}}
+  amdgpu.wmma 16x16x64 %arg0 * %arg0 + %arg3 {clamp} : vector<32xi8>, vector<32xi8>, vector<8xi32>
+
+  // CHECK: rocdl.wmma.f32.16x16x64.fp8_fp8 {{.*}}, {{.*}}, %arg4
+  amdgpu.wmma 16x16x64 %arg1 * %arg1 + %arg4 : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x64.fp8_fp8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x64 %arg1 * %arg1 + %arg5 : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<8xf16>
+
+  // CHECK: rocdl.wmma.f32.16x16x64.fp8_bf8 {{.*}}, {{.*}}, %arg4
+  amdgpu.wmma 16x16x64 %arg1 * %arg2 + %arg4 : vector<32xf8E4M3FN>, vector<32xf8E5M2>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x64.fp8_bf8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x64 %arg1 * %arg2 + %arg5 : vector<32xf8E4M3FN>, vector<32xf8E5M2>, vector<8xf16>
+
+  // CHECK: rocdl.wmma.f32.16x16x64.bf8_bf8 {{.*}}, {{.*}}, %arg4
+  amdgpu.wmma 16x16x64 %arg2 * %arg2 + %arg4 : vector<32xf8E5M2>, vector<32xf8E5M2>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x64.bf8_bf8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x64 %arg2 * %arg2 + %arg5 : vector<32xf8E5M2>, vector<32xf8E5M2>, vector<8xf16>
+
+  // CHECK: rocdl.wmma.f32.16x16x64.bf8_fp8 {{.*}}, {{.*}}, %arg4
+  amdgpu.wmma 16x16x64 %arg2 * %arg1 + %arg4 : vector<32xf8E5M2>, vector<32xf8E4M3FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x64.bf8_fp8 {{.*}}, {{.*}}, %arg5, {{.*}} : (vector<8xi32>, vector<8xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x64 %arg2 * %arg1 + %arg5 : vector<32xf8E5M2>, vector<32xf8E4M3FN>, vector<8xf16>
+
+  func.return
+}
+
+// CHECK-LABEL: @wmma_k128
+func.func @wmma_k128(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<64xf8E5M2>,
+                     %arg2 : vector<8xf32>, %arg3 : vector<8xf16>) {
+  // CHECK: rocdl.wmma.f32.16x16x128.fp8_fp8 {{.*}}, {{.*}}, %arg2
+  amdgpu.wmma 16x16x128 %arg0 * %arg0 + %arg2 : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x128.fp8_fp8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x128 %arg0 * %arg0 + %arg3 : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf16>
+
+  // CHECK: rocdl.wmma.f32.16x16x128.fp8_bf8 {{.*}}, {{.*}}, %arg2
+  amdgpu.wmma 16x16x128 %arg0 * %arg1 + %arg2 : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x128.fp8_bf8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x128 %arg0 * %arg1 + %arg3 : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf16>
+
+  // CHECK: rocdl.wmma.f32.16x16x128.bf8_bf8 {{.*}}, {{.*}}, %arg2
+  amdgpu.wmma 16x16x128 %arg1 * %arg1 + %arg2 : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x128.bf8_bf8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x128 %arg1 * %arg1 + %arg3 : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf16>
+
+  // CHECK: rocdl.wmma.f32.16x16x128.bf8_fp8 {{.*}}, {{.*}}, %arg2
+  amdgpu.wmma 16x16x128 %arg1 * %arg0 + %arg2 : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.f16.16x16x128.bf8_fp8 {{.*}}, {{.*}}, %arg3, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf16>, i1)
+  amdgpu.wmma 16x16x128 %arg1 * %arg0 + %arg3 : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf16>
+
+  func.return
+}

--- a/external/llvm-project/mlir/test/Dialect/AMDGPU/invalid.mlir
+++ b/external/llvm-project/mlir/test/Dialect/AMDGPU/invalid.mlir
@@ -120,9 +120,49 @@ func.func @no_negation(%a: f32, %b: f32, %c: vector<32xf32>) -> vector<32xf32> {
 
 // -----
 
-func.func @wmma(%arg0 : vector<16xf16>, %arg1 : vector<8xi32>) -> vector<8xi32> {
-  // expected-error@+1 {{'amdgpu.wmma' op Expected int sources with int destination}}
-  %0 = amdgpu.wmma %arg0 * %arg0 + %arg1 : vector<16xf16>, vector<16xf16>, vector<8xi32>
+func.func @wmma_f16_i32(%arg0 : vector<16xf16>, %arg1 : vector<8xi32>) -> vector<8xi32> {
+  // expected-error@+1 {{'amdgpu.wmma' op expected int sources with int destination}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 : vector<16xf16>, vector<16xf16>, vector<8xi32>
+  func.return %0 : vector<8xi32>
+}
+
+// -----
+
+func.func @wmma_i16_f32(%arg0 : vector<16xi8>, %arg1 : vector<8xf32>) -> vector<8xf32> {
+  // expected-error@+1 {{'amdgpu.wmma' op expected float sources with float destination}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// -----
+
+func.func @wmma_no_k_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector<8xi32> {
+  // expected-error@+1 {{'amdgpu.wmma' expected 3 dimensions in MNK dimension list}}
+  %0 = amdgpu.wmma 16x16 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xi32>
+  func.return %0 : vector<8xi32>
+}
+
+// -----
+
+func.func @wmma_wrong_m_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector<8xi32> {
+  // expected-error@+1 {{'amdgpu.wmma' op attribute 'm' failed to satisfy constraint: 32-bit signless integer attribute whose value is one of {16}}}
+  %0 = amdgpu.wmma 32x16x16 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xi32>
+  func.return %0 : vector<8xi32>
+}
+
+// -----
+
+func.func @wmma_wrong_n_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector<8xi32> {
+  // expected-error@+1 {{'amdgpu.wmma' op attribute 'n' failed to satisfy constraint: 32-bit signless integer attribute whose value is one of {16}}}
+  %0 = amdgpu.wmma 16x32x16 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xi32>
+  func.return %0 : vector<8xi32>
+}
+
+// -----
+
+func.func @wmma_wrong_k_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector<8xi32> {
+  // expected-error@+1 {{'amdgpu.wmma' op attribute 'k' failed to satisfy constraint: 32-bit signless integer attribute whose value is one of {16, 32}}}
+  %0 = amdgpu.wmma 16x16x24 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xi32>
   func.return %0 : vector<8xi32>
 }
 

--- a/external/llvm-project/mlir/test/Dialect/AMDGPU/invalid.mlir
+++ b/external/llvm-project/mlir/test/Dialect/AMDGPU/invalid.mlir
@@ -144,14 +144,6 @@ func.func @wmma_no_k_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector
 
 // -----
 
-func.func @wmma_wrong_m_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector<8xi32> {
-  // expected-error@+1 {{'amdgpu.wmma' op attribute 'm' failed to satisfy constraint: 32-bit signless integer attribute whose value is one of {16}}}
-  %0 = amdgpu.wmma 32x16x16 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xi32>
-  func.return %0 : vector<8xi32>
-}
-
-// -----
-
 func.func @wmma_wrong_n_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector<8xi32> {
   // expected-error@+1 {{'amdgpu.wmma' op attribute 'n' failed to satisfy constraint: 32-bit signless integer attribute whose value is one of {16}}}
   %0 = amdgpu.wmma 16x32x16 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xi32>
@@ -161,14 +153,62 @@ func.func @wmma_wrong_n_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vec
 // -----
 
 func.func @wmma_wrong_k_dim(%arg0 : vector<16xi8>, %arg1 : vector<8xi32>) -> vector<8xi32> {
-  // expected-error@+1 {{'amdgpu.wmma' op attribute 'k' failed to satisfy constraint: 32-bit signless integer attribute whose value is one of {16, 32}}}
+  // expected-error@+1 {{'amdgpu.wmma' op attribute 'k' failed to satisfy constraint: 32-bit signless integer attribute whose value is one of {4, 16, 32, 64, 128}}}
   %0 = amdgpu.wmma 16x16x24 %arg0 * %arg0 + %arg1 : vector<16xi8>, vector<16xi8>, vector<8xi32>
   func.return %0 : vector<8xi32>
 }
 
 // -----
 
-// Missinng `resetOffset`
+func.func @wmma_source_length_mismatch(%arg0 : vector<8xf16>, %arg1 : vector<16xf16>, %arg2 : vector<8xf32>) -> vector<8xf32> {
+  // expected-error@+1 {{'amdgpu.wmma' op source vectors have different lengths}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg1 + %arg2 : vector<8xf16>, vector<16xf16>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// -----
+
+func.func @wmma_mismatched_float_types(%arg0 : vector<8xf16>, %arg1 : vector<8xbf16>, %arg2 : vector<8xf32>) -> vector<8xf32> {
+  // expected-error@+1 {{'amdgpu.wmma' op source element types must match (except for fp8/bf8)}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg1 + %arg2 : vector<8xf16>, vector<8xbf16>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// -----
+
+func.func @wmma_mismatched_int_types(%arg0 : vector<8xi8>, %arg1 : vector<8xi4>, %arg2 : vector<8xi32>) -> vector<8xi32> {
+  // expected-error@+1 {{'amdgpu.wmma' op source element types must match (except for fp8/bf8)}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg1 + %arg2 : vector<8xi8>, vector<8xi4>, vector<8xi32>
+  func.return %0 : vector<8xi32>
+}
+
+// -----
+
+func.func @wmma_clamp_float(%arg0 : vector<8xf16>, %arg1 : vector<8xf32>) -> vector<8xf32> {
+  // expected-error@+1 {{'amdgpu.wmma' op clamp flag is not supported for float types}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 {clamp} : vector<8xf16>, vector<8xf16>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// -----
+
+func.func @wmma_unsignedA_float(%arg0 : vector<8xf16>, %arg1 : vector<8xf32>) -> vector<8xf32> {
+  // expected-error@+1 {{'amdgpu.wmma' op unsigned flags are not supported for float types}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 {unsignedA} : vector<8xf16>, vector<8xf16>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// -----
+
+func.func @wmma_unsignedB_float(%arg0 : vector<8xf16>, %arg1 : vector<8xf32>) -> vector<8xf32> {
+  // expected-error@+1 {{'amdgpu.wmma' op unsigned flags are not supported for float types}}
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 {unsignedB} : vector<8xf16>, vector<8xf16>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// -----
+
+// Missing `resetOffset`
 func.func @fat_raw_buffer_cast_stripped_offset(%m: memref<8xi32, strided<[1], offset: ?>, #gpu.address_space<global>>) -> memref<8xi32, #amdgpu.address_space<fat_raw_buffer>> {
   // expected-error@+1 {{'amdgpu.fat_raw_buffer_cast' op expected result type to be 'memref<8xi32, strided<[1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>' but got 'memref<8xi32, #amdgpu.address_space<fat_raw_buffer>>'}}
   %ret = amdgpu.fat_raw_buffer_cast %m : memref<8xi32, strided<[1], offset: ?>, #gpu.address_space<global>> to memref<8xi32, #amdgpu.address_space<fat_raw_buffer>>

--- a/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
@@ -524,6 +524,41 @@ func.func @wmma_i32_16x16x32_i4(%arg0 : vector<16xi4>, %arg1 : vector<8xi32>) ->
   func.return %0 : vector<8xi32>
 }
 
+// CHECK-LABEL: func @wmma_f32_16x16x4_f32
+func.func @wmma_f32_16x16x4_f32(%arg0 : vector<2xf32>, %arg1 : vector<8xf32>) -> vector<8xf32> {
+  // CHECK: amdgpu.wmma 16x16x4
+  %0 = amdgpu.wmma 16x16x4 %arg0 * %arg0 + %arg1 : vector<2xf32>, vector<2xf32>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// CHECK-LABEL: func @wmma_f32_16x16x64_f8
+func.func @wmma_f32_16x16x64_f8(%arg0 : vector<32xf8E4M3FN>, %arg1 : vector<8xf32>) -> vector<8xf32> {
+  // CHECK: amdgpu.wmma 16x16x64
+  %0 = amdgpu.wmma 16x16x64 %arg0 * %arg0 + %arg1 : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// CHECK-LABEL: func @wmma_f32_16x16x64_bf8
+func.func @wmma_f32_16x16x64_bf8(%arg0 : vector<32xf8E5M2>, %arg1 : vector<8xf32>) -> vector<8xf32> {
+  // CHECK: amdgpu.wmma 16x16x64
+  %0 = amdgpu.wmma 16x16x64 %arg0 * %arg0 + %arg1 : vector<32xf8E5M2>, vector<32xf8E5M2>, vector<8xf32>
+  func.return %0 : vector<8xf32>
+}
+
+// CHECK-LABEL: func @wmma_f16_16x16x64_bf8
+func.func @wmma_f16_16x16x64_bf8(%arg0 : vector<32xf8E5M2>, %arg1 : vector<8xf16>) -> vector<8xf16> {
+  // CHECK: amdgpu.wmma 16x16x64
+  %0 = amdgpu.wmma 16x16x64 %arg0 * %arg0 + %arg1 : vector<32xf8E5M2>, vector<32xf8E5M2>, vector<8xf16>
+  func.return %0 : vector<8xf16>
+}
+
+// CHECK-LABEL: func @wmma_f16_16x16x64_f8
+func.func @wmma_f16_16x16x64_f8(%arg0 : vector<32xf8E4M3FN>, %arg1 : vector<8xf16>) -> vector<8xf16> {
+  // CHECK: amdgpu.wmma 16x16x64
+  %0 = amdgpu.wmma 16x16x64 %arg0 * %arg0 + %arg1 : vector<32xf8E4M3FN>, vector<32xf8E4M3FN>, vector<8xf16>
+  func.return %0 : vector<8xf16>
+}
+
 // CHECK-LABEL: func @swizzle_bitmode
 func.func @swizzle_bitmode(%arg0 : f32) -> f32 {
   // CHECK: amdgpu.swizzle_bitmode

--- a/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
@@ -510,11 +510,18 @@ func.func @mfma(%arg0 : f32, %arg1 : vector<32xf32>) -> vector<32xf32> {
   func.return %0 : vector<32xf32>
 }
 
-// CHECK-LABEL: func @wmma
-func.func @wmma(%arg0 : vector<16xf16>, %arg1 : vector<8xf16>) -> vector<8xf16> {
-  // CHECK: amdgpu.wmma
-  %0 = amdgpu.wmma %arg0 * %arg0 + %arg1 : vector<16xf16>, vector<16xf16>, vector<8xf16>
+// CHECK-LABEL: func @wmma_f16_16x16x16_f16
+func.func @wmma_f16_16x16x16_f16(%arg0 : vector<16xf16>, %arg1 : vector<8xf16>) -> vector<8xf16> {
+  // CHECK: amdgpu.wmma 16x16x16
+  %0 = amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 : vector<16xf16>, vector<16xf16>, vector<8xf16>
   func.return %0 : vector<8xf16>
+}
+
+// CHECK-LABEL: func @wmma_i32_16x16x32_i4
+func.func @wmma_i32_16x16x32_i4(%arg0 : vector<16xi4>, %arg1 : vector<8xi32>) -> vector<8xi32> {
+  // CHECK: amdgpu.wmma 16x16x32
+  %0 = amdgpu.wmma 16x16x32 %arg0 * %arg0 + %arg1 : vector<16xi4>, vector<16xi4>, vector<8xi32>
+  func.return %0 : vector<8xi32>
 }
 
 // CHECK-LABEL: func @swizzle_bitmode

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -816,9 +816,11 @@ llvm.func @rocdl.mfma.scale.f32.16x16x128.f8f6f4(%arg0 : i32,
 }
 
 llvm.func @rocdl.wmma(%arg0 : vector<8xf32>, %arg1 : vector<16 x f16>, %arg2 : vector<16 x i16>, %arg3 : vector<8 x i32>,
-                      %arg4 : vector<2xi32>, %arg5 : vector<4xi32>, %arg6 : vector<4xf32>, %arg7 : vector<8xf16>, %arg8 : vector<8xi16>) -> vector<8xf32> {
+                      %arg4 : vector<2xi32>, %arg5 : vector<4xi32>, %arg6 : vector<4xf32>, %arg7 : vector<8xf16>, %arg8 : vector<8xi16>,
+                      %arg9 : vector<32xf16>, %arg10 : vector<16xf32>, %arg11 : vector<4xf32>, %arg12 : vector<32xf32>, %arg13 : vector<64xf32>, 
+                      %arg14 : vector<64xi32>, %arg15 : vector<64xf16>, %arg16 : vector<16xbf16>, %arg17 : vector<32xbf16>) -> vector<8xf32> {
   %zero = llvm.mlir.constant(false) : i1
-
+  %zero_i16 = llvm.mlir.constant(0 : i16) : i16
   // ---- Wave32 -----
 
   // f16 -> f32
@@ -848,6 +850,83 @@ llvm.func @rocdl.wmma(%arg0 : vector<8xf32>, %arg1 : vector<16 x f16>, %arg2 : v
   // int4 -> int32 (signA = {0,1}, signB = {0,1}, clamp = {0,1})
   // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x32.iu4.v8i32.v2i32(i1 {{.*}}, <2 x i32> %{{.*}}, i1 {{.*}}, <2 x i32> %{{.*}}, <8 x i32> %{{.*}}, i1 {{.*}})
   %r6.gfx12 = rocdl.wmma.i32.16x16x32.iu4 %zero, %arg4, %zero, %arg4, %arg3, %zero : (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
+
+  // f32 -> f32
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x4.f32.v4f32.v16f32(i1 {{.*}}, <16 x float> %{{.*}}, i1 {{.*}}, <16 x float> %{{.*}}, i16 0, <4 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r1.gfx1250 = rocdl.wmma.f32.16x16x4.f32 %zero, %arg10, %zero, %arg10, %zero_i16, %arg11, %zero, %zero : (i1, vector<16xf32>, i1, vector<16xf32>, i16, vector<4xf32>, i1, i1) -> vector<4xf32>
+
+  // f16 -> f32
+  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.f16.v32f32.v16f16(i1 {{.*}}, <16 x half> %{{.*}}, i1 {{.*}}, <16 x half> %{{.*}}, i16 0, <32 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r2.gfx1250 = rocdl.wmma.f32.16x16x32.f16 %zero, %arg1, %zero, %arg1, %zero_i16, %arg12, %zero, %zero : (i1, vector<16xf16>, i1, vector<16xf16>, i16, vector<32xf32>, i1, i1) -> vector<32xf32>
+
+  // bf16 -> f32
+  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.bf16.v32f32.v16bf16(i1 {{.*}}, <16 x bfloat> %{{.*}}, i1 {{.*}}, <16 x bfloat> %{{.*}}, i16 0, <32 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r3.gfx1250 = rocdl.wmma.f32.16x16x32.bf16 %zero, %arg16, %zero, %arg16, %zero_i16, %arg12, %zero, %zero : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<32xf32>, i1, i1) -> vector<32xf32>
+
+  // f16 -> f16
+  // CHECK: call <32 x half> @llvm.amdgcn.wmma.f16.16x16x32.f16.v32f16.v16f16(i1 {{.*}}, <16 x half> %{{.*}}, i1 {{.*}}, <16 x half> %{{.*}}, i16 0, <32 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r4.gfx1250 = rocdl.wmma.f16.16x16x32.f16 %zero, %arg1, %zero, %arg1, %zero_i16, %arg9, %zero, %zero : (i1, vector<16xf16>, i1, vector<16xf16>, i16, vector<32xf16>, i1, i1) -> vector<32xf16>
+
+  // bf16 -> bf16
+  // CHECK: call <32 x bfloat> @llvm.amdgcn.wmma.bf16.16x16x32.bf16.v32bf16.v16bf16(i1 {{.*}}, <16 x bfloat> %{{.*}}, i1 {{.*}}, <16 x bfloat> %{{.*}}, i16 0, <32 x bfloat> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r5.gfx1250 = rocdl.wmma.bf16.16x16x32.bf16 %zero, %arg16, %zero, %arg16, %zero_i16, %arg17, %zero, %zero : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<32xbf16>, i1, i1) -> vector<32xbf16>
+
+  // bf16 -> bf16 / f32
+  // CHECK: call <32 x bfloat> @llvm.amdgcn.wmma.bf16f32.16x16x32.bf16.v32bf16.v16bf16.v32f32(i1 {{.*}}, <16 x bfloat> %{{.*}}, i1 {{.*}}, <16 x bfloat> %{{.*}}, i16 0, <32 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r6.gfx1250 = rocdl.wmma.bf16f32.16x16x32.bf16 %zero, %arg16, %zero, %arg16, %zero_i16, %arg12, %zero, %zero : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<32xf32>, i1, i1) -> vector<32xbf16>
+
+  // f8/bf8 -> f16/f32
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.fp8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r7.gfx1250 = rocdl.wmma.f32.16x16x64.fp8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.fp8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r8.gfx1250 = rocdl.wmma.f32.16x16x64.fp8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.bf8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r9.gfx1250 = rocdl.wmma.f32.16x16x64.bf8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x64.bf8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r10.gfx1250 = rocdl.wmma.f32.16x16x64.bf8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.fp8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r11.gfx1250 = rocdl.wmma.f16.16x16x64.fp8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.fp8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r12.gfx1250 = rocdl.wmma.f16.16x16x64.fp8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.bf8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r13.gfx1250 = rocdl.wmma.f16.16x16x64.bf8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x64.bf8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r14.gfx1250 = rocdl.wmma.f16.16x16x64.bf8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.fp8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r15.gfx1250 = rocdl.wmma.f32.16x16x128.fp8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.fp8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r16.gfx1250 = rocdl.wmma.f32.16x16x128.fp8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.bf8.fp8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r17.gfx1250 = rocdl.wmma.f32.16x16x128.bf8_fp8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x float> @llvm.amdgcn.wmma.f32.16x16x128.bf8.bf8.v64f32.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x float> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r18.gfx1250 = rocdl.wmma.f32.16x16x128.bf8_bf8 %arg5, %arg5, %zero_i16, %arg13, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf32>, i1, i1) -> vector<64xf32>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r19.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r20.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.bf8.fp8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r21.gfx1250 = rocdl.wmma.f16.16x16x128.bf8_fp8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.bf8.bf8.v64f16.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{.*}}, i16 0, <64 x half> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r22.gfx1250 = rocdl.wmma.f16.16x16x128.bf8_bf8 %arg5, %arg5, %zero_i16, %arg15, %zero, %zero : (vector<4xi32>, vector<4xi32>, i16, vector<64xf16>, i1, i1) -> vector<64xf16>
+
+  // iu8 -> i32
+  // CHECK: call <64 x i32> @llvm.amdgcn.wmma.i32.16x16x64.iu8.v64i32.v4i32(i1 {{.*}}, <4 x i32> %{{.*}}, i1 {{.*}}, <4 x i32> %{{.*}}, <64 x i32> %{{.*}}, i1 {{.*}}, i1 {{.*}})
+  %r23.gfx1250 = rocdl.wmma.i32.16x16x64.iu8 %zero, %arg5, %zero, %arg5, %arg14, %zero, %zero : (i1, vector<4xi32>, i1, vector<4xi32>, vector<64xi32>, i1, i1) -> vector<64xi32>
 
   // ---- Wave64 -----
 

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -969,8 +969,8 @@ defvar NativeMemoryOpTypes =
      F8E4M3FN, F4E2M1FN, F8E8M0FNU,
      VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32, F4E2M1FN, F8E8M0FNU]>,
      VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
-     VectorOfLengthAndType<[2, 4, 8, 16], [I8, F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2,
-                                           F8E4M3FN]>];
+     VectorOfLengthAndType<[2, 4, 8, 16, 32, 64], [I8, F8E5M2FNUZ, F8E4M3FNUZ,
+                                                   F8E5M2, F8E4M3FN]>];
 
 // in_bounds_load
 def Rock_InBoundsLoadOp

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -55,6 +55,8 @@ struct WmmaInsnInfo {
   StringRef insn;
   int64_t inputVectorLen;
   int64_t outputVectorLen;
+  int64_t mPerAccel;
+  int64_t nPerAccel;
 };
 
 // Key type for WMMA instruction maps: (TypeId, K dimension)
@@ -62,7 +64,8 @@ using WmmaInsnKey = std::pair<WmmaTypeId, int64_t>;
 
 struct WmmaInsn {
   StringRef insn;
-  int64_t dPerAccel;
+  int64_t mPerAccel;
+  int64_t nPerAccel;
   int64_t kDim;
   int64_t outputStride;
   int64_t mRepeats;

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -22,9 +22,48 @@
 namespace mlir {
 namespace rock {
 
+// Type IDs for WMMA instruction selection
+// Naming convention: InputType(s)_To_OutputType_TyId
+enum class WmmaTypeId : uint32_t {
+  // F32 output
+  F32_To_F32_TyId = 0, // F32 x F32 -> F32
+  F16_To_F32_TyId,     // F16 x F16 -> F32
+  Bf16_To_F32_TyId,    // BF16 x BF16 -> F32
+  Fp8Fp8_To_F32_TyId,  // FP8 x FP8 -> F32
+  Fp8Bf8_To_F32_TyId,  // FP8 x BF8 -> F32
+  Bf8Fp8_To_F32_TyId,  // BF8 x FP8 -> F32
+  Bf8Bf8_To_F32_TyId,  // BF8 x BF8 -> F32
+
+  // F16 output
+  F16_To_F16_TyId,    // F16 x F16 -> F16
+  Fp8Fp8_To_F16_TyId, // FP8 x FP8 -> F16
+  Fp8Bf8_To_F16_TyId, // FP8 x BF8 -> F16
+  Bf8Fp8_To_F16_TyId, // BF8 x FP8 -> F16
+  Bf8Bf8_To_F16_TyId, // BF8 x BF8 -> F16
+
+  // BF16 output
+  Bf16_To_Bf16_TyId,    // BF16 x BF16 -> BF16
+  Bf16_To_Bf16F32_TyId, // BF16 x BF16 -> mixed BF16/F32
+
+  // Integer output
+  I8_To_I32_TyId, // I8 x I8 -> I32
+  I4_To_I32_TyId  // I4 x I4 -> I32
+};
+
+// Information needed to create a WMMA instruction
+struct WmmaInsnInfo {
+  StringRef insn;
+  int64_t inputVectorLen;
+  int64_t outputVectorLen;
+};
+
+// Key type for WMMA instruction maps: (TypeId, K dimension)
+using WmmaInsnKey = std::pair<WmmaTypeId, int64_t>;
+
 struct WmmaInsn {
   StringRef insn;
   int64_t dPerAccel;
+  int64_t kDim;
   int64_t outputStride;
   int64_t mRepeats;
   int64_t nRepeats;
@@ -36,7 +75,8 @@ public:
   bool isCoherentWithK(int64_t kpack, int64_t kPerBlock);
   static FailureOr<WmmaInsn> select(Type elementTypeA, Type elementTypeB,
                                     int64_t waveSize, StringRef arch,
-                                    int64_t mPerWave, int64_t nPerWave);
+                                    int64_t mPerWave, int64_t nPerWave,
+                                    int64_t kPack, int64_t kPackPerBlock);
 };
 } // namespace rock
 } // namespace mlir

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -112,6 +112,18 @@ static constexpr AmdArchInfo
               /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/12,
               /*hasFp8ConversionInstrs=*/false,
               /*hasOcpFp8ConversionInstrs=*/true, /*hasScaledGemm=*/false,
+              /*maxNumXCC=*/1),
+    // TODO: Verify gfx1250 specifications (shared memory sizes, SGPR count, etc.)
+    // when available
+    gfx1250Info(GemmFeatures::dot | GemmFeatures::atomic_add |
+                  GemmFeatures::atomic_fmax_f32 | GemmFeatures::wmma |
+                  GemmFeatures::atomic_add_f16 |
+                  GemmFeatures::atomic_add_bf16,
+              /*waveSize=*/32, /*maxWavesPerEU*/ 16, /*totalSGPRPerEU*/ 800,
+              /*totalVGPRPerEU*/ 1536, /*totalSharedMemPerCU*/ 131072,
+              /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/12,
+              /*hasFp8ConversionInstrs=*/false,
+              /*hasOcpFp8ConversionInstrs=*/true, /*hasScaledGemm=*/false,
               /*maxNumXCC=*/1);
 
 static std::tuple<StringRef, unsigned> parseArchString(StringRef arch) {
@@ -367,7 +379,9 @@ AmdArchInfo mlir::rock::lookupArchInfo(StringRef arch) {
     return rdna3Info;
   }
   if (major == "gfx12") {
-    return rdna4Info;
+    return llvm::StringSwitch<AmdArchInfo>(minor)
+        .Case("50", gfx1250Info)
+        .Default(rdna4Info);
   }
   auto msg = "Unsupported architecture: " + arch.str();
   llvm_unreachable(msg.c_str());

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -710,20 +710,44 @@ static LogicalResult verifyGemmTypes(Operation *op, GemmFeatures features,
                                      StringRef arch, Type elemTypeA,
                                      Type elemTypeB, Type elemTypeC) {
   bool isGfx11 = arch.contains("gfx11");
+  bool isGfx1250 = arch.contains("gfx1250");
   if (isa<Float8E8M0FNUType>(elemTypeA) || isa<Float8E8M0FNUType>(elemTypeB)) {
     return op->emitOpError(
         "Matrix A or B is not allowed to have Float8E8M0FNU types");
   }
   if (bitEnumContainsAll(features, GemmFeatures::wmma)) {
-    if (!(elemTypeA.isF16() || elemTypeA.isBF16() || elemTypeA.isInteger(8))) {
+    // Validate input data types based on architecture
+    bool isValidTypeA = elemTypeA.isF16() || elemTypeA.isBF16() ||
+                        elemTypeA.isInteger(8) || isFloat8Type(elemTypeA);
+
+    // gfx1250 additionally supports F32
+    if (isGfx1250)
+      isValidTypeA = isValidTypeA || elemTypeA.isF32();
+
+    // gfx11 doesn't support float8 types
+    if (isGfx11 && isFloat8Type(elemTypeA))
+      isValidTypeA = false;
+
+    if (!isValidTypeA) {
       if (isGfx11)
         return op->emitOpError("Wmma supports only F16/BF16/int8 data types");
-      if (!isFloat8Type(elemTypeA))
+      if (isGfx1250)
         return op->emitOpError(
-            "Wmma supports only F16/BF16/int8/E4M3/E5M2 data types");
+            "Wmma supports only F32/F16/BF16/int8/E4M3/E5M2 data types");
+      return op->emitOpError(
+          "Wmma supports only F16/BF16/int8/E4M3/E5M2 data types");
     }
-    if (elemTypeA != elemTypeB)
-      return op->emitOpError("Wmma does not support mixed types");
+
+    // Validate mixed types
+    if (elemTypeA != elemTypeB) {
+      // gfx1250 allows mixed precision for float8 types only
+      bool allowMixed =
+          isGfx1250 && isFloat8Type(elemTypeA) && isFloat8Type(elemTypeB);
+      if (!allowMixed)
+        return op->emitOpError(isGfx1250 ? "Wmma on gfx1250 supports mixed "
+                                           "types only for FP8/BF8 combinations"
+                                         : "Wmma does not support mixed types");
+    }
   }
   if (bitEnumContainsAll(features, GemmFeatures::mfma)) {
     bool isGfx95 = arch.contains("gfx95");

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -17,53 +17,270 @@
 using namespace mlir;
 using namespace mlir::rock;
 
-static Type getRetType(Type inputType) {
+static Type getRetType(Type inputType, WmmaTypeId typeId) {
   Builder b(inputType.getContext());
-  if (inputType.isInteger(8))
+
+  // Integer types always output I32
+  if (typeId == WmmaTypeId::I8_To_I32_TyId ||
+      typeId == WmmaTypeId::I4_To_I32_TyId)
     return b.getI32Type();
 
+  // F16 output variants
+  if (typeId == WmmaTypeId::F16_To_F16_TyId ||
+      typeId == WmmaTypeId::Fp8Fp8_To_F16_TyId ||
+      typeId == WmmaTypeId::Fp8Bf8_To_F16_TyId ||
+      typeId == WmmaTypeId::Bf8Fp8_To_F16_TyId ||
+      typeId == WmmaTypeId::Bf8Bf8_To_F16_TyId)
+    return b.getF16Type();
+
+  // BF16 output variants
+  if (typeId == WmmaTypeId::Bf16_To_Bf16_TyId ||
+      typeId == WmmaTypeId::Bf16_To_Bf16F32_TyId)
+    return b.getBF16Type();
+
+  // Default: F32 output
   return b.getF32Type();
 }
 
-bool WmmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
-  int64_t inputVectorLen = argTypeA.getNumElements();
-  if (kPerBlock * kpack < inputVectorLen) {
+// Convert input types to type ID. This handles both same-type and mixed-type
+// inputs and always uses F32/I32 outputs
+static WmmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
+  // Same type inputs
+  if (dataTypeA == dataTypeB) {
+    if (dataTypeA.isF32())
+      return WmmaTypeId::F32_To_F32_TyId;
+    if (dataTypeA.isF16())
+      return WmmaTypeId::F16_To_F32_TyId;
+    if (dataTypeA.isBF16())
+      return WmmaTypeId::Bf16_To_F32_TyId;
+    if (dataTypeA.isInteger(8))
+      return WmmaTypeId::I8_To_I32_TyId;
+    if (dataTypeA.isInteger(4))
+      return WmmaTypeId::I4_To_I32_TyId;
+  }
+
+  // Mixed precision FP8/BF8 combinations
+  if (isa<Float8E4M3FNType>(dataTypeA) && isa<Float8E4M3FNType>(dataTypeB))
+    return WmmaTypeId::Fp8Fp8_To_F32_TyId;
+  if (isa<Float8E4M3FNType>(dataTypeA) && isa<Float8E5M2Type>(dataTypeB))
+    return WmmaTypeId::Fp8Bf8_To_F32_TyId;
+  if (isa<Float8E5M2Type>(dataTypeA) && isa<Float8E4M3FNType>(dataTypeB))
+    return WmmaTypeId::Bf8Fp8_To_F32_TyId;
+  if (isa<Float8E5M2Type>(dataTypeA) && isa<Float8E5M2Type>(dataTypeB))
+    return WmmaTypeId::Bf8Bf8_To_F32_TyId;
+
+  llvm_unreachable("Unsupported WMMA input type combination");
+}
+
+// WMMA instructions available on gfx11
+static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx11() {
+  static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
+      {{WmmaTypeId::F16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 16, 8}},
+      {{WmmaTypeId::Bf16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 16, 8}},
+      {{WmmaTypeId::I8_To_I32_TyId, 16},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 16, 8}},
+  };
+  return insnMap;
+}
+
+// WMMA instructions available on gfx12
+static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx12() {
+  static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
+      {{WmmaTypeId::F16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 8, 8}},
+      {{WmmaTypeId::Bf16_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 8, 8}},
+      {{WmmaTypeId::I8_To_I32_TyId, 16},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 8, 8}},
+
+      // FP8/BF8
+      {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName(), 8, 8}},
+      {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 16},
+       {ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName(), 8, 8}},
+  };
+  return insnMap;
+}
+
+// WMMA instructions available on gfx1250
+static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &
+getWmmaInsnMapGfx1250() {
+  static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
+      // F32
+      {{WmmaTypeId::F32_To_F32_TyId, 4},
+       {ROCDL::wmma_f32_16x16x4_f32::getOperationName(), 2, 8}},
+
+      // F16/BF16
+      {{WmmaTypeId::F16_To_F32_TyId, 32},
+       {ROCDL::wmma_f32_16x16x32_f16::getOperationName(), 16, 8}},
+      {{WmmaTypeId::Bf16_To_F32_TyId, 32},
+       {ROCDL::wmma_f32_16x16x32_bf16::getOperationName(), 16, 8}},
+
+      // FP8/BF8 (k=64)
+      {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_fp8_fp8::getOperationName(), 32, 8}},
+      {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_fp8_bf8::getOperationName(), 32, 8}},
+      {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_bf8_fp8::getOperationName(), 32, 8}},
+      {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 64},
+       {ROCDL::wmma_f32_16x16x64_bf8_bf8::getOperationName(), 32, 8}},
+
+      // FP8/BF8 (k=128)
+      {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_fp8_fp8::getOperationName(), 64, 8}},
+      {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_fp8_bf8::getOperationName(), 64, 8}},
+      {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_bf8_fp8::getOperationName(), 64, 8}},
+      {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 128},
+       {ROCDL::wmma_f32_16x16x128_bf8_bf8::getOperationName(), 64, 8}},
+
+      // I8
+      {{WmmaTypeId::I8_To_I32_TyId, 64},
+       {ROCDL::wmma_i32_16x16x64_iu8::getOperationName(), 32, 8}},
+  };
+  return insnMap;
+}
+
+// Helper function to validate K coherence
+// Returns true if kPerBlock * kPack is sufficient for the given inputVectorLen
+static bool isKCoherent(int64_t inputVectorLen, int64_t kPack,
+                        int64_t kPackPerBlock) {
+  if (kPackPerBlock * kPack % inputVectorLen != 0) {
     LLVM_DEBUG(llvm::dbgs()
-               << "kPerBlock*kpack needs to be a multiple of inputLen "
-               << inputVectorLen << "\n");
+               << "kPerBlock*kpack needs to be a multiple of inputLen: "
+               << kPackPerBlock << " * " << kPack << " = "
+               << (kPackPerBlock * kPack) << " % " << inputVectorLen << "\n");
     return false;
   }
   return true;
 }
 
+bool WmmaInsn::isCoherentWithK(int64_t kpack, int64_t kPerBlock) {
+  int64_t inputVectorLen = argTypeA.getNumElements();
+  return isKCoherent(inputVectorLen, kpack, kPerBlock);
+}
+
 FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
                                      mlir::Type elementTypeB, int64_t waveSize,
                                      StringRef arch, int64_t mPerWave,
-                                     int64_t nPerWave) {
-  LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma group selection:\n"
+                                     int64_t nPerWave, int64_t kPack,
+                                     int64_t kPackPerBlock) {
+  LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma instruction selection:\n"
                           << "elementTypeA: " << elementTypeA << "\n"
                           << "elementTypeB: " << elementTypeB << "\n"
+                          << "arch: " << arch << "\n"
                           << "mPerWave: " << mPerWave << "\n"
-                          << "nPerWave: " << nPerWave << "\n");
+                          << "nPerWave: " << nPerWave << "\n"
+                          << "kPack: " << kPack << "\n"
+                          << "kPackPerBlock: " << kPackPerBlock << "\n");
 
-  if (elementTypeA != elementTypeB)
-    return failure();
-
+  // WMMA only supports wave32
   if (waveSize != 32)
     return failure();
 
-  // Length of the input vectors that need to be passed to the WMMA
-  int64_t inputVectorLen = 8;
-  // Length of the ouput vector that needs to be passed to the WMMA
-  int64_t outputVectorLen = 8;
-  // Number of rows/cols a given wmma instruction computes
-  int64_t dPerAccel = 16;
+  // Architecture detection
+  bool isGfx11 = arch.contains("gfx11");
+  bool isGfx1250 = arch.contains("gfx1250");
 
-  int64_t outStride = 2;
-  if (arch.contains("gfx11")) {
-    inputVectorLen = 16;
+  // Convert element types to ID for map lookup. Handles both same-type and
+  // mixed-type inputs
+  WmmaTypeId typeId = convertTypesToId(elementTypeA, elementTypeB);
+
+  // Select instruction based on architecture priority: gfx1250 > gfx12 > gfx11
+  const WmmaInsnInfo *insnInfo = nullptr;
+  int64_t selectedKDim = 0; // Track the selected K dimension from the map key
+
+  if (isGfx1250) {
+    auto &gfx1250Map = getWmmaInsnMapGfx1250();
+
+    // FP8/BF8 types have multiple K options and we need to select the best one.
+    // We will always try to select the largest K value that is coherent with
+    // the KPack and KPackPerBlock, and then fall back to the smaller values
+    // if need be.
+    if (typeId >= WmmaTypeId::Fp8Fp8_To_F32_TyId &&
+        typeId <= WmmaTypeId::Bf8Bf8_To_F32_TyId) {
+      for (int64_t k : {128, 64}) {
+        auto it = gfx1250Map.find({typeId, k});
+        if (it != gfx1250Map.end()) {
+          const WmmaInsnInfo *info = &it->second;
+          if (isKCoherent(info->inputVectorLen, kPack, kPackPerBlock)) {
+            insnInfo = info;
+            selectedKDim = k; // Extract K from the key
+            LLVM_DEBUG(llvm::dbgs() << "Selected gfx1250 instruction: "
+                                    << insnInfo->insn << "\n");
+            break;
+          }
+        }
+      }
+    } else {
+      // All other types have only one K value, so we can just directly look
+      // that up
+      int64_t k;
+      if (typeId == WmmaTypeId::F32_To_F32_TyId) {
+        k = 4;
+      } else if (typeId == WmmaTypeId::I8_To_I32_TyId) {
+        k = 64;
+      } else {
+        // F16/BF16 types
+        k = 32;
+      }
+
+      auto it = gfx1250Map.find({typeId, k});
+      if (it != gfx1250Map.end()) {
+        insnInfo = &it->second;
+        selectedKDim = k;
+        LLVM_DEBUG(llvm::dbgs() << "Selected gfx1250 instruction: "
+                                << insnInfo->insn << "\n");
+      }
+    }
   }
 
+  // Use gfx12 only if we don't have gfx1250 or gfx11
+  if (!insnInfo && !isGfx1250 && !isGfx11) {
+    auto &gfx12Map = getWmmaInsnMapGfx12();
+    auto it = gfx12Map.find({typeId, 16});
+    if (it != gfx12Map.end()) {
+      insnInfo = &it->second;
+      selectedKDim = 16;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Selected gfx12 instruction: " << insnInfo->insn << "\n");
+    }
+  }
+
+  // Fall back to gfx11 if we are using gfx12, or if we explicitly ask for gfx11
+  if (!insnInfo && !isGfx1250 && isGfx11) {
+    auto &gfx11Map = getWmmaInsnMapGfx11();
+    auto it = gfx11Map.find({typeId, 16});
+    if (it != gfx11Map.end()) {
+      insnInfo = &it->second;
+      selectedKDim = 16;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Selected gfx11 instruction: " << insnInfo->insn << "\n");
+    }
+  }
+
+  if (!insnInfo)
+    return failure();
+
+  // Extract instruction info
+  int64_t inputVectorLen = insnInfo->inputVectorLen;
+  int64_t outputVectorLen = insnInfo->outputVectorLen;
+  int64_t kDim = selectedKDim;
+  StringRef insn = insnInfo->insn;
+
+  // WMMA constants
+  int64_t dPerAccel = 16; // M=N=16 for all WMMA
+
+  // Architecture-specific outStride
+  // gfx11: full-wave K cooperation -> outStride=2
+  // gfx12/gfx1250: half-wave K cooperation -> outStride=outputVectorLen
+  int64_t outStride = isGfx11 ? 2 : outputVectorLen;
+
+  // Validate dimensions
   if (mPerWave % inputVectorLen != 0 || mPerWave % dPerAccel != 0)
     return failure();
   if (nPerWave % inputVectorLen != 0 || nPerWave % dPerAccel != 0)
@@ -75,23 +292,8 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
   VectorType argTypeA = VectorType::get({inputVectorLen}, elementTypeA);
   VectorType argTypeB = VectorType::get({inputVectorLen}, elementTypeB);
   VectorType retType =
-      VectorType::get({outputVectorLen}, getRetType(elementTypeA));
+      VectorType::get({outputVectorLen}, getRetType(elementTypeA, typeId));
 
-  StringRef insn;
-  if (elementTypeA.isF16()) {
-    insn = ROCDL::wmma_f32_16x16x16_f16::getOperationName();
-  } else if (elementTypeA.isBF16()) {
-    insn = ROCDL::wmma_f32_16x16x16_bf16::getOperationName();
-  } else if (elementTypeA.isInteger(8)) {
-    insn = ROCDL::wmma_i32_16x16x16_iu8::getOperationName();
-  } else if (isa<Float8E4M3FNType>(elementTypeA)) {
-    insn = ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName();
-  } else if (isa<Float8E5M2Type>(elementTypeA)) {
-    insn = ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName();
-  } else {
-    return failure();
-  }
-
-  return WmmaInsn{insn,     dPerAccel, outStride, mRepeats,
-                  nRepeats, argTypeA,  argTypeB,  retType};
+  return WmmaInsn{insn,     dPerAccel, kDim,     outStride, mRepeats,
+                  nRepeats, argTypeA,  argTypeB, retType};
 }

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -76,11 +76,11 @@ static WmmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
 static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx11() {
   static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
       {{WmmaTypeId::F16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 16, 8}},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 16, 8, 16, 16}},
       {{WmmaTypeId::Bf16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 16, 8}},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 16, 8, 16, 16}},
       {{WmmaTypeId::I8_To_I32_TyId, 16},
-       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 16, 8}},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 16, 8, 16, 16}},
   };
   return insnMap;
 }
@@ -89,17 +89,17 @@ static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx11() {
 static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx12() {
   static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
       {{WmmaTypeId::F16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 8, 8}},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 8, 8, 16, 16}},
       {{WmmaTypeId::Bf16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 8, 8}},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 8, 8, 16, 16}},
       {{WmmaTypeId::I8_To_I32_TyId, 16},
-       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 8, 8}},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 8, 8, 16, 16}},
 
       // FP8/BF8
       {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName(), 8, 8}},
+       {ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName(), 8, 8, 16, 16}},
       {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName(), 8, 8}},
+       {ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName(), 8, 8, 16, 16}},
   };
   return insnMap;
 }
@@ -110,37 +110,37 @@ getWmmaInsnMapGfx1250() {
   static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
       // F32
       {{WmmaTypeId::F32_To_F32_TyId, 4},
-       {ROCDL::wmma_f32_16x16x4_f32::getOperationName(), 2, 8}},
+       {ROCDL::wmma_f32_16x16x4_f32::getOperationName(), 2, 8, 16, 16}},
 
       // F16/BF16
       {{WmmaTypeId::F16_To_F32_TyId, 32},
-       {ROCDL::wmma_f32_16x16x32_f16::getOperationName(), 16, 8}},
+       {ROCDL::wmma_f32_16x16x32_f16::getOperationName(), 16, 8, 16, 16}},
       {{WmmaTypeId::Bf16_To_F32_TyId, 32},
-       {ROCDL::wmma_f32_16x16x32_bf16::getOperationName(), 16, 8}},
+       {ROCDL::wmma_f32_16x16x32_bf16::getOperationName(), 16, 8, 16, 16}},
 
       // FP8/BF8 (k=64)
       {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_fp8_fp8::getOperationName(), 32, 8}},
+       {ROCDL::wmma_f32_16x16x64_fp8_fp8::getOperationName(), 32, 8, 16, 16}},
       {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_fp8_bf8::getOperationName(), 32, 8}},
+       {ROCDL::wmma_f32_16x16x64_fp8_bf8::getOperationName(), 32, 8, 16, 16}},
       {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_bf8_fp8::getOperationName(), 32, 8}},
+       {ROCDL::wmma_f32_16x16x64_bf8_fp8::getOperationName(), 32, 8, 16, 16}},
       {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_bf8_bf8::getOperationName(), 32, 8}},
+       {ROCDL::wmma_f32_16x16x64_bf8_bf8::getOperationName(), 32, 8, 16, 16}},
 
       // FP8/BF8 (k=128)
       {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_fp8_fp8::getOperationName(), 64, 8}},
+       {ROCDL::wmma_f32_16x16x128_fp8_fp8::getOperationName(), 64, 8, 16, 16}},
       {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_fp8_bf8::getOperationName(), 64, 8}},
+       {ROCDL::wmma_f32_16x16x128_fp8_bf8::getOperationName(), 64, 8, 16, 16}},
       {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_bf8_fp8::getOperationName(), 64, 8}},
+       {ROCDL::wmma_f32_16x16x128_bf8_fp8::getOperationName(), 64, 8, 16, 16}},
       {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_bf8_bf8::getOperationName(), 64, 8}},
+       {ROCDL::wmma_f32_16x16x128_bf8_bf8::getOperationName(), 64, 8, 16, 16}},
 
       // I8
       {{WmmaTypeId::I8_To_I32_TyId, 64},
-       {ROCDL::wmma_i32_16x16x64_iu8::getOperationName(), 32, 8}},
+       {ROCDL::wmma_i32_16x16x64_iu8::getOperationName(), 32, 8, 16, 16}},
   };
   return insnMap;
 }
@@ -271,9 +271,8 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
   int64_t outputVectorLen = insnInfo->outputVectorLen;
   int64_t kDim = selectedKDim;
   StringRef insn = insnInfo->insn;
-
-  // WMMA constants
-  int64_t dPerAccel = 16; // M=N=16 for all WMMA
+  int64_t mPerAccel = insnInfo->mPerAccel;
+  int64_t nPerAccel = insnInfo->nPerAccel;
 
   // Architecture-specific outStride
   // gfx11: full-wave K cooperation -> outStride=2
@@ -281,19 +280,19 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
   int64_t outStride = isGfx11 ? 2 : outputVectorLen;
 
   // Validate dimensions
-  if (mPerWave % inputVectorLen != 0 || mPerWave % dPerAccel != 0)
+  if (mPerWave % inputVectorLen != 0 || mPerWave % mPerAccel != 0)
     return failure();
-  if (nPerWave % inputVectorLen != 0 || nPerWave % dPerAccel != 0)
+  if (nPerWave % inputVectorLen != 0 || nPerWave % nPerAccel != 0)
     return failure();
 
-  int64_t mRepeats = mPerWave / dPerAccel;
-  int64_t nRepeats = nPerWave / dPerAccel;
+  int64_t mRepeats = mPerWave / mPerAccel;
+  int64_t nRepeats = nPerWave / nPerAccel;
 
   VectorType argTypeA = VectorType::get({inputVectorLen}, elementTypeA);
   VectorType argTypeB = VectorType::get({inputVectorLen}, elementTypeB);
   VectorType retType =
       VectorType::get({outputVectorLen}, getRetType(elementTypeA, typeId));
 
-  return WmmaInsn{insn,     dPerAccel, kDim,     outStride, mRepeats,
-                  nRepeats, argTypeA,  argTypeB, retType};
+  return WmmaInsn{insn, mPerAccel, nPerAccel, kDim, outStride, mRepeats,
+                  nRepeats, argTypeA, argTypeB, retType};
 }

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -780,9 +780,9 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
   }
 
   // Reject invalid KPACK values.
-  auto maybeWmmaInsn =
-      WmmaInsn::select(dataTypeA, dataTypeB, waveSize, arch,
-                       param.getMPerWave(), param.getNPerWave());
+  auto maybeWmmaInsn = WmmaInsn::select(
+      dataTypeA, dataTypeB, waveSize, arch, param.getMPerWave(),
+      param.getNPerWave(), param.getKpack(), param.getKpackPerBlock());
   if (failed(maybeWmmaInsn)) {
     LLVM_DEBUG(llvm::dbgs() << "Failed to select wmma instruction.\n");
     return failure();
@@ -883,9 +883,9 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
   std::copy_if(
       params.begin(), params.end(), std::back_inserter(res),
       [&](const InitParamsAccel &param) {
-        auto maybeWmmaInsn =
-            WmmaInsn::select(dataTypeA, dataTypeB, waveSize, arch,
-                             param.gemmMPerWave, param.gemmNPerWaveOrMnPerXdl);
+        auto maybeWmmaInsn = WmmaInsn::select(
+            dataTypeA, dataTypeB, waveSize, arch, param.gemmMPerWave,
+            param.gemmNPerWaveOrMnPerXdl, param.gemmKPack, param.gemmKPerBlock);
         if (failed(maybeWmmaInsn)) {
           return false;
         }

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -1071,9 +1071,21 @@ void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
   auto vectorC =
       memref::LoadOp::create(b, loc, vectorType, bufferC, regCOffset);
 
-  auto mfma = amdgpu::WMMAOp::create(b, loc, vectorType, argA, argB, vectorC,
-                                     /*subwordOffset=*/0, /*unsignedA=*/false,
-                                     /*unsignedB=*/false, /*clamp=*/true);
+  // WMMAOp requires explicit m, n, k dimensions as IntegerAttrs
+  auto mAttr = b.getI32IntegerAttr(wmmaInsn.dPerAccel);
+  auto nAttr = b.getI32IntegerAttr(wmmaInsn.dPerAccel);
+  auto kAttr = b.getI32IntegerAttr(wmmaInsn.kDim);
+  auto subwordOffsetAttr = b.getI32IntegerAttr(0);
+
+  // Clamp flag is only valid for integer output types
+  Type elementType = vectorType.getElementType();
+  UnitAttr clampAttr =
+      isa<IntegerType>(elementType) ? b.getUnitAttr() : nullptr;
+
+  auto mfma = amdgpu::WMMAOp::create(b, loc, vectorType, mAttr, nAttr, kAttr,
+                                     argA, argB, vectorC, subwordOffsetAttr,
+                                     /*unsignedA=*/nullptr,
+                                     /*unsignedB=*/nullptr, clampAttr);
   auto vectorD = mfma.getDestD();
 
   memref::StoreOp::create(b, loc, vectorD, bufferC, regCOffset);
@@ -1227,10 +1239,12 @@ AccelEmitter::select(GemmFeatures features, Type dataTypeA, Type dataTypeB,
     return std::make_unique<MfmaEmitter>(*maybeMfmaInsnGroup, arch,
                                          tuningParams);
   } else if (isWmma) {
+    WmmaGemmParamsAttr wmmaParams = cast<WmmaGemmParamsAttr>(tuningParams);
     int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
-    auto maybeWmmaInsnGroup = WmmaInsn::select(dataTypeA, dataTypeB, waveSize,
-                                               arch, tuningParams.getMPerWave(),
-                                               tuningParams.getNPerWave());
+    auto maybeWmmaInsnGroup =
+        WmmaInsn::select(dataTypeA, dataTypeB, waveSize, arch,
+                         wmmaParams.getMPerWave(), wmmaParams.getNPerWave(),
+                         wmmaParams.getKpack(), wmmaParams.getKpackPerBlock());
     if (failed(maybeWmmaInsnGroup)) {
       return nullptr;
     }

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -782,8 +782,8 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
   params.nResultVectors = 1;
 
   params.kpackPerThread = kpackPerBlock;
-  params.mPerAccel = wmmaInsn.dPerAccel;
-  params.nPerAccel = wmmaInsn.dPerAccel;
+  params.mPerAccel = wmmaInsn.mPerAccel;
+  params.nPerAccel = wmmaInsn.nPerAccel;
   // Pre-gfx12 each thread in the wave is loading an entire groups
   // of Ks to reduce. So, if there are 32 threads in a wave and
   // and we want to do a(16x16) * b(16x16), 16 threads are loading a vector
@@ -796,7 +796,9 @@ AccelEmitterParams WmmaEmitter::initAccelEmitterParams(
     // to reduce. For instance, with the previous example, each
     // thread is loading a vector of 8 Ks. The first 16 threads are
     // loading k=[0:8] the second 16 threads are loading k=[8:16] threads
-    int64_t numReductions = waveSize / wmmaInsn.dPerAccel;
+    assert(wmmaInsn.mPerAccel == wmmaInsn.nPerAccel &&
+           "Currently only supported for equal mPerAccel and nPerAccel");
+    int64_t numReductions = waveSize / wmmaInsn.mPerAccel;
     params.kpackPerThread /= numReductions;
   }
   params.kBasePerThread = (params.kpackPerThread * kPack) / params.kBase;
@@ -1072,8 +1074,8 @@ void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
       memref::LoadOp::create(b, loc, vectorType, bufferC, regCOffset);
 
   // WMMAOp requires explicit m, n, k dimensions as IntegerAttrs
-  auto mAttr = b.getI32IntegerAttr(wmmaInsn.dPerAccel);
-  auto nAttr = b.getI32IntegerAttr(wmmaInsn.dPerAccel);
+  auto mAttr = b.getI32IntegerAttr(wmmaInsn.mPerAccel);
+  auto nAttr = b.getI32IntegerAttr(wmmaInsn.nPerAccel);
   auto kAttr = b.getI32IntegerAttr(wmmaInsn.kDim);
   auto subwordOffsetAttr = b.getI32IntegerAttr(0);
 
@@ -1125,8 +1127,8 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
     dimNamesM.push_back(/*4=*/"item_i");
   }
   SmallVector<int64_t, 7> orderedDimStridesM{/*0=*/mPerBlock,
-                                             /*1=*/mWaves * wmmaInsn.dPerAccel,
-                                             /*2=*/wmmaInsn.dPerAccel};
+                                             /*1=*/mWaves * wmmaInsn.mPerAccel,
+                                             /*2=*/wmmaInsn.mPerAccel};
   if (isGfx11) {
     orderedDimStridesM.push_back(/*3=*/wmmaInsn.outputStride);
   } else {
@@ -1142,8 +1144,8 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
                                       /*2=*/"wave_n",
                                       /*3=*/"n_tid"};
   SmallVector<int64_t, 5> orderedDimStridesN{/*0=*/nPerBlock,
-                                             /*1=*/nWaves * wmmaInsn.dPerAccel,
-                                             /*2=*/wmmaInsn.dPerAccel,
+                                             /*1=*/nWaves * wmmaInsn.nPerAccel,
+                                             /*2=*/wmmaInsn.nPerAccel,
                                              /*3=*/1};
   SmallVector<int64_t, 7> dimSizesN;
   convertDimStridestoSizes(orderedDimStridesN, nLen, dimSizesN);
@@ -1157,9 +1159,11 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
          mRepeats * nRepeats * retNumElements},
         loc);
     splitMemoryCoords.passThrough({"g_block", "m_block", "n_block"});
+    assert(wmmaInsn.mPerAccel == wmmaInsn.nPerAccel &&
+           "Currently only supported for equal mPerAccel and nPerAccel");
     splitMemoryCoords.merge(
         {"wave_m", "wave_n", "m_tid", "n_tid"}, {3, 4, 5, 6}, "tid",
-        {mWaves, nWaves, waveSize / wmmaInsn.dPerAccel, wmmaInsn.dPerAccel});
+        {mWaves, nWaves, waveSize / wmmaInsn.mPerAccel, wmmaInsn.mPerAccel});
     splitMemoryCoords.merge({"rep_i", "rep_j", "item_i"}, {7, 8, 9}, "item",
                             {mRepeats, nRepeats, retNumElements});
     TransformMapAttr splitMemoryCoordsAttr = splitMemoryCoords.get();

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
@@ -11,7 +11,7 @@ func.func @rock_accel_gemm_wmma(%matrixA : memref<1x4xvector<16xf16>, 5>,
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
-  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] : vector<16xf16>, vector<16xf16>, vector<8xf32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
   rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1100",
@@ -40,7 +40,7 @@ func.func @rock_accel_gemm_wmma_gfx12(%matrixA : memref<1x4xvector<8xf16>, 5>,
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<8xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<8xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
-  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] : vector<8xf16>, vector<8xf16>, vector<8xf32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
   rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
     arch = "amdgcn-amd-amdhsa:gfx1200",
@@ -70,7 +70,7 @@ func.func @rock_accel_gemm_wmma_repeats(%matrixA : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xf16>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xf32>, 5>
-  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] : vector<16xf16>, vector<16xf16>, vector<8xf32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xf32>, 5>
   %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xf32>, 5> to memref<2x2xvector<8xf32>, 5>
   rock.threadwise_gemm_accel %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
@@ -101,7 +101,7 @@ func.func @rock_accel_gemm_wmma_repeats_int8(%matrixA : memref<1x4xvector<16xi8>
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x4xvector<16xi8>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
-  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] {clamp} : vector<16xi8>, vector<16xi8>, vector<8xi32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
   %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2xvector<8xi32>, 5>
   rock.threadwise_gemm_accel %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
@@ -132,7 +132,7 @@ func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<1x2xvecto
   // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
   // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xi8>, 5>
   // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4xvector<8xi32>, 5>
-  // CHECK: amdgpu.wmma %[[a]] * %[[b]] + %[[c]]
+  // CHECK: amdgpu.wmma 16x16x16 %[[a]] * %[[b]] + %[[c]] {clamp} : vector<16xi8>, vector<16xi8>, vector<8xi32>
   // CHECK: memref.store {{.*}}, {{.*}} : memref<4xvector<8xi32>, 5>
   %matrixCView = rock.transform %matrixC by #transform_map0: memref<4xvector<8xi32>, 5> to memref<2x2xvector<8xi32>, 5>
   rock.threadwise_gemm_accel %matrixCView += %matrixA * %matrixB at [%c1, %c1, %c0] features = wmma {
@@ -149,5 +149,382 @@ func.func @rock_accel_gemm_wmma_partial_repeats_int8(%matrixA : memref<1x2xvecto
        outputSwizzle = 2,
        forceUnroll = true>
      } : memref<2x2xvector<8xi32>, 5> += memref<1x2xvector<16xi8>, 5> * memref<1x2xvector<16xi8>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_f32
+func.func @rock_accel_gemm_wmma_gfx1250_f32(%matrixA : memref<1x1xvector<2xf32>, 5>,
+                                             %matrixB : memref<1x1xvector<2xf32>, 5>,
+                                             %matrixC : memref<1x1xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x1xvector<2xf32>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x1xvector<2xf32>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x4 %[[a]] * %[[b]] + %[[c]] : vector<2xf32>, vector<2xf32>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 1,
+       mPerWave = 16,
+       nPerWave = 16,
+       kpack = 4,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x1xvector<2xf32>, 5> * memref<1x1xvector<2xf32>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_f16_k32
+func.func @rock_accel_gemm_wmma_gfx1250_f16_k32(%matrixA : memref<1x2xvector<16xf16>, 5>,
+                                                 %matrixB : memref<1x2xvector<16xf16>, 5>,
+                                                 %matrixC : memref<1x1xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xf16>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x32 %[[a]] * %[[b]] + %[[c]] : vector<16xf16>, vector<16xf16>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 2,
+       mPerWave = 16,
+       nPerWave = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x2xvector<16xf16>, 5> * memref<1x2xvector<16xf16>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf16_k32
+func.func @rock_accel_gemm_wmma_gfx1250_bf16_k32(%matrixA : memref<1x2xvector<16xbf16>, 5>,
+                                                  %matrixB : memref<1x2xvector<16xbf16>, 5>,
+                                                  %matrixC : memref<1x1xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<1x2xvector<16xbf16>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<1x2xvector<16xbf16>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<1x1xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x32 %[[a]] * %[[b]] + %[[c]] : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<1x1xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 2,
+       mPerWave = 16,
+       nPerWave = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x2xvector<16xbf16>, 5> * memref<1x2xvector<16xbf16>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k64(%matrixA : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E4M3FN>, 5> * memref<4x4xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k64(%matrixA : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E4M3FN>, 5> * memref<4x4xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k64(%matrixA : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E5M2>, 5> * memref<4x4xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k64(%matrixA : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixB : memref<4x4xvector<64xf8E5M2>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf8E5M2>, 5> * memref<4x4xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_fp8_k128(%matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> * memref<4x8xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_fp8_bf8_k128(%matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> * memref<4x8xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_fp8_k128(%matrixA : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E5M2>, 5> * memref<4x8xvector<64xf8E4M3FN>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k128
+func.func @rock_accel_gemm_wmma_gfx1250_bf8_bf8_k128(%matrixA : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                     %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E5M2>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E5M2>, 5> * memref<4x8xvector<64xf8E5M2>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_i8_k64
+func.func @rock_accel_gemm_wmma_gfx1250_i8_k64(%matrixA : memref<4x4xvector<32xi8>, 5>,
+                                               %matrixB : memref<4x4xvector<32xi8>, 5>,
+                                               %matrixC : memref<4x4xvector<8xi32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x4xvector<32xi8>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x4xvector<32xi8>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xi32>, 5>
+  // CHECK: amdgpu.wmma 16x16x64 %[[a]] * %[[b]] + %[[c]] {clamp} : vector<32xi8>, vector<32xi8>, vector<8xi32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xi32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xi32>, 5> += memref<4x4xvector<32xi8>, 5> * memref<4x4xvector<32xi8>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_k_selection
+func.func @rock_accel_gemm_wmma_gfx1250_k_selection(%matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+                                                    %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+                                                    %matrixC : memref<4x4xvector<8xf32>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK: %[[a:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E4M3FN>, 5>
+  // CHECK: %[[b:.*]] = memref.load {{.*}} : memref<4x8xvector<64xf8E5M2>, 5>
+  // CHECK: %[[c:.*]] = memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK: amdgpu.wmma 16x16x128 %[[a]] * %[[b]] + %[[c]] : vector<64xf8E4M3FN>, vector<64xf8E5M2>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA * %matrixB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> * memref<4x8xvector<64xf8E5M2>, 5>
   return
 }

--- a/mlir/test/common_utils/common.py
+++ b/mlir/test/common_utils/common.py
@@ -11,6 +11,7 @@ def get_arch_features(arch: str):
     arch_features = None
     support_mfma = False
     support_wmma = False
+    support_f32_accel = False
     major = chip_name[:-2]
     minor = chip_name[-2:]
     if major == 'gfx9':
@@ -37,11 +38,15 @@ def get_arch_features(arch: str):
         arch_features = 'dot|atomic_add|atomic_add_f16|atomic_add_bf16|atomic_fmax_f32|wmma'
     if arch_features and 'mfma' in arch_features:
         support_mfma = True
+        support_f32_accel = True
         pass
     elif arch_features and 'wmma' in arch_features:
         support_wmma = True
+        # Only gfx1250 wmma supports f32
+        if major == 'gfx12' and minor == '50':
+            support_f32_accel = True
         pass
-    return arch_features, support_mfma, support_wmma
+    return arch_features, support_mfma, support_wmma, support_f32_accel
 
 
 def hip_check(call_result):

--- a/mlir/test/e2e/PrAttentionF32.cfg
+++ b/mlir/test/e2e/PrAttentionF32.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma):
+if (not config.arch_f32_accel):
   config.unsupported = True

--- a/mlir/test/e2e/PrConvElementwiseGemmF32.cfg
+++ b/mlir/test/e2e/PrConvElementwiseGemmF32.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma):
+if (not config.arch_f32_accel):
   config.unsupported = True

--- a/mlir/test/e2e/PrConvElementwiseGemmF32SplitK.cfg
+++ b/mlir/test/e2e/PrConvElementwiseGemmF32SplitK.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma) or (not 'atomic_add' in config.features):
+if (not config.arch_f32_accel) or (not 'atomic_add' in config.features):
   config.unsupported = True

--- a/mlir/test/e2e/PrGemmElementwiseGemmF32.cfg
+++ b/mlir/test/e2e/PrGemmElementwiseGemmF32.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma):
+if (not config.arch_f32_accel):
   config.unsupported = True

--- a/mlir/test/e2e/PrGemmElementwiseGemmF32SplitK.cfg
+++ b/mlir/test/e2e/PrGemmElementwiseGemmF32SplitK.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma) or (not 'atomic_add' in config.features):
+if (not config.arch_f32_accel) or (not 'atomic_add' in config.features):
   config.unsupported = True

--- a/mlir/test/e2e/conv_wrw_perf_config.cfg
+++ b/mlir/test/e2e/conv_wrw_perf_config.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma):
+if (not config.arch_f32_accel):
   config.unsupported = True

--- a/mlir/test/e2e/gemm_split_k_f32.cfg
+++ b/mlir/test/e2e/gemm_split_k_f32.cfg
@@ -1,2 +1,2 @@
-if not 'atomic_add' in config.features or not config.arch_support_mfma:
+if not 'atomic_add' in config.features or not config.arch_f32_accel:
   config.unsupported = True

--- a/mlir/test/e2e/lit.site.cfg.py.in
+++ b/mlir/test/e2e/lit.site.cfg.py.in
@@ -46,12 +46,13 @@ config.arch = ""
 config.features = None
 config.arch_support_mfma = False
 config.arch_support_wmma = False
+config.arch_f32_accel = False
 if config.rocm_path:
     try:
         agents = get_agents()
         config.arch = ','.join(agents)
         for x in agents:
-            config.features, config.arch_support_mfma, config.arch_support_wmma = get_arch_features(x)
+            config.features, config.arch_support_mfma, config.arch_support_wmma, config.arch_f32_accel = get_arch_features(x)
             config.substitutions.append(('%features', config.features))
 
         # Check other features here

--- a/mlir/test/fusion/e2e/lit.site.cfg.py.in
+++ b/mlir/test/fusion/e2e/lit.site.cfg.py.in
@@ -35,7 +35,7 @@ config.rocmlir_common_python_tests_utils = "@ROCMLIR_COMMON_PYTHON_TESTS_UTILS@"
 
 # Add common python test utils
 sys.path.append(config.rocmlir_common_python_tests_utils)
-from common import get_agents
+from common import get_agents, get_arch_features
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.
@@ -53,15 +53,19 @@ config.no_AMD_GPU = False
 config.arch = ""
 config.arch_support_mfma = False
 config.arch_support_wmma = False
+config.arch_f32_accel = False
 if config.rocm_path:
     try:
         agents = get_agents()
         config.arch = ','.join(agents)
         for x in agents:
-            if any([arch in x for arch in ["gfx908", "gfx90a", "gfx942", "gfx950"]]):
+            _, support_mfma, support_wmma, support_f32_accel = get_arch_features(x)
+            if support_mfma:
                 config.arch_support_mfma = True
-            elif "gfx11" in x or "gfx12" in x:
+            if support_wmma:
                 config.arch_support_wmma = True
+            if support_f32_accel:
+                config.arch_f32_accel = True
             # Check other features here
         if not config.arch:
             config.no_AMD_GPU = True

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-attention/f32/lit.local.cfg
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-attention/f32/lit.local.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma):
+if (not config.arch_f32_accel):
   config.unsupported = True

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-conv-gemm/f32/lit.local.cfg
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-conv-gemm/f32/lit.local.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma):
+if (not config.arch_f32_accel):
   config.unsupported = True

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/lit.local.cfg
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-gemm-gemm/f32/lit.local.cfg
@@ -1,2 +1,2 @@
-if (not config.arch_support_mfma):
+if (not config.arch_f32_accel):
   config.unsupported = True

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-gemm-splitk/f32/lit.local.cfg
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-gemm-splitk/f32/lit.local.cfg
@@ -1,2 +1,2 @@
-if config.no_AMD_GPU or not 'atomic_add' in config.features or not config.arch_support_mfma:
+if config.no_AMD_GPU or not 'atomic_add' in config.features or not config.arch_f32_accel:
   config.unsupported = True

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/lit.local.cfg
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-splitk/f32/lit.local.cfg
@@ -1,2 +1,2 @@
-if config.no_AMD_GPU or not 'atomic_add' in config.features or not config.arch_support_mfma:
+if config.no_AMD_GPU or not 'atomic_add' in config.features or not config.arch_f32_accel:
   config.unsupported = True

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -76,6 +76,7 @@ config.no_AMD_GPU = False
 config.arch = ""
 config.arch_support_mfma = False
 config.arch_support_wmma = False
+config.arch_f32_accel = False
 config.features = None
 if config.rocm_path:
     try:
@@ -83,7 +84,7 @@ if config.rocm_path:
         config.arch = ','.join(agents)
         for x in agents:
             if not config.features:
-                config.features, config.arch_support_mfma, config.arch_support_wmma = get_arch_features(x)
+                config.features, config.arch_support_mfma, config.arch_support_wmma, config.arch_f32_accel = get_arch_features(x)
                 config.substitutions.append(('%features', config.features))
         if not config.arch:
             config.no_AMD_GPU = True


### PR DESCRIPTION
## Motivation

Related to : https://github.com/ROCm/rocMLIR-internal/issues/2048

## Technical Details

This PR enable F32 WMMA test on gfx1250 by introducing a new configuration entry: config.arch_f32_accel

## Test Plan

Verify that F32 WMMA tests run on gfx1250

