### PR TITLE
Reduce noise in rocmlir-tuning-driver when measuring small kernels

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -271,6 +271,84 @@ struct CompilationResult {
   SmallVector<uint32_t> gridSizes;
 };
 
+static LogicalResult
+measureSmallKernel(unsigned iterations, hipStream_t stream,
+                   const std::vector<hipFunction_t> &functions,
+                   ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
+                   std::vector<void *> &argPointers,
+                   std::vector<float> &measurements, float &smallKernelCpuMs) {
+  // Special case for small kernels, where we measure the time for all kernels
+  // at once, using CPU timers.
+  auto iterationStart = std::chrono::steady_clock::now();
+  for (unsigned iter = 0; iter < iterations; ++iter) {
+    if (failed(flushInstructionCache(stream))) {
+      return failure();
+    }
+    if (failed(flushL2Cache(stream))) {
+      return failure();
+    }
+    for (auto [func, blockSize, gridSize] :
+         llvm::zip(functions, blockSizes, gridSizes)) {
+      HIPCHECK(hipExtModuleLaunchKernel(
+          func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
+          argPointers.data(), nullptr, nullptr, nullptr));
+    }
+  }
+
+  HIPCHECK(hipStreamSynchronize(stream));
+  smallKernelCpuMs = std::chrono::duration<float, std::milli>(
+                         std::chrono::steady_clock::now() - iterationStart)
+                         .count();
+  measurements.push_back(smallKernelCpuMs / iterations);
+  return success();
+}
+
+static LogicalResult
+measureLargeKernel(unsigned iterations, hipStream_t stream,
+                   const std::vector<hipFunction_t> &functions,
+                   ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
+                   std::vector<void *> &argPointers,
+                   std::vector<float> &measurements) {
+  // Measure runs normally.
+  for (unsigned iter = 0; iter < iterations; ++iter) {
+    if (failed(flushInstructionCache(stream))) {
+      return failure();
+    }
+    if (failed(flushL2Cache(stream))) {
+      return failure();
+    }
+    HIPCHECK(hipStreamSynchronize(stream));
+
+    float totalMilliseconds = 0.0;
+
+    for (auto [func, blockSize, gridSize] :
+         llvm::zip(functions, blockSizes, gridSizes)) {
+      hipEvent_t startEvent, stopEvent;
+      HIPCHECK(hipEventCreate(&startEvent));
+      HIPCHECK(hipEventCreate(&stopEvent));
+
+      HIPCHECK(hipExtModuleLaunchKernel(
+          func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
+          argPointers.data(), nullptr, startEvent, stopEvent));
+      HIPCHECK(hipStreamSynchronize(stream));
+
+      float currentMilliseconds = 0.0;
+      HIPCHECK(
+          hipEventElapsedTime(&currentMilliseconds, startEvent, stopEvent));
+
+      HIPCHECK(hipEventDestroy(stopEvent));
+      HIPCHECK(hipEventDestroy(startEvent));
+
+      totalMilliseconds += currentMilliseconds;
+    }
+
+    measurements.push_back(totalMilliseconds);
+  }
+
+  std::sort(measurements.begin(), measurements.end());
+  return success();
+}
+
 // In order to match rocprof, returns time in nanoseconds
 static FailureOr<double>
 benchmarkKernels(ArrayRef<std::string> binaries,
@@ -370,7 +448,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   // Depending on the runtime of the kernel
   // we use a different approach to measure the runs.
   // We consider a kernel to be small if it takes less than 1ms to run.
-  constexpr float smallKernelThreshold = 1.0;
+  constexpr float smallKernelThreshold = 1.0f;
   bool isSmallKernel = totalMillisecondsWarmup < smallKernelThreshold;
   unsigned iterations = params.numIterations;
 
@@ -383,67 +461,14 @@ benchmarkKernels(ArrayRef<std::string> binaries,
                                                   totalMillisecondsWarmup)));
 
   if (isSmallKernel) {
-    // Special case for small kernels, where we measure the time for all kernels
-    // at once, using CPU timers.
-    auto iterationStart = std::chrono::steady_clock::now();
-    for (unsigned iter = 0; iter < iterations; ++iter) {
-      if (failed(flushInstructionCache(stream))) {
-        return failure();
-      }
-      if (failed(flushL2Cache(stream))) {
-        return failure();
-      }
-      for (auto [func, blockSize, gridSize] :
-           llvm::zip(functions, blockSizes, gridSizes)) {
-        HIPCHECK(hipExtModuleLaunchKernel(
-            func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-            argPointers.data(), nullptr, nullptr, nullptr));
-      }
-    }
-
-    HIPCHECK(hipStreamSynchronize(stream));
-    smallKernelCpuMs = std::chrono::duration<float, std::milli>(
-                           std::chrono::steady_clock::now() - iterationStart)
-                           .count();
-    measurements.push_back(smallKernelCpuMs / iterations);
+    if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
+                                  gridSizes, argPointers, measurements,
+                                  smallKernelCpuMs)))
+      return failure();
   } else {
-    // Measure runs normally.
-    for (unsigned iter = 0; iter < iterations; ++iter) {
-      if (failed(flushInstructionCache(stream))) {
-        return failure();
-      }
-      if (failed(flushL2Cache(stream))) {
-        return failure();
-      }
-      HIPCHECK(hipStreamSynchronize(stream));
-
-      float totalMilliseconds = 0.0;
-
-      for (auto [func, blockSize, gridSize] :
-           llvm::zip(functions, blockSizes, gridSizes)) {
-        hipEvent_t startEvent, stopEvent;
-        HIPCHECK(hipEventCreate(&startEvent));
-        HIPCHECK(hipEventCreate(&stopEvent));
-
-        HIPCHECK(hipExtModuleLaunchKernel(
-            func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-            argPointers.data(), nullptr, startEvent, stopEvent));
-        HIPCHECK(hipStreamSynchronize(stream));
-
-        float currentMilliseconds = 0.0;
-        HIPCHECK(
-            hipEventElapsedTime(&currentMilliseconds, startEvent, stopEvent));
-
-        HIPCHECK(hipEventDestroy(stopEvent));
-        HIPCHECK(hipEventDestroy(startEvent));
-
-        totalMilliseconds += currentMilliseconds;
-      }
-
-      measurements.push_back(totalMilliseconds);
-    }
-
-    std::sort(measurements.begin(), measurements.end());
+    if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
+                                  gridSizes, argPointers, measurements)))
+      return failure();
   }
 
   if (params.showStats) {

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -51,6 +51,7 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <mutex>
 #include <thread>
@@ -359,6 +360,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   }
   totalMillisecondsWarmup /= params.warmupIterations;
