### PR TITLE
Handle negative time measurements in rocmlir-tuning-driver

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -463,6 +463,16 @@ benchmarkKernels(ArrayRef<std::string> binaries,
         HIPCHECK(hipEventDestroy(stopEvent));
         HIPCHECK(hipEventDestroy(startEvent));
 
+        // hipEventElapsedTime seemingly can return negative values for fast
+        // kernels due to GPU clock precision issues. This is extremely relevant
+        // when we have a small number of warmup iterations (e.g., 1) for small
+        // kernels. Clamp to the documented resolution of ~1 microsecond
+        // (0.001 ms) if this is the case.
+        if (currentMilliseconds < 0.0f) {
+          constexpr float minMeasurableMs = 0.001f;
+          currentMilliseconds = minMeasurableMs;
+        }
+
         totalMillisecondsWarmup += static_cast<double>(currentMilliseconds);
       }
     }


### PR DESCRIPTION
## Motivation

This PR adds some extra handling for timing measurements in rocmlir-tuning-driver so that we are never using negative values. Solves https://github.com/ROCm/rocMLIR-internal/issues/2208

## Technical Details

The official [HIP documentation](https://rocm.docs.amd.com/projects/HIP/en/develop/doxygen/html/group___event.html#gad4128b815cb475c8e13c7e66ff6250b7) states that `hipEventElapsedTime` has a minimum resolution of 1 microsecond. This could be particularly problematic when trying to measure small kernels when using a small number of warmup iterations. We have logic paths to handle accurately computing the time for small kernels, but in the check that determines if we are working with a small kernel we could still run into this issue. The solution is to clamp negative values to the smallest documented resolution of ~1 microsecond when calculating the total warmup time.

## Test Plan

- Repeated running of the failing command

## Test Result

- Prior to this change, repeatedly running `./bin/rocmlir-gen -operation gemm -t f32 -out_datatype f32 --arch gfx1201 --num_cu 64 -g 12 -m 1 -k 1 -n 64 -transA=False -transB=False --perf_config= | ./bin/rocmlir-tuning-driver --tuning-space=exhaustive --num-iterations=10 --warmup-iterations=1 --sleep-us=100 --show-all-measurements=true --num-compile-threads=11 --use-median` would fail every other time. After the change, I've ran this command about 20 times and all are passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
