### PR TITLE
Fix nonAccel perfconfig

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockAttrDefs.td
@@ -251,7 +251,7 @@ def Rock_GeneralGemmParamsAttr : Rock_Attr<"GeneralGemmParams", [RockTuningParam
 
   let extraClassDeclaration = [{
     void getPerfConfigStr(::llvm::SmallVectorImpl<char> &perfStr) {
-      ("v4:" + Twine(getBlockSize()) + ","
+      ("v3:" + Twine(getBlockSize()) + ","
       + Twine(getMPerBlock()) + ","
       + Twine(getNPerBlock()) + ","
       + Twine(getKPerBlock()) + ","

--- a/mlir/test/rocmlir-gen/emit-tuning-space.mlir
+++ b/mlir/test/rocmlir-gen/emit-tuning-space.mlir
@@ -1,5 +1,5 @@
 // RUN: rocmlir-gen -p --arch gfx1100 --operation=gemm --emit-tuning-space=full | FileCheck %s --check-prefixes=CHECK-NAVI
-// CHECK-NAVI: v4:64,32,32,4,2,4,1,1,2
+// CHECK-NAVI: v3:64,32,32,4,2,4,1,1,2
 
 // RUN: rocmlir-gen --arch gfx90a --operation=gemm -t f32 -g 1 -m 64 -k 128 -n 64 --num_cu=104 --emit-tuning-space=full | FileCheck %s --check-prefixes=CHECK-MI
 // CHECK-MI: v4:64,64,8,32,32,16,4,4,1,2,1,1

--- a/mlir/unittests/Dialect/Rock/CMakeLists.txt
+++ b/mlir/unittests/Dialect/Rock/CMakeLists.txt
@@ -4,6 +4,7 @@ set(ROCK_UNITTEST_SOURCES
   loweringUtilsTests.cpp
   transformMapUtilsTests.cpp
   InitParamsAccelTests.cpp
+  InitParamsNonAccelTests.cpp
 )
 
 if(NOT WIN32)

--- a/mlir/unittests/Dialect/Rock/InitParamsNonAccelTests.cpp
+++ b/mlir/unittests/Dialect/Rock/InitParamsNonAccelTests.cpp
@@ -1,0 +1,94 @@
+//===- InitParamsNonAccelTests.cpp - Tests for InitParamsNonAccel --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace mlir::rock;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// v3 perfconfig
+//===----------------------------------------------------------------------===//
+
+TEST(V3Config, First) {
+  InitParamsAccel validParams;
+  bool isValidPerfConfig =
+      validParams.deserialize("v3:64,32,32,4,2,4,1,1,2");
+
+  EXPECT_EQ(isValidPerfConfig, true);
+  EXPECT_EQ(validParams.gemmBThreadCopyMoreGemmKPack, true);
+  EXPECT_EQ(validParams.gemmAThreadCopyMoreGemmK, true);
+  EXPECT_EQ(validParams.getKPack(), 4);
+  EXPECT_EQ(validParams.gemmKPack, 4);
+  EXPECT_EQ(validParams.splitKFactor, 2);
+  EXPECT_EQ(validParams.gemmMPerWave, 32);
+  EXPECT_EQ(validParams.gemmNPerWave, 32);
+  EXPECT_EQ(validParams.gemmNPerWaveOrMnPerXdl, 0);
+  EXPECT_EQ(validParams.gemmScheduleVersion, 3);
+  EXPECT_EQ(validParams.gemmMnPerXdl, 16);
+  EXPECT_EQ(validParams.outputSwizzle, 2);
+  EXPECT_EQ(validParams.getVersion(), InitParamsAccel::Version::V4);
+  EXPECT_EQ(validParams.gemmMPerBlock, 64);
+  EXPECT_EQ(validParams.gemmNPerBlock, 64);
+  EXPECT_EQ(validParams.gemmKPerBlock, 8);
+}
+
+TEST(V4Config, Second) {
+  InitParamsAccel validParams;
+  bool isValidPerfConfig =
+      validParams.deserialize("v3:64,64,32,4,2,4,1,1,2");
+
+  EXPECT_EQ(isValidPerfConfig, true);
+  EXPECT_EQ(validParams.gemmBThreadCopyMoreGemmKPack, true);
+  EXPECT_EQ(validParams.gemmAThreadCopyMoreGemmK, false);
+  EXPECT_EQ(validParams.getKPack(), 4);
+  EXPECT_EQ(validParams.gemmKPack, 4);
+  EXPECT_EQ(validParams.splitKFactor, 9);
+  EXPECT_EQ(validParams.gemmMPerWave, 64);
+  EXPECT_EQ(validParams.gemmNPerWave, 32);
+  EXPECT_EQ(validParams.gemmNPerWaveOrMnPerXdl, 0);
+  EXPECT_EQ(validParams.gemmScheduleVersion, 2);
+  EXPECT_EQ(validParams.gemmMnPerXdl, 32);
+  EXPECT_EQ(validParams.outputSwizzle, 2);
+  EXPECT_EQ(validParams.getVersion(), InitParamsAccel::Version::V4);
+  EXPECT_EQ(validParams.gemmMPerBlock, 128);
+  EXPECT_EQ(validParams.gemmNPerBlock, 64);
+  EXPECT_EQ(validParams.gemmKPerBlock, 8);
+}
+
+//===----------------------------------------------------------------------===//
+// Negative Tests
+//===----------------------------------------------------------------------===//
+
+TEST(NegativeTests, NoVersion) {
+  InitParamsAccel validParams;
+  bool isValidPerfConfig =
+      validParams.deserialize("128,64,8,64,32,4,9,2,2,0,1");
+
+  EXPECT_EQ(isValidPerfConfig, false);
+}
+
+TEST(NegativeTests, WrongNumberV3) {
+  InitParamsAccel validParams;
+  bool isValidPerfConfig =
+      validParams.deserialize("v3:64,32,32,4,2,4,1,1");
+
+  EXPECT_EQ(isValidPerfConfig, false);
+}
+
+TEST(NegativeTests, Empty) {
+  InitParamsAccel validParams;
+  bool isValidPerfConfig = validParams.deserialize("");
+
+  EXPECT_EQ(isValidPerfConfig, false);
+}
+
+} // end anonymous namespace

--- a/mlir/unittests/Dialect/Rock/InitParamsNonAccelTests.cpp
+++ b/mlir/unittests/Dialect/Rock/InitParamsNonAccelTests.cpp
@@ -1,4 +1,5 @@
-//===- InitParamsNonAccelTests.cpp - Tests for InitParamsNonAccel --------------===//
+//===- InitParamsNonAccelTests.cpp - Tests for InitParamsNonAccel
+//--------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -19,49 +20,39 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 TEST(V3Config, First) {
-  InitParamsAccel validParams;
-  bool isValidPerfConfig =
-      validParams.deserialize("v3:64,32,32,4,2,4,1,1,2");
+  InitParamsNonAccel validParams;
+  bool isValidPerfConfig = validParams.deserialize("v3:64,32,32,4,2,4,1,1,2");
 
   EXPECT_EQ(isValidPerfConfig, true);
-  EXPECT_EQ(validParams.gemmBThreadCopyMoreGemmKPack, true);
-  EXPECT_EQ(validParams.gemmAThreadCopyMoreGemmK, true);
-  EXPECT_EQ(validParams.getKPack(), 4);
-  EXPECT_EQ(validParams.gemmKPack, 4);
-  EXPECT_EQ(validParams.splitKFactor, 2);
-  EXPECT_EQ(validParams.gemmMPerWave, 32);
-  EXPECT_EQ(validParams.gemmNPerWave, 32);
-  EXPECT_EQ(validParams.gemmNPerWaveOrMnPerXdl, 0);
-  EXPECT_EQ(validParams.gemmScheduleVersion, 3);
-  EXPECT_EQ(validParams.gemmMnPerXdl, 16);
+  EXPECT_EQ(validParams.blockSize, static_cast<uint32_t>(64));
+  EXPECT_EQ(validParams.gemmMPerBlock, 32);
+  EXPECT_EQ(validParams.gemmNPerBlock, 32);
+  EXPECT_EQ(validParams.gemmKPerBlock, 4);
+  EXPECT_EQ(validParams.gemmMPerThread, 2);
+  EXPECT_EQ(validParams.gemmNPerThread, 4);
+  EXPECT_EQ(validParams.splitKFactor, 1);
+  EXPECT_EQ(validParams.gemmScheduleVersion, 1);
   EXPECT_EQ(validParams.outputSwizzle, 2);
-  EXPECT_EQ(validParams.getVersion(), InitParamsAccel::Version::V4);
-  EXPECT_EQ(validParams.gemmMPerBlock, 64);
-  EXPECT_EQ(validParams.gemmNPerBlock, 64);
-  EXPECT_EQ(validParams.gemmKPerBlock, 8);
+  EXPECT_EQ(validParams.getKPack(), 1);
+  EXPECT_EQ(validParams.getVersion(), InitParamsNonAccel::Version::V3);
 }
 
-TEST(V4Config, Second) {
-  InitParamsAccel validParams;
-  bool isValidPerfConfig =
-      validParams.deserialize("v3:64,64,32,4,2,4,1,1,2");
+TEST(V3Config, Second) {
+  InitParamsNonAccel validParams;
+  bool isValidPerfConfig = validParams.deserialize("v3:128,64,32,8,4,2,3,1,2");
 
   EXPECT_EQ(isValidPerfConfig, true);
-  EXPECT_EQ(validParams.gemmBThreadCopyMoreGemmKPack, true);
-  EXPECT_EQ(validParams.gemmAThreadCopyMoreGemmK, false);
-  EXPECT_EQ(validParams.getKPack(), 4);
-  EXPECT_EQ(validParams.gemmKPack, 4);
-  EXPECT_EQ(validParams.splitKFactor, 9);
-  EXPECT_EQ(validParams.gemmMPerWave, 64);
-  EXPECT_EQ(validParams.gemmNPerWave, 32);
-  EXPECT_EQ(validParams.gemmNPerWaveOrMnPerXdl, 0);
-  EXPECT_EQ(validParams.gemmScheduleVersion, 2);
-  EXPECT_EQ(validParams.gemmMnPerXdl, 32);
-  EXPECT_EQ(validParams.outputSwizzle, 2);
-  EXPECT_EQ(validParams.getVersion(), InitParamsAccel::Version::V4);
-  EXPECT_EQ(validParams.gemmMPerBlock, 128);
-  EXPECT_EQ(validParams.gemmNPerBlock, 64);
+  EXPECT_EQ(validParams.blockSize, static_cast<uint32_t>(128));
+  EXPECT_EQ(validParams.gemmMPerBlock, 64);
+  EXPECT_EQ(validParams.gemmNPerBlock, 32);
   EXPECT_EQ(validParams.gemmKPerBlock, 8);
+  EXPECT_EQ(validParams.gemmMPerThread, 4);
+  EXPECT_EQ(validParams.gemmNPerThread, 2);
+  EXPECT_EQ(validParams.splitKFactor, 3);
+  EXPECT_EQ(validParams.gemmScheduleVersion, 1);
+  EXPECT_EQ(validParams.outputSwizzle, 2);
+  EXPECT_EQ(validParams.getKPack(), 1);
+  EXPECT_EQ(validParams.getVersion(), InitParamsNonAccel::Version::V3);
 }
 
 //===----------------------------------------------------------------------===//
@@ -69,7 +60,7 @@ TEST(V4Config, Second) {
 //===----------------------------------------------------------------------===//
 
 TEST(NegativeTests, NoVersion) {
-  InitParamsAccel validParams;
+  InitParamsNonAccel validParams;
   bool isValidPerfConfig =
       validParams.deserialize("128,64,8,64,32,4,9,2,2,0,1");
 
@@ -77,15 +68,14 @@ TEST(NegativeTests, NoVersion) {
 }
 
 TEST(NegativeTests, WrongNumberV3) {
-  InitParamsAccel validParams;
-  bool isValidPerfConfig =
-      validParams.deserialize("v3:64,32,32,4,2,4,1,1");
+  InitParamsNonAccel validParams;
+  bool isValidPerfConfig = validParams.deserialize("v3:64,32,32,4,2,4,1,1");
 
   EXPECT_EQ(isValidPerfConfig, false);
 }
 
 TEST(NegativeTests, Empty) {
-  InitParamsAccel validParams;
+  InitParamsNonAccel validParams;
   bool isValidPerfConfig = validParams.deserialize("");
 
   EXPECT_EQ(isValidPerfConfig, false);


### PR DESCRIPTION
## Motivation

A bug was introduced in https://github.com/ROCm/rocMLIR/pull/2088 that makes non-accel tuning fail. Non accel perfConfig has to stay in v3 for now due to the number of params.

## Technical Details

Add tests for nonaccel perfConfig and change it back to v3.

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