+  assert(totalMillisecondsWarmup >= 0.0f &&
+         "totalMillisecondsWarmup must be greater than 0");
 
   // Measure runs
   std::vector<float> measurements;
@@ -368,12 +371,21 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   // We consider a kernel to be small if it takes less than 1ms to run.
   constexpr float smallKernelThreshold = 1.0;
   bool isSmallKernel = totalMillisecondsWarmup < smallKernelThreshold;
+  unsigned iterations = params.numIterations;
+
+  // We want to get at least 10ms of kernel execution time
+  // (counting all iterations), so increase the number of iterations
+  // if necessary.
+  constexpr float minTotalMilliseconds = 10.0f;
+  iterations = std::max<unsigned>(
+      iterations, static_cast<unsigned>(std::ceil(minTotalMilliseconds /
+                                                  totalMillisecondsWarmup)));
 
   if (isSmallKernel) {
     // Special case for small kernels, where we measure the time for all kernels
     // at once, using CPU timers.
     auto iterationStart = std::chrono::steady_clock::now();
-    for (unsigned iter = 0; iter < params.numIterations; ++iter) {
+    for (unsigned iter = 0; iter < iterations; ++iter) {
       for (auto [func, blockSize, gridSize] :
            llvm::zip(functions, blockSizes, gridSizes)) {
         HIPCHECK(hipExtModuleLaunchKernel(
@@ -387,10 +399,10 @@ benchmarkKernels(ArrayRef<std::string> binaries,
         std::chrono::duration<float, std::milli>(
             std::chrono::steady_clock::now() - iterationStart)
             .count();
-    measurements.push_back(totalMilliseconds / params.numIterations);
+    measurements.push_back(totalMilliseconds / iterations);
   } else {
     // Measure runs normally.
-    for (unsigned iter = 0; iter < params.numIterations; ++iter) {
+    for (unsigned iter = 0; iter < iterations; ++iter) {
       if (failed(flushInstructionCache(stream))) {
         return failure();
       }

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -329,6 +329,9 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
     for (auto [func, blockSize, gridSize] :
          llvm::zip(functions, blockSizes, gridSizes)) {
       hipEvent_t startEvent, stopEvent;
+      // We use hipEventDisableSystemFence and hipEventReleaseToDevice to try
+      // to improve accuracy of the measurements. More details here:
+      // https://github.com/ROCm/rocMLIR/pull/2119#discussion_r2564849591
       HIPCHECK(hipEventCreateWithFlags(
           &startEvent, hipEventDisableSystemFence | hipEventReleaseToDevice));
       HIPCHECK(hipEventCreateWithFlags(

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -441,6 +441,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   }
 
   if (params.showStats) {
+    // We cannot show stats because the small kernel case uses one timer
+    // only, so we cannot actually compute the min, max, etc.
     if (isSmallKernel) {
       llvm::outs() << "show-stats not avaiable for small kernels\t";
     }

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -410,55 +410,60 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
-  // Warmup run. We measure the warmup to get an estimate of the kernel runtime.
-  // We will use this estimate to determine if the kernel is small or not.
-  float totalMillisecondsWarmup = 0.0;
-  HIPCHECK(hipStreamSynchronize(stream));
-  for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
-    for (auto [func, blockSize, gridSize] :
-         llvm::zip(functions, blockSizes, gridSizes)) {
-      hipEvent_t startEvent, stopEvent;
-      HIPCHECK(hipEventCreate(&startEvent));
-      HIPCHECK(hipEventCreate(&stopEvent));
+  // Depending on the runtime of the kernel,
+  // we will use a different approach to measure the runs.
+  // We consider a kernel to be small if it takes less than 1ms to run.
+  constexpr float smallKernelThreshold = 1.0f;
+  bool isSmallKernel = false;
+  unsigned iterations = params.numIterations;
 
-      HIPCHECK(hipExtModuleLaunchKernel(
-          func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-          argPointers.data(), nullptr, startEvent, stopEvent));
+  if (params.warmupIterations > 0) {
+    // Warmup run. We measure the warmup to get an estimate of the kernel
+    // runtime. We will use this estimate to determine if the kernel is small or
+    // not.
+    float totalMillisecondsWarmup = 0.0;
+    HIPCHECK(hipStreamSynchronize(stream));
+    for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
+      for (auto [func, blockSize, gridSize] :
+           llvm::zip(functions, blockSizes, gridSizes)) {
+        hipEvent_t startEvent, stopEvent;
+        HIPCHECK(hipEventCreate(&startEvent));
+        HIPCHECK(hipEventCreate(&stopEvent));
 
-      HIPCHECK(hipStreamSynchronize(stream));
+        HIPCHECK(hipExtModuleLaunchKernel(
+            func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
+            argPointers.data(), nullptr, startEvent, stopEvent));
 
-      float currentMilliseconds = 0.0;
-      HIPCHECK(
-          hipEventElapsedTime(&currentMilliseconds, startEvent, stopEvent));
+        HIPCHECK(hipStreamSynchronize(stream));
 
-      HIPCHECK(hipEventDestroy(stopEvent));
-      HIPCHECK(hipEventDestroy(startEvent));
+        float currentMilliseconds = 0.0;
+        HIPCHECK(
+            hipEventElapsedTime(&currentMilliseconds, startEvent, stopEvent));
 
-      totalMillisecondsWarmup += currentMilliseconds;
+        HIPCHECK(hipEventDestroy(stopEvent));
+        HIPCHECK(hipEventDestroy(startEvent));
+
+        totalMillisecondsWarmup += currentMilliseconds;
+      }
     }
+    totalMillisecondsWarmup /= params.warmupIterations;
+    assert(totalMillisecondsWarmup >= 0.0f &&
+           "totalMillisecondsWarmup must be greater than 0");
+
+    // We want to get at least 1ms of kernel execution time
+    // (counting all iterations), so increase the number of iterations
+    // if necessary.
+    constexpr float minTotalMilliseconds = 1.0f;
+    iterations = std::max<unsigned>(
+        iterations, static_cast<unsigned>(std::ceil(minTotalMilliseconds /
+                                                    totalMillisecondsWarmup)));
+
+    isSmallKernel = totalMillisecondsWarmup < smallKernelThreshold;
   }
-  totalMillisecondsWarmup /= params.warmupIterations;
-  assert(totalMillisecondsWarmup >= 0.0f &&
-         "totalMillisecondsWarmup must be greater than 0");
 
   // Measure runs
   std::vector<float> measurements;
   float smallKernelCpuMs = 0.0f;
-
-  // Depending on the runtime of the kernel
-  // we use a different approach to measure the runs.
-  // We consider a kernel to be small if it takes less than 1ms to run.
-  constexpr float smallKernelThreshold = 1.0f;
-  bool isSmallKernel = totalMillisecondsWarmup < smallKernelThreshold;
-  unsigned iterations = params.numIterations;
-
-  // We want to get at least 1ms of kernel execution time
-  // (counting all iterations), so increase the number of iterations
-  // if necessary.
-  constexpr float minTotalMilliseconds = 1.0f;
-  iterations = std::max<unsigned>(
-      iterations, static_cast<unsigned>(std::ceil(minTotalMilliseconds /
-                                                  totalMillisecondsWarmup)));
 
   if (isSmallKernel) {
     if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -276,7 +276,7 @@ static LogicalResult
 measureSmallKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   std::vector<void *> &argPointers,
+                   const std::vector<void *> &argPointers,
                    std::vector<double> &measurements, double &smallKernelCpuMs,
                    bool benchmarkMode) {
   // Special case for small kernels, where we measure the time for all kernels
@@ -313,7 +313,7 @@ static LogicalResult
 measureLargeKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   std::vector<void *> &argPointers,
+                   const std::vector<void *> &argPointers,
                    std::vector<double> &measurements) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {
@@ -639,12 +639,11 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   }
 
   // 4. Collect perf configs to compile
-  bool benchmarkMode = false;
+  bool benchmarkMode = !benchmarkConfig.empty();
   std::vector<SmallString<64>> configs;
-  if (!benchmarkConfig.empty()) {
+  if (benchmarkMode) {
     // Benchmark mode - just one config
     configs.emplace_back(benchmarkConfig);
-    benchmarkMode = true;
   } else {
     // Tuning mode - all configs from tuning space
     std::unique_ptr<rock::TuningParamSet> tuningSpace(

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -329,13 +329,15 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
     for (auto [func, blockSize, gridSize] :
          llvm::zip(functions, blockSizes, gridSizes)) {
       hipEvent_t startEvent, stopEvent;
-      HIPCHECK(hipEventCreate(&startEvent));
-      HIPCHECK(hipEventCreate(&stopEvent));
+      HIPCHECK(hipEventCreateWithFlags(
+          &startEvent, hipEventDisableSystemFence | hipEventReleaseToDevice));
+      HIPCHECK(hipEventCreateWithFlags(
+          &stopEvent, hipEventDisableSystemFence | hipEventReleaseToDevice));
 
       HIPCHECK(hipExtModuleLaunchKernel(
           func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
           argPointers.data(), nullptr, startEvent, stopEvent));
-      HIPCHECK(hipStreamSynchronize(stream));
+      HIPCHECK(hipEventSynchronize(stopEvent));
 
       float currentMilliseconds = 0.0;
       HIPCHECK(

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -276,7 +276,7 @@ static LogicalResult
 measureSmallKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   const std::vector<void *> &argPointers,
+                   std::vector<void *> &argPointers,
                    std::vector<double> &measurements, double &smallKernelCpuMs,
                    bool benchmarkMode) {
   // Special case for small kernels, where we measure the time for all kernels
@@ -313,7 +313,7 @@ static LogicalResult
 measureLargeKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   const std::vector<void *> &argPointers,
+                   std::vector<void *> &argPointers,
                    std::vector<double> &measurements) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -272,20 +272,26 @@ struct CompilationResult {
   SmallVector<uint32_t> gridSizes;
 };
 
-static LogicalResult measureSmallKernel(
-    unsigned iterations, hipStream_t stream,
-    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
-    ArrayRef<uint32_t> gridSizes, std::vector<void *> &argPointers,
-    std::vector<double> &measurements, double &smallKernelCpuMs) {
+static LogicalResult
+measureSmallKernel(unsigned iterations, hipStream_t stream,
+                   const std::vector<hipFunction_t> &functions,
+                   ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
+                   std::vector<void *> &argPointers,
+                   std::vector<double> &measurements, double &smallKernelCpuMs,
+                   bool benchmarkMode) {
   // Special case for small kernels, where we measure the time for all kernels
   // at once, using CPU timers.
   auto iterationStart = std::chrono::steady_clock::now();
   for (unsigned iter = 0; iter < iterations; ++iter) {
-    if (failed(flushInstructionCache(stream))) {
-      return failure();
-    }
-    if (failed(flushL2Cache(stream))) {
-      return failure();
+    // Do not flush caches in benchmark mode, as we do not want to
+    // time the cache flush (it's okay if we are running in tuning mode).
+    if (!benchmarkMode) {
+      if (failed(flushInstructionCache(stream))) {
+        return failure();
+      }
+      if (failed(flushL2Cache(stream))) {
+        return failure();
+      }
     }
     for (auto [func, blockSize, gridSize] :
          llvm::zip(functions, blockSizes, gridSizes)) {
@@ -354,7 +360,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
                  ArrayRef<std::string> funcNames, ArrayRef<uint32_t> blockSizes,
                  ArrayRef<uint32_t> gridSizes, ArrayRef<void *> hostBuffers,
                  MutableArrayRef<void *> gpuBuffers,
-                 ArrayRef<size_t> bufferSizes, const BenchmarkParams &params) {
+                 ArrayRef<size_t> bufferSizes, const BenchmarkParams &params,
+                 bool benchmarkMode) {
   hipStream_t stream;
   HIPCHECK(hipStreamCreate(&stream));
   auto streamCleanup = llvm::make_scope_exit([&]() {
@@ -467,7 +474,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   if (isSmallKernel) {
     if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
                                   gridSizes, argPointers, measurements,
-                                  smallKernelCpuMs)))
+                                  smallKernelCpuMs, benchmarkMode)))
       return failure();
   } else {
     if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
@@ -630,10 +637,12 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   }
 
   // 4. Collect perf configs to compile
+  bool benchmarkMode = false;
   std::vector<SmallString<64>> configs;
   if (!benchmarkConfig.empty()) {
     // Benchmark mode - just one config
     configs.emplace_back(benchmarkConfig);
+    benchmarkMode = true;
   } else {
     // Tuning mode - all configs from tuning space
     std::unique_ptr<rock::TuningParamSet> tuningSpace(
@@ -836,7 +845,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
 
     FailureOr<double> timing = benchmarkKernels(
         result.hipModules, kernelFuncNames, result.blockSizes, result.gridSizes,
-        hostBuffers, gpuBuffers, bufferLengths, benchmarkParams);
+        hostBuffers, gpuBuffers, bufferLengths, benchmarkParams, benchmarkMode);
 
     if (failed(timing)) {
       llvm::errs() << "Kernel execution failed\n";

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -331,8 +331,6 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
-  llvm::errs() << "Hey\n";
-
   // Warmup run
   float totalMillisecondsWarmup = 0.0;
   HIPCHECK(hipStreamSynchronize(stream));
@@ -361,21 +359,20 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   }
   totalMillisecondsWarmup /= params.warmupIterations;
 
-  llvm::errs() << "Hey 2\n";
-
   // Measure runs
   std::vector<float> measurements;
 
-  // Depending on the runtime of the kernel (small kernel or normal kernel), 
+  // Depending on the runtime of the kernel
   // we use a different approach to measure the runs.
-  // We consider a small kernel if it takes less than 1ms to run.
+  // We consider a kernel to be small if it takes less than 1ms to run.
   constexpr float smallKernelThreshold = 1.0;
+  bool isSmallKernel = totalMillisecondsWarmup < smallKernelThreshold;
 
-  if (totalMillisecondsWarmup < smallKernelThreshold) {
-    // Special case for small kernels, where we launch all kernels
-    // asynchronously and measure the total host time.
+  if (isSmallKernel) {
+    // Special case for small kernels, where we measure the time for all kernels
+    // at once, using CPU timers.
     auto iterationStart = std::chrono::steady_clock::now();
-    for (unsigned iter = 0; iter < params.numIterations; ++iter) {    
+    for (unsigned iter = 0; iter < params.numIterations; ++iter) {
       for (auto [func, blockSize, gridSize] :
            llvm::zip(functions, blockSizes, gridSizes)) {
         HIPCHECK(hipExtModuleLaunchKernel(
@@ -383,7 +380,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
             argPointers.data(), nullptr, nullptr, nullptr));
       }
     }
-  
+
     HIPCHECK(hipStreamSynchronize(stream));
     float totalMilliseconds =
         std::chrono::duration<float, std::milli>(
@@ -391,7 +388,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
             .count();
     measurements.push_back(totalMilliseconds / params.numIterations);
   } else {
-    // Measure runs normally.    
+    // Measure runs normally.
     for (unsigned iter = 0; iter < params.numIterations; ++iter) {
       if (failed(flushInstructionCache(stream))) {
         return failure();
@@ -404,7 +401,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
       float totalMilliseconds = 0.0;
 
       for (auto [func, blockSize, gridSize] :
-          llvm::zip(functions, blockSizes, gridSizes)) {
+           llvm::zip(functions, blockSizes, gridSizes)) {
         hipEvent_t startEvent, stopEvent;
         HIPCHECK(hipEventCreate(&startEvent));
         HIPCHECK(hipEventCreate(&stopEvent));
@@ -430,16 +427,21 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     std::sort(measurements.begin(), measurements.end());
   }
 
-  if (params.showStats && measurements.size() > 1) {
-    float median = computeMedian(measurements);
-    float min = measurements.front();
-    float max = measurements.back();
-    float mean = computeMean(measurements);
-    float stdDev = computeStdDev(measurements, mean);
-    float coefficientOfVariation = (mean > 0) ? (stdDev / mean * 100) : 0;
-    llvm::outs() << "[min: " << min << ", median: " << median
-                 << ", max: " << max << ", stddev: " << stdDev
-                 << ", cv: " << coefficientOfVariation << "%]\t";
+  if (params.showStats) {
+    if (isSmallKernel) {
+      llvm::outs() << "show-stats not avaiable for small kernels\t";
+    }
+    if (measurements.size() > 1) {
+      float median = computeMedian(measurements);
+      float min = measurements.front();
+      float max = measurements.back();
+      float mean = computeMean(measurements);
+      float stdDev = computeStdDev(measurements, mean);
+      float coefficientOfVariation = (mean > 0) ? (stdDev / mean * 100) : 0;
+      llvm::outs() << "[min: " << min << ", median: " << median
+                   << ", max: " << max << ", stddev: " << stdDev
+                   << ", cv: " << coefficientOfVariation << "%]\t";
+    }
   }
 
   auto msToNs = [](float ms) { return 1e6 * static_cast<double>(ms); };

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -410,10 +410,6 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
-  // Depending on the runtime of the kernel,
-  // we will use a different approach to measure the runs.
-  // We consider a kernel to be small if it takes less than 1ms to run.
-  constexpr float smallKernelThreshold = 1.0f;
   bool isSmallKernel = false;
   unsigned iterations = params.numIterations;
 
@@ -458,6 +454,11 @@ benchmarkKernels(ArrayRef<std::string> binaries,
         iterations, static_cast<unsigned>(std::ceil(minTotalMilliseconds /
                                                     totalMillisecondsWarmup)));
 
+    // Depending on the runtime of the kernel,
+    // we will use a different approach to measure the runs.
+    // We consider a kernel to be small if a single iteration takes less than
+    // 1ms to run.
+    constexpr float smallKernelThreshold = 1.0f;
     isSmallKernel = totalMillisecondsWarmup < smallKernelThreshold;
   }
 

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -365,6 +365,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
   // Measure runs
   std::vector<float> measurements;
+  float smallKernelCpuMs = 0.0f;
 
   // Depending on the runtime of the kernel
   // we use a different approach to measure the runs.
@@ -395,11 +396,10 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
 
     HIPCHECK(hipStreamSynchronize(stream));
-    float totalMilliseconds =
-        std::chrono::duration<float, std::milli>(
-            std::chrono::steady_clock::now() - iterationStart)
-            .count();
-    measurements.push_back(totalMilliseconds / iterations);
+    smallKernelCpuMs = std::chrono::duration<float, std::milli>(
+                           std::chrono::steady_clock::now() - iterationStart)
+                           .count();
+    measurements.push_back(smallKernelCpuMs / iterations);
   } else {
     // Measure runs normally.
     for (unsigned iter = 0; iter < iterations; ++iter) {
@@ -441,10 +441,11 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   }
 
   if (params.showStats) {
-    // We cannot show stats because the small kernel case uses one timer
-    // only, so we cannot actually compute the min, max, etc.
+    // We cannot show the rest of the stats because the small kernel case uses
+    // one timer only, so we cannot actually compute the min, max, etc.
     if (isSmallKernel) {
-      llvm::outs() << "show-stats not avaiable for small kernels\t";
+      llvm::outs() << "[total CPUTime: " << smallKernelCpuMs
+                   << "iterations: " << iterations << "]\t";
     }
     if (measurements.size() > 1) {
       float median = computeMedian(measurements);

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -329,13 +329,8 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
     for (auto [func, blockSize, gridSize] :
          llvm::zip(functions, blockSizes, gridSizes)) {
       hipEvent_t startEvent, stopEvent;
-      // We use hipEventDisableSystemFence and hipEventReleaseToDevice to try
-      // to improve accuracy of the measurements. More details here:
-      // https://github.com/ROCm/rocMLIR/pull/2119#discussion_r2564849591
-      HIPCHECK(hipEventCreateWithFlags(
-          &startEvent, hipEventDisableSystemFence | hipEventReleaseToDevice));
-      HIPCHECK(hipEventCreateWithFlags(
-          &stopEvent, hipEventDisableSystemFence | hipEventReleaseToDevice));
+      HIPCHECK(hipEventCreate(&startEvent));
+      HIPCHECK(hipEventCreate(&stopEvent));
 
       HIPCHECK(hipExtModuleLaunchKernel(
           func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -331,30 +331,12 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
+  llvm::errs() << "Hey\n";
+
   // Warmup run
+  float totalMillisecondsWarmup = 0.0;
+  HIPCHECK(hipStreamSynchronize(stream));
   for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
-    for (auto [func, blockSize, gridSize] :
-         llvm::zip(functions, blockSizes, gridSizes)) {
-      HIPCHECK(hipExtModuleLaunchKernel(
-          func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-          argPointers.data(), nullptr, nullptr, nullptr));
-    }
-  }
-
-  // Measure runs
-  std::vector<float> measurements;
-
-  for (unsigned iter = 0; iter < params.numIterations; ++iter) {
-    if (failed(flushInstructionCache(stream))) {
-      return failure();
-    }
-    if (failed(flushL2Cache(stream))) {
-      return failure();
-    }
-    HIPCHECK(hipStreamSynchronize(stream));
-
-    float totalMilliseconds = 0.0;
-
     for (auto [func, blockSize, gridSize] :
          llvm::zip(functions, blockSizes, gridSizes)) {
       hipEvent_t startEvent, stopEvent;
@@ -363,7 +345,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
       HIPCHECK(hipExtModuleLaunchKernel(
           func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-          argPointers.data(), nullptr, startEvent, stopEvent));
+          argPointers.data(), nullptr, nullptr, nullptr));
+
       HIPCHECK(hipStreamSynchronize(stream));
 
       float currentMilliseconds = 0.0;
@@ -373,13 +356,79 @@ benchmarkKernels(ArrayRef<std::string> binaries,
       HIPCHECK(hipEventDestroy(stopEvent));
       HIPCHECK(hipEventDestroy(startEvent));
 
-      totalMilliseconds += currentMilliseconds;
+      totalMillisecondsWarmup += currentMilliseconds;
+    }
+  }
+  totalMillisecondsWarmup /= params.warmupIterations;
+
+  llvm::errs() << "Hey 2\n";
+
+  // Measure runs
+  std::vector<float> measurements;
+
+  // Depending on the runtime of the kernel (small kernel or normal kernel), 
+  // we use a different approach to measure the runs.
+  // We consider a small kernel if it takes less than 1ms to run.
+  constexpr float smallKernelThreshold = 1.0;
+
+  if (totalMillisecondsWarmup < smallKernelThreshold) {
+    // Special case for small kernels, where we launch all kernels
+    // asynchronously and measure the total host time.
+    auto iterationStart = std::chrono::steady_clock::now();
+    for (unsigned iter = 0; iter < params.numIterations; ++iter) {    
+      for (auto [func, blockSize, gridSize] :
+           llvm::zip(functions, blockSizes, gridSizes)) {
+        HIPCHECK(hipExtModuleLaunchKernel(
+            func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
+            argPointers.data(), nullptr, nullptr, nullptr));
+      }
+    }
+  
+    HIPCHECK(hipStreamSynchronize(stream));
+    float totalMilliseconds =
+        std::chrono::duration<float, std::milli>(
+            std::chrono::steady_clock::now() - iterationStart)
+            .count();
+    measurements.push_back(totalMilliseconds / params.numIterations);
+  } else {
+    // Measure runs normally.    
+    for (unsigned iter = 0; iter < params.numIterations; ++iter) {
+      if (failed(flushInstructionCache(stream))) {
+        return failure();
+      }
+      if (failed(flushL2Cache(stream))) {
+        return failure();
+      }
+      HIPCHECK(hipStreamSynchronize(stream));
+
+      float totalMilliseconds = 0.0;
+
+      for (auto [func, blockSize, gridSize] :
+          llvm::zip(functions, blockSizes, gridSizes)) {
+        hipEvent_t startEvent, stopEvent;
+        HIPCHECK(hipEventCreate(&startEvent));
+        HIPCHECK(hipEventCreate(&stopEvent));
+
+        HIPCHECK(hipExtModuleLaunchKernel(
+            func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
+            argPointers.data(), nullptr, startEvent, stopEvent));
+        HIPCHECK(hipStreamSynchronize(stream));
+
+        float currentMilliseconds = 0.0;
+        HIPCHECK(
+            hipEventElapsedTime(&currentMilliseconds, startEvent, stopEvent));
+
+        HIPCHECK(hipEventDestroy(stopEvent));
+        HIPCHECK(hipEventDestroy(startEvent));
+
+        totalMilliseconds += currentMilliseconds;
+      }
+
+      measurements.push_back(totalMilliseconds);
     }
 
-    measurements.push_back(totalMilliseconds);
+    std::sort(measurements.begin(), measurements.end());
   }
-
-  std::sort(measurements.begin(), measurements.end());
 
   if (params.showStats && measurements.size() > 1) {
     float median = computeMedian(measurements);

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -190,7 +190,7 @@ static benchmark::DataType getDataType(Type inputType) {
     return failure();                                                          \
   }
 
-static float computeMedian(const std::vector<float> &values) {
+static double computeMedian(const std::vector<double> &values) {
   if (values.empty())
     return 0.0;
 
@@ -205,11 +205,11 @@ static float computeMedian(const std::vector<float> &values) {
   return values[n / 2];
 }
 
-static float computeMean(const std::vector<float> &values) {
+static double computeMean(const std::vector<double> &values) {
   if (values.empty())
     return 0.0;
 
-  float sum = 0.0;
+  double sum = 0.0;
   for (size_t i = 0; i < values.size(); ++i) {
     sum += values[i];
   }
@@ -217,21 +217,21 @@ static float computeMean(const std::vector<float> &values) {
   return sum / values.size();
 }
 
-static float computeStdDev(const std::vector<float> &values, float mean) {
+static double computeStdDev(const std::vector<double> &values, double mean) {
   if (values.size() < 2)
     return 0.0;
 
-  float sumSquares = 0.0;
+  double sumSquares = 0.0;
   for (float val : values) {
-    float diff = val - mean;
+    double diff = val - mean;
     sumSquares += diff * diff;
   }
 
   return std::sqrt(sumSquares / values.size());
 }
 
-static std::vector<float> trimValues(const std::vector<float> &values,
-                                     unsigned trimPct) {
+static std::vector<double> trimValues(const std::vector<double> &values,
+                                      unsigned trimPct) {
   if (values.empty() || trimPct == 0)
     return values;
 
@@ -245,7 +245,8 @@ static std::vector<float> trimValues(const std::vector<float> &values,
   size_t startIdx = trimCount;
   size_t endIdx = values.size() - trimCount;
 
-  return std::vector<float>(values.begin() + startIdx, values.begin() + endIdx);
+  return std::vector<double>(values.begin() + startIdx,
+                             values.begin() + endIdx);
 }
 
 struct BenchmarkParams {
@@ -271,12 +272,11 @@ struct CompilationResult {
   SmallVector<uint32_t> gridSizes;
 };
 
-static LogicalResult
-measureSmallKernel(unsigned iterations, hipStream_t stream,
-                   const std::vector<hipFunction_t> &functions,
-                   ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   std::vector<void *> &argPointers,
-                   std::vector<float> &measurements, float &smallKernelCpuMs) {
+static LogicalResult measureSmallKernel(
+    unsigned iterations, hipStream_t stream,
+    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
+    ArrayRef<uint32_t> gridSizes, std::vector<void *> &argPointers,
+    std::vector<double> &measurements, double &smallKernelCpuMs) {
   // Special case for small kernels, where we measure the time for all kernels
   // at once, using CPU timers.
   auto iterationStart = std::chrono::steady_clock::now();
@@ -296,7 +296,7 @@ measureSmallKernel(unsigned iterations, hipStream_t stream,
   }
 
   HIPCHECK(hipStreamSynchronize(stream));
-  smallKernelCpuMs = std::chrono::duration<float, std::milli>(
+  smallKernelCpuMs = std::chrono::duration<double, std::milli>(
                          std::chrono::steady_clock::now() - iterationStart)
                          .count();
   measurements.push_back(smallKernelCpuMs / iterations);
@@ -308,7 +308,7 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
                    std::vector<void *> &argPointers,
-                   std::vector<float> &measurements) {
+                   std::vector<double> &measurements) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {
     if (failed(flushInstructionCache(stream))) {
@@ -319,7 +319,7 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
     }
     HIPCHECK(hipStreamSynchronize(stream));
 
-    float totalMilliseconds = 0.0;
+    double totalMilliseconds = 0.0;
 
     for (auto [func, blockSize, gridSize] :
          llvm::zip(functions, blockSizes, gridSizes)) {
@@ -339,7 +339,7 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
       HIPCHECK(hipEventDestroy(stopEvent));
       HIPCHECK(hipEventDestroy(startEvent));
 
-      totalMilliseconds += currentMilliseconds;
+      totalMilliseconds += static_cast<double>(currentMilliseconds);
     }
 
     measurements.push_back(totalMilliseconds);
@@ -417,7 +417,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     // Warmup run. We measure the warmup to get an estimate of the kernel
     // runtime. We will use this estimate to determine if the kernel is small or
     // not.
-    float totalMillisecondsWarmup = 0.0;
+    double totalMillisecondsWarmup = 0.0;
     HIPCHECK(hipStreamSynchronize(stream));
     for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
       for (auto [func, blockSize, gridSize] :
@@ -439,7 +439,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
         HIPCHECK(hipEventDestroy(stopEvent));
         HIPCHECK(hipEventDestroy(startEvent));
 
-        totalMillisecondsWarmup += currentMilliseconds;
+        totalMillisecondsWarmup += static_cast<double>(currentMilliseconds);
       }
     }
     totalMillisecondsWarmup /= params.warmupIterations;
@@ -463,8 +463,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   }
 
   // Measure runs
-  std::vector<float> measurements;
-  float smallKernelCpuMs = 0.0f;
+  std::vector<double> measurements;
+  double smallKernelCpuMs = 0.0;
 
   if (isSmallKernel) {
     if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
@@ -497,7 +497,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   }
 
-  auto msToNs = [](float ms) { return 1e6 * static_cast<double>(ms); };
+  auto msToNs = [](double ms) { return 1e6 * ms; };
   if (params.useMedian)
     return msToNs(computeMedian(measurements));
   // else

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -331,7 +331,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
-  // Warmup run
+  // Warmup run. We measure the warmup to get an estimate of the kernel runtime.
+  // We will use this estimate to determine if the kernel is small or not.
   float totalMillisecondsWarmup = 0.0;
   HIPCHECK(hipStreamSynchronize(stream));
   for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -344,7 +344,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
       HIPCHECK(hipExtModuleLaunchKernel(
           func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-          argPointers.data(), nullptr, nullptr, nullptr));
+          argPointers.data(), nullptr, startEvent, stopEvent));
 
       HIPCHECK(hipStreamSynchronize(stream));
 

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -374,10 +374,10 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   bool isSmallKernel = totalMillisecondsWarmup < smallKernelThreshold;
   unsigned iterations = params.numIterations;
 
-  // We want to get at least 10ms of kernel execution time
+  // We want to get at least 1ms of kernel execution time
   // (counting all iterations), so increase the number of iterations
   // if necessary.
-  constexpr float minTotalMilliseconds = 10.0f;
+  constexpr float minTotalMilliseconds = 1.0f;
   iterations = std::max<unsigned>(
       iterations, static_cast<unsigned>(std::ceil(minTotalMilliseconds /
                                                   totalMillisecondsWarmup)));

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -387,6 +387,12 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     // at once, using CPU timers.
     auto iterationStart = std::chrono::steady_clock::now();
     for (unsigned iter = 0; iter < iterations; ++iter) {
+      if (failed(flushInstructionCache(stream))) {
+        return failure();
+      }
+      if (failed(flushL2Cache(stream))) {
+        return failure();
+      }
       for (auto [func, blockSize, gridSize] :
            llvm::zip(functions, blockSizes, gridSizes)) {
         HIPCHECK(hipExtModuleLaunchKernel(

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -317,7 +317,6 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
     if (failed(flushL2Cache(stream))) {
       return failure();
     }
-    HIPCHECK(hipStreamSynchronize(stream));
 
     double totalMilliseconds = 0.0;
 
@@ -418,7 +417,6 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     // runtime. We will use this estimate to determine if the kernel is small or
     // not.
     double totalMillisecondsWarmup = 0.0;
-    HIPCHECK(hipStreamSynchronize(stream));
     for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
       for (auto [func, blockSize, gridSize] :
            llvm::zip(functions, blockSizes, gridSizes)) {


### PR DESCRIPTION
## Motivation

Noise during tuning is pretty high. See https://github.com/ROCm/rocMLIR-internal/issues/2032 for some results and also further details about why we are suffering from that noise. In summary, it comes from very fast kernels, which we cannot measure in a reliable way.

## Technical Details

This PR adds 2 ideas:
1. For small (i.e., _quick_) kernels (wet set a threshold called `smallKernelThreshold`, which controls what is a small kernel for us), we measure the runtime in a different way:
    - Old way (used for _slow_ kernels): Measure every independent run using GPU timers, then compute the average of all runs.
    - New way (used for _quick_ kernels): Measure the runtime of all iterations (runs) at once using a CPU timer.
2. We set another threshold, called `minTotalMilliseconds`, which ensures that the runtime of all iterations will be take at least that amount of time. For example, let's assume we have specified 10 iterations, and each iteration takes 0.01ms, and `minTotalMilliseconds=1`. Then, iterations will be increased to 100, so that the total runtime will reach the minimum threshold.

## Test Plan

Noise is reduced significantly (at least on MI300/MI350) for medium inputs, see:

- https://github.com/ROCm/rocMLIR-internal/issues/2032#issuecomment-3571152005
- https://github.com/ROCm/rocMLIR-internal/issues/2032#issuecomment-3581539328

Tiny inputs still show significant noise - this suggests that maybe we need another approach for those. I have the impression that actually those inputs cannot be measured reliably. Because they are very close or in the same range of the kernel launch overhead (~5 microseconds), there is not much else we can do about it.

## Test Result

No new tests were added.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
