### PR TITLE
Change XCD remapping logic

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridLayoutEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridLayoutEmitter.cpp
@@ -35,26 +35,43 @@ using namespace mlir::rock;
 using namespace mlir::arith;
 using namespace mlir::rock::layout;
 
+// based on
+// https://github.com/HazyResearch/HipKittens/blob/7f6986b502396aa865c0c80625121daf7caa756d/include/common/util.cuh#L78
 static Value rearrangeWorkgroupsForXCC(Location loc, PatternRewriter &b,
                                        Value bid, int64_t gridSize,
-                                       int64_t numChipletsPerGroup) {
-  Value numChipletsVal =
-      b.createOrFold<ConstantIndexOp>(loc, numChipletsPerGroup);
-  int64_t wgsPerChiplet = (gridSize) / numChipletsPerGroup;
-  Value wgsPerChipletVal = b.createOrFold<ConstantIndexOp>(loc, wgsPerChiplet);
-  Value logicalChipletId = RemUIOp::create(b, loc, bid, numChipletsVal);
-  Value wgIdPerLogicalChiplet = DivUIOp::create(b, loc, bid, numChipletsVal);
-  Value rearrangedBid = AddIOp::create(
-      b, loc, wgIdPerLogicalChiplet,
-      MulIOp::create(b, loc, logicalChipletId, wgsPerChipletVal));
-  int64_t lastNumChipletMultiple =
-      (gridSize - 1) - (gridSize % numChipletsPerGroup);
-  Value lastNumChipletMultipleVal =
-      b.createOrFold<ConstantIndexOp>(loc, lastNumChipletMultiple);
-  Value isBidLargerThanlastNumChipletMultiple = arith::CmpIOp::create(
-      b, loc, arith::CmpIPredicate::sgt, bid, lastNumChipletMultipleVal);
-  bid = arith::SelectOp::create(b, loc, isBidLargerThanlastNumChipletMultiple,
-                                bid, rearrangedBid);
+                                       int64_t numChiplets, int64_t chunkSize) {
+  Value numChipletsVal = b.createOrFold<ConstantIndexOp>(loc, numChiplets);
+  Value chunkSizeVal = b.createOrFold<ConstantIndexOp>(loc, chunkSize);
+
+  // Current XCD
+  Value xcd = RemUIOp::create(b, loc, bid, numChipletsVal);
+
+  // Largest full (numChiplets*chunkSize)-aligned block
+  int64_t block = numChiplets * chunkSize;
+  int64_t limit = (gridSize / block) * block;
+  Value blockVal = b.createOrFold<ConstantIndexOp>(loc, block);
+  Value limitVal = b.createOrFold<ConstantIndexOp>(loc, limit);
+
+  // Local BID (within round-robin assignment)
+  Value localBid = DivUIOp::create(b, loc, bid, numChipletsVal);
+  Value chunkIdx = DivUIOp::create(b, loc, localBid, chunkSizeVal);
+  Value posInChunk = RemUIOp::create(b, loc, localBid, chunkSizeVal);
+
+  // New BID
+  // newBid = chunkIdx * block + xcd * chunkSize + posInChunk;
+  Value newBid = AddIOp::create(
+      b, loc,
+      AddIOp::create(b, loc, MulIOp::create(b, loc, chunkIdx, blockVal),
+                     MulIOp::create(b, loc, xcd, chunkSizeVal)),
+      posInChunk);
+
+  // If bid beyond the last full block, leave unchanged
+  // if (bid > limit) return bid;
+  Value isBidLargerThanLastFullBlock =
+      arith::CmpIOp::create(b, loc, arith::CmpIPredicate::sgt, bid, limitVal);
+  bid = arith::SelectOp::create(b, loc, isBidLargerThanLastFullBlock, bid,
+                                newBid);
+
   return bid;
 }
 
