### PR TITLE
Fix bug during migraphx-ci build

### DIFF
--- a/mlir/utils/jenkins/Dockerfile.migraphx-ci
+++ b/mlir/utils/jenkins/Dockerfile.migraphx-ci
@@ -1,5 +1,6 @@
 ARG ROCM_VERSION=7.0
 FROM rocm/mlir:rocm${ROCM_VERSION}-latest
+ARG ROCM_VERSION
 ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
 
 # --------------------- Section 4: MIGraphX dependencies ---------------


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix for migraphx-ci build failure.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
From [docker docs](https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact):
_"An ARG declared before a FROM is outside of a build stage, so it can't be used in any instruction after a FROM. To use the default value of an ARG declared before the first FROM use an ARG instruction without a value inside of a build stage"_

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
