### PR TITLE
[rocmlir-tuning-driver] Add rotating buffers and inline instruction cache flush

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -18,6 +18,8 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Rock/IR/GetRockInfo.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
@@ -26,6 +28,7 @@
 #include "mlir/Dialect/Rock/Tuning/RockTuning.h"
 #include "mlir/Dialect/Rock/utility/fusionUtils.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
+// #include "mlir/IR/IRBuilder.h"
 #include "mlir/ExecutionEngine/RocmDeviceName.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -41,12 +44,17 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/Passes.h"
 
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/Program.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <atomic>
 #include <cassert>
@@ -298,6 +306,142 @@ struct CompilationResult {
   SmallVector<uint32_t> gridSizes;
 };
 
+// Insert instruction cache flush assembly at the beginning of kernel functions
+static LogicalResult insertInstructionCacheFlush(ModuleOp module) {
+  // The assembly string for instruction cache flush (from CacheFlush.cpp)
+  constexpr const char *icacheFlushAsm = "s_icache_inv\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t"
+                                         "s_nop 0\n\t";
+
+  MLIRContext *ctx = module.getContext();
+  OpBuilder builder(ctx);
+  bool foundAnyKernel = false;
+
+  // module.dump();
+  // llvm::outs() << "module.walk()\n";
+
+  // Walk through all LLVM functions that are kernels
+  // After backend pipeline, kernels should be in LLVM dialect
+  WalkResult result = module.walk([&](LLVM::LLVMFuncOp funcOp) -> WalkResult {
+    // Check if this is a kernel function
+    // Kernels are typically in GPU modules or have specific calling conventions
+    bool isKernel = funcOp->hasAttr("gpu.kernel") &&
+                    funcOp->getParentOfType<gpu::GPUModuleOp>();
+
+    // llvm::outs() << "funcOp: ";
+    // funcOp->dump();
+    // llvm::outs() << "funcOp->getParentOfType<gpu::GPUModuleOp>(): ";
+    // funcOp->getParentOfType<gpu::GPUModuleOp>()->dump();
+    // llvm::outs() << "funcOp.getCConv(): ";
+    // // funcOp.getCConv().dump();
+
+    if (!isKernel)
+      return WalkResult::advance();
+
+    foundAnyKernel = true;
+
+    // Get the entry block
+    if (funcOp.getBody().empty())
+      return WalkResult::advance();
+
+    Block *entryBlock = &funcOp.getBody().front();
+    if (entryBlock->empty())
+      return WalkResult::advance();
+
+    // Insert the inline assembly at the beginning of the entry block
+    builder.setInsertionPointToStart(entryBlock);
+
+    // Create LLVM inline assembly operation
+    // Format: llvm.inline_asm has_side_effects asm_string, constraints,
+    // operands For our case: no operands, no return value, just side effects
+    ValueRange emptyOperands;
+    auto asmDialectAttr =
+        LLVM::AsmDialectAttr::get(ctx, LLVM::AsmDialect::AD_ATT);
+    builder.create<LLVM::InlineAsmOp>(
+        funcOp.getLoc(),
+        /*resultTypes=*/TypeRange(LLVM::LLVMVoidType::get(ctx)),
+        /*operands=*/emptyOperands,
+        /*asm_string=*/icacheFlushAsm,
+        /*constraints=*/"",
+        /*has_side_effects=*/true,
+        /*is_align_stack=*/false,
+        /*tail_call_kind=*/LLVM::TailCallKind::None,
+        /*asm_dialect=*/asmDialectAttr,
+        /*operand_attrs=*/ArrayAttr());
+
+    return WalkResult::advance();
+  });
+
+  module.dump();
+  llvm::outs() << "module.walk()\n";
+
+  return foundAnyKernel ? success() : failure();
+}
+
+// Disassemble and print binary to verify inserted assembly
+static void printDisassembly(const std::string &binaryData,
+                             const std::string &kernelName) {
+  // Write binary to temporary file
+  int tempFd = -1;
+  llvm::SmallString<128> tempFilename;
+  if (llvm::sys::fs::createTemporaryFile("kernel", "hsaco", tempFd,
+                                         tempFilename)) {
+    llvm::errs() << "Failed to create temporary file for disassembly\n";
+    return;
+  }
+  llvm::FileRemover cleanup(tempFilename);
+
+  {
+    llvm::raw_fd_ostream tempOs(tempFd, true);
+    tempOs.write(binaryData.data(), binaryData.size());
+    tempOs.flush();
+  }
+
+  // Try to find llvm-objdump or rocm-objdump
+  llvm::ErrorOr<std::string> objdumpPath =
+      llvm::sys::findProgramByName("llvm-objdump");
+  if (!objdumpPath) {
+    objdumpPath = llvm::sys::findProgramByName("rocm-objdump");
+  }
+
+  if (!objdumpPath) {
+    llvm::errs()
+        << "Could not find llvm-objdump or rocm-objdump for disassembly\n";
+    return;
+  }
+
+  // Run objdump to disassemble
+  llvm::SmallVector<llvm::StringRef, 4> args;
+  args.push_back(*objdumpPath);
+  args.push_back("-d");                 // Disassemble
+  args.push_back("--arch-name=amdgcn"); // AMD GPU architecture
+  args.push_back(tempFilename);
+
+  llvm::outs() << "\n=== Disassembly for kernel: " << kernelName << " ===\n";
+  std::string errMsg;
+  int retCode = llvm::sys::ExecuteAndWait(*objdumpPath, args, std::nullopt, {},
+                                          0, 0, &errMsg);
+  if (retCode != 0) {
+    llvm::errs() << "Failed to disassemble binary: " << errMsg << "\n";
+  }
+  llvm::outs() << "=== End disassembly ===\n\n";
+}
+
 static LogicalResult measureSmallKernel(
     unsigned iterations, hipStream_t stream,
     const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
@@ -313,11 +457,6 @@ static LogicalResult measureSmallKernel(
     const std::vector<void *> &argPointers = argPointersSets[bufferSet];
 
     // 2. Flush caches.
-    if (!benchmarkMode) {
-      if (failed(flushInstructionCache(stream))) {
-        return failure();
-      }
-    }
     // We only do explicit L2 flush when we are not rotating buffers.
     if (numRotatingBuffers == 1) {
       if (failed(flushL2Cache(stream))) {
@@ -353,9 +492,6 @@ static LogicalResult measureLargeKernel(
     unsigned bufferSet = iter % numRotatingBuffers;
     const std::vector<void *> &argPointers = argPointersSets[bufferSet];
 
-    if (failed(flushInstructionCache(stream))) {
-      return failure();
-    }
     // We only do explicit L2 flush when we are not rotating buffers.
     if (numRotatingBuffers == 1) {
       if (failed(flushL2Cache(stream))) {
@@ -823,13 +959,31 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       PassManager threadApplicability(&threadCtx,
                                       PassManager::getAnyOpAnchorName(),
                                       PassManager::Nesting::Implicit);
-      PassManager threadCompilation(&threadCtx,
-                                    PassManager::getAnyOpAnchorName(),
-                                    PassManager::Nesting::Implicit);
+      PassManager threadKernelPipeline(&threadCtx,
+                                       PassManager::getAnyOpAnchorName(),
+                                       PassManager::Nesting::Implicit);
+      PassManager threadBackendPipelineLLVM(&threadCtx,
+                                            PassManager::getAnyOpAnchorName(),
+                                            PassManager::Nesting::Implicit);
+      PassManager threadBackendPipelineBinary(&threadCtx,
+                                              PassManager::getAnyOpAnchorName(),
+                                              PassManager::Nesting::Implicit);
 
       rock::buildKernelPipeline(threadApplicability, applicabilityOpts);
-      rock::buildKernelPipeline(threadCompilation, compilationKernOpts);
-      rock::buildBackendPipeline(threadCompilation, backendOpts);
+      rock::buildKernelPipeline(threadKernelPipeline, compilationKernOpts);
+
+      // Backend pipeline to generate LLVM IR (compile=false)
+      rock::BackendOptions backendOptsLLVM;
+      backendOptsLLVM.triple = backendOpts.triple;
+      backendOptsLLVM.chip = backendOpts.chip;
+      backendOptsLLVM.features = backendOpts.features;
+      backendOptsLLVM.optLevel = backendOpts.optLevel;
+      backendOptsLLVM.compile = false;
+      backendOptsLLVM.suppressDiagnostic = backendOpts.suppressDiagnostic;
+      rock::buildBackendPipeline(threadBackendPipelineLLVM, backendOptsLLVM);
+
+      // Backend pipeline to compile LLVM IR to binary (compile=true)
+      rock::buildBackendPipeline(threadBackendPipelineBinary, backendOpts);
 
       StringAttr perfConfigAttr =
           StringAttr::get(&threadCtx, result.perfConfig);
@@ -875,10 +1029,42 @@ static LogicalResult runTuningLoop(ModuleOp source) {
             tunedFunc->getAttrOfType<IntegerAttr>("grid_size").getInt());
       }
 
-      // Compilation
-      if (failed(threadCompilation.run(sourceCopy.get()))) {
+      // Run kernel pipeline first (lowers Rock to GPU/LLVM dialect)
+      if (failed(threadKernelPipeline.run(sourceCopy.get()))) {
         std::lock_guard<std::mutex> lock(outputMutex);
-        llvm::errs() << "Backend pipeline failed for config: "
+        llvm::errs() << "Kernel pipeline failed for config: "
+                     << result.perfConfig << "\n";
+        result.status = CompilationStatus::CompilationFailed;
+        compilationFailed.store(true, std::memory_order_relaxed);
+        return result;
+      }
+
+      // Run backend pipeline with compile=false to generate LLVM IR
+      if (failed(threadBackendPipelineLLVM.run(sourceCopy.get()))) {
+        std::lock_guard<std::mutex> lock(outputMutex);
+        llvm::errs() << "Backend pipeline (LLVM IR) failed for config: "
+                     << result.perfConfig << "\n";
+        result.status = CompilationStatus::CompilationFailed;
+        compilationFailed.store(true, std::memory_order_relaxed);
+        return result;
+      }
+
+      // Insert instruction cache flush assembly at the beginning of kernel
+      // functions This must be done after backend pipeline generates LLVM IR
+      if (failed(insertInstructionCacheFlush(sourceCopy.get()))) {
+        std::lock_guard<std::mutex> lock(outputMutex);
+        llvm::errs() << "Failed to insert instruction cache flush for config: "
+                     << result.perfConfig << "\n";
+        result.status = CompilationStatus::CompilationFailed;
+        compilationFailed.store(true, std::memory_order_relaxed);
+        return result;
+      }
+
+      // Run backend pipeline with compile=true to compile LLVM IR to binary
+      // (includes the inserted assembly)
+      if (failed(threadBackendPipelineBinary.run(sourceCopy.get()))) {
+        std::lock_guard<std::mutex> lock(outputMutex);
+        llvm::errs() << "Backend pipeline (binary) failed for config: "
                      << result.perfConfig << "\n";
         result.status = CompilationStatus::CompilationFailed;
         compilationFailed.store(true, std::memory_order_relaxed);
@@ -894,11 +1080,17 @@ static LogicalResult runTuningLoop(ModuleOp source) {
           compilationFailed.store(true, std::memory_order_relaxed);
           return result;
         }
-        result.hipModules.push_back(
-            cast<gpu::ObjectAttr>(binary.getObjects()[0])
-                .getObject()
-                .getValue()
-                .str());
+        std::string binaryData = cast<gpu::ObjectAttr>(binary.getObjects()[0])
+                                     .getObject()
+                                     .getValue()
+                                     .str();
+        result.hipModules.push_back(binaryData);
+
+        // Print disassembly to verify inserted assembly
+        {
+          std::lock_guard<std::mutex> lock(outputMutex);
+          printDisassembly(binaryData, fnName);
+        }
       }
 
       result.status = CompilationStatus::Success;

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -300,23 +300,24 @@ struct CompilationResult {
 
 static LogicalResult measureSmallKernel(
     unsigned iterations, hipStream_t stream,
-    ArrayRef<const std::vector<hipFunction_t>> functionsPerIteration,
-    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-    ArrayRef<std::vector<void *>> argPointersSets, unsigned numRotatingBuffers,
-    std::vector<double> &measurements, double &smallKernelCpuMs,
-    bool benchmarkMode) {
+    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
+    ArrayRef<uint32_t> gridSizes, ArrayRef<std::vector<void *>> argPointersSets,
+    unsigned numRotatingBuffers, std::vector<double> &measurements,
+    double &smallKernelCpuMs, bool benchmarkMode) {
   // Special case for small kernels, where we measure the time for all kernels
   // at once, using CPU timers.
   auto iterationStart = std::chrono::steady_clock::now();
   for (unsigned iter = 0; iter < iterations; ++iter) {
-    // 1. Select which buffer set and function set to use for this iteration.
+    // 1. Select which buffer set to use for this iteration.
     unsigned bufferSet = iter % numRotatingBuffers;
-    unsigned functionSet = iter % iterations;
     const std::vector<void *> &argPointers = argPointersSets[bufferSet];
-    const std::vector<hipFunction_t> &functions =
-        functionsPerIteration[functionSet];
 
     // 2. Flush caches.
+    if (!benchmarkMode) {
+      if (failed(flushInstructionCache(stream))) {
+        return failure();
+      }
+    }
     // We only do explicit L2 flush when we are not rotating buffers.
     if (numRotatingBuffers == 1) {
       if (failed(flushL2Cache(stream))) {
@@ -343,18 +344,14 @@ static LogicalResult measureSmallKernel(
 
 static LogicalResult measureLargeKernel(
     unsigned iterations, hipStream_t stream,
-    ArrayRef<const std::vector<hipFunction_t>> functionsPerIteration,
-    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-    ArrayRef<std::vector<void *>> argPointersSets, unsigned numRotatingBuffers,
-    std::vector<double> &measurements) {
+    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
+    ArrayRef<uint32_t> gridSizes, ArrayRef<std::vector<void *>> argPointersSets,
+    unsigned numRotatingBuffers, std::vector<double> &measurements) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {
-    // Select which buffer set and function set to use for this iteration
+    // Select which buffer set to use for this iteration
     unsigned bufferSet = iter % numRotatingBuffers;
-    unsigned functionSet = iter % iterations;
     const std::vector<void *> &argPointers = argPointersSets[bufferSet];
-    const std::vector<hipFunction_t> &functions =
-        functionsPerIteration[functionSet];
 
     if (failed(flushInstructionCache(stream))) {
       return failure();
@@ -427,67 +424,29 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   }
 
-  // Create multiple copies of kernel binaries (one per iteration) to avoid
-  // cache effects from reusing the same memory location
-  // We create enough copies for the maximum possible iterations (iterations can
-  // be increased after warmup, so we use a reasonable maximum)
-  unsigned initialIterations = params.numIterations;
-  constexpr unsigned maxIterations = 100; // Reasonable maximum
-  unsigned maxPossibleIterations = std::max(initialIterations, maxIterations);
-
-  std::vector<std::vector<char>> binaryCopies;
-  binaryCopies.reserve(binaries.size() * maxPossibleIterations);
-  for (unsigned iter = 0; iter < maxPossibleIterations; ++iter) {
-    for (const std::string &binary : binaries) {
-      // Create a copy of the binary in a new memory location
-      std::vector<char> binaryCopy(binary.begin(), binary.end());
-      binaryCopies.push_back(std::move(binaryCopy));
-    }
-  }
-
-  // Load all module copies (one set per iteration, up to maxPossibleIterations)
-  std::vector<std::vector<hipModule_t>> modulesPerIteration;
-  std::vector<std::vector<hipFunction_t>> functionsPerIteration;
-  modulesPerIteration.reserve(maxPossibleIterations);
-  functionsPerIteration.reserve(maxPossibleIterations);
-
+  // Load all modules once to reduce overhead
+  std::vector<hipModule_t> modules;
+  std::vector<hipFunction_t> functions;
   auto moduleCleanup = llvm::make_scope_exit([&]() {
-    for (auto &modules : modulesPerIteration) {
-      for (hipModule_t mod : modules) {
-        if (!mod)
-          continue;
-        hipError_t status = hipModuleUnload(mod);
-        if (status != hipSuccess) {
-          llvm::errs() << "HIP error in hipModuleUnload: "
-                       << hipGetErrorString(status) << "\n";
-        }
+    for (hipModule_t mod : modules) {
+      if (!mod)
+        continue;
+      hipError_t status = hipModuleUnload(mod);
+      if (status != hipSuccess) {
+        llvm::errs() << "HIP error in hipModuleUnload: "
+                     << hipGetErrorString(status) << "\n";
       }
     }
   });
 
-  // Load modules and functions for each iteration
-  for (unsigned iter = 0; iter < maxPossibleIterations; ++iter) {
-    std::vector<hipModule_t> modules;
-    std::vector<hipFunction_t> functions;
-    modules.reserve(funcNames.size());
-    functions.reserve(funcNames.size());
+  for (auto [binary, funcName] : llvm::zip(binaries, funcNames)) {
+    hipModule_t mod;
+    HIPCHECK(hipModuleLoadData(&mod, binary.c_str()));
+    modules.push_back(mod);
 
-    for (size_t funcIdx = 0; funcIdx < funcNames.size(); ++funcIdx) {
-      size_t binaryCopyIdx = iter * funcNames.size() + funcIdx;
-      const std::vector<char> &binaryCopy = binaryCopies[binaryCopyIdx];
-      const std::string &funcName = funcNames[funcIdx];
-
-      hipModule_t mod;
-      HIPCHECK(hipModuleLoadData(&mod, binaryCopy.data()));
-      modules.push_back(mod);
-
-      hipFunction_t func;
-      HIPCHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
-      functions.push_back(func);
-    }
-
-    modulesPerIteration.push_back(std::move(modules));
-    functionsPerIteration.push_back(std::move(functions));
+    hipFunction_t func;
+    HIPCHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
+    functions.push_back(func);
   }
 
   // Sleep guard to avoid GPU throttling
@@ -512,20 +471,12 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   }
 
   bool isSmallKernel = false;
-  unsigned iterations = initialIterations;
+  unsigned iterations = params.numIterations;
 
   // We need at least as many iterations as we have rotating buffers.
   if (iterations < numBufferSets) {
     llvm::errs()
         << "numIterations must be greater than or equal to numBufferSets\n";
-    return failure();
-  }
-
-  // Ensure we don't exceed the maximum number of iterations we prepared for
-  if (iterations > maxPossibleIterations) {
-    llvm::errs() << "Requested iterations (" << iterations
-                 << ") exceeds maximum prepared iterations ("
-                 << maxPossibleIterations << ")\n";
     return failure();
   }
 
@@ -535,16 +486,12 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     // not.
     double totalMillisecondsWarmup = 0.0;
     for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
-      // Select which buffer set and function set to use for this warmup
-      // iteration
+      // Select which buffer set to use for this warmup iteration
       unsigned bufferSet = iter % numBufferSets;
-      unsigned functionSet = iter % iterations;
       const std::vector<void *> &warmupArgPointers = argPointersSets[bufferSet];
-      const std::vector<hipFunction_t> &warmupFunctions =
-          functionsPerIteration[functionSet];
 
       for (auto [func, blockSize, gridSize] :
-           llvm::zip(warmupFunctions, blockSizes, gridSizes)) {
+           llvm::zip(functions, blockSizes, gridSizes)) {
         hipEvent_t startEvent, stopEvent;
         HIPCHECK(hipEventCreate(&startEvent));
         HIPCHECK(hipEventCreate(&stopEvent));
@@ -574,19 +521,9 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     // (counting all iterations), so increase the number of iterations
     // if necessary.
     constexpr float minTotalMilliseconds = 1.0f;
-    unsigned newIterations = std::max<unsigned>(
+    iterations = std::max<unsigned>(
         iterations, static_cast<unsigned>(std::ceil(minTotalMilliseconds /
                                                     totalMillisecondsWarmup)));
-
-    // Ensure we don't exceed the maximum number of iterations we prepared for
-    if (newIterations > maxPossibleIterations) {
-      llvm::errs() << "Computed iterations (" << newIterations
-                   << ") exceeds maximum prepared iterations ("
-                   << maxPossibleIterations << "). Limiting to maximum.\n";
-      iterations = maxPossibleIterations;
-    } else {
-      iterations = newIterations;
-    }
 
     // Depending on the runtime of the kernel,
     // we will use a different approach to measure the runs.
@@ -602,16 +539,16 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
   if (isSmallKernel) {
     llvm::errs() << "Running small kernel\n";
-    if (failed(measureSmallKernel(iterations, stream, functionsPerIteration,
-                                  blockSizes, gridSizes, argPointersSets,
-                                  numBufferSets, measurements, smallKernelCpuMs,
+    if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
+                                  gridSizes, argPointersSets, numBufferSets,
+                                  measurements, smallKernelCpuMs,
                                   benchmarkMode)))
       return failure();
   } else {
     llvm::errs() << "Running large kernel\n";
-    if (failed(measureLargeKernel(iterations, stream, functionsPerIteration,
-                                  blockSizes, gridSizes, argPointersSets,
-                                  numBufferSets, measurements)))
+    if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
+                                  gridSizes, argPointersSets, numBufferSets,
+                                  measurements)))
       return failure();
   }
 

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -160,6 +160,11 @@ static llvm::cl::opt<unsigned> numCompileThreads(
     llvm::cl::desc("Number of parallel compilation threads (0 = auto)"),
     llvm::cl::value_desc("thread count"), llvm::cl::init(0));
 
+static llvm::cl::opt<unsigned> numRotatingBuffers(
+    "num-rotating-buffers",
+    llvm::cl::desc("Number of rotating buffers to use for benchmarking"),
+    llvm::cl::value_desc("number of buffers"), llvm::cl::init(5));
+
 // Ripped out of JitRunner.cpp
 static OwningOpRef<ModuleOp> parseMLIRInput(StringRef inputFilename,
                                             MLIRContext *context) {
@@ -276,6 +281,7 @@ struct BenchmarkParams {
   rock::TuningParamSetKind tuningSpaceKind;
   const unsigned numCompileThreads;
   std::string benchmarkConfig;
+  unsigned numRotatingBuffers;
 };
 
 enum class CompilationStatus {
@@ -296,23 +302,37 @@ static LogicalResult
 measureSmallKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   std::vector<void *> &argPointers,
+                   MutableArrayRef<void *> gpuBuffers, unsigned numArgs,
+                   unsigned numRotatingBuffers,
                    std::vector<double> &measurements, double &smallKernelCpuMs,
                    bool benchmarkMode) {
   // Special case for small kernels, where we measure the time for all kernels
   // at once, using CPU timers.
   auto iterationStart = std::chrono::steady_clock::now();
   for (unsigned iter = 0; iter < iterations; ++iter) {
-    // Do not flush caches in benchmark mode, as we do not want to
-    // time the cache flush (it's okay if we are running in tuning mode).
-    if (!benchmarkMode) {
-      if (failed(flushInstructionCache(stream))) {
-        return failure();
-      }
+    // 1. Select which buffer set to use for this iteration.
+    unsigned bufferSet = iter % numRotatingBuffers;
+
+    // Build argPointers for this buffer set
+    std::vector<void *> argPointers;
+    argPointers.reserve(numArgs);
+    for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
+      size_t bufferIdx = bufferSet * numArgs + argIdx;
+      argPointers.push_back(reinterpret_cast<void *>(&gpuBuffers[bufferIdx]));
+    }
+
+    // 2. Flush instruction cache.
+    if (failed(flushInstructionCache(stream))) {
+      return failure();
+    }
+    // We only do explicit L2 flush when we are not rotating buffers.
+    if (numRotatingBuffers == 1) {
       if (failed(flushL2Cache(stream))) {
         return failure();
       }
     }
+
+    // 3. Launch the actualkernels.
     for (auto [func, blockSize, gridSize] :
          llvm::zip(functions, blockSizes, gridSizes)) {
       HIPCHECK(hipExtModuleLaunchKernel(
@@ -333,15 +353,30 @@ static LogicalResult
 measureLargeKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   std::vector<void *> &argPointers,
+                   MutableArrayRef<void *> gpuBuffers, unsigned numArgs,
+                   unsigned numRotatingBuffers,
                    std::vector<double> &measurements) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {
+    // Select which buffer set to use for this iteration
+    unsigned bufferSet = iter % numRotatingBuffers;
+
+    // Build argPointers for this buffer set
+    std::vector<void *> argPointers;
+    argPointers.reserve(numArgs);
+    for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
+      size_t bufferIdx = bufferSet * numArgs + argIdx;
+      argPointers.push_back(reinterpret_cast<void *>(&gpuBuffers[bufferIdx]));
+    }
+
     if (failed(flushInstructionCache(stream))) {
       return failure();
     }
-    if (failed(flushL2Cache(stream))) {
-      return failure();
+    // We only do explicit L2 flush when we are not rotating buffers.
+    if (numRotatingBuffers == 1) {
+      if (failed(flushL2Cache(stream))) {
+        return failure();
+      }
     }
 
     double totalMilliseconds = 0.0;
@@ -391,16 +426,17 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
-  // Initialize device buffers
-  for (size_t i = 0; i < bufferSizes.size(); i++) {
-    HIPCHECK(hipMemcpyAsync(gpuBuffers[i], hostBuffers[i], bufferSizes[i],
-                            hipMemcpyHostToDevice, stream));
-  }
-
-  // HIP wants an array of pointers to each argument
-  std::vector<void *> argPointers;
-  for (void *&item : gpuBuffers) {
-    argPointers.push_back(reinterpret_cast<void *>(&item));
+  // Initialize all rotating device buffers
+  // Buffer layout: [arg0_set0, arg1_set0, ..., argM-1_set0, arg0_set1, ...]
+  unsigned numArgs = bufferSizes.size();
+  unsigned numBufferSets = params.numRotatingBuffers;
+  for (unsigned bufferSet = 0; bufferSet < numBufferSets; ++bufferSet) {
+    for (size_t argIdx = 0; argIdx < numArgs; ++argIdx) {
+      size_t bufferIdx = bufferSet * numArgs + argIdx;
+      HIPCHECK(hipMemcpyAsync(gpuBuffers[bufferIdx], hostBuffers[argIdx],
+                              bufferSizes[argIdx], hipMemcpyHostToDevice,
+                              stream));
+    }
   }
 
   // Load all modules once to reduce overhead
@@ -438,12 +474,31 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   bool isSmallKernel = false;
   unsigned iterations = params.numIterations;
 
+  // We need at least as many iterations as we have rotating buffers.
+  if (iterations < numBufferSets) {
+    llvm::errs()
+        << "numIterations must be greater than or equal to numBufferSets\n";
+    return failure();
+  }
+
   if (params.warmupIterations > 0) {
     // Warmup run. We measure the warmup to get an estimate of the kernel
     // runtime. We will use this estimate to determine if the kernel is small or
     // not.
     double totalMillisecondsWarmup = 0.0;
     for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
+      // Select which buffer set to use for this warmup iteration
+      unsigned bufferSet = iter % numBufferSets;
+
+      // Build argPointers for this buffer set
+      std::vector<void *> warmupArgPointers;
+      warmupArgPointers.reserve(numArgs);
+      for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
+        size_t bufferIdx = bufferSet * numArgs + argIdx;
+        warmupArgPointers.push_back(
+            reinterpret_cast<void *>(&gpuBuffers[bufferIdx]));
+      }
+
       for (auto [func, blockSize, gridSize] :
            llvm::zip(functions, blockSizes, gridSizes)) {
         hipEvent_t startEvent, stopEvent;
@@ -452,7 +507,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
         HIPCHECK(hipExtModuleLaunchKernel(
             func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-            argPointers.data(), nullptr, startEvent, stopEvent));
+            warmupArgPointers.data(), nullptr, startEvent, stopEvent));
 
         HIPCHECK(hipStreamSynchronize(stream));
 
@@ -492,12 +547,14 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
   if (isSmallKernel) {
     if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, argPointers, measurements,
-                                  smallKernelCpuMs, benchmarkMode)))
+                                  gridSizes, gpuBuffers, numArgs, numBufferSets,
+                                  measurements, smallKernelCpuMs,
+                                  benchmarkMode)))
       return failure();
   } else {
     if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, argPointers, measurements)))
+                                  gridSizes, gpuBuffers, numArgs, numBufferSets,
+                                  measurements)))
       return failure();
   }
 
@@ -657,19 +714,30 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   });
   assert(argTypes.size() == bufferLengths.size() &&
          "number of arguments and buffer lengths must match");
+
+  // Allocate host buffers (one per argument)
   for (auto [argType, bufferLength] : llvm::zip(argTypes, bufferLengths)) {
     benchmark::DataType type = getDataType(getElementTypeOrSelf(argType));
     void *hostBuffer = benchmark::allocAndFill(type, bufferLength);
-    void *gpuBuffer = nullptr;
-    hipError_t hipStatus = hipMalloc(&gpuBuffer, bufferLength);
-    if (hipStatus != hipSuccess) {
-      free(hostBuffer);
-      llvm::errs() << "HIP error in hipMalloc(gpuBuffer): "
-                   << hipGetErrorString(hipStatus) << "\n";
-      return failure();
-    }
     hostBuffers.push_back(hostBuffer);
-    gpuBuffers.push_back(gpuBuffer);
+  }
+
+  // Allocate rotating GPU buffers (N copies of each buffer)
+  // Buffer layout: [arg0_set0, arg1_set0, ..., argM-1_set0, arg0_set1, ...]
+  unsigned numArgs = argTypes.size();
+  unsigned numBufferSets = numRotatingBuffers;
+  for (unsigned bufferSet = 0; bufferSet < numBufferSets; ++bufferSet) {
+    for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
+      size_t bufferLength = bufferLengths[argIdx];
+      void *gpuBuffer = nullptr;
+      hipError_t hipStatus = hipMalloc(&gpuBuffer, bufferLength);
+      if (hipStatus != hipSuccess) {
+        llvm::errs() << "HIP error in hipMalloc(gpuBuffer): "
+                     << hipGetErrorString(hipStatus) << "\n";
+        return failure();
+      }
+      gpuBuffers.push_back(gpuBuffer);
+    }
   }
 
   // 4. Multi-iteration tuning loop
@@ -681,7 +749,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   const BenchmarkParams benchmarkParams = {
       numIterations,     warmupIterations, useMedian,           trimPercent,
       sleepUs,           showStats,        showAllMeasurements, tuningSpaceKind,
-      numCompileThreads, benchmarkConfig};
+      numCompileThreads, benchmarkConfig,  numRotatingBuffers};
 
   unsigned numTuningIterations =
       rock::getNumberOfIterations(benchmarkParams.tuningSpaceKind);

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -601,14 +601,12 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   double smallKernelCpuMs = 0.0;
 
   if (isSmallKernel) {
-    llvm::errs() << "Running small kernel\n";
     if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
                                   gridSizes, argPointersSets, numBufferSets,
                                   measurements, smallKernelCpuMs,
                                   benchmarkMode)))
       return failure();
   } else {
-    llvm::errs() << "Running large kernel\n";
     if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
                                   gridSizes, argPointersSets, numBufferSets,
                                   measurements)))

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -298,32 +298,25 @@ struct CompilationResult {
   SmallVector<uint32_t> gridSizes;
 };
 
