### PR TITLE
Non power of two tile sizes

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/Support/LogicalResult.h"
 
 namespace mlir {
 class Operation;
@@ -173,7 +174,7 @@ Value normalizeMatrix(Value matrix, OpBuilder &b, Location loc,
 // and the iter id dimensions, so that the threads write in a contiguous fashion
 // minimizing LDS bank conflicts.  This transformation swap those dimensions
 // back before producing the final output view
-TopDownTMBuilder
+FailureOr<TopDownTMBuilder>
 swapThreadIdAndIteration(TopDownTMBuilder &toMatrixC, int64_t mBlocks,
                          int64_t nBlocks, int64_t copyMPerThread,
                          int64_t copyNPerThread, int64_t mPerBlock,

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -728,13 +728,15 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
         "gemmBlockN", 4, {"n_repeat", "n_cuwaves", "n_cuwave", "n_thread"},
         {gemmNRepeat, nCuwavesPerBlock, nThreadsPerCuwave, nPerThread});
 
-    swapThreadIdAndIteration(
+    FailureOr<TopDownTMBuilder> swapRes = swapThreadIdAndIteration(
         toMatrixC, /*mBlocks=*/bidGridLengths[1],
         /*nBlocks=*/bidGridLengths[2], maybeVecDimInfoA->inDPerThread,
         maybeVecDimInfoB->inDPerThread, mPerBlock, nPerBlock,
         ldsLayoutConfigA.doSwapThreadIterSubDims,
         ldsLayoutConfigB.doSwapThreadIterSubDims,
         /*isBlockwise=*/false, transformAttrs);
+    if (failed(swapRes))
+      return failure();
 
     Value registerC = registerMatrixCAllocOp;
     ArrayAttr idToMatrixCMaps = b.getArrayAttr(transformAttrs);

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -17,6 +17,7 @@
 
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MathExtras.h"
 #include <memory>
 
 #define DEBUG_TYPE "rock-tuning-parameter"
@@ -475,6 +476,16 @@ PopulateParamsXDL::isValidBlockwiseGemm(RockAccelTuningParamAttrInterface param,
     return failure();
   }
 
+  if (param.getMPerWave() % param.getMnPerXdl() != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "tuning: mPerWave not divisible by mnPerXdl\n");
+    return failure();
+  }
+
+  if (param.getNPerWave() % param.getMnPerXdl() != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "tuning: nPerWave not divisible by mnPerXdl\n");
+    return failure();
+  }
+
   // Reject invalid blockSize
   int64_t kPerBlock = param.getKpackPerBlock() * param.getKpack();
   int64_t mPerBlock = param.getMPerBlock();
@@ -653,6 +664,16 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
 
   if ((param.getNPerBlock() % param.getNPerWave()) != 0)
     return failure();
+
+  if (param.getMPerWave() % param.getMnPerXdl() != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "tuning: mPerWave not divisible by mnPerXdl\n");
+    return failure();
+  }
+
+  if (param.getNPerWave() % param.getMnPerXdl() != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "tuning: nPerWave not divisible by mnPerXdl\n");
+    return failure();
+  }
 
   // Sledgehammer hotfix because not unrolling sometimes makes the register
   // allocator break. This should be refined quickly.

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -30,7 +30,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/LogicalResult.h"
-#include <algorithm>
 #include <cstdint>
 #include <random>
 
