### PR TITLE
Fix num_cu bug in convert-rock-to-gpu

### DIFF
--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -208,6 +208,10 @@ void LowerRockOpsToGPUPass::runOnOperation() {
     if (succeeded(maybeArch)) {
       gpuFunc->setAttr("arch", maybeArch.value());
     }
+    FailureOr<int64_t> maybeNumCU = rock::getNumCU(theFunc);
+    if (succeeded(maybeNumCU)) {
+      gpuFunc->setAttr("num_cu", b.getI32IntegerAttr(maybeNumCU.value()));
+    }
 
     int32_t indexWidth = 32;
     if (theFunc->hasAttr("rock.64bitindex"))

--- a/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/mlir/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -210,7 +210,7 @@ void LowerRockOpsToGPUPass::runOnOperation() {
     }
     FailureOr<int64_t> maybeNumCU = rock::getNumCU(theFunc);
     if (succeeded(maybeNumCU)) {
-      gpuFunc->setAttr("num_cu", b.getI32IntegerAttr(maybeNumCU.value()));
+      gpuFunc->setAttr("num_cu", b.getI64IntegerAttr(maybeNumCU.value()));
     }
 
     int32_t indexWidth = 32;

--- a/mlir/test/Conversion/RockToGPU/num_cu.mlir
+++ b/mlir/test/Conversion/RockToGPU/num_cu.mlir
@@ -1,6 +1,5 @@
 // RUN: rocmlir-opt -convert-rock-to-gpu -split-input-file %s | FileCheck %s
 
-
 // CHECK: module attributes {gpu.container_module}
 // CHECK-NEXT: gpu.module @misckernel_module
 // CHECK-NEXT: gpu.func @misckernel(%{{.*}}: memref<?xf32>, %{{.*}}: memref<?xf32>) 

--- a/mlir/test/Conversion/RockToGPU/num_cu.mlir
+++ b/mlir/test/Conversion/RockToGPU/num_cu.mlir
@@ -1,0 +1,43 @@
+// RUN: rocmlir-opt -convert-rock-to-gpu -split-input-file %s | FileCheck %s
+
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-NEXT: gpu.module @misckernel_module
+// CHECK-NEXT: gpu.func @misckernel(%{{.*}}: memref<?xf32>, %{{.*}}: memref<?xf32>) 
+// CHECK-SAME: workgroup(%arg2 : memref<64xf32, #gpu.address_space<workgroup>> {llvm.align = 64 : i64})
+// CHECK-SAME: kernel
+// CHECK-SAME: arch = "amdgcn-amd-amdhsa:gfx1100"
+// CHECK-SAME: block_size = 128 : i32
+// CHECK-SAME: grid_size = 256 : i32
+// CHECK-SAME: known_block_size = array<i32: 128, 1, 1>
+// CHECK-SAME: known_grid_size = array<i32: 256, 1, 1>
+// CHECK-SAME: num_cu = 96 : i32
+// CHECK-SAME: rocdl.unsafe_fp_atomics = true
+// CHECK-SAME: rocdl.waves_per_eu = 2 : i32
+// CHECK-SAME: rock.shared_buffer_size = 256 : i32
+module {
+  func.func @misckernel(%arg0: memref<?xf32>, %arg1: memref<?xf32>) attributes {block_size = 128 : i32, enable_splitk_for_tuning, features = #rock<GemmFeatures wmma|dot|atomic_add|atomic_fmax_f32>, grid_size = 256 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx1100", num_cu = 96 : i64} {
+    %lds = rock.alloc() : memref<64xf32, #gpu.address_space<workgroup>>
+    
+    // CHECK: gpu.barrier
+    rock.workgroup_barrier
+
+    // CHECK: gpu.lds_barrier
+    rock.lds_barrier
+
+    // CHECK: %{{.*}} = gpu.block_id x
+    %bid = rock.workgroup_id : index
+
+    // CHECK: %{{.*}} = gpu.thread_id x
+    %tid = rock.workitem_id : index
+
+    %idx = arith.muli %bid, %tid : index
+
+    %val = memref.load %arg0[%idx] : memref<?xf32>
+    %val_lds = memref.load %lds[%idx] : memref<64xf32, #gpu.address_space<workgroup>>
+
+    memref.store %val, %arg1[%idx] : memref<?xf32>
+    memref.store %val_lds, %arg1[%idx] : memref<?xf32>
+    return
+  }
+}

--- a/mlir/test/Conversion/RockToGPU/num_cu.mlir
+++ b/mlir/test/Conversion/RockToGPU/num_cu.mlir
@@ -10,7 +10,7 @@
 // CHECK-SAME: grid_size = 256 : i32
 // CHECK-SAME: known_block_size = array<i32: 128, 1, 1>
 // CHECK-SAME: known_grid_size = array<i32: 256, 1, 1>
-// CHECK-SAME: num_cu = 96 : i32
+// CHECK-SAME: num_cu = 96 : i64
 // CHECK-SAME: rocdl.unsafe_fp_atomics = true
 // CHECK-SAME: rocdl.waves_per_eu = 2 : i32
 // CHECK-SAME: rock.shared_buffer_size = 256 : i32


### PR DESCRIPTION
## Motivation

num_cu was not copied to the gpufunc, so waves_per_eu is computed incorrectly. 

## Technical Details

Fix this issue by copying num_cu if available and adding a LIT test.

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
