### PR TITLE
Disable tranpose loads for numWaves>4

### DIFF
--- a/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
+++ b/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
@@ -278,6 +278,13 @@ LDSTransposeDecision decideLDSTransposeForOperands(
   }
   // else - implicitly: neither operand usable, enableA/enableB remain false.
 
+  // TODO: adapt code to support numWaves = 8, 16 and 32 (only wmma).
+  int64_t numWaves = (mPerBlock * nPerBlock) / (mPerWave * nPerWave);
+  if (numWaves > 4) {
+    result.enableA = false;
+    result.enableB = false;
+  }
+
   return result;
 }
 
@@ -720,31 +727,31 @@ static std::pair<Value, Value> computeLDSBaseOffsets(PatternRewriter &b,
 //
 // Parameters:
 //   waveId        - Runtime wave ID inside the workgroup.
-//   physicalWaves - Total number of waves (compile-time).
 //
 // Returns:
 //   WaveGridLayout containing:
 //     - wavesInM, wavesInN: Grid dimensions.
 //     - waveM, waveN:      This wave's assigned 2D grid coordinates.
 //===----------------------------------------------------------------------===//
-static WaveGridLayout computeWaveGridLayout(PatternRewriter &b, Location loc,
-                                            Value waveId, int64_t physicalWaves,
-                                            int64_t mPerWave, int64_t nPerWave,
-                                            int64_t mPerBlock,
-                                            int64_t nPerBlock) {
+static FailureOr<WaveGridLayout>
+computeWaveGridLayout(PatternRewriter &b, Location loc, Value waveId,
+                      int64_t mPerWave, int64_t nPerWave, int64_t mPerBlock,
+                      int64_t nPerBlock) {
   // Calculate how many wave-sized tiles fit in the block dimensions
   // These determine the wave grid, not accounting for outer loop repeats
   int64_t waveTilesInM = mPerBlock / mPerWave;
   int64_t waveTilesInN = nPerBlock / nPerWave;
+  int64_t numWaves = waveTilesInM * waveTilesInN;
 
   // Determine wave grid layout based on physical waves and wave tiles
   // This distributes waves spatially across M and N dimensions
-  // Note: physicalWaves can only be 1, 2, 3, or 4 (for 64, 128, 192, 256
+  // Note: numWaves can only be 1, 2, 3, or 4 (for 64, 128, 192, 256
   // threads)
+  // TODO: numWaves can be 8 and 16 (and 32 for wmma) as well, update this code
   int64_t wavesInM = 1;
   int64_t wavesInN = 1;
 
-  switch (physicalWaves) {
+  switch (numWaves) {
   case 1:
     // Single wave: always 1×1
     wavesInM = 1;
@@ -805,7 +812,7 @@ static WaveGridLayout computeWaveGridLayout(PatternRewriter &b, Location loc,
     }
     break;
   default:
-    llvm_unreachable("Invalid physicalWaves: blockSize / waveSize");
+    return failure();
   }
 
   LLVM_DEBUG(llvm::dbgs() << "[lds_transpose] Wave grid layout: " << wavesInM
@@ -818,7 +825,7 @@ static WaveGridLayout computeWaveGridLayout(PatternRewriter &b, Location loc,
   Value waveM = arith::DivUIOp::create(b, loc, waveId, wavesInNVal);
   Value waveN = arith::RemUIOp::create(b, loc, waveId, wavesInNVal);
 
-  return {wavesInM, wavesInN, waveM, waveN};
+  return WaveGridLayout{wavesInM, wavesInN, waveM, waveN};
 }
 
 //===----------------------------------------------------------------------===//
@@ -1084,7 +1091,6 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
   Value waveSizeVal = arith::ConstantIndexOp::create(b, loc, waveSize);
   Value lane = arith::RemUIOp::create(b, loc, tid, waveSizeVal);
   Value waveId = arith::DivUIOp::create(b, loc, tid, waveSizeVal);
-  int64_t physicalWaves = blockSize / waveSize;
 
   // Read parameters directly from config
   int64_t dDim = config.getMfmaDDim();
@@ -1099,8 +1105,11 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
       config.getIsOperandA() ? OperandKind::A : OperandKind::B;
 
   // Compute wave grid layout and decompose wave ID into 2D position
-  WaveGridLayout waveGrid = computeWaveGridLayout(
-      b, loc, waveId, physicalWaves, mPerWave, nPerWave, mPerBlock, nPerBlock);
+  FailureOr<WaveGridLayout> maybeWaveGrid = computeWaveGridLayout(
+      b, loc, waveId, mPerWave, nPerWave, mPerBlock, nPerBlock);
+  assert(succeeded(maybeWaveGrid) &&
+         "If we decided to use transpose load, this must work");
+  WaveGridLayout waveGrid = maybeWaveGrid.value();
   Value waveM = waveGrid.waveM;
   Value waveN = waveGrid.waveN;
 

--- a/mlir/test/Dialect/Rock/lds_transpose_attributes_toblockwise.mlir
+++ b/mlir/test/Dialect/Rock/lds_transpose_attributes_toblockwise.mlir
@@ -1,0 +1,30 @@
+// RUN: rocmlir-opt -split-input-file -rock-gridwise-gemm-to-blockwise %s | FileCheck %s
+
+#params_double = #rock.mfma_gemm_params<
+  kpackPerBlock = 32, mPerBlock = 256, nPerBlock = 256,
+  kpack = 1, mPerWave = 64, nPerWave = 64,
+  mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 4,
+  outputSwizzle = 2, forceUnroll = true>
+
+module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  // CHECK-LABEL: func.func @test_lds_transpose_attributes_double_buffering
+  func.func @test_lds_transpose_attributes_double_buffering(
+      %arg0: memref<2048xf16>,
+      %arg1: memref<2048xf16>,
+      %arg2: memref<4096xf16>)
+      attributes {block_size = 256 : i32, grid_size = 1 : i32,
+                  enable_splitk_for_tuning, kernel,
+                  num_cu = 256 : i64} {
+    %a = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{32, 64} ["k", "m"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 32, 64] -> [2048]> : memref<2048xf16> to memref<1x32x64xf16>
+    %b = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{32, 64} ["k", "n"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 32, 64] -> [2048]> : memref<2048xf16> to memref<1x32x64xf16>
+    %c = rock.transform %arg2 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{64, 64} ["m", "n"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 64, 64] -> [4096]> : memref<4096xf16> to memref<1x64x64xf16>
+
+    // CHECK-NOT: ldsTransposeEnabled
+    rock.gridwise_gemm_accel(%a, %b, %c)
+      storeMethod(set)
+      features = mfma|dot|atomic_add|atomic_add_bf16|atomic_add_f16|direct_to_lds_32b|direct_to_lds_128b
+      {blockSize = 256 : i32, gridSize = 1 : i32, params = #params_double}
+      : memref<1x32x64xf16>, memref<1x32x64xf16>, memref<1x64x64xf16>
+    return
+  }
+}

--- a/mlir/test/Dialect/Rock/lds_transpose_attributes_toblockwise.mlir
+++ b/mlir/test/Dialect/Rock/lds_transpose_attributes_toblockwise.mlir
@@ -1,18 +1,24 @@
 // RUN: rocmlir-opt -split-input-file -rock-gridwise-gemm-to-blockwise %s | FileCheck %s
 
-#params_double = #rock.mfma_gemm_params<
+#params_16 = #rock.mfma_gemm_params<
   kpackPerBlock = 32, mPerBlock = 256, nPerBlock = 256,
   kpack = 1, mPerWave = 64, nPerWave = 64,
   mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 4,
   outputSwizzle = 2, forceUnroll = true>
 
+#params_8 = #rock.mfma_gemm_params<
+  kpackPerBlock = 32, mPerBlock = 256, nPerBlock = 128,
+  kpack = 1, mPerWave = 64, nPerWave = 64,
+  mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 4,
+  outputSwizzle = 2, forceUnroll = true>
+
 module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // CHECK-LABEL: func.func @test_lds_transpose_attributes_double_buffering
-  func.func @test_lds_transpose_attributes_double_buffering(
+  // CHECK-LABEL: func.func @test_16_waves
+  func.func @test_16_waves(
       %arg0: memref<2048xf16>,
       %arg1: memref<2048xf16>,
       %arg2: memref<4096xf16>)
-      attributes {block_size = 256 : i32, grid_size = 1 : i32,
+      attributes {block_size = 1024 : i32, grid_size = 1 : i32,
                   enable_splitk_for_tuning, kernel,
                   num_cu = 256 : i64} {
     %a = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{32, 64} ["k", "m"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 32, 64] -> [2048]> : memref<2048xf16> to memref<1x32x64xf16>
@@ -23,7 +29,28 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
     rock.gridwise_gemm_accel(%a, %b, %c)
       storeMethod(set)
       features = mfma|dot|atomic_add|atomic_add_bf16|atomic_add_f16|direct_to_lds_32b|direct_to_lds_128b
-      {blockSize = 256 : i32, gridSize = 1 : i32, params = #params_double}
+      {blockSize = 1024 : i32, gridSize = 1 : i32, params = #params_16}
+      : memref<1x32x64xf16>, memref<1x32x64xf16>, memref<1x64x64xf16>
+    return
+  }
+
+  // CHECK-LABEL: func.func @test_8_waves
+  func.func @test_8_waves(
+      %arg0: memref<2048xf16>,
+      %arg1: memref<2048xf16>,
+      %arg2: memref<4096xf16>)
+      attributes {block_size = 512 : i32, grid_size = 1 : i32,
+                  enable_splitk_for_tuning, kernel,
+                  num_cu = 256 : i64} {
+    %a = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{32, 64} ["k", "m"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 32, 64] -> [2048]> : memref<2048xf16> to memref<1x32x64xf16>
+    %b = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{32, 64} ["k", "n"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 32, 64] -> [2048]> : memref<2048xf16> to memref<1x32x64xf16>
+    %c = rock.transform %arg2 by <affine_map<(d0, d1, d2) -> (d1 * 64 + d2)> by [<Unmerge{64, 64} ["m", "n"] at [1, 2] -> ["raw"] at [0]>, <AddDim{1} ["g"] at [0] -> [] at []>] bounds = [1, 64, 64] -> [4096]> : memref<4096xf16> to memref<1x64x64xf16>
+
+    // CHECK-NOT: ldsTransposeEnabled
+    rock.gridwise_gemm_accel(%a, %b, %c)
+      storeMethod(set)
+      features = mfma|dot|atomic_add|atomic_add_bf16|atomic_add_f16|direct_to_lds_32b|direct_to_lds_128b
+      {blockSize = 512 : i32, gridSize = 1 : i32, params = #params_8}
       : memref<1x32x64xf16>, memref<1x32x64xf16>, memref<1x64x64xf16>
     return
   }


### PR DESCRIPTION
## Motivation

Tranpose load code doesn't work for `numWaves>4`. Tuning is broken on MI350. So, until we have a proper fix, let's disable tranpose loads for `numWaves>4`. I have created a ticket: https://github.com/ROCm/rocMLIR-internal/issues/2175

## Technical Details

See Motivation.

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