@@ -41,6 +40,40 @@
 
 namespace mlir {
 namespace rock {
+
+static std::vector<uint32_t> computeDPerBlock(TuningParamSetKind tuningKind) {
+  std::vector<uint32_t> dPerBlockList;
+
+  if (tuningKind == TuningParamSetKind::Greedy) {
+    for (uint32_t dPerBlock = 16; dPerBlock <= 256; dPerBlock += 16) {
+      dPerBlockList.push_back(dPerBlock);
+    }
+  } else {
+    for (uint32_t dPerBlock = 16; dPerBlock <= 256; dPerBlock *= 2) {
+      dPerBlockList.push_back(dPerBlock);
+    }
+  }
+  return dPerBlockList;
+}
+
+static SmallVector<uint32_t> compute1MPerBlock(TuningParamSetKind tuningKind,
+                                               uint32_t gemm0MPerBlock) {
+  SmallVector<uint32_t> mPerBlockList;
+  if (tuningKind == TuningParamSetKind::Greedy) {
+    for (uint32_t mPerBlock = gemm0MPerBlock; mPerBlock <= 256;
+         mPerBlock += 16) {
+      if (mPerBlock % gemm0MPerBlock == 0)
+        mPerBlockList.push_back(mPerBlock);
+    }
+  } else {
+    for (uint32_t mPerBlock = gemm0MPerBlock; mPerBlock <= 256;
+         mPerBlock *= 2) {
+      if (mPerBlock % gemm0MPerBlock == 0)
+        mPerBlockList.push_back(mPerBlock);
+    }
+  }
+  return mPerBlockList;
+}
 
 static SmallVector<uint32_t> computeDPerWave(TuningParamSetKind tuningKind,
                                              uint32_t dPerBlock,
@@ -135,9 +168,10 @@ getSchedules(Operation *op, const TuningParamSetKind &tuningKind) {
 
 static std::vector<std::vector<uint32_t>>
 getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
+  auto dPerBlock = computeDPerBlock(kind);
   std::vector<std::vector<uint32_t>> validRangeAccelGemmParams = {
-      {16, 32, 64, 128, 256},     // M/block
-      {16, 32, 64, 128, 256},     // N/block
+      dPerBlock,                  // M/block
+      dPerBlock,                  // N/block
       {1, 2, 4, 8},               // K/block
       {16, 32},                   // MnPerXdl
       {1, 4, 8, 16, 32},          // kPack
@@ -145,8 +179,8 @@ getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
       {0, 1}};                    // forceUnroll
 
   std::vector<std::vector<uint32_t>> validRangeAccelGemmParams8BitReduction = {
-      {16, 32, 64, 128, 256},     // M/block
-      {16, 32, 64, 128, 256},     // N/block
+      dPerBlock,                  // M/block
+      dPerBlock,                  // N/block
       {4, 8, 16, 32},             // K/block
       {16, 32},                   // MnPerXdl
       {1, 4, 8, 16},              // kPack
@@ -162,8 +196,8 @@ getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
                       : validRangeAccelGemmParams;
 
   std::vector<std::vector<uint32_t>> validRangeWmmaGemmParams = {
-      {16, 32, 64, 128, 256},     // M/block
-      {16, 32, 64, 128, 256},     // N/block
+      dPerBlock,                  // M/block
+      dPerBlock,                  // N/block
       {1, 2, 4, 8},               // K/block
       {16},                       // MnPerXdl
       {4, 8, 16},                 // kPack
@@ -177,27 +211,20 @@ getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
   return validRangeWmmaGemmParams;
 }
 
-static SmallVector<uint32_t> compute1MPerBlock(uint32_t gemm0MPerBlock) {
-  SmallVector<uint32_t> mPerBlockList;
-  for (uint32_t mPerBlock = gemm0MPerBlock; mPerBlock <= 256; mPerBlock *= 2) {
-    mPerBlockList.push_back(mPerBlock);
-  }
-  return mPerBlockList;
-}
-
 static std::vector<std::vector<uint32_t>>
 getAccelRangeAttn(RockGemmGemmWrapperInterface gemmGemmOp,
                   TuningParamSetKind kind) {
+  auto dPerBlock = computeDPerBlock(kind);
   static const std::vector<std::vector<uint32_t>> validRangeAttnParamsMFMA = {
-      /*gemm0MPerBlock=*/{16, 32, 64, 128, 256},
-      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
+      /*gemm0MPerBlock=*/dPerBlock,
+      /*gemm0NPerBlock=*/dPerBlock,
       /*kPackPerBlock=*/{2, 4, 8, 16, 32, 64},
       /*mnPerXdl=*/{4, 16, 32},
       /*kPack=*/{4, 8, 16},
       getSchedules(gemmGemmOp, kind)};
   static const std::vector<std::vector<uint32_t>> validRangeAttnParamsWMMA = {
-      /*gemm0MPerBlock=*/{16, 32, 64, 128},
-      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
+      /*gemm0MPerBlock=*/dPerBlock,
+      /*gemm0NPerBlock=*/dPerBlock,
       /*kPackPerBlock=*/{2, 4, 8, 16, 32, 64},
       /*mnPerXdl=*/{16},
       /*kPack=*/{4, 8, 16},
@@ -241,7 +268,8 @@ static void createAttnTuningRangeGreedyPhase1(
   for (uint32_t gemm0MPerBlock : params[0]) {
     SmallVector<uint32_t> mPerWaveRange =
         computeDPerWave(TuningParamSetKind::Greedy, gemm0MPerBlock, waveSize);
-    SmallVector<uint32_t> mPerBlockGemm1 = compute1MPerBlock(gemm0MPerBlock);
+    SmallVector<uint32_t> mPerBlockGemm1 =
+        compute1MPerBlock(TuningParamSetKind::Greedy, gemm0MPerBlock);
     for (uint32_t gemm1MPerBlock : mPerBlockGemm1) {
       for (uint32_t gemm0NPerBlock : params[1]) {
         SmallVector<uint32_t> nPerWaveRange = computeDPerWave(
@@ -255,8 +283,10 @@ static void createAttnTuningRangeGreedyPhase1(
                                    optimalSplitKFactors.size();
         uint32_t numRandomIterations =
             std::min(numRandomPerTileSize, totalIterations);
-        for (uint32_t randomIteration = 0;
-             randomIteration < numRandomIterations;) {
+        for (uint32_t randomIteration = 0, iterations = 0;
+             (randomIteration < numRandomIterations) &&
+             (iterations < 2 * numRandomIterations);
+             iterations++) {
           uint32_t gemmKPerBlock = params[2][rng() % params[2].size()];
           uint32_t gemmMPerWave = mPerWaveRange[rng() % mPerWaveRange.size()];
           uint32_t gemmNPerWave = nPerWaveRange[rng() % nPerWaveRange.size()];
@@ -308,7 +338,6 @@ static void createAttnTuningRangeGreedyPhase2(
 
   SmallVector<uint32_t> mPerWaveRange =
       computeDPerWave(TuningParamSetKind::Greedy, gemm0MPerBlock, waveSize);
-  SmallVector<uint32_t> mPerBlockGemm1 = compute1MPerBlock(gemm0MPerBlock);
   SmallVector<uint32_t> nPerWaveRange =
       computeDPerWave(TuningParamSetKind::Greedy, gemm0NPerBlock, waveSize);
   auto optimalSplitKFactors =
@@ -363,7 +392,8 @@ static void createAttnTuningRangeBF(TuningParamSet *newSpace,
   for (uint32_t gemm0MPerBlock : validRangeAttnParams[0]) {
     SmallVector<uint32_t> mPerWaveRange =
         computeDPerWave(kind, gemm0MPerBlock, waveSize);
-    SmallVector<uint32_t> mPerBlockGemm1 = compute1MPerBlock(gemm0MPerBlock);
+    SmallVector<uint32_t> mPerBlockGemm1 =
+        compute1MPerBlock(kind, gemm0MPerBlock);
     for (uint32_t gemm1MPerBlock : mPerBlockGemm1) {
       for (uint32_t gemm0NPerBlock : validRangeAttnParams[1]) {
         SmallVector<uint32_t> nPerWaveRange =
@@ -776,8 +806,10 @@ static void createGemmTuningRangeGreedyPhase1(TuningParamSet *newSpace,
                                  params[6].size();
       uint32_t numRandomIterations =
           std::min(numRandomPerTileSize, totalIterations);
-      for (uint32_t randomIteration = 0;
-           randomIteration < numRandomIterations;) {
+      for (uint32_t randomIteration = 0, iterations = 0;
+           (randomIteration < numRandomIterations) &&
+           (iterations < 2 * numRandomIterations);
+           iterations++) {
         uint32_t gemmKPerBlock = params[2][rng() % params[2].size()];
         uint32_t gemmMPerWave = mPerWaveRange[rng() % mPerWaveRange.size()];
         uint32_t gemmNPerWave = nPerWaveRange[rng() % nPerWaveRange.size()];

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LogicalResult.h"
 
 using namespace mlir;
 using namespace mlir::arith;
@@ -371,11 +372,13 @@ llvm::FailureOr<RegsAsMatrixSubTiles> MfmaEmitter::computeOutputTransforms(
     // threadid/iter dimensions on both the M/N axis.
     SmallVector<Attribute> transformAttrs{splitMemoryCoordsAttr,
                                           toRowsAndColsAttr};
-    mlir::rock::swapThreadIdAndIteration(
+    FailureOr<TopDownTMBuilder> swapRes = mlir::rock::swapThreadIdAndIteration(
         toMatrixC, /*mBlocks=*/bidGridLengths[1], /*nBlocks=*/bidGridLengths[2],
         inMPerThread, inNPerThread, mPerBlock, nPerBlock,
         doSwapThreadIterSubDimsForM, doSwapThreadIterSubDimsForN,
         /*isBlockwise=*/false, transformAttrs);
+    if (failed(swapRes))
+      return failure();
 
     ret.gridSubTile = b.getArrayAttr(transformAttrs);
   }
@@ -1188,11 +1191,13 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
                       ArrayRef<int64_t>{dimSizesN}.slice(1));
 
     SmallVector<Attribute> transformAttrs{splitMemoryCoordsAttr};
-    mlir::rock::swapThreadIdAndIteration(
+    FailureOr<TopDownTMBuilder> swapRes = mlir::rock::swapThreadIdAndIteration(
         toMatrixC, /*mBlocks=*/bidGridLengths[1], /*nBlocks=*/bidGridLengths[2],
         inMPerThread, inNPerThread, mPerBlock, nPerBlock,
         doSwapThreadIterSubDimsForM, doSwapThreadIterSubDimsForN,
         /**isBlockwise=*/false, transformAttrs);
+    if (failed(swapRes))
+      return failure();
 
     ret.gridSubTile = b.getArrayAttr(transformAttrs);
   }

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/FormatVariadic.h"
 
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 using namespace mlir;
 using namespace mlir::rock;
 
@@ -231,8 +232,14 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getLoadRegsAsTileViews(
 
   // Note: (kThreads * dThreads) = (kPerBlock * dPerBlock) / dataPerThread) =
   // blockSize
-  int64_t kThreads = kPerBlock / kPerThread;
+  if (dPerBlock % dPerThread != 0) {
+    return failure();
+  }
   int64_t dThreads = dPerBlock / dPerThread;
+  int64_t kThreads = blockSize / dThreads;
+  if (kThreads * dThreads != blockSize) {
+    return failure();
+  }
 
   RegsAsMatrixSubTiles gpuViews;
   {
@@ -325,8 +332,14 @@ FailureOr<RegsAsMatrixSubTiles> mlir::rock::getPackedRegsAsTileViews(
 
   // Note: (kThreads * dThreads) = (kPerBlock * dPerBlock) / dataPerThread) =
   // blockSize
-  int64_t kThreads = kPerBlock / kPerThread;
+  if (dPerBlock % dPerThread != 0) {
+    return failure();
+  }
   int64_t dThreads = dPerBlock / dPerThread;
+  int64_t kThreads = blockSize / dThreads;
+  if (kThreads * dThreads != blockSize) {
+    return failure();
+  }
 
   int64_t kpackPerThread = std::min(kPerThread, kpack);
   assert(kPerThread % kpackPerThread == 0);
@@ -459,7 +472,7 @@ Value mlir::rock::padMatrix(Value matrix, OpBuilder &b, Location loc,
   return TransformOp::create(b, loc, matrix, padAttr);
 }
 
-TopDownTMBuilder mlir::rock::swapThreadIdAndIteration(
+FailureOr<TopDownTMBuilder> mlir::rock::swapThreadIdAndIteration(
     TopDownTMBuilder &toMatrixC, int64_t mBlocks, int64_t nBlocks,
     int64_t copyMPerThread, int64_t copyNPerThread, int64_t mPerBlock,
     int64_t nPerBlock, bool doSwapThreadIterSubDimsForM,
@@ -480,6 +493,8 @@ TopDownTMBuilder mlir::rock::swapThreadIdAndIteration(
       splitAgain.passThrough({"gemmBlockM"}, {idx}, {"gemmBlockM"});
       idx += 1;
     } else {
+      if (mPerBlock % copyMPerThread != 0)
+        return failure();
       splitAgain.merge({"m_iter", "m_tid"}, {idx, idx + 1}, "gemmBlockM",
                        {copyMPerThread, mPerBlock / copyMPerThread});
       idx += 2;
@@ -487,9 +502,12 @@ TopDownTMBuilder mlir::rock::swapThreadIdAndIteration(
 
     if (!doSwapThreadIterSubDimsForN)
       splitAgain.passThrough({"gemmBlockN"}, {idx}, {"gemmBlockN"});
-    else
+    else {
+      if (nPerBlock % copyNPerThread != 0)
+        return failure();
       splitAgain.merge({"n_iter", "n_tid"}, {idx, idx + 1}, "gemmBlockN",
                        {copyNPerThread, nPerBlock / copyNPerThread});
+    }
   }
   TransformMapAttr splitAgainAttr = splitAgain.get();
   transformAttr.push_back(splitAgainAttr);

--- a/mlir/test/e2e/AttentionNonPowerOfTwoTileSize.cfg
+++ b/mlir/test/e2e/AttentionNonPowerOfTwoTileSize.cfg
@@ -1,0 +1,2 @@
+if not (config.arch_support_mfma or config.arch_support_wmma):
+  config.unsupported = True

--- a/mlir/test/e2e/AttentionNonPowerOfTwoTileSize.toml
+++ b/mlir/test/e2e/AttentionNonPowerOfTwoTileSize.toml
@@ -1,0 +1,71 @@
+directory = "AttentionNonPowerOfTwoTileSize"
+prefix = "rocmlir-gen"
+suffix = "--operation attention --arch %arch -pv %random_data -rand_min 0 -rand_max 1 -rand_type float %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "t"
+values = ["f16", "bf16", "i8"]
+prefix = "-t "
+
+[[axis]]
+name = "transQ"
+values = ["true", "false"]
+prefix = "--transQ="
+
+[[axis]]
+name = "transK"
+values = ["true", "false"]
+prefix = "--transK="
+
+[[axis]]
+name = "transV"
+values = ["true", "false"]
+prefix = "--transV="
+
+[[axis]]
+name = "transO"
+values = ["true", "false"]
+prefix = "--transO="
+
+[[axis]]
+name = "perf_config"
+values = ["attn:v3:64,64,192,32,32,96,16,8,1,1,2,1", "attn:v3:64,64,96,8,32,48,16,8,1,1,2,1"]
+prefix = "--perf_config "
+
+## attention variant
+[[suite]]
+name = "attention_non_power_of_two_tile_size"
+
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# cross attention
+[[suite.test]]
+config = "-seq_len_q 128 -seq_len_k 27 -head_dim_qk 64 -head_dim_v 32 --with-attn-scale --with-attn-bias"
+
+# issue 1661
+[[suite.test]]
+config = "-seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# causal
+[[suite.test]]
+config = "-seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"
+
+# GQA + KV Cache batch=3 + return LSE
+[[suite.test]]
+config = "-rand 1 -return_lse -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + KV Cache batch=3 + return LSE + split-kv
+[[suite.test]]
+config = "-rand 1 -return_lse -split_kv 4 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + KV Cache batch=3 + return LSE + split-kv (padding)
+[[suite.test]]
+config = "-rand 1 -return_lse -split_kv 8 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --with-attn-bias"
+
+# GQA + causal + KV Cache batch=3 + return LSE + split-kv (padding)
+[[suite.test]]
+config = "-rand 1 -return_lse -split_kv 8 -current_seq_len=17,1,32 -g 3 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 1 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -causal --with-attn-scale --with-attn-bias"

--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -61,6 +61,7 @@ if (ROCK_E2E_TEST_ENABLED)
   GemmScaled
   GemmScaledF32
   MixedConvLayouts
+  GemmVariantsNonPowerOfTwoTileSize
   )
   list(APPEND CONFIGS
   Resnet50Config
@@ -95,6 +96,7 @@ if (ROCK_E2E_TEST_ENABLED)
   AttentionDirectToLDS
   GemmElementwiseGemmDirectToLDS
   ConvElementwiseGemmDirectToLDS
+  AttentionNonPowerOfTwoTileSize
   )
 endif()
 # Create a list for dummy files

--- a/mlir/test/e2e/GemmVariantsNonPowerOfTwoTileSize.toml
+++ b/mlir/test/e2e/GemmVariantsNonPowerOfTwoTileSize.toml
@@ -1,0 +1,44 @@
+directory = "GemmVariantsNonPowerOfTwoTileSize"
+prefix = "rocmlir-gen"
+suffix = "--operation gemm --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "transA"
+values = ["true", "false"]
+prefix = "--transA="
+
+[[axis]]
+name = "transB"
+values = ["true", "false"]
+prefix = "--transB="
+
+[[axis]]
+name = "transC"
+values = ["true", "false"]
+prefix = "--transC="
+
+[[axis]]
+name = "data type"
+values = ["f16", "bf16", "i8", "fp8_fp8"]
+prefix = "-t "
+
+[[axis]]
+name = "perf_config"
+values = ["v4:96,96,8,48,48,16,8,1,1,2,1,1", "v4:192,96,8,96,48,16,8,1,1,2,1,1"]
+prefix = "--perf_config "
+
+## Gemm variants
+[[suite]]
+name = "gemm_variants_non_power_of_two_tile_size"
+
+[[suite.test]]
+config = "-g 3 -m 1024 -k 769 -n 1024"
+
+[[suite.test]]
+config = "-g 1 -m 1024 -k 769 -n 1024"
+
+# Let's make sure the very silly thing works
+[[suite.test]]
+config = "-g 1 -m 1 -k 1 -n 1"
+
+


### PR DESCRIPTION
## Motivation

Enable non-power of two tile sizes.

## Technical Details

Changes mainly to `RockTuningImpl.cpp` to enable non power of two tile sizes and extra checks to disable kernels that don't work.

Results for f16 on MI350: https://github.com/ROCm/rocMLIR-internal/issues/1894#issuecomment-3569662947

## Test Plan

All tests pass. Add new tests with non-power of two tile sizes.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
