### PR TITLE
Greedy tuning

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/GridwiseGemmParams.h
@@ -470,6 +470,11 @@ protected:
                                           Type dataTypeB) override;
 };
 
+FailureOr<std::pair<RockAccelTuningParamAttrInterface,
+                    RockAccelTuningParamAttrInterface>>
+getAttentionTuningParams(OpBuilder &b, RockGemmGemmWrapperInterface gemmGemmOp,
+                         AttnPerfConfigAttr attnPerfConfig);
+
 } // namespace rock
 } // namespace mlir
 #endif // MLIR_DIALECT_ROCK_GRIDWISE_GEMM_PARAMS_H

--- a/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
@@ -61,6 +61,9 @@ struct TuningParamSpaceSettings {
 // Get the number of iterations needed for a given tuning kind
 unsigned getNumberOfIterations(TuningParamSetKind kind);
 
+// Whether the tuning kind needs to have the best of previous iteration
+bool needToUpdateBest(TuningParamSetKind kind);
+
 // Modified function signature to support multiple iterations
 TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
                                         TuningParamSpaceSettings &settings);

--- a/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
@@ -32,7 +32,9 @@ enum class TuningParamSetKind : uint32_t {
   // configurations that have been shown not to yield good performance.
   // (Note: this filtering is currently unimplemented).
   Full = 1,
-  // A greedy approach that explores exhaustive tuning space.
+  // Tune all possible tile sizes and try N random configurations for each tile
+  // size. Then, greedily select the best tile size, and brute force tune the
+  // rest of params
   Greedy = 2,
   // A tuning space consisting of all possible sets of tuning parameters,
   // excluding those that could not be applicable to the given problem.
@@ -51,13 +53,17 @@ struct TuningParamSet {
   KernelType primaryOpType;
 };
 
+struct TuningParamSpaceSettings {
+  unsigned iteration = 0;
+  StringRef winningConfig = "";
+};
+
 // Get the number of iterations needed for a given tuning kind
 unsigned getNumberOfIterations(TuningParamSetKind kind);
 
 // Modified function signature to support multiple iterations
 TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
-                                        unsigned iteration = 0,
-                                        StringRef winningConfig = "");
+                                        TuningParamSpaceSettings &settings);
 // Get a parameters from the set of tunable parameters.
 bool tuningGetParam(TuningParamSet *tuningSpace, unsigned pos,
                     ParamEntry *paramEntry);

--- a/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/RockTuning.h
@@ -32,9 +32,11 @@ enum class TuningParamSetKind : uint32_t {
   // configurations that have been shown not to yield good performance.
   // (Note: this filtering is currently unimplemented).
   Full = 1,
+  // A greedy approach that explores exhaustive tuning space.
+  Greedy = 2,
   // A tuning space consisting of all possible sets of tuning parameters,
   // excluding those that could not be applicable to the given problem.
-  Exhaustive = 2,
+  Exhaustive = 3,
 };
 
 // Parameter container holding a parameter and serialized string
@@ -49,7 +51,13 @@ struct TuningParamSet {
   KernelType primaryOpType;
 };
 
-TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind);
+// Get the number of iterations needed for a given tuning kind
+unsigned getNumberOfIterations(TuningParamSetKind kind);
+
+// Modified function signature to support multiple iterations
+TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
+                                        unsigned iteration = 0,
+                                        StringRef winningConfig = "");
 // Get a parameters from the set of tunable parameters.
 bool tuningGetParam(TuningParamSet *tuningSpace, unsigned pos,
                     ParamEntry *paramEntry);

--- a/mlir/lib/CAPI/Dialect/Rock.cpp
+++ b/mlir/lib/CAPI/Dialect/Rock.cpp
@@ -44,7 +44,8 @@ mlirRockTuningSpaceCreate(MlirModule module, RocmlirTuningParamSetKind kind) {
     break;
   }
   auto mod = unwrap(module);
-  newParams = rock::createTunableParamSpace(mod, ourKind);
+  rock::TuningParamSpaceSettings settings;
+  newParams = rock::createTunableParamSpace(mod, ourKind, settings);
   return wrap(newParams);
 }
 

--- a/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/AffixTuningParameters.cpp
@@ -288,37 +288,6 @@ void AffixTuningParameters::affixTuningParametersImpl(
   }
 }
 
