### PR TITLE
Add rocMLIR support for gfx1250 scaled wmma instructions

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -911,6 +911,15 @@ def MFMAOutTypes : AnyTypeOf<[F64,
 def ScaledMFMAInTypes : AnyTypeOf<[VectorOfLengthAndType<[32], [F8E5M2, F8E4M3FN]>,
                                    VectorOfLengthAndType<[32], [F6E2M3FN, F6E3M2FN, F4E2M1FN]>]>;
 def ScaledMFMAOutTypes : AnyTypeOf<[VectorOfLengthAndType<[4, 16], [F32]>]>;
+
+// scaled_wmma
+def ScaledWMMAInTypes
+    : AnyTypeOf<[VectorOfLengthAndType<[64], [F8E5M2, F8E4M3FN]>,
+                 VectorOfLengthAndType<[64], [F6E2M3FN, F6E3M2FN]>,
+                 VectorOfLengthAndType<[64, 128], [F4E2M1FN]>]>;
+
+def ScaledWMMAOutTypes : AnyTypeOf<[VectorOfLengthAndType<[8, 16], [F32]>]>;
+
 // wmma
 def WMMAInTypes : AnyTypeOf<[VectorOfLengthAndType<[2], [F32]>,
                              VectorOfLengthAndType<[4, 8, 16], [F16, BF16]>,
@@ -1197,5 +1206,78 @@ def AMDGPU_ScaledMFMAOp :
     `:` type($scalesA) `,` type($sourceA) `,` type($scalesB) `,` type($sourceB) `,` type($destC)
   }];
   let hasCanonicalizer = 1;
+}
+
+def AMDGPU_ScaledWMMAOp
+    : AMDGPU_Op<"scaled_wmma", [AllTypesMatch<["destC", "destD"]>, Pure]>,
+      Arguments<(ins ConfinedAttr<I32Attr, [IntIsOneOf<[16, 32]>]>:$m,
+          ConfinedAttr<I32Attr, [IntIsOneOf<[16]>]>:$n,
+          ConfinedAttr<I32Attr, [IntIsOneOf<[128]>]>:$k,
+          ScaledWMMAInTypes:$sourceA, ScaledWMMAInTypes:$sourceB,
+          ScaledWMMAOutTypes:$destC,
+          VectorOfLengthAndType<[4, 8], [F8E8M0FNU, F8E4M3FN]>:$scaleA,
+          ConfinedAttr<I32Attr, [IntIsOneOf<[0, 16]>]>:$a_first_scale_lane,
+          VectorOfLengthAndType<[4, 8], [F8E8M0FNU, F8E4M3FN]>:$scaleB,
+          ConfinedAttr<I32Attr, [IntIsOneOf<[0, 16]>]>:$b_first_scale_lane)>,
+      Results<(outs ScaledWMMAOutTypes:$destD)> {
+  // TODO: E5M3FNU scales are supported, but there is not yet MLIR support for
+  // this datatype. Once we have support for that, update the scaleA and scaleB
+  // types here.
+  let summary = "MLIR wrapper for scaled wmma instructions";
+  let description = [{
+    The `amdgpu.scaled_wmma` op is an MLIR wrapper around intrinsics for scaled
+    `wmma` instructions. These instructions perform matrix multiplication with
+    per-block scaling of inputs, supporting fp4, fp6, and fp8 data formats.
+
+    The scale instructions support a block size of 16 or 32 and two tile sizes:
+    - 16x16x128 with mixed f8/f6/f4 formats (output: vector<8xf32>)
+    - 32x16x128 with f4 format only (output: vector<16xf32>)
+
+    Scale parameters (`scaleA`, `scaleB`) are small vectors of f8 scale values
+    (either f8E8M0FNU, or f8E4M3FN) that are packed into i32/i64 values during
+    lowering. Each lane can operate on 4 bytes (4 scale values), and the
+    number of scales required for each matrix is determined by:
+      num_scales_A = (M × K) / block_size
+      num_scales_B = (N × K) / block_size
+      
+    The index attributes (`a_first_scale_lane`, `b_first_scale_lane`) select
+    which lane to start reading scale values from (0 or 16):
+    - For block size 32, 32 lanes across a single wave are used for the scale
+    values. If the number of scales (num_scales_A or num_scales_B) can fit
+    into half of the available lanes
+    (i.e., num_scales / scales_per_lane == 16 (num_lanes)),
+    then then first_scale_lane can be either 0 or 16. If all lanes are required
+    for storing the scale values (num_scales / scales_per_lane == 32 (num_lanes)),
+    then the first_scale_lane must be 0.
+    - For block size 16, the same rules apply as above except that there are 64
+    lanes across two waves that are used for the scale values. When
+    num_scales / scales_per_lane == 32 (num lanes), then 16 lanes from each wave are used.
+    first_scale_lane of 0 or 16 will decide which lanes are used for this. When
+    num_scales / scales_per_lane == 64 (num_lanes), then first_scale_lane must
+    be set to 0.
+
+    Example:
+    ```mlir
+      // 16x16x128: fp8 inputs
+      %0 = amdgpu.scaled_wmma 16x16x128 (%scaleVecA * %matA) * (%scaleVecB * %matB) + %matC
+        {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32}
+        : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>,
+        vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf32>
+
+      // 32x16x128: fp4 inputs with different scale lanes
+      %1 = amdgpu.scaled_wmma 32x16x128 (%scaleVecD * %matD) * (%scaleVecE * %matE) + %matF
+        {a_first_scale_lane = 0 : i32, b_first_scale_lane = 16 : i32}
+        : vector<8xf8E4M3FN>, vector<128xf4E2M1FN>,
+        vector<8xf8E4M3FN>, vector<64xf4E2M1FN>, vector<16xf32>
+    ```
+  }];
+  let assemblyFormat = [{
+    custom<MNKDimensionList>($m, $n, $k) ` `
+    `(` $scaleA `*` $sourceA `)` `*`
+    `(` $scaleB `*` $sourceB `)` `+` $destC
+    attr-dict
+    `:` type($scaleA) `,` type($sourceA) `,` type($scaleB) `,` type($sourceB) `,` type($destC)
+  }];
+  let hasVerifier = 1;
 }
 #endif // AMDGPU

--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -585,25 +585,25 @@ def ROCDL_smfmac_f32_32x32x32_fp8_fp8 : ROCDL_Mfma_IntrOp<"smfmac.f32.32x32x32.f
 class ROCDL_WMMA_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
     [0], [0], [], 1, 0, 0, 0, [], []>,
   Arguments<(ins 
-             LLVM_ScalarOrVectorOf<AB>:$A, 
-             LLVM_ScalarOrVectorOf<AB>:$B,
-             LLVM_ScalarOrVectorOf<CD>:$C)> {
+             LLVM_ScalarOrVectorOf<AB>:$a, 
+             LLVM_ScalarOrVectorOf<AB>:$b,
+             LLVM_ScalarOrVectorOf<CD>:$c)> {
   let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
   let assemblyFormat = [{
-    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+    $a `,` $b `,` $c attr-dict `:` functional-type(operands, $res)
   }];
 }
 
 class ROCDL_WMMA_Opsel_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
     [0], [1], [], 1, 0, 0, 0, [3], ["opsel"]>,
   Arguments<(ins 
-             LLVM_ScalarOrVectorOf<AB>:$A,
-             LLVM_ScalarOrVectorOf<AB>:$B,
-             LLVM_ScalarOrVectorOf<CD>:$C, 
+             LLVM_ScalarOrVectorOf<AB>:$a,
+             LLVM_ScalarOrVectorOf<AB>:$b,
+             LLVM_ScalarOrVectorOf<CD>:$c, 
              DefaultValuedAttr<I1Attr, "0">:$opsel)> {
   let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
   let assemblyFormat = [{
-    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+    $a `,` $b `,` $c attr-dict `:` functional-type(operands, $res)
   }];
 }
 
@@ -611,14 +611,14 @@ class ROCDL_WMMA_IU_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mne
     [0], [1], [], 1, 0, 0, 0, [0, 2, 5], ["signA", "signB", "clamp"]>,
   Arguments<(ins 
              DefaultValuedAttr<I1Attr, "0">:$signA,
-             LLVM_ScalarOrVectorOf<AB>:$A, 
+             LLVM_ScalarOrVectorOf<AB>:$a, 
              DefaultValuedAttr<I1Attr, "0">:$signB,
-             LLVM_ScalarOrVectorOf<AB>:$B,
-             LLVM_ScalarOrVectorOf<CD>:$C, 
+             LLVM_ScalarOrVectorOf<AB>:$b,
+             LLVM_ScalarOrVectorOf<CD>:$c, 
              DefaultValuedAttr<I1Attr, "0">:$clamp)> {
   let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
   let assemblyFormat = [{
-    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+    $a `,` $b `,` $c attr-dict `:` functional-type(operands, $res)
   }];
 }
 
@@ -626,31 +626,31 @@ class ROCDL_WMMA_ModsAll_Reuse_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL
     [0], [1], [], 1, 0, 0, 0, [0, 2, 4, 6, 7], ["signA", "signB","modC","reuseA","reuseB"]>,
   Arguments<(ins 
              DefaultValuedAttr<I1Attr, "0">:$signA,
-             LLVM_ScalarOrVectorOf<AB>:$A, 
+             LLVM_ScalarOrVectorOf<AB>:$a, 
              DefaultValuedAttr<I1Attr, "0">:$signB,
-             LLVM_ScalarOrVectorOf<AB>:$B,
+             LLVM_ScalarOrVectorOf<AB>:$b,
              DefaultValuedAttr<I16Attr, "0">:$modC, 
-             LLVM_ScalarOrVectorOf<CD>:$C, 
+             LLVM_ScalarOrVectorOf<CD>:$c, 
              DefaultValuedAttr<I1Attr, "0">:$reuseA, 
              DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
   let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
   let assemblyFormat = [{
-    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+    $a `,` $b `,` $c attr-dict `:` functional-type(operands, $res)
   }];
 }
 
 class ROCDL_WMMA_ModsC_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp<mnemonic,
     [0], [0], [], 1, 0, 0, 0, [2, 4, 5], ["modC","reuseA","reuseB"]>,
   Arguments<(ins 
-             LLVM_ScalarOrVectorOf<AB>:$A, 
-             LLVM_ScalarOrVectorOf<AB>:$B,
+             LLVM_ScalarOrVectorOf<AB>:$a, 
+             LLVM_ScalarOrVectorOf<AB>:$b,
              DefaultValuedAttr<I16Attr, "0">:$modC, 
-             LLVM_ScalarOrVectorOf<CD>:$C, 
+             LLVM_ScalarOrVectorOf<CD>:$c, 
              DefaultValuedAttr<I1Attr, "0">:$reuseA, 
              DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
   let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
   let assemblyFormat = [{
-    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+    $a `,` $b `,` $c attr-dict `:` functional-type(operands, $res)
   }];
 }
 
@@ -658,16 +658,16 @@ class ROCDL_WMMA_ModsAll_Diff_IntrOp<string mnemonic, Type AB, Type C, Type D> :
     [0], [1, 5], [], 1, 0, 0, 0, [0, 2, 4, 6, 7], ["signA", "signB","modC","reuseA","reuseB"]>,
   Arguments<(ins 
              DefaultValuedAttr<I1Attr, "0">:$signA,
-             LLVM_ScalarOrVectorOf<AB>:$A, 
+             LLVM_ScalarOrVectorOf<AB>:$a, 
              DefaultValuedAttr<I1Attr, "0">:$signB,
-             LLVM_ScalarOrVectorOf<AB>:$B,
+             LLVM_ScalarOrVectorOf<AB>:$b,
              DefaultValuedAttr<I16Attr, "0">:$modC, 
-             LLVM_ScalarOrVectorOf<C>:$C, 
+             LLVM_ScalarOrVectorOf<C>:$c, 
              DefaultValuedAttr<I1Attr, "0">:$reuseA, 
              DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
   let results = (outs LLVM_ScalarOrVectorOf<D>:$res);
   let assemblyFormat = [{
-    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+    $a `,` $b `,` $c attr-dict `:` functional-type(operands, $res)
   }];
 }
 
