### PR TITLE
Fix Flash Attention precision loss on RDNA3 (gfx11xx)

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -313,6 +313,39 @@ static LDSLayoutConfigDim getLDSLayoutConfigDim(Type elementType, int64_t kpack,
   return cfg;
 }
 
+// Check if any block argument of the given type has an immediate arith.extf
+// user in the region. Used to detect when GEMM0 output is immediately extended
+// to a wider type for softmax.
+static bool hasImmediateExtension(Region &region, Type inputType) {
+  bool found = false;
+  region.walk([&](linalg::GenericOp genOp) {
+    Block &body = genOp.getRegion().front();
+    for (BlockArgument arg : body.getArguments()) {
+      if (arg.getType() != inputType)
+        continue;
+      for (Operation *user : arg.getUsers()) {
+        if (isa<arith::ExtFOp>(user)) {
+          found = true;
+          return WalkResult::interrupt();
+        }
+      }
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+// Replace arith.extf ops that extend a value to the target type with the
+// value itself (since the extension is now a no-op).
+static void replaceRedundantExtensions(PatternRewriter &rewriter, Value value,
+                                       Type targetType) {
+  for (Operation *user : llvm::make_early_inc_range(value.getUsers())) {
+    auto extfOp = dyn_cast<arith::ExtFOp>(user);
+    if (extfOp && extfOp.getType() == targetType)
+      rewriter.replaceOp(extfOp, value);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // GridwiseGemm lowering.
 //===----------------------------------------------------------------------===//
@@ -1623,6 +1656,54 @@ struct GridwiseAttentionAccelRewritePattern
         mapper.map(operand, tilebuffer);
       }
       newLinalgOp = cast<linalg::GenericOp>(rewriter.clone(*genOp, mapper));
+
+      // Update block argument types to match the new buffer element types.
+      // This is needed when buffer types change (e.g., f16 -> f32 for
+      // attention with FP32 softmax) to avoid type mismatches.
+      Block &newBlock = newLinalgOp.getRegion().front();
+      for (auto [arg, buffer] :
+           llvm::zip(newBlock.getArguments(), inputTileBuffers)) {
+        Type newElemType = cast<MemRefType>(buffer.getType()).getElementType();
+        Type oldElemType = arg.getType();
+        if (oldElemType == newElemType)
+          continue;
+
+        arg.setType(newElemType);
+
+        for (Operation *user : llvm::make_early_inc_range(arg.getUsers())) {
+          // Case 1: arith.extf that's now a no-op (input already in wide type)
+          if (auto extfOp = dyn_cast<arith::ExtFOp>(user)) {
+            if (extfOp.getType() == newElemType)
+              rewriter.replaceOp(extfOp, arg);
+            continue;
+          }
+
+          // Case 2: arithmetic ops need operand extension and result update
+          rewriter.setInsertionPoint(user);
+          bool needsUpdate = false;
+
+          for (OpOperand &operand : user->getOpOperands()) {
+            if (operand.get() == arg || operand.get().getType() != oldElemType)
+              continue;
+            Value extended = arith::ExtFOp::create(rewriter, user->getLoc(),
+                                                   newElemType, operand.get());
+            operand.set(extended);
+            needsUpdate = true;
+          }
+
+          if (!needsUpdate)
+            continue;
+
+          // Update result types and clean up downstream extf ops
+          for (OpResult result : user->getResults()) {
+            if (result.getType() != oldElemType)
+              continue;
+            result.setType(newElemType);
+            replaceRedundantExtensions(rewriter, result, newElemType);
+          }
+        }
+      }
+
       SmallVector<AffineMap> indexingMaps;
       for (size_t i = 0; i < inputTileBuffers.size(); i++) {
         indexingMaps.push_back(rewriter.getMultiDimIdentityMap(1));
@@ -2237,6 +2318,14 @@ struct GridwiseAttentionAccelRewritePattern
     Type gemmOutElemType = elemTypeV;
     if (elemTypeQ == rewriter.getI8Type()) {
       gemmOutElemType = rewriter.getI32Type();
+    } else if (op.getEnableSoftmax() &&
+               hasImmediateExtension(op.getPreSoftmaxBody(), elemTypeV)) {
+      // For attention with softmax where the gemm0 output is immediately
+      // extended to a wider type, use the softmax type for the intermediate
+      // GEMM0 output buffer to avoid FP32->FP16->FP32 roundtrip precision
+      // loss. The WMMA accumulator is FP32, and truncating to FP16 before
+      // softmax causes significant precision loss on RDNA3 (gfx11xx) GPUs.
+      gemmOutElemType = elemTypeSoftmax;
     }
     Type fusionOutElemType = elemTypeV;
     op.getPreSoftmaxBody().walk([&](linalg::GenericOp genOp) {


### PR DESCRIPTION
# Fix Flash Attention precision loss on RDNA3 (gfx11xx)

## Problem

Flash Attention on RDNA3 (gfx1100/Navi31) GPUs was failing precision tests with error ratios exceeding 2.0x compared to PyTorch reference. The issue manifested in `test_flash_attn_triton_amd.py` tests.

## Root Cause

The WMMA instructions on RDNA3 accumulate in FP32, but the intermediate GEMM0 output buffer was being allocated as FP16 (matching the input type), and preSoftmaxBody immediately extends back to FP32 via `arith.extf` for softmax. This caused an unnecessary FP32→FP16→FP32 roundtrip. This roundtrip loses precision.

## Solution

In `GridwiseGemmToBlockwise.cpp`, detect when the `preSoftmaxBody` contains an immediate `arith.extf` operation on the GEMM0 output. When detected:

1. Allocate `gemm0OutBuffer` in FP32 (the softmax precision type) instead of FP16
2. Update `linalg.generic` block argument types to match the new buffer type
3. Replace now redundant `arith.extf` ops (FP32→FP32) with their input
4. Extend other operands in arithmetic ops to maintain type consistency

This keeps the WMMA FP32 result in FP32 until after softmax, eliminating the precision loss.

NOTE: THIS IS STILL JUST A DRAFT TO CONFIRM THAT IT FIXES A PROBLEM.