### PR TITLE
Enable partial early exit

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1826,31 +1826,45 @@ struct GridwiseAttentionAccelRewritePattern
     return std::make_tuple(start, end, gemm0MBlocksLastIter, currentSeqLen);
   }
 
-  // Helper function to compute the 'someWorkToDo' condition used for early
-  // exit optimization.
-  Value computeIfWorkToDo(PatternRewriter &rewriter, Location loc, Value start,
-                          Value end, int64_t splitKV, int64_t gemm0MPerBlock,
-                          std::optional<APInt> prePadG0M, bool isCausal,
-                          bool isKVCache) const {
+  // Helper function to determine if early exit optimization is possible.
+  // Early exit requires splitKV > 1 and at least one of: padding in gemm0M,
+  // causal masking, or KV cache.
+  static bool isEarlyExitPossible(int64_t splitKV, int64_t gemm0MPerBlock,
+                                  std::optional<APInt> prePadG0M, bool isCausal,
+                                  bool isKVCache) {
     // We have no work to do if (1) and (2 || 3) conditions are true:
     // 1. split-kv > 1
     // 2. there's padding in gemm0M && (at least) the last block in split-kv
     // dimension has nothing to do
     // 3. (kvcache || causal) && (end <= start)
     if (splitKV == 1)
-      return nullptr;
+      return false;
 
-    // Condition 2: some padding in gemm0M
-    // if prePadM < gemm0MPerBlock, then the last block has some work to do
     bool earlyExitDueToPadding =
         prePadG0M.has_value() &&
         (prePadG0M.value().getSExtValue() >= gemm0MPerBlock);
-
-    // Condition 3: causal or kvcache
     bool earlyExitDueToCausalOrKVCache = isCausal || isKVCache;
 
-    if (!earlyExitDueToPadding && !earlyExitDueToCausalOrKVCache)
-      return nullptr;
+    return earlyExitDueToPadding || earlyExitDueToCausalOrKVCache;
+  }
+
+  // Helper function to compute the 'someWorkToDo' condition used for early
+  // exit optimization.
+  FailureOr<Value> computeIfWorkToDo(PatternRewriter &rewriter, Location loc,
+                                     Value start, Value end, int64_t splitKV,
+                                     int64_t gemm0MPerBlock,
+                                     std::optional<APInt> prePadG0M,
+                                     bool isCausal, bool isKVCache) const {
+    if (!isEarlyExitPossible(splitKV, gemm0MPerBlock, prePadG0M, isCausal,
+                             isKVCache))
+      return failure();
+
+    // Determine which condition applies to generate the appropriate runtime
+    // check
+    bool earlyExitDueToPadding =
+        prePadG0M.has_value() &&
+        (prePadG0M.value().getSExtValue() >= gemm0MPerBlock);
+    bool earlyExitDueToCausalOrKVCache = isCausal || isKVCache;
 
     Value someWorkToDo;
     // For dynamic kernels, no need to check padding condition. start/end
@@ -1883,14 +1897,14 @@ struct GridwiseAttentionAccelRewritePattern
                                         std::optional<APInt> prePadG0M,
                                         bool isCausal, bool isKVCache) const {
     // Compute the work condition using the extracted helper function
-    Value someWorkToDo =
+    FailureOr<Value> maybeSomeWorkToDo =
         computeIfWorkToDo(rewriter, loc, start, end, splitKV, gemm0MPerBlock,
                           prePadG0M, isCausal, isKVCache);
 
-    if (!someWorkToDo)
+    if (failed(maybeSomeWorkToDo))
       return std::nullopt;
 
-    scf::IfOp ifb = scf::IfOp::create(rewriter, loc, someWorkToDo,
+    scf::IfOp ifb = scf::IfOp::create(rewriter, loc, maybeSomeWorkToDo.value(),
                                       /*withElseRegion=*/false);
     rewriter.setInsertionPointToStart(&ifb.getThenRegion().front());
 
@@ -1966,6 +1980,10 @@ struct GridwiseAttentionAccelRewritePattern
     int64_t gemm0MBlocks = gemm0M / gemm0MPerBlock;
     int64_t gemm0NBlocks = gemm0N / gemm0NPerBlock;
     int64_t gemm1kpack = gemm1TuningParams.getKpack();
+
+    // Compute whether early exit is possible
+    bool earlyExitPossible = isEarlyExitPossible(
+        splitKV, gemm0MPerBlock, op.getPrePadG0M(), isCausal, isKVCache);
 
     int64_t scheduleVersion = gemm0TuningParams.getScheduleVersion();
     int64_t scheduleVersionG1 = gemm1TuningParams.getScheduleVersion();
@@ -2191,9 +2209,6 @@ struct GridwiseAttentionAccelRewritePattern
       gemm1OutBuffer = createBufferForGemmOut(
           loc, elemTypeSoftmax, accelParamsGemm1, rewriter, gemm1MBlocks);
     }
-    // Zero gemm1OutBuffer to ensure it contains valid data even when early exit
-    // skips computation (needed for MIGraphX when softmax is disabled)
-    zeroAccBuffer(rewriter, loc, gemm1OutBuffer);
 
     SmallVector<int64_t, 3> gemm1BidGridLengths = {gemm0G, gemm1MBlocks,
                                                    gemm1NBlocks};
@@ -2260,11 +2275,13 @@ struct GridwiseAttentionAccelRewritePattern
         Type elemTypeLse = cast<MemRefType>(lse.getType()).getElementType();
         lseBuffer = createBufferForGemmOut(loc, elemTypeLse, accelParamsGemm1,
                                            rewriter);
-        // Initialize lseBuffer to -infinity (use the correct type for lse)
-        auto negInfLse = createConstantFloatOp(
-            rewriter, loc, elemTypeLse, elemTypeLse,
-            -std::numeric_limits<float>::infinity(), APFloat::opOK);
-        FillOp::create(rewriter, loc, lseBuffer, negInfLse);
+        // Initialize lseBuffer to -infinity only when early exit is possible.
+        if (earlyExitPossible) {
+          auto negInfLse = createConstantFloatOp(
+              rewriter, loc, elemTypeLse, elemTypeLse,
+              -std::numeric_limits<float>::infinity(), APFloat::opOK);
+          FillOp::create(rewriter, loc, lseBuffer, negInfLse);
+        }
       }
 
       zeroAccBuffer(rewriter, loc, attentionOutAccBuffer);

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1880,27 +1880,33 @@ struct GridwiseAttentionAccelRewritePattern
     return someWorkToDo;
   }
 
