### PR TITLE
Report error when invalid transformMap is created

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
@@ -176,10 +176,10 @@ protected:
   void addTransform(TransformType type, ArrayRef<int64_t> params,
                     ArrayRef<StringRef> startNames,
                     ArrayRef<uint32_t> startDims, ArrayRef<StringRef> endNames,
-                    ArrayRef<uint32_t> endDims) override final;
+                    ArrayRef<uint32_t> endDims) final;
   void extractBounds(SmallVectorImpl<int64_t> &upperDims,
-                     SmallVectorImpl<int64_t> &lowerDims) override final;
-  int64_t paddingSign() const override final;
+                     SmallVectorImpl<int64_t> &lowerDims) final;
+  int64_t paddingSign() const final;
 };
 
 /// A wrapper around a TopDownTMBuilder that looks up end dimensions in a
@@ -274,7 +274,7 @@ protected:
   void addTransform(TransformType type, ArrayRef<int64_t> params,
                     ArrayRef<StringRef> startNames,
                     ArrayRef<uint32_t> startDims, ArrayRef<StringRef> endNames,
-                    ArrayRef<uint32_t> endDims) override final;
+                    ArrayRef<uint32_t> endDims) final;
   void extractBounds(SmallVectorImpl<int64_t> &upperDims,
                      SmallVectorImpl<int64_t> &lowerDims) override final;
   int64_t paddingSign() const override final;

--- a/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/TransformMapBuilder.h
@@ -276,8 +276,8 @@ protected:
                     ArrayRef<uint32_t> startDims, ArrayRef<StringRef> endNames,
                     ArrayRef<uint32_t> endDims) final;
   void extractBounds(SmallVectorImpl<int64_t> &upperDims,
-                     SmallVectorImpl<int64_t> &lowerDims) override final;
-  int64_t paddingSign() const override final;
+                     SmallVectorImpl<int64_t> &lowerDims) final;
+  int64_t paddingSign() const final;
 };
 
 /// A wrapper around a BottomUpTMBuilder that looks up end dimensions in a

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -481,8 +481,8 @@ void TopDownTMBuilder::addTransform(TransformType type,
                               startNames, startDims, endNames, endDims);
   if (!attr) {
     emitError().report();
-    llvm::report_fatal_error(
-        Twine("Failed to add transform of type ") + getNameForTransformType(type));
+    llvm::report_fatal_error(Twine("Failed to add transform of type ") +
+                             getNameForTransformType(type));
   }
   result.push_back(attr);
 }
@@ -698,8 +698,8 @@ void BottomUpTMBuilder::addTransform(TransformType type,
                               endDims, startNames, startDims);
   if (!attr) {
     emitError().report();
-    llvm::report_fatal_error(
-        Twine("Failed to add transform of type ") + getNameForTransformType(type));
+    llvm::report_fatal_error(Twine("Failed to add transform of type ") +
+                             getNameForTransformType(type));
   }
   result.push_back(attr);
 }

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -481,7 +481,8 @@ void TopDownTMBuilder::addTransform(TransformType type,
                               startNames, startDims, endNames, endDims);
   if (!attr) {
     emitError().report();
-    llvm::report_fatal_error(Twine("Failed to add transform "));
+    llvm::report_fatal_error(
+        Twine("Failed to add transform of type ") + getNameForTransformType(type));
   }
   result.push_back(attr);
 }
@@ -697,7 +698,8 @@ void BottomUpTMBuilder::addTransform(TransformType type,
                               endDims, startNames, startDims);
   if (!attr) {
     emitError().report();
-    llvm::report_fatal_error(Twine("Failed to add transform "));
+    llvm::report_fatal_error(
+        Twine("Failed to add transform of type ") + getNameForTransformType(type));
   }
   result.push_back(attr);
 }

--- a/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
+++ b/mlir/lib/Dialect/Rock/IR/TransformMapBuilder.cpp
@@ -480,7 +480,8 @@ void TopDownTMBuilder::addTransform(TransformType type,
       getTransformAttrChecked(emitError, b.getContext(), type, params,
                               startNames, startDims, endNames, endDims);
   if (!attr) {
-    return;
+    emitError().report();
+    llvm::report_fatal_error(Twine("Failed to add transform "));
   }
   result.push_back(attr);
 }
@@ -695,7 +696,8 @@ void BottomUpTMBuilder::addTransform(TransformType type,
       getTransformAttrChecked(emitError, b.getContext(), type, params, endNames,
                               endDims, startNames, startDims);
   if (!attr) {
-    return;
+    emitError().report();
+    llvm::report_fatal_error(Twine("Failed to add transform "));
   }
   result.push_back(attr);
 }

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1739,7 +1739,7 @@ FailureOr<Value> mlir::rock::addPassThroughIndices(OpBuilder &b,
   /// shapes match up.
   ArrayRef<int64_t> underlyingShape =
       cast<ShapedType>(ret.getType()).getShape();
-  if (pos > underlyingShape.size()) {
+  if (static_cast<size_t>(pos) > underlyingShape.size()) {
     LLVM_DEBUG(llvm::dbgs() << "Invalid position for addPassThroughIndices: "
                             << pos << "\n");
     return failure();


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/rocMLIR-internal/issues/2113
## Technical Details

If transformMapAttr is failing verification checks then it should result in error and compilation crash instead of silently letting it through. 

## Test Plan

Ran  all tests locally with LIT_OPTS="-vas" and i don't see any crash or any error being reported. 

Reverted changes from https://github.com/ROCm/rocMLIR/pull/2083 which originally exposed the issue to see if it silently passes or not.  With changes from this PR it crashes and reports the error instead of silently passing. 

## Test Result

CI is passed

## Submission Checklist