@@ -71,28 +88,14 @@ GridCoordinates rock::layout::makeGroupedGridLayout(PatternRewriter &b,
                                                     Location loc, Value bid,
                                                     GridLayoutInfo info,
                                                     StringRef arch) {
-  // Currently the firmware will launch workgroups
-  // in a round-robin fashion to each chiplet. However
-  // we would want a group (>=1) of chiplets to perform
-  // a spatially local tile.
-  // Therefore, adjust bid to make every consecutive #groups of chiplets
-  // be slowest changing in the grid.
-  int64_t numChiplets = getNumChiplets(arch, info.numCU);
-  if (numChiplets > 1) {
-    // It was empirically found that two chiplets as a group
-    // computing a spatial mxn tile has better locality throughout.
-    int64_t numChipletsPerGroup = std::ceil(numChiplets / 2);
-    int64_t gridSize = info.gBlocks * info.mBlocks * info.nBlocks;
-    bid = rearrangeWorkgroupsForXCC(loc, b, bid, gridSize, numChipletsPerGroup);
-  }
-
   // Heuristic to compute groupSize
   // This also covers the cases where the output width is larger
   // than the input width
+  int64_t numChiplets = getNumChiplets(arch, info.numCU);
   int64_t bitWidthIn = info.inputType.getIntOrFloatBitWidth();
   int64_t bitWidthOut = info.outputType.getIntOrFloatBitWidth();
-  int64_t groupSize =
-      std::ceil(std::sqrt(info.numCU)) * (bitWidthOut / bitWidthIn);
+  int64_t groupSize = std::ceil(std::sqrt(info.numCU / numChiplets)) *
+                      (bitWidthOut / bitWidthIn);
   // use gridGroupSize if it's not zero
   if (info.gridGroupSize != 0) {
     groupSize = info.gridGroupSize;
@@ -101,6 +104,20 @@ GridCoordinates rock::layout::makeGroupedGridLayout(PatternRewriter &b,
   } else {
     LLVM_DEBUG(llvm::dbgs()
                << "Using heuristic to set groupSize to " << groupSize << "\n");
+  }
+
+  // Currently the firmware will launch workgroups
+  // in a round-robin fashion to each chiplet. However
+  // we would want a group (>=1) of chiplets to perform
+  // a spatially local tile.
+  // Therefore, adjust bid to make every consecutive #groups of chiplets
+  // be slowest changing in the grid.
+  if (numChiplets > 1) {
+    int64_t gridSize = info.gBlocks * info.mBlocks * info.nBlocks;
+    int64_t chunkSize = std::min(groupSize * groupSize,
+                                 std::max(int64_t{1}, gridSize / numChiplets));
+    bid = rearrangeWorkgroupsForXCC(loc, b, bid, gridSize, numChiplets,
+                                    chunkSize);
   }
 
   Value mBlocksPerGroup = b.createOrFold<ConstantIndexOp>(loc, groupSize);
@@ -140,10 +157,9 @@ rock::layout::makeGxNGridLayout(PatternRewriter &b, Location loc, Value bid,
   // be slowest changing in the grid.
   int64_t numChiplets = getNumChiplets(arch, numCU);
   if (numChiplets > 1) {
-    // It was empirically found that two chiplets as a group
-    // computing a spatial mxn tile has better locality throughout.
-    int64_t numChipletsPerGroup = std::ceil(numChiplets / 2);
-    bid = rearrangeWorkgroupsForXCC(loc, b, bid, gridSize, numChipletsPerGroup);
+    int64_t chunkSize = std::max(int64_t{1}, gridSize / numChiplets);
+    bid = rearrangeWorkgroupsForXCC(loc, b, bid, gridSize, numChiplets,
+                                    chunkSize);
   }
   Value g1NBlockCountVal = b.createOrFold<ConstantIndexOp>(loc, nBlocks);
 

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -171,9 +171,9 @@ getFinetuningParams(int64_t maxWavesPerEU) {
     wavesPerEUList.push_back(wavesPerEU);
   }
   std::vector<std::vector<int64_t>> finetuningParams = {
-      {0, 1},                 // outputSwizzle
-      wavesPerEUList,         // wavesPerEU
-      {0, 4, 8, 16, 32, 64}}; // gridGroupSize
+      {0, 1},                       // outputSwizzle
+      wavesPerEUList,               // wavesPerEU
+      {0, 1, 2, 4, 8, 16, 32, 64}}; // gridGroupSize
   return finetuningParams;
 }
 

--- a/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_gemm_accel_lowering.mlir
@@ -84,15 +84,19 @@ func.func @fp8_bf8_xdlops_ocp(%arg0: memref<1x128x128xf8E4M3FN>, %arg1: memref<1
 
 #xdlops_gemm_params2 = #rock.accel_gemm_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0, forceUnroll = true>
 // CHECK: @chiplet_grid
-func.func @chiplet_grid(%arg0: memref<1x32x128xf32>, %arg1: memref<1x32x256xf32>, %arg2: memref<1x128x256xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 228 : i32} {
+func.func @chiplet_grid(%arg0: memref<1x32x1280xf32>, %arg1: memref<1x32x2560xf32>, %arg2: memref<1x1280x2560xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 228 : i32} {
   // CHECK: %[[BID:.+]] = rock.workgroup_id
-  // CHECK-DAG: %[[CHIPLET_GRP_ID:.+]] = arith.remui %[[BID]], %c4 : index
-  // CHECK-DAG: %[[CHIPLET_BID:.+]] = arith.divui %[[BID]], %c4 : index
-  // CHECK-DAG: %[[CHIPLET_GRP_ID_LSHIFT:.+]] = arith.muli %[[CHIPLET_GRP_ID]], %c2 : index
-  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[CHIPLET_BID]], %[[CHIPLET_GRP_ID_LSHIFT]] : index
-  // CHECK-DAG: %[[IS_TAIL_BID:.+]] = arith.cmpi sgt, %[[BID]], %c7 : index
-  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_TAIL_BID]], %[[BID]], %[[MAYBE_NEW_BID]] : index
-  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params2} : memref<1x32x128xf32>, memref<1x32x256xf32>, memref<1x128x256xf32>
+  // CHECK-DAG: %[[XCD:.+]] = arith.remui %[[BID]], %c8 : index
+  // CHECK-DAG: %[[LOCAL_BID:.+]] = arith.divui %[[BID]], %c8 : index
+  // CHECK-DAG: %[[CHUNK_IDX:.+]] = arith.divui %[[LOCAL_BID]], %c36 : index
+  // CHECK-DAG: %[[POS_IN_CHUNK:.+]] = arith.remui %[[LOCAL_BID]], %c36 : index
+  // CHECK-DAG: %[[CHUNK_IDX_BY_BLOCK:.+]] = arith.muli %[[CHUNK_IDX]], %c288 : index
+  // CHECK-DAG: %[[XCD_BY_CHUNKSIZE:.+]] = arith.muli %[[XCD]], %c36 : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID_PARTIAL:.+]] = arith.addi %[[CHUNK_IDX_BY_BLOCK]], %[[XCD_BY_CHUNKSIZE]] : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[MAYBE_NEW_BID_PARTIAL]], %[[POS_IN_CHUNK]] : index
+  // CHECK-DAG: %[[IS_LARGER_THAN_FULLBLOCK:.+]] = arith.cmpi sgt, %[[BID]], %c576 : index
+  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_LARGER_THAN_FULLBLOCK]], %[[BID]], %[[MAYBE_NEW_BID]] : index
+  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params2} : memref<1x32x1280xf32>, memref<1x32x2560xf32>, memref<1x1280x2560xf32>
   return
 }
 