-  void runEarlyExit(PatternRewriter &rewriter, Location loc, Value start,
-                    Value end, int64_t splitKV, int64_t gemm0MPerBlock,
-                    std::optional<APInt> prePadG0M, bool isCausal,
-                    bool isKVCache, bool skipRunEarlyExit) const {
+  std::optional<scf::IfOp> runEarlyExit(PatternRewriter &rewriter, Location loc,
+                                        Value start, Value end, int64_t splitKV,
+                                        int64_t gemm0MPerBlock,
+                                        std::optional<APInt> prePadG0M,
+                                        bool isCausal, bool isKVCache,
+                                        bool skipRunEarlyExit) const {
     // skipRunEarlyExit disables early exit logic as the MIGraphX flash decoding
     // implementation requires that the first of two kernels is initialized to
     // zero (and not left uninitialized as is the case with early exit logic).
     if (skipRunEarlyExit)
-      return;
+      return std::nullopt;
 
     // Compute the work condition using the extracted helper function
     Value someWorkToDo =
         computeIfWorkToDo(rewriter, loc, start, end, splitKV, gemm0MPerBlock,
-                            prePadG0M, isCausal, isKVCache);
+                          prePadG0M, isCausal, isKVCache);
 
     if (!someWorkToDo)
-      return;
+      return std::nullopt;
 
     scf::IfOp ifb = scf::IfOp::create(rewriter, loc, someWorkToDo,
                                       /*withElseRegion=*/false);
     rewriter.setInsertionPointToStart(&ifb.getThenRegion().front());
+    
+    // Return the IfOp so caller can close it later (by setting insertion point
+    // after it) to ensure output writes happen unconditionally
+    return ifb;
   }
 
   LogicalResult matchAndRewrite(GridwiseAttentionAccelOp op,
@@ -2195,6 +2201,9 @@ struct GridwiseAttentionAccelRewritePattern
       gemm1OutBuffer = createBufferForGemmOut(
           loc, elemTypeSoftmax, accelParamsGemm1, rewriter, gemm1MBlocks);
     }
+    // Zero gemm1OutBuffer to ensure it contains valid data even when early exit
+    // skips computation (needed for MIGraphX when softmax is disabled)
+    zeroAccBuffer(rewriter, loc, gemm1OutBuffer);
 
     SmallVector<int64_t, 3> gemm1BidGridLengths = {gemm0G, gemm1MBlocks,
                                                    gemm1NBlocks};
@@ -2261,6 +2270,8 @@ struct GridwiseAttentionAccelRewritePattern
         Type elemTypeLse = cast<MemRefType>(lse.getType()).getElementType();
         lseBuffer = createBufferForGemmOut(loc, elemTypeLse, accelParamsGemm1,
                                            rewriter);
+        // Initialize lseBuffer to -infinity
+        FillOp::create(rewriter, loc, lseBuffer, negInfSumTyped);
       }
 
       zeroAccBuffer(rewriter, loc, attentionOutAccBuffer);
@@ -2292,10 +2303,13 @@ struct GridwiseAttentionAccelRewritePattern
                      gemm0M, gemm0MPerBlock, gemm0NPerBlock, splitKV, isCausal,
                      isKVCache, op.getNumRepeatsGQAAttr());
 