@@ -675,15 +675,65 @@ class ROCDL_WMMA_ModsAB_IntrOp<string mnemonic, Type AB, Type CD> : ROCDL_IntrOp
     [0], [1], [], 1, 0, 0, 0, [0, 2, 5, 6], ["signA", "signB", "reuseA","reuseB"]>,
   Arguments<(ins 
              DefaultValuedAttr<I1Attr, "0">:$signA,
-             LLVM_ScalarOrVectorOf<AB>:$A, 
+             LLVM_ScalarOrVectorOf<AB>:$a, 
              DefaultValuedAttr<I1Attr, "0">:$signB,
-             LLVM_ScalarOrVectorOf<AB>:$B,
-             LLVM_ScalarOrVectorOf<CD>:$C, 
+             LLVM_ScalarOrVectorOf<AB>:$b,
+             LLVM_ScalarOrVectorOf<CD>:$c, 
              DefaultValuedAttr<I1Attr, "0">:$reuseA, 
              DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
   let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
   let assemblyFormat = [{
-    $A `,` $B `,` $C attr-dict `:` functional-type(operands, $res)
+    $a `,` $b `,` $c attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+// Overloaded operands: [1, 3] refers to LLVM intrinsic parameter positions where
+// A is at position 1 and B is at position 3 (after format parameters).
+class ROCDL_WMMA_Scale_IntrOp<string mnemonic, Type AB, Type CD, Type ScaleExpTy> : ROCDL_IntrOp<mnemonic,
+    [0], [1, 3], [], 1, 0, 0, 0, [0, 2, 4, 6, 7, 9, 10, 12, 13], 
+    ["fmtA", "fmtB", "modC", "scaleAType", "fmtScaleA", 
+     "scaleBType", "fmtScaleB", "reuseA", "reuseB"]>,
+  Arguments<(ins 
+             DefaultValuedAttr<I32Attr, "0">:$fmtA,
+             LLVM_ScalarOrVectorOf<AB>:$a, 
+             DefaultValuedAttr<I32Attr, "0">:$fmtB,
+             LLVM_ScalarOrVectorOf<AB>:$b,
+             DefaultValuedAttr<I16Attr, "0">:$modC, 
+             LLVM_ScalarOrVectorOf<CD>:$c,
+             DefaultValuedAttr<I32Attr, "0">:$scaleAType,
+             DefaultValuedAttr<I32Attr, "0">:$fmtScaleA,
+             ScaleExpTy:$scaleA,
+             DefaultValuedAttr<I32Attr, "0">:$scaleBType,
+             DefaultValuedAttr<I32Attr, "0">:$fmtScaleB,
+             ScaleExpTy:$scaleB,
+             DefaultValuedAttr<I1Attr, "0">:$reuseA,
+             DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $a `,` $b `,` $c `,` $scaleA `,` $scaleB attr-dict `:` functional-type(operands, $res)
+  }];
+}
+
+class ROCDL_WMMA_Scale_F4_IntrOp<string mnemonic, Type AB, Type CD, Type ScaleExpTy> : ROCDL_IntrOp<mnemonic,
+    [0], [0, 1], [], 1, 0, 0, 0, [2, 4, 5, 7, 8, 10, 11], 
+    ["modC", "scaleAType", "fmtScaleA", 
+     "scaleBType", "fmtScaleB", "reuseA", "reuseB"]>,
+  Arguments<(ins 
+             LLVM_ScalarOrVectorOf<AB>:$a, 
+             LLVM_ScalarOrVectorOf<AB>:$b,
+             DefaultValuedAttr<I16Attr, "0">:$modC, 
+             LLVM_ScalarOrVectorOf<CD>:$c,
+             DefaultValuedAttr<I32Attr, "0">:$scaleAType,
+             DefaultValuedAttr<I32Attr, "0">:$fmtScaleA,
+             ScaleExpTy:$scaleA,
+             DefaultValuedAttr<I32Attr, "0">:$scaleBType,
+             DefaultValuedAttr<I32Attr, "0">:$fmtScaleB,
+             ScaleExpTy:$scaleB,
+             DefaultValuedAttr<I1Attr, "0">:$reuseA,
+             DefaultValuedAttr<I1Attr, "0">:$reuseB)> {
+  let results = (outs LLVM_ScalarOrVectorOf<CD>:$res);
+  let assemblyFormat = [{
+    $a `,` $b `,` $c `,` $scaleA `,` $scaleB attr-dict `:` functional-type(operands, $res)
   }];
 }
 
@@ -724,6 +774,12 @@ def ROCDL_wmma_f16_16x16x128_fp8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x1
 def ROCDL_wmma_f16_16x16x128_bf8_fp8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x128.bf8_fp8", AnyInteger, F16>;
 def ROCDL_wmma_f16_16x16x128_bf8_bf8 : ROCDL_WMMA_ModsC_IntrOp<"wmma.f16.16x16x128.bf8_bf8", AnyInteger, F16>;
 def ROCDL_wmma_i32_16x16x64_iu8 : ROCDL_WMMA_ModsAB_IntrOp<"wmma.i32.16x16x64.iu8", AnyInteger, AnyInteger>;
+
+// Scaled wmma intrinsics (available from gfx1250)
+def ROCDL_wmma_scale_f32_16x16x128_f8f6f4   : ROCDL_WMMA_Scale_IntrOp<"wmma.scale.f32.16x16x128.f8f6f4", AnyInteger, F32, I32>;
+def ROCDL_wmma_scale16_f32_16x16x128_f8f6f4 : ROCDL_WMMA_Scale_IntrOp<"wmma.scale16.f32.16x16x128.f8f6f4", AnyInteger, F32, I64>;
+def ROCDL_wmma_scale_f32_32x16x128_f4       : ROCDL_WMMA_Scale_F4_IntrOp<"wmma.scale.f32.32x16x128.f4", AnyInteger, F32, I32>;
+def ROCDL_wmma_scale16_f32_32x16x128_f4     : ROCDL_WMMA_Scale_F4_IntrOp<"wmma.scale16.f32.32x16x128.f4", AnyInteger, F32, I64>;
 
 //===---------------------------------------------------------------------===//
 // LDS transpose intrinsics (available in GFX950)

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -615,8 +615,8 @@ struct SchedBarrierOpLowering : public ConvertOpToLLVMPattern<SchedBarrierOp> {
 
 } // namespace
 
-/// Converts a MFMA vector operand from MLIR AMDGPU dialect convention to ROCDL
-/// and LLVM AMDGPU intrinsics convention.
+/// Pack small float vector operands (fp4/fp6/fp8/bf16) into the format
+/// expected by scaled matrix multiply intrinsics (MFMA/WMMA).
 ///
 /// Specifically:
 /// 1. If the element type is bfloat16, bitcast it to i16 unless rocdl intrinsic
@@ -630,9 +630,9 @@ struct SchedBarrierOpLowering : public ConvertOpToLLVMPattern<SchedBarrierOp> {
 /// Note that the type of `input` has already been LLVM type converted:
 /// therefore 8-bit and smaller floats are represented as their corresponding
 /// `iN` integers.
-static Value convertMFMAVectorOperand(ConversionPatternRewriter &rewriter,
-                                      Location loc, Value input,
-                                      bool allowBf16 = true) {
+static Value packSmallFloatVectorOperand(ConversionPatternRewriter &rewriter,
+                                         Location loc, Value input,
+                                         bool allowBf16 = true) {
   Type inputType = input.getType();
   if (auto vectorType = dyn_cast<VectorType>(inputType)) {
     if (vectorType.getElementType().isBF16() && !allowBf16)
@@ -656,23 +656,58 @@ static Value convertMFMAVectorOperand(ConversionPatternRewriter &rewriter,
   return input;
 }
 
-/// Converts the scaled MFMA operands, `scalesA` and `scalesB`, from MLIR AMDGPU
-/// dialect convention to ROCDL and LLVM AMDGPU intrinsics convention.
+/// Converts the scaled MFMA/WMMA operands, `scalesA` and `scalesB`, from MLIR
+/// AMDGPU dialect convention to ROCDL and LLVM AMDGPU intrinsics convention.
 ///
 /// Specifically:
 /// 1. If `input` is a i8 value, zero extend it to i32
-/// 2. If `input` is a vector of length 4 and type i8, cast it to i32
+/// 2. If `input` is a vector of length 4 or 8 and type i8, cast it to i32
 ///
 /// Note that the type of `input` has already been LLVM type converted:
 /// therefore 8-bit and smaller floats are represented as their corresponding
 /// `iN` integers.
-static Value castMFMAScaleOperand(ConversionPatternRewriter &rewriter,
-                                  Location loc, Value input) {
-  Type inputType = input.getType();
-  Type outputType = rewriter.getI32Type();
-  if (auto intType = dyn_cast<IntegerType>(inputType))
-    return LLVM::ZExtOp::create(rewriter, loc, outputType, input);
-  return LLVM::BitcastOp::create(rewriter, loc, outputType, input);
+static Value castScaleOperand(ConversionPatternRewriter &rewriter, Location loc,
+                              Value input) {
+return TypeSwitch<Type, Value>(input.getType())
+  .Case([&](IntegerType) {
+    // Handle scalar i8: zero extend to i32.
+    return LLVM::ZExtOp::create(rewriter, loc, rewriter.getI32Type(),
+            input);
+  })
+  .Case([&](VectorType vectorType) {
+    // Handle vector<4xi8> -> i32 or vector<8xi8> -> i64.
+    int64_t numElements = vectorType.getNumElements();
+    assert((numElements == 4 || numElements == 8) &&
+    "scale operand must be a vector of length 4 or 8");
+    IntegerType outputType =
+    (numElements == 4) ? rewriter.getI32Type() : rewriter.getI64Type();
+    return LLVM::BitcastOp::create(rewriter, loc, outputType, input);
+  })
+  .DefaultUnreachable("unexpected input type for scale operand");
+}
+
+/// Maps f8 scale element types to WMMA scale format codes.
+static std::optional<uint32_t> getWmmaScaleFormat(Type elemType) {
+  return TypeSwitch<Type, std::optional<uint32_t>>(elemType)
+      .Case([](Float8E8M0FNUType) { return 0; })
+      .Case([](Float8E4M3FNType) { return 2; })
+      .Default(std::nullopt);
+}
+
+/// Determines the ROCDL intrinsic name for scaled WMMA based on dimensions
+/// and scale block size (16 or 32).
+static std::optional<StringRef>
+getScaledWmmaIntrinsicName(int64_t m, int64_t n, int64_t k, bool isScale16) {
+  if (m == 16 && n == 16 && k == 128)
+    return isScale16
+               ? ROCDL::wmma_scale16_f32_16x16x128_f8f6f4::getOperationName()
+               : ROCDL::wmma_scale_f32_16x16x128_f8f6f4::getOperationName();
+
+  if (m == 32 && n == 16 && k == 128)
+    return isScale16 ? ROCDL::wmma_scale16_f32_32x16x128_f4::getOperationName()
+                     : ROCDL::wmma_scale_f32_32x16x128_f4::getOperationName();
+
+  return std::nullopt;
 }
 
 /// Push an input operand. If it is a float type, nothing to do. If it is
@@ -921,7 +956,7 @@ static std::optional<StringRef> mfmaOpToIntrinsic(MFMAOp mfma,
   return std::nullopt;
 }
 
-static std::optional<uint32_t> mfmaTypeSelectCode(Type mlirElemType) {
+static std::optional<uint32_t> smallFloatTypeToFormatCode(Type mlirElemType) {
   return llvm::TypeSwitch<Type, std::optional<uint32_t>>(mlirElemType)
       .Case([](Float8E4M3FNType) { return 0u; })
       .Case([](Float8E5M2Type) { return 1u; })
@@ -950,8 +985,8 @@ mfmaOpToScaledIntrinsic(Type aType, Type bType, Type destType, uint32_t m,
   if (!isa<Float32Type>(destType))
     return std::nullopt;
 
-  std::optional<uint32_t> aTypeCode = mfmaTypeSelectCode(aType);
-  std::optional<uint32_t> bTypeCode = mfmaTypeSelectCode(bType);
+  std::optional<uint32_t> aTypeCode = smallFloatTypeToFormatCode(aType);
+  std::optional<uint32_t> bTypeCode = smallFloatTypeToFormatCode(bType);
   if (!aTypeCode || !bTypeCode)
     return std::nullopt;
 
@@ -1215,9 +1250,9 @@ struct MFMAOpLowering : public ConvertOpToLLVMPattern<MFMAOp> {
     }();
     OperationState loweredOp(loc, intrinsicName);
     loweredOp.addTypes(intrinsicOutType);
-    loweredOp.addOperands({convertMFMAVectorOperand(
+    loweredOp.addOperands({packSmallFloatVectorOperand(
                                rewriter, loc, adaptor.getSourceA(), allowBf16),
-                           convertMFMAVectorOperand(
+                           packSmallFloatVectorOperand(
                                rewriter, loc, adaptor.getSourceB(), allowBf16),
                            adaptor.getDestC()});
     if (isScaled) {
@@ -1264,8 +1299,8 @@ struct ScaledMFMAOpLowering : public ConvertOpToLLVMPattern<ScaledMFMAOp> {
     OperationState loweredOp(loc, intrinsicName);
     loweredOp.addTypes(intrinsicOutType);
     loweredOp.addOperands(
-        {convertMFMAVectorOperand(rewriter, loc, adaptor.getSourceA()),
-         convertMFMAVectorOperand(rewriter, loc, adaptor.getSourceB()),
+        {packSmallFloatVectorOperand(rewriter, loc, adaptor.getSourceA()),
+         packSmallFloatVectorOperand(rewriter, loc, adaptor.getSourceB()),
          adaptor.getDestC()});
     Value scalesIdxA =
         createI32Constant(rewriter, loc, adaptor.getScalesIdxA());
@@ -1276,10 +1311,10 @@ struct ScaledMFMAOpLowering : public ConvertOpToLLVMPattern<ScaledMFMAOp> {
          createI32Constant(rewriter, loc, bTypeCode),
          /*scales idx A=*/scalesIdxA,
          /*scales A*/
-         castMFMAScaleOperand(rewriter, loc, adaptor.getScalesA()),
+         castScaleOperand(rewriter, loc, adaptor.getScalesA()),
          /*scales idx B=*/scalesIdxB,
          /*scales B*/
-         castMFMAScaleOperand(rewriter, loc, adaptor.getScalesB())});
+         castScaleOperand(rewriter, loc, adaptor.getScalesB())});
     Value lowered = rewriter.create(loweredOp)->getResult(0);
     rewriter.replaceOp(op, lowered);
     return success();
@@ -1361,6 +1396,111 @@ struct WMMAOpLowering : public ConvertOpToLLVMPattern<WMMAOp> {
       maybeCastBack = LLVM::BitcastOp::create(rewriter, loc, outType,
                                               lowered->getResult(0));
     rewriter.replaceOp(op, maybeCastBack->getResults());
+
+    return success();
+  }
+};
+
+struct ScaledWMMAOpLowering : public ConvertOpToLLVMPattern<ScaledWMMAOp> {
+  ScaledWMMAOpLowering(const LLVMTypeConverter &converter, Chipset chipset)
+      : ConvertOpToLLVMPattern<ScaledWMMAOp>(converter), chipset(chipset) {}
+
+  Chipset chipset;
+
+  LogicalResult
+  matchAndRewrite(ScaledWMMAOp op, ScaledWMMAOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto outType =
+        typeConverter->convertType<VectorType>(op.getDestD().getType());
+    if (!outType)
+      return rewriter.notifyMatchFailure(op, "type conversion failed");
+
+    if (chipset < kGfx1250)
+      return op->emitOpError("WMMA scale only supported on gfx1250+");
+
+    int64_t m = op.getM();
+    int64_t n = op.getN();
+    int64_t k = op.getK();
+
+    Type aElemType = getElementTypeOrSelf(op.getSourceA().getType());
+    Type bElemType = getElementTypeOrSelf(op.getSourceB().getType());
+
+    std::optional<uint32_t> aFmtCode = smallFloatTypeToFormatCode(aElemType);
+    std::optional<uint32_t> bFmtCode = smallFloatTypeToFormatCode(bElemType);
+
+    if (!aFmtCode || !bFmtCode)
+      return op.emitOpError("unsupported element types for scaled_wmma");
+
+    // Get scale vector types and determine variant (scale vs scale16).
+    auto scaleAVecType = cast<VectorType>(op.getScaleA().getType());
+    auto scaleBVecType = cast<VectorType>(op.getScaleB().getType());
+
+    if (scaleAVecType.getNumElements() != scaleBVecType.getNumElements())
+      return op.emitOpError("scaleA and scaleB must have equal vector length");
+
+    // Extract scale format from element types.
+    Type scaleAElemType = scaleAVecType.getElementType();
+    Type scaleBElemType = scaleBVecType.getElementType();
+
+    std::optional<uint32_t> scaleAFmt = getWmmaScaleFormat(scaleAElemType);
+    std::optional<uint32_t> scaleBFmt = getWmmaScaleFormat(scaleBElemType);
+
+    if (!scaleAFmt || !scaleBFmt)
+      return op.emitOpError("unsupported scale element types");
+
+    // Determine which intrinsic to use based on dimensions.
+    bool isScale16 = (scaleAVecType.getNumElements() == 8);
+    std::optional<StringRef> intrinsicName =
+        getScaledWmmaIntrinsicName(m, n, k, isScale16);
+    if (!intrinsicName)
+      return op.emitOpError("unsupported scaled_wmma dimensions: ")
+             << m << "x" << n << "x" << k;
+
+    SmallVector<NamedAttribute, 8> attrs;
+
+    // The f4 variant does not have fmtA and fmtB attributes.
+    bool is32x16 = (m == 32 && n == 16 && k == 128);
+    if (!is32x16) {
+      attrs.emplace_back("fmtA", rewriter.getI32IntegerAttr(*aFmtCode));
+      attrs.emplace_back("fmtB", rewriter.getI32IntegerAttr(*bFmtCode));
+    }
+
+    // modC uses default value of 0.
+    attrs.emplace_back("modC", rewriter.getI16IntegerAttr(0));
+
+    // Scale attributes. Convert user-facing firstScaleLane (0 or 16) to the
+    // half of the wave that is being selected (0 or 1).
+    attrs.emplace_back(
+        "scaleAType", rewriter.getI32IntegerAttr(op.getAFirstScaleLane() / 16));
+    attrs.emplace_back("fmtScaleA", rewriter.getI32IntegerAttr(*scaleAFmt));
+    attrs.emplace_back(
+        "scaleBType", rewriter.getI32IntegerAttr(op.getBFirstScaleLane() / 16));
+    attrs.emplace_back("fmtScaleB", rewriter.getI32IntegerAttr(*scaleBFmt));
+
+    // Reuse flags use default value of false.
+    attrs.emplace_back("reuseA", rewriter.getBoolAttr(false));
+    attrs.emplace_back("reuseB", rewriter.getBoolAttr(false));
+
+    // Convert typed float vectors to packed format.
+    Value sourceA =
+        packSmallFloatVectorOperand(rewriter, loc, adaptor.getSourceA());
+    Value sourceB =
+        packSmallFloatVectorOperand(rewriter, loc, adaptor.getSourceB());
+
+    // Pack scale vectors into i32/i64.
+    Value packedScaleA = castScaleOperand(rewriter, loc, adaptor.getScaleA());
+    Value packedScaleB = castScaleOperand(rewriter, loc, adaptor.getScaleB());
+
+    // Create the intrinsic call.
+    OperationState loweredOp(loc, *intrinsicName);
+    loweredOp.addTypes(outType);
+    loweredOp.addOperands(
+        {sourceA, sourceB, adaptor.getDestC(), packedScaleA, packedScaleB});
+    loweredOp.addAttributes(attrs);
+
+    Operation *lowered = rewriter.create(loweredOp);
+    rewriter.replaceOp(op, lowered->getResults());
 
     return success();
   }
@@ -2220,10 +2360,10 @@ void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                ROCDL::RawPtrBufferAtomicCmpSwap>,
            AMDGPUDPPLowering, MemoryCounterWaitOpLowering, LDSBarrierOpLowering,
            SchedBarrierOpLowering, MFMAOpLowering, ScaledMFMAOpLowering,
-           WMMAOpLowering, ExtPackedFp8OpLowering, ScaledExtPackedOpLowering,
-           PackedScaledTruncOpLowering, PackedTrunc2xFp8OpLowering,
-           PackedStochRoundFp8OpLowering, GatherToLDSOpLowering,
-           AsyncLoadToLDSOpLowering, TransposeLoadOpLowering,
-           AMDGPUPermlaneLowering>(converter, chipset);
+           WMMAOpLowering, ScaledWMMAOpLowering, ExtPackedFp8OpLowering,
+           ScaledExtPackedOpLowering, PackedScaledTruncOpLowering,
+           PackedTrunc2xFp8OpLowering, PackedStochRoundFp8OpLowering,
+           GatherToLDSOpLowering, AsyncLoadToLDSOpLowering,
+           TransposeLoadOpLowering, AMDGPUPermlaneLowering>(converter, chipset);
   patterns.add<AMDGPUSwizzleBitModeLowering>(converter);
 }

--- a/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/external/llvm-project/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -413,6 +413,103 @@ LogicalResult WMMAOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ScaledWMMAOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ScaledWMMAOp::verify() {
+  // Helper functions for type classification.
+  auto isF8 = llvm::IsaPred<Float8E4M3FNType, Float8E5M2Type>;
+  auto isF6 = llvm::IsaPred<Float6E2M3FNType, Float6E3M2FNType>;
+  auto isF4 = llvm::IsaPred<Float4E2M1FNType>;
+  auto isScaleF8 = llvm::IsaPred<Float8E8M0FNUType, Float8E4M3FNType>;
+  auto isE8M0 = llvm::IsaPred<Float8E8M0FNUType>;
+  auto isE4M3 = llvm::IsaPred<Float8E4M3FNType>;
+
+  auto sourceAType = cast<VectorType>(getSourceA().getType());
+  auto sourceBType = cast<VectorType>(getSourceB().getType());
+  auto destType = cast<VectorType>(getDestC().getType());
+
+  // Validate source element types are small floats (fp4/fp6/fp8).
+  Type aElemType = sourceAType.getElementType();
+  Type bElemType = sourceBType.getElementType();
+
+  // Validate vector lengths based on dimensions.
+  int64_t m = getM();
+  int64_t aLen = sourceAType.getNumElements();
+  int64_t bLen = sourceBType.getNumElements();
+  int64_t expectedOutLen = (m == 16) ? 8 : 16;
+
+  if (destType.getNumElements() != expectedOutLen)
+    return emitOpError("expected output vector of length ")
+           << expectedOutLen << " but got " << destType.getNumElements();
+
+  if (m == 16) {
+    // For 16×16×128: both A and B must be 64 elements.
+    if (aLen != 64)
+      return emitOpError(
+                 "for 16x16x128, sourceA must have 64 elements but got ")
+             << aLen;
+    if (bLen != 64)
+      return emitOpError(
+                 "for 16x16x128, sourceB must have 64 elements but got ")
+             << bLen;
+  } else { // m == 32
+    // For 32×16×128: only fp4 is supported, A is 128, B is 64.
+    if (!isF4(aElemType) && !isF4(bElemType))
+      return emitOpError("32x16x128 only supports fp4 element types");
+
+    if (aLen != 128)
+      return emitOpError(
+                 "for 32x16x128, sourceA must have 128 elements but got ")
+             << aLen;
+    if (bLen != 64)
+      return emitOpError(
+                 "for 32x16x128, sourceB must have 64 elements but got ")
+             << bLen;
+
+    // For 32x16x128, matrix A uses all 32 lanes so a_first_scale_lane must be
+    // 0.
+    if (getAFirstScaleLane() != 0)
+      return emitOpError("for 32x16x128, a_first_scale_lane must be 0");
+  }
+
+  // Validate scale types and their compatibility with matrix element types.
+  auto scaleAType = cast<VectorType>(getScaleA().getType());
+  auto scaleBType = cast<VectorType>(getScaleB().getType());
+  Type scaleAElemType = scaleAType.getElementType();
+  Type scaleBElemType = scaleBType.getElementType();
+
+  // Validate scale element types are valid scale f8 types (E8M0FNU or E4M3FN).
+  if (!isScaleF8(scaleAElemType) || !isScaleF8(scaleBElemType))
+    return emitOpError(
+        "scale operands must have f8 element types (E8M0FNU or E4M3FN)");
+
+  // Any matrices A/B (fp8|fp6|fp4) with E8M0 scales for matrix A/B are valid.
+  if (isE8M0(scaleAElemType) && isE8M0(scaleBElemType))
+    return success();
+
+  // Matrix A (F8|F6) x Matrix B (F4) with Scale A (E8M0), Scale B (E5M3|E4M3).
+  if ((isF8(aElemType) || isF6(aElemType)) && isE8M0(scaleAElemType) &&
+      isF4(bElemType) && isE4M3(scaleBElemType))
+    return success();
+
+  // Matrix A (F4) x Matrix B (F8|F6) with Scale A (E5M3|E4M3), Scale B (E8M0).
+  if (isF4(aElemType) && isE4M3(scaleAElemType) &&
+      (isF8(bElemType) || isF6(bElemType)) && isE8M0(scaleBElemType))
+    return success();
+
+  // Matrix A (F4) x Matrix B (F4) with Scale A (E4M3), Scale B (E4M3).
+  if (isF4(aElemType) && isF4(bElemType) && isE4M3(scaleAElemType) &&
+      isE4M3(scaleBElemType))
+    return success();
+
+  // No valid combination matched.
+  return emitOpError("invalid combination of matrix and scale types: ")
+         << "sourceA=" << aElemType << ", scaleA=" << scaleAElemType
+         << ", sourceB=" << bElemType << ", scaleB=" << scaleBElemType;
+}
+
+//===----------------------------------------------------------------------===//
 // MFMAOp
 //===----------------------------------------------------------------------===//
 LogicalResult MFMAOp::verify() {

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx1250.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/wmma-gfx1250.mlir
@@ -89,11 +89,123 @@ func.func @wmma_k128(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<64xf8E5M2>,
   return
 }
 
+// CHECK-LABEL: @wmma_scale_16x16x128_fp8
+func.func @wmma_scale_16x16x128_fp8(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<64xf6E2M3FN>,
+                                    %arg2 : vector<8xf32>, %arg3 : vector<4xf8E8M0FNU>) {
+  // CHECK: rocdl.wmma.scale.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf32>, i32, i32) -> vector<8xf32>
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg0) * (%arg3 * %arg0) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.scale.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} {fmtA = 2 : i32, fmtB = 2 : i32, scaleAType = 1 : i32} : (vector<12xi32>, vector<12xi32>, vector<8xf32>, i32, i32) -> vector<8xf32>
+  %1 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg1) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 16 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<8xf32>
+
+  func.return
+}
+
+// CHECK-LABEL: @wmma_scale_16x16x128_fp6
+func.func @wmma_scale_16x16x128_fp6(%arg0 : vector<64xf6E2M3FN>, %arg1 : vector<64xf6E3M2FN>,
+                                    %arg2 : vector<8xf32>, %arg3 : vector<4xf8E8M0FNU>) {
+  // CHECK: rocdl.wmma.scale.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} {fmtA = 2 : i32, fmtB = 2 : i32} : (vector<12xi32>, vector<12xi32>, vector<8xf32>, i32, i32) -> vector<8xf32>
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg0) * (%arg3 * %arg0) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.scale.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} {fmtA = 3 : i32, fmtB = 3 : i32} : (vector<12xi32>, vector<12xi32>, vector<8xf32>, i32, i32) -> vector<8xf32>
+  %1 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg1) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<4xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<8xf32>
+
+  func.return
+}
+
+// CHECK-LABEL: @wmma_scale_16x16x128_mixed
+func.func @wmma_scale_16x16x128_mixed(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<64xf6E2M3FN>,
+                                      %arg2 : vector<64xf4E2M1FN>, %arg3 : vector<8xf32>,
+                                      %arg4 : vector<4xf8E8M0FNU>, %arg5 : vector<4xf8E4M3FN>) {
+  // CHECK: rocdl.wmma.scale.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg3, {{.*}}, {{.*}} {fmtB = 4 : i32, fmtScaleB = 2 : i32} : (vector<16xi32>, vector<8xi32>, vector<8xf32>, i32, i32) -> vector<8xf32>
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg4 * %arg0) * (%arg5 * %arg2) + %arg3 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.scale.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg3, {{.*}}, {{.*}} {fmtA = 2 : i32, fmtB = 4 : i32, fmtScaleB = 2 : i32} : (vector<12xi32>, vector<8xi32>, vector<8xf32>, i32, i32) -> vector<8xf32>
+  %1 = amdgpu.scaled_wmma 16x16x128 (%arg4 * %arg1) * (%arg5 * %arg2) + %arg3 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<8xf32>
+
+  func.return
+}
+
+// CHECK-LABEL: @wmma_scale16_16x16x128_fp8
+func.func @wmma_scale16_16x16x128_fp8(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<64xf6E3M2FN>,
+                                      %arg2 : vector<8xf32>, %arg3 : vector<8xf8E8M0FNU>) {
+  // CHECK: rocdl.wmma.scale16.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} : (vector<16xi32>, vector<16xi32>, vector<8xf32>, i64, i64) -> vector<8xf32>
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg0) * (%arg3 * %arg0) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<8xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf32>
+
+  // CHECK: rocdl.wmma.scale16.f32.16x16x128.f8f6f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} {fmtA = 3 : i32, fmtB = 3 : i32, scaleAType = 1 : i32} : (vector<12xi32>, vector<12xi32>, vector<8xf32>, i64, i64) -> vector<8xf32>
+  %1 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg1) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 16 : i32, b_first_scale_lane = 0 : i32} : vector<8xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<8xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<8xf32>
+
+  func.return
+}
+
+// CHECK-LABEL: @wmma_scale_32x16x128_fp4
+func.func @wmma_scale_32x16x128_fp4(%arg0 : vector<128xf4E2M1FN>, %arg1 : vector<64xf4E2M1FN>,
+                                    %arg2 : vector<16xf32>, %arg3 : vector<4xf8E4M3FN>) {
+  // CHECK: rocdl.wmma.scale.f32.32x16x128.f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} {fmtScaleA = 2 : i32, fmtScaleB = 2 : i32} : (vector<16xi32>, vector<8xi32>, vector<16xf32>, i32, i32) -> vector<16xf32>
+  %0 = amdgpu.scaled_wmma 32x16x128 (%arg3 * %arg0) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E4M3FN>, vector<128xf4E2M1FN>, vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<16xf32>
+
+  func.return
+}
+
+// CHECK-LABEL: @wmma_scale16_32x16x128_fp4
+func.func @wmma_scale16_32x16x128_fp4(%arg0 : vector<128xf4E2M1FN>, %arg1 : vector<64xf4E2M1FN>,
+                                      %arg2 : vector<16xf32>, %arg3 : vector<8xf8E4M3FN>) {
+  // CHECK: rocdl.wmma.scale16.f32.32x16x128.f4 {{.*}}, {{.*}}, %arg2, {{.*}}, {{.*}} {fmtScaleA = 2 : i32, fmtScaleB = 2 : i32} : (vector<16xi32>, vector<8xi32>, vector<16xf32>, i64, i64) -> vector<16xf32>
+  %0 = amdgpu.scaled_wmma 32x16x128 (%arg3 * %arg0) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<8xf8E4M3FN>, vector<128xf4E2M1FN>, vector<8xf8E4M3FN>, vector<64xf4E2M1FN>, vector<16xf32>
+
+  func.return
+}
+
 // -----
 
 func.func @wmma_unsupported_k(%arg0 : vector<8xf16>, %arg1 : vector<8xf32>) {
   // expected-error@below {{'amdgpu.wmma' op no intrinsic matching WMMA on the given chipset}}
   // expected-error@below {{failed to legalize operation 'amdgpu.wmma'}}
   amdgpu.wmma 16x16x16 %arg0 * %arg0 + %arg1 : vector<8xf16>, vector<8xf16>, vector<8xf32>
+  return
+}
+
+// -----
+
+func.func @scaled_wmma_wrong_output_length(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<16xf32>,
+                                           %arg2 : vector<4xf8E8M0FNU>) {
+  // expected-error@below {{'amdgpu.scaled_wmma' op expected output vector of length 8 but got 16}}
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg2 * %arg0) * (%arg2 * %arg0) + %arg1 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<16xf32>
+  return
+}
+
+func.func @scaled_wmma_16x16_wrong_sourceA_length(%arg0 : vector<128xf4E2M1FN>, %arg1 : vector<64xf4E2M1FN>,
+                                                  %arg2 : vector<8xf32>, %arg3 : vector<4xf8E8M0FNU>) {
+  // expected-error@below {{'amdgpu.scaled_wmma' op for 16x16x128, sourceA must have 64 elements but got 128}}
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg0) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<128xf4E2M1FN>, vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<8xf32>
+  return
+}
+
+func.func @scaled_wmma_16x16_wrong_sourceB_length(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<128xf4E2M1FN>,
+                                                  %arg2 : vector<8xf32>, %arg3 : vector<4xf8E8M0FNU>) {
+  // expected-error@below {{'amdgpu.scaled_wmma' op for 16x16x128, sourceB must have 64 elements but got 128}}
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg0) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<4xf8E8M0FNU>, vector<128xf4E2M1FN>, vector<8xf32>
+  return
+}
+
+func.func @scaled_wmma_32x16_wrong_sourceA_length(%arg0 : vector<64xf4E2M1FN>, %arg1 : vector<64xf4E2M1FN>,
+                                                  %arg2 : vector<16xf32>, %arg3 : vector<4xf8E4M3FN>) {
+  // expected-error@below {{'amdgpu.scaled_wmma' op for 32x16x128, sourceA must have 128 elements but got 64}}
+  %0 = amdgpu.scaled_wmma 32x16x128 (%arg3 * %arg0) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<16xf32>
+  return
+}
+
+func.func @scaled_wmma_32x16_wrong_sourceB_length(%arg0 : vector<128xf4E2M1FN>, %arg1 : vector<128xf4E2M1FN>,
+                                                  %arg2 : vector<16xf32>, %arg3 : vector<4xf8E4M3FN>) {
+  // expected-error@below {{'amdgpu.scaled_wmma' op for 32x16x128, sourceB must have 64 elements but got 128}}
+  %0 = amdgpu.scaled_wmma 32x16x128 (%arg3 * %arg0) * (%arg3 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E4M3FN>, vector<128xf4E2M1FN>, vector<4xf8E4M3FN>, vector<128xf4E2M1FN>, vector<16xf32>
+  return
+}
+
+func.func @scaled_wmma_invalid_type_combination(%arg0 : vector<64xf8E4M3FN>, %arg1 : vector<64xf6E2M3FN>,
+                                                %arg2 : vector<8xf32>, %arg3 : vector<4xf8E8M0FNU>,
+                                                %arg4 : vector<4xf8E4M3FN>) {
+  // expected-error@below {{'amdgpu.scaled_wmma' op invalid combination of matrix and scale types}}
+  %0 = amdgpu.scaled_wmma 16x16x128 (%arg3 * %arg0) * (%arg4 * %arg1) + %arg2 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<4xf8E4M3FN>, vector<64xf6E2M3FN>, vector<8xf32>
   return
 }

--- a/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
+++ b/external/llvm-project/mlir/test/Dialect/AMDGPU/ops.mlir
@@ -685,3 +685,25 @@ func.func @memory_counter_wait() {
   amdgpu.memory_counter_wait exp(4)
   func.return
 }
+
+// CHECK-LABEL: func @wmma_scale
+func.func @wmma_scale(%fp8_src: vector<64xf8E4M3FN>, %fp6_alt_src: vector<64xf6E3M2FN>,
+                      %fp6_src: vector<64xf6E2M3FN>, %fp4_src_a: vector<128xf4E2M1FN>,
+                      %fp4_src_b: vector<64xf4E2M1FN>,
+                      %dst0: vector<8xf32>, %dst1: vector<16xf32>,
+                      %scale_vec4: vector<4xf8E8M0FNU>, %scale_vec8: vector<8xf8E8M0FNU>,
+                      %scale_vec4_e4m3: vector<4xf8E4M3FN>) {
+  // CHECK: amdgpu.scaled_wmma 16x16x128 ({{.*}} * {{.*}}) * ({{.*}} * {{.*}}) + {{.*}} {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf32>
+  %0 = amdgpu.scaled_wmma 16x16x128 (%scale_vec4 * %fp8_src) * (%scale_vec4 * %fp8_src) + %dst0 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<4xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: amdgpu.scaled_wmma 16x16x128 ({{.*}} * {{.*}}) * ({{.*}} * {{.*}}) + {{.*}} {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<4xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<8xf32>
+  %1 = amdgpu.scaled_wmma 16x16x128 (%scale_vec4 * %fp6_alt_src) * (%scale_vec4 * %fp6_alt_src) + %dst0 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<4xf8E8M0FNU>, vector<64xf6E3M2FN>, vector<8xf32>
+  // CHECK: amdgpu.scaled_wmma 16x16x128 ({{.*}} * {{.*}}) * ({{.*}} * {{.*}}) + {{.*}} {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<8xf32>
+  %2 = amdgpu.scaled_wmma 16x16x128 (%scale_vec4 * %fp6_src) * (%scale_vec4 * %fp6_src) + %dst0 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<8xf32>
+  // CHECK: amdgpu.scaled_wmma 16x16x128 ({{.*}} * {{.*}}) * ({{.*}} * {{.*}}) + {{.*}} {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<8xf32>
+  %3 = amdgpu.scaled_wmma 16x16x128 (%scale_vec4_e4m3 * %fp4_src_b) * (%scale_vec4 * %fp6_src) + %dst0 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<4xf8E8M0FNU>, vector<64xf6E2M3FN>, vector<8xf32>
+  // CHECK: amdgpu.scaled_wmma 16x16x128 ({{.*}} * {{.*}}) * ({{.*}} * {{.*}}) + {{.*}} {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<8xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf32>
+  %4 = amdgpu.scaled_wmma 16x16x128 (%scale_vec8 * %fp8_src) * (%scale_vec8 * %fp8_src) + %dst0 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<8xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf8E8M0FNU>, vector<64xf8E4M3FN>, vector<8xf32>
+  // CHECK: amdgpu.scaled_wmma 32x16x128 ({{.*}} * {{.*}}) * ({{.*}} * {{.*}}) + {{.*}} {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E4M3FN>, vector<128xf4E2M1FN>, vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<16xf32>
+  %5 = amdgpu.scaled_wmma 32x16x128 (%scale_vec4_e4m3 * %fp4_src_a) * (%scale_vec4_e4m3 * %fp4_src_b) + %dst1 {a_first_scale_lane = 0 : i32, b_first_scale_lane = 0 : i32} : vector<4xf8E4M3FN>, vector<128xf4E2M1FN>, vector<4xf8E4M3FN>, vector<64xf4E2M1FN>, vector<16xf32>
+  func.return
+}

--- a/external/llvm-project/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -1305,6 +1305,26 @@ llvm.func @rocdl.cvt.scalef32.sr.pk16(%v16xf32: vector<16xf32>,
 
 // -----
 
+// CHECK-LABEL: @rocdl_wmma_scale_ops
+llvm.func @rocdl_wmma_scale_ops(%a_f8: vector<8xi32>, %a_f4: vector<4xi32>, %c_f32: vector<4xf32>, %c16_f32: vector<16xf32>,
+                                 %scale_i32: i32, %scale_i64: i64) {
+  // CHECK: rocdl.wmma.scale.f32.16x16x128.f8f6f4 %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (vector<8xi32>, vector<8xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  %r0 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %a_f8, %a_f8, %c_f32, %scale_i32, %scale_i32 : (vector<8xi32>, vector<8xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+
+  // CHECK: rocdl.wmma.scale16.f32.16x16x128.f8f6f4 %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (vector<8xi32>, vector<8xi32>, vector<4xf32>, i64, i64) -> vector<4xf32>
+  %r1 = rocdl.wmma.scale16.f32.16x16x128.f8f6f4 %a_f8, %a_f8, %c_f32, %scale_i64, %scale_i64 : (vector<8xi32>, vector<8xi32>, vector<4xf32>, i64, i64) -> vector<4xf32>
+
+  // CHECK: rocdl.wmma.scale.f32.32x16x128.f4 %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (vector<4xi32>, vector<4xi32>, vector<16xf32>, i32, i32) -> vector<16xf32>
+  %r2 = rocdl.wmma.scale.f32.32x16x128.f4 %a_f4, %a_f4, %c16_f32, %scale_i32, %scale_i32 : (vector<4xi32>, vector<4xi32>, vector<16xf32>, i32, i32) -> vector<16xf32>
+
+  // CHECK: rocdl.wmma.scale16.f32.32x16x128.f4 %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (vector<4xi32>, vector<4xi32>, vector<16xf32>, i64, i64) -> vector<16xf32>
+  %r3 = rocdl.wmma.scale16.f32.32x16x128.f4 %a_f4, %a_f4, %c16_f32, %scale_i64, %scale_i64 : (vector<4xi32>, vector<4xi32>, vector<16xf32>, i64, i64) -> vector<16xf32>
+
+  llvm.return
+}
+
+// -----
+
 // expected-error@below {{attribute attached to unexpected op}}
 func.func private @expected_llvm_func() attributes { rocdl.kernel }
 

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -905,6 +905,30 @@ llvm.func @rocdl.wmma(%arg0 : vector<8xf32>, %arg1 : vector<16 x f16>, %arg2 : v
   // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x32.iu4.v8i32.v2i32(i1 false, <2 x i32> %{{.*}} i1 false, <2 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
   %r6.gfx12 = rocdl.wmma.i32.16x16x32.iu4 %arg4, %arg4, %arg3 {signA = false, signB = false, clamp = false} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
 
+  // Test signA=true, signB=false for iu8
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu8.v8i32.v4i32(i1 true, <4 x i32> %{{.*}} i1 false, <4 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
+  %r5a = rocdl.wmma.i32.16x16x16.iu8 %arg5, %arg5, %arg3 {signA = true, signB = false, clamp = false} : (vector<4xi32>, vector<4xi32>, vector<8xi32>) -> vector<8xi32>
+
+  // Test signA=false, signB=true for iu8
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu8.v8i32.v4i32(i1 false, <4 x i32> %{{.*}} i1 true, <4 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
+  %r5b = rocdl.wmma.i32.16x16x16.iu8 %arg5, %arg5, %arg3 {signA = false, signB = true, clamp = false} : (vector<4xi32>, vector<4xi32>, vector<8xi32>) -> vector<8xi32>
+
+  // Test signA=true, signB=true, clamp=true for iu8
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu8.v8i32.v4i32(i1 true, <4 x i32> %{{.*}} i1 true, <4 x i32> %{{.*}} <8 x i32> %{{.*}} i1 true)
+  %r5c = rocdl.wmma.i32.16x16x16.iu8 %arg5, %arg5, %arg3 {signA = true, signB = true, clamp = true} : (vector<4xi32>, vector<4xi32>, vector<8xi32>) -> vector<8xi32>
+
+  // Test signA=true, signB=false for iu4
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu4.v8i32.v2i32(i1 true, <2 x i32> %{{.*}} i1 false, <2 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
+  %r6a = rocdl.wmma.i32.16x16x16.iu4 %arg4, %arg4, %arg3 {signA = true, signB = false, clamp = false} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
+
+  // Test signA=false, signB=true, clamp=true for iu4
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x16.iu4.v8i32.v2i32(i1 false, <2 x i32> %{{.*}} i1 true, <2 x i32> %{{.*}} <8 x i32> %{{.*}} i1 true)
+  %r6b = rocdl.wmma.i32.16x16x16.iu4 %arg4, %arg4, %arg3 {signA = false, signB = true, clamp = true} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
+
+  // Test signA=true, signB=true for iu4 gfx12
+  // CHECK: call <8 x i32> @llvm.amdgcn.wmma.i32.16x16x32.iu4.v8i32.v2i32(i1 true, <2 x i32> %{{.*}} i1 true, <2 x i32> %{{.*}} <8 x i32> %{{.*}} i1 false)
+  %r6c = rocdl.wmma.i32.16x16x32.iu4 %arg4, %arg4, %arg3 {signA = true, signB = true, clamp = false} : (vector<2xi32>, vector<2xi32>, vector<8xi32>) -> vector<8xi32>
+
   // f32 -> f32
   // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x4.f32.v4f32.v16f32(i1 false, <16 x float> %{{.*}} i1 false, <16 x float> %{{.*}} i16 0, <4 x float> %{{.*}} i1 false, i1 false)
   %r1.gfx1250 = rocdl.wmma.f32.16x16x4.f32 %arg10, %arg10, %arg11 {signA = false, signB = false, modC = 0 : i16} : (vector<16xf32>, vector<16xf32>, vector<4xf32>) -> vector<4xf32>
@@ -968,7 +992,7 @@ llvm.func @rocdl.wmma(%arg0 : vector<8xf32>, %arg1 : vector<16 x f16>, %arg2 : v
 
   // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.fp8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
   %r19.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_fp8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
-  
+
   // CHECK: call <64 x half> @llvm.amdgcn.wmma.f16.16x16x128.fp8.bf8.v64f16.v4i32(<4 x i32> %{{.*}} <4 x i32> %{{.*}} i16 0, <64 x half> %{{.*}} i1 false, i1 false)
   %r20.gfx1250 = rocdl.wmma.f16.16x16x128.fp8_bf8 %arg5, %arg5, %arg15 {signA = false, signB = false, modC = 0 : i16} : (vector<4xi32>, vector<4xi32>, vector<64xf16>) -> vector<64xf16>
 
@@ -981,6 +1005,26 @@ llvm.func @rocdl.wmma(%arg0 : vector<8xf32>, %arg1 : vector<16 x f16>, %arg2 : v
   // iu8 -> i32
   // CHECK: call <64 x i32> @llvm.amdgcn.wmma.i32.16x16x64.iu8.v64i32.v4i32(i1 false, <4 x i32> %{{.*}} i1 false, <4 x i32> %{{.*}} <64 x i32> %{{.*}} i1 false, i1 false)
   %r23.gfx1250 = rocdl.wmma.i32.16x16x64.iu8 %arg5, %arg5, %arg14 {signA = false, signB = false} : (vector<4xi32>, vector<4xi32>, vector<64xi32>) -> vector<64xi32>
+
+  // Test signA=true, signB=true for iu8 gfx1250  
+  // CHECK: call <64 x i32> @llvm.amdgcn.wmma.i32.16x16x64.iu8.v64i32.v4i32(i1 true, <4 x i32> %{{.*}} i1 true, <4 x i32> %{{.*}} <64 x i32> %{{.*}} i1 false, i1 false)
+  %r23a.gfx1250 = rocdl.wmma.i32.16x16x64.iu8 %arg5, %arg5, %arg14 {signA = true, signB = true} : (vector<4xi32>, vector<4xi32>, vector<64xi32>) -> vector<64xi32>
+
+  // Test signA=true, signB=false, reuseA=true, reuseB=true for iu8 gfx1250
+  // CHECK: call <64 x i32> @llvm.amdgcn.wmma.i32.16x16x64.iu8.v64i32.v4i32(i1 true, <4 x i32> %{{.*}} i1 false, <4 x i32> %{{.*}} <64 x i32> %{{.*}} i1 true, i1 true)
+  %r23b.gfx1250 = rocdl.wmma.i32.16x16x64.iu8 %arg5, %arg5, %arg14 {signA = true, signB = false, reuseA = true, reuseB = true} : (vector<4xi32>, vector<4xi32>, vector<64xi32>) -> vector<64xi32>
+
+  // Test signA=true, signB=true with modC=1 for f32 gfx1250
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.f32.16x16x4.f32.v4f32.v16f32(i1 true, <16 x float> %{{.*}} i1 true, <16 x float> %{{.*}} i16 1, <4 x float> %{{.*}} i1 false, i1 false)
+  %r1a.gfx1250 = rocdl.wmma.f32.16x16x4.f32 %arg10, %arg10, %arg11 {signA = true, signB = true, modC = 1 : i16, reuseA = false, reuseB = false} : (vector<16xf32>, vector<16xf32>, vector<4xf32>) -> vector<4xf32>
+
+  // Test with modC=2 and signA=false, signB=true, reuseA=true for f16 gfx1250
+  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.f16.v32f32.v16f16(i1 false, <16 x half> %{{.*}} i1 true, <16 x half> %{{.*}} i16 2, <32 x float> %{{.*}} i1 true, i1 false)
+  %r2a.gfx1250 = rocdl.wmma.f32.16x16x32.f16 %arg1, %arg1, %arg12 {signA = false, signB = true, modC = 2 : i16, reuseA = true, reuseB = false} : (vector<16xf16>, vector<16xf16>, vector<32xf32>) -> vector<32xf32>
+
+  // Test with modC=3 and signA=true, signB=true, reuseB=true for bf16 gfx1250
+  // CHECK: call <32 x float> @llvm.amdgcn.wmma.f32.16x16x32.bf16.v32f32.v16bf16(i1 true, <16 x bfloat> %{{.*}} i1 true, <16 x bfloat> %{{.*}} i16 3, <32 x float> %{{.*}} i1 false, i1 true)
+  %r3a.gfx1250 = rocdl.wmma.f32.16x16x32.bf16 %arg16, %arg16, %arg12 {signA = true, signB = true, modC = 3 : i16, reuseA = false, reuseB = true} : (vector<16xbf16>, vector<16xbf16>, vector<32xf32>) -> vector<32xf32>
 
   // ---- Wave64 -----
 
@@ -1183,6 +1227,113 @@ llvm.func @rocdl.raw.ptr.buffer.load.lds(%rsrc : !llvm.ptr<8>, %dstLds : !llvm.p
   rocdl.raw.ptr.buffer.load.lds %rsrc, %dstLds, %size, %voffset, %soffset, %offset, %aux
 
   llvm.return
+}
+
+llvm.func @rocdl.wmma.scale(%arg0: i32, %arg1: vector<4xf32>, %arg2: vector<8xi32>,
+                            %arg3: vector<12xi32>, %arg5: vector<16xi32>,
+                            %arg8: i64, %arg9: vector<8xf32>) -> vector<4xf32> {
+  // CHECK-LABEL: rocdl.wmma.scale
+  
+  // Test with default attributes (all zeros/false)
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v16i32(i32 0, <16 x i32> %{{.*}}, i32 0, <16 x i32> %{{.*}}, i16 0, <4 x float> %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i1 false, i1 false)
+  %r00 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg5, %arg1, %arg0, %arg0
+    {fmtA = 0 : i32, fmtB = 0 : i32, modC = 0 : i16,
+     scaleAType = 0 : i32, fmtScaleA = 0 : i32,
+     scaleBType = 0 : i32, fmtScaleB = 0 : i32,
+     reuseA = false, reuseB = false} :
+    (vector<16xi32>, vector<16xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test with different matrix formats (FP8 x BF8)
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v16i32(i32 0, <16 x i32> %{{.*}}, i32 1, <16 x i32> %{{.*}}, i16 0, <4 x float> %{{.*}}, i32 1, i32 1, i32 %{{.*}}, i32 1, i32 1, i32 %{{.*}}, i1 false, i1 false)
+  %r01 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg5, %arg1, %arg0, %arg0
+    {fmtA = 0 : i32, fmtB = 1 : i32, modC = 0 : i16,
+     scaleAType = 1 : i32, fmtScaleA = 1 : i32,
+     scaleBType = 1 : i32, fmtScaleB = 1 : i32,
+     reuseA = false, reuseB = false} :
+    (vector<16xi32>, vector<16xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test with FP8 x FP6 (different vector sizes) and modC = 1 (negate)
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v12i32(i32 0, <16 x i32> %{{.*}}, i32 2, <12 x i32> %{{.*}}, i16 1, <4 x float> %{{.*}}, i32 2, i32 2, i32 %{{.*}}, i32 2, i32 2, i32 %{{.*}}, i1 false, i1 false)
+  %r02 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg3, %arg1, %arg0, %arg0
+    {fmtA = 0 : i32, fmtB = 2 : i32, modC = 1 : i16,
+     scaleAType = 2 : i32, fmtScaleA = 2 : i32,
+     scaleBType = 2 : i32, fmtScaleB = 2 : i32,
+     reuseA = false, reuseB = false} :
+    (vector<16xi32>, vector<12xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test with BF8 x BF6 and modC = 2 (abs)
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v12i32(i32 1, <16 x i32> %{{.*}}, i32 3, <12 x i32> %{{.*}}, i16 2, <4 x float> %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i1 false, i1 false)
+  %r03 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg3, %arg1, %arg0, %arg0
+    {fmtA = 1 : i32, fmtB = 3 : i32, modC = 2 : i16,
+     scaleAType = 0 : i32, fmtScaleA = 0 : i32,
+     scaleBType = 0 : i32, fmtScaleB = 0 : i32,
+     reuseA = false, reuseB = false} :
+    (vector<16xi32>, vector<12xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test with FP8 x FP4 and modC = 3 (negate(abs))
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v8i32(i32 0, <16 x i32> %{{.*}}, i32 4, <8 x i32> %{{.*}}, i16 3, <4 x float> %{{.*}}, i32 3, i32 3, i32 %{{.*}}, i32 3, i32 3, i32 %{{.*}}, i1 false, i1 false)
+  %r04 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg2, %arg1, %arg0, %arg0
+    {fmtA = 0 : i32, fmtB = 4 : i32, modC = 3 : i16,
+     scaleAType = 3 : i32, fmtScaleA = 3 : i32,
+     scaleBType = 3 : i32, fmtScaleB = 3 : i32,
+     reuseA = false, reuseB = false} :
+    (vector<16xi32>, vector<8xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test with reuseA = true
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v16i32(i32 2, <16 x i32> %{{.*}}, i32 2, <16 x i32> %{{.*}}, i16 0, <4 x float> %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i1 true, i1 false)
+  %r10 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg5, %arg1, %arg0, %arg0
+    {fmtA = 2 : i32, fmtB = 2 : i32, modC = 0 : i16,
+     scaleAType = 0 : i32, fmtScaleA = 0 : i32,
+     scaleBType = 0 : i32, fmtScaleB = 0 : i32,
+     reuseA = true, reuseB = false} :
+    (vector<16xi32>, vector<16xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test with reuseB = true
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v16i32(i32 3, <16 x i32> %{{.*}}, i32 3, <16 x i32> %{{.*}}, i16 0, <4 x float> %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i32 0, i32 0, i32 %{{.*}}, i1 false, i1 true)
+  %r11 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg5, %arg1, %arg0, %arg0
+    {fmtA = 3 : i32, fmtB = 3 : i32, modC = 0 : i16,
+     scaleAType = 0 : i32, fmtScaleA = 0 : i32,
+     scaleBType = 0 : i32, fmtScaleB = 0 : i32,
+     reuseA = false, reuseB = true} :
+    (vector<16xi32>, vector<16xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test with both reuseA and reuseB = true
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4.v4f32.v16i32.v16i32(i32 4, <16 x i32> %{{.*}}, i32 4, <16 x i32> %{{.*}}, i16 1, <4 x float> %{{.*}}, i32 1, i32 1, i32 %{{.*}}, i32 1, i32 1, i32 %{{.*}}, i1 true, i1 true)
+  %r12 = rocdl.wmma.scale.f32.16x16x128.f8f6f4 %arg5, %arg5, %arg1, %arg0, %arg0
+    {fmtA = 4 : i32, fmtB = 4 : i32, modC = 1 : i16,
+     scaleAType = 1 : i32, fmtScaleA = 1 : i32,
+     scaleBType = 1 : i32, fmtScaleB = 1 : i32,
+     reuseA = true, reuseB = true} :
+    (vector<16xi32>, vector<16xi32>, vector<4xf32>, i32, i32) -> vector<4xf32>
+  
+  // Test scale16 variant with i64 scale exponents
+  // CHECK: call <4 x float> @llvm.amdgcn.wmma.scale16.f32.16x16x128.f8f6f4.v4f32.v16i32.v16i32(i32 0, <16 x i32> %{{.*}}, i32 1, <16 x i32> %{{.*}}, i16 2, <4 x float> %{{.*}}, i32 2, i32 2, i64 %{{.*}}, i32 2, i32 2, i64 %{{.*}}, i1 false, i1 false)
+  %r_scale16 = rocdl.wmma.scale16.f32.16x16x128.f8f6f4 %arg5, %arg5, %arg1, %arg8, %arg8
+    {fmtA = 0 : i32, fmtB = 1 : i32, modC = 2 : i16,
+     scaleAType = 2 : i32, fmtScaleA = 2 : i32,
+     scaleBType = 2 : i32, fmtScaleB = 2 : i32,
+     reuseA = false, reuseB = false} :
+    (vector<16xi32>, vector<16xi32>, vector<4xf32>, i64, i64) -> vector<4xf32>
+  
+  // Test f4 variant (no matrix format parameters)
+  // CHECK: call <8 x float> @llvm.amdgcn.wmma.scale.f32.32x16x128.f4.v8f32.v16i32.v8i32(<16 x i32> %{{.*}}, <8 x i32> %{{.*}}, i16 0, <8 x float> %{{.*}}, i32 1, i32 1, i32 %{{.*}}, i32 1, i32 1, i32 %{{.*}}, i1 false, i1 false)
+  %r_f4 = rocdl.wmma.scale.f32.32x16x128.f4 %arg5, %arg2, %arg9, %arg0, %arg0
+    {modC = 0 : i16,
+     scaleAType = 1 : i32, fmtScaleA = 1 : i32,
+     scaleBType = 1 : i32, fmtScaleB = 1 : i32,
+     reuseA = false, reuseB = false} :
+    (vector<16xi32>, vector<8xi32>, vector<8xf32>, i32, i32) -> vector<8xf32>
+  
+  // Test f4 scale16 variant with varied attributes
+  // CHECK: call <8 x float> @llvm.amdgcn.wmma.scale16.f32.32x16x128.f4.v8f32.v16i32.v8i32(<16 x i32> %{{.*}}, <8 x i32> %{{.*}}, i16 3, <8 x float> %{{.*}}, i32 2, i32 3, i64 %{{.*}}, i32 3, i32 2, i64 %{{.*}}, i1 true, i1 true)
+  %r_f4_scale16 = rocdl.wmma.scale16.f32.32x16x128.f4 %arg5, %arg2, %arg9, %arg8, %arg8
+    {modC = 3 : i16,
+     scaleAType = 2 : i32, fmtScaleA = 3 : i32,
+     scaleBType = 3 : i32, fmtScaleB = 2 : i32,
+     reuseA = true, reuseB = true} :
+    (vector<16xi32>, vector<8xi32>, vector<8xf32>, i64, i64) -> vector<8xf32>
+  
+  llvm.return %r00 : vector<4xf32>
 }
 
 llvm.func @rocdl.raw.ptr.buffer.atomic.f32(%rsrc : !llvm.ptr<8>,

--- a/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/AccelEmitter.h
@@ -85,9 +85,12 @@ struct AccelEmitterParams {
 struct AccelEmitter {
 
   /// Select the right accelerator based on the set of features and architecture
+  /// If \p forScaledOp is true, selects the scaled WMMA instruction for types
+  /// that support both scaled and unscaled variants (e.g., FP8).
   static std::unique_ptr<AccelEmitter>
   select(GemmFeatures features, Type dataTypeA, Type dataTypeB, StringRef arch,
-         RockAccelTuningParamAttrInterface tuningParams);
+         RockAccelTuningParamAttrInterface tuningParams,
+         bool forScaledOp = false);
 
   /// Emit the actual intrinsic in the threadwise operation
   /// If scaleA and scaleB are provided, emits a scaled version

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1009,10 +1009,10 @@ defvar SupportedMemoryElems = [F32, F16, BF16, I1, I<4>, I8, I16, I32,
 defvar NativeMemoryOpTypes =
     [F32, F16, BF16, I<4>, I8, I16, I32, F8E5M2FNUZ, F8E4M3FNUZ, F8E5M2,
      F8E4M3FN, F4E2M1FN, F8E8M0FNU,
-     VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32, F4E2M1FN, F8E8M0FNU]>,
+     VectorOfLengthAndType<[2, 4, 8, 16, 32], [F32, I32, F8E8M0FNU]>,
      VectorOfLengthAndType<[2, 4, 8, 16], [F16, BF16]>,
      VectorOfLengthAndType<[2, 4, 8, 16, 32, 64], [I8, F8E5M2FNUZ, F8E4M3FNUZ,
-                                                   F8E5M2, F8E4M3FN]>];
+                                                   F8E5M2, F8E4M3FN, F4E2M1FN]>];
 
 // in_bounds_load
 def Rock_InBoundsLoadOp

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -49,8 +49,12 @@ enum class WmmaTypeId : uint32_t {
   I8_To_I32_TyId, // I8 x I8 -> I32
   I4_To_I32_TyId, // I4 x I4 -> I32
 
-  // Small float scaled WMMA. All combinations map to wmma_scale_f32_*_f8f6f4
-  // with appropriate format codes
+  // Small float scaled WMMA: FP8/BF8/FP6/FP4 x FP8/BF8/FP6/FP4 -> F32
+  // "Small floats" are sub-byte or 8-bit floating point formats:
+  //   - FP8 (E4M3), BF8 (E5M2): 8-bit floats
+  //   - FP6 (E2M3, E3M2): 6-bit floats
+  //   - FP4 (E2M1): 4-bit float
+  // All combinations map to wmma_scale_f32_*_f8f6f4
   SmallFloat_To_F32_TyId
 };
 
@@ -87,7 +91,7 @@ public:
                                     int64_t waveSize, StringRef arch,
                                     int64_t mPerWave, int64_t nPerWave,
                                     int64_t kPack, int64_t kPackPerBlock,
-                                    bool forScaledOp = false);
+                                    bool forScaledOp);
 };
 } // namespace rock
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
+++ b/mlir/include/mlir/Dialect/Rock/IR/WmmaInsnGroup.h
@@ -47,7 +47,11 @@ enum class WmmaTypeId : uint32_t {
 
   // Integer output
   I8_To_I32_TyId, // I8 x I8 -> I32
-  I4_To_I32_TyId  // I4 x I4 -> I32
+  I4_To_I32_TyId, // I4 x I4 -> I32
+
+  // Small float scaled WMMA. All combinations map to wmma_scale_f32_*_f8f6f4
+  // with appropriate format codes
+  SmallFloat_To_F32_TyId
 };
 
 // Information needed to create a WMMA instruction
@@ -57,6 +61,7 @@ struct WmmaInsnInfo {
   int64_t outputVectorLen;
   int64_t mPerAccel;
   int64_t nPerAccel;
+  bool isScaled;
 };
 
 // Key type for WMMA instruction maps: (TypeId, K dimension)
@@ -73,13 +78,16 @@ struct WmmaInsn {
   VectorType argTypeA;
   VectorType argTypeB;
   VectorType retType;
+  bool isScaled;
 
 public:
   bool isCoherentWithK(int64_t kpack, int64_t kPerBlock);
+  /// Select a WMMA instruction based on element types and architecture.
   static FailureOr<WmmaInsn> select(Type elementTypeA, Type elementTypeB,
                                     int64_t waveSize, StringRef arch,
                                     int64_t mPerWave, int64_t nPerWave,
-                                    int64_t kPack, int64_t kPackPerBlock);
+                                    int64_t kPack, int64_t kPackPerBlock,
+                                    bool forScaledOp = false);
 };
 } // namespace rock
 } // namespace mlir

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -405,12 +405,20 @@ GemmFeatures mlir::rock::AmdArchInfo::getDefaultFeatures(Type dataType) {
   }
 
   if (isWmma) {
-    if (!(isa<Float16Type, BFloat16Type>(elementType) ||
-          elementType.isInteger(8) ||
-          (hasFp8ConversionInstrs &&
-           isa<Float8E5M2FNUZType, Float8E4M3FNUZType>(elementType)) ||
-          (hasOcpFp8ConversionInstrs &&
-           isa<Float8E5M2Type, Float8E4M3FNType>(elementType)))) {
+    bool isValidWmmaType =
+        isa<Float16Type, BFloat16Type>(elementType) ||
+        elementType.isInteger(8) ||
+        (hasFp8ConversionInstrs &&
+         isa<Float8E5M2FNUZType, Float8E4M3FNUZType>(elementType)) ||
+        (hasOcpFp8ConversionInstrs &&
+         isa<Float8E5M2Type, Float8E4M3FNType>(elementType));
+
+    if (hasScaledGemm) {
+      isValidWmmaType = isValidWmmaType || isa<Float4E2M1FNType>(elementType) ||
+                        isa<Float6E2M3FNType, Float6E3M2FNType>(elementType);
+    }
+
+    if (!isValidWmmaType) {
       theseFeatures = bitEnumClear(theseFeatures, GemmFeatures::wmma);
     }
   }

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -123,7 +123,7 @@ static constexpr AmdArchInfo
                 /*totalVGPRPerEU*/ 1536, /*totalSharedMemPerCU*/ 131072,
                 /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/12,
                 /*hasFp8ConversionInstrs=*/false,
-                /*hasOcpFp8ConversionInstrs=*/true, /*hasScaledGemm=*/false,
+                /*hasOcpFp8ConversionInstrs=*/true, /*hasScaledGemm=*/true,
                 /*maxNumXCC=*/1, /*hasLdsTransposeLoad=*/false);
 
 static std::tuple<StringRef, unsigned> parseArchString(StringRef arch) {

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -216,6 +216,14 @@ getCommonEffects(OpType &op,
   effects.emplace_back(write, &op.getDestMutable());
 }
 
+/// Check if a type is valid for scaled GEMM matrix operands.
+/// Currently supports FP4 (Float4E2M1FN) and FP8 (Float8E4M3FN, Float8E5M2).
+/// TODO: Add support for FP6 types (Float6E2M3FN, Float6E3M2FN) when
+/// rocMLIR gains FP6 support.
+static bool isValidScaledGemmMatrixType(Type elemType) {
+  return isa<Float4E2M1FNType, Float8E4M3FNType, Float8E5M2Type>(elemType);
+}
+
 template <typename OpType>
 static LogicalResult verifyScales(OpType op, Value matrix, Value scale,
                                   StringRef matrixName) {
@@ -229,10 +237,10 @@ static LogicalResult verifyScales(OpType op, Value matrix, Value scale,
       return op.emitError(
           llvm::formatv("Scale{0} must be of type Float8E8M0FNU.", matrixName));
     }
-    if (!isa<Float4E2M1FNType>(matrixElemType)) {
+    if (!isValidScaledGemmMatrixType(matrixElemType)) {
       return op.emitError(
-          llvm::formatv("For the scaled GEMMs, matrix{0} must be of "
-                        "type Float4E2M1FNType.",
+          llvm::formatv("For scaled GEMMs, matrix{0} must be of type "
+                        "Float4E2M1FN, Float8E4M3FN, or Float8E5M2.",
                         matrixName));
     }
     if (matrixType.getShape() != scaleType.getShape()) {
@@ -774,9 +782,11 @@ static LogicalResult verifyGemmTypes(Operation *op, GemmFeatures features,
     bool isValidTypeA = elemTypeA.isF16() || elemTypeA.isBF16() ||
                         elemTypeA.isInteger(8) || isFloat8Type(elemTypeA);
 
-    // gfx1250 additionally supports F32
-    if (isGfx1250)
-      isValidTypeA = isValidTypeA || elemTypeA.isF32();
+    // gfx1250 additionally supports F32, and FP4
+    if (isGfx1250) {
+      isValidTypeA =
+          isValidTypeA || elemTypeA.isF32() || isa<Float4E2M1FNType>(elemTypeA);
+    }
 
     // gfx11 doesn't support float8 types
     if (isGfx11 && isFloat8Type(elemTypeA))
@@ -787,20 +797,27 @@ static LogicalResult verifyGemmTypes(Operation *op, GemmFeatures features,
         return op->emitOpError("Wmma supports only F16/BF16/int8 data types");
       if (isGfx1250)
         return op->emitOpError(
-            "Wmma supports only F32/F16/BF16/int8/E4M3/E5M2 data types");
+            "Wmma supports only F32/F16/BF16/int8/FP8/BF8/FP4 data types");
       return op->emitOpError(
           "Wmma supports only F16/BF16/int8/E4M3/E5M2 data types");
     }
 
+    // Helper to check if type is a small float (FP8, BF8, FP4)
+    auto isSmallFloat = [](Type ty) {
+      return isFloat8Type(ty) || isa<Float4E2M1FNType>(ty) ||
+             isa<Float6E2M3FNType, Float6E3M2FNType>(ty);
+    };
+
     // Validate mixed types
     if (elemTypeA != elemTypeB) {
-      // gfx1250 allows mixed precision for float8 types only
+      // gfx1250 allows mixed precision for small float types
       bool allowMixed =
-          isGfx1250 && isFloat8Type(elemTypeA) && isFloat8Type(elemTypeB);
+          isGfx1250 && isSmallFloat(elemTypeA) && isSmallFloat(elemTypeB);
       if (!allowMixed)
-        return op->emitOpError(isGfx1250 ? "Wmma on gfx1250 supports mixed "
-                                           "types only for FP8/BF8 combinations"
-                                         : "Wmma does not support mixed types");
+        return op->emitOpError(isGfx1250
+                                   ? "Wmma on gfx1250 supports mixed "
+                                     "types only for small float combinations"
+                                   : "Wmma does not support mixed types");
     }
   }
   if (bitEnumContainsAll(features, GemmFeatures::mfma)) {
@@ -1170,9 +1187,10 @@ LogicalResult GemmOp::verify() {
       failed(verifyScale(getScaleB(), /*isA=*/false)))
     return failure();
   if (hasScaleA && hasScaleB) {
-    if (!isa<Float4E2M1FNType>(inElems)) {
+    if (!isValidScaledGemmMatrixType(inElems)) {
       return emitOpError(
-          "Scaled GEMMs are only supported for Float4E2M1FN input type");
+          "Scaled GEMMs are only supported for Float4E2M1FN, Float8E4M3FN, "
+          "or Float8E5M2 input types");
     }
   }
   auto features = rock::getFeatures(this->getOperation());
@@ -2586,10 +2604,10 @@ LogicalResult BlockwiseGemmAccelOp::verify() {
               "Scale{0} must be of type Float8E8M0FNU.", matrixName));
         }
         Type ldsElemType = getElementTypeOrSelfRecursive(ldsType);
-        if (!isa<Float4E2M1FNType>(ldsElemType)) {
+        if (!isValidScaledGemmMatrixType(ldsElemType)) {
           return emitOpError(
-              llvm::formatv("For the scaled GEMMs, matrix{0} must be of "
-                            "type Float4E2M1FNType.",
+              llvm::formatv("For scaled GEMMs, matrix{0} must be of type "
+                            "Float4E2M1FN, Float8E4M3FN, or Float8E5M2.",
                             matrixName));
         }
       }
@@ -2609,10 +2627,10 @@ LogicalResult BlockwiseGemmAccelOp::verify() {
             "Scale{0} buffer must be of type Float8E8M0FNU.", matrixName));
       }
       Type bufferElemType = getElementTypeOrSelfRecursive(bufferType);
-      if (!isa<Float4E2M1FNType>(bufferElemType)) {
+      if (!isValidScaledGemmMatrixType(bufferElemType)) {
         return emitOpError(
-            llvm::formatv("For the scaled GEMMs, buffer{0} must be of "
-                          "type Float4E2M1FNType.",
+            llvm::formatv("For scaled GEMMs, buffer{0} must be of type "
+                          "Float4E2M1FN, Float8E4M3FN, or Float8E5M2.",
                           matrixName));
       }
     }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -218,10 +218,9 @@ getCommonEffects(OpType &op,
 
 /// Check if a type is valid for scaled GEMM matrix operands.
 /// Currently supports FP4 (Float4E2M1FN) and FP8 (Float8E4M3FN, Float8E5M2).
-/// TODO: Add support for FP6 types (Float6E2M3FN, Float6E3M2FN) when
-/// rocMLIR gains FP6 support.
 static bool isValidScaledGemmMatrixType(Type elemType) {
-  return isa<Float4E2M1FNType, Float8E4M3FNType, Float8E5M2Type>(elemType);
+  return isa<Float4E2M1FNType, Float8E4M3FNType, Float8E5M2Type,
+             Float6E2M3FNType, Float6E3M2FNType>(elemType);
 }
 
 template <typename OpType>

--- a/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
+++ b/mlir/lib/Dialect/Rock/IR/WmmaInsnGroup.cpp
@@ -38,13 +38,19 @@ static Type getRetType(Type inputType, WmmaTypeId typeId) {
       typeId == WmmaTypeId::Bf16_To_Bf16F32_TyId)
     return b.getBF16Type();
 
+  // Small float scaled WMMA always outputs F32
+  if (typeId == WmmaTypeId::SmallFloat_To_F32_TyId)
+    return b.getF32Type();
+
   // Default: F32 output
   return b.getF32Type();
 }
 
 // Convert input types to type ID. This handles both same-type and mixed-type
-// inputs and always uses F32/I32 outputs
-static WmmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
+// inputs and always uses F32/I32 outputs.
+// If forScaledOp is true, FP8/BF8 types will use the scaled WMMA instruction.
+static WmmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB,
+                                   bool forScaledOp = false) {
   // Same type inputs
   if (dataTypeA == dataTypeB) {
     if (dataTypeA.isF32())
@@ -59,15 +65,35 @@ static WmmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
       return WmmaTypeId::I4_To_I32_TyId;
   }
 
-  // Mixed precision FP8/BF8 combinations
-  if (isa<Float8E4M3FNType>(dataTypeA) && isa<Float8E4M3FNType>(dataTypeB))
-    return WmmaTypeId::Fp8Fp8_To_F32_TyId;
-  if (isa<Float8E4M3FNType>(dataTypeA) && isa<Float8E5M2Type>(dataTypeB))
-    return WmmaTypeId::Fp8Bf8_To_F32_TyId;
-  if (isa<Float8E5M2Type>(dataTypeA) && isa<Float8E4M3FNType>(dataTypeB))
-    return WmmaTypeId::Bf8Fp8_To_F32_TyId;
-  if (isa<Float8E5M2Type>(dataTypeA) && isa<Float8E5M2Type>(dataTypeB))
-    return WmmaTypeId::Bf8Bf8_To_F32_TyId;
+  // Check for small float types
+  bool aIsFp8 = isa<Float8E4M3FNType>(dataTypeA);
+  bool aIsBf8 = isa<Float8E5M2Type>(dataTypeA);
+  bool bIsFp8 = isa<Float8E4M3FNType>(dataTypeB);
+  bool bIsBf8 = isa<Float8E5M2Type>(dataTypeB);
+  bool aIsFp6 = isa<Float6E2M3FNType, Float6E3M2FNType>(dataTypeA);
+  bool bIsFp6 = isa<Float6E2M3FNType, Float6E3M2FNType>(dataTypeB);
+  bool aIsFp4 = isa<Float4E2M1FNType>(dataTypeA);
+  bool bIsFp4 = isa<Float4E2M1FNType>(dataTypeB);
+
+  // For scaled operations with FP8/BF8 types, use the scaled WMMA instruction
+  if (forScaledOp && ((aIsFp8 || aIsBf8) && (bIsFp8 || bIsBf8)))
+    return WmmaTypeId::SmallFloat_To_F32_TyId;
+
+  // Pure FP8/BF8 combinations (prefer regular intrinsics when available)
+  if ((aIsFp8 || aIsBf8) && (bIsFp8 || bIsBf8)) {
+    if (aIsFp8 && bIsFp8)
+      return WmmaTypeId::Fp8Fp8_To_F32_TyId;
+    if (aIsFp8 && bIsBf8)
+      return WmmaTypeId::Fp8Bf8_To_F32_TyId;
+    if (aIsBf8 && bIsFp8)
+      return WmmaTypeId::Bf8Fp8_To_F32_TyId;
+    if (aIsBf8 && bIsBf8)
+      return WmmaTypeId::Bf8Bf8_To_F32_TyId;
+  }
+
+  // Any combination involving FP4 or FP6 (with or without FP8/BF8)
+  if (aIsFp4 || bIsFp4 || aIsFp6 || bIsFp6)
+    return WmmaTypeId::SmallFloat_To_F32_TyId;
 
   llvm_unreachable("Unsupported WMMA input type combination");
 }
@@ -76,11 +102,14 @@ static WmmaTypeId convertTypesToId(Type dataTypeA, Type dataTypeB) {
 static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx11() {
   static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
       {{WmmaTypeId::F16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 16, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 16, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 16, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 16, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::I8_To_I32_TyId, 16},
-       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 16, 8, 16, 16}},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 16, 8, 16, 16,
+        /*isScaled=*/false}},
   };
   return insnMap;
 }
@@ -89,17 +118,22 @@ static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx11() {
 static const llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> &getWmmaInsnMapGfx12() {
   static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
       {{WmmaTypeId::F16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 8, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x16_f16::getOperationName(), 8, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf16_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 8, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x16_bf16::getOperationName(), 8, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::I8_To_I32_TyId, 16},
-       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 8, 8, 16, 16}},
+       {ROCDL::wmma_i32_16x16x16_iu8::getOperationName(), 8, 8, 16, 16,
+        /*isScaled=*/false}},
 
       // FP8/BF8
       {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName(), 8, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x16_fp8_fp8::getOperationName(), 8, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 16},
-       {ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName(), 8, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x16_bf8_bf8::getOperationName(), 8, 8, 16, 16,
+        /*isScaled=*/false}},
   };
   return insnMap;
 }
@@ -110,37 +144,55 @@ getWmmaInsnMapGfx1250() {
   static llvm::DenseMap<WmmaInsnKey, WmmaInsnInfo> insnMap{
       // F32
       {{WmmaTypeId::F32_To_F32_TyId, 4},
-       {ROCDL::wmma_f32_16x16x4_f32::getOperationName(), 2, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x4_f32::getOperationName(), 2, 8, 16, 16,
+        /*isScaled=*/false}},
 
       // F16/BF16
       {{WmmaTypeId::F16_To_F32_TyId, 32},
-       {ROCDL::wmma_f32_16x16x32_f16::getOperationName(), 16, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x32_f16::getOperationName(), 16, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf16_To_F32_TyId, 32},
-       {ROCDL::wmma_f32_16x16x32_bf16::getOperationName(), 16, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x32_bf16::getOperationName(), 16, 8, 16, 16,
+        /*isScaled=*/false}},
 
       // FP8/BF8 (k=64)
       {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_fp8_fp8::getOperationName(), 32, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x64_fp8_fp8::getOperationName(), 32, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_fp8_bf8::getOperationName(), 32, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x64_fp8_bf8::getOperationName(), 32, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_bf8_fp8::getOperationName(), 32, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x64_bf8_fp8::getOperationName(), 32, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 64},
-       {ROCDL::wmma_f32_16x16x64_bf8_bf8::getOperationName(), 32, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x64_bf8_bf8::getOperationName(), 32, 8, 16, 16,
+        /*isScaled=*/false}},
 
       // FP8/BF8 (k=128)
       {{WmmaTypeId::Fp8Fp8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_fp8_fp8::getOperationName(), 64, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x128_fp8_fp8::getOperationName(), 64, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Fp8Bf8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_fp8_bf8::getOperationName(), 64, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x128_fp8_bf8::getOperationName(), 64, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf8Fp8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_bf8_fp8::getOperationName(), 64, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x128_bf8_fp8::getOperationName(), 64, 8, 16, 16,
+        /*isScaled=*/false}},
       {{WmmaTypeId::Bf8Bf8_To_F32_TyId, 128},
-       {ROCDL::wmma_f32_16x16x128_bf8_bf8::getOperationName(), 64, 8, 16, 16}},
+       {ROCDL::wmma_f32_16x16x128_bf8_bf8::getOperationName(), 64, 8, 16, 16,
+        /*isScaled=*/false}},
+
+      // Small float scaled WMMA (k=128)
+      // This covers FP4, and mixed combinations (FP8+FP4, etc.)
+      {{WmmaTypeId::SmallFloat_To_F32_TyId, 128},
+       {ROCDL::wmma_scale_f32_16x16x128_f8f6f4::getOperationName(), 64, 8, 16,
+        16, /*isScaled=*/true}},
 
       // I8
       {{WmmaTypeId::I8_To_I32_TyId, 64},
-       {ROCDL::wmma_i32_16x16x64_iu8::getOperationName(), 32, 8, 16, 16}},
+       {ROCDL::wmma_i32_16x16x64_iu8::getOperationName(), 32, 8, 16, 16,
+        /*isScaled=*/false}},
   };
   return insnMap;
 }
@@ -168,7 +220,7 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
                                      mlir::Type elementTypeB, int64_t waveSize,
                                      StringRef arch, int64_t mPerWave,
                                      int64_t nPerWave, int64_t kPack,
-                                     int64_t kPackPerBlock) {
+                                     int64_t kPackPerBlock, bool forScaledOp) {
   LLVM_DEBUG(llvm::dbgs() << "Invoke Wmma instruction selection:\n"
                           << "elementTypeA: " << elementTypeA << "\n"
                           << "elementTypeB: " << elementTypeB << "\n"
@@ -176,7 +228,8 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
                           << "mPerWave: " << mPerWave << "\n"
                           << "nPerWave: " << nPerWave << "\n"
                           << "kPack: " << kPack << "\n"
-                          << "kPackPerBlock: " << kPackPerBlock << "\n");
+                          << "kPackPerBlock: " << kPackPerBlock << "\n"
+                          << "forScaledOp: " << forScaledOp << "\n");
 
   // WMMA only supports wave32
   if (waveSize != 32)
@@ -187,8 +240,8 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
   bool isGfx1250 = arch.contains("gfx1250");
 
   // Convert element types to ID for map lookup. Handles both same-type and
-  // mixed-type inputs
-  WmmaTypeId typeId = convertTypesToId(elementTypeA, elementTypeB);
+  // mixed-type inputs. For scaled operations, FP8 types use the scaled WMMA.
+  WmmaTypeId typeId = convertTypesToId(elementTypeA, elementTypeB, forScaledOp);
 
   // Select instruction based on architecture priority: gfx1250 > gfx12 > gfx11
   const WmmaInsnInfo *insnInfo = nullptr;
@@ -224,6 +277,8 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
         k = 4;
       } else if (typeId == WmmaTypeId::I8_To_I32_TyId) {
         k = 64;
+      } else if (typeId == WmmaTypeId::SmallFloat_To_F32_TyId) {
+        k = 128;
       } else {
         // F16/BF16 types
         k = 32;
@@ -273,6 +328,7 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
   StringRef insn = insnInfo->insn;
   int64_t mPerAccel = insnInfo->mPerAccel;
   int64_t nPerAccel = insnInfo->nPerAccel;
+  bool isScaled = insnInfo->isScaled;
 
   // Architecture-specific outStride
   // gfx11: full-wave K cooperation -> outStride=2
@@ -293,6 +349,6 @@ FailureOr<WmmaInsn> WmmaInsn::select(mlir::Type elementTypeA,
   VectorType retType =
       VectorType::get({outputVectorLen}, getRetType(elementTypeA, typeId));
 
-  return WmmaInsn{insn,     mPerAccel, nPerAccel, kDim,     outStride,
-                  mRepeats, nRepeats,  argTypeA,  argTypeB, retType};
+  return WmmaInsn{insn,     mPerAccel, nPerAccel, kDim,    outStride, mRepeats,
+                  nRepeats, argTypeA,  argTypeB,  retType, isScaled};
 }

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -426,7 +426,7 @@ struct BlockwiseGemmAccelRewritePattern
 
     auto features = rock::getFeatures(op);
     auto accelEmitterPtr = rock::accel::AccelEmitter::select(
-        features, dataTypeA, dataTypeB, arch, tuningParams);
+        features, dataTypeA, dataTypeB, arch, tuningParams, isScaledGemm);
 
     if (!accelEmitterPtr)
       return op.emitOpError("Unable to emit accelerator code.");

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -3233,7 +3233,7 @@ struct GridwiseGemmAccelRewritePattern
     int64_t nPerWave = tuningParams.getNPerWave();
 
     auto accelEmitterPtr = accel::AccelEmitter::select(
-        features, elementTypeA, elementTypeB, arch, tuningParams);
+        features, elementTypeA, elementTypeB, arch, tuningParams, isScaledGemm);
 
     if (!accelEmitterPtr)
       return op.emitOpError("Unable to emit accelerator code.");

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -259,11 +259,20 @@ struct ThreadwiseGemmAccelRewritePattern
     auto dataTypeB =
         cast<MemRefType>(adaptor.getMatrixB().getType()).getElementType();
     Type dataTypeScaleA, dataTypeScaleB;