@@ -100,15 +104,19 @@ func.func @chiplet_grid(%arg0: memref<1x32x128xf32>, %arg1: memref<1x32x256xf32>
 
 #xdlops_gemm_params2 = #rock.accel_gemm_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0, forceUnroll = true>
 // CHECK: @chiplet_grid_mi308
-func.func @chiplet_grid_mi308(%arg0: memref<1x32x128xf32>, %arg1: memref<1x32x256xf32>, %arg2: memref<1x128x256xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 80 : i32} {
+func.func @chiplet_grid_mi308(%arg0: memref<1x32x1280xf32>, %arg1: memref<1x32x2560xf32>, %arg2: memref<1x1280x2560xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 80 : i32} {
   // CHECK: %[[BID:.+]] = rock.workgroup_id
-  // CHECK-DAG: %[[CHIPLET_GRP_ID:.+]] = arith.remui %[[BID]], %c2 : index
-  // CHECK-DAG: %[[CHIPLET_BID:.+]] = arith.divui %[[BID]], %c2 : index
-  // CHECK-DAG: %[[CHIPLET_GRP_ID_LSHIFT:.+]] = arith.muli %[[CHIPLET_GRP_ID]], %c4 : index
-  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[CHIPLET_BID]], %[[CHIPLET_GRP_ID_LSHIFT]] : index
-  // CHECK-DAG: %[[IS_TAIL_BID:.+]] = arith.cmpi sgt, %[[BID]], %c7 : index
-  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_TAIL_BID]], %[[BID]], %[[MAYBE_NEW_BID]] : index
-  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params2} : memref<1x32x128xf32>, memref<1x32x256xf32>, memref<1x128x256xf32>
+  // CHECK-DAG: %[[XCD:.+]] = arith.remui %[[BID]], %c4 : index
+  // CHECK-DAG: %[[LOCAL_BID:.+]] = arith.divui %[[BID]], %c4 : index
+  // CHECK-DAG: %[[CHUNK_IDX:.+]] = arith.divui %[[LOCAL_BID]], %c25 : index
+  // CHECK-DAG: %[[POS_IN_CHUNK:.+]] = arith.remui %[[LOCAL_BID]], %c25 : index
+  // CHECK-DAG: %[[CHUNK_IDX_BY_BLOCK:.+]] = arith.muli %[[CHUNK_IDX]], %c100 : index
+  // CHECK-DAG: %[[XCD_BY_CHUNKSIZE:.+]] = arith.muli %[[XCD]], %c25 : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID_PARTIAL:.+]] = arith.addi %[[CHUNK_IDX_BY_BLOCK]], %[[XCD_BY_CHUNKSIZE]] : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[MAYBE_NEW_BID_PARTIAL]], %[[POS_IN_CHUNK]] : index
+  // CHECK-DAG: %[[IS_LARGER_THAN_FULLBLOCK:.+]] = arith.cmpi sgt, %[[BID]], %c800 : index
+  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_LARGER_THAN_FULLBLOCK]], %[[BID]], %[[MAYBE_NEW_BID]] : index
+  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params2} : memref<1x32x1280xf32>, memref<1x32x2560xf32>, memref<1x1280x2560xf32>
   return
 }
 