-    // early exit if there is no work to do for this block
-    runEarlyExit(rewriter, loc, start, end, splitKV, gemm0MPerBlock,
-                 op.getPrePadG0M(), isCausal, isKVCache,
-                 /*skipRunEarlyExit=*/true);
+    // Early exit: Skip all computation when there's no work but always write
+    // output (zeros).
+    // This wraps Q loads, M/K loops, GEMMs, softmax, etc. in a conditional.
+    std::optional<scf::IfOp> earlyExitIf =
+        runEarlyExit(rewriter, loc, start, end, splitKV, gemm0MPerBlock,
+                     op.getPrePadG0M(), isCausal, isKVCache,
+                     /*skipRunEarlyExit=*/false);
 
     // create matrix params (LDS transpose not supported for attention)
     BlockwiseMatrixParamsAttr matrixParamsK = BlockwiseMatrixParamsAttr::get(
@@ -2333,90 +2347,24 @@ struct GridwiseAttentionAccelRewritePattern
     Value zero = rewriter.createOrFold<ConstantIndexOp>(loc, 0);
     if (prefetchQTile) {
       LLVM_DEBUG(llvm::dbgs()
-                 << "rock.attention: gemm0K is equal to gemm0KPerBlock\n");
+                 << "rock.attention: gemm0K is equal to gemm0KPerBlock, "
+                 << "prefetching Q tile into regs\n");
 
-      // Optimization: Compute work condition for conditional Q load.
-      // When there's no work to do (e.g., due to causal masking or KV-cache),
-      // skip the expensive global memory read of Q and zero registers instead.
-      Value someWorkToDo =
-          computeIfWorkToDo(rewriter, loc, start, end, splitKV,
-                              gemm0MPerBlock, op.getPrePadG0M(), isCausal,
-                              isKVCache);
+      // it is fine m iteration to be zero as it irrelevant to Q tensor
+      // as the first gemm is Kt x Qt.
+      auto gridCoordsGemm0LoadQ = layout::makeGxNGridLayout(
+          rewriter, loc, bid, zero, gemm0NBlocks, gridSize, arch, splitKVConst);
 
-      if (someWorkToDo) {
-        LLVM_DEBUG(llvm::dbgs()
-                   << "rock.attention: Conditional Q load optimization enabled "
-                   << "(splitKV > 1 with causal/kvcache/padding)\n");
+      Value ldsByteBufferQ = nullptr;
+      if (!doBypassLDSForQ)
+        ldsByteBufferQ =
+            createLDSByteBuffer(rewriter, loc, ldsByteBufferQSize, elemTypeQ);
 
-        // Create if-else block: load Q only if there's work, otherwise zero
-        // registers
-        scf::IfOp qLoadIf = scf::IfOp::create(rewriter, loc, someWorkToDo,
-                                              /*withElseRegion=*/true);
-
-        // Then region: Load Q from global memory (when there's work to do)
-        {
-          PatternRewriter::InsertionGuard guard(rewriter);
-          rewriter.setInsertionPointToStart(&qLoadIf.getThenRegion().front());
-
-          LLVM_DEBUG(llvm::dbgs()
-                     << "rock.attention: Prefetching Q tile into regs "
-                     << "(has work to do)\n");
-
-          // it is fine m iteration to be zero as it irrelevant to Q tensor
-          // as the first gemm is Kt x Qt.
-          auto gridCoordsGemm0LoadQ = layout::makeGxNGridLayout(
-              rewriter, loc, bid, zero, gemm0NBlocks, gridSize, arch,
-              splitKVConst);
-
-          Value ldsByteBufferQ = nullptr;
-          if (!doBypassLDSForQ)
-            ldsByteBufferQ = createLDSByteBuffer(rewriter, loc,
-                                                 ldsByteBufferQSize, elemTypeQ);
-
-          loadAndStoreGemmInputTile(
-              rewriter, loc, inQ, /*kiter=*/zero, tid, gridCoordsGemm0LoadQ,
-              ldsByteBufferQ, preAccelRegBuffersQForLoad, loadTypeQ, "n",
-              blockSize, elemTypeQ, elemTypeQLoad, gemm0TuningParams,
-              featuresAttr, matrixParamsK, matrixParamsQ);
-        }
-
-        // Else region: Zero Q registers
-        {
-          PatternRewriter::InsertionGuard guard(rewriter);
-          rewriter.setInsertionPointToStart(&qLoadIf.getElseRegion().front());
-
-          LLVM_DEBUG(llvm::dbgs()
-                     << "rock.attention: Skipping Q load, zeroing registers "
-                     << "instead (no work to do)\n");
-
-          // Zero both the load buffer and the compute buffer
-          zeroAccBuffer(rewriter, loc, preAccelRegBuffersQForLoad);
-          if (preAccelRegBuffersQ != preAccelRegBuffersQForLoad)
-            zeroAccBuffer(rewriter, loc, preAccelRegBuffersQ);
-        }
-
-        // Continue after the if-else block
-        rewriter.setInsertionPointAfter(qLoadIf);
-      } else {
-        // No early exit conditions apply - always load Q (normal case when
-        // splitKV == 1 and not causal/kvcache)
-        // it is fine m iteration to be zero as it irrelevant to Q tensor
-        // as the first gemm is Kt x Qt.
-        auto gridCoordsGemm0LoadQ = layout::makeGxNGridLayout(
-            rewriter, loc, bid, zero, gemm0NBlocks, gridSize, arch,
-            splitKVConst);
-
-        Value ldsByteBufferQ = nullptr;
-        if (!doBypassLDSForQ)
-          ldsByteBufferQ =
-              createLDSByteBuffer(rewriter, loc, ldsByteBufferQSize, elemTypeQ);
-
-        loadAndStoreGemmInputTile(
-            rewriter, loc, inQ, /*kiter=*/zero, tid, gridCoordsGemm0LoadQ,
-            ldsByteBufferQ, preAccelRegBuffersQForLoad, loadTypeQ, "n",
-            blockSize, elemTypeQ, elemTypeQLoad, gemm0TuningParams,
-            featuresAttr, matrixParamsK, matrixParamsQ);
-      }
+      loadAndStoreGemmInputTile(
+          rewriter, loc, inQ, /*kiter=*/zero, tid, gridCoordsGemm0LoadQ,
+          ldsByteBufferQ, preAccelRegBuffersQForLoad, loadTypeQ, "n", blockSize,
+          elemTypeQ, elemTypeQLoad, gemm0TuningParams, featuresAttr,
+          matrixParamsK, matrixParamsQ);
     }
 
     bool dynamicMLoop = splitKV != 1 || isCausal || isKVCache;
