### PR TITLE
(Async)DirectToLDS support in WMMA

### DIFF
--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1991,9 +1991,8 @@ LogicalResult GlobalLoadToLDSOp::verify() {
     return emitOpError("Destination memref must live in workgroup memory");
 
   int64_t numBits = getTransferType().getIntOrFloatBitWidth();
-  if (numBits != 128 && numBits != 64 &&numBits != 32 && numBits != 8)
-    return emitOpError(
-        "only 8, 32, 64 and 128 bit loads are supported");
+  if (numBits != 128 && numBits != 64 && numBits != 32 && numBits != 8)
+    return emitOpError("only 8, 32, 64 and 128 bit loads are supported");
   unsigned bitWidth = cast<ShapedType>(sourceType).getElementTypeBitWidth();
   unsigned destBitWidth = cast<ShapedType>(destType).getElementTypeBitWidth();
   // For 4-bit source types (f4, i4), add validation checks as GPU can not do

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -1991,9 +1991,9 @@ LogicalResult GlobalLoadToLDSOp::verify() {
     return emitOpError("Destination memref must live in workgroup memory");
 
   int64_t numBits = getTransferType().getIntOrFloatBitWidth();
-  if (numBits != 128 && numBits != 32)
+  if (numBits != 128 && numBits != 64 &&numBits != 32 && numBits != 8)
     return emitOpError(
-        "Direct to LDS is implemented for 128bit and 32bit loads only");
+        "only 8, 32, 64 and 128 bit loads are supported");
   unsigned bitWidth = cast<ShapedType>(sourceType).getElementTypeBitWidth();
   unsigned destBitWidth = cast<ShapedType>(destType).getElementTypeBitWidth();
   // For 4-bit source types (f4, i4), add validation checks as GPU can not do

--- a/mlir/lib/Dialect/Rock/Transforms/LowerRockOpsToROCDLOps.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/LowerRockOpsToROCDLOps.cpp
@@ -43,37 +43,52 @@ struct AsyncWaitOpConversion
   using ConvertOpToLLVMPattern<rock::AsyncWaitOp>::ConvertOpToLLVMPattern;
 
   AsyncWaitOpConversion(const LLVMTypeConverter &converter,
-                        amdgpu::Chipset chipset, bool supportsDirectToLDS)
+                        amdgpu::Chipset chipset, bool supportsDirectToLDS,
+                        bool supportsAsyncDirectToLDS)
       : ConvertOpToLLVMPattern<rock::AsyncWaitOp>(converter), chipset(chipset),
-        supportsDirectToLDS(supportsDirectToLDS) {}
+        supportsDirectToLDS(supportsDirectToLDS),
+        supportsAsyncDirectToLDS(supportsAsyncDirectToLDS) {}
 
   mlir::amdgpu::Chipset chipset;
   bool supportsDirectToLDS;
+  bool supportsAsyncDirectToLDS;
 
   LogicalResult
   matchAndRewrite(rock::AsyncWaitOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Erase the op when DirectToLDS is not supported
-    if (!supportsDirectToLDS) {
+    if (!supportsDirectToLDS && !supportsAsyncDirectToLDS) {
+      LLVM_DEBUG(llvm::dbgs() << "AsyncWaitOpConversion: arch does not support "
+                                 "DirectToLDS or AsyncDirectToLDS\n");
       rewriter.eraseOp(op);
       return success();
     }
 
     auto loc = op->getLoc();
 
-    // Clamp vmcnt to 6bits; a lower vmcnt will produce a conservative wait
-    unsigned vmCnt = std::min(63u, op.getNumInst());
+    if (supportsAsyncDirectToLDS) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "AsyncWaitOpConversion: arch supports AsyncDirectToLDS\n");
+      unsigned asyncCnt = std::min(63u, 0u);
+      ROCDL::WaitAsynccntOp::create(rewriter, loc, asyncCnt);
+      ROCDL::SBarrierOp::create(rewriter, loc);
+    } else { // supportsDirectToLDS
+      LLVM_DEBUG(llvm::dbgs()
+                 << "AsyncWaitOpConversion: arch supports DirectToLDS\n");
+      // Clamp vmcnt to 6bits; a lower vmcnt will produce a conservative wait
+      unsigned vmCnt = std::min(63u, op.getNumInst());
 
-    // Extract low and high bits and combine while setting all other bits to 1
-    unsigned lowBits = vmCnt & 0xF;
-    unsigned highBits = vmCnt >> 4 << 14;
-    unsigned otherCnts = ~0xC00F; // C00F has bits 15:14 and 3:0 set
-    unsigned waitValue = lowBits | highBits | otherCnts;
+      // Extract low and high bits and combine while setting all other bits to 1
+      unsigned lowBits = vmCnt & 0xF;
+      unsigned highBits = vmCnt >> 4 << 14;
+      unsigned otherCnts = ~0xC00F; // C00F has bits 15:14 and 3:0 set
+      unsigned waitValue = lowBits | highBits | otherCnts;
 
-    ROCDL::SWaitcntOp::create(rewriter, loc, waitValue);
-    ROCDL::SBarrierOp::create(rewriter, loc);
+      ROCDL::SWaitcntOp::create(rewriter, loc, waitValue);
+      ROCDL::SBarrierOp::create(rewriter, loc);
+    }
+
     rewriter.eraseOp(op);
-
     return success();
   }
 };
@@ -99,11 +114,13 @@ struct LowerRockOpsToROCDLOpsPass final
     // Check if the GPU supports DirectToLDS
     AmdArchInfo archInfo = lookupArchInfo(chipset);
     bool supportsDirectToLDS = isDirectToLDSSupported(archInfo.defaultFeatures);
+    bool supportsAsyncDirectToLDS = isAsyncDirectToLDSSupported(chipset);
 
     LLVMConversionTarget target(getContext());
     target.addIllegalOp<rock::AsyncWaitOp>();
     patterns.add<AsyncWaitOpConversion>(converter, *maybeChipset,
-                                        supportsDirectToLDS);
+                                        supportsDirectToLDS,
+                                        supportsAsyncDirectToLDS);
     target.addLegalDialect<ROCDL::ROCDLDialect>();
 
     if (failed(applyPartialConversion(op, target, std::move(patterns))))

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1366,14 +1366,14 @@ struct GlobalLoadToLDSRewritePattern
             b, loc, arith::CmpIPredicate::uge, coords[0], numElems);
         cond = arith::AndIOp::create(b, loc, fallsOffEnd, cond);
       }
-      auto guard =
-          scf::IfOp::create(b, loc, TypeRange(), cond, /*hasThen=*/ true, /*hasElse=*/ true);
+      auto guard = scf::IfOp::create(b, loc, TypeRange(), cond,
+                                     /*hasThen=*/true, /*hasElse=*/true);
       Block *thenBlock = guard.getBody(0);
       Block *elseBlock = guard.getBody(1);
-      
+
       // Build the then block: move the original operation
       b.moveOpBefore(op, thenBlock, thenBlock->begin());
-      
+
       // Build the else block: store zeros to the same destination location
       b.setInsertionPointToEnd(elseBlock);
       Type transferType = op.getTransferType();
