### PR TITLE
Add debug messages to calculateBlockGemmPerformanceParameters

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -139,15 +139,23 @@ LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
     return failure();
   GeneralGemmBlockStructure derived = *maybeDerived;
 
-  if (params.getMPerThread() < 2 || params.getMPerThread() > 4)
+  if (params.getMPerThread() < 2 || params.getMPerThread() > 4) {
+    LLVM_DEBUG(llvm::dbgs() << "gemmMPerThread is not in the range [2, 4]\n");
     return failure();
+  }
 
-  if (params.getNPerThread() < 2 || params.getNPerThread() > 4)
+  if (params.getNPerThread() < 2 || params.getNPerThread() > 4) {
+    LLVM_DEBUG(llvm::dbgs() << "gemmNPerThread is not in the range [2, 4]\n");
     return failure();
+  }
 
   if (params.getMPerBlock() % params.getMPerThread() != 0 ||
-      params.getNPerBlock() % params.getNPerThread() != 0)
+      params.getNPerBlock() % params.getNPerThread() != 0) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "gemmMPerBlock or gemmNPerBlock aren't divisible by "
+                  "gemmMPerThread or gemmNPerThread\n");
     return failure();
+  }
 
   int64_t threadGemmMPerCluster = params.getMPerThread() *
                                   derived.mThreadsPerCuwave *
@@ -158,9 +166,9 @@ LogicalResult PopulateParams::calculateBlockGemmPerformanceParameters(
 
   if ((params.getMPerBlock() % threadGemmMPerCluster != 0) ||
       (params.getNPerBlock() % threadGemmNPerCluster != 0)) {
-    LLVM_DEBUG(
-        llvm::dbgs()
-        << "M per block or N per block aren't divisible by M/N per cluster\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "gemmMPerBlock or gemmNPerBlock aren't divisible by "
+                  "threadGemmMPerCluster or threadGemmNPerCluster\n");
     return failure();
   }
 

--- a/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/GridwiseGemmParams.cpp
@@ -423,8 +423,12 @@ PopulateParamsXDL::isValidBlockwiseGemm(RockAccelTuningParamAttrInterface param,
 
   const int64_t waveSize = mlir::rock::lookupArchInfo(arch).waveSize;
   int64_t blockSize = obtainBlockSize(waveSize, param);
-  if (blockSize > maxHardwareWorkgroupSize)
+  if (blockSize > maxHardwareWorkgroupSize) {
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsXDL::isValidBlockwiseGemm: block size too large.\n");
     return failure();
+  }
   // TBD: support fp16/bf16
 
   // clang-format off
@@ -445,7 +449,10 @@ PopulateParamsXDL::isValidBlockwiseGemm(RockAccelTuningParamAttrInterface param,
 
   if (param.getMnPerXdl() > param.getMPerWave() ||
       param.getMnPerXdl() > param.getNPerWave()) {
-    LLVM_DEBUG(llvm::dbgs() << "mnPerXdl is too large:" << param << "\n");
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsXDL::isValidBlockwiseGemm: mnPerXdl is too large:"
+        << param << "\n");
     return failure();
   }
 
@@ -466,28 +473,39 @@ PopulateParamsXDL::isValidBlockwiseGemm(RockAccelTuningParamAttrInterface param,
       (param.getNPerBlock() % minDPerWave != 0) ||
       ((param.getKpackPerBlock() * param.getKpack()) % validKPerWaveFactor !=
        0)) {
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsXDL::isValidBlockwiseGemm: "
+                               "invalid repeats and k distributions\n");
     return failure();
   }
 
   if (blockSize < waveSize) {
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsXDL::isValidBlockwiseGemm: block size too small.\n");
     return failure();
   }
 
   if ((param.getMPerBlock() % param.getMPerWave()) != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsXDL::isValidBlockwiseGemm: "
+                               "mPerBlock not divisible by mPerWave\n");
     return failure();
   }
 
   if ((param.getNPerBlock() % param.getNPerWave()) != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsXDL::isValidBlockwiseGemm: "
+                               "nPerBlock not divisible by nPerWave\n");
     return failure();
   }
 
   if (param.getMPerWave() % param.getMnPerXdl() != 0) {
-    LLVM_DEBUG(llvm::dbgs() << "tuning: mPerWave not divisible by mnPerXdl\n");
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsXDL::isValidBlockwiseGemm: "
+                               "mPerWave not divisible by mnPerXdl\n");
     return failure();
   }
 
   if (param.getNPerWave() % param.getMnPerXdl() != 0) {
-    LLVM_DEBUG(llvm::dbgs() << "tuning: nPerWave not divisible by mnPerXdl\n");
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsXDL::isValidBlockwiseGemm: "
+                               "nPerWave not divisible by mnPerXdl\n");
     return failure();
   }
 
@@ -496,13 +514,17 @@ PopulateParamsXDL::isValidBlockwiseGemm(RockAccelTuningParamAttrInterface param,
   int64_t mPerBlock = param.getMPerBlock();
   int64_t nPerBlock = param.getNPerBlock();
   if (!isValidBlockSize(blockSize, kPerBlock, mPerBlock, nPerBlock)) {
-    LLVM_DEBUG(llvm::dbgs() << "tuning: Block size too large.\n");
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsXDL::isValidBlockwiseGemm: Block size too large.\n");
     return failure();
   }
 
   // Sledgehammer hotfix because not unrolling sometimes makes the register
   // allocator break. This should be refined quickly.
   if (!cast<RockTuningParamAttrInterface>(param).getForceUnroll()) {
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsXDL::isValidBlockwiseGemm: force "
+                               "unroll is disabled\n");
     return failure();
   }
 