@@ -2912,6 +2860,16 @@ struct GridwiseAttentionAccelRewritePattern
       Value lseBufferView = transform(
           rewriter, lseBuffer, attentionOutAccBufferThreadSubTileViewMaps);
       computeLse(rewriter, loc, lseBufferView, sumRowBuffer, maxRowBuffer);
+    }
+
+    // Close the early exit if block here. Everything above this point is
+    // conditional (only runs when there's work to do). Everything below
+    // (output writes) always executes, writing zeros when there's no work.
+    if (earlyExitIf.has_value()) {
+      rewriter.setInsertionPointAfter(*earlyExitIf);
+      LLVM_DEBUG(llvm::dbgs()
+                 << "rock.attention: early exit enabled - "
+                 << "output writes will execute unconditionally\n");
     }
 
     MemRefType outAccBufferOutType =

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1826,39 +1826,41 @@ struct GridwiseAttentionAccelRewritePattern
     return std::make_tuple(start, end, gemm0MBlocksLastIter, currentSeqLen);
   }
 
-  void runEarlyExit(PatternRewriter &rewriter, Location loc, Value start,
-                    Value end, int64_t splitKV, int64_t gemm0MPerBlock,
-                    std::optional<APInt> prePadG0M, bool isCausal,
-                    bool isKVCache, bool skipRunEarlyExit) const {
-    // we need to do early exit if (1) and (2 || 3) conditions are true:
+  // Helper function to compute the 'someWorkToDo' condition used for early
+  // exit optimization. This can be used independently of creating an if block,
+  // allowing us to conditionally skip expensive operations (like Q loads)
+  // while still ensuring output buffers are initialized.
+  Value computeIfWorkToDo(PatternRewriter &rewriter, Location loc,
+                            Value start, Value end, int64_t splitKV,
+                            int64_t gemm0MPerBlock,
+                            std::optional<APInt> prePadG0M, bool isCausal,
+                            bool isKVCache) const {
+    // We need have no work to do if (1) and (2 || 3) conditions are true:
     // 1. split-kv > 1
     // 2. there's padding in gemm0M && (at least) the last block in split-kv
     // dimension has nothing to do
     // 3. (kvcache || causal) && (end <= start)
+    if (splitKV == 1)
+      return nullptr;
 
-    // skipRunEarlyExit disables early exit logic as the MIGraphX flash decoding
-    // implementation requires that the first of two kernels is initialized to
-    // zero (and not left uninitialized as is the case with early exit logic).
-    if (splitKV == 1 || skipRunEarlyExit)
-      return;
-
-    // condition 2: some padding in gemm0M
-    // if prePadM < gemm0MPerBlock, then, the last block has some work to do
+    // Condition 2: some padding in gemm0M
+    // if prePadM < gemm0MPerBlock, then the last block has some work to do
     bool earlyExitDueToPadding =
         prePadG0M.has_value() &&
         (prePadG0M.value().getSExtValue() >= gemm0MPerBlock);
-    // condition 3: causal or kvcache
+
+    // Condition 3: causal or kvcache
     bool earlyExitDueToCausalOrKVCache = isCausal || isKVCache;
 
     if (!earlyExitDueToPadding && !earlyExitDueToCausalOrKVCache)
-      return;
+      return nullptr;
 
     Value someWorkToDo;
-    // for dynamic kernels, no need to check padding condition. start/end checks
-    // can handle padding as well.
+    // For dynamic kernels, no need to check padding condition. start/end
+    // checks can handle padding as well.
     if (earlyExitDueToCausalOrKVCache) {
-      // if end is less than (or equal) start, then we can early exit the split
-      // KV loop.
+      // If end is less than (or equal) start, then we can early exit the
+      // split KV loop.
       someWorkToDo = arith::CmpIOp::create(
           rewriter, loc, arith::CmpIPredicate::ugt, end, start);
     } else if (earlyExitDueToPadding) {
@@ -1869,12 +1871,33 @@ struct GridwiseAttentionAccelRewritePattern
       Value startIteration =
           arith::MulIOp::create(rewriter, loc, start, constGemm0MPerBlock);
 
-      // if startIteration is less than (or equal) prePadMValue, then we can
-      // early exit the split KV loop.
+      // If startIteration is less than prePadMValue, then there is work to do
       someWorkToDo =
           arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ult,
                                 startIteration, prePadMValue);
     }
+
+    return someWorkToDo;
+  }
+
+  void runEarlyExit(PatternRewriter &rewriter, Location loc, Value start,
+                    Value end, int64_t splitKV, int64_t gemm0MPerBlock,
+                    std::optional<APInt> prePadG0M, bool isCausal,
+                    bool isKVCache, bool skipRunEarlyExit) const {
+    // skipRunEarlyExit disables early exit logic as the MIGraphX flash decoding
+    // implementation requires that the first of two kernels is initialized to
+    // zero (and not left uninitialized as is the case with early exit logic).
+    if (skipRunEarlyExit)
+      return;
+
+    // Compute the work condition using the extracted helper function
+    Value someWorkToDo =
+        computeIfWorkToDo(rewriter, loc, start, end, splitKV, gemm0MPerBlock,
+                            prePadG0M, isCausal, isKVCache);
+
+    if (!someWorkToDo)
+      return;
+
     scf::IfOp ifb = scf::IfOp::create(rewriter, loc, someWorkToDo,
                                       /*withElseRegion=*/false);
     rewriter.setInsertionPointToStart(&ifb.getThenRegion().front());
@@ -2311,23 +2334,89 @@ struct GridwiseAttentionAccelRewritePattern
     if (prefetchQTile) {
       LLVM_DEBUG(llvm::dbgs()
                  << "rock.attention: gemm0K is equal to gemm0KPerBlock\n");
-      LLVM_DEBUG(llvm::dbgs()
-                 << "rock.attention: Prefetching Q tile into regs...\n");
-      // it is fine m iteration to be zero as it irrelevant to Q tensor
-      // as the first gemm is Kt x Qt.
-      auto gridCoordsGemm0LoadQ = layout::makeGxNGridLayout(
-          rewriter, loc, bid, zero, gemm0NBlocks, gridSize, arch, splitKVConst);
 
-      Value ldsByteBufferQ = nullptr;
-      if (!doBypassLDSForQ)
-        ldsByteBufferQ =
-            createLDSByteBuffer(rewriter, loc, ldsByteBufferQSize, elemTypeQ);
+      // Optimization: Compute work condition for conditional Q load.
+      // When there's no work to do (e.g., due to causal masking or KV-cache),
+      // skip the expensive global memory read of Q and zero registers instead.
+      Value someWorkToDo =
+          computeIfWorkToDo(rewriter, loc, start, end, splitKV,
+                              gemm0MPerBlock, op.getPrePadG0M(), isCausal,
+                              isKVCache);
 
-      loadAndStoreGemmInputTile(
-          rewriter, loc, inQ, /*kiter=*/zero, tid, gridCoordsGemm0LoadQ,
-          ldsByteBufferQ, preAccelRegBuffersQForLoad, loadTypeQ, "n", blockSize,
-          elemTypeQ, elemTypeQLoad, gemm0TuningParams, featuresAttr,
-          matrixParamsK, matrixParamsQ);
+      if (someWorkToDo) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "rock.attention: Conditional Q load optimization enabled "
+                   << "(splitKV > 1 with causal/kvcache/padding)\n");
+
+        // Create if-else block: load Q only if there's work, otherwise zero
+        // registers
+        scf::IfOp qLoadIf = scf::IfOp::create(rewriter, loc, someWorkToDo,
+                                              /*withElseRegion=*/true);
+
+        // Then region: Load Q from global memory (when there's work to do)
+        {
+          PatternRewriter::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPointToStart(&qLoadIf.getThenRegion().front());
+
+          LLVM_DEBUG(llvm::dbgs()
+                     << "rock.attention: Prefetching Q tile into regs "
+                     << "(has work to do)\n");
+
+          // it is fine m iteration to be zero as it irrelevant to Q tensor
+          // as the first gemm is Kt x Qt.
+          auto gridCoordsGemm0LoadQ = layout::makeGxNGridLayout(
+              rewriter, loc, bid, zero, gemm0NBlocks, gridSize, arch,
+              splitKVConst);
+
+          Value ldsByteBufferQ = nullptr;
+          if (!doBypassLDSForQ)
+            ldsByteBufferQ = createLDSByteBuffer(rewriter, loc,
+                                                 ldsByteBufferQSize, elemTypeQ);
+
+          loadAndStoreGemmInputTile(
+              rewriter, loc, inQ, /*kiter=*/zero, tid, gridCoordsGemm0LoadQ,
+              ldsByteBufferQ, preAccelRegBuffersQForLoad, loadTypeQ, "n",
+              blockSize, elemTypeQ, elemTypeQLoad, gemm0TuningParams,
+              featuresAttr, matrixParamsK, matrixParamsQ);
+        }
+
+        // Else region: Zero Q registers
+        {
+          PatternRewriter::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPointToStart(&qLoadIf.getElseRegion().front());
+
+          LLVM_DEBUG(llvm::dbgs()
+                     << "rock.attention: Skipping Q load, zeroing registers "
+                     << "instead (no work to do)\n");
+
+          // Zero both the load buffer and the compute buffer
+          zeroAccBuffer(rewriter, loc, preAccelRegBuffersQForLoad);
+          if (preAccelRegBuffersQ != preAccelRegBuffersQForLoad)
+            zeroAccBuffer(rewriter, loc, preAccelRegBuffersQ);
+        }
+
+        // Continue after the if-else block
+        rewriter.setInsertionPointAfter(qLoadIf);
+      } else {
+        // No early exit conditions apply - always load Q (normal case when
+        // splitKV == 1 and not causal/kvcache)
+        // it is fine m iteration to be zero as it irrelevant to Q tensor
+        // as the first gemm is Kt x Qt.
+        auto gridCoordsGemm0LoadQ = layout::makeGxNGridLayout(
+            rewriter, loc, bid, zero, gemm0NBlocks, gridSize, arch,
+            splitKVConst);
+
+        Value ldsByteBufferQ = nullptr;
+        if (!doBypassLDSForQ)
+          ldsByteBufferQ =
+              createLDSByteBuffer(rewriter, loc, ldsByteBufferQSize, elemTypeQ);
+
+        loadAndStoreGemmInputTile(
+            rewriter, loc, inQ, /*kiter=*/zero, tid, gridCoordsGemm0LoadQ,
+            ldsByteBufferQ, preAccelRegBuffersQForLoad, loadTypeQ, "n",
+            blockSize, elemTypeQ, elemTypeQLoad, gemm0TuningParams,
+            featuresAttr, matrixParamsK, matrixParamsQ);
+      }
     }
 
     bool dynamicMLoop = splitKV != 1 || isCausal || isKVCache;

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1884,14 +1884,7 @@ struct GridwiseAttentionAccelRewritePattern
                                         Value start, Value end, int64_t splitKV,
                                         int64_t gemm0MPerBlock,
                                         std::optional<APInt> prePadG0M,