@@ -1703,46 +1703,49 @@ struct InBoundsStoreRewritePattern : public OpRewritePattern<InBoundsStoreOp> {
 
       if (srcBits == destBits) {
         b.replaceOpWithNewOp<memref::StoreOp>(op, op.getData(), op.getDest(),
-                                            op.getCoords());
-      }
-      else if (srcBits > destBits && (srcBits % destBits == 0)) {
+                                              op.getCoords());
+      } else if (srcBits > destBits && (srcBits % destBits == 0)) {
         unsigned ratio = srcBits / destBits;
 
         // Bitcast the source operand to a vector<1 x srcType>
         VectorType singleElemVecType = VectorType::get({1}, srcElemType);
-        Value dataToBitcast = b.create<vector::BroadcastOp>(loc, singleElemVecType, data);
+        Value dataToBitcast =
+            b.create<vector::BroadcastOp>(loc, singleElemVecType, data);
 
         // Create a vector type with smaller elements for bitcasting
         // vector<ratio x destType>
         VectorType bitcastType = VectorType::get({ratio}, destElemType);
-        
+
         // Bitcast the source data to the smaller element type
-        Value bitcastData = b.create<vector::BitCastOp>(loc, bitcastType, dataToBitcast);
+        Value bitcastData =
+            b.create<vector::BitCastOp>(loc, bitcastType, dataToBitcast);
 
         // Create stores for each element
         int64_t lastDim = coords.size() - 1;
         Value baseLastCoord = coords[lastDim];
-        
+
         for (unsigned i = 0; i < ratio; ++i) {
           // Extract the i-th element from the bitcast vector
           Value index = b.create<arith::ConstantIndexOp>(loc, i);
           Value elem = b.create<vector::ExtractOp>(loc, bitcastData, index);
-          
+
           // Calculate new coordinates: increment the last coordinate by i
           SmallVector<Value> newCoords(coords.begin(), coords.end());
           if (i > 0) {
             Value offset = b.create<arith::ConstantIndexOp>(loc, i);
-            newCoords[lastDim] = b.create<arith::AddIOp>(loc, baseLastCoord, offset);
+            newCoords[lastDim] =
+                b.create<arith::AddIOp>(loc, baseLastCoord, offset);
           }
-          
+
           // Create the store operation - use StoreOp for scalar elements
           b.create<memref::StoreOp>(loc, elem, dest, newCoords);
         }
-        
+
         b.eraseOp(op);
-      } 
-      else {
-        return op.emitError("Source element type is larger than destination, but not a multiple of the destination element type");
+      } else {
+        return op.emitError(
+            "Source element type is larger than destination, but not a "
+            "multiple of the destination element type");
       }
     }
     return success();

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1367,32 +1367,21 @@ struct GlobalLoadToLDSRewritePattern
         cond = arith::AndIOp::create(b, loc, fallsOffEnd, cond);
       }
       auto guard =
-          scf::IfOp::create(b, loc, TypeRange(), cond, /*hasThen=*/ true, /*hasElse=*/ false);
-      // Remove implicit yields from both blocks
-      llvm::errs() << "Module: " << op->getParentOfType<ModuleOp>() << "\n";
+          scf::IfOp::create(b, loc, TypeRange(), cond, /*hasThen=*/ true, /*hasElse=*/ true);
       Block *thenBlock = guard.getBody(0);
-      // Block *elseBlock = guard.getBody(1);
+      Block *elseBlock = guard.getBody(1);
+      
+      // Build the then block: move the original operation
       b.moveOpBefore(op, thenBlock, thenBlock->begin());
-      // b.eraseOp(thenBlock->getTerminator());
-      // b.eraseOp(elseBlock->getTerminator());
-
-      // b.replaceOp(op, guard);
-
-      // Clone the operation into the then block
-      // b.setInsertionPointToStart(thenBlock);
-      // auto oldOp = op;
-      // op = b.clone(*op);
-      // b.eraseOp(oldOp);
       
-      // b.setInsertionPointToEnd(guard.getBody(1));
-      // Value zeroes = createZeroConstantOp(b, loc, originalLoadedType);
-      // scf::YieldOp::create(b, loc, zeroes);
-      // b.setInsertionPointToEnd(guard.getBody(0));
-      // Value hack = createZeroConstantOp(b, loc, originalLoadedType);
-      // scf::YieldOp::create(b, loc, hack);
+      // Build the else block: store zeros to the same destination location
+      b.setInsertionPointToEnd(elseBlock);
+      Type transferType = op.getTransferType();
+      Value zeroValue = createZeroConstantOp(b, loc, transferType);
+      InBoundsStoreOp::create(b, loc, zeroValue, dest, destCoords);
+      scf::YieldOp::create(b, loc);
 
-      
-      llvm::errs() << "Module: " << op->getParentOfType<ModuleOp>() << "\n";
+      // sss
       b.setInsertionPointToEnd(thenBlock);
     }
 

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1351,16 +1351,51 @@ struct GlobalLoadToLDSRewritePattern
                         (numBytes.trunc(32).isNegative() || emitOobChecks ||
                          op.getCanReadOffEnd());
 
-    if (emitOobChecks && !useBufferOps) {
-      return op->emitError(
-          "If we need to emit OOB checks, we must use buffer ops");
-    }
-
     source = asGlobal(b, source);
     if (useBufferOps && emitOobChecks && coords.empty()) {
       source = zeroDMemrefAsOneD(b, source);
       coords.push_back(b.createOrFold<ConstantIndexOp>(loc, 0));
     }
+
+    Type originalLoadedType = op.getTransferType();
+    PatternRewriter::InsertionGuard insertGuard(b);
+    if (asyncDirectToLDS && emitOobChecks && !useBufferOps) {
+      Value cond = valid;
+      if (op.getCanReadOffEnd()) {
+        Value fallsOffEnd = arith::CmpIOp::create(
+            b, loc, arith::CmpIPredicate::uge, coords[0], numElems);
+        cond = arith::AndIOp::create(b, loc, fallsOffEnd, cond);
+      }
+      auto guard =
+          scf::IfOp::create(b, loc, TypeRange(), cond, /*hasThen=*/ true, /*hasElse=*/ false);
+      // Remove implicit yields from both blocks
+      llvm::errs() << "Module: " << op->getParentOfType<ModuleOp>() << "\n";
+      Block *thenBlock = guard.getBody(0);
+      // Block *elseBlock = guard.getBody(1);
+      b.moveOpBefore(op, thenBlock, thenBlock->begin());
+      // b.eraseOp(thenBlock->getTerminator());
+      // b.eraseOp(elseBlock->getTerminator());
+
+      // b.replaceOp(op, guard);
+
+      // Clone the operation into the then block
+      // b.setInsertionPointToStart(thenBlock);
+      // auto oldOp = op;
+      // op = b.clone(*op);
+      // b.eraseOp(oldOp);
+      
+      // b.setInsertionPointToEnd(guard.getBody(1));
+      // Value zeroes = createZeroConstantOp(b, loc, originalLoadedType);
+      // scf::YieldOp::create(b, loc, zeroes);
+      // b.setInsertionPointToEnd(guard.getBody(0));
+      // Value hack = createZeroConstantOp(b, loc, originalLoadedType);
+      // scf::YieldOp::create(b, loc, hack);
+
+      
+      llvm::errs() << "Module: " << op->getParentOfType<ModuleOp>() << "\n";
+      b.setInsertionPointToEnd(thenBlock);
+    }
+
     if (useBufferOps) {
       // Implement bounds checks for buffer ops by sending any out of bounds
       // write off the end of the buffer, causing the hardware to return 0
@@ -1389,6 +1424,9 @@ struct GlobalLoadToLDSRewritePattern
             : amdgpu::GatherToLDSOp::create(b, loc, source, coords, dest,
                                             destCoords, op.getTransferType());
 
+    if (asyncDirectToLDS && emitOobChecks && !useBufferOps) {
+      scf::YieldOp::create(b, loc);
+    }
     b.replaceOp(op, toLDSOp);
     return success();
   }

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1687,8 +1687,63 @@ struct InBoundsStoreRewritePattern : public OpRewritePattern<InBoundsStoreOp> {
           op, op.getData(), op.getDest(), op.getCoords(),
           /*inbounds=*/ArrayRef<bool>(true));
     } else {
-      b.replaceOpWithNewOp<memref::StoreOp>(op, op.getData(), op.getDest(),
+      Location loc = op.getLoc();
+      Value data = op.getData();
+      Value dest = op.getDest();
+      auto coords = op.getCoords();
+
+      // Get element types
+      Type srcElemType = getElementTypeOrSelf(data.getType());
+      MemRefType destMemRefType = cast<MemRefType>(dest.getType());
+      Type destElemType = destMemRefType.getElementType();
+
+      // Get bit widths
+      unsigned srcBits = srcElemType.getIntOrFloatBitWidth();
+      unsigned destBits = destElemType.getIntOrFloatBitWidth();
+
+      if (srcBits == destBits) {
+        b.replaceOpWithNewOp<memref::StoreOp>(op, op.getData(), op.getDest(),
                                             op.getCoords());
+      }
+      else if (srcBits > destBits && (srcBits % destBits == 0)) {
+        unsigned ratio = srcBits / destBits;
+
+        // Bitcast the source operand to a vector<1 x srcType>
+        VectorType singleElemVecType = VectorType::get({1}, srcElemType);
+        Value dataToBitcast = b.create<vector::BroadcastOp>(loc, singleElemVecType, data);
+
+        // Create a vector type with smaller elements for bitcasting
+        // vector<ratio x destType>
+        VectorType bitcastType = VectorType::get({ratio}, destElemType);
+        
+        // Bitcast the source data to the smaller element type
+        Value bitcastData = b.create<vector::BitCastOp>(loc, bitcastType, dataToBitcast);
+
+        // Create stores for each element
+        int64_t lastDim = coords.size() - 1;
+        Value baseLastCoord = coords[lastDim];
+        
+        for (unsigned i = 0; i < ratio; ++i) {
+          // Extract the i-th element from the bitcast vector
+          Value index = b.create<arith::ConstantIndexOp>(loc, i);
+          Value elem = b.create<vector::ExtractOp>(loc, bitcastData, index);
+          
+          // Calculate new coordinates: increment the last coordinate by i
+          SmallVector<Value> newCoords(coords.begin(), coords.end());
+          if (i > 0) {
+            Value offset = b.create<arith::ConstantIndexOp>(loc, i);
+            newCoords[lastDim] = b.create<arith::AddIOp>(loc, baseLastCoord, offset);
+          }
+          
+          // Create the store operation - use StoreOp for scalar elements
+          b.create<memref::StoreOp>(loc, elem, dest, newCoords);
+        }
+        
+        b.eraseOp(op);
+      } 
+      else {
+        return op.emitError("Source element type is larger than destination, but not a multiple of the destination element type");
+      }
     }
     return success();
   }

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -1359,7 +1359,11 @@ struct GlobalLoadToLDSRewritePattern
 
     Type originalLoadedType = op.getTransferType();
     PatternRewriter::InsertionGuard insertGuard(b);