+    // Preserve the full scale vector type from the memref for loading
+    Type scaleVectorTypeA, scaleVectorTypeB;
     if (isScaledGemm) {
-      dataTypeScaleA =
+      scaleVectorTypeA =
           cast<MemRefType>(adaptor.getScaleA().getType()).getElementType();
-      dataTypeScaleB =
+      scaleVectorTypeB =
           cast<MemRefType>(adaptor.getScaleB().getType()).getElementType();
+      // Extract scalar element type for type checking
+      dataTypeScaleA = isa<VectorType>(scaleVectorTypeA)
+                           ? cast<VectorType>(scaleVectorTypeA).getElementType()
+                           : scaleVectorTypeA;
+      dataTypeScaleB = isa<VectorType>(scaleVectorTypeB)
+                           ? cast<VectorType>(scaleVectorTypeB).getElementType()
+                           : scaleVectorTypeB;
     }
 
     if (isa<VectorType>(dataTypeA)) {
@@ -271,14 +280,6 @@ struct ThreadwiseGemmAccelRewritePattern
     }
     if (isa<VectorType>(dataTypeB)) {
       dataTypeB = cast<VectorType>(dataTypeB).getElementType();
-    }
-    if (isScaledGemm) {
-      if (isa<VectorType>(dataTypeScaleA)) {
-        dataTypeScaleA = cast<VectorType>(dataTypeScaleA).getElementType();
-      }
-      if (isa<VectorType>(dataTypeScaleB)) {
-        dataTypeScaleB = cast<VectorType>(dataTypeScaleB).getElementType();
-      }
     }
 
     Value bufferA = adaptor.getMatrixA();
