### PR TITLE
More tuning improvements 

### DIFF
--- a/external/llvm-project/mlir/lib/IR/MLIRContext.cpp
+++ b/external/llvm-project/mlir/lib/IR/MLIRContext.cpp
@@ -76,7 +76,7 @@ struct MLIRContextOptions {
 static llvm::ManagedStatic<MLIRContextOptions> clOptions;
 
 static bool isThreadingGloballyDisabled() {
-#if MLIR_ENABLE_THREADS != 0
+#if LLVM_ENABLE_THREADS != 0
   return clOptions.isConstructed() && clOptions->disableThreading;
 #else
   return true;

--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ThreadPool.h"
 
 #include <atomic>
 #include <cassert>
@@ -86,6 +87,24 @@ void pArgs(const std::tuple<Ts...> &formals, void **_vargs) {
 
 using namespace mlir;
 using namespace rocmlir::tuningdriver;
+
+//===----------------------------------------------------------------------===//
+// Shared Resources for Multi-threaded Compilation
+//===----------------------------------------------------------------------===//
+
+/// Returns a shared dialect registry, initialized exactly once.
+static DialectRegistry &getSharedDialectRegistry() {
+  static std::once_flag initFlag;
+  static DialectRegistry registry;
+  std::call_once(initFlag, []() { registerRocMLIRDialects(registry); });
+  return registry;
+}
+
+/// Returns a shared LLVM ThreadPool for all MLIR contexts.
+static llvm::DefaultThreadPool &getSharedThreadPool() {
+  static llvm::DefaultThreadPool pool;
+  return pool;
+}
 
 static llvm::cl::opt<std::string> inputFilename{
     llvm::cl::Positional, llvm::cl::desc("<input file>"), llvm::cl::init("-")};
@@ -297,9 +316,13 @@ struct ThreadResources {
                   const rock::KernelOptions &applicabilityOpts,
                   const rock::KernelOptions &compilationKernOpts,
                   const rock::BackendOptions &backendOpts) {
-    DialectRegistry registry;
-    registerRocMLIRDialects(registry);
-    ctx = std::make_unique<MLIRContext>(registry);
+    // Use the shared dialect registry (initialized exactly once)
+    DialectRegistry &registry = getSharedDialectRegistry();
+    // Create context with threading disabled internally, attach shared pool
+    ctx = std::make_unique<MLIRContext>(registry,
+                                        MLIRContext::Threading::DISABLED);
+    ctx->setThreadPool(getSharedThreadPool());
+    ctx->loadAllAvailableDialects();
     ctx->getDiagEngine().registerHandler([](Diagnostic &) {});
 
     // Pre-build pipelines once per thread


### PR DESCRIPTION
## Motivation

- Creates dialect registry only once. 
- Uses the same threadPool for all the threads. 
- Renames MLIR_ENABLE_THREADS to LLVM_ENALBE_THREADS. There is no compile time flag as MLIR_ENALBE_THREADS. `rocm/llvm` has it incorrectly. `llvm/llvm` uses LLVM_ENABLE_THREADS
- Only copy GPU buffers once and use same buffer for benchmarking for perf configs. 

## Testing 
`rocmlir-gen -m 1500 -n 1152 -k 896 --operation gemm --arch gfx942 --num_cu 80`

| Tuning Mode | develop | tuningImprovements | Improvement |
|-------------|---------|-------------------|-------------|
| **Quick** | 1.50s | 1.53s | -2% (slower) |
| **Full** | 19.5s | 19.5s | ~0% (same) |
| **Exhaustive** | 4m 2.6s | 3m 59.5s | **~1.3% faster** |