@@ -288,20 +296,24 @@ func.func @gemm_wavespereu_outputswizzle(%arg0: memref<1x32x128xf32>, %arg1: mem
 
 // -----
 
-#xdlops_gemm_params_gridgroupsize = #rock.accel_gemm_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 64, forceUnroll = true>
+#xdlops_gemm_params_gridgroupsize = #rock.accel_gemm_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 9, forceUnroll = true>
 // CHECK: @grid_group_size
-func.func @grid_group_size(%arg0: memref<1x32x128xf32>, %arg1: memref<1x32x256xf32>, %arg2: memref<1x128x256xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 228 : i32} {
+func.func @grid_group_size(%arg0: memref<1x32x1280xf32>, %arg1: memref<1x32x2560xf32>, %arg2: memref<1x1280x2560xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 228 : i32} {
   // CHECK: %[[BID:.+]] = rock.workgroup_id
-  // CHECK-DAG: %[[CHIPLET_GRP_ID:.+]] = arith.remui %[[BID]], %c4 : index
-  // CHECK-DAG: %[[CHIPLET_BID:.+]] = arith.divui %[[BID]], %c4 : index
-  // CHECK-DAG: %[[CHIPLET_GRP_ID_LSHIFT:.+]] = arith.muli %[[CHIPLET_GRP_ID]], %c2 : index
-  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[CHIPLET_BID]], %[[CHIPLET_GRP_ID_LSHIFT]] : index
-  // CHECK-DAG: %[[IS_TAIL_BID:.+]] = arith.cmpi sgt, %[[BID]], %c7 : index
-  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_TAIL_BID]], %[[BID]], %[[MAYBE_NEW_BID]] : index
-  // CHECK-DAG: %[[NEW_BID2:.+]] = arith.remui %[[NEW_BID]], %c8 : index
-  // CHECK-DAG: %[[GROUD_ID:.+]] = arith.divui %[[NEW_BID2]], %c256 : index
-  // CHECK-DAG: %[[FIRST_BID_M:.+]] = arith.muli %[[GROUD_ID]], %c64 : index
-  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params_gridgroupsize} : memref<1x32x128xf32>, memref<1x32x256xf32>, memref<1x128x256xf32>
+  // CHECK-DAG: %[[XCD:.+]] = arith.remui %[[BID]], %c8 : index
+  // CHECK-DAG: %[[LOCAL_BID:.+]] = arith.divui %[[BID]], %c8 : index
+  // CHECK-DAG: %[[CHUNK_IDX:.+]] = arith.divui %[[LOCAL_BID]], %c81 : index
+  // CHECK-DAG: %[[POS_IN_CHUNK:.+]] = arith.remui %[[LOCAL_BID]], %c81 : index
+  // CHECK-DAG: %[[CHUNK_IDX_BY_BLOCK:.+]] = arith.muli %[[CHUNK_IDX]], %c648 : index
+  // CHECK-DAG: %[[XCD_BY_CHUNKSIZE:.+]] = arith.muli %[[XCD]], %c81 : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID_PARTIAL:.+]] = arith.addi %[[CHUNK_IDX_BY_BLOCK]], %[[XCD_BY_CHUNKSIZE]] : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[MAYBE_NEW_BID_PARTIAL]], %[[POS_IN_CHUNK]] : index
+  // CHECK-DAG: %[[IS_LARGER_THAN_FULLBLOCK:.+]] = arith.cmpi sgt, %[[BID]], %c648 : index
+  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_LARGER_THAN_FULLBLOCK]], %[[BID]], %[[MAYBE_NEW_BID]] : index
+  // CHECK-DAG: %[[NEW_BID2:.+]] = arith.remui %[[NEW_BID]], %c800 : index
+  // CHECK-DAG: %[[GROUP_ID:.+]] = arith.divui %[[NEW_BID2]], %c360 : index
+  // CHECK-DAG: %[[FIRST_BID_M:.+]] = arith.muli %[[GROUP_ID]], %c9 : index
+  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params_gridgroupsize} : memref<1x32x1280xf32>, memref<1x32x2560xf32>, memref<1x1280x2560xf32>
   return
 }
 