-static RockAccelTuningParamAttrInterface
-deriveGemm1TuningParams(OpBuilder &builder, RockGemmGemmWrapperInterface op,
-                        AttnPerfConfigAttr attnPerfConfig) {
-  auto gemm0TuningParams =
-      cast<RockAccelTuningParamAttrInterface>(op.getGemm0Params().value());
-  int64_t gemm1KPack = gemm0TuningParams.getKpack();
-  if (auto gemm0XdlDerivedParams =
-          dyn_cast<MfmaGemmParamsAttr>(op.getGemm0Params().value())) {
-    return MfmaGemmParamsAttr::get(
-        builder.getContext(), gemm0TuningParams.getMPerBlock() / gemm1KPack,
-        attnPerfConfig.getMPerBlockG1(), gemm0XdlDerivedParams.getNPerBlock(),
-        gemm0TuningParams.getKpack(),
-        gemm0TuningParams.getMPerWave() * (attnPerfConfig.getMPerBlockG1() /
-                                           gemm0TuningParams.getMPerBlock()),
-        gemm0XdlDerivedParams.getNPerWave(),
-        gemm0XdlDerivedParams.getMnPerXdl(), attnPerfConfig.getSplitKFactor(),
-        gemm0XdlDerivedParams.getScheduleVersion(),
-        gemm0XdlDerivedParams.getOutputSwizzle(),
-        gemm0XdlDerivedParams.getForceUnroll());
-  }
-  return WmmaGemmParamsAttr::get(
-      builder.getContext(), gemm0TuningParams.getMPerBlock() / gemm1KPack,
-      attnPerfConfig.getMPerBlockG1(), attnPerfConfig.getNPerBlockG0(),
-      gemm0TuningParams.getKpack(),
-      gemm0TuningParams.getMPerWave() *
-          (attnPerfConfig.getMPerBlockG1() / gemm0TuningParams.getMPerBlock()),
-      gemm0TuningParams.getNPerWave(), gemm0TuningParams.getMnPerXdl(),
-      attnPerfConfig.getSplitKFactor(), gemm0TuningParams.getScheduleVersion(),
-      gemm0TuningParams.getOutputSwizzle(), gemm0TuningParams.getForceUnroll());
-}
-
 void AffixTuningParameters::affixTuningParametersImpl(
     RockGemmGemmWrapperInterface op) {
   OpBuilder builder(op.getContext());
@@ -364,55 +333,22 @@ void AffixTuningParameters::affixTuningParametersImpl(
     return signalPassFailure();
   }
 
-  GemmFeatures features = rock::getFeatures(op);
-  RockAccelTuningParamAttrInterface accelParams0;
-  if (bitEnumContainsAny(features, GemmFeatures::mfma)) {
-    accelParams0 = MfmaGemmParamsAttr::get(
-        builder.getContext(), attnPerfConfig.getKpackPerBlock(),
-        attnPerfConfig.getMPerBlockG0(), attnPerfConfig.getNPerBlockG0(),
-        attnPerfConfig.getKpack(), attnPerfConfig.getMPerWave(),
-        attnPerfConfig.getNPerWave(), attnPerfConfig.getMnPerXdl(), 1,
-        attnPerfConfig.getScheduleVersion(), attnPerfConfig.getOutputSwizzle(),
-        attnPerfConfig.getForceUnroll());
-  } else {
-    accelParams0 = WmmaGemmParamsAttr::get(
-        builder.getContext(), attnPerfConfig.getKpackPerBlock(),
-        attnPerfConfig.getMPerBlockG0(), attnPerfConfig.getNPerBlockG0(),
-        attnPerfConfig.getKpack(), attnPerfConfig.getMPerWave(),
-        attnPerfConfig.getNPerWave(), attnPerfConfig.getMnPerXdl(), 1,
-        attnPerfConfig.getScheduleVersion(), attnPerfConfig.getOutputSwizzle(),
-        attnPerfConfig.getForceUnroll());
-  }
-  op.setGemm0ParamsAttr(accelParams0);
-  if (attnPerfConfig.getMPerBlockG0() > attnPerfConfig.getMPerBlockG1()) {
-    op.emitError(
-        "The MPerBlockG0 should be larger or equal to getMPerBlockG1.");
+  auto accelParams = getAttentionTuningParams(builder, op, attnPerfConfig);
+  if (failed(accelParams)) {
+    op.emitError("The provided perf config is not valid");
     return signalPassFailure();
   }
-  RockAccelTuningParamAttrInterface accelParams1 =
-      deriveGemm1TuningParams(builder, op, attnPerfConfig);
+  RockAccelTuningParamAttrInterface accelParams0, accelParams1;
+  accelParams0 = accelParams->first;
+  accelParams1 = accelParams->second;
+  LLVM_DEBUG(llvm::dbgs() << "accelParams0=" << accelParams0 << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "accelParams1=" << accelParams1 << "\n");
+  op.setGemm0ParamsAttr(accelParams0);
   op.setGemm1ParamsAttr(accelParams1);
   int64_t waveSize = rock::lookupArchInfo(rock::getArchValue(op)).waveSize;
   int64_t blockSize = waveSize * accelParams0.getNPerBlock() *
                       accelParams0.getMPerBlock() /
                       (accelParams0.getMPerWave() * accelParams0.getNPerWave());
-  auto populateParamsAccelPtr = PopulateParamsAccel::select(features);
-  LLVM_DEBUG(llvm::dbgs() << "accelParams0=" << accelParams0 << "\n");
-  LLVM_DEBUG(llvm::dbgs() << "accelParams1=" << accelParams1 << "\n");
-  LogicalResult isValidBlockwiseGemm0 =
-      populateParamsAccelPtr->isValidBlockwiseGemm(
-          accelParams0, cast<MemRefType>(op.getAType()).getElementType(),
-          cast<MemRefType>(op.getBType()).getElementType(),
-          rock::getArchValue(op));
-  LogicalResult isValidBlockwiseGemm1 =
-      populateParamsAccelPtr->isValidBlockwiseGemm(
-          accelParams1, cast<MemRefType>(op.getCType()).getElementType(),
-          cast<MemRefType>(op.getCType()).getElementType(),
-          rock::getArchValue(op));
-  if (isValidBlockwiseGemm0.failed() || isValidBlockwiseGemm1.failed()) {
-    op.emitError("The provided perf config is not valid");
-    return signalPassFailure();
-  }
 
   IntegerAttr blockSizeAttr = builder.getI32IntegerAttr(blockSize);
   func::FuncOp funcOp = getOperation();

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -729,3 +729,83 @@ Attribute PopulateParamsWmma::getGemmParamsAttr(
       validParams.gemmScheduleVersion, validParams.outputSwizzle,
       validParams.gemmAThreadCopyMoreGemmK);
 }
+
+static RockAccelTuningParamAttrInterface
+deriveGemm1TuningParams(OpBuilder &b, RockGemmGemmWrapperInterface op,
+                        AttnPerfConfigAttr attnPerfConfig) {
+  auto gemm0TuningParams =
+      cast<RockAccelTuningParamAttrInterface>(op.getGemm0Params().value());
+  int64_t gemm1KPack = gemm0TuningParams.getKpack();
+  if (auto gemm0XdlDerivedParams =
+          dyn_cast<MfmaGemmParamsAttr>(op.getGemm0Params().value())) {
+    return MfmaGemmParamsAttr::get(
+        b.getContext(), gemm0TuningParams.getMPerBlock() / gemm1KPack,
+        attnPerfConfig.getMPerBlockG1(), gemm0XdlDerivedParams.getNPerBlock(),
+        gemm0TuningParams.getKpack(),
+        gemm0TuningParams.getMPerWave() * (attnPerfConfig.getMPerBlockG1() /
+                                           gemm0TuningParams.getMPerBlock()),
+        gemm0XdlDerivedParams.getNPerWave(),
+        gemm0XdlDerivedParams.getMnPerXdl(), attnPerfConfig.getSplitKFactor(),
+        gemm0XdlDerivedParams.getScheduleVersion(),
+        gemm0XdlDerivedParams.getOutputSwizzle(),
+        gemm0XdlDerivedParams.getForceUnroll());
+  }
+  return WmmaGemmParamsAttr::get(
+      b.getContext(), gemm0TuningParams.getMPerBlock() / gemm1KPack,
+      attnPerfConfig.getMPerBlockG1(), attnPerfConfig.getNPerBlockG0(),
+      gemm0TuningParams.getKpack(),
+      gemm0TuningParams.getMPerWave() *
+          (attnPerfConfig.getMPerBlockG1() / gemm0TuningParams.getMPerBlock()),
+      gemm0TuningParams.getNPerWave(), gemm0TuningParams.getMnPerXdl(),
+      attnPerfConfig.getSplitKFactor(), gemm0TuningParams.getScheduleVersion(),
+      gemm0TuningParams.getOutputSwizzle(), gemm0TuningParams.getForceUnroll());
+}
+
+FailureOr<std::pair<RockAccelTuningParamAttrInterface,
+                    RockAccelTuningParamAttrInterface>>
+mlir::rock::getAttentionTuningParams(OpBuilder &b,
+                                     RockGemmGemmWrapperInterface op,
+                                     AttnPerfConfigAttr attnPerfConfig) {
+  GemmFeatures features = rock::getFeatures(op);
+  RockAccelTuningParamAttrInterface accelParams0;
+  if (bitEnumContainsAny(features, GemmFeatures::mfma)) {
+    accelParams0 = MfmaGemmParamsAttr::get(
+        b.getContext(), attnPerfConfig.getKpackPerBlock(),
+        attnPerfConfig.getMPerBlockG0(), attnPerfConfig.getNPerBlockG0(),
+        attnPerfConfig.getKpack(), attnPerfConfig.getMPerWave(),
+        attnPerfConfig.getNPerWave(), attnPerfConfig.getMnPerXdl(), 1,
+        attnPerfConfig.getScheduleVersion(), attnPerfConfig.getOutputSwizzle(),
+        attnPerfConfig.getForceUnroll());
+  } else {
+    accelParams0 = WmmaGemmParamsAttr::get(
+        b.getContext(), attnPerfConfig.getKpackPerBlock(),
+        attnPerfConfig.getMPerBlockG0(), attnPerfConfig.getNPerBlockG0(),
+        attnPerfConfig.getKpack(), attnPerfConfig.getMPerWave(),
+        attnPerfConfig.getNPerWave(), attnPerfConfig.getMnPerXdl(), 1,
+        attnPerfConfig.getScheduleVersion(), attnPerfConfig.getOutputSwizzle(),
+        attnPerfConfig.getForceUnroll());
+  }
+  if (attnPerfConfig.getMPerBlockG1() % attnPerfConfig.getMPerBlockG0() != 0) {
+    return failure();
+  }
+  if (attnPerfConfig.getMPerBlockG0() % attnPerfConfig.getKpack() != 0) {
+    return failure();
+  }
+  RockAccelTuningParamAttrInterface accelParams1 =
+      deriveGemm1TuningParams(b, op, attnPerfConfig);
+  auto populateParamsAccelPtr = PopulateParamsAccel::select(features);
+  LogicalResult isValidBlockwiseGemm0 =
+      populateParamsAccelPtr->isValidBlockwiseGemm(
+          accelParams0, cast<MemRefType>(op.getAType()).getElementType(),
+          cast<MemRefType>(op.getBType()).getElementType(),
+          rock::getArchValue(op));
+  LogicalResult isValidBlockwiseGemm1 =
+      populateParamsAccelPtr->isValidBlockwiseGemm(
+          accelParams1, cast<MemRefType>(op.getCType()).getElementType(),
+          cast<MemRefType>(op.getCType()).getElementType(),
+          rock::getArchValue(op));
+  if (isValidBlockwiseGemm0.failed() || isValidBlockwiseGemm1.failed()) {
+    return failure();
+  }
+  return std::make_pair(accelParams0, accelParams1);
+}

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -731,13 +731,12 @@ Attribute PopulateParamsWmma::getGemmParamsAttr(
 }
 
 static RockAccelTuningParamAttrInterface
-deriveGemm1TuningParams(OpBuilder &b, RockGemmGemmWrapperInterface op,
+deriveGemm1TuningParams(OpBuilder &b,
+                        RockAccelTuningParamAttrInterface gemm0TuningParams,
                         AttnPerfConfigAttr attnPerfConfig) {
-  auto gemm0TuningParams =
-      cast<RockAccelTuningParamAttrInterface>(op.getGemm0Params().value());
   int64_t gemm1KPack = gemm0TuningParams.getKpack();
   if (auto gemm0XdlDerivedParams =
-          dyn_cast<MfmaGemmParamsAttr>(op.getGemm0Params().value())) {
+          dyn_cast<MfmaGemmParamsAttr>(gemm0TuningParams)) {
     return MfmaGemmParamsAttr::get(
         b.getContext(), gemm0TuningParams.getMPerBlock() / gemm1KPack,
         attnPerfConfig.getMPerBlockG1(), gemm0XdlDerivedParams.getNPerBlock(),
@@ -792,7 +791,7 @@ mlir::rock::getAttentionTuningParams(OpBuilder &b,
     return failure();
   }
   RockAccelTuningParamAttrInterface accelParams1 =
-      deriveGemm1TuningParams(b, op, attnPerfConfig);
+      deriveGemm1TuningParams(b, accelParams0, attnPerfConfig);
   auto populateParamsAccelPtr = PopulateParamsAccel::select(features);
   LogicalResult isValidBlockwiseGemm0 =
       populateParamsAccelPtr->isValidBlockwiseGemm(

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -177,7 +177,7 @@ getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
 
 static SmallVector<uint32_t> compute1MPerBlock(uint32_t gemm0MPerBlock) {
   SmallVector<uint32_t> mPerBlockList;
-  for (uint32_t mPerBlock = gemm0MPerBlock; mPerBlock < 512; mPerBlock *= 2) {
+  for (uint32_t mPerBlock = gemm0MPerBlock; mPerBlock <= 256; mPerBlock *= 2) {
     mPerBlockList.push_back(mPerBlock);
   }
   return mPerBlockList;

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -211,6 +211,13 @@ getAccelRangeAttn(RockGemmGemmWrapperInterface gemmGemmOp,
   return validRangeAttnParams;
 }
 
+static LogicalResult
+paramsAttnProbablyValid(OpBuilder &b, RockGemmGemmWrapperInterface gemmGemmOp,
+                        AttnPerfConfigAttr &params) {
+  auto accelParams = getAttentionTuningParams(b, gemmGemmOp, params);
+  return succeeded(accelParams) ? success() : failure();
+}
+
 // Generate random configs for greedy first iteration (Phase 1)
 static void createAttnTuningRangeGreedyPhase1(
     TuningParamSet *newSpace, RockGemmGemmWrapperInterface gemmGemmOp,
@@ -247,7 +254,7 @@ static void createAttnTuningRangeGreedyPhase1(
         uint32_t numRandomIterations =
             std::min(numRandomPerTileSize, totalIterations);
         for (uint32_t randomIteration = 0;
-             randomIteration < numRandomIterations; randomIteration++) {
+             randomIteration < numRandomIterations;) {
           uint32_t gemmKPerBlock = params[2][rng() % params[2].size()];
           uint32_t gemmMPerWave = mPerWaveRange[rng() % mPerWaveRange.size()];
           uint32_t gemmNPerWave = nPerWaveRange[rng() % nPerWaveRange.size()];
@@ -262,8 +269,11 @@ static void createAttnTuningRangeGreedyPhase1(
               gemm0NPerBlock, gemmKPerBlock, gemmMPerWave, gemmNPerWave,
               gemmMnPerXdl, gemmKPack, splitKFactor, gemmSchedule,
               outputSwizzle, true);
-          newSpace->tuningRange.push_back(
-              cast<RockTuningParamAttrInterface>(params));
+          if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+            newSpace->tuningRange.push_back(
+                cast<RockTuningParamAttrInterface>(params));
+            randomIteration++;
+          }
         }
       }
     }

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -264,14 +264,14 @@ static void createAttnTuningRangeGreedyPhase1(
           uint32_t splitKFactor =
               optimalSplitKFactors[rng() % optimalSplitKFactors.size()];
 
-          auto params = AttnPerfConfigAttr::get(
+          auto attnParams = AttnPerfConfigAttr::get(
               gemmGemmOp.getContext(), gemm0MPerBlock, gemm1MPerBlock,
               gemm0NPerBlock, gemmKPerBlock, gemmMPerWave, gemmNPerWave,
               gemmMnPerXdl, gemmKPack, splitKFactor, gemmSchedule,
               outputSwizzle, true);
-          if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+          if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, attnParams))) {
             newSpace->tuningRange.push_back(
-                cast<RockTuningParamAttrInterface>(params));
+                cast<RockTuningParamAttrInterface>(attnParams));
             randomIteration++;
           }
         }
@@ -319,14 +319,15 @@ static void createAttnTuningRangeGreedyPhase2(
           for (uint32_t gemmKPack : validRangeAttnParams[4]) {
             for (int64_t splitKFactor : optimalSplitKFactors) {
               for (uint32_t gemmSchedule : validRangeAttnParams[5]) {
-                auto params = AttnPerfConfigAttr::get(
+                auto attnParams = AttnPerfConfigAttr::get(
                     gemmGemmOp.getContext(), gemm0MPerBlock, gemm1MPerBlock,
                     gemm0NPerBlock, gemmKPerBlock, gemmMPerWave, gemmNPerWave,
                     gemmMnPerXdl, gemmKPack, splitKFactor, gemmSchedule,
                     outputSwizzle, true);
-                if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+                if (succeeded(
+                        paramsAttnProbablyValid(b, gemmGemmOp, attnParams))) {
                   newSpace->tuningRange.push_back(
-                      cast<RockTuningParamAttrInterface>(params));
+                      cast<RockTuningParamAttrInterface>(attnParams));
                 }
               }
             }
@@ -382,15 +383,15 @@ static void createAttnTuningRangeBF(TuningParamSet *newSpace,
                           continue;
                         }
                       }
-                      auto params = AttnPerfConfigAttr::get(
+                      auto attnParams = AttnPerfConfigAttr::get(
                           gemmGemmOp.getContext(), gemm0MPerBlock,
                           gemm1MPerBlock, gemm0NPerBlock, gemmKPerBlock,
                           gemmMPerWave, gemmNPerWave, gemmMnPerXdl, gemmKPack,
                           splitKFactor, gemmSchedule, outputSwizzle, true);
-                      if (succeeded(
-                              paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+                      if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp,
+                                                            attnParams))) {
                         newSpace->tuningRange.push_back(
-                            cast<RockTuningParamAttrInterface>(params));
+                            cast<RockTuningParamAttrInterface>(attnParams));
                       }
                     }
                   }
@@ -683,13 +684,13 @@ static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op gemmGemmOp,
     }
     for (auto [mPerBlockG0, mPerBlockG1, nPerBlockG0, kPackBerBlock, mPerWave,
                nPerWave, mnPerXdl, kPack] : attnQuickTuningListMFMA) {
-      auto params = AttnPerfConfigAttr::get(
+      auto attnParams = AttnPerfConfigAttr::get(
           gemmGemmOp.getContext(), mPerBlockG0, mPerBlockG1, nPerBlockG0,
           kPackBerBlock, mPerWave, nPerWave, mnPerXdl, kPack, splitKFactor,
           gemmSchedule, outputSwizzle, true);
-      if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+      if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, attnParams))) {
         newSpace->tuningRange.push_back(
-            cast<RockTuningParamAttrInterface>(params));
+            cast<RockTuningParamAttrInterface>(attnParams));
       }
     }
   } else if (bitEnumContainsAll(currentFeatures, GemmFeatures::wmma)) {
@@ -704,13 +705,13 @@ static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op gemmGemmOp,
         PerfConfigVals{128, 128, 128, 8, 32, 32, 16, 8}};
     for (auto [mPerBlockG0, mPerBlockG1, nPerBlockG0, kPackBerBlock, mPerWave,
                nPerWave, mnPerXdl, kPack] : attnQuickTuningListWMMA) {
-      auto params = AttnPerfConfigAttr::get(
+      auto attnParams = AttnPerfConfigAttr::get(
           gemmGemmOp.getContext(), mPerBlockG0, mPerBlockG1, nPerBlockG0,
           kPackBerBlock, mPerWave, nPerWave, mnPerXdl, kPack, splitKFactor,
           gemmSchedule, outputSwizzle, true);
-      if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+      if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, attnParams))) {
         newSpace->tuningRange.push_back(
-            cast<RockTuningParamAttrInterface>(params));
+            cast<RockTuningParamAttrInterface>(attnParams));
       }
     }
   }

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -34,7 +34,9 @@
 #include <cstdint>
 #include <random>
 
-#define NUM_RANDOM_PER_TILE_SIZE 50
+// Found experimentally, might need to change it if we add more params to the
+// tuning space
+#define NUM_RANDOM_PERFCONFIGS_PER_TILE_SIZE 50
 #define RND_SEED 42
 
 namespace mlir {
@@ -718,6 +720,18 @@ static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op gemmGemmOp,
   // We only support GPUs with matrix accelerator extensions
 }
 