@@ -515,14 +537,15 @@ PopulateParamsXDL::isValidBlockwiseGemm(RockAccelTuningParamAttrInterface param,
       MfmaInsnGroup::select(dataTypeA, dataTypeB, arch, mnPerXdl,
                             param.getKpack(), param.getKpackPerBlock());
   if (failed(maybeMfmaInsnGroup)) {
-    LLVM_DEBUG(llvm::dbgs() << "Failed to select xdlops instruction group.\n");
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsXDL::isValidBlockwiseGemm: "
+                               "Failed to select xdlops instruction group.\n");
     return failure();
   }
   MfmaInsnGroup mfmaGroup = *maybeMfmaInsnGroup;
   if (!mfmaGroup.isCoherentWithK(param.getKpack(), param.getKpackPerBlock())) {
-    LLVM_DEBUG(
-        llvm::dbgs()
-        << "Mfma instruction group selection is not compatible with k.\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "PopulateParamsXDL::isValidBlockwiseGemm: Mfma instruction "
+                  "group selection is not compatible with k.\n");
     return failure();
   }
 
@@ -592,7 +615,10 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
   const int64_t waveSize = mlir::rock::lookupArchInfo(arch).waveSize;
   int64_t blockSize = obtainBlockSize(waveSize, param);
   if (blockSize > maxHardwareWorkgroupSize)
-    return failure();
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsWmma::isValidBlockwiseGemm: block size too large.\n");
+  return failure();
 
   // clang-format off
   std::vector<std::tuple<int, int, int>> validWaveGemmSize =
@@ -614,13 +640,18 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
   // clang-format on
 
   if (param.getMnPerXdl() != 16) {
-    LLVM_DEBUG(llvm::dbgs() << "mnPerXdl must be 16\n");
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsWmma::isValidBlockwiseGemm: mnPerXdl must be 16\n");
     return failure();
   }
 
   if (param.getMnPerXdl() > param.getMPerWave() ||
       param.getMnPerXdl() > param.getNPerWave()) {
-    LLVM_DEBUG(llvm::dbgs() << "mnPerXdl is too large:" << param << "\n");
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsWmma::isValidBlockwiseGemm: mnPerXdl is too large:"
+        << param << "\n");
     return failure();
   }
 
@@ -633,31 +664,44 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
   if ((param.getMPerBlock() % minDPerWave != 0) ||
       (param.getNPerBlock() % minDPerWave != 0) ||
       (param.getKpackPerBlock() % validKPerWaveFactor != 0)) {
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsWmma::isValidBlockwiseGemm: "
+                               "invalid repeats and k distributions\n");
     return failure();
   }
 
   if (blockSize < waveSize)
-    return failure();
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "PopulateParamsWmma::isValidBlockwiseGemm: block size too small.\n");
+  return failure();
 
   if ((param.getMPerBlock() % param.getMPerWave()) != 0)
-    return failure();
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsWmma::isValidBlockwiseGemm: "
+                               "mPerBlock not divisible by mPerWave\n");
+  return failure();
 
   if ((param.getNPerBlock() % param.getNPerWave()) != 0)
-    return failure();
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsWmma::isValidBlockwiseGemm: "
+                               "nPerBlock not divisible by nPerWave\n");
+  return failure();
 
   if (param.getMPerWave() % param.getMnPerXdl() != 0) {
-    LLVM_DEBUG(llvm::dbgs() << "tuning: mPerWave not divisible by mnPerXdl\n");
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsWmma::isValidBlockwiseGemm: "
+                               "mPerWave not divisible by mnPerXdl\n");
     return failure();
   }
 
   if (param.getNPerWave() % param.getMnPerXdl() != 0) {
-    LLVM_DEBUG(llvm::dbgs() << "tuning: nPerWave not divisible by mnPerXdl\n");
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsWmma::isValidBlockwiseGemm: "
+                               "nPerWave not divisible by mnPerXdl\n");
     return failure();
   }
 
   // Sledgehammer hotfix because not unrolling sometimes makes the register
   // allocator break. This should be refined quickly.
   if (!param.getForceUnroll()) {
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsWmma::isValidBlockwiseGemm: "
+                               "force unroll is disabled\n");
     return failure();
   }
 
@@ -666,13 +710,15 @@ LogicalResult PopulateParamsWmma::isValidBlockwiseGemm(
       dataTypeA, dataTypeB, waveSize, arch, param.getMPerWave(),
       param.getNPerWave(), param.getKpack(), param.getKpackPerBlock());
   if (failed(maybeWmmaInsn)) {
-    LLVM_DEBUG(llvm::dbgs() << "Failed to select wmma instruction.\n");
+    LLVM_DEBUG(llvm::dbgs() << "PopulateParamsWmma::isValidBlockwiseGemm: "
+                               "Failed to select wmma instruction.\n");
     return failure();
   }
   WmmaInsn wmmaInsn = *maybeWmmaInsn;
   if (!wmmaInsn.isCoherentWithK(param.getKpack(), param.getKpackPerBlock())) {
     LLVM_DEBUG(llvm::dbgs()
-               << "Wmma instruction selection is not compatible with k.\n");
+               << "PopulateParamsWmma::isValidBlockwiseGemm: Wmma instruction "
+                  "selection is not compatible with k.\n");
     return failure();
   }
 


### PR DESCRIPTION
## Motivation

I get `Incoherent blockGemm tuning parameter size` errors very frequently and I always keep adding this debug messages to see what's wrong.

## Technical Details

Added debug messages

## Test Plan

No new test was added

## Test Result

All test pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