@@ -309,17 +321,21 @@ func.func @grid_group_size(%arg0: memref<1x32x128xf32>, %arg1: memref<1x32x256xf
 
 #xdlops_gemm_params_gridgroupsize_default = #rock.accel_gemm_params<kpackPerBlock = 4, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0, forceUnroll = true>
 // CHECK: @grid_group_size_default
-func.func @grid_group_size_default(%arg0: memref<1x32x128xf32>, %arg1: memref<1x32x256xf32>, %arg2: memref<1x128x256xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 228 : i32} {
+func.func @grid_group_size_default(%arg0: memref<1x32x1280xf32>, %arg1: memref<1x32x2560xf32>, %arg2: memref<1x1280x2560xf32>) attributes {block_size = 256 : i32, grid_size = 8 : i32, arch = "amdgcn-amd-amdhsa:gfx942", numCU = 228 : i32} {
   // CHECK: %[[BID:.+]] = rock.workgroup_id
-  // CHECK-DAG: %[[CHIPLET_GRP_ID:.+]] = arith.remui %[[BID]], %c4 : index
-  // CHECK-DAG: %[[CHIPLET_BID:.+]] = arith.divui %[[BID]], %c4 : index
-  // CHECK-DAG: %[[CHIPLET_GRP_ID_LSHIFT:.+]] = arith.muli %[[CHIPLET_GRP_ID]], %c2 : index
-  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[CHIPLET_BID]], %[[CHIPLET_GRP_ID_LSHIFT]] : index
-  // CHECK-DAG: %[[IS_TAIL_BID:.+]] = arith.cmpi sgt, %[[BID]], %c7 : index
-  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_TAIL_BID]], %[[BID]], %[[MAYBE_NEW_BID]] : index
-  // CHECK-DAG: %[[NEW_BID2:.+]] = arith.remui %[[NEW_BID]], %c8 : index
-  // CHECK-DAG: %[[GROUD_ID:.+]] = arith.divui %[[NEW_BID2]], %c64 : index
-  // CHECK-DAG: %[[FIRST_BID_M:.+]] = arith.muli %[[GROUD_ID]], %c16 : index
-  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params_gridgroupsize_default} : memref<1x32x128xf32>, memref<1x32x256xf32>, memref<1x128x256xf32>
+  // CHECK-DAG: %[[XCD:.+]] = arith.remui %[[BID]], %c8 : index
+  // CHECK-DAG: %[[LOCAL_BID:.+]] = arith.divui %[[BID]], %c8 : index
+  // CHECK-DAG: %[[CHUNK_IDX:.+]] = arith.divui %[[LOCAL_BID]], %c36 : index
+  // CHECK-DAG: %[[POS_IN_CHUNK:.+]] = arith.remui %[[LOCAL_BID]], %c36 : index
+  // CHECK-DAG: %[[CHUNK_IDX_BY_BLOCK:.+]] = arith.muli %[[CHUNK_IDX]], %c288 : index
+  // CHECK-DAG: %[[XCD_BY_CHUNKSIZE:.+]] = arith.muli %[[XCD]], %c36 : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID_PARTIAL:.+]] = arith.addi %[[CHUNK_IDX_BY_BLOCK]], %[[XCD_BY_CHUNKSIZE]] : index
+  // CHECK-DAG: %[[MAYBE_NEW_BID:.+]] = arith.addi %[[MAYBE_NEW_BID_PARTIAL]], %[[POS_IN_CHUNK]] : index
+  // CHECK-DAG: %[[IS_LARGER_THAN_FULLBLOCK:.+]] = arith.cmpi sgt, %[[BID]], %c576 : index
+  // CHECK-DAG: %[[NEW_BID:.+]] = arith.select %[[IS_LARGER_THAN_FULLBLOCK]], %[[BID]], %[[MAYBE_NEW_BID]] : index
+  // CHECK-DAG: %[[NEW_BID2:.+]] = arith.remui %[[NEW_BID]], %c800 : index
+  // CHECK-DAG: %[[GROUP_ID:.+]] = arith.divui %[[NEW_BID2]], %c240 : index
+  // CHECK-DAG: %[[FIRST_BID_M:.+]] = arith.muli %[[GROUP_ID]], %c6 : index
+  rock.gridwise_gemm_accel(%arg0, %arg1, %arg2) storeMethod( set) {blockSize = 256 : i32, gridSize = 900 : i32, params = #xdlops_gemm_params_gridgroupsize_default} : memref<1x32x1280xf32>, memref<1x32x2560xf32>, memref<1x1280x2560xf32>
   return
 }


