### PR TITLE
Use constrained range for the scaled gemms on PR tests

### DIFF
--- a/mlir/test/e2e/PrGemmScaled.toml
+++ b/mlir/test/e2e/PrGemmScaled.toml
@@ -1,6 +1,6 @@
 directory = "PrGemmScaled"
 prefix = "rocmlir-gen"
-suffix = "--operation gemm -out_dtype f32 --scaledGemm --arch %arch %pv %random_data -rand_type float %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation gemm -out_dtype f32 --scaledGemm --arch %arch %pv %constrained_float_range_random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "transA"

--- a/mlir/test/e2e/PrGemmScaledSplitK.toml
+++ b/mlir/test/e2e/PrGemmScaledSplitK.toml
@@ -1,6 +1,6 @@
 directory = "PrGemmScaledSplitK"
 prefix = "rocmlir-gen"
-suffix = "--operation gemm -out_dtype f32 --arch %arch %pv %random_data -rand_type float %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation gemm -out_dtype f32 --arch %arch %pv %constrained_float_range_random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "splitKFactor"


### PR DESCRIPTION

## Motivation

Fixes https://github.com/ROCm/rocMLIR-internal/issues/2153
## Technical Details

GPU kernel is with FP4 with F8E8M0 scales. On the PR CI it uses `-pv_with_gpu` which generates F32 GEMM kernel. It can lead to quantization problems and therefore create false positives. Use contrained_range to limit f32 random values within [-1, 1].  
## Test Plan

PR CI Passes. 
## Test Result