-                                        bool isCausal, bool isKVCache,
-                                        bool skipRunEarlyExit) const {
-    // skipRunEarlyExit disables early exit logic as the MIGraphX flash decoding
-    // implementation requires that the first of two kernels is initialized to
-    // zero (and not left uninitialized as is the case with early exit logic).
-    if (skipRunEarlyExit)
-      return std::nullopt;
-
+                                        bool isCausal, bool isKVCache) const {
     // Compute the work condition using the extracted helper function
     Value someWorkToDo =
         computeIfWorkToDo(rewriter, loc, start, end, splitKV, gemm0MPerBlock,
@@ -2307,12 +2300,11 @@ struct GridwiseAttentionAccelRewritePattern
                      isKVCache, op.getNumRepeatsGQAAttr());
 
     // Early exit: Skip all computation when there's no work but always write
-    // output (zeros).
+    // output.
     // This wraps Q loads, M/K loops, GEMMs, softmax, etc. in a conditional.
     std::optional<scf::IfOp> earlyExitIf =
         runEarlyExit(rewriter, loc, start, end, splitKV, gemm0MPerBlock,
-                     op.getPrePadG0M(), isCausal, isKVCache,
-                     /*skipRunEarlyExit=*/false);
+                     op.getPrePadG0M(), isCausal, isKVCache);
 
     // create matrix params (LDS transpose not supported for attention)
     BlockwiseMatrixParamsAttr matrixParamsK = BlockwiseMatrixParamsAttr::get(

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1827,15 +1827,13 @@ struct GridwiseAttentionAccelRewritePattern
   }
 
   // Helper function to compute the 'someWorkToDo' condition used for early
