### PR TITLE
Tweak argument handling and options in parameter sweeps

### DIFF
--- a/mlir/utils/performance/attentionSweeps.py
+++ b/mlir/utils/performance/attentionSweeps.py
@@ -189,11 +189,16 @@ def main():
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--quiet', action='store_true')
     parser.add_argument('--jobs', type=int, default=os.cpu_count())
-    parser.add_argument('--mlir-build-dir', type=str, default=find_mlir_build_dir()),
+    parser.add_argument('--mlir-build-dir', type=str, default=None)
     parser.add_argument('--samples', type=int, default=1000)
     parser.add_argument('--log-failures', action='store_true')
 
     args = parser.parse_args()
+    
+    # Set default mlir-build-dir if not provided
+    if args.mlir_build_dir is None:
+        args.mlir_build_dir = find_mlir_build_dir()
+    
     arch = get_arch()
     chip_match = GFX_CHIP_RE.search(arch)
     if chip_match is None:

--- a/mlir/utils/performance/attentionSweeps.py
+++ b/mlir/utils/performance/attentionSweeps.py
@@ -194,11 +194,11 @@ def main():
     parser.add_argument('--log-failures', action='store_true')
 
     args = parser.parse_args()
-    
+
     # Set default mlir-build-dir if not provided
     if args.mlir_build_dir is None:
         args.mlir_build_dir = find_mlir_build_dir()
-    
+
     arch = get_arch()
     chip_match = GFX_CHIP_RE.search(arch)
     if chip_match is None:

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -613,11 +613,11 @@ def main() -> bool:
         help="The build directory of MLIR based kernel generator",
     )
     args = parser.parse_args()
-    
+
     # Set default mlir-build-dir if not provided
     if args.mlir_build_dir is None:
         args.mlir_build_dir = perfRunner.find_mlir_build_dir()
-    
+
     arch = get_arch()
     supported_codepath = ['mfma', 'vanilla', 'wmma']
     # If codepath not provided or not supported, infer it from the arch

--- a/mlir/utils/performance/parameterSweeps.py
+++ b/mlir/utils/performance/parameterSweeps.py
@@ -609,10 +609,15 @@ def main() -> bool:
     parser.add_argument(
         "--mlir-build-dir",
         type=str,
-        default=perfRunner.find_mlir_build_dir(),
+        default=None,
         help="The build directory of MLIR based kernel generator",
     )
     args = parser.parse_args()
+    
+    # Set default mlir-build-dir if not provided
+    if args.mlir_build_dir is None:
+        args.mlir_build_dir = perfRunner.find_mlir_build_dir()
+    
     arch = get_arch()
     supported_codepath = ['mfma', 'vanilla', 'wmma']
     # If codepath not provided or not supported, infer it from the arch


### PR DESCRIPTION
## Motivation
Default parameter evaluation was causing issue https://github.com/ROCm/rocMLIR-internal/issues/2178
In Python, default argument values are evaluated at function definition time, not at call time. This means find_mlir_build_dir() was being executed during module import, even before main() was called. This function performs filesystem operations and git commands that could fail or behave unexpectedly in the CI environment during flake8's static analysis phase.

This PR should resolve https://github.com/ROCm/rocMLIR-internal/issues/2178

## Technical Details
Changed the default value to None and deferred the evaluation to runtime. This ensures find_mlir_build_dir() is only called when the script is actually executed, not during module import when flake8 analyzes the code.

## Test Plan

- Python syntax validation successful
- Module imports without errors
- GitHub Actions CI - flake8
- Jenkins CI - Parameter Sweeps

## Test Result

✅ Python syntax validation successful
✅ Module imports without errors
[✅](https://github.com/ROCm/rocMLIR/actions/runs/20429655959) GitHub Actions CI - flake8
[✅](https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-2181/2/pipeline) Jenkins CI - Parameter Sweeps

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