-static LogicalResult
-measureSmallKernel(unsigned iterations, hipStream_t stream,
-                   const std::vector<hipFunction_t> &functions,
-                   ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   MutableArrayRef<void *> gpuBuffers, unsigned numArgs,
-                   unsigned numRotatingBuffers,
-                   std::vector<double> &measurements, double &smallKernelCpuMs,
-                   bool benchmarkMode) {
+static LogicalResult measureSmallKernel(
+    unsigned iterations, hipStream_t stream,
+    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
+    ArrayRef<uint32_t> gridSizes, ArrayRef<std::vector<void *>> argPointersSets,
+    unsigned numRotatingBuffers, std::vector<double> &measurements,
+    double &smallKernelCpuMs, bool benchmarkMode) {
   // Special case for small kernels, where we measure the time for all kernels
   // at once, using CPU timers.
   auto iterationStart = std::chrono::steady_clock::now();
   for (unsigned iter = 0; iter < iterations; ++iter) {
     // 1. Select which buffer set to use for this iteration.
     unsigned bufferSet = iter % numRotatingBuffers;
+    const std::vector<void *> &argPointers = argPointersSets[bufferSet];
 
-    // Build argPointers for this buffer set
-    std::vector<void *> argPointers;
-    argPointers.reserve(numArgs);
-    for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
-      size_t bufferIdx = bufferSet * numArgs + argIdx;
-      argPointers.push_back(reinterpret_cast<void *>(&gpuBuffers[bufferIdx]));
-    }
-
-    // 2. Flush instruction cache.
-    if (failed(flushInstructionCache(stream))) {
-      return failure();
+    // 2. Flush caches.
+    if (!benchmarkMode) {
+      if (failed(flushInstructionCache(stream))) {
+        return failure();
+      }
     }
     // We only do explicit L2 flush when we are not rotating buffers.
     if (numRotatingBuffers == 1) {
@@ -337,7 +330,7 @@ measureSmallKernel(unsigned iterations, hipStream_t stream,
          llvm::zip(functions, blockSizes, gridSizes)) {
       HIPCHECK(hipExtModuleLaunchKernel(
           func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-          argPointers.data(), nullptr, nullptr, nullptr));
+          const_cast<void **>(argPointers.data()), nullptr, nullptr, nullptr));
     }
   }
 
@@ -349,25 +342,16 @@ measureSmallKernel(unsigned iterations, hipStream_t stream,
   return success();
 }
 
-static LogicalResult
-measureLargeKernel(unsigned iterations, hipStream_t stream,
-                   const std::vector<hipFunction_t> &functions,
-                   ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   MutableArrayRef<void *> gpuBuffers, unsigned numArgs,
-                   unsigned numRotatingBuffers,
-                   std::vector<double> &measurements) {
+static LogicalResult measureLargeKernel(
+    unsigned iterations, hipStream_t stream,
+    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
+    ArrayRef<uint32_t> gridSizes, ArrayRef<std::vector<void *>> argPointersSets,
+    unsigned numRotatingBuffers, std::vector<double> &measurements) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {
     // Select which buffer set to use for this iteration
     unsigned bufferSet = iter % numRotatingBuffers;
-
-    // Build argPointers for this buffer set
-    std::vector<void *> argPointers;
-    argPointers.reserve(numArgs);
-    for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
-      size_t bufferIdx = bufferSet * numArgs + argIdx;
-      argPointers.push_back(reinterpret_cast<void *>(&gpuBuffers[bufferIdx]));
-    }
+    const std::vector<void *> &argPointers = argPointersSets[bufferSet];
 
     if (failed(flushInstructionCache(stream))) {
       return failure();
@@ -387,9 +371,10 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
       HIPCHECK(hipEventCreate(&startEvent));
       HIPCHECK(hipEventCreate(&stopEvent));
 
-      HIPCHECK(hipExtModuleLaunchKernel(
-          func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-          argPointers.data(), nullptr, startEvent, stopEvent));
+      HIPCHECK(hipExtModuleLaunchKernel(func, gridSize * blockSize, 1, 1,
+                                        blockSize, 1, 1, 0, stream,
+                                        const_cast<void **>(argPointers.data()),
+                                        nullptr, startEvent, stopEvent));
       HIPCHECK(hipEventSynchronize(stopEvent));
 
       float currentMilliseconds = 0.0;
@@ -471,6 +456,20 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
+  // Pre-build argPointers for all buffer sets (reused for warmup and
+  // measurement)
+  std::vector<std::vector<void *>> argPointersSets;
+  argPointersSets.reserve(numBufferSets);
+  for (unsigned bufferSet = 0; bufferSet < numBufferSets; ++bufferSet) {
+    std::vector<void *> argPointers;
+    argPointers.reserve(numArgs);
+    for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
+      size_t bufferIdx = bufferSet * numArgs + argIdx;
+      argPointers.push_back(reinterpret_cast<void *>(&gpuBuffers[bufferIdx]));
+    }
+    argPointersSets.push_back(std::move(argPointers));
+  }
+
   bool isSmallKernel = false;
   unsigned iterations = params.numIterations;
 
@@ -489,15 +488,7 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
       // Select which buffer set to use for this warmup iteration
       unsigned bufferSet = iter % numBufferSets;
-
-      // Build argPointers for this buffer set
-      std::vector<void *> warmupArgPointers;
-      warmupArgPointers.reserve(numArgs);
-      for (unsigned argIdx = 0; argIdx < numArgs; ++argIdx) {
-        size_t bufferIdx = bufferSet * numArgs + argIdx;
-        warmupArgPointers.push_back(
-            reinterpret_cast<void *>(&gpuBuffers[bufferIdx]));
-      }
+      const std::vector<void *> &warmupArgPointers = argPointersSets[bufferSet];
 
       for (auto [func, blockSize, gridSize] :
            llvm::zip(functions, blockSizes, gridSizes)) {
@@ -507,7 +498,8 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
         HIPCHECK(hipExtModuleLaunchKernel(
             func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
-            warmupArgPointers.data(), nullptr, startEvent, stopEvent));
+            const_cast<void **>(warmupArgPointers.data()), nullptr, startEvent,
+            stopEvent));
 
         HIPCHECK(hipStreamSynchronize(stream));
 
@@ -546,14 +538,16 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   double smallKernelCpuMs = 0.0;
 
   if (isSmallKernel) {
+    llvm::errs() << "Running small kernel\n";
     if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, gpuBuffers, numArgs, numBufferSets,
+                                  gridSizes, argPointersSets, numBufferSets,
                                   measurements, smallKernelCpuMs,
                                   benchmarkMode)))
       return failure();
   } else {
+    llvm::errs() << "Running large kernel\n";
     if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, gpuBuffers, numArgs, numBufferSets,
+                                  gridSizes, argPointersSets, numBufferSets,
                                   measurements)))
       return failure();
   }

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -49,12 +49,8 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/Program.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <atomic>
 #include <cassert>