-    if (asyncDirectToLDS && emitOobChecks && !useBufferOps) {
+    if (emitOobChecks && !useBufferOps) {
+      if (!asyncDirectToLDS) {
+        return op->emitError(
+            "If we need to emit OOB checks, we must use buffer ops");
+      }
       Value cond = valid;
       if (op.getCanReadOffEnd()) {
         Value fallsOffEnd = arith::CmpIOp::create(
@@ -1371,17 +1375,17 @@ struct GlobalLoadToLDSRewritePattern
       Block *thenBlock = guard.getBody(0);
       Block *elseBlock = guard.getBody(1);
 
-      // Build the then block: move the original operation
+      // Build the then block: move the GlobalLoadToLDSOp inside.
       b.moveOpBefore(op, thenBlock, thenBlock->begin());
 
-      // Build the else block: store zeros to the same destination location
+      // Build the else block: store zeros to the GlobalLoadToLDSOp destination.
       b.setInsertionPointToEnd(elseBlock);
       Type transferType = op.getTransferType();
       Value zeroValue = createZeroConstantOp(b, loc, transferType);
       InBoundsStoreOp::create(b, loc, zeroValue, dest, destCoords);
       scf::YieldOp::create(b, loc);
 
-      // sss
+      // Reset insertion point to the end of the then block.
       b.setInsertionPointToEnd(thenBlock);
     }
 

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -687,7 +687,7 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
   auto archInfo = rock::lookupArchInfo(arch.value());
 
   int64_t numValues = dstBufferType.getNumElements();
-  bool hwDirectToLDS128b, hwDirectToLDS32b;
+  bool hwDirectToLDS128b, hwDirectToLDS32b, hwAsyncDirectToLDS;
   if (isGlobalToLDS) {
     if (transforms.empty()) {
       return emitError(loc) << "transforms is empty";
@@ -701,12 +701,11 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
 
     auto features = archInfo.defaultFeatures;
     hwDirectToLDS128b =
-        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b) ||
-        isAsyncDirectToLDSSupported(arch.value());
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b);
     hwDirectToLDS32b =
-        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b) ||
-        isAsyncDirectToLDSSupported(arch.value());
-    if (!hwDirectToLDS128b && !hwDirectToLDS32b) {
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
+    hwAsyncDirectToLDS = isAsyncDirectToLDSSupported(arch.value());
+    if (!hwDirectToLDS128b && !hwDirectToLDS32b && !hwAsyncDirectToLDS) {
       return emitError(loc) << "Direct to LDS is not supported by the hardware";
     }
   }
@@ -862,7 +861,7 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
         assert(128 % dstBufferType.getElementTypeBitWidth() == 0);
         constantNumElements = 128 / dstBufferType.getElementTypeBitWidth();
         directToLDSType = b.getF128Type();
-        if (!hwDirectToLDS128b) {
+        if (!hwDirectToLDS128b && !hwAsyncDirectToLDS) {
           return emitError(loc)
                  << "128 bits direct to LDS is not supported by the hardware";
         }
@@ -870,7 +869,7 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
         assert(32 % dstBufferType.getElementTypeBitWidth() == 0);
         constantNumElements = 32 / dstBufferType.getElementTypeBitWidth();
         directToLDSType = b.getF32Type();
-        if (!hwDirectToLDS32b) {
+        if (!hwDirectToLDS32b && !hwAsyncDirectToLDS) {
           return emitError(loc)
                  << "32 bits direct to LDS is not supported by the hardware";
         }

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -683,15 +683,14 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
 
   auto arch = getArch(op);
   if (failed(arch))
-    return emitError(loc) << "can't get arch\n";
+    return emitError(loc) << "can't get arch";
   auto archInfo = rock::lookupArchInfo(arch.value());
 
   int64_t numValues = dstBufferType.getNumElements();
   bool hwDirectToLDS128b, hwDirectToLDS32b;
   if (isGlobalToLDS) {
     if (transforms.empty()) {
-      LLVM_DEBUG(llvm::dbgs() << "transforms is empty.\n");
-      return failure();
+      return emitError(loc) << "transforms is empty";
     }
     TransformMapAttr topMap = cast<TransformMapAttr>(transforms[0]);
     numValues = topMap.getUpperBounds().asArrayRef().back();
@@ -702,13 +701,11 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
 
     auto features = archInfo.defaultFeatures;
     hwDirectToLDS128b =
-        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b);
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b) || isAsyncDirectToLDSSupported(arch.value());
     hwDirectToLDS32b =
-        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b) || isAsyncDirectToLDSSupported(arch.value());
     if (!hwDirectToLDS128b && !hwDirectToLDS32b) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Direct to LDS is not supported by the hardware\n");
-      return failure();
+      return emitError(loc) << "Direct to LDS is not supported by the hardware";
     }
   }
 
@@ -864,20 +861,14 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
         constantNumElements = 128 / dstBufferType.getElementTypeBitWidth();
         directToLDSType = b.getF128Type();
         if (!hwDirectToLDS128b) {
-          LLVM_DEBUG(
-              llvm::dbgs()
-              << "128 bits direct to LDS is not supported by the hardware\n");
-          return failure();
+          return emitError(loc) << "128 bits direct to LDS is not supported by the hardware";          
         }
       } else {
         assert(32 % dstBufferType.getElementTypeBitWidth() == 0);
         constantNumElements = 32 / dstBufferType.getElementTypeBitWidth();
         directToLDSType = b.getF32Type();
         if (!hwDirectToLDS32b) {
-          LLVM_DEBUG(
-              llvm::dbgs()
-              << "32 bits direct to LDS is not supported by the hardware\n");
-          return failure();
+          return emitError(loc) << "32 bits direct to LDS is not supported by the hardware";
         }
       }
       assert(srcStride == constantNumElements);

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -883,6 +883,45 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
       // LDS index is wavefront-uniform as that is needed by load to LDS
       // instruction
       ldsIndex = arith::AddIOp::create(b, loc, ldsIndex, ldsIndexWave);
+
+      if (isAsyncDirectToLDSSupported(maybeArch.value())) {
+        // Whereas DirectToLDS works like a gather (where every thread will have
+        // the same output index), async DirectToLDS actually works like a
+        // traditional load, so we must take into account the thread-specific
+        // offset here.
+        if (loadTypeByteWidth == 16) {
+          assert(128 % dstBufferType.getElementTypeBitWidth() == 0);
+
+          Value waveTid = ldsCoords[2];
+          int64_t elementTypeBitWidth = dstBufferType.getElementTypeBitWidth();
+          // Calculate: tid * 16 * 8 / elementTypeBitWidth = tid * 128 /
+          // elementTypeBitWidth
+          Value tidMul128 = arith::MulIOp::create(
+              b, loc, waveTid, arith::ConstantIndexOp::create(b, loc, 128));
+          Value elementTypeBitWidthVal =
+              arith::ConstantIndexOp::create(b, loc, elementTypeBitWidth);
+          Value tidOffset = b.createOrFold<arith::DivUIOp>(
+              loc, tidMul128, elementTypeBitWidthVal);
+          ldsIndex = arith::AddIOp::create(b, loc, ldsIndex, tidOffset);
+        } else if (loadTypeByteWidth == 4) {
+          assert(32 % dstBufferType.getElementTypeBitWidth() == 0);
+
+          Value waveTid = ldsCoords[2];
+          int64_t elementTypeBitWidth = dstBufferType.getElementTypeBitWidth();
+          // Calculate: tid * 4 * 8 / elementTypeBitWidth = tid * 32 /
+          // elementTypeBitWidth
+          Value tidMul32 = arith::MulIOp::create(
+              b, loc, waveTid, arith::ConstantIndexOp::create(b, loc, 32));
+          Value elementTypeBitWidthVal =
+              arith::ConstantIndexOp::create(b, loc, elementTypeBitWidth);
+          Value tidOffset = b.createOrFold<arith::DivUIOp>(
+              loc, tidMul32, elementTypeBitWidthVal);
+          ldsIndex = arith::AddIOp::create(b, loc, ldsIndex, tidOffset);
+        } else {
+          llvm_unreachable("unsupported for now");
+        }
+      }
+
       GlobalLoadToLDSOp::create(b, loc, buffer, dest, validity, directToLDSType,
                                 loadLoop.getLowerCoords(/*domain=*/0),
                                 ValueRange{ldsIndex}, needs64BitIdx);

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -701,9 +701,11 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
 
     auto features = archInfo.defaultFeatures;
     hwDirectToLDS128b =
