### PR TITLE
[EXTERNAL] Fix uninitialized memory in gpu-to-hsaco 

### DIFF
--- a/external/llvm-project/mlir/test/Integration/GPU/ROCM/gpu-to-hsaco.mlir
+++ b/external/llvm-project/mlir/test/Integration/GPU/ROCM/gpu-to-hsaco.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s \
+// RUN: | mlir-opt -convert-scf-to-cf \
 // RUN: | mlir-opt -gpu-kernel-outlining \
 // RUN: | mlir-opt -pass-pipeline='builtin.module(gpu.module(strip-debuginfo,convert-gpu-to-rocdl),rocdl-attach-target{chip=%chip})' \
 // RUN: | mlir-opt -gpu-to-llvm -reconcile-unrealized-casts -gpu-module-to-binary \
@@ -27,6 +28,13 @@ func.func @main() {
   %22 = memref.cast %arg0 : memref<5xf32> to memref<?xf32>
   %cast = memref.cast %22 : memref<?xf32> to memref<*xf32>
   gpu.host_register %cast : memref<*xf32>
+  %zero = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  scf.for %i = %c0 to %c5 step %c1 {
+    memref.store %zero, %22[%i] : memref<?xf32>
+  }
   %23 = memref.cast %22 : memref<?xf32> to memref<*xf32>
   call @printMemrefF32(%23) : (memref<*xf32>) -> ()
   %24 = arith.constant 1.0 : f32


### PR DESCRIPTION
## Motivation

This PR fixes an intermittent timeout/failure that we see when running the PR CI.

This fixes https://github.com/ROCm/rocMLIR-internal/issues/2146

## Technical Details

It appears that reading uninitialized registered memory triggers a different (and problematic) synchronization code path in the ROCm runtime, possibly involving resource allocation or lock contention that doesn't occur when memory is pre-initialized.

## Test Plan

- Multiple clean runs (~5) of the PR CI

## Test Result

- [ ] Consecutive clean runs of the PR CI (that don't hit other CI issues):
  - Run 1: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2129/2/pipeline-overview/?selected-node=893
  - Run 2: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2129/3/pipeline-overview/
  - Run 3:
  - Run 4:
  - Run 5:

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
