### PR TITLE
Check command errors on tunningRunner (and other nits)

### DIFF
--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -278,7 +278,15 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
                                                    stdin=kernel_gen.stdout,
                                                    stdout=subprocess.PIPE,
                                                    stderr=subprocess.PIPE)
-                    kernel_gen.stdout.close()
+                    # Wait for both processes to finish.
+                    tuning_loop_stdout, _ = tuning_loop.communicate()
+                    kernel_gen.communicate()
+
+                    # Make sure both processes finished successfully.
+                    if kernel_gen.returncode != 0:
+                        raise RuntimeError(f'rocmlir-gen command failed: {kernel_gen_command}')
+                    if tuning_loop.returncode != 0:
+                        raise RuntimeError(f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}')
                 else:
                     # pipe to rocmlir_gen --emit-tuning-key
                     tuning_key = subprocess.Popen(
@@ -295,10 +303,14 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
                                                    tuning_driver_args + [test_vector],
                                                    stdout=subprocess.PIPE,
                                                    stderr=subprocess.PIPE)
+                    # Wait and make sure the process finished successfully.
+                    tuning_loop_stdout, _ = tuning_loop.communicate()
+                    if tuning_loop.returncode != 0:
+                        raise RuntimeError(f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}')
 
                 # Tune, printing progress as we go to avoid CI timeouts
                 winning_config, max_tflops, entries = get_winning_config(
-                    tuning_loop.stdout, config, paths, options)
+                    tuning_loop_stdout, config, paths, options)
 
             except TuningError as e:
                 log_error(error_title, str(e), outfile)

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -88,7 +88,10 @@ def verify_kernel_with_perfconfig(perfconfig, config, paths: Paths, options: Opt
         ] + mlir_cpu_runner_args
 
     if options.debug:
+        print('Running commands:', file=sys.stderr)
         print(rocmlir_gen_command, file=sys.stderr)
+        print(rocmlir_driver_command, file=sys.stderr)
+        print(profiler_command, file=sys.stderr)
 
     prevdir = os.getcwd()
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -279,16 +279,27 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
                                                    stdout=subprocess.PIPE,
                                                    stderr=subprocess.PIPE)
                     # Wait for both processes to finish.
-                    tuning_loop_stdout, _ = tuning_loop.communicate()
+                    tuning_loop_stdout, tuning_loop_stderr = tuning_loop.communicate()
                     kernel_gen.communicate()
 
                     # Make sure both processes finished successfully.
                     if kernel_gen.returncode != 0:
-                        raise RuntimeError(f'rocmlir-gen command failed: {kernel_gen_command}')
+                        error_msg = f"rocmlir-gen failed with return code {kernel_gen.returncode}"
+                        log_error(error_title, error_msg, outfile)
+                        if options.abort_on_error:
+                            return False
+                        else:
+                            continue
                     if tuning_loop.returncode != 0:
-                        raise RuntimeError(
-                            f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}'
-                        )
+                        error_msg = f"rocmlir-tuning-driver failed with return code {tuning_loop.returncode}"
+                        stderr_content = tuning_loop_stderr.decode('utf-8').strip()
+                        if stderr_content:
+                            error_msg += f"\nstderr:\n{stderr_content}"
+                        log_error(error_title, error_msg, outfile)
+                        if options.abort_on_error:
+                            return False
+                        else:
+                            continue
                 else:
                     # pipe to rocmlir_gen --emit-tuning-key
                     tuning_key = subprocess.Popen(
@@ -306,11 +317,17 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
                                                    stdout=subprocess.PIPE,
                                                    stderr=subprocess.PIPE)
                     # Wait and make sure the process finished successfully.
-                    tuning_loop_stdout, _ = tuning_loop.communicate()
+                    tuning_loop_stdout, tuning_loop_stderr = tuning_loop.communicate()
                     if tuning_loop.returncode != 0:
-                        raise RuntimeError(
-                            f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}'
-                        )
+                        error_msg = f"rocmlir-tuning-driver failed with return code {tuning_loop.returncode}"
+                        stderr_content = tuning_loop_stderr.decode('utf-8').strip()
+                        if stderr_content:
+                            error_msg += f"\nstderr:\n{stderr_content}"
+                        log_error(error_title, error_msg, outfile)
+                        if options.abort_on_error:
+                            return False
+                        else:
+                            continue
 
                 # Tune, printing progress as we go to avoid CI timeouts
                 winning_config, max_tflops, entries = get_winning_config(
@@ -331,17 +348,6 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
                     if tuning_loop.poll() is None:
                         tuning_loop.terminate()
                     tuning_loop.wait()
-
-            if tuning_loop.returncode != 0:
-                error_msg = f"rocmlir-tuning-driver failed with return code {tuning_loop.returncode}"
-                stderr_content = tuning_loop.stderr.read().decode('utf-8').strip()
-                if stderr_content:
-                    error_msg += f"\nstderr:\n{stderr_content}"
-                log_error(error_title, error_msg, outfile)
-                if options.abort_on_error:
-                    return False
-                else:
-                    continue
 
             if winning_config == "None":
                 log_error(error_title, "No valid perf config found", outfile)

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -286,7 +286,9 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
                     if kernel_gen.returncode != 0:
                         raise RuntimeError(f'rocmlir-gen command failed: {kernel_gen_command}')
                     if tuning_loop.returncode != 0:
-                        raise RuntimeError(f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}')
+                        raise RuntimeError(
+                            f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}'
+                        )
                 else:
                     # pipe to rocmlir_gen --emit-tuning-key
                     tuning_key = subprocess.Popen(
@@ -306,7 +308,9 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
                     # Wait and make sure the process finished successfully.
                     tuning_loop_stdout, _ = tuning_loop.communicate()
                     if tuning_loop.returncode != 0:
-                        raise RuntimeError(f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}')
+                        raise RuntimeError(
+                            f'rocmlir-tuning-driver command failed: {paths.mlir_paths.rocmlir_tuning_driver_path} {tuning_driver_args}'
+                        )
 
                 # Tune, printing progress as we go to avoid CI timeouts
                 winning_config, max_tflops, entries = get_winning_config(

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -331,7 +331,7 @@ def tune_mlir_kernels(configs, conf_class, paths: Paths, options: Options):
 
                 # Tune, printing progress as we go to avoid CI timeouts
                 winning_config, max_tflops, entries = get_winning_config(
-                    tuning_loop_stdout, config, paths, options)
+                    tuning_loop_stdout.splitlines(), config, paths, options)
 
             except TuningError as e:
                 log_error(error_title, str(e), outfile)


### PR DESCRIPTION
## Motivation

If any command we run with subprocess.Popen fails, we will ignore the error and keep going. This makes debugging unnecessarily hard.

## Technical Details

This PR adds 3 small improvements:
- Print all commands that are about to be run (1st commit)
- Abort if the tuning output is empty (2nd commit)
- Check the return code from the commands we run and fail early if any of them fail (3rd commit)

## Test Plan

No new test was added

## Test Result

Test pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