-  // exit optimization. This can be used independently of creating an if block,
-  // allowing us to conditionally skip expensive operations (like Q loads)
-  // while still ensuring output buffers are initialized.
+  // exit optimization.
   Value computeIfWorkToDo(PatternRewriter &rewriter, Location loc,
                             Value start, Value end, int64_t splitKV,
                             int64_t gemm0MPerBlock,
                             std::optional<APInt> prePadG0M, bool isCausal,
                             bool isKVCache) const {
-    // We need have no work to do if (1) and (2 || 3) conditions are true:
+    // We have no work to do if (1) and (2 || 3) conditions are true:
     // 1. split-kv > 1
     // 2. there's padding in gemm0M && (at least) the last block in split-kv
     // dimension has nothing to do
@@ -2342,8 +2340,9 @@ struct GridwiseAttentionAccelRewritePattern
     Value zero = rewriter.createOrFold<ConstantIndexOp>(loc, 0);
     if (prefetchQTile) {
       LLVM_DEBUG(llvm::dbgs()
-                 << "rock.attention: gemm0K is equal to gemm0KPerBlock, "
-                 << "prefetching Q tile into regs\n");
+                 << "rock.attention: gemm0K is equal to gemm0KPerBlock\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "rock.attention: Prefetching Q tile into regs...\n");
 
       // it is fine m iteration to be zero as it irrelevant to Q tensor
       // as the first gemm is Kt x Qt.

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -1828,11 +1828,10 @@ struct GridwiseAttentionAccelRewritePattern
 
   // Helper function to compute the 'someWorkToDo' condition used for early
   // exit optimization.
-  Value computeIfWorkToDo(PatternRewriter &rewriter, Location loc,
-                            Value start, Value end, int64_t splitKV,
-                            int64_t gemm0MPerBlock,
-                            std::optional<APInt> prePadG0M, bool isCausal,
-                            bool isKVCache) const {
+  Value computeIfWorkToDo(PatternRewriter &rewriter, Location loc, Value start,
+                          Value end, int64_t splitKV, int64_t gemm0MPerBlock,
+                          std::optional<APInt> prePadG0M, bool isCausal,
+                          bool isKVCache) const {
     // We have no work to do if (1) and (2 || 3) conditions are true:
     // 1. split-kv > 1
     // 2. there's padding in gemm0M && (at least) the last block in split-kv
@@ -1894,7 +1893,7 @@ struct GridwiseAttentionAccelRewritePattern
     scf::IfOp ifb = scf::IfOp::create(rewriter, loc, someWorkToDo,
                                       /*withElseRegion=*/false);
     rewriter.setInsertionPointToStart(&ifb.getThenRegion().front());
-    
+
     // Return the IfOp so caller can close it later (by setting insertion point
     // after it) to ensure output writes happen unconditionally
     return ifb;

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -2270,8 +2270,11 @@ struct GridwiseAttentionAccelRewritePattern
         Type elemTypeLse = cast<MemRefType>(lse.getType()).getElementType();
         lseBuffer = createBufferForGemmOut(loc, elemTypeLse, accelParamsGemm1,
                                            rewriter);
-        // Initialize lseBuffer to -infinity
-        FillOp::create(rewriter, loc, lseBuffer, negInfSumTyped);
+        // Initialize lseBuffer to -infinity (use the correct type for lse)
+        auto negInfLse = createConstantFloatOp(
+            rewriter, loc, elemTypeLse, elemTypeLse,
+            -std::numeric_limits<float>::infinity(), APFloat::opOK);
+        FillOp::create(rewriter, loc, lseBuffer, negInfLse);
       }
 
       zeroAccBuffer(rewriter, loc, attentionOutAccBuffer);

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -513,6 +513,9 @@ func.func @gridwise_attn_splitkv_lse_kvcache(%arg0: memref<1x384x64xf32>, %arg1:
   // CHECK-NEXT: %[[lse:.+]] = arith.mulf %[[lseLog2]], %[[log2]] : f32
   // CHECK-NEXT: rock.in_bounds_store %[[lse]] -> %[[lseBuffer:.+]][{{.*}}] : f32 -> memref<16xf32, #gpu.address_space<private>>, index
   // CHECK-NEXT: rock.yield
+  // Verify that the early exit scf.if block closes before the writes
+  // CHECK: }
+  // CHECK-NEXT: }
   // CHECK: rock.threadwise_write_all {{.*}} by  set : memref<32xf32, #gpu.address_space<private>> -> memref<8x64x384xf32>
   // CHECK-NEXT: rock.threadwise_write_all {{.*}} %[[lseBuffer]] {{.*}} set : memref<16xf32, #gpu.address_space<private>> -> memref<8x384xf32>
   rock.gridwise_attention_accel(%0, %arg1, %arg2, %arg4, %arg3, %arg5) features =  mfma|dot|atomic_add|atomic_add_f16 preSoftmaxOps = {} {

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -11,13 +11,13 @@
 // CHECK: %[[QTr0:.+]] = rock.transform %[[Q]] by
 
 // init maxRow buffer
-// CHECK-DAG: rock.fill(%[[maxRowBuf:.+]], %[[negInf]])
+// CHECK-DAG: rock.fill(%[[maxRowBuf:.+]], %[[negInf]]) : memref<1xf32
 
 // init sumRow buffer
-// CHECK-DAG: rock.fill(%[[sumRowBuf:.+]], %[[zeroF32]])
+// CHECK-DAG: rock.fill(%[[sumRowBuf:.+]], %[[zeroF32]]) : memref<1xf32
 
 // init attentionAcc buffer
-// CHECK-DAG: rock.fill(%[[attnOutBuf:.+]], %[[zeroF32]])
+// CHECK-DAG: rock.fill(%[[attnOutBuf:.+]], %[[zeroF32]]) : memref<2x16xf32
 
 // Outer N-tile loop
 // CHECK: scf.for
@@ -496,12 +496,8 @@ func.func @gridwise_attn_splitkv_lse_kvcache(%arg0: memref<1x384x64xf32>, %arg1:
   // CHECK-NEXT: %[[endSplitKV:.+]] = arith.muli %[[splitPlusOne]], %[[gemm0MIterations]] : index
   // CHECK-NEXT: %[[endIter:.+]] = arith.minui %[[numIter]], %[[endSplitKV]] : index
   // CHECK-NEXT: %[[lastIter:.+]] = arith.subi %[[endIter]], %[[c1]] : index
-  
-  // TODO: Revert this change when we don't need to skipEarlyExit workaround for
-  //       flash decoding
-  // BUG-CHECK-NEXT: %[[someWorkToDo:.+]] = arith.cmpi ugt, %[[endIter]], %[[startIter]] : index
-  // BUG-CHECK-NEXT: scf.if %[[someWorkToDo]]
-
+  // CHECK-NEXT: %[[someWorkToDo:.+]] = arith.cmpi ugt, %[[endIter]], %[[startIter]] : index
+  // CHECK-NEXT: scf.if %[[someWorkToDo]]
   // CHECK-NEXT: scf.for %[[iterIndex:.+]] = %[[startIter]] to %[[endIter]] step %[[c1]] {
   // CHECK: %[[comparison:.+]] = arith.cmpi eq, %[[iterIndex]], %[[lastIter]] : index
   // CHECK-NEXT: scf.if %[[comparison]] {

--- a/mlir/test/Dialect/Rock/toblockwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/toblockwise_attention_accel_lowering.mlir
@@ -10,13 +10,13 @@
 // CHECK-DAG: %[[QTr0:.+]] = rock.transform %[[Q]] by
 
 // init maxRow buffer
-// CHECK-DAG: rock.fill(%[[maxRowBuf:.+]], %[[negInf]])
+// CHECK-DAG: rock.fill(%[[maxRowBuf:.+]], %[[negInf]]) : memref<1xf32
 
 // init sumRow buffer
-// CHECK-DAG: rock.fill(%[[sumRowBuf:.+]], %[[zeroF32]])
+// CHECK-DAG: rock.fill(%[[sumRowBuf:.+]], %[[zeroF32]]) : memref<1xf32
 
 // init attentionAcc buffer
-// CHECK-DAG: rock.fill(%[[attnOutBuf:.+]], %[[zeroF32]])
+// CHECK-DAG: rock.fill(%[[attnOutBuf:.+]], %[[zeroF32]]) : memref<2x16xf32
 
 // Outer N-tile loop
 // CHECK: scf.for

--- a/mlir/test/fusion/pr-e2e/rock-attention-pipeline-early-exit.mlir
+++ b/mlir/test/fusion/pr-e2e/rock-attention-pipeline-early-exit.mlir
@@ -4,3 +4,10 @@
 // RUN: | FileCheck %s
 
 // CHECK: [1 1 1]
+
+// RUN: rocmlir-gen -rand 1 -operation attention -t f16 -g 1 -seq_len_q 1 -seq_len_k 8192 -num_heads_q 64 -num_heads_kv 8 -head_dim_qk 512  -head_dim_v 512 -causal=true  -return_lse=true -split_kv=128 -current_seq_len=16 --arch %arch -pv \
+// RUN: | rocmlir-driver -c \
+// RUN: | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext -entry-point-result=void \
+// RUN: | FileCheck %s --check-prefix=LLAMA
+
+// LLAMA: [1 1 1]

--- a/mlir/test/fusion/pr-e2e/rock-attention-pipeline-early-exit.mlir
+++ b/mlir/test/fusion/pr-e2e/rock-attention-pipeline-early-exit.mlir
@@ -11,3 +11,4 @@
 // RUN: | FileCheck %s --check-prefix=LLAMA
 
 // LLAMA: [1 1 1]
+


### PR DESCRIPTION
## Motivation
 This PR improves on the early exit workaround while still initializing output buffers (needed for MIGraphX implementation of flash decoding).
 
 Implements: https://github.com/ROCm/rocMLIR-internal/issues/2171

## Technical Details

The early exit `scf.if` block is updated so that it wraps the main loop and all of the setup logic (including loading/prefetching the Q tensor), while still writing to the output buffer + LSE buffer.

When early exit takes place the output buffer will be initialized to all zeros, and the LSE buffer will be set to -inf.

## Test Plan

- Nightly CI

## Test Result

- [x] Nightly CI: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2158/6/pipeline-overview
- [x] See performance testing results in https://github.com/ROCm/rocMLIR-internal/issues/2171#issuecomment-3618699074

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