### PR DESCRIPTION
## Motivation

Try HipKittens XCD remapping. 

## Technical Details

HipKittens XCD remapping creates a chunkSize that is related to groupSize (for https://triton-lang.org/main/getting-started/tutorials/03-matrix-multiplication.html#l2-cache-optimizations L2 optimization). They set `chunkSize=groupSize*groupSize`, which to me makes sense, as that's what an XCD is going to process.

I've also updated the groupSize heuristic from `groupSize = std::ceil(std::sqrt(info.numCU / numChiplets)) * (bitWidthOut / bitWidthIn)` to `groupSize = std::ceil(std::sqrt(info.numCU / numChiplets)) * (bitWidthOut / bitWidthIn)` to take into account the number of chiplets. This (the original formula and the new one) assumes we have a single workgroup per CU. Now, we make sure the group only stays inside one chiplet only.

I've also changed how they define chunkSize, they do:
```
int64_t chunkSize = groupSize * groupSize;
```

Here we are doing:
```
int64_t chunkSize = std::min(groupSize * groupSize,
                                 std::max(int64_t{1}, gridSize / numChiplets));
```

Note that what they do wouldn't do any remapping for small kernels, the change makes sure we always do XCD remapping.


## Perf data on MI350

Comparing this branch vs greedy_third_iteration branch (it's based on it). We get improvement (>1.05x) on 26 GEMMs of the tier1 list. It gets worser perf for 8 GEMMs, but all of them are >0.91x. Max speed up is 1.16x.

Note I've set the same groupSize tuning space for greedy_third_iteration as well.

I'm getting attention results as well. 
Partial results for attention, out of the first 47 configs, it improves one of them 1.15x, the rest are roughly the same run-time.

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
