### PR TITLE
Diff-base detection in Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
           echo "BASE_REF=$BASE_REF"
-          git fetch origin ${{ github.base_ref }} --depth=1 || true
+          git fetch origin ${BASE_REF#origin/} --depth=1 || true
 
           # Verify that BASE_REF exists locally
           if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,30 +41,40 @@ jobs:
         id: changes
         shell: bash
         run: |
+          echo "Determining merge base..."
+
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            BASE_REF="origin/${{ github.base_ref }}"
           else
-            BASE_SHA="${{ github.event.before }}"
+            BASE_REF="origin/${{ github.ref_name }}"
           fi
-          HEAD_SHA="${{ github.sha }}"
-          # list added/modified files, restrict to mlir/**/*.py
-          files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
+
+          echo "BASE_REF=$BASE_REF"
+          git fetch origin ${{ github.base_ref }} --depth=1 || true
+
+          BASE_SHA=$(git merge-base HEAD "$BASE_REF")
+          echo "BASE_SHA=$BASE_SHA"
+
+          # Get added/modified Python files under mlir/
+          files=$(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD \
                     | grep -E '^mlir/.*\.py$' || true)
+
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$files" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          echo "Changed files:"
+
+          echo "Changed Python files:"
           echo "$files"
 
       - name: Run flake8
         if: steps.changes.outputs.files != ''
         run: |
-          flake8 --ignore=E501,E251,E124,W605,W504,E131,E126,W503 ${{ steps.changes.outputs.files }}
+          flake8 --ignore=E501,E251,E124,W605,W504,E131,E126,W503 \
+            ${{ steps.changes.outputs.files }}
 
       - name: Run YAPF check
         if: steps.changes.outputs.files != ''
         run: |
-          # --diff prints a unified diff and returns non-zero if changes would be made
           yapf --diff ${{ steps.changes.outputs.files }} \
             || (echo "Format issues found. Fix locally with: yapf -i <files>"; exit 1)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
           echo "BASE_REF=$BASE_REF"
           git fetch origin ${{ github.base_ref }} --depth=1 || true
 
+          # Verify that BASE_REF exists locally
+          if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+            echo "Error: Base ref '$BASE_REF' does not exist locally. Fetch may have failed." >&2
+            exit 1
+          fi
           BASE_SHA=$(git merge-base HEAD "$BASE_REF")
           echo "BASE_SHA=$BASE_SHA"
 


### PR DESCRIPTION
## Motivation

Some PRs randomly fail with Python lint and format check errors, but it has no python changes at all.

- Resolves https://github.com/ROCm/rocMLIR-internal/issues/2140

## Technical Details

Use diff-base detection for python linting in Github Actions CI to correctly detect changed files and prevent false lint failures.

## Test Plan

Can be tested after it's on develop

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