-        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b) || isAsyncDirectToLDSSupported(arch.value());
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b) ||
+        isAsyncDirectToLDSSupported(arch.value());
     hwDirectToLDS32b =
-        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b) || isAsyncDirectToLDSSupported(arch.value());
+        bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b) ||
+        isAsyncDirectToLDSSupported(arch.value());
     if (!hwDirectToLDS128b && !hwDirectToLDS32b) {
       return emitError(loc) << "Direct to LDS is not supported by the hardware";
     }
@@ -861,14 +863,16 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
         constantNumElements = 128 / dstBufferType.getElementTypeBitWidth();
         directToLDSType = b.getF128Type();
         if (!hwDirectToLDS128b) {
-          return emitError(loc) << "128 bits direct to LDS is not supported by the hardware";          
+          return emitError(loc)
+                 << "128 bits direct to LDS is not supported by the hardware";
         }
       } else {
         assert(32 % dstBufferType.getElementTypeBitWidth() == 0);
         constantNumElements = 32 / dstBufferType.getElementTypeBitWidth();
         directToLDSType = b.getF32Type();
         if (!hwDirectToLDS32b) {
-          return emitError(loc) << "32 bits direct to LDS is not supported by the hardware";
+          return emitError(loc)
+                 << "32 bits direct to LDS is not supported by the hardware";
         }
       }
       assert(srcStride == constantNumElements);

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -866,7 +866,7 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
   int64_t kPerBlock = tuningParams.getKpackPerBlock();
   int64_t mPerWave = tuningParams.getMPerWave();
   int64_t nPerWave = tuningParams.getNPerWave();
-  int64_t kPack = tuningParams.getKpack();  
+  int64_t kPack = tuningParams.getKpack();
   bool rotateDWithK = matrixParams.getRotateDWithK();
   bool ldsLayoutDxK = matrixParams.getLDSLayoutDxK();
 
@@ -888,7 +888,7 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
     kVec = kPack;
     kPerBlock *= kPack;
     assert(!rotateDWithK && "rotateDWithK must not be enabled for directToLds");
-  }                                 
+  }
 
   // Extract relevant derived parameters
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
@@ -906,16 +906,18 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
                             {blockSize, dRepeats, kIter * kVec});
   splitTid.merge({"wave_id", "lane_id"}, {0, 1}, "tid",
                  {blockSize / waveSize, waveSize});
+  splitTid.merge({"k_iter", "k_vec"}, {3, 4}, "k_iter", {kIter, kVec});
 
-  splitTid.passThrough({"d_iter", "k_iter"}, {2, 3}, {"d_iter", "k_iter"});
+  splitTid.passThrough({"d_iter"}, {2}, {"d_iter"});
   TransformMapAttr splitTidAttr = splitTid.get();
   transformAttrs.push_back(splitTidAttr);
 
   TopDownTMBuilder splitWaveId =
       TopDownTMBuilder::below(splitTid, splitTidAttr);
   splitWaveId.merge({"wave_m", "wave_n"}, {0, 1}, "wave_id", {mWaves, nWaves});
-  splitWaveId.passThrough({"lane_id", "d_iter", "k_iter"}, {2, 3, 4},
-                          {"lane_id", "d_iter", "k_iter"});
+  splitWaveId.passThrough({"lane_id", "d_iter", "k_iter", "k_vec"},
+                          {2, 3, 4, 5},
+                          {"lane_id", "d_iter", "k_iter", "k_vec"});
   TransformMapAttr splitWaveIdAttr = splitWaveId.get();
   transformAttrs.push_back(splitWaveIdAttr);
 

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -869,9 +869,11 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
   int64_t kPack = tuningParams.getKpack();
   bool rotateDWithK = matrixParams.getRotateDWithK();
   bool ldsLayoutDxK = matrixParams.getLDSLayoutDxK();
+  int64_t dPerThread = matrixParams.getInDPerThread();
 
   // Extract relevant emitter parameters
   int64_t kpackPerThread = accelEmitterParams.kpackPerThread;
+  int64_t kpackPerBlock = tuningParams.getKpackPerBlock();
   int64_t dRepeats = (dName == "m" ? accelEmitterParams.mRepeats
                                    : accelEmitterParams.nRepeats);
   int64_t dPerAccel = (dName == "m" ? accelEmitterParams.mPerAccel
@@ -889,6 +891,12 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
     kPerBlock *= kPack;
     assert(!rotateDWithK && "rotateDWithK must not be enabled for directToLds");
   }
+
+  llvm::errs() << "WmmaEmitter::wrapLDSBufferForLoad values:\n";
+  llvm::errs() << "- kPack: " << kPack << "\n";
+  llvm::errs() << "- kVec: " << kVec << "\n";
+  llvm::errs() << "- kpackPerBlock: " << kPerBlock << "\n";
+  llvm::errs() << "- kpackPerThread: " << kpackPerThread << "\n";
 
   // Extract relevant derived parameters
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
@@ -923,9 +931,9 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
 
   TopDownTMBuilder replicateLanes =
       TopDownTMBuilder::below(splitWaveId, splitWaveIdAttr);
-  replicateLanes.passThrough({"wave_m", "wave_n", "d_iter", "k_iter"},
-                             {0, 1, 4, 5},
-                             {"wave_m", "wave_n", "d_iter", "k_iter"});
+  replicateLanes.passThrough({"wave_m", "wave_n", "d_iter", "k_iter", "k_vec"},
+                             {0, 1, 4, 5, 6},
+                             {"wave_m", "wave_n", "d_iter", "k_iter", "k_vec"});
 
   replicateLanes.merge({"block_id", "block_td"}, {2, 3}, "lane_id",
                        {waveSize / dPerAccel, dPerAccel});
@@ -934,7 +942,13 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
 
   TopDownTMBuilder toLDSRowCol =
       TopDownTMBuilder::below(replicateLanes, replicateLanesAttr);