@@ -332,23 +328,10 @@ static LogicalResult insertInstructionCacheFlush(ModuleOp module) {
   OpBuilder builder(ctx);
   bool foundAnyKernel = false;
 
-  // module.dump();
-  // llvm::outs() << "module.walk()\n";
-
-  // Walk through all LLVM functions that are kernels
-  // After backend pipeline, kernels should be in LLVM dialect
+  // Walk through all LLVM functions that are kernels.
   WalkResult result = module.walk([&](LLVM::LLVMFuncOp funcOp) -> WalkResult {
-    // Check if this is a kernel function
-    // Kernels are typically in GPU modules or have specific calling conventions
     bool isKernel = funcOp->hasAttr("gpu.kernel") &&
                     funcOp->getParentOfType<gpu::GPUModuleOp>();
-
-    // llvm::outs() << "funcOp: ";
-    // funcOp->dump();
-    // llvm::outs() << "funcOp->getParentOfType<gpu::GPUModuleOp>(): ";
-    // funcOp->getParentOfType<gpu::GPUModuleOp>()->dump();
-    // llvm::outs() << "funcOp.getCConv(): ";
-    // // funcOp.getCConv().dump();
 
     if (!isKernel)
       return WalkResult::advance();
@@ -366,16 +349,12 @@ static LogicalResult insertInstructionCacheFlush(ModuleOp module) {
     // Insert the inline assembly at the beginning of the entry block
     builder.setInsertionPointToStart(entryBlock);
 
-    // Create LLVM inline assembly operation
-    // Format: llvm.inline_asm has_side_effects asm_string, constraints,
-    // operands For our case: no operands, no return value, just side effects
-    ValueRange emptyOperands;
     auto asmDialectAttr =
         LLVM::AsmDialectAttr::get(ctx, LLVM::AsmDialect::AD_ATT);
     builder.create<LLVM::InlineAsmOp>(
         funcOp.getLoc(),
         /*resultTypes=*/TypeRange(LLVM::LLVMVoidType::get(ctx)),
-        /*operands=*/emptyOperands,
+        /*operands=*/ValueRange(),
         /*asm_string=*/icacheFlushAsm,
         /*constraints=*/"",
         /*has_side_effects=*/true,
@@ -387,59 +366,7 @@ static LogicalResult insertInstructionCacheFlush(ModuleOp module) {
     return WalkResult::advance();
   });
 
-  module.dump();
-  llvm::outs() << "module.walk()\n";
-
   return foundAnyKernel ? success() : failure();
-}
-
-// Disassemble and print binary to verify inserted assembly
-static void printDisassembly(const std::string &binaryData,
-                             const std::string &kernelName) {
-  // Write binary to temporary file
-  int tempFd = -1;
-  llvm::SmallString<128> tempFilename;
-  if (llvm::sys::fs::createTemporaryFile("kernel", "hsaco", tempFd,
-                                         tempFilename)) {
-    llvm::errs() << "Failed to create temporary file for disassembly\n";
-    return;
-  }
-  llvm::FileRemover cleanup(tempFilename);
-
-  {
-    llvm::raw_fd_ostream tempOs(tempFd, true);
-    tempOs.write(binaryData.data(), binaryData.size());
-    tempOs.flush();
-  }
-
-  // Try to find llvm-objdump or rocm-objdump
-  llvm::ErrorOr<std::string> objdumpPath =
-      llvm::sys::findProgramByName("llvm-objdump");
-  if (!objdumpPath) {
-    objdumpPath = llvm::sys::findProgramByName("rocm-objdump");
-  }
-
-  if (!objdumpPath) {
-    llvm::errs()
-        << "Could not find llvm-objdump or rocm-objdump for disassembly\n";
-    return;
-  }
-
-  // Run objdump to disassemble
-  llvm::SmallVector<llvm::StringRef, 4> args;
-  args.push_back(*objdumpPath);
-  args.push_back("-d");                 // Disassemble
-  args.push_back("--arch-name=amdgcn"); // AMD GPU architecture
-  args.push_back(tempFilename);
-
-  llvm::outs() << "\n=== Disassembly for kernel: " << kernelName << " ===\n";
-  std::string errMsg;
-  int retCode = llvm::sys::ExecuteAndWait(*objdumpPath, args, std::nullopt, {},
-                                          0, 0, &errMsg);
-  if (retCode != 0) {
-    llvm::errs() << "Failed to disassemble binary: " << errMsg << "\n";
-  }
-  llvm::outs() << "=== End disassembly ===\n\n";
 }
 
 static LogicalResult measureSmallKernel(
@@ -1080,17 +1007,11 @@ static LogicalResult runTuningLoop(ModuleOp source) {
           compilationFailed.store(true, std::memory_order_relaxed);
           return result;
         }
-        std::string binaryData = cast<gpu::ObjectAttr>(binary.getObjects()[0])
-                                     .getObject()
-                                     .getValue()
-                                     .str();
-        result.hipModules.push_back(binaryData);
-
-        // Print disassembly to verify inserted assembly
-        {
-          std::lock_guard<std::mutex> lock(outputMutex);
-          printDisassembly(binaryData, fnName);
-        }
+        result.hipModules.push_back(
+            cast<gpu::ObjectAttr>(binary.getObjects()[0])
+                .getObject()
+                .getValue()
+                .str());
       }
 
       result.status = CompilationStatus::Success;

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -300,24 +300,23 @@ struct CompilationResult {
 
 static LogicalResult measureSmallKernel(
     unsigned iterations, hipStream_t stream,
-    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
-    ArrayRef<uint32_t> gridSizes, ArrayRef<std::vector<void *>> argPointersSets,
-    unsigned numRotatingBuffers, std::vector<double> &measurements,
-    double &smallKernelCpuMs, bool benchmarkMode) {
+    ArrayRef<const std::vector<hipFunction_t>> functionsPerIteration,
+    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
+    ArrayRef<std::vector<void *>> argPointersSets, unsigned numRotatingBuffers,
+    std::vector<double> &measurements, double &smallKernelCpuMs,
+    bool benchmarkMode) {
   // Special case for small kernels, where we measure the time for all kernels
   // at once, using CPU timers.
   auto iterationStart = std::chrono::steady_clock::now();
   for (unsigned iter = 0; iter < iterations; ++iter) {
-    // 1. Select which buffer set to use for this iteration.
+    // 1. Select which buffer set and function set to use for this iteration.
     unsigned bufferSet = iter % numRotatingBuffers;
+    unsigned functionSet = iter % iterations;
     const std::vector<void *> &argPointers = argPointersSets[bufferSet];
+    const std::vector<hipFunction_t> &functions =
+        functionsPerIteration[functionSet];
 
     // 2. Flush caches.
-    if (!benchmarkMode) {
-      if (failed(flushInstructionCache(stream))) {
-        return failure();
-      }
-    }
     // We only do explicit L2 flush when we are not rotating buffers.
     if (numRotatingBuffers == 1) {
       if (failed(flushL2Cache(stream))) {
@@ -344,14 +343,18 @@ static LogicalResult measureSmallKernel(
 
 static LogicalResult measureLargeKernel(
     unsigned iterations, hipStream_t stream,
-    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
-    ArrayRef<uint32_t> gridSizes, ArrayRef<std::vector<void *>> argPointersSets,
-    unsigned numRotatingBuffers, std::vector<double> &measurements) {
+    ArrayRef<const std::vector<hipFunction_t>> functionsPerIteration,
+    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
+    ArrayRef<std::vector<void *>> argPointersSets, unsigned numRotatingBuffers,
+    std::vector<double> &measurements) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {
-    // Select which buffer set to use for this iteration
+    // Select which buffer set and function set to use for this iteration
     unsigned bufferSet = iter % numRotatingBuffers;
+    unsigned functionSet = iter % iterations;
     const std::vector<void *> &argPointers = argPointersSets[bufferSet];
+    const std::vector<hipFunction_t> &functions =
+        functionsPerIteration[functionSet];
 
     if (failed(flushInstructionCache(stream))) {
       return failure();
@@ -424,29 +427,67 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     }
   }
 
-  // Load all modules once to reduce overhead
-  std::vector<hipModule_t> modules;
-  std::vector<hipFunction_t> functions;
+  // Create multiple copies of kernel binaries (one per iteration) to avoid
+  // cache effects from reusing the same memory location
+  // We create enough copies for the maximum possible iterations (iterations can
+  // be increased after warmup, so we use a reasonable maximum)
+  unsigned initialIterations = params.numIterations;
+  constexpr unsigned maxIterations = 100; // Reasonable maximum
+  unsigned maxPossibleIterations = std::max(initialIterations, maxIterations);
+
+  std::vector<std::vector<char>> binaryCopies;
+  binaryCopies.reserve(binaries.size() * maxPossibleIterations);
+  for (unsigned iter = 0; iter < maxPossibleIterations; ++iter) {
+    for (const std::string &binary : binaries) {
+      // Create a copy of the binary in a new memory location
+      std::vector<char> binaryCopy(binary.begin(), binary.end());
+      binaryCopies.push_back(std::move(binaryCopy));
+    }
+  }
+
+  // Load all module copies (one set per iteration, up to maxPossibleIterations)
+  std::vector<std::vector<hipModule_t>> modulesPerIteration;
+  std::vector<std::vector<hipFunction_t>> functionsPerIteration;
+  modulesPerIteration.reserve(maxPossibleIterations);
+  functionsPerIteration.reserve(maxPossibleIterations);
+
   auto moduleCleanup = llvm::make_scope_exit([&]() {
-    for (hipModule_t mod : modules) {
-      if (!mod)
-        continue;
-      hipError_t status = hipModuleUnload(mod);
-      if (status != hipSuccess) {
-        llvm::errs() << "HIP error in hipModuleUnload: "
-                     << hipGetErrorString(status) << "\n";
+    for (auto &modules : modulesPerIteration) {
+      for (hipModule_t mod : modules) {
+        if (!mod)
+          continue;
+        hipError_t status = hipModuleUnload(mod);
+        if (status != hipSuccess) {
+          llvm::errs() << "HIP error in hipModuleUnload: "
+                       << hipGetErrorString(status) << "\n";
+        }
       }
     }
   });
 
-  for (auto [binary, funcName] : llvm::zip(binaries, funcNames)) {
-    hipModule_t mod;
-    HIPCHECK(hipModuleLoadData(&mod, binary.c_str()));
-    modules.push_back(mod);
+  // Load modules and functions for each iteration
+  for (unsigned iter = 0; iter < maxPossibleIterations; ++iter) {
+    std::vector<hipModule_t> modules;
+    std::vector<hipFunction_t> functions;
+    modules.reserve(funcNames.size());
+    functions.reserve(funcNames.size());
 
-    hipFunction_t func;
-    HIPCHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
-    functions.push_back(func);
+    for (size_t funcIdx = 0; funcIdx < funcNames.size(); ++funcIdx) {
+      size_t binaryCopyIdx = iter * funcNames.size() + funcIdx;
+      const std::vector<char> &binaryCopy = binaryCopies[binaryCopyIdx];
+      const std::string &funcName = funcNames[funcIdx];
+
+      hipModule_t mod;
+      HIPCHECK(hipModuleLoadData(&mod, binaryCopy.data()));
+      modules.push_back(mod);
+
+      hipFunction_t func;
+      HIPCHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
+      functions.push_back(func);
+    }
+
+    modulesPerIteration.push_back(std::move(modules));
+    functionsPerIteration.push_back(std::move(functions));
   }
 
   // Sleep guard to avoid GPU throttling
@@ -471,12 +512,20 @@ benchmarkKernels(ArrayRef<std::string> binaries,
   }
 
   bool isSmallKernel = false;
-  unsigned iterations = params.numIterations;
+  unsigned iterations = initialIterations;
 
   // We need at least as many iterations as we have rotating buffers.
   if (iterations < numBufferSets) {
     llvm::errs()
         << "numIterations must be greater than or equal to numBufferSets\n";
+    return failure();
+  }
+
+  // Ensure we don't exceed the maximum number of iterations we prepared for
+  if (iterations > maxPossibleIterations) {
+    llvm::errs() << "Requested iterations (" << iterations
+                 << ") exceeds maximum prepared iterations ("
+                 << maxPossibleIterations << ")\n";
     return failure();
   }
 
@@ -486,12 +535,16 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     // not.
     double totalMillisecondsWarmup = 0.0;
     for (unsigned iter = 0; iter < params.warmupIterations; ++iter) {
-      // Select which buffer set to use for this warmup iteration
+      // Select which buffer set and function set to use for this warmup
+      // iteration
       unsigned bufferSet = iter % numBufferSets;
+      unsigned functionSet = iter % iterations;
       const std::vector<void *> &warmupArgPointers = argPointersSets[bufferSet];
+      const std::vector<hipFunction_t> &warmupFunctions =
+          functionsPerIteration[functionSet];
 
       for (auto [func, blockSize, gridSize] :
-           llvm::zip(functions, blockSizes, gridSizes)) {
+           llvm::zip(warmupFunctions, blockSizes, gridSizes)) {
         hipEvent_t startEvent, stopEvent;
         HIPCHECK(hipEventCreate(&startEvent));
         HIPCHECK(hipEventCreate(&stopEvent));
@@ -521,9 +574,19 @@ benchmarkKernels(ArrayRef<std::string> binaries,
     // (counting all iterations), so increase the number of iterations
     // if necessary.
     constexpr float minTotalMilliseconds = 1.0f;
-    iterations = std::max<unsigned>(
+    unsigned newIterations = std::max<unsigned>(
         iterations, static_cast<unsigned>(std::ceil(minTotalMilliseconds /
                                                     totalMillisecondsWarmup)));
+
+    // Ensure we don't exceed the maximum number of iterations we prepared for
+    if (newIterations > maxPossibleIterations) {
+      llvm::errs() << "Computed iterations (" << newIterations
+                   << ") exceeds maximum prepared iterations ("
+                   << maxPossibleIterations << "). Limiting to maximum.\n";
+      iterations = maxPossibleIterations;
+    } else {
+      iterations = newIterations;
+    }
 
     // Depending on the runtime of the kernel,
     // we will use a different approach to measure the runs.
@@ -539,16 +602,16 @@ benchmarkKernels(ArrayRef<std::string> binaries,
 
   if (isSmallKernel) {
     llvm::errs() << "Running small kernel\n";
-    if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, argPointersSets, numBufferSets,
-                                  measurements, smallKernelCpuMs,
+    if (failed(measureSmallKernel(iterations, stream, functionsPerIteration,
+                                  blockSizes, gridSizes, argPointersSets,
+                                  numBufferSets, measurements, smallKernelCpuMs,
                                   benchmarkMode)))
       return failure();
   } else {
     llvm::errs() << "Running large kernel\n";
-    if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, argPointersSets, numBufferSets,
-                                  measurements)))
+    if (failed(measureLargeKernel(iterations, stream, functionsPerIteration,
+                                  blockSizes, gridSizes, argPointersSets,
+                                  numBufferSets, measurements)))
       return failure();
   }
 


### PR DESCRIPTION
## Motivation

See https://github.com/ROCm/rocMLIR-internal/issues/2149 for motivation.

## Technical Details

This PR removes calls to both `flushL2Cache` and `flushInstructionCache`, replacing them with other approach:
- For `flushL2Cache`: This PR implements rotating buffers. The idea is to allocate multiple buffers that are rotated on every iteration, with the goal of avoiding cache reuse from one iteration to another. We also have a new option `num-rotating-buffers` to control how many rotating buffers are used (default is 5).
- For `flushInstructionCache`: This PR implements `insertInstructionCacheFlush`, which inserts the kernel containing `s_icache_inv` plus `nop`s into the actual kernel that we want to executing, thus avoiding the launch overhead of the `flushInstructionCache` kernel. The compilation of the kernel is adapted to make a intermediate step at LLVM IR level, where we insert the assembly, which later get lowered to a binary.

## Test Plan

No new test was added.

## Test Result

All test pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