+bool needToUpdateBest(TuningParamSetKind kind) {
+  switch (kind) {
+  case TuningParamSetKind::Quick:
+  case TuningParamSetKind::Full:
+  case TuningParamSetKind::Exhaustive:
+    return false;
+  case TuningParamSetKind::Greedy:
+    return true;
+  }
+  llvm_unreachable("invalid tuning kind");
+}
+
 unsigned getNumberOfIterations(TuningParamSetKind kind) {
   switch (kind) {
   case TuningParamSetKind::Quick:
@@ -874,6 +888,9 @@ createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
         if (!rock::isAccel(currentFeatures) &&
             kind == TuningParamSetKind::Greedy) {
           kind = TuningParamSetKind::Exhaustive;
+          // TODO: tuningRunner hides this warning
+          llvm::errs() << "Greedy tuning not implemented for non-accel, using "
+                          "Exhaustive instead\n";
         }
         switch (kind) {
         case TuningParamSetKind::Full:
@@ -883,9 +900,9 @@ createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
         case TuningParamSetKind::Greedy:
           if (settings.iteration == 0) {
             // First iteration: random configs per tile size
-            createGemmTuningRangeGreedyPhase1(newSpace, op, isSplitKFusible,
-                                              NUM_RANDOM_PER_TILE_SIZE,
-                                              RND_SEED);
+            createGemmTuningRangeGreedyPhase1(
+                newSpace, op, isSplitKFusible,
+                NUM_RANDOM_PERFCONFIGS_PER_TILE_SIZE, RND_SEED);
           } else {
             // Second iteration: brute force with winning tile sizes
             createGemmTuningRangeGreedyPhase2(newSpace, op, isSplitKFusible,
@@ -910,9 +927,9 @@ createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
         case TuningParamSetKind::Greedy:
           if (settings.iteration == 0) {
             // First iteration: random configs per tile size
-            createAttnTuningRangeGreedyPhase1(newSpace, op, isSplitKFusible,
-                                              NUM_RANDOM_PER_TILE_SIZE,
-                                              RND_SEED);
+            createAttnTuningRangeGreedyPhase1(
+                newSpace, op, isSplitKFusible,
+                NUM_RANDOM_PERFCONFIGS_PER_TILE_SIZE, RND_SEED);
           } else {
             // Second iteration: brute force with winning tile sizes
             createAttnTuningRangeGreedyPhase2(newSpace, op, isSplitKFusible,

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -132,27 +132,23 @@ getSchedules(Operation *op, const TuningParamSetKind &tuningKind) {
 
 static std::vector<std::vector<uint32_t>>
 getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
-  // M/block N/block K/block MnPerXdl kPack scheduleVersion
-  // aCopyMore/forceUnroll
   std::vector<std::vector<uint32_t>> validRangeAccelGemmParams = {
-      {16, 32, 64, 128, 256},
-      {16, 32, 64, 128, 256},
-      {1, 2, 4, 8},
-      {16, 32},
-      {1, 4, 8, 16, 32},
-      getSchedules(gemmOp, kind),
-      {0, 1}};
+      {16, 32, 64, 128, 256},     // M/block
+      {16, 32, 64, 128, 256},     // N/block
+      {1, 2, 4, 8},               // K/block
+      {16, 32},                   // MnPerXdl
+      {1, 4, 8, 16, 32},          // kPack
+      getSchedules(gemmOp, kind), // scheduleVersion
+      {0, 1}};                    // forceUnroll
 
-  // M/block N/block K/block MnPerXdl kPack scheduleVersion
-  // aCopyMore/forceUnroll
   std::vector<std::vector<uint32_t>> validRangeAccelGemmParams8BitReduction = {
-      {16, 32, 64, 128, 256},
-      {16, 32, 64, 128, 256},
-      {4, 8, 16, 32},
-      {16, 32},
-      {1, 4, 8, 16},
-      getSchedules(gemmOp, TuningParamSetKind::Greedy),
-      {0, 1}};
+      {16, 32, 64, 128, 256},     // M/block
+      {16, 32, 64, 128, 256},     // N/block
+      {4, 8, 16, 32},             // K/block
+      {16, 32},                   // MnPerXdl
+      {1, 4, 8, 16},              // kPack
+      getSchedules(gemmOp, kind), // scheduleVersion
+      {0, 1}};                    // forceUnroll
 
   Type inTypeA = gemmOp.getAType();
   bool is8BitReduction =
@@ -162,16 +158,14 @@ getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
       is8BitReduction ? validRangeAccelGemmParams8BitReduction
                       : validRangeAccelGemmParams;
 
-  // M/block N/block K/block Mn/Xdl kPack scheduleVersion
-  // aCopyMore/forceUnroll
   std::vector<std::vector<uint32_t>> validRangeWmmaGemmParams = {
-      {16, 32, 64, 128, 256},
-      {16, 32, 64, 128, 256},
-      {1, 2, 4, 8},
-      {16},
-      {4, 8, 16},
-      getSchedules(gemmOp, TuningParamSetKind::Greedy),
-      {0, 1}};
+      {16, 32, 64, 128, 256},     // M/block
+      {16, 32, 64, 128, 256},     // N/block
+      {1, 2, 4, 8},               // K/block
+      {16},                       // MnPerXdl
+      {4, 8, 16},                 // kPack
+      getSchedules(gemmOp, kind), // scheduleVersion
+      {0, 1}};                    // forceUnroll
 
   GemmFeatures currentFeatures = rock::getFeatures(gemmOp);
   if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma))

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -30,9 +30,40 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/LogicalResult.h"
 #include <algorithm>
+#include <cstdint>
+#include <random>
+
+#define NUM_RANDOM_PER_TILE_SIZE 50
+#define RND_SEED 42
 
 namespace mlir {
 namespace rock {
+
+static SmallVector<uint32_t> computeDPerWave(TuningParamSetKind tuningKind,
+                                             uint32_t dPerBlock,
+                                             int64_t waveSize) {
+  SmallVector<uint32_t> dPerWaveList;
+  uint32_t maxDPerWave = (tuningKind != TuningParamSetKind::Full)
+                             ? std::numeric_limits<uint32_t>::max()
+                             : 128;
+
+  uint32_t maxFactor = 16;
+  if (tuningKind != TuningParamSetKind::Full) {
+    maxFactor = maxHardwareWorkgroupSize / waveSize;
+  }
+  for (uint32_t factor = 1; factor <= maxFactor; factor *= 2) {
+    if (dPerBlock % factor != 0)
+      continue;
+
+    uint32_t dPerWave = dPerBlock / factor;
+    // mnPerXdl is 16 or higher (we do not use block != 1 mfmas)
+    // and dPerWave >= mnPerXdl
+    if (dPerWave >= 16 && dPerWave <= maxDPerWave)
+      dPerWaveList.push_back(dPerWave);
+  }
+  assert(!dPerWaveList.empty() && "dPerWaveList can't be empty");
+  return dPerWaveList;
+}
 
 static SmallVector<int64_t>
 computeOptimalSplitKFactors(RockGemmGemmWrapperInterface gemmGemmOp,
@@ -76,14 +107,14 @@ computeOptimalSplitKFactors(RockGemmGemmWrapperInterface gemmGemmOp,
   return {1, 3, 4};
 }
 
-// only enable tuning over gemm schedules when doing exhaustive tuning
+// only enable tuning over gemm schedules when doing exhaustive/greedy tuning
 static std::vector<uint32_t>
 getSchedules(Operation *op, const TuningParamSetKind &tuningKind) {
   auto features = rock::lookupArchInfo(rock::getArchValue(op)).defaultFeatures;
   bool directToLDS = isDirectToLDSSupported(features);
 
   std::vector<GemmLoadTileType> loadTypes{GemmLoadTileType::Default};
-  if (tuningKind == TuningParamSetKind::Exhaustive) {
+  if (tuningKind != TuningParamSetKind::Full) {
     loadTypes.push_back(GemmLoadTileType::DoubleBuffer);
     if (directToLDS) {
       loadTypes.push_back(GemmLoadTileType::DirectToLDSDefault);
@@ -99,61 +130,244 @@ getSchedules(Operation *op, const TuningParamSetKind &tuningKind) {
   return schedules;
 }
 
+static std::vector<std::vector<uint32_t>>
+getAccelRangeGemm(RockGemmWrapperInterface gemmOp, TuningParamSetKind kind) {
+  // M/block N/block K/block MnPerXdl kPack scheduleVersion
+  // aCopyMore/forceUnroll
+  std::vector<std::vector<uint32_t>> validRangeAccelGemmParams = {
+      {16, 32, 64, 128, 256},
+      {16, 32, 64, 128, 256},
+      {1, 2, 4, 8},
+      {16, 32},
+      {1, 4, 8, 16, 32},
+      getSchedules(gemmOp, kind),
+      {0, 1}};
+
+  // M/block N/block K/block MnPerXdl kPack scheduleVersion
+  // aCopyMore/forceUnroll
+  std::vector<std::vector<uint32_t>> validRangeAccelGemmParams8BitReduction = {
+      {16, 32, 64, 128, 256},
+      {16, 32, 64, 128, 256},
+      {4, 8, 16, 32},
+      {16, 32},
+      {1, 4, 8, 16},
+      getSchedules(gemmOp, TuningParamSetKind::Greedy),
+      {0, 1}};
+
+  Type inTypeA = gemmOp.getAType();
+  bool is8BitReduction =
+      inTypeA.isInteger(8) ||
+      (inTypeA.getIntOrFloatBitWidth() == 8 && isa<FloatType>(inTypeA));
+  std::vector<std::vector<uint32_t>> &xdlopsParams =
+      is8BitReduction ? validRangeAccelGemmParams8BitReduction
+                      : validRangeAccelGemmParams;
+
+  // M/block N/block K/block Mn/Xdl kPack scheduleVersion
+  // aCopyMore/forceUnroll
+  std::vector<std::vector<uint32_t>> validRangeWmmaGemmParams = {
+      {16, 32, 64, 128, 256},
+      {16, 32, 64, 128, 256},
+      {1, 2, 4, 8},
+      {16},
+      {4, 8, 16},
+      getSchedules(gemmOp, TuningParamSetKind::Greedy),
+      {0, 1}};
+
+  GemmFeatures currentFeatures = rock::getFeatures(gemmOp);
+  if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma))
+    return xdlopsParams;
+
+  return validRangeWmmaGemmParams;
+}
+
+static SmallVector<uint32_t> compute1MPerBlock(uint32_t gemm0MPerBlock) {
+  SmallVector<uint32_t> mPerBlockList;
+  for (uint32_t mPerBlock = gemm0MPerBlock; mPerBlock < 512; mPerBlock *= 2) {
+    mPerBlockList.push_back(mPerBlock);
+  }
+  return mPerBlockList;
+}
+
+static std::vector<std::vector<uint32_t>>
+getAccelRangeAttn(RockGemmGemmWrapperInterface gemmGemmOp,
+                  TuningParamSetKind kind) {
+  static const std::vector<std::vector<uint32_t>> validRangeAttnParamsMFMA = {
+      /*gemm0MPerBlock=*/{16, 32, 64, 128, 256},
+      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
+      /*kPackPerBlock=*/{2, 4, 8, 16, 32, 64},
+      /*mnPerXdl=*/{4, 16, 32},
+      /*kPack=*/{4, 8, 16},
+      getSchedules(gemmGemmOp, kind)};
+  static const std::vector<std::vector<uint32_t>> validRangeAttnParamsWMMA = {
+      /*gemm0MPerBlock=*/{16, 32, 64, 128},
+      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
+      /*kPackPerBlock=*/{2, 4, 8, 16, 32, 64},
+      /*mnPerXdl=*/{16},
+      /*kPack=*/{4, 8, 16},
+      getSchedules(gemmGemmOp, kind)};
+  GemmFeatures features = rock::getFeatures(gemmGemmOp);
+
+  std::vector<std::vector<uint32_t>> validRangeAttnParams;
+  if (bitEnumContainsAny(features, GemmFeatures::mfma)) {
+    validRangeAttnParams = validRangeAttnParamsMFMA;
+  } else if (bitEnumContainsAny(features, GemmFeatures::wmma)) {
+    validRangeAttnParams = validRangeAttnParamsWMMA;
+  }
+  return validRangeAttnParams;
+}
+
+// Generate random configs for greedy first iteration (Phase 1)
+static void createAttnTuningRangeGreedyPhase1(
+    TuningParamSet *newSpace, RockGemmGemmWrapperInterface gemmGemmOp,
+    bool isSplitKFusible, unsigned numRandomPerTileSize, unsigned int seed) {
+  GemmFeatures features = rock::getFeatures(gemmGemmOp);
+  OpBuilder b(gemmGemmOp.getContext());
+  const std::vector<std::vector<uint32_t>> params =
+      getAccelRangeAttn(gemmGemmOp, TuningParamSetKind::Greedy);
+  std::mt19937 rng(seed);
+  int64_t waveSize =
+      rock::lookupArchInfo(rock::getArchValue(gemmGemmOp)).waveSize;
+  if (!bitEnumContainsAny(features, GemmFeatures::mfma) &&
+      !bitEnumContainsAny(features, GemmFeatures::wmma)) {
+    // We only support GPUs with matrix accelerator extensions
+    return;
+  }
+
+  int64_t outputSwizzle{2};
+  for (uint32_t gemm0MPerBlock : params[0]) {
+    SmallVector<uint32_t> mPerWaveRange =
+        computeDPerWave(TuningParamSetKind::Greedy, gemm0MPerBlock, waveSize);
+    SmallVector<uint32_t> mPerBlockGemm1 = compute1MPerBlock(gemm0MPerBlock);
+    for (uint32_t gemm1MPerBlock : mPerBlockGemm1) {
+      for (uint32_t gemm0NPerBlock : params[1]) {
+        SmallVector<uint32_t> nPerWaveRange = computeDPerWave(
+            TuningParamSetKind::Greedy, gemm0NPerBlock, waveSize);
+        auto optimalSplitKFactors = computeOptimalSplitKFactors(
+            gemmGemmOp, gemm0NPerBlock, isSplitKFusible);
+
+        uint32_t totalIterations = params[2].size() * mPerWaveRange.size() *
+                                   nPerWaveRange.size() * params[3].size() *
+                                   params[4].size() * params[5].size() *
+                                   optimalSplitKFactors.size();
+        uint32_t numRandomIterations =
+            std::min(numRandomPerTileSize, totalIterations);
+        for (uint32_t randomIteration = 0;
+             randomIteration < numRandomIterations; randomIteration++) {
+          uint32_t gemmKPerBlock = params[2][rng() % params[2].size()];
+          uint32_t gemmMPerWave = mPerWaveRange[rng() % mPerWaveRange.size()];
+          uint32_t gemmNPerWave = nPerWaveRange[rng() % nPerWaveRange.size()];
+          uint32_t gemmMnPerXdl = params[3][rng() % params[3].size()];
+          uint32_t gemmKPack = params[4][rng() % params[4].size()];
+          uint32_t gemmSchedule = params[5][rng() % params[5].size()];
+          uint32_t splitKFactor =
+              optimalSplitKFactors[rng() % optimalSplitKFactors.size()];
+
+          auto params = AttnPerfConfigAttr::get(
+              gemmGemmOp.getContext(), gemm0MPerBlock, gemm1MPerBlock,
+              gemm0NPerBlock, gemmKPerBlock, gemmMPerWave, gemmNPerWave,
+              gemmMnPerXdl, gemmKPack, splitKFactor, gemmSchedule,
+              outputSwizzle, true);
+          newSpace->tuningRange.push_back(
+              cast<RockTuningParamAttrInterface>(params));
+        }
+      }
+    }
+  }
+}
+
+// Generate brute force configs for greedy second iteration (Phase 2)
+static void createAttnTuningRangeGreedyPhase2(
+    TuningParamSet *newSpace, RockGemmGemmWrapperInterface gemmGemmOp,
+    bool isSplitKFusible, StringRef winningConfig) {
+  const std::vector<std::vector<uint32_t>> validRangeAttnParams =
+      getAccelRangeAttn(gemmGemmOp, TuningParamSetKind::Greedy);
+  GemmFeatures features = rock::getFeatures(gemmGemmOp);
+  bool isWMMA = bitEnumContainsAny(features, GemmFeatures::wmma);
+  if (!bitEnumContainsAny(features, GemmFeatures::mfma) && !isWMMA) {
+    // We only support GPUs with matrix accelerator extensions
+    return;
+  }
+  int64_t waveSize =
+      rock::lookupArchInfo(rock::getArchValue(gemmGemmOp)).waveSize;
+  int64_t outputSwizzle{2};
+  OpBuilder b(gemmGemmOp.getContext());
+
+  auto attnPerfConfig =
+      AttnPerfConfigAttr::get(b.getStringAttr(winningConfig), isWMMA);
+  assert(attnPerfConfig && "Tile sizes must be extracted from winning config");
+  uint32_t gemm0MPerBlock = attnPerfConfig.getMPerBlockG0();
+  uint32_t gemm1MPerBlock = attnPerfConfig.getMPerBlockG1();
+  uint32_t gemm0NPerBlock = attnPerfConfig.getNPerBlockG0();
+
+  SmallVector<uint32_t> mPerWaveRange =
+      computeDPerWave(TuningParamSetKind::Greedy, gemm0MPerBlock, waveSize);
+  SmallVector<uint32_t> mPerBlockGemm1 = compute1MPerBlock(gemm0MPerBlock);
+  SmallVector<uint32_t> nPerWaveRange =
+      computeDPerWave(TuningParamSetKind::Greedy, gemm0NPerBlock, waveSize);
+  auto optimalSplitKFactors =
+      computeOptimalSplitKFactors(gemmGemmOp, gemm0NPerBlock, isSplitKFusible);
+
+  for (uint32_t gemmKPerBlock : validRangeAttnParams[2]) {
+    for (uint32_t gemmMPerWave : mPerWaveRange) {
+      for (uint32_t gemmNPerWave : nPerWaveRange) {
+        for (uint32_t gemmMnPerXdl : validRangeAttnParams[3]) {
+          for (uint32_t gemmKPack : validRangeAttnParams[4]) {
+            for (int64_t splitKFactor : optimalSplitKFactors) {
+              for (uint32_t gemmSchedule : validRangeAttnParams[5]) {
+                auto params = AttnPerfConfigAttr::get(
+                    gemmGemmOp.getContext(), gemm0MPerBlock, gemm1MPerBlock,
+                    gemm0NPerBlock, gemmKPerBlock, gemmMPerWave, gemmNPerWave,
+                    gemmMnPerXdl, gemmKPack, splitKFactor, gemmSchedule,
+                    outputSwizzle, true);
+                newSpace->tuningRange.push_back(
+                    cast<RockTuningParamAttrInterface>(params));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 // Keep in sync with attentionSweeps.py
 // The full space is a brute-force search for attention kernels
 static void createAttnTuningRangeBF(TuningParamSet *newSpace,
                                     RockGemmGemmWrapperInterface gemmGemmOp,
                                     bool isSplitKFusible,
                                     TuningParamSetKind kind) {
-  static const std::vector<std::vector<uint32_t>> validRangeAttnParamsMFMA = {
-      /*gemm0MPerBlock=*/{16, 32, 64, 128, 256},
-      /*gemm1MPerBlock=*/{16, 32, 64, 128, 256},
-      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
-      /*kPackPerBlock=*/{2, 4, 8, 16, 32, 64},
-      /*mPerWave=*/{16, 32, 64, 128, 256},
-      /*nPerWave=*/{16, 32, 64, 128, 256},
-      /*mnPerXdl=*/{4, 16, 32},
-      /*kPack=*/{4, 8, 16},
-      getSchedules(gemmGemmOp, kind)};
-  static const std::vector<std::vector<uint32_t>> validRangeAttnParamsWMMA = {
-      /*gemm0MPerBlock=*/{16, 32, 64, 128},
-      /*gemm1MPerBlock=*/{16, 32, 64, 128},
-      /*gemm0NPerBlock=*/{16, 32, 64, 128, 256},
-      /*kPackPerBlock=*/{2, 4, 8, 16, 32, 64},
-      /*mPerWave=*/{16, 32, 64},
-      /*nPerWave=*/{16, 32, 64},
-      /*mnPerXdl=*/{16},
-      /*kPack=*/{4, 8, 16},
-      getSchedules(gemmGemmOp, kind)};
+  const std::vector<std::vector<uint32_t>> validRangeAttnParams =
+      getAccelRangeAttn(gemmGemmOp, kind);
   GemmFeatures features = rock::getFeatures(gemmGemmOp);
   int64_t numEUPerCU =
       rock::lookupArchInfo(rock::getArchValue(gemmGemmOp)).numEUPerCU;
-  std::vector<std::vector<uint32_t>> validRangeAttnParams;
-  bool isWMMA = false;
-  if (bitEnumContainsAny(features, GemmFeatures::mfma)) {
-    validRangeAttnParams = validRangeAttnParamsMFMA;
-  } else if (bitEnumContainsAny(features, GemmFeatures::wmma)) {
-    isWMMA = true;
-    validRangeAttnParams = validRangeAttnParamsWMMA;
-  } else {
-    // We only support GPUs with matrix accelerator extentions
+  bool isWMMA = bitEnumContainsAny(features, GemmFeatures::wmma);
+  if (!bitEnumContainsAny(features, GemmFeatures::mfma) && !isWMMA) {
+    // We only support GPUs with matrix accelerator extensions
     return;
   }
+  int64_t waveSize =
+      rock::lookupArchInfo(rock::getArchValue(gemmGemmOp)).waveSize;
   int64_t outputSwizzle{2};
   OpBuilder b(gemmGemmOp.getContext());
   for (uint32_t gemm0MPerBlock : validRangeAttnParams[0]) {
-    for (uint32_t gemm1MPerBlock : validRangeAttnParams[1]) {
-      for (uint32_t gemm0NPerBlock : validRangeAttnParams[2]) {
+    SmallVector<uint32_t> mPerWaveRange =
+        computeDPerWave(kind, gemm0MPerBlock, waveSize);
+    SmallVector<uint32_t> mPerBlockGemm1 = compute1MPerBlock(gemm0MPerBlock);
+    for (uint32_t gemm1MPerBlock : mPerBlockGemm1) {
+      for (uint32_t gemm0NPerBlock : validRangeAttnParams[1]) {
+        SmallVector<uint32_t> nPerWaveRange =
+            computeDPerWave(kind, gemm0NPerBlock, waveSize);
         auto optimalSplitKFactors = computeOptimalSplitKFactors(
             gemmGemmOp, gemm0NPerBlock, isSplitKFusible);
 
-        for (uint32_t gemmKPerBlock : validRangeAttnParams[3]) {
-          for (uint32_t gemmMPerWave : validRangeAttnParams[4]) {
-            for (uint32_t gemmNPerWave : validRangeAttnParams[5]) {
-              for (uint32_t gemmMnPerXdl : validRangeAttnParams[6]) {
-                for (uint32_t gemmKPack : validRangeAttnParams[7]) {
+        for (uint32_t gemmKPerBlock : validRangeAttnParams[2]) {
+          for (uint32_t gemmMPerWave : mPerWaveRange) {
+            for (uint32_t gemmNPerWave : nPerWaveRange) {
+              for (uint32_t gemmMnPerXdl : validRangeAttnParams[3]) {
+                for (uint32_t gemmKPack : validRangeAttnParams[4]) {
                   for (int64_t splitKFactor : optimalSplitKFactors) {
-                    for (uint32_t gemmSchedule : validRangeAttnParams[8]) {
+                    for (uint32_t gemmSchedule : validRangeAttnParams[5]) {
                       if (isWMMA) {
                         int64_t rdnaWaves = (gemm0MPerBlock / gemmMPerWave) *
                                             (gemm0NPerBlock / gemmNPerWave);
@@ -161,18 +375,13 @@ static void createAttnTuningRangeBF(TuningParamSet *newSpace,
                           continue;
                         }
                       }
-                      if (gemm0MPerBlock >= gemmMPerWave &&
-                          gemm1MPerBlock >= gemmMPerWave &&
-                          gemm1MPerBlock >= gemm0MPerBlock &&
-                          gemm0NPerBlock >= gemmNPerWave) {
-                        auto params = AttnPerfConfigAttr::get(
-                            gemmGemmOp.getContext(), gemm0MPerBlock,
-                            gemm1MPerBlock, gemm0NPerBlock, gemmKPerBlock,
-                            gemmMPerWave, gemmNPerWave, gemmMnPerXdl, gemmKPack,
-                            splitKFactor, gemmSchedule, outputSwizzle, true);
-                        newSpace->tuningRange.push_back(
-                            cast<RockTuningParamAttrInterface>(params));
-                      }
+                      auto params = AttnPerfConfigAttr::get(
+                          gemmGemmOp.getContext(), gemm0MPerBlock,
+                          gemm1MPerBlock, gemm0NPerBlock, gemmKPerBlock,
+                          gemmMPerWave, gemmNPerWave, gemmMnPerXdl, gemmKPack,
+                          splitKFactor, gemmSchedule, outputSwizzle, true);
+                      newSpace->tuningRange.push_back(
+                          cast<RockTuningParamAttrInterface>(params));
                     }
                   }
                 }
@@ -292,70 +501,37 @@ static void createGemmTuningRangeBF(TuningParamSet *newSpace,
   const std::vector<std::vector<uint32_t>> validRangeGeneralGemmParams = {
       {64, 128, 256}, {32, 64, 128}, {32, 64, 128}, {4, 8, 16}, {2, 4}, {2, 4}};
 
-  // M/block N/block K/block M/wave N/wave kPack scheduleVersion
-  // aCopyMore/forceUnroll
-  const std::vector<std::vector<uint32_t>> validRangeAccelGemmParams = {
-      {4, 8, 16, 32, 64, 128, 256},
-      {16, 32, 64, 128, 256},
-      {1, 2, 4, 8},
-      {4, 8, 16, 32, 64, 128},
-      {4, 8, 16, 32, 64, 128},
-      {4, 16, 32},
-      {1, 4, 8, 16, 32},
-      getSchedules(gemmOp, kind),
-      {0, 1}};
+  const std::vector<std::vector<uint32_t>> accelParams =
+      getAccelRangeGemm(gemmOp, kind);
 
-  // M/block N/block K/block M/wave N/wave MnPerXdl kPack scheduleVersion
-  // aCopyMore/forceUnroll
-  const std::vector<std::vector<uint32_t>>
-      validRangeAccelGemmParams8BitReduction = {{4, 8, 16, 32, 64, 128, 256},
-                                                {16, 32, 64, 128, 256},
-                                                {4, 8, 16, 32},
-                                                {4, 8, 16, 32, 64, 128},
-                                                {4, 8, 16, 32, 64, 128},
-                                                {16, 32},
-                                                {1, 4, 8, 16},
-                                                getSchedules(gemmOp, kind),
-                                                {0, 1}};
-
-  // M/block N/block K/block M/wave N/wave Mn/Xdl kPack scheduleVersion
-  // aCopyMore/forceUnroll
-  const std::vector<std::vector<uint32_t>> validRangeWmmaGemmParams = {
-      {4, 8, 16, 32, 64, 128, 256},
-      {16, 32, 64, 128, 256},
-      {1, 2, 4, 8},
-      {4, 8, 16, 32, 64, 128},
-      {4, 8, 16, 32, 64, 128},
-      {16},
-      {4, 8, 16},
-      getSchedules(gemmOp, kind),
-      {0, 1}};
+  GemmFeatures currentFeatures = rock::getFeatures(gemmOp);
+  std::unique_ptr<PopulateParamsAccel> tuningInfo;
+  if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma))
+    tuningInfo = std::make_unique<PopulateParamsXDL>();
+  else
+    tuningInfo = std::make_unique<PopulateParamsWmma>();
+  int64_t waveSize = rock::lookupArchInfo(rock::getArchValue(gemmOp)).waveSize;
 
   OpBuilder b(gemmOp.getContext());
-  GemmFeatures currentFeatures = rock::getFeatures(gemmOp);
-  if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma)) {
-    PopulateParamsXDL tuningInfo;
-    // XDLOPS
-    Type inTypeA = gemmOp.getAType();
-    bool is8BitReduction =
-        inTypeA.isInteger(8) ||
-        (inTypeA.getIntOrFloatBitWidth() == 8 && isa<FloatType>(inTypeA));
-    const std::vector<std::vector<uint32_t>> &xdlopsParams =
-        is8BitReduction ? validRangeAccelGemmParams8BitReduction
-                        : validRangeAccelGemmParams;
-    for (uint32_t gemmMPerBlock : xdlopsParams[0]) {
-      for (uint32_t gemmNPerBlock : xdlopsParams[1]) {
-        for (uint32_t gemmKPerBlock : xdlopsParams[2]) {
-          for (uint32_t gemmMPerWave : xdlopsParams[3]) {
-            for (uint32_t gemmNPerWave : xdlopsParams[4]) {
-              for (uint32_t gemmMnPerXdl : xdlopsParams[5]) {
-                for (uint32_t gemmKPack : xdlopsParams[6]) {
+  if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma) ||
+      bitEnumContainsAll(currentFeatures, GemmFeatures::wmma)) {
+    for (uint32_t gemmMPerBlock : accelParams[0]) {
+      SmallVector<uint32_t> mPerWaveRange =
+          computeDPerWave(kind, gemmMPerBlock, waveSize);
+      for (uint32_t gemmNPerBlock : accelParams[1]) {
+        SmallVector<uint32_t> nPerWaveRange =
+            computeDPerWave(kind, gemmNPerBlock, waveSize);
+        for (uint32_t gemmKPerBlock : accelParams[2]) {
+          for (uint32_t gemmMPerWave : mPerWaveRange) {
+            for (uint32_t gemmNPerWave : nPerWaveRange) {
+              for (uint32_t gemmMnPerXdl : accelParams[3]) {
+                for (uint32_t gemmKPack : accelParams[4]) {
                   auto optimalSplitKFactors = computeOptimalSplitKFactors(
                       gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock,
                       gemmKPack, isSplitKFusible);
                   for (int64_t splitKFactor : optimalSplitKFactors) {
-                    for (int64_t gemmSchedule : xdlopsParams[7]) {
-                      for (uint32_t forceUnroll : xdlopsParams[8]) {
+                    for (int64_t gemmSchedule : accelParams[5]) {
+                      for (uint32_t forceUnroll : accelParams[6]) {
                         // hardcode outputSwizzle to heuristics = 2
                         InitParamsAccel gemmParams(
                             gemmMPerBlock, gemmNPerBlock, gemmKPerBlock,
@@ -363,15 +539,15 @@ static void createGemmTuningRangeBF(TuningParamSet *newSpace,
                             splitKFactor, gemmSchedule, 2, forceUnroll, true);
                         if (gemmMPerBlock >= gemmMPerWave &&
                             gemmNPerBlock >= gemmMnPerXdl) {
-                          if (succeeded(tuningInfo.paramsProbablyValid(
+                          if (succeeded(tuningInfo->paramsProbablyValid(
                                   b, info, gemmParams)) &&
-                              (kind == TuningParamSetKind::Exhaustive ||
-                               succeeded(tuningInfo.couldBePerformant(
+                              (kind != TuningParamSetKind::Full ||
+                               succeeded(tuningInfo->couldBePerformant(
                                    info, gemmParams))))
                             newSpace->tuningRange.push_back(
                                 cast<RockTuningParamAttrInterface>(
-                                    tuningInfo.getGemmParamsAttr(b,
-                                                                 gemmParams)));
+                                    tuningInfo->getGemmParamsAttr(b,
+                                                                  gemmParams)));
                         }
                       }
                     }
@@ -383,49 +559,8 @@ static void createGemmTuningRangeBF(TuningParamSet *newSpace,
         }
       }
     }
-  } else if (bitEnumContainsAll(currentFeatures, GemmFeatures::wmma)) {
-    // Wmma
-    const std::vector<std::vector<uint32_t>> &wmmaParams =
-        validRangeWmmaGemmParams;
-    PopulateParamsWmma tuningInfo;
-    for (uint32_t gemmMPerBlock : wmmaParams[0]) {
-      for (uint32_t gemmNPerBlock : wmmaParams[1]) {
-        for (uint32_t gemmKPerBlock : wmmaParams[2]) {
-          for (uint32_t gemmMPerWave : wmmaParams[3]) {
-            for (uint32_t gemmNPerWave : wmmaParams[4]) {
-              for (uint32_t gemmMnPerXdl : wmmaParams[5]) {
-                for (uint32_t gemmKPack : wmmaParams[6]) {
-                  auto optimalSplitKFactors = computeOptimalSplitKFactors(
-                      gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock,
-                      gemmKPack, isSplitKFusible);
-                  for (auto splitKFactor : optimalSplitKFactors) {
-                    for (uint32_t gemmSchedule : wmmaParams[7]) {
-                      for (uint32_t forceUnroll : wmmaParams[8]) {
-                        // hardcode outputSwizzle to heuristics = 2
-                        InitParamsAccel gemmParams(
-                            gemmMPerBlock, gemmNPerBlock, gemmKPerBlock,
-                            gemmMPerWave, gemmNPerWave, gemmMnPerXdl, gemmKPack,
-                            splitKFactor, gemmSchedule, 2, forceUnroll, true);
-                        if (succeeded(tuningInfo.paramsProbablyValid(
-                                b, info, gemmParams)) &&
-                            (kind == TuningParamSetKind::Exhaustive ||
-                             succeeded(tuningInfo.couldBePerformant(
-                                 info, gemmParams))))
-                          newSpace->tuningRange.push_back(
-                              cast<RockTuningParamAttrInterface>(
-                                  tuningInfo.getGemmParamsAttr(b, gemmParams)));
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
   } else {
-    // Non-XDLOPS
+    // Non-accel
     PopulateParams tuningInfo;
     for (uint32_t blockSize : validRangeGeneralGemmParams[0]) {
       for (uint32_t gemmMPerBlock : validRangeGeneralGemmParams[1]) {
@@ -444,7 +579,7 @@ static void createGemmTuningRangeBF(TuningParamSet *newSpace,
                       gemmMPerThread, gemmNPerThread, splitKFactor, 1, 2);
                   if (succeeded(tuningInfo.paramsProbablyValid(b, info,
                                                                gemmParams)) &&
-                      (kind == TuningParamSetKind::Exhaustive ||
+                      (kind != TuningParamSetKind::Full ||
                        succeeded(
                            tuningInfo.couldBePerformant(info, gemmParams))))
                     newSpace->tuningRange.push_back(
@@ -565,10 +700,150 @@ static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op attnOp,
           cast<RockTuningParamAttrInterface>(params));
     }
   }
-  // We only support GPUs with matrix accelerator extentions
+  // We only support GPUs with matrix accelerator extensions
 }
 
-TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind) {
+unsigned getNumberOfIterations(TuningParamSetKind kind) {
+  switch (kind) {
+  case TuningParamSetKind::Quick:
+  case TuningParamSetKind::Full:
+  case TuningParamSetKind::Exhaustive:
+    return 1;
+  case TuningParamSetKind::Greedy:
+    return 2;
+  }
+  return 1;
+}
+
+// Generate random configs for greedy first iteration (Phase 1)
+static void createGemmTuningRangeGreedyPhase1(TuningParamSet *newSpace,
+                                              RockGemmWrapperInterface gemmOp,
+                                              bool isSplitKFusible,
+                                              unsigned numRandomPerTileSize,
+                                              unsigned int seed) {
+  GemmFeatures currentFeatures = rock::getFeatures(gemmOp);
+  auto info = PopulateParamsInfo::fromOp(gemmOp);
+  OpBuilder b(gemmOp.getContext());
+  const std::vector<std::vector<uint32_t>> params =
+      getAccelRangeGemm(gemmOp, TuningParamSetKind::Greedy);
+  std::mt19937 rng(seed);
+  std::unique_ptr<PopulateParamsAccel> tuningInfo;
+  if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma))
+    tuningInfo = std::make_unique<PopulateParamsXDL>();
+  else
+    tuningInfo = std::make_unique<PopulateParamsWmma>();
+  int64_t waveSize = rock::lookupArchInfo(rock::getArchValue(gemmOp)).waveSize;
+
+  for (uint32_t gemmMPerBlock : params[0]) {
+    SmallVector<uint32_t> mPerWaveRange =
+        computeDPerWave(TuningParamSetKind::Greedy, gemmMPerBlock, waveSize);
+    for (uint32_t gemmNPerBlock : params[1]) {
+      SmallVector<uint32_t> nPerWaveRange =
+          computeDPerWave(TuningParamSetKind::Greedy, gemmNPerBlock, waveSize);
+      uint32_t totalIterations = params[2].size() * mPerWaveRange.size() *
+                                 nPerWaveRange.size() * params[3].size() *
+                                 params[4].size() * params[5].size() *
+                                 params[6].size();
+      uint32_t numRandomIterations =
+          std::min(numRandomPerTileSize, totalIterations);
+      for (uint32_t randomIteration = 0;
+           randomIteration < numRandomIterations;) {
+        uint32_t gemmKPerBlock = params[2][rng() % params[2].size()];
+        uint32_t gemmMPerWave = mPerWaveRange[rng() % mPerWaveRange.size()];
+        uint32_t gemmNPerWave = nPerWaveRange[rng() % nPerWaveRange.size()];
+        uint32_t gemmMnPerXdl = params[3][rng() % params[3].size()];
+        uint32_t gemmKPack = params[4][rng() % params[4].size()];
+        uint32_t gemmSchedule = params[5][rng() % params[5].size()];
+        uint32_t forceUnroll = params[6][rng() % params[6].size()];
+        auto optimalSplitKFactors = computeOptimalSplitKFactors(
+            gemmOp, gemmMPerBlock, gemmNPerBlock, gemmKPerBlock, gemmKPack,
+            isSplitKFusible);
+        uint32_t splitKFactor =
+            optimalSplitKFactors[rng() % optimalSplitKFactors.size()];
+        // hardcode outputSwizzle to heuristics = 2
+        InitParamsAccel gemmParams(gemmMPerBlock, gemmNPerBlock, gemmKPerBlock,
+                                   gemmMPerWave, gemmNPerWave, gemmMnPerXdl,
+                                   gemmKPack, splitKFactor, gemmSchedule, 2,
+                                   forceUnroll, true);
+        if (succeeded(tuningInfo->paramsProbablyValid(b, info, gemmParams))) {
+          newSpace->tuningRange.push_back(cast<RockTuningParamAttrInterface>(
+              tuningInfo->getGemmParamsAttr(b, gemmParams)));
+          randomIteration++;
+        }
+      }
+    }
+  }
+}
+
+// Generate brute force configs for greedy second iteration (Phase 2)
+static void createGemmTuningRangeGreedyPhase2(TuningParamSet *newSpace,
+                                              RockGemmWrapperInterface gemmOp,
+                                              bool isSplitKFusible,
+                                              StringRef winningConfig) {
+  auto info = PopulateParamsInfo::fromOp(gemmOp);
+  OpBuilder b(gemmOp.getContext());
+  GemmFeatures currentFeatures = rock::getFeatures(gemmOp);
+
+  uint32_t winningMPerBlock, winningNPerBlock;
+  InitParamsAccel validParams;
+  auto populateParamsAccelPtr = PopulateParamsAccel::select(currentFeatures);
+  LogicalResult status = populateParamsAccelPtr->obtainTuningParameters(
+      gemmOp, winningConfig, validParams);
+  assert(llvm::succeeded(status) &&
+         "Tile sizes must be extracted from winning config");
+  winningMPerBlock = validParams.gemmMPerBlock;
+  winningNPerBlock = validParams.gemmNPerBlock;
+
+  const std::vector<std::vector<uint32_t>> params =
+      getAccelRangeGemm(gemmOp, TuningParamSetKind::Greedy);
+  std::unique_ptr<PopulateParamsAccel> tuningInfo;
+  if (bitEnumContainsAll(currentFeatures, GemmFeatures::mfma))
+    tuningInfo = std::make_unique<PopulateParamsXDL>();
+  else
+    tuningInfo = std::make_unique<PopulateParamsWmma>();
+  int64_t waveSize = rock::lookupArchInfo(rock::getArchValue(gemmOp)).waveSize;
+  SmallVector<uint32_t> mPerWaveRange =
+      computeDPerWave(TuningParamSetKind::Greedy, winningMPerBlock, waveSize);
+  SmallVector<uint32_t> nPerWaveRange =
+      computeDPerWave(TuningParamSetKind::Greedy, winningNPerBlock, waveSize);
+
+  for (uint32_t gemmKPerBlock : params[2]) {
+    for (uint32_t gemmMPerWave : mPerWaveRange) {
+      for (uint32_t gemmNPerWave : nPerWaveRange) {
+        for (uint32_t gemmMnPerXdl : params[3]) {
+          for (uint32_t gemmKPack : params[4]) {
+            auto optimalSplitKFactors = computeOptimalSplitKFactors(
+                gemmOp, winningMPerBlock, winningNPerBlock, gemmKPerBlock,
+                gemmKPack, isSplitKFusible);
+            for (int64_t splitKFactor : optimalSplitKFactors) {
+              for (int64_t gemmSchedule : params[5]) {
+                for (uint32_t forceUnroll : params[6]) {
+                  // hardcode outputSwizzle to heuristics = 2
+                  InitParamsAccel gemmParams(
+                      winningMPerBlock, winningNPerBlock, gemmKPerBlock,
+                      gemmMPerWave, gemmNPerWave, gemmMnPerXdl, gemmKPack,
+                      splitKFactor, gemmSchedule, 2, forceUnroll, true);
+                  if (winningMPerBlock >= gemmMPerWave &&
+                      winningNPerBlock >= gemmMnPerXdl) {
+                    if (succeeded(tuningInfo->paramsProbablyValid(b, info,
+                                                                  gemmParams)))
+                      newSpace->tuningRange.push_back(
+                          cast<RockTuningParamAttrInterface>(
+                              tuningInfo->getGemmParamsAttr(b, gemmParams)));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
+                                        unsigned iteration,
+                                        StringRef winningConfig) {
   struct TuningParamSet *newSpace;
   newSpace = new TuningParamSet();
 
@@ -577,10 +852,28 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind) {
   // create range and heuristic
   WalkResult findPrimary =
       mod->walk([&](rock::RockGemmWrapperInterface op) -> WalkResult {
+        GemmFeatures currentFeatures = rock::getFeatures(op);
+        // greedy is not implemented for non-accel
+        if (!rock::isAccel(currentFeatures) &&
+            kind == TuningParamSetKind::Greedy) {
+          kind = TuningParamSetKind::Exhaustive;
+        }
         switch (kind) {
         case TuningParamSetKind::Full:
         case TuningParamSetKind::Exhaustive:
           createGemmTuningRangeBF(newSpace, op, isSplitKFusible, kind);
+          break;
+        case TuningParamSetKind::Greedy:
+          if (iteration == 0) {
+            // First iteration: random configs per tile size
+            createGemmTuningRangeGreedyPhase1(newSpace, op, isSplitKFusible,
+                                              NUM_RANDOM_PER_TILE_SIZE,
+                                              RND_SEED);
+          } else {
+            // Second iteration: brute force with winning tile sizes
+            createGemmTuningRangeGreedyPhase2(newSpace, op, isSplitKFusible,
+                                              winningConfig);
+          }
           break;
         case TuningParamSetKind::Quick:
           createQuickTuningRange(newSpace, op);
@@ -596,6 +889,18 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind) {
         case TuningParamSetKind::Full:
         case TuningParamSetKind::Exhaustive:
           createAttnTuningRangeBF(newSpace, op, isSplitKFusible, kind);
+          break;
+        case TuningParamSetKind::Greedy:
+          if (iteration == 0) {
+            // First iteration: random configs per tile size
+            createAttnTuningRangeGreedyPhase1(newSpace, op, isSplitKFusible,
+                                              NUM_RANDOM_PER_TILE_SIZE,
+                                              RND_SEED);
+          } else {
+            // Second iteration: brute force with winning tile sizes
+            createAttnTuningRangeGreedyPhase2(newSpace, op, isSplitKFusible,
+                                              winningConfig);
+          }
           break;
         case TuningParamSetKind::Quick:
           createAttnTuningRangeQuick(newSpace, op, elemType);

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -324,8 +324,10 @@ static void createAttnTuningRangeGreedyPhase2(
                     gemm0NPerBlock, gemmKPerBlock, gemmMPerWave, gemmNPerWave,
                     gemmMnPerXdl, gemmKPack, splitKFactor, gemmSchedule,
                     outputSwizzle, true);
-                newSpace->tuningRange.push_back(
-                    cast<RockTuningParamAttrInterface>(params));
+                if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+                  newSpace->tuningRange.push_back(
+                      cast<RockTuningParamAttrInterface>(params));
+                }
               }
             }
           }
@@ -385,8 +387,11 @@ static void createAttnTuningRangeBF(TuningParamSet *newSpace,
                           gemm1MPerBlock, gemm0NPerBlock, gemmKPerBlock,
                           gemmMPerWave, gemmNPerWave, gemmMnPerXdl, gemmKPack,
                           splitKFactor, gemmSchedule, outputSwizzle, true);
-                      newSpace->tuningRange.push_back(
-                          cast<RockTuningParamAttrInterface>(params));
+                      if (succeeded(
+                              paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+                        newSpace->tuningRange.push_back(
+                            cast<RockTuningParamAttrInterface>(params));
+                      }
                     }
                   }
                 }
@@ -647,10 +652,10 @@ static void createQuickTuningRange(TuningParamSet *newSpace,
 // This is temporary workaround to make MIGraphX integration
 // work until the tuning is setup for attention ops properly.
 template <typename Op>
-static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op attnOp,
+static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op gemmGemmOp,
                                        Type elemType) {
-  OpBuilder b(attnOp.getContext());
-  GemmFeatures currentFeatures = rock::getFeatures(attnOp);
+  OpBuilder b(gemmGemmOp.getContext());
+  GemmFeatures currentFeatures = rock::getFeatures(gemmGemmOp);
   int64_t splitKFactor{1}, gemmSchedule{1}, outputSwizzle{2};
   // g0Mpb, g1Mpb, g0Npb, Kpb, mPw, mnPxdl, kpack
   using PerfConfigVals = std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t,
@@ -679,11 +684,13 @@ static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op attnOp,
     for (auto [mPerBlockG0, mPerBlockG1, nPerBlockG0, kPackBerBlock, mPerWave,
                nPerWave, mnPerXdl, kPack] : attnQuickTuningListMFMA) {
       auto params = AttnPerfConfigAttr::get(
-          attnOp.getContext(), mPerBlockG0, mPerBlockG1, nPerBlockG0,
+          gemmGemmOp.getContext(), mPerBlockG0, mPerBlockG1, nPerBlockG0,
           kPackBerBlock, mPerWave, nPerWave, mnPerXdl, kPack, splitKFactor,
           gemmSchedule, outputSwizzle, true);
-      newSpace->tuningRange.push_back(
-          cast<RockTuningParamAttrInterface>(params));
+      if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+        newSpace->tuningRange.push_back(
+            cast<RockTuningParamAttrInterface>(params));
+      }
     }
   } else if (bitEnumContainsAll(currentFeatures, GemmFeatures::wmma)) {
     const SmallVector<PerfConfigVals, 7> attnQuickTuningListWMMA{
@@ -698,11 +705,13 @@ static void createAttnTuningRangeQuick(TuningParamSet *newSpace, Op attnOp,
     for (auto [mPerBlockG0, mPerBlockG1, nPerBlockG0, kPackBerBlock, mPerWave,
                nPerWave, mnPerXdl, kPack] : attnQuickTuningListWMMA) {
       auto params = AttnPerfConfigAttr::get(
-          attnOp.getContext(), mPerBlockG0, mPerBlockG1, nPerBlockG0,
+          gemmGemmOp.getContext(), mPerBlockG0, mPerBlockG1, nPerBlockG0,
           kPackBerBlock, mPerWave, nPerWave, mnPerXdl, kPack, splitKFactor,
           gemmSchedule, outputSwizzle, true);
-      newSpace->tuningRange.push_back(
-          cast<RockTuningParamAttrInterface>(params));
+      if (succeeded(paramsAttnProbablyValid(b, gemmGemmOp, params))) {
+        newSpace->tuningRange.push_back(
+            cast<RockTuningParamAttrInterface>(params));
+      }
     }
   }
   // We only support GPUs with matrix accelerator extensions

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/LogicalResult.h"
 #include <algorithm>
@@ -706,10 +707,11 @@ unsigned getNumberOfIterations(TuningParamSetKind kind) {
   case TuningParamSetKind::Greedy:
     return 2;
   }
-  return 1;
+  llvm_unreachable("invalid tuning kind");
 }
 
-// Generate random configs for greedy first iteration (Phase 1)
+// Tune MperBlock and NPerBlock only, generating random configs for the rest of
+// parameters (greedy tuning, phase 1)
 static void createGemmTuningRangeGreedyPhase1(TuningParamSet *newSpace,
                                               RockGemmWrapperInterface gemmOp,
                                               bool isSplitKFusible,
@@ -769,7 +771,8 @@ static void createGemmTuningRangeGreedyPhase1(TuningParamSet *newSpace,
   }
 }
 
-// Generate brute force configs for greedy second iteration (Phase 2)
+// With MperBlock and NPerBlock already set, tune for the rest of parameters by
+// brute force (greedy tuning, phase 2)
 static void createGemmTuningRangeGreedyPhase2(TuningParamSet *newSpace,
                                               RockGemmWrapperInterface gemmOp,
                                               bool isSplitKFusible,
@@ -835,9 +838,9 @@ static void createGemmTuningRangeGreedyPhase2(TuningParamSet *newSpace,
   }
 }
 
-TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
-                                        unsigned iteration,
-                                        StringRef winningConfig) {
+TuningParamSet *
+createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
+                        rock::TuningParamSpaceSettings &settings) {
   struct TuningParamSet *newSpace;
   newSpace = new TuningParamSet();
 
@@ -858,7 +861,7 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
           createGemmTuningRangeBF(newSpace, op, isSplitKFusible, kind);
           break;
         case TuningParamSetKind::Greedy:
-          if (iteration == 0) {
+          if (settings.iteration == 0) {
             // First iteration: random configs per tile size
             createGemmTuningRangeGreedyPhase1(newSpace, op, isSplitKFusible,
                                               NUM_RANDOM_PER_TILE_SIZE,
@@ -866,7 +869,7 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
           } else {
             // Second iteration: brute force with winning tile sizes
             createGemmTuningRangeGreedyPhase2(newSpace, op, isSplitKFusible,
-                                              winningConfig);
+                                              settings.winningConfig);
           }
           break;
         case TuningParamSetKind::Quick:
@@ -885,7 +888,7 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
           createAttnTuningRangeBF(newSpace, op, isSplitKFusible, kind);
           break;
         case TuningParamSetKind::Greedy:
-          if (iteration == 0) {
+          if (settings.iteration == 0) {
             // First iteration: random configs per tile size
             createAttnTuningRangeGreedyPhase1(newSpace, op, isSplitKFusible,
                                               NUM_RANDOM_PER_TILE_SIZE,
@@ -893,7 +896,7 @@ TuningParamSet *createTunableParamSpace(ModuleOp mod, TuningParamSetKind kind,
           } else {
             // Second iteration: brute force with winning tile sizes
             createAttnTuningRangeGreedyPhase2(newSpace, op, isSplitKFusible,
-                                              winningConfig);
+                                              settings.winningConfig);
           }
           break;
         case TuningParamSetKind::Quick:

--- a/mlir/test/rocmlir-gen/emit-tuning-space.mlir
+++ b/mlir/test/rocmlir-gen/emit-tuning-space.mlir
@@ -14,10 +14,10 @@
 // CHECK-EXHAUSTIVE-DIRECTTOLDS-DOUBLE: v4:64,64,8,16,16,16,4,4,4,2,1,1
 
 // RUN: rocmlir-gen --arch gfx950 --operation=attention -t f32 -g 1 -head_dim_qk 32 -head_dim_v 32 -num_heads_q 128 -num_heads_kv 128 -seq_len_q 1024 -seq_len_k 1024 --num_cu=256 --emit-tuning-space=exhaustive | FileCheck %s --check-prefixes=CHECK-EXHAUSTIVE-ATTN-DIRECTTOLDS-SINGLE
-// CHECK-EXHAUSTIVE-ATTN-DIRECTTOLDS-SINGLE: attn:v3:32,64,32,16,32,32,4,8,1,3,2,1
+// CHECK-EXHAUSTIVE-ATTN-DIRECTTOLDS-SINGLE: attn:v3:32,64,32,16,32,32,16,8,1,3,2,1
 
 // RUN: rocmlir-gen --arch gfx950 --operation=attention -t f32 -g 1 -head_dim_qk 32 -head_dim_v 32 -num_heads_q 128 -num_heads_kv 128 -seq_len_q 1024 -seq_len_k 1024 --num_cu=256 --emit-tuning-space=exhaustive | FileCheck %s --check-prefixes=CHECK-EXHAUSTIVE-ATTN-DIRECTTOLDS-DOUBLE
-// CHECK-EXHAUSTIVE-ATTN-DIRECTTOLDS-DOUBLE: attn:v3:32,64,32,16,32,32,4,8,1,4,2,1
+// CHECK-EXHAUSTIVE-ATTN-DIRECTTOLDS-DOUBLE: attn:v3:32,64,32,16,32,32,16,8,1,4,2,1
 
 // RUN: rocmlir-gen -p --arch gfx1100 --operation=attention -t f16 --emit-tuning-space=exhaustive | FileCheck %s --check-prefixes=CHECK-SCHEDULING-ATTENTION
 // CHECK-SCHEDULING-ATTENTION: attn:v3:128,128,256,64,32,32,16,16,1,2,2,1

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -5546,8 +5546,9 @@ int main(int argc, char **argv) {
   }
 
   if (emitTuningSpace.getNumOccurrences() > 0) {
+    rock::TuningParamSpaceSettings settings;
     std::unique_ptr<rock::TuningParamSet> tunableParams(
-        rock::createTunableParamSpace(*module, emitTuningSpace));
+        rock::createTunableParamSpace(*module, emitTuningSpace, settings));
     SmallString<64> perfConfig;
     for (auto param : tunableParams->tuningRange) {
       param.getPerfConfigStr(perfConfig);

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -758,14 +758,15 @@ static LogicalResult runTuningLoop(ModuleOp source) {
         return copy;
       };
 
-      // Applicability check
-      OwningOpRef<ModuleOp> sourceCopy =
-          copyIRThread(threadSource.get(), perfConfigAttr);
-      if (!rock::isModuleFusible(sourceCopy.get(), result.perfConfig)) {
+      if (doesModuleHaveFusions(threadSource.get()) &&
+          !rock::isModuleFusible(threadSource.get(), result.perfConfig)) {
         result.status = CompilationStatus::NotApplicable;
         return result;
       }
 
+      // Applicability check
+      OwningOpRef<ModuleOp> sourceCopy =
+          copyIRThread(threadSource.get(), perfConfigAttr);
       if (failed(threadApplicability.run(sourceCopy.get()))) {
         result.status = CompilationStatus::NotApplicable;
         return result;
@@ -855,6 +856,9 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     }
 
     int64_t validResults = 0;
+    // Sequential benchmarking phase (must be sequential for accurate timing)
+    // Note: Due to early exit on compilation failures, only NotApplicable and
+    // Success statuses are possible here.
     for (const auto &result : compilationResults) {
       llvm::outs() << result.perfConfig << "\t";
 

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -88,7 +88,7 @@ void pArgs(const std::tuple<Ts...> &formals, void **_vargs) {
 using namespace mlir;
 using namespace rocmlir::tuningdriver;
 
-llvm::cl::opt<std::string> inputFilename{
+static llvm::cl::opt<std::string> inputFilename{
     llvm::cl::Positional, llvm::cl::desc("<input file>"), llvm::cl::init("-")};
 
 static llvm::cl::opt<rock::TuningParamSetKind> tuningSpaceKind(
@@ -98,6 +98,11 @@ static llvm::cl::opt<rock::TuningParamSetKind> tuningSpaceKind(
                    "Quick tuning space"),
         clEnumValN(rock::TuningParamSetKind::Full, "full",
                    "Full tuning space, excluding known-bad configurations"),
+        clEnumValN(
+            rock::TuningParamSetKind::Greedy, "greedy",
+            "Tune all possible tile sizes and try N random configurations for "
+            "each tile size. Then, greedily select the best tile size, and "
+            "brute force tune the rest of params"),
         clEnumValN(rock::TuningParamSetKind::Exhaustive, "exhaustive",
                    "All tuning space combinations, even inapplicable ones")),
     llvm::cl::value_desc("tuning space to use"),
@@ -210,8 +215,8 @@ static double computeMean(const std::vector<double> &values) {
     return 0.0;
 
   double sum = 0.0;
-  for (size_t i = 0; i < values.size(); ++i) {
-    sum += values[i];
+  for (double value : values) {
+    sum += value;
   }
 
   return sum / values.size();
@@ -256,6 +261,9 @@ struct BenchmarkParams {
   unsigned trimPercent;
   unsigned sleepUs;
   bool showStats;
+  rock::TuningParamSetKind tuningSpaceKind;
+  const unsigned numCompileThreads;
+  std::string benchmarkConfig;
 };
 
 enum class CompilationStatus {
@@ -360,8 +368,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
                  ArrayRef<std::string> funcNames, ArrayRef<uint32_t> blockSizes,
                  ArrayRef<uint32_t> gridSizes, ArrayRef<void *> hostBuffers,
                  MutableArrayRef<void *> gpuBuffers,
-                 ArrayRef<size_t> bufferSizes, const BenchmarkParams &params,
-                 bool benchmarkMode) {
+                 ArrayRef<size_t> bufferSizes, const BenchmarkParams &params) {
+  bool benchmarkMode = !params.benchmarkConfig.empty();
   hipStream_t stream;
   HIPCHECK(hipStreamCreate(&stream));
   auto streamCleanup = llvm::make_scope_exit([&]() {
@@ -636,222 +644,253 @@ static LogicalResult runTuningLoop(ModuleOp source) {
     gpuBuffers.push_back(gpuBuffer);
   }
 
-  // 4. Collect perf configs to compile
-  bool benchmarkMode = !benchmarkConfig.empty();
-  std::vector<SmallString<64>> configs;
-  if (benchmarkMode) {
-    // Benchmark mode - just one config
-    configs.emplace_back(benchmarkConfig);
-  } else {
-    // Tuning mode - all configs from tuning space
-    std::unique_ptr<rock::TuningParamSet> tuningSpace(
-        rock::createTunableParamSpace(source, tuningSpaceKind));
-
-    if (tuningSpace->tuningRange.empty()) {
-      llvm::errs() << "Tuning range is empty\n";
-      return failure();
-    }
-
-    for (rock::RockTuningParamAttrInterface tuningAttr :
-         tuningSpace->tuningRange) {
-      SmallString<64> perfConfig;
-      tuningAttr.getPerfConfigStr(perfConfig);
-      configs.push_back(perfConfig);
-    }
-  }
+  // 4. Multi-iteration tuning loop
+  SmallString<64> bestConfigOverall;
+  float bestTimeOverall = std::numeric_limits<float>::max();
 
   // NOTE: Compilation (PassManager::run()) resets the cl opts, so we have to
   // save the values.
-  const BenchmarkParams benchmarkParams = {numIterations, warmupIterations,
-                                           useMedian,     trimPercent,
-                                           sleepUs,       showStats};
+  const BenchmarkParams benchmarkParams = {
+      numIterations,   warmupIterations,  useMedian,
+      trimPercent,     sleepUs,           showStats,
+      tuningSpaceKind, numCompileThreads, benchmarkConfig};
 
-  // Determine number of parallel threads
-  unsigned numThreads = (numCompileThreads > 0)
-                            ? numCompileThreads
-                            : std::thread::hardware_concurrency();
-  if (numThreads == 0)
-    numThreads = 4; // fallback
-
-  // Don't create more threads than configs to compile
-  numThreads = std::min(numThreads, static_cast<unsigned>(configs.size()));
-
-  // Serialize source module once (shared by all threads for cloning)
-  std::string sourceModuleStr;
-  llvm::raw_string_ostream sourceOs(sourceModuleStr);
-  source->print(sourceOs);
-  sourceOs.flush();
-
-  // Parallel compilation phase
-  std::vector<CompilationResult> compilationResults(configs.size());
-  std::mutex outputMutex; // For thread-safe console output
-  std::atomic<bool> compilationFailed{
-      false}; // Flag to signal early termination
-
-  auto compileConfig = [&](size_t idx) -> CompilationResult {
-    CompilationResult result;
-    result.perfConfig = configs[idx];
-    // Each thread needs its own context and pass managers for thread-safety
-    DialectRegistry threadRegistry;
-    registerRocMLIRDialects(threadRegistry);
-    MLIRContext threadCtx(threadRegistry);
-    threadCtx.getDiagEngine().registerHandler([](Diagnostic &diag) {});
-
-    // Parse the serialized module in this thread's context
-    OwningOpRef<ModuleOp> threadSource =
-        parseSourceString<ModuleOp>(sourceModuleStr, &threadCtx);
-    if (!threadSource)
-      return result;
-
-    // Set up pipelines for this thread
-    PassManager threadApplicability(&threadCtx,
-                                    PassManager::getAnyOpAnchorName(),
-                                    PassManager::Nesting::Implicit);
-    PassManager threadCompilation(&threadCtx, PassManager::getAnyOpAnchorName(),
-                                  PassManager::Nesting::Implicit);
-
-    rock::buildKernelPipeline(threadApplicability, applicabilityOpts);
-    rock::buildKernelPipeline(threadCompilation, compilationKernOpts);
-    rock::buildBackendPipeline(threadCompilation, backendOpts);
-
-    StringAttr perfConfigAttr = StringAttr::get(&threadCtx, result.perfConfig);
-
-    // Helper to copy IR with perf config set
-    auto copyIRThread = [&](ModuleOp src,
-                            StringAttr attr) -> OwningOpRef<ModuleOp> {
-      OwningOpRef<ModuleOp> copy = cast<ModuleOp>(src->clone());
-      copy->walk([&attr](rock::RockGemmWrapperInterface op) {
-        op->setAttr("perf_config", attr);
-      });
-      copy->walk([&attr](rock::RockGemmGemmWrapperInterface op) {
-        op->setAttr("perf_config", attr);
-      });
-      return copy;
-    };
-
-    if (doesModuleHaveFusions(threadSource.get()) &&
-        !rock::isModuleFusible(threadSource.get(), result.perfConfig)) {
-      result.status = CompilationStatus::NotApplicable;
-      return result;
-    }
-
-    // Applicability check
-    OwningOpRef<ModuleOp> sourceCopy =
-        copyIRThread(threadSource.get(), perfConfigAttr);
-    if (failed(threadApplicability.run(sourceCopy.get()))) {
-      result.status = CompilationStatus::NotApplicable;
-      return result;
-    }
-
-    // Extract block and grid sizes
-    for (auto &fnName : kernelFuncNames) {
-      auto tunedFunc = sourceCopy->lookupSymbol<func::FuncOp>(fnName);
-      if (!tunedFunc) {
-        result.status = CompilationStatus::CompilationFailed;
-        compilationFailed.store(true, std::memory_order_relaxed);
-        return result;
-      }
-      result.blockSizes.push_back(
-          tunedFunc->getAttrOfType<IntegerAttr>("block_size").getInt());
-      result.gridSizes.push_back(
-          tunedFunc->getAttrOfType<IntegerAttr>("grid_size").getInt());
-    }
-
-    // Compilation
-    if (failed(threadCompilation.run(sourceCopy.get()))) {
-      std::lock_guard<std::mutex> lock(outputMutex);
-      llvm::errs() << "Backend pipeline failed for config: "
-                   << result.perfConfig << "\n";
-      result.status = CompilationStatus::CompilationFailed;
-      compilationFailed.store(true, std::memory_order_relaxed);
-      return result;
-    }
-
-    // Extract binaries
-    for (const auto &fnName : kernelFuncNames) {
-      auto binary = sourceCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
-      if (!binary) {
-        result.status = CompilationStatus::CompilationFailed;
-        compilationFailed.store(true, std::memory_order_relaxed);
-        return result;
-      }
-      result.hipModules.push_back(cast<gpu::ObjectAttr>(binary.getObjects()[0])
-                                      .getObject()
-                                      .getValue()
-                                      .str());
-    }
-
-    result.status = CompilationStatus::Success;
-    return result;
-  };
-
-  // Launch parallel compilation tasks with dynamic work stealing
-  // Note: We use atomic counter instead of static partitioning because
-  // compilation times vary dramatically between configs (NotApplicable is fast,
-  // full compilation is slow). Dynamic work stealing provides better load
-  // balancing by allowing fast threads to pick up more work.
-  {
-    std::atomic<size_t> nextIdx{0};
-
-    // Thread pool with work stealing pattern
-    auto worker = [&]() {
-      while (true) {
-        // Check if any compilation has failed (relaxed: just an optimization
-        // hint)
-        if (compilationFailed.load(std::memory_order_relaxed))
-          break;
-
-        size_t idx = nextIdx.fetch_add(1, std::memory_order_relaxed);
-        if (idx >= configs.size())
-          break;
-
-        compilationResults[idx] = compileConfig(idx);
-      }
-    };
-
-    std::vector<std::thread> threads;
-    threads.reserve(numThreads);
-    for (unsigned i = 0; i < numThreads; ++i) {
-      threads.emplace_back(worker);
-    }
-
-    for (auto &t : threads) {
-      t.join();
-    }
-  }
-
-  // Check if any compilation failed and terminate early
-  if (compilationFailed.load(std::memory_order_relaxed)) {
-    llvm::errs()
-        << "Compilation failed for one or more configs. Terminating.\n";
+  unsigned numTuningIterations =
+      rock::getNumberOfIterations(benchmarkParams.tuningSpaceKind);
+  if (!benchmarkParams.benchmarkConfig.empty() && numTuningIterations != 1) {
+    llvm::errs() << "benchmarking should do a single tuning iteration\n";
     return failure();
   }
 
-  // Sequential benchmarking phase (must be sequential for accurate timing)
-  // Note: Due to early exit on compilation failures, only NotApplicable and
-  // Success statuses are possible here.
-  for (const auto &result : compilationResults) {
-    llvm::outs() << result.perfConfig << "\t";
+  // Main iteration loop - wraps config generation, compilation, AND
+  // benchmarking
+  for (unsigned iterIdx = 0; iterIdx < numTuningIterations; ++iterIdx) {
+    // PHASE 1: Collect perf configs for this iteration
+    std::vector<SmallString<64>> configs;
 
-    if (result.status == CompilationStatus::NotApplicable) {
-      llvm::outs() << "N/A\n";
-      continue;
+    if (!benchmarkParams.benchmarkConfig.empty()) {
+      // Benchmark mode - just one config
+      configs.emplace_back(benchmarkParams.benchmarkConfig);
+    } else {
+      // Tuning mode - get configs from tuning space
+      std::unique_ptr<rock::TuningParamSet> tuningSpace(
+          rock::createTunableParamSpace(source, benchmarkParams.tuningSpaceKind,
+                                        iterIdx, bestConfigOverall));
+
+      if (tuningSpace->tuningRange.empty()) {
+        llvm::errs() << "Tuning range is empty for iteration " << iterIdx
+                     << "\n";
+        return failure();
+      }
+
+      for (rock::RockTuningParamAttrInterface tuningAttr :
+           tuningSpace->tuningRange) {
+        SmallString<64> perfConfig;
+        tuningAttr.getPerfConfigStr(perfConfig);
+        configs.push_back(perfConfig);
+      }
     }
 
-    // At this point, status must be Success (we exited early on any failures)
-    assert(result.status == CompilationStatus::Success &&
-           "Unexpected compilation status in benchmarking phase");
+    // Determine number of parallel threads
+    unsigned numThreads = (benchmarkParams.numCompileThreads > 0)
+                              ? benchmarkParams.numCompileThreads
+                              : std::thread::hardware_concurrency();
+    if (numThreads == 0)
+      numThreads = 4; // fallback
 
-    FailureOr<double> timing = benchmarkKernels(
-        result.hipModules, kernelFuncNames, result.blockSizes, result.gridSizes,
-        hostBuffers, gpuBuffers, bufferLengths, benchmarkParams, benchmarkMode);
+    // Don't create more threads than configs to compile
+    numThreads = std::min(numThreads, static_cast<unsigned>(configs.size()));
 
-    if (failed(timing)) {
-      llvm::errs() << "Kernel execution failed\n";
+    // Serialize source module once (shared by all threads for cloning)
+    std::string sourceModuleStr;
+    llvm::raw_string_ostream sourceOs(sourceModuleStr);
+    source->print(sourceOs);
+    sourceOs.flush();
+
+    // PHASE 2: Parallel compilation phase
+    std::vector<CompilationResult> compilationResults(configs.size());
+    std::mutex outputMutex; // For thread-safe console output
+    std::atomic<bool> compilationFailed{
+        false}; // Flag to signal early termination
+
+    auto compileConfig = [&](size_t idx) -> CompilationResult {
+      CompilationResult result;
+      result.perfConfig = configs[idx];
+      // Each thread needs its own context and pass managers for thread-safety
+      DialectRegistry threadRegistry;
+      registerRocMLIRDialects(threadRegistry);
+      MLIRContext threadCtx(threadRegistry);
+      threadCtx.getDiagEngine().registerHandler([](Diagnostic &diag) {});
+
+      // Parse the serialized module in this thread's context
+      OwningOpRef<ModuleOp> threadSource =
+          parseSourceString<ModuleOp>(sourceModuleStr, &threadCtx);
+      if (!threadSource)
+        return result;
+
+      // Set up pipelines for this thread
+      PassManager threadApplicability(&threadCtx,
+                                      PassManager::getAnyOpAnchorName(),
+                                      PassManager::Nesting::Implicit);
+      PassManager threadCompilation(&threadCtx,
+                                    PassManager::getAnyOpAnchorName(),
+                                    PassManager::Nesting::Implicit);
+
+      rock::buildKernelPipeline(threadApplicability, applicabilityOpts);
+      rock::buildKernelPipeline(threadCompilation, compilationKernOpts);
+      rock::buildBackendPipeline(threadCompilation, backendOpts);
+
+      StringAttr perfConfigAttr =
+          StringAttr::get(&threadCtx, result.perfConfig);
+
+      // Helper to copy IR with perf config set
+      auto copyIRThread = [&](ModuleOp src,
+                              StringAttr attr) -> OwningOpRef<ModuleOp> {
+        OwningOpRef<ModuleOp> copy = cast<ModuleOp>(src->clone());
+        copy->walk([&attr](rock::RockGemmWrapperInterface op) {
+          op->setAttr("perf_config", attr);
+        });
+        copy->walk([&attr](rock::RockGemmGemmWrapperInterface op) {
+          op->setAttr("perf_config", attr);
+        });
+        return copy;
+      };
+
+      // Applicability check
+      OwningOpRef<ModuleOp> sourceCopy =
+          copyIRThread(threadSource.get(), perfConfigAttr);
+      if (!rock::isModuleFusible(sourceCopy.get(), result.perfConfig)) {
+        result.status = CompilationStatus::NotApplicable;
+        return result;
+      }
+
+      if (failed(threadApplicability.run(sourceCopy.get()))) {
+        result.status = CompilationStatus::NotApplicable;
+        return result;
+      }
+
+      // Extract block and grid sizes
+      for (auto &fnName : kernelFuncNames) {
+        auto tunedFunc = sourceCopy->lookupSymbol<func::FuncOp>(fnName);
+        if (!tunedFunc) {
+          result.status = CompilationStatus::CompilationFailed;
+          compilationFailed.store(true, std::memory_order_relaxed);
+          return result;
+        }
+        result.blockSizes.push_back(
+            tunedFunc->getAttrOfType<IntegerAttr>("block_size").getInt());
+        result.gridSizes.push_back(
+            tunedFunc->getAttrOfType<IntegerAttr>("grid_size").getInt());
+      }
+
+      // Compilation
+      if (failed(threadCompilation.run(sourceCopy.get()))) {
+        std::lock_guard<std::mutex> lock(outputMutex);
+        llvm::errs() << "Backend pipeline failed for config: "
+                     << result.perfConfig << "\n";
+        result.status = CompilationStatus::CompilationFailed;
+        compilationFailed.store(true, std::memory_order_relaxed);
+        return result;
+      }
+
+      // Extract binaries
+      for (const auto &fnName : kernelFuncNames) {
+        auto binary =
+            sourceCopy->lookupSymbol<gpu::BinaryOp>(fnName + "_module");
+        if (!binary) {
+          result.status = CompilationStatus::CompilationFailed;
+          compilationFailed.store(true, std::memory_order_relaxed);
+          return result;
+        }
+        result.hipModules.push_back(
+            cast<gpu::ObjectAttr>(binary.getObjects()[0])
+                .getObject()
+                .getValue()
+                .str());
+      }
+
+      result.status = CompilationStatus::Success;
+      return result;
+    };
+
+    // Launch parallel compilation tasks with dynamic work stealing
+    // Note: We use atomic counter instead of static partitioning because
+    // compilation times vary dramatically between configs (NotApplicable is
+    // fast, full compilation is slow). Dynamic work stealing provides better
+    // load balancing by allowing fast threads to pick up more work.
+    {
+      std::atomic<size_t> nextIdx{0};
+
+      auto worker = [&]() {
+        while (true) {
+          if (compilationFailed.load(std::memory_order_relaxed))
+            break;
+
+          size_t idx = nextIdx.fetch_add(1, std::memory_order_relaxed);
+          if (idx >= configs.size())
+            break;
+
+          compilationResults[idx] = compileConfig(idx);
+        }
+      };
+
+      std::vector<std::thread> threads;
+      threads.reserve(numThreads);
+      for (unsigned i = 0; i < numThreads; ++i) {
+        threads.emplace_back(worker);
+      }
+
+      for (auto &t : threads) {
+        t.join();
+      }
+    }
+
+    // Check if any compilation failed and terminate early
+    if (compilationFailed.load(std::memory_order_relaxed)) {
+      llvm::errs()
+          << "Compilation failed for one or more configs. Terminating.\n";
       return failure();
     }
-    llvm::outs() << timing << "\n";
-  }
+
+    int64_t validResults = 0;
+    for (const auto &result : compilationResults) {
+      llvm::outs() << result.perfConfig << "\t";
+
+      if (result.status == CompilationStatus::NotApplicable) {
+        llvm::outs() << "N/A\n";
+        continue;
+      }
+
+      assert(result.status == CompilationStatus::Success &&
+             "Unexpected compilation status in benchmarking phase");
+
+      FailureOr<double> timing =
+          benchmarkKernels(result.hipModules, kernelFuncNames,
+                           result.blockSizes, result.gridSizes, hostBuffers,
+                           gpuBuffers, bufferLengths, benchmarkParams);
+
+      if (failed(timing)) {
+        llvm::errs() << "Kernel execution failed\n";
+        return failure();
+      }
+      llvm::outs() << timing.value() << "\n";
+
+      validResults++;
+      // Find best config
+      if (numTuningIterations > 1) {
+        if (timing.value() < bestTimeOverall) {
+          bestTimeOverall = timing.value();
+          bestConfigOverall = result.perfConfig;
+        }
+      }
+    }
+
+    if (validResults == 0) {
+      llvm::errs() << "No valid configurations found\n";
+      return failure();
+    }
+  } // End of iteration loop
+
   return success();
 }
 #undef HIPCHECK

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -100,7 +100,8 @@ static llvm::cl::opt<rock::TuningParamSetKind> tuningSpaceKind(
                    "Full tuning space, excluding known-bad configurations"),
         clEnumValN(
             rock::TuningParamSetKind::Greedy, "greedy",
-            "Tune all possible tile sizes and try N random configurations for "
+            "Tune all possible tile sizes and try NUM_RANDOM_PER_TILE_SIZE "
+            "random configurations for "
             "each tile size. Then, greedily select the best tile size, and "
             "brute force tune the rest of params"),
         clEnumValN(rock::TuningParamSetKind::Exhaustive, "exhaustive",

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -674,9 +674,10 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       configs.emplace_back(benchmarkParams.benchmarkConfig);
     } else {
       // Tuning mode - get configs from tuning space
+      rock::TuningParamSpaceSettings settings{iterIdx, bestConfigOverall};
       std::unique_ptr<rock::TuningParamSet> tuningSpace(
           rock::createTunableParamSpace(source, benchmarkParams.tuningSpaceKind,
-                                        iterIdx, bestConfigOverall));
+                                        settings));
 
       if (tuningSpace->tuningRange.empty()) {
         llvm::errs() << "Tuning range is empty for iteration " << iterIdx

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -883,7 +883,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
 
       validResults++;
       // Find best config
-      if (numTuningIterations > 1) {
+      if (rock::needToUpdateBest(benchmarkParams.tuningSpaceKind)) {
         if (timing.value() < bestTimeOverall) {
           bestTimeOverall = timing.value();
           bestConfigOverall = result.perfConfig;

--- a/mlir/utils/performance/configs/tier1-attention-configs
+++ b/mlir/utils/performance/configs/tier1-attention-configs
@@ -1,52 +1,52 @@
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 16 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 10 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 10 -seq_len_q 4096 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 1024 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 40 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 40 -seq_len_q 256 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 40 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96 -with-attn-scale False -with-attn-bias False
--t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 1500 -seq_len_k 1500 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 64 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 2 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
--t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 1 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 1 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
--t f32 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
--t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 1 -seq_len_k 4097 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
--t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 4096 -head_dim_qk 16 -head_dim_v 16 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 4096 -seq_len_k 7 -head_dim_qk 16 -head_dim_v 16 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 32 -head_dim_v 32 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 300 -seq_len_q 196 -seq_len_k 196 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 12 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 576 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 2304 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 144 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 900 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 3600 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 225 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 16 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64
+-t f32 -transQ false -transK true -transV false -transO false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 10 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 10 -seq_len_q 4096 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 1024 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 40 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 40 -seq_len_q 256 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 40 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK false -transV false -transO false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512
+-t f16 -transQ false -transK true -transV false -transO false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512
+-t f16 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128
+-t f16 -transQ false -transK true -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128
+-t f16 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96
+-t f16 -transQ false -transK true -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96
+-t f32 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 1500 -seq_len_k 1500 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK false -transV false -transO false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 64 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK false -transV false -transO false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
+-t f16 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
+-t f32 -transQ false -transK false -transV false -transO false -g 2 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512
+-t f32 -transQ false -transK true -transV false -transO false -g 1 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512
+-t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 1 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
+-t f32 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
+-t f32 -transQ false -transK true -transV false -transO false -g 32 -seq_len_q 1 -seq_len_k 4097 -head_dim_qk 128 -head_dim_v 128
+-t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 4096 -head_dim_qk 16 -head_dim_v 16
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 4096 -seq_len_k 7 -head_dim_qk 16 -head_dim_v 16
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 32 -head_dim_v 32
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 300 -seq_len_q 196 -seq_len_k 196 -head_dim_qk 64 -head_dim_v 64
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 12 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 512 -head_dim_v 512
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 512 -head_dim_v 512
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 576 -head_dim_qk 160 -head_dim_v 160
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 2304 -head_dim_qk 80 -head_dim_v 80
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 40 -head_dim_v 40
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 144 -head_dim_qk 160 -head_dim_v 160
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 900 -head_dim_qk 160 -head_dim_v 160
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 40 -head_dim_v 40
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 3600 -head_dim_qk 80 -head_dim_v 80
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 225 -head_dim_qk 160 -head_dim_v 160
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160

--- a/mlir/utils/performance/configs/tier1-attention-configs
+++ b/mlir/utils/performance/configs/tier1-attention-configs
@@ -1,52 +1,52 @@
--t f16 -transQ false -transK true -transV false -transO false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 16 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64
--t f32 -transQ false -transK true -transV false -transO false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 10 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 10 -seq_len_q 4096 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 1024 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 40 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 40 -seq_len_q 256 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 40 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK false -transV false -transO false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512
--t f16 -transQ false -transK true -transV false -transO false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512
--t f16 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128
--t f16 -transQ false -transK true -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128
--t f16 -transQ false -transK false -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96
--t f16 -transQ false -transK true -transV false -transO false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96
--t f32 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 1500 -seq_len_k 1500 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK false -transV false -transO false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 64 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK false -transV false -transO false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
--t f16 -transQ false -transK true -transV false -transO false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64
--t f32 -transQ false -transK false -transV false -transO false -g 2 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512
--t f32 -transQ false -transK true -transV false -transO false -g 1 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512
--t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
--t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 1 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
--t f32 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
--t f32 -transQ false -transK true -transV false -transO false -g 32 -seq_len_q 1 -seq_len_k 4097 -head_dim_qk 128 -head_dim_v 128
--t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 4096 -head_dim_qk 16 -head_dim_v 16
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 4096 -seq_len_k 7 -head_dim_qk 16 -head_dim_v 16
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 32 -head_dim_v 32
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 300 -seq_len_q 196 -seq_len_k 196 -head_dim_qk 64 -head_dim_v 64
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 12 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 512 -head_dim_v 512
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 512 -head_dim_v 512
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 576 -head_dim_qk 160 -head_dim_v 160
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 2304 -head_dim_qk 80 -head_dim_v 80
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 40 -head_dim_v 40
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 144 -head_dim_qk 160 -head_dim_v 160
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 900 -head_dim_qk 160 -head_dim_v 160
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 40 -head_dim_v 40
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 3600 -head_dim_qk 80 -head_dim_v 80
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 225 -head_dim_qk 160 -head_dim_v 160
--transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 16 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 10 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 10 -seq_len_q 4096 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 1024 -seq_len_k 1024 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 1024 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 40 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 40 -seq_len_q 256 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 40 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 1 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 96 -head_dim_v 96 -with-attn-scale False -with-attn-bias False
+-t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 1500 -seq_len_k 1500 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 12 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 64 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 20 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -g 2 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
+-t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 1 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
+-t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 1 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
+-t f32 -transQ false -transK true -transV false -transO false -causal true -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
+-t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 1 -seq_len_k 4097 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
+-t f32 -transQ false -transK true -transV false -transO false -causal false -return_lse false -g 32 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 4096 -head_dim_qk 16 -head_dim_v 16 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 4096 -seq_len_k 7 -head_dim_qk 16 -head_dim_v 16 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 32 -head_dim_v 32 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 300 -seq_len_q 196 -seq_len_k 196 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 12 -seq_len_q 4096 -seq_len_k 4096 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 512 -head_dim_v 512 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 576 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 2304 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 9216 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 576 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 2304 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 144 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 9216 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 144 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 900 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 14400 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 77 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 900 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 14400 -seq_len_k 77 -head_dim_qk 40 -head_dim_v 40 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 3600 -seq_len_k 3600 -head_dim_qk 80 -head_dim_v 80 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 225 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False
+-transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 225 -seq_len_k 77 -head_dim_qk 160 -head_dim_v 160 -with-attn-scale False -with-attn-bias False

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -344,7 +344,7 @@ def main(args=None):
 
     parser.add_argument("--tuning-space",
                         default="full",
-                        choices=["quick", "full", "exhaustive"],
+                        choices=["quick", "full", "greedy", "exhaustive"],
                         help="Which space of tuning configs should be used while tuning")
     parser.add_argument("--quiet",
                         "-q",


### PR DESCRIPTION
## Motivation

Introduce a tuning mode that is fast but explores the tuning space. Full tuning doesn't explore all params. This is useful to make development of new features faster, so we don't have to wait lots of time to get results of "new branch" vs "develop".

## Technical Details

We tune all possible tile sizes (mPerBlock, nPerBlock) and try N random perfConfigs (where the rest of params are random). Then, greedily select the best tile size, and brute force tune the rest of params.

## Results

See https://github.com/ROCm/rocMLIR-internal/issues/2150#issuecomment-3581033470

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