-  if (isGfx11) {
+  if (true) { // e.g., gfx1250
+    // d = d_i*dWaves*dPerAccel + wave_d*dPerAccel + lane_id
+    // toLDSRowCol.unmerge("d", 0, {"d_iter", thisWaveDim, "lane_id"},
+    //   {dRepeats, dWaves, dPerAccel});
+    toLDSRowCol.unmerge("k", 1, {"block_id", "k_iter"}, {kIter, kVec});
+  } else if (isGfx11) {
+    // assert(false && "not implemented!dd!!");
     toLDSRowCol.passThrough({"k"}, {1}, {"k_iter"});
     toLDSRowCol.ignore("block_id");
   } else {
@@ -948,17 +962,21 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
   TransformMapAttr toLDSRowColAttr = toLDSRowCol.get();
   transformAttrs.push_back(toLDSRowColAttr);
 
-  int64_t stride = (kPack == 1 ? matrixParams.getInDPerThread() : 1);
-  auto offset = rotateIf(matrixParams.getRotateDWithK(), toLDSRowCol,
-                         toLDSRowColAttr, stride, "d", dPerBlock, 0, "k",
-                         kPerBlock, {}, {"k"}, transformAttrs);
+  int64_t stride = (kPack == 1 ? dPerThread : 1);
+  auto offset =
+      rotateIf(rotateDWithK, toLDSRowCol, toLDSRowColAttr, stride, "d",
+               dPerBlock, 0, "k", kPerBlock, {}, {"k"}, transformAttrs);
 
-  if (ldsLayoutDxK)
+  // llvm::errs() << "offsetAttr 1: " << offset.get() << "\n";             
+  if (ldsLayoutDxK) {
+    llvm::errs() << "dPerBlock: " << dPerBlock << "\n";
+    llvm::errs() << "kPerBlock: " << kPerBlock << "\n";
     offset.unmerge("source_offset", 0, {"d", "k"}, {dPerBlock, kPerBlock});
-  else
+  } else
     offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
 
   TransformMapAttr offsetAttr = offset.get();
+  llvm::errs() << "offsetAttr 2: " << offset.get() << "\n";
   transformAttrs.push_back(offsetAttr);
 
   ArrayAttr ldsRead = b.getArrayAttr(transformAttrs);
@@ -971,6 +989,8 @@ WmmaEmitter::createAccelGemmOperandTransforms(
     ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
     int64_t dInCopyPerThread, StringRef dName, bool isKContiguousDim,
     bool rotateDWithK, bool doSplitKAcrossThreadsFirst) const {
+
+  assert(false && "not implemented!!");
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
   StringRef otherWaveDim = dName == "m" ? "wave_n" : "wave_m";
   StringRef thisBlockDim = dName == "m" ? "m_block" : "n_block";
@@ -1071,7 +1091,8 @@ WmmaEmitter::createAccelGemmOperandTransforms(
       toLDSRowCol.passThrough({"k_loop", "g_block"});
       toLDSRowCol.passThrough({thisBlockDim}, {2}, {thisBlockDim});
       toLDSRowCol.passThrough({"kpack"}, {3}, {"kpack"});
-      if (isGfx11) {
+      if (true) {
+        assert(false && "not implemented");
         toLDSRowCol.passThrough({"k"}, {5}, {"k_iter"});
         toLDSRowCol.ignore("block_id");
       } else {

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -866,12 +866,9 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
   int64_t kPerBlock = tuningParams.getKpackPerBlock();
   int64_t mPerWave = tuningParams.getMPerWave();
   int64_t nPerWave = tuningParams.getNPerWave();
-  int64_t kPack = tuningParams.getKpack();
-  // TODO: gfx10 supports directToLDS. Implement it.
-  assert(!matrixParams.getDirectToLDS() &&
-         "direct to LDS not supported for WMMA");
-  assert(!matrixParams.getLDSLayoutDxK() &&
-         "WMMA only supports LDS layout KxD for now");
+  int64_t kPack = tuningParams.getKpack();  
+  bool rotateDWithK = matrixParams.getRotateDWithK();
+  bool ldsLayoutDxK = matrixParams.getLDSLayoutDxK();
 
   // Extract relevant emitter parameters
   int64_t kpackPerThread = accelEmitterParams.kpackPerThread;
@@ -879,6 +876,19 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
                                    : accelEmitterParams.nRepeats);
   int64_t dPerAccel = (dName == "m" ? accelEmitterParams.mPerAccel
                                     : accelEmitterParams.nPerAccel);
+  int64_t kIter = kpackPerThread;
+  int64_t kVec = 1;
+  // Note that when directToLDS is disabled, we are loading vector<kpackxdtype>
+  // from LDS, so we load kpackPerThread. When directToLDS is enabled, we
+  // load vector<1xdtype>, so each thread will load kpackPerThread * kPack.
+  if (matrixParams.getDirectToLDS()) {
+    // kVec is kPack for directToLDS because as explained above, the
+    // non-directToLDS case, has a dtype=vector<kpackxdtype>. So, we need to
+    // handle both cases.
+    kVec = kPack;
+    kPerBlock *= kPack;
+    assert(!rotateDWithK && "rotateDWithK must not be enabled for directToLds");
+  }                                 
 
   // Extract relevant derived parameters
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
@@ -893,7 +903,7 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
   // Compute source offset as
   // sourceOffset = k_i * MN + (laneId % wmmaInputLen) + waveOffset * mn_i;
   TopDownTMBuilder splitTid(b, {"tid", "d_iter", "k_iter"},
-                            {blockSize, dRepeats, kpackPerThread});
+                            {blockSize, dRepeats, kIter * kVec});
   splitTid.merge({"wave_id", "lane_id"}, {0, 1}, "tid",
                  {blockSize / waveSize, waveSize});
 
@@ -927,7 +937,7 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
     toLDSRowCol.ignore("block_id");
   } else {
     toLDSRowCol.unmerge({"k"}, 1, {"block_id", "k_iter"},
-                        {wmmaInsn.outputStride, kpackPerThread});
+                        {wmmaInsn.outputStride, kIter * kVec});
   }
   toLDSRowCol.unmerge("d", 0, {"d_iter", thisWaveDim, "block_td"},
                       {dRepeats, dWaves, dPerAccel});
@@ -941,7 +951,10 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
                          toLDSRowColAttr, stride, "d", dPerBlock, 0, "k",
                          kPerBlock, {}, {"k"}, transformAttrs);
 
-  offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
+  if (ldsLayoutDxK)
+    offset.unmerge("source_offset", 0, {"d", "k"}, {dPerBlock, kPerBlock});
+  else
+    offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
 
   TransformMapAttr offsetAttr = offset.get();
   transformAttrs.push_back(offsetAttr);

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -873,7 +873,6 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
 
   // Extract relevant emitter parameters
   int64_t kpackPerThread = accelEmitterParams.kpackPerThread;
-  int64_t kpackPerBlock = tuningParams.getKpackPerBlock();
   int64_t dRepeats = (dName == "m" ? accelEmitterParams.mRepeats
                                    : accelEmitterParams.nRepeats);
   int64_t dPerAccel = (dName == "m" ? accelEmitterParams.mPerAccel
@@ -891,12 +890,6 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
     kPerBlock *= kPack;
     assert(!rotateDWithK && "rotateDWithK must not be enabled for directToLds");
   }
-
-  llvm::errs() << "WmmaEmitter::wrapLDSBufferForLoad values:\n";
-  llvm::errs() << "- kPack: " << kPack << "\n";
-  llvm::errs() << "- kVec: " << kVec << "\n";
-  llvm::errs() << "- kpackPerBlock: " << kPerBlock << "\n";
-  llvm::errs() << "- kpackPerThread: " << kpackPerThread << "\n";
 
   // Extract relevant derived parameters
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
@@ -942,18 +935,14 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
 
   TopDownTMBuilder toLDSRowCol =
       TopDownTMBuilder::below(replicateLanes, replicateLanesAttr);
-  if (true) { // e.g., gfx1250
-    // d = d_i*dWaves*dPerAccel + wave_d*dPerAccel + lane_id
-    // toLDSRowCol.unmerge("d", 0, {"d_iter", thisWaveDim, "lane_id"},
-    //   {dRepeats, dWaves, dPerAccel});
-    toLDSRowCol.unmerge("k", 1, {"block_id", "k_iter"}, {kIter, kVec});
-  } else if (isGfx11) {
-    // assert(false && "not implemented!dd!!");
-    toLDSRowCol.passThrough({"k"}, {1}, {"k_iter"});
+  if (isGfx11) {
+    // k = k_iter * k_vec
+    toLDSRowCol.unmerge({"k"}, 1, {"k_iter", "k_vec"}, {kIter, kVec});
     toLDSRowCol.ignore("block_id");
   } else {
-    toLDSRowCol.unmerge({"k"}, 1, {"block_id", "k_iter"},
-                        {wmmaInsn.outputStride, kIter * kVec});
+    // k = block_id * outputStride + k_iter * k_vec
+    toLDSRowCol.unmerge({"k"}, 1, {"block_id", "k_iter", "k_vec"},
+                        {wmmaInsn.outputStride, kIter, kVec});
   }
   toLDSRowCol.unmerge("d", 0, {"d_iter", thisWaveDim, "block_td"},
                       {dRepeats, dWaves, dPerAccel});
@@ -963,20 +952,16 @@ Value WmmaEmitter::wrapLDSBufferForLoad(
   transformAttrs.push_back(toLDSRowColAttr);
 
   int64_t stride = (kPack == 1 ? dPerThread : 1);
-  auto offset =
-      rotateIf(rotateDWithK, toLDSRowCol, toLDSRowColAttr, stride, "d",
-               dPerBlock, 0, "k", kPerBlock, {}, {"k"}, transformAttrs);
+  auto offset = rotateIf(matrixParams.getRotateDWithK(), toLDSRowCol,
+                         toLDSRowColAttr, stride, "d", dPerBlock, 0, "k",
+                         kPerBlock, {}, {"k"}, transformAttrs);
 
-  // llvm::errs() << "offsetAttr 1: " << offset.get() << "\n";             
-  if (ldsLayoutDxK) {
-    llvm::errs() << "dPerBlock: " << dPerBlock << "\n";
-    llvm::errs() << "kPerBlock: " << kPerBlock << "\n";
+  if (ldsLayoutDxK)
     offset.unmerge("source_offset", 0, {"d", "k"}, {dPerBlock, kPerBlock});
-  } else
+  else
     offset.unmerge("source_offset", 0, {"k", "d"}, {kPerBlock, dPerBlock});
 
   TransformMapAttr offsetAttr = offset.get();
-  llvm::errs() << "offsetAttr 2: " << offset.get() << "\n";
   transformAttrs.push_back(offsetAttr);
 
   ArrayAttr ldsRead = b.getArrayAttr(transformAttrs);
@@ -989,8 +974,6 @@ WmmaEmitter::createAccelGemmOperandTransforms(
     ArrayRef<int64_t> bidGridLengths, int64_t blockSize,
     int64_t dInCopyPerThread, StringRef dName, bool isKContiguousDim,
     bool rotateDWithK, bool doSplitKAcrossThreadsFirst) const {
-
-  assert(false && "not implemented!!");
   StringRef thisWaveDim = dName == "m" ? "wave_m" : "wave_n";
   StringRef otherWaveDim = dName == "m" ? "wave_n" : "wave_m";
   StringRef thisBlockDim = dName == "m" ? "m_block" : "n_block";
@@ -1091,8 +1074,7 @@ WmmaEmitter::createAccelGemmOperandTransforms(
       toLDSRowCol.passThrough({"k_loop", "g_block"});
       toLDSRowCol.passThrough({thisBlockDim}, {2}, {thisBlockDim});
       toLDSRowCol.passThrough({"kpack"}, {3}, {"kpack"});
-      if (true) {
-        assert(false && "not implemented");
+      if (isGfx11) {
         toLDSRowCol.passThrough({"k"}, {5}, {"k_iter"});
         toLDSRowCol.ignore("block_id");
       } else {

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -1209,13 +1209,12 @@ mlir::rock::getVectorDim(Location loc, Value matrix, Type elemType,
       // For direct to LDS, we will try if we can load 128b per thread first.
       // If not possible, we will try 32b. If not possible, we can't use direct
       // to LDS.
-      if (directToLDS128b || isAsyncDirectToLDSSupported(arch.value()))
+      if (directToLDS128b)
         maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
             matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack, 128,
             loc);
 
-      if (failed(maybeCopyDPerThread) &&
-          (directToLDS32b || isAsyncDirectToLDSSupported(arch.value())))
+      if (failed(maybeCopyDPerThread) && directToLDS32b)
         maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
             matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack, 32,
             loc);

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -1185,22 +1185,37 @@ mlir::rock::getVectorDim(Location loc, Value matrix, Type elemType,
         bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b);
     bool directToLDS32b =
         bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
-    assert(directToLDS128b || directToLDS32b || isAsyncDirectToLDSSupported(arch.value()));
-    // TODO: Differentiate between different async DirectToLDS byte widths. Right now, it will
-    // attempt to load 128b per thread first, and then 32b.
+    bool asyncDirectToLDS = isAsyncDirectToLDSSupported(arch.value());
+    if (!directToLDS128b && !directToLDS32b && !asyncDirectToLDS) {
+      return emitError(loc) << "direct to LDS is not supported by the hardware";
+    }
 
-    // For direct to LDS, we will try if we can load 128b per thread first.
-    // If not possible, we will try 32b. If not possible, we can't use direct to
-    // LDS.
-    if (directToLDS128b || isAsyncDirectToLDSSupported(arch.value()))
-      maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
-          matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack, 128,
-          loc);
+    if (asyncDirectToLDS) {
+      // For async direct to LDS, we support all load widths (8, 32, 64 and 128
+      // bits), so attempt to use all of them, sorted from highest to lowest.
+      for (int64_t loadWidth : {128, 64, 32, 8}) {
+        maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
+            matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack,
+            loadWidth, loc);
+        if (succeeded(maybeCopyDPerThread)) {
+          break;
+        }
+      }
+    } else {
+      // For direct to LDS, we will try if we can load 128b per thread first.
+      // If not possible, we will try 32b. If not possible, we can't use direct
+      // to LDS.
+      if (directToLDS128b || isAsyncDirectToLDSSupported(arch.value()))
+        maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
+            matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack, 128,
+            loc);
 
-    if (failed(maybeCopyDPerThread) && (directToLDS32b || isAsyncDirectToLDSSupported(arch.value())))
-      maybeCopyDPerThread =
-          computeCopyPerThreadDirectToLDS(matrix, elemType, copyPerThread,
-                                          kPerBlock, dPerBlock, kpack, 32, loc);
+      if (failed(maybeCopyDPerThread) &&
+          (directToLDS32b || isAsyncDirectToLDSSupported(arch.value())))
+        maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
+            matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack, 32,
+            loc);
+    }
   } else {
     maybeCopyDPerThread = computeCopyPerThread(
         elemType, copyPerThread, kPerBlock, dPerBlock, kpack, loc);

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -1032,7 +1032,9 @@ computeCopyPerThreadDirectToLDS(Value matrix, Type elementType,
   int64_t copyDPerThread = 0;
   // TODO: we need targetBits=96 if we want direct to LDS for f6
   if (targetBits % elementType.getIntOrFloatBitWidth() != 0) {
-    LLVM_DEBUG(llvm::dbgs() << "err1\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << targetBits << "%" << elementType.getIntOrFloatBitWidth()
+               << " != 0\n");
     return failure();
   }
 
@@ -1062,19 +1064,21 @@ computeCopyPerThreadDirectToLDS(Value matrix, Type elementType,
   // if the fastest dimension doesn't match inputDimLen. We can't use direct to
   // LDS.
   if (copyFastestDimPerThread != inputDimLen) {
-    LLVM_DEBUG(llvm::dbgs() << "err2: " << copyFastestDimPerThread << " != " << inputDimLen << "\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << copyFastestDimPerThread << " != " << inputDimLen << "\n");
     return failure();
   }
 
   if (copyKPerThread == 0 || copyDPerThread == 0) {
-    LLVM_DEBUG(llvm::dbgs() << "err3\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << copyKPerThread << " == 0 || " << copyDPerThread << " == 0\n");
     return failure();
   }
   if (kPerBlock < copyKPerThread || dPerBlock < copyDPerThread) {
-    LLVM_DEBUG(llvm::dbgs() << "err4\n");
+    LLVM_DEBUG(llvm::dbgs() << kPerBlock << " < " << copyKPerThread << " || "
+                            << dPerBlock << " < " << copyDPerThread << "\n");
     return failure();
   }
-  LLVM_DEBUG(llvm::dbgs() << "all good, success\n");
   return std::make_tuple(dim, copyKPerThread, copyDPerThread);
 }
 

--- a/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/loweringUtils.cpp
@@ -1031,8 +1031,10 @@ computeCopyPerThreadDirectToLDS(Value matrix, Type elementType,
   int64_t copyKPerThread = 0;
   int64_t copyDPerThread = 0;
   // TODO: we need targetBits=96 if we want direct to LDS for f6
-  if (targetBits % elementType.getIntOrFloatBitWidth() != 0)
+  if (targetBits % elementType.getIntOrFloatBitWidth() != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "err1\n");
     return failure();
+  }
 
   int64_t inputDimLen = targetBits / elementType.getIntOrFloatBitWidth();
 
@@ -1060,15 +1062,19 @@ computeCopyPerThreadDirectToLDS(Value matrix, Type elementType,
   // if the fastest dimension doesn't match inputDimLen. We can't use direct to
   // LDS.
   if (copyFastestDimPerThread != inputDimLen) {
+    LLVM_DEBUG(llvm::dbgs() << "err2: " << copyFastestDimPerThread << " != " << inputDimLen << "\n");
     return failure();
   }
 
   if (copyKPerThread == 0 || copyDPerThread == 0) {
+    LLVM_DEBUG(llvm::dbgs() << "err3\n");
     return failure();
   }
   if (kPerBlock < copyKPerThread || dPerBlock < copyDPerThread) {
+    LLVM_DEBUG(llvm::dbgs() << "err4\n");
     return failure();
   }
+  LLVM_DEBUG(llvm::dbgs() << "all good, success\n");
   return std::make_tuple(dim, copyKPerThread, copyDPerThread);
 }
 
@@ -1174,27 +1180,24 @@ mlir::rock::getVectorDim(Location loc, Value matrix, Type elemType,
     auto arch = getArch(matrix.getDefiningOp());
     if (failed(arch))
       return emitError(loc) << "can't get arch\n";
-    // TODO: Implement this for WMMA.
-    StringRef archValue = rock::getArchValue(matrix.getDefiningOp());
-    if (archValue.contains("gfx1250")) {
-      return emitError(loc) << "AsyncDirectToLDS is not implemented for WMMA";
-    }
     auto features = rock::lookupArchInfo(arch.value()).defaultFeatures;
     bool directToLDS128b =
         bitEnumContainsAll(features, GemmFeatures::direct_to_lds_128b);
     bool directToLDS32b =
         bitEnumContainsAll(features, GemmFeatures::direct_to_lds_32b);
-    assert(directToLDS128b || directToLDS32b);
+    assert(directToLDS128b || directToLDS32b || isAsyncDirectToLDSSupported(arch.value()));
+    // TODO: Differentiate between different async DirectToLDS byte widths. Right now, it will
+    // attempt to load 128b per thread first, and then 32b.
 
     // For direct to LDS, we will try if we can load 128b per thread first.
     // If not possible, we will try 32b. If not possible, we can't use direct to
     // LDS.
-    if (directToLDS128b)
+    if (directToLDS128b || isAsyncDirectToLDSSupported(arch.value()))
       maybeCopyDPerThread = computeCopyPerThreadDirectToLDS(
           matrix, elemType, copyPerThread, kPerBlock, dPerBlock, kpack, 128,
           loc);
 
-    if (failed(maybeCopyDPerThread) && directToLDS32b)
+    if (failed(maybeCopyDPerThread) && (directToLDS32b || isAsyncDirectToLDSSupported(arch.value())))
       maybeCopyDPerThread =
           computeCopyPerThreadDirectToLDS(matrix, elemType, copyPerThread,
                                           kPerBlock, dPerBlock, kpack, 32, loc);

--- a/mlir/test/Dialect/Rock/async_load_to_lds.mlir
+++ b/mlir/test/Dialect/Rock/async_load_to_lds.mlir
@@ -1,0 +1,4 @@
+// Check that we are generating async_load_to_lds
+
+// RUN: rocmlir-gen -g 3 -m 1024 -k 768 -n 1024 --transA=true --transB=true --transC=false -t f16 -perf_config=v3:64,64,8,32,32,8,1,4,2,1,1  --operation gemm --arch gfx1250 | rocmlir-driver -c --mlir-print-ir-after=rock-sugar-to-loops -o /dev/null 2>&1 | FileCheck %s
+// CHECK: amdgpu.async_load_to_lds

--- a/mlir/test/Dialect/Rock/async_wait_lowering.mlir
+++ b/mlir/test/Dialect/Rock/async_wait_lowering.mlir
@@ -1,21 +1,27 @@
-// RUN: rocmlir-opt %s --rock-to-rocdl
-func.func @async_wait_lowering() {
+// RUN: rocmlir-opt %s --rock-to-rocdl=chipset=gfx950 | FileCheck %s -check-prefix=GFX950
+// RUN: rocmlir-opt %s --rock-to-rocdl=chipset=gfx1250 | FileCheck %s -check-prefix=GFX1250
+llvm.func @async_wait_lowering() {
   // The waitcnt stores all counters in one i32 bits 15:14 and 3:0 store the vmcnt we have to wait on
-  // CHECK: rocdl.s.waitcnt -49168
-  // CHECK: rocdl.s.barrier
+  // GFX950: rocdl.s.waitcnt -49168
+  // GFX950: rocdl.s.barrier
+  // GFX1250: rocdl.s.wait.asynccnt 0
   rock.async_wait {numInst =  0 : i32}
-  // CHECK: rocdl.s.waitcnt -49167
-  // CHECK: rocdl.s.barrier
+  // GFX950: rocdl.s.waitcnt -49167
+  // GFX950: rocdl.s.barrier
+  // GFX1250: rocdl.s.wait.asynccnt 0
   rock.async_wait {numInst =  1 : i32}
-  // CHECK: rocdl.s.waitcnt -2
-  // CHECK: rocdl.s.barrier
+  // GFX950: rocdl.s.waitcnt -2
+  // GFX950: rocdl.s.barrier
+  // GFX1250: rocdl.s.wait.asynccnt 0
   rock.async_wait {numInst =  62 : i32}
-  // CHECK: rocdl.s.waitcnt -1
-  // CHECK: rocdl.s.barrier
+  // GFX950: rocdl.s.waitcnt -1
+  // GFX950: rocdl.s.barrier
+  // GFX1250: rocdl.s.wait.asynccnt 0
   rock.async_wait {numInst =  63 : i32}
   // Check that we clamp values > 63
-  // CHECK: rocdl.s.waitcnt -1
-  // CHECK: rocdl.s.barrier
+  // GFX950: rocdl.s.waitcnt -1
+  // GFX950: rocdl.s.barrier
+  // GFX1250: rocdl.s.wait.asynccnt 0
   rock.async_wait {numInst =  64 : i32}
-  return  
+  llvm.return
 }

--- a/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
@@ -119,4 +119,37 @@ func.func @load_4bit_boundary_case_to_lds_f4E2M1FN(%mem: memref<4294967295xf4E2M
     return
 }
 
+// CHECK-LABEL: func.func @load_conditionally_oob_checks
+// CHECK-SAME: (%[[mem:.*]]: memref<512xf16>)
+func.func @load_conditionally_oob_checks(%arg0: memref<512xf16>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
+  %c5 = arith.constant 5 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = rock.alloc() : memref<4096xf16, #gpu.address_space<workgroup>>
+  scf.for %arg3 = %c0 to %c5 step %c1 {
+    %1 = arith.index_cast %arg3 : index to i1
+    %2 = arith.addi %arg3, %arg3 : index
+    rock.global_load_to_lds %arg0[%arg3] -> %0[%2] if %1 {transferType = f128} : memref<512xf16> -> memref<4096xf16, #gpu.address_space<workgroup>>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @load_8bit_async_direct_to_lds
+// CHECK-SAME: (%[[mem:.*]]: memref<192xi8>)
+func.func @load_8bit_async_direct_to_lds(%mem: memref<192xi8>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
+    %c0 = arith.constant 0 : index
+    %true = arith.constant true
+    %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
+    %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<8xi8, #gpu.address_space<workgroup>>
+    // Test 8-bit (1-byte) load width for async direct to LDS
+    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+    // CHECK-SAME: #gpu.address_space<global>
+    // GFX942: amdgpu.gather_to_lds %[[cast]]
+    // GFX942-SAME: i8, memref<192xi8, #gpu.address_space<global>>, memref<8xi8, #gpu.address_space<workgroup>>
+    // GFX1250: amdgpu.async_load_to_lds %[[cast]]
+    // GFX1250-SAME: i8, memref<192xi8, #gpu.address_space<global>>, memref<8xi8, #gpu.address_space<workgroup>>
+    rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0] if %true {transferType = i8} : memref<192xi8> -> memref<8xi8, #gpu.address_space<workgroup>>
+    return
+}
+
 }

--- a/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_to_lds.mlir
@@ -126,30 +126,31 @@ func.func @load_conditionally_oob_checks(%arg0: memref<512xf16>) attributes {ker
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0 = rock.alloc() : memref<4096xf16, #gpu.address_space<workgroup>>
+  // Check that we generate a buffer_load for gfx950 and a global_load with oob checks for gfx1250
+  // GFX1250: %[[zerosvec:.*]] = arith.constant dense<0.000000e+00> : vector<1xf128>
+  // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
+  // CHECK-SAME: #gpu.address_space<global>
+  // GFX942: %[[fatBuff:.*]] = amdgpu.fat_raw_buffer_cast %[[cast]]
+  // GFX942-SAME: memref<512xf16, #gpu.address_space<global>> to memref<512xf16, #amdgpu.address_space<fat_raw_buffer>>
+  // CHECK: scf.for %[[index:.*]] = {{.*}}
   scf.for %arg3 = %c0 to %c5 step %c1 {
+    // CHECK: %[[cond:.*]] = arith.index_cast %[[index]] : index to i1
     %1 = arith.index_cast %arg3 : index to i1
     %2 = arith.addi %arg3, %arg3 : index
+    // GFX942: amdgpu.gather_to_lds %[[fatBuff]]
+    // GFX942-SAME: f128, memref<512xf16, #amdgpu.address_space<fat_raw_buffer>>, memref<4096xf16, #gpu.address_space<workgroup>>
+    // GFX1250: scf.if %[[cond]] {
+    // GFX1250:   amdgpu.async_load_to_lds %[[cast]]
+    // GFX1250-SAME: f128, memref<512xf16, #gpu.address_space<global>>, memref<4096xf16, #gpu.address_space<workgroup>>
+    // GFX1250: else {
+    // GFX1250:  %[[bitcast:.*]] = vector.bitcast %[[zerosvec]] : vector<1xf128> to vector<8xf16>
+    // GFX1250:  %[[extracted1:.*]] = vector.extract %[[bitcast]][0] : f16 from vector<8xf16>
+    // GFX1250:  memref.store %[[extracted1]], {{.*}} : memref<4096xf16, #gpu.address_space<workgroup>>
+    // GFX1250:  %[[extracted7:.*]] = vector.extract %[[bitcast]][7] : f16 from vector<8xf16>
+    // GFX1250:  memref.store %[[extracted7]], {{.*}} : memref<4096xf16, #gpu.address_space<workgroup>>
     rock.global_load_to_lds %arg0[%arg3] -> %0[%2] if %1 {transferType = f128} : memref<512xf16> -> memref<4096xf16, #gpu.address_space<workgroup>>
   }
   return
-}
-
-// CHECK-LABEL: func.func @load_8bit_async_direct_to_lds
-// CHECK-SAME: (%[[mem:.*]]: memref<192xi8>)
-func.func @load_8bit_async_direct_to_lds(%mem: memref<192xi8>) attributes {kernel, arch = "##TOKEN_ARCH##"} {
-    %c0 = arith.constant 0 : index
-    %true = arith.constant true
-    %lds = rock.alloc() : memref<64xi8, #gpu.address_space<workgroup>>
-    %lds_view = memref.view %lds[%c0][] : memref<64xi8, #gpu.address_space<workgroup>> to memref<8xi8, #gpu.address_space<workgroup>>
-    // Test 8-bit (1-byte) load width for async direct to LDS
-    // CHECK: %[[cast:.*]] = memref.memory_space_cast %[[mem]]
-    // CHECK-SAME: #gpu.address_space<global>
-    // GFX942: amdgpu.gather_to_lds %[[cast]]
-    // GFX942-SAME: i8, memref<192xi8, #gpu.address_space<global>>, memref<8xi8, #gpu.address_space<workgroup>>
-    // GFX1250: amdgpu.async_load_to_lds %[[cast]]
-    // GFX1250-SAME: i8, memref<192xi8, #gpu.address_space<global>>, memref<8xi8, #gpu.address_space<workgroup>>
-    rock.global_load_to_lds %mem[%c0] -> %lds_view[%c0] if %true {transferType = i8} : memref<192xi8> -> memref<8xi8, #gpu.address_space<workgroup>>
-    return
 }
 
 }

--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -89,6 +89,7 @@ if (ROCK_E2E_TEST_ENABLED)
   )
   list(APPEND CONFIGS
   GemmDirectToLDS
+  GemmAsyncDirectToLDS
   GemmDirectToLDSF4
   ConvDirectToLDS
   AttentionSchedule

--- a/mlir/test/e2e/GemmAsyncDirectToLDS.cfg
+++ b/mlir/test/e2e/GemmAsyncDirectToLDS.cfg
@@ -1,6 +1,8 @@
 if not config.arch.startswith("gfx1250"):
   config.unsupported = True
 
+# This is useful when running on the emulator, to propagate the environment variables
+# to the runner.
 import os
 
 for key, value in os.environ.items():

--- a/mlir/test/e2e/GemmAsyncDirectToLDS.cfg
+++ b/mlir/test/e2e/GemmAsyncDirectToLDS.cfg
@@ -1,0 +1,9 @@
+if not config.arch.startswith("gfx1250"):
+  config.unsupported = True
+
+import os
+
+for key, value in os.environ.items():
+  if key.startswith('LD_') or key.startswith('HSA_'):
+    print(f"Propagating {key} = {value}")
+    config.environment[key] = value

--- a/mlir/test/e2e/GemmAsyncDirectToLDS.toml
+++ b/mlir/test/e2e/GemmAsyncDirectToLDS.toml
@@ -32,4 +32,4 @@ prefix = "-perf_config="
 name = "async_load_to_lds_e2e"
 
 [[suite.test]]
-config = "-g 1 -m 1024 -k 768 -n 1024"
+config = "-g 1 -m 128 -k 128 -n 128"

--- a/mlir/test/e2e/GemmAsyncDirectToLDS.toml
+++ b/mlir/test/e2e/GemmAsyncDirectToLDS.toml
@@ -1,0 +1,35 @@
+directory = "GemmAsyncDirectToLDS"
+prefix = "rocmlir-gen"
+suffix = "--operation gemm --arch %arch %pv %random_data %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "transA"
+values = ["true", "false"]
+prefix = "--transA="
+
+[[axis]]
+name = "transB"
+values = ["true", "false"]
+prefix = "--transB="
+
+[[axis]]
+name = "transC"
+values = ["true", "false"]
+prefix = "--transC="
+
+[[axis]]
+name = "data type"
+values = ["f16"]
+prefix = "-t "
+
+[[axis]]
+name = "schedule_version"
+values = ["v3:64,64,8,32,32,8,1,4,2,1,1"]
+prefix = "-perf_config="
+
+## Async Load to LDS E2E tests
+[[suite]]
+name = "async_load_to_lds_e2e"
+
+[[suite.test]]
+config = "-g 1 -m 1024 -k 768 -n 1024"

--- a/mlir/test/e2e/GemmAsyncDirectToLDS.toml
+++ b/mlir/test/e2e/GemmAsyncDirectToLDS.toml
@@ -24,7 +24,7 @@ prefix = "-t "
 
 [[axis]]
 name = "schedule_version"
-values = ["v3:64,64,8,32,32,8,1,4,2,1,1"]
+values = ["v3:64,64,8,32,32,8,1,4,2,1,1", "v3:64,64,8,32,32,8,1,3,2,1,1"]
 prefix = "-perf_config="
 
 ## Async Load to LDS E2E tests
@@ -33,3 +33,9 @@ name = "async_load_to_lds_e2e"
 
 [[suite.test]]
 config = "-g 1 -m 128 -k 128 -n 128"
+
+[[suite.test]]
+config = "-g 1 -m 512 -k 1 -n 512"
+
+[[suite.test]]
+config = "-g 1 -m 512 -k 32 -n 512"


### PR DESCRIPTION
## Motivation

In #2072 we introduced support for async DirectToLDS for gfx1250. However, DirectToLDS is not supported for WMMA, so gfx1250 would still be unable to use async DirectToLDS. 

This PR implements it, plus other required features, in order to give full support for async DirectToLDS in gfx1250.

## Technical Details

This PR adds the following:
- Support for DirectToLDS for WMMA (gfx1250 is the only GPU available that can exploit it).
- Changed the way Async DirectToLDS loads from memory: Previously we assumed it behaved like a gather (i.e., like traditional DirectToLDS), but it actually works like a normal load, so we must take into account the thread ID when computing the destination indices for the op.
- Generate `WaitAsynccntOp` when lowering `rock::AsyncWaitOp`. Similarly to how `SWaitcntOp` is needed for traditional DirectToLDS, `WaitAsynccntOp` is required to wait for async load ops.
- Added support for out-of-bounds checks (`emitOobChecks`) in `GlobalLoadToLDS` lowering in SugarToLoops. The idea is to follow `GlobalLoad` lowering, however is not easy to do so.

### More details about the `emitOobChecks` support
1. We cannot reuse code from `GlobalLoad` lowering in `GlobalLoadToLDS` lowering because the ops have one radical difference: the former returns an SSA value with the result, whereas the latter does not. We might want to cleanup this in the future.
2. In the `else` condition that we generate when out-of-bound checks are needed, we have to store zeros into LDS. However, `GlobalLoadToLDS` has `transferType`, meaning that we might need to write multiple elements (e.g., if `transferType` is `f64` but LDS buffer is `f16`). My approach is to use `InBoundsStoreOp` and add support to such op to write multiple elements. Note that we might want to separate this into another PR.

## Test Plan

- Added E2E test (`GemmAsyncDirectToLDS`).
- Adapted LIT tests due to change in `rock::AsyncWaitOp` lowering.
- Added LIT test in `lowering_global_load_to_lds` to exercise the case of OOB checks.

## Test Result

All new E2E test pass on the emulator.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