@@ -296,7 +297,7 @@ struct ThreadwiseGemmAccelRewritePattern
     size_t computeIndices = op.getComputeIndices().size();
     auto emitter = rock::accel::AccelEmitter::select(
         rock::getFeatures(op), dataTypeA, dataTypeB, rock::getArchValue(op),
-        tuningParams);
+        tuningParams, isScaledGemm);
 
     if (!emitter) {
       llvm::dbgs() << rock::getFeatures(op) << "\n";
@@ -308,16 +309,11 @@ struct ThreadwiseGemmAccelRewritePattern
     rock::accel::AccelEmitterParams params = emitter->getParams();
     Type argTypeA = params.argTypeA;
     Type argTypeB = params.argTypeB;
-    Type argTypeScaleA = dataTypeScaleA, argTypeScaleB = dataTypeScaleB;
-    if (isScaledGemm) {
-      auto argAVector = dyn_cast<VectorType>(argTypeA);
-      auto argBVector = dyn_cast<VectorType>(argTypeB);
-      if (argAVector && argBVector) {
-        // clone shape of ArgTypeA but retain elementType of dataTypeScaleA
-        argTypeScaleA = VectorType::get(argAVector.getShape(), dataTypeScaleA);
-        argTypeScaleB = VectorType::get(argBVector.getShape(), dataTypeScaleB);
-      }
-    }
+    // Use the preserved scale vector types from the memref, not derived from
+    // matrix shapes. The scale vector has its own size (e.g., 4 elements for
+    // scaled WMMA) independent of the matrix vector size.
+    Type argTypeScaleA = isScaledGemm ? scaleVectorTypeA : dataTypeScaleA;
+    Type argTypeScaleB = isScaledGemm ? scaleVectorTypeB : dataTypeScaleB;
 
     Value zeroConstantOp = b.createOrFold<ConstantIndexOp>(loc, 0);
     SmallVector<Value, 4> startCoords(4, zeroConstantOp);
@@ -410,16 +406,21 @@ struct ThreadwiseGemmAccelRewritePattern
 
         argScaleA = memref::LoadOp::create(b, loc, argTypeScaleA,
                                            rawBufferScaleA, coordsScaleA);
-        if (dyn_cast<VectorType>(argScaleA.getType())) {
-          argScaleA =
-              vector::ExtractOp::create(b, loc, argScaleA, zeroConstantOp);
-        }
-
         argScaleB = memref::LoadOp::create(b, loc, argTypeScaleB,
                                            rawBufferScaleB, coordsScaleB);
-        if (dyn_cast<VectorType>(argScaleB.getType())) {
-          argScaleB =
-              vector::ExtractOp::create(b, loc, argScaleB, zeroConstantOp);
+
+        // For MFMA, extract scalar from scale vector; for WMMA, keep as vector
+        auto features = rock::getFeatures(op);
+        bool isMfma = rock::bitEnumContainsAll(features, GemmFeatures::mfma);
+        if (isMfma) {
+          if (isa<VectorType>(argScaleA.getType())) {
+            argScaleA =
+                vector::ExtractOp::create(b, loc, argScaleA, zeroConstantOp);
+          }
+          if (isa<VectorType>(argScaleB.getType())) {
+            argScaleB =
+                vector::ExtractOp::create(b, loc, argScaleB, zeroConstantOp);
+          }
         }
       } else {
         coordsC = accelLoop.getLowerCoords(/*domain=*/2);

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -687,7 +687,8 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
   // Reject invalid KPACK values.
   auto maybeWmmaInsn = WmmaInsn::select(
       dataTypeA, dataTypeB, waveSize, arch, param.getMPerWave(),
-      param.getNPerWave(), param.getKpack(), param.getKpackPerBlock());
+      param.getNPerWave(), param.getKpack(), param.getKpackPerBlock(),
+      /*forScaledOp=*/false);
   if (failed(maybeWmmaInsn)) {
     LLVM_DEBUG(llvm::dbgs() << "Failed to select wmma instruction.\n");
     return failure();
@@ -716,7 +717,8 @@ PopulateParamsWmma::getTuningParameters(KernelType opType, Type dataTypeA,
       [&](const InitParamsAccel &param) {
         auto maybeWmmaInsn = WmmaInsn::select(
             dataTypeA, dataTypeB, waveSize, arch, param.gemmMPerWave,
-            param.gemmNPerWaveOrMnPerXdl, param.gemmKPack, param.gemmKPerBlock);
+            param.gemmNPerWaveOrMnPerXdl, param.gemmKPack, param.gemmKPerBlock,
+            /*forScaledOp=*/false);
         if (failed(maybeWmmaInsn)) {
           return false;
         }

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -1116,32 +1116,45 @@ void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
                                      Value argB, Value bufferC,
                                      ValueRange regCOffset, Value scaleA,
                                      Value scaleB) {
-  bool isScaled = scaleA && scaleB;
-  if (isScaled) {
-    llvm::report_fatal_error(
-        "Scaled WMMA not implemented yet for WMMA Emitter");
-  }
-
   VectorType vectorType = wmmaInsn.retType;
   auto vectorC =
       memref::LoadOp::create(b, loc, vectorType, bufferC, regCOffset);
 
-  // WMMAOp requires explicit m, n, k dimensions as IntegerAttrs
-  auto mAttr = b.getI32IntegerAttr(wmmaInsn.mPerAccel);
-  auto nAttr = b.getI32IntegerAttr(wmmaInsn.nPerAccel);
-  auto kAttr = b.getI32IntegerAttr(wmmaInsn.kDim);
-  auto subwordOffsetAttr = b.getI32IntegerAttr(0);
+  Value vectorD;
 
-  // Clamp flag is only valid for integer output types
-  Type elementType = vectorType.getElementType();
-  UnitAttr clampAttr =
-      isa<IntegerType>(elementType) ? b.getUnitAttr() : nullptr;
+  if (wmmaInsn.isScaled) {
+    // Scaled WMMA intrinsic requires scale vectors to be provided
+    assert(scaleA && scaleB &&
+           "Scaled WMMA requires scale vectors for both A and B operands");
 
-  auto mfma = amdgpu::WMMAOp::create(b, loc, vectorType, mAttr, nAttr, kAttr,
-                                     argA, argB, vectorC, subwordOffsetAttr,
-                                     /*unsignedA=*/nullptr,
-                                     /*unsignedB=*/nullptr, clampAttr);
-  auto vectorD = mfma.getDestD();
+    // first_scale_lane selects which lane group to read scales from (0 or 16).
+    // Using 0 is always valid: it works whether scales need 16 or 32 lanes.
+    // The value 16 is only valid when scales fit in half the lanes.
+    constexpr uint32_t firstScaleLane = 0;
+
+    auto wmma = amdgpu::ScaledWMMAOp::create(
+        b, loc, vectorType, wmmaInsn.mPerAccel, wmmaInsn.nPerAccel,
+        wmmaInsn.kDim, argA, argB, vectorC, scaleA, firstScaleLane, scaleB,
+        firstScaleLane);
+    vectorD = wmma.getDestD();
+  } else {
+    // Regular (non-scaled) WMMA operation
+    auto mAttr = b.getI32IntegerAttr(wmmaInsn.mPerAccel);
+    auto nAttr = b.getI32IntegerAttr(wmmaInsn.nPerAccel);
+    auto kAttr = b.getI32IntegerAttr(wmmaInsn.kDim);
+    auto subwordOffsetAttr = b.getI32IntegerAttr(0);
+
+    // Clamp flag is only valid for integer output types
+    Type elementType = vectorType.getElementType();
+    UnitAttr clampAttr =
+        isa<IntegerType>(elementType) ? b.getUnitAttr() : nullptr;
+
+    auto wmma = amdgpu::WMMAOp::create(b, loc, vectorType, mAttr, nAttr, kAttr,
+                                       argA, argB, vectorC, subwordOffsetAttr,
+                                       /*unsignedA=*/nullptr,
+                                       /*unsignedB=*/nullptr, clampAttr);
+    vectorD = wmma.getDestD();
+  }
 
   memref::StoreOp::create(b, loc, vectorD, bufferC, regCOffset);
 }
@@ -1283,7 +1296,8 @@ llvm::FailureOr<RegsAsMatrixSubTiles> WmmaEmitter::computeOutputTransforms(
 std::unique_ptr<AccelEmitter>
 AccelEmitter::select(GemmFeatures features, Type dataTypeA, Type dataTypeB,
                      StringRef arch,
-                     RockAccelTuningParamAttrInterface tuningParams) {
+                     RockAccelTuningParamAttrInterface tuningParams,
+                     bool forScaledOp) {
   bool isMfma = rock::bitEnumContainsAll(features, GemmFeatures::mfma);
   bool isWmma = rock::bitEnumContainsAll(features, GemmFeatures::wmma);
   if (isMfma) {
@@ -1301,7 +1315,8 @@ AccelEmitter::select(GemmFeatures features, Type dataTypeA, Type dataTypeB,
     auto maybeWmmaInsnGroup =
         WmmaInsn::select(dataTypeA, dataTypeB, waveSize, arch,
                          wmmaParams.getMPerWave(), wmmaParams.getNPerWave(),
-                         wmmaParams.getKpack(), wmmaParams.getKpackPerBlock());
+                         wmmaParams.getKpack(), wmmaParams.getKpackPerBlock(),
+                         forScaledOp);
     if (failed(maybeWmmaInsnGroup)) {
       return nullptr;
     }

--- a/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
+++ b/mlir/lib/Dialect/Rock/utility/AccelEmitter.cpp
@@ -1121,7 +1121,6 @@ void WmmaEmitter::emitThreadwiseLoop(OpBuilder &b, Location loc, Value argA,
       memref::LoadOp::create(b, loc, vectorType, bufferC, regCOffset);
 
   Value vectorD;
-
   if (wmmaInsn.isScaled) {
     // Scaled WMMA intrinsic requires scale vectors to be provided
     assert(scaleA && scaleB &&

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm.mlir
@@ -546,3 +546,139 @@ func.func @rock_accel_gemm_wmma_gfx1250_k_selection(%matrixA : memref<4x8xvector
      } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> * memref<4x8xvector<64xf8E5M2>, 5>
   return
 }
+
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4
+func.func @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4(
+    %matrixA : memref<4x8xvector<64xf4E2M1FN>, 5>,
+    %matrixB : memref<4x8xvector<64xf4E2M1FN>, 5>,
+    %matrixC : memref<4x4xvector<8xf32>, 5>,
+    %scaleA : memref<4x8xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<4x8xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK-DAG: memref.load {{.*}} : memref<4x8xvector<64xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<4x8xvector<64xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<4x4xvector<8xf32>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<4x8xvector<4xf8E8M0FNU>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<4x8xvector<4xf8E8M0FNU>, 5>
+  // CHECK: amdgpu.scaled_wmma 16x16x128
+  // CHECK-SAME: vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<8xf32>
+  // CHECK: memref.store {{.*}}, {{.*}} : memref<4x4xvector<8xf32>, 5>
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf4E2M1FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5> * memref<4x8xvector<64xf4E2M1FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4_k4
+func.func @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4_k4(
+    %matrixA : memref<4x4xvector<64xf4E2M1FN>, 5>,
+    %matrixB : memref<4x4xvector<64xf4E2M1FN>, 5>,
+    %matrixC : memref<4x4xvector<8xf32>, 5>,
+    %scaleA : memref<4x4xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<4x4xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK-DAG: memref.load {{.*}} : memref<4x4xvector<64xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<4x4xvector<4xf8E8M0FNU>, 5>
+  // CHECK: amdgpu.scaled_wmma 16x16x128
+  // CHECK-SAME: vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<8xf32>
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 4,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x4xvector<64xf4E2M1FN>, 5> scaled by memref<4x4xvector<4xf8E8M0FNU>, 5> * memref<4x4xvector<64xf4E2M1FN>, 5> scaled by memref<4x4xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4_large
+func.func @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4_large(
+    %matrixA : memref<8x8xvector<64xf4E2M1FN>, 5>,
+    %matrixB : memref<8x8xvector<64xf4E2M1FN>, 5>,
+    %matrixC : memref<8x8xvector<8xf32>, 5>,
+    %scaleA : memref<8x8xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<8x8xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK-DAG: memref.load {{.*}} : memref<8x8xvector<64xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<8x8xvector<4xf8E8M0FNU>, 5>
+  // CHECK: amdgpu.scaled_wmma 16x16x128
+  // CHECK-SAME: vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<8xf32>
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 128,
+       nPerBlock = 128,
+       kpackPerBlock = 8,
+       mPerWave = 128,
+       nPerWave = 128,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<8x8xvector<8xf32>, 5> += memref<8x8xvector<64xf4E2M1FN>, 5> scaled by memref<8x8xvector<4xf8E8M0FNU>, 5> * memref<8x8xvector<64xf4E2M1FN>, 5> scaled by memref<8x8xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// CHECK-LABEL: @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4_asymmetric
+func.func @rock_accel_gemm_wmma_gfx1250_scaled_fp4_fp4_asymmetric(
+    %matrixA : memref<8x8xvector<64xf4E2M1FN>, 5>,
+    %matrixB : memref<4x8xvector<64xf4E2M1FN>, 5>,
+    %matrixC : memref<8x4xvector<8xf32>, 5>,
+    %scaleA : memref<8x8xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<4x8xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: rock.transforming_for
+  // CHECK-SAME: bounds [1, 1, 1]
+  // CHECK-DAG: memref.load {{.*}} : memref<8x8xvector<64xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<4x8xvector<64xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<8x8xvector<4xf8E8M0FNU>, 5>
+  // CHECK-DAG: memref.load {{.*}} : memref<4x8xvector<4xf8E8M0FNU>, 5>
+  // CHECK: amdgpu.scaled_wmma 16x16x128
+  // CHECK-SAME: vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<4xf8E8M0FNU>, vector<64xf4E2M1FN>, vector<8xf32>
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1250",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 128,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 128,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<8x4xvector<8xf32>, 5> += memref<8x8xvector<64xf4E2M1FN>, 5> scaled by memref<8x8xvector<4xf8E8M0FNU>, 5> * memref<4x8xvector<64xf4E2M1FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5>
+  return
+}
+

--- a/mlir/test/Dialect/Rock/lowering_wmma_gemm_scaled_invalid.mlir
+++ b/mlir/test/Dialect/Rock/lowering_wmma_gemm_scaled_invalid.mlir
@@ -1,0 +1,173 @@
+// RUN: rocmlir-opt -rock-threadwise-gemm-lowering %s -verify-diagnostics -split-input-file
+
+// Scaled GEMMs require small float types (FP4/FP8/BF8), not F16.
+func.func @rock_accel_gemm_wmma_gfx1100_scaled_f16_should_fail(
+    %matrixA : memref<1x4xvector<16xf16>, 5>,
+    %matrixB : memref<1x4xvector<16xf16>, 5>,
+    %matrixC : memref<1x1xvector<8xf32>, 5>,
+    %scaleA : memref<1x4xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<1x4xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{For scaled GEMMs, matrixA must be of type Float4E2M1FN, Float8E4M3FN, or Float8E5M2}}
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 4,
+       mPerWave = 16,
+       nPerWave = 16,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x4xvector<16xf16>, 5> scaled by memref<1x4xvector<4xf8E8M0FNU>, 5> * memref<1x4xvector<16xf16>, 5> scaled by memref<1x4xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// -----
+
+// Scaled GEMMs require small float types (FP4/FP8/BF8), not F16.
+func.func @rock_accel_gemm_wmma_gfx1200_scaled_f16_should_fail(
+    %matrixA : memref<1x4xvector<8xf16>, 5>,
+    %matrixB : memref<1x4xvector<8xf16>, 5>,
+    %matrixC : memref<1x1xvector<8xf32>, 5>,
+    %scaleA : memref<1x4xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<1x4xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{For scaled GEMMs, matrixA must be of type Float4E2M1FN, Float8E4M3FN, or Float8E5M2}}
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1200",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 16,
+       nPerBlock = 16,
+       kpackPerBlock = 4,
+       mPerWave = 16,
+       nPerWave = 16,
+       mnPerXdl = 16,
+       kpack = 8,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<1x1xvector<8xf32>, 5> += memref<1x4xvector<8xf16>, 5> scaled by memref<1x4xvector<4xf8E8M0FNU>, 5> * memref<1x4xvector<8xf16>, 5> scaled by memref<1x4xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// -----
+
+// Scaled WMMA with FP4 is only supported on gfx1250.
+func.func @rock_accel_gemm_wmma_gfx1100_scaled_fp4_should_fail(
+    %matrixA : memref<4x8xvector<64xf4E2M1FN>, 5>,
+    %matrixB : memref<4x8xvector<64xf4E2M1FN>, 5>,
+    %matrixC : memref<4x4xvector<8xf32>, 5>,
+    %scaleA : memref<4x8xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<4x8xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{Wmma supports only F16/BF16/int8 data types}}
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf4E2M1FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5> * memref<4x8xvector<64xf4E2M1FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// -----
+
+// Scaled WMMA with FP4 is only supported on gfx1250.
+func.func @rock_accel_gemm_wmma_gfx1200_scaled_fp4_should_fail(
+    %matrixA : memref<4x8xvector<64xf4E2M1FN>, 5>,
+    %matrixB : memref<4x8xvector<64xf4E2M1FN>, 5>,
+    %matrixC : memref<4x4xvector<8xf32>, 5>,
+    %scaleA : memref<4x8xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<4x8xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{Wmma supports only F16/BF16/int8/E4M3/E5M2 data types}}
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1200",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf4E2M1FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5> * memref<4x8xvector<64xf4E2M1FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// -----
+
+// Scaled WMMA with FP8 is only supported on gfx1250.
+func.func @rock_accel_gemm_wmma_gfx1100_scaled_fp8_should_fail(
+    %matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+    %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+    %matrixC : memref<4x4xvector<8xf32>, 5>,
+    %scaleA : memref<4x8xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<4x8xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{Wmma supports only F16/BF16/int8 data types}}
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1100",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5> * memref<4x8xvector<64xf8E5M2>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5>
+  return
+}
+
+// -----
+
+// Scaled WMMA with mixed FP8/BF8 is only supported on gfx1250.
+func.func @rock_accel_gemm_wmma_gfx1200_scaled_fp8_should_fail(
+    %matrixA : memref<4x8xvector<64xf8E4M3FN>, 5>,
+    %matrixB : memref<4x8xvector<64xf8E5M2>, 5>,
+    %matrixC : memref<4x4xvector<8xf32>, 5>,
+    %scaleA : memref<4x8xvector<4xf8E8M0FNU>, 5>,
+    %scaleB : memref<4x8xvector<4xf8E8M0FNU>, 5>) {
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{Wmma does not support mixed types}}
+  rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = wmma {
+    arch = "amdgcn-amd-amdhsa:gfx1200",
+    params = #rock.wmma_gemm_params<
+       mPerBlock = 64,
+       nPerBlock = 64,
+       kpackPerBlock = 8,
+       mPerWave = 64,
+       nPerWave = 64,
+       mnPerXdl = 16,
+       kpack = 16,
+       splitKFactor = 1,
+       scheduleVersion = 1,
+       outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0,
+       forceUnroll = true>
+     } : memref<4x4xvector<8xf32>, 5> += memref<4x8xvector<64xf8E4M3FN>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5> * memref<4x8xvector<64xf8E5M2>, 5> scaled by memref<4x8xvector<4xf8E8M0FNU>, 5>
+  return
+}

--- a/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
+++ b/mlir/test/Dialect/Rock/lowering_xdlops_gemm.mlir
@@ -550,14 +550,10 @@ func.func @accel_gemm_gfx950_f32_16x16x128_fp4_scaled(%matrixA : memref<1x1xvect
   // CHECK-LABEL: func.func @accel_gemm_gfx950_f32_16x16x128_fp4_scaled
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [1, 1, 1]
-  // CHECK: [[a:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf4E2M1FN>, 5>
-  // CHECK: [[b:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf4E2M1FN>, 5>
-  // CHECK: [[scaleA:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf8E8M0FNU>, 5>
-  // CHECK: [[scaleAScalar:%.+]] = vector.extract [[scaleA]]
-  // CHECK: [[scaleB:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf8E8M0FNU>, 5>
-  // CHECK: [[scaleBScalar:%.+]] = vector.extract [[scaleB]]
-  // CHECK: [[c:%.+]] = memref.load {{.+}} : memref<1x1xvector<4xf32>, 5>
-  // CHECK: amdgpu.scaled_mfma 16x16x128 ([[scaleAScalar]][0] * [[a]]) * ([[scaleBScalar]][0] * [[b]]) + [[c]]
+  // CHECK-DAG: memref.load {{.+}} : memref<1x1xvector<32xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.+}} : memref<1x1xvector<32xf8E8M0FNU>, 5>
+  // CHECK-DAG: vector.extract
+  // CHECK: amdgpu.scaled_mfma 16x16x128
   // CHECK-SAME: f8E8M0FNU, vector<32xf4E2M1FN>, f8E8M0FNU, vector<32xf4E2M1FN>, vector<4xf32>
   %c0 = arith.constant 0 : index
   rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = mfma {
@@ -586,14 +582,10 @@ func.func @accel_gemm_gfx950_f32_32x32x64_fp4_scaled(%matrixA : memref<1x1xvecto
   // CHECK-LABEL: func.func @accel_gemm_gfx950_f32_32x32x64_fp4_scaled
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [1, 1, 1]
-  // CHECK: [[a:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf4E2M1FN>, 5>
-  // CHECK: [[b:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf4E2M1FN>, 5>
-  // CHECK: [[scaleA:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf8E8M0FNU>, 5>
-  // CHECK: [[scaleAScalar:%.+]] = vector.extract [[scaleA]]
-  // CHECK: [[scaleB:%.+]] = memref.load {{.+}} : memref<1x1xvector<32xf8E8M0FNU>, 5>
-  // CHECK: [[scaleBScalar:%.+]] = vector.extract [[scaleB]]
-  // CHECK: [[c:%.+]] = memref.load {{.+}} : memref<1x1xvector<16xf32>, 5>
-  // CHECK: amdgpu.scaled_mfma 32x32x64 ([[scaleAScalar]][0] * [[a]]) * ([[scaleBScalar]][0] * [[b]]) + [[c]]
+  // CHECK-DAG: memref.load {{.+}} : memref<1x1xvector<32xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.+}} : memref<1x1xvector<32xf8E8M0FNU>, 5>
+  // CHECK-DAG: vector.extract
+  // CHECK: amdgpu.scaled_mfma 32x32x64
   // CHECK-SAME: f8E8M0FNU, vector<32xf4E2M1FN>, f8E8M0FNU, vector<32xf4E2M1FN>, vector<16xf32>
   %c0 = arith.constant 0 : index
   rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = mfma {
@@ -622,14 +614,10 @@ func.func @accel_gemm_gfx950_f32_16x16x512_fp4_scaled_multi(%matrixA : memref<1x
   // CHECK-LABEL: func.func @accel_gemm_gfx950_f32_16x16x512_fp4_scaled_multi
   // CHECK: rock.transforming_for
   // CHECK-SAME: bounds [1, 1, 1]
-  // CHECK: [[a:%.+]] = memref.load {{.+}} : memref<1x4xvector<32xf4E2M1FN>, 5>
-  // CHECK: [[b:%.+]] = memref.load {{.+}} : memref<1x4xvector<32xf4E2M1FN>, 5>
-  // CHECK: [[scaleA:%.+]] = memref.load {{.+}} : memref<1x4xvector<32xf8E8M0FNU>, 5>
-  // CHECK: [[scaleAScalar:%.+]] = vector.extract [[scaleA]]
-  // CHECK: [[scaleB:%.+]] = memref.load {{.+}} : memref<1x4xvector<32xf8E8M0FNU>, 5>
-  // CHECK: [[scaleBScalar:%.+]] = vector.extract [[scaleB]]
-  // CHECK: [[c:%.+]] = memref.load {{.+}} : memref<1x1xvector<4xf32>, 5>
-  // CHECK: amdgpu.scaled_mfma 16x16x128 ([[scaleAScalar]][0] * [[a]]) * ([[scaleBScalar]][0] * [[b]]) + [[c]]
+  // CHECK-DAG: memref.load {{.+}} : memref<1x4xvector<32xf4E2M1FN>, 5>
+  // CHECK-DAG: memref.load {{.+}} : memref<1x4xvector<32xf8E8M0FNU>, 5>
+  // CHECK-DAG: vector.extract
+  // CHECK: amdgpu.scaled_mfma 16x16x128
   // CHECK-SAME: f8E8M0FNU, vector<32xf4E2M1FN>, f8E8M0FNU, vector<32xf4E2M1FN>, vector<4xf32>
   %c0 = arith.constant 0 : index
   rock.threadwise_gemm_accel %matrixC += %matrixA scaled by %scaleA * %matrixB scaled by %scaleB at [%c0, %c0, %c0] features = mfma {


### PR DESCRIPTION
## Motivation

This PR adds in new scaled wmma instructions that are available on gfx1250. 

This implements: https://github.com/ROCm/rocMLIR-internal/issues/2133

## Technical Details

Upstream changes needed for this:
- https://github.com/llvm/llvm-project/pull/165915
- https://github.com/llvm/llvm-project/pull/169854

Note: Both of these external commits can be dropped when the December upstream merge goes in

rocMLIR changes:
- Add extra logic in WmmaInsnGroup/AccelEmitter
- Updates to AmdArchDb to allow for fp4 wmma types

## Test Plan

- Nightly CI
- gfx1250 emulation tests

## Test Result

- [ ] Nightly CI
- [ ] gfx1250 emulation

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
