### PR TITLE
Add INT8 support for LDS transpose load

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1229,12 +1229,12 @@ defvar SameShapeVectorOfI1 = [{
 def Rock_LDSTransposeLoadOp
     : Rock_Op<"lds_transpose_load", [DeclareOpInterfaceMethods<
                                         MemoryEffectsOpInterface>]>,
-      Arguments<(ins Arg<MemRefOf<[F16, BF16, F8E4M3FN, F8E5M2]>,
+      Arguments<(ins Arg<MemRefOf<[F16, BF16, F8E4M3FN, F8E5M2, I8]>,
                          "LDS source buffer">:$source,
           Variadic<Index>:$indices)>,
-      Results<(outs AnyTypeOf<
-          [VectorOfLengthAndType<[4], [F16, BF16]>,
-           VectorOfLengthAndType<[8], [F8E4M3FN, F8E5M2]>]>:$result)> {
+      Results<(outs AnyTypeOf<[VectorOfLengthAndType<[4], [F16, BF16]>,
+                               VectorOfLengthAndType<[8], [F8E4M3FN, F8E5M2,
+                                                           I8]>]>:$result)> {
   let summary =
       "Hardware-assisted LDS transpose load for matrix accelerator tile";
   let description = [{
@@ -1249,7 +1249,8 @@ def Rock_LDSTransposeLoadOp
     - Uses ds_read_tr16_b64 instruction
     - Returns vector<4xtype> (4 elements per thread)
 
-    For 8-bit types (f8E4M3FN, f8E5M2 - OCP FP8 for gfx950):
+    For 8-bit types (f8E4M3FN, f8E5M2 - OCP FP8 for gfx950; i8 - INT8 for
+    gfx950):
     - Uses ds_read_tr8_b64 instruction
     - Returns vector<8xtype> (8 elements per thread)
 

--- a/mlir/include/mlir/Dialect/Rock/utility/LdsTransposeLoad.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/LdsTransposeLoad.h
@@ -118,6 +118,10 @@ inline bool isFp8Type(Type t) {
   return isa<Float8E4M3FNType>(t) || isa<Float8E5M2Type>(t);
 }
 
+// Returns true if `t` is i8. INT8 uses ds_read_tr8_b64 like FP8/BF8 but
+// maps to the mfma_i32_*_i8 instruction family.
+inline bool isInt8Type(Type t) { return t.isInteger(8); }
+
 // Build LDS transpose config attribute from already-computed MFMA params.
 // Used in BlockwiseLoadTileToThreadwise when decision was made upstream.
 // Requires mfmaDDim > 0 and mfmaKDim > 0 (asserted).

--- a/mlir/include/mlir/Dialect/Rock/utility/LdsTransposeLoad.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/LdsTransposeLoad.h
@@ -21,17 +21,24 @@
 // to the LDS transpose load operation in an accelerator-friendly layout.
 //
 // It is intended to simplify the IR generation logic and ensure
-// consistent handling of f16/bf16/fp8/bf8 matrix accelerator tile loads from
-// LDS memory.
+// consistent handling of f16/bf16/fp8/bf8/i8 matrix accelerator tile loads
+// from LDS memory.
 //
 // Supported element types:
 // - f16, bf16: uses ds_read_tr16_b64 (returns 4 elements per thread)
 // - f8E4M3FN, f8E5M2 (OCP FP8): uses ds_read_tr8_b64 (returns 8 elements)
+// - i8 (INT8): uses ds_read_tr8_b64 (returns 8 elements per thread)
 //
-// Supported MFMA geometries:
-// - Standard: (16,16), (16,32), (32,8), (32,16) - single-rate or double-rate
-// - Scaled FP8: (16,128) - quad-rate (4 ds_read_tr8 calls per K tile)
-// - Scaled FP8: (32,64) - quad-rate (4 ds_read_tr8 calls per K tile)
+// Supported MFMA geometries (per element type):
+// - F16/BF16:
+//     (16,16), (32,8)    - single-rate (1 ds_read_tr16 call per K tile)
+//     (16,32), (32,16)   - double-rate (2 ds_read_tr16 calls per K tile)
+// - FP8 / BF8 (f8E4M3FN, f8E5M2):
+//     (16,32), (32,16)   - single-rate (1 ds_read_tr8 call per K tile)
+//     (16,128), (32,64)  - quad-rate (4 ds_read_tr8 calls per K tile)
+// - INT8 (i8):
+//     (16,32), (32,16)   - single-rate (1 ds_read_tr8 call per K tile)
+//     (16,64), (32,32)   - double-rate (2 ds_read_tr8 calls per K tile)
 //
 //===----------------------------------------------------------------------===//
 
@@ -52,27 +59,46 @@ enum class OperandKind { A, B };
 // Returns true if the given (D, K) MFMA geometry is one of the geometries
 // recognized by the LDS transpose load lowering.
 // Recognized combinations:
-//   Standard:   (16,16), (16,32), (32,8), (32,16)
-//   Scaled FP8: (16,128) quad-rate, (32,64) quad-rate
+//   Standard:    (16,16), (16,32), (32,8), (32,16)
+//   Scaled FP8:  (16,128) quad-rate, (32,64) quad-rate
+//   INT8 double: (16,64), (32,32)
 // Note: this is geometry-only recognition. Element-type compatibility
-// (e.g., FP8-only quad-rate) is enforced separately by the caller.
+// (e.g., FP8-only quad-rate, INT8-only double-rate (16,64)/(32,32)) is
+// enforced separately by the caller.
 inline bool isValidLdsTransposeMfmaGeometry(int64_t dDim, int64_t kDim) {
-  return (dDim == 16 && (kDim == 16 || kDim == 32 || kDim == 128)) ||
-         (dDim == 32 && (kDim == 8 || kDim == 16 || kDim == 64));
+  return (dDim == 16 &&
+          (kDim == 16 || kDim == 32 || kDim == 64 || kDim == 128)) ||
+         (dDim == 32 && (kDim == 8 || kDim == 16 || kDim == 32 || kDim == 64));
 }
 
 // Returns true if (D, K) is a quad-rate FP8/BF8-only geometry. These
 // geometries map to the scaled FP8 MFMA instructions and must not be paired
-// with f16/bf16 destinations.
+// with f16/bf16/i8 destinations.
 inline bool isFp8OnlyLdsTransposeGeometry(int64_t dDim, int64_t kDim) {
   return (dDim == 16 && kDim == 128) || (dDim == 32 && kDim == 64);
 }
 
 // Returns true if (D, K) is a single-rate F16/BF16-only geometry, i.e. one
-// not used by any FP8/BF8 MFMA instruction. These geometries must not be
-// paired with f8E4M3FN/f8E5M2 destinations.
+// not used by any FP8/BF8/INT8 MFMA instruction. These geometries must not
+// be paired with f8E4M3FN/f8E5M2/i8 destinations.
 inline bool isF16OnlyLdsTransposeGeometry(int64_t dDim, int64_t kDim) {
   return (dDim == 16 && kDim == 16) || (dDim == 32 && kDim == 8);
+}
+
+// Returns true if (D, K) is a double-rate INT8-only geometry. These
+// geometries map to mfma_i32_16x16x64_i8 and mfma_i32_32x32x32_i8 and must
+// not be paired with f16/bf16/f8E4M3FN/f8E5M2 destinations.
+inline bool isInt8OnlyLdsTransposeGeometry(int64_t dDim, int64_t kDim) {
+  return (dDim == 16 && kDim == 64) || (dDim == 32 && kDim == 32);
+}
+
+// Returns true if (D, K) is a double-rate F16/BF16 geometry. The geometry
+// pair (16,32)/(32,16) is shared with FP8/BF8/INT8 single-rate, but for
+// 16-bit element types it lowers to two ds_read_tr16_b64 calls (low + high
+// halves of kMfma=16, vector<4xf16> each). For FP8/BF8/INT8 the same
+// geometry is single-rate (one ds_read_tr8_b64 already covers kMfma).
+inline bool isF16DoubleRateGeometry(int64_t dDim, int64_t kDim) {
+  return (dDim == 16 && kDim == 32) || (dDim == 32 && kDim == 16);
 }
 
 // Returns true if numWaves is a supported wave count for the LDS transpose
@@ -95,7 +121,8 @@ inline bool isFp8Type(Type t) {
 // Build LDS transpose config attribute from already-computed MFMA params.
 // Used in BlockwiseLoadTileToThreadwise when decision was made upstream.
 // Requires mfmaDDim > 0 and mfmaKDim > 0 (asserted).
-// Valid combinations: (16,16), (16,32), (16,128), (32,8), (32,16), (32,64)
+// Valid combinations: (16,16), (16,32), (16,64), (16,128), (32,8), (32,16),
+//                     (32,32), (32,64)
 LDSTransposeConfigAttr buildTransposeAttrFromParams(
     PatternRewriter &rewriter, int64_t mfmaDDim, int64_t mfmaKDim,
     int64_t mPerBlock, int64_t nPerBlock, int64_t kPerBlock, int64_t mPerWave,

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -570,7 +570,8 @@ LogicalResult LDSTransposeConfigAttr::verify(
     return emitError()
            << "invalid MFMA geometry (" << dDim << "x" << kDim
            << ") for LDS transpose - valid combinations: "
-              "(16,16), (16,32), (16,128), (32,8), (32,16), (32,64)";
+              "(16,16), (16,32), (16,64), (16,128), (32,8), (32,16), "
+              "(32,32), (32,64)";
   }
 
   // Validate positive dimensions
@@ -2364,17 +2365,21 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
                          "live in workgroup (LDS) memory");
     bool isFp8 = hwtranspose::isFp8Type(destElemType);
     bool is16Bit = destElemType.isF16() || destElemType.isBF16();
-    if (!is16Bit && !isFp8)
+    bool isInt8 = destElemType.isInteger(8);
+    if (!is16Bit && !isFp8 && !isInt8)
       return emitOpError("ldsTransposeConfig only supports f16, bf16, "
-                         "f8E4M3FN, or f8E5M2 destination element types");
+                         "f8E4M3FN, f8E5M2, or i8 destination element types");
     int64_t dDim = cfg.getDDim();
     int64_t kDim = cfg.getKDim();
-    if (isFp8 && hwtranspose::isF16OnlyLdsTransposeGeometry(dDim, kDim))
+    if (!is16Bit && hwtranspose::isF16OnlyLdsTransposeGeometry(dDim, kDim))
       return emitOpError("MFMA geometry (")
-             << dDim << "x" << kDim << ") is not supported for FP8/BF8";
-    if (is16Bit && hwtranspose::isFp8OnlyLdsTransposeGeometry(dDim, kDim))
+             << dDim << "x" << kDim << ") is not supported for FP8/BF8/INT8";
+    if (!isFp8 && hwtranspose::isFp8OnlyLdsTransposeGeometry(dDim, kDim))
       return emitOpError("quad-rate MFMA geometry (")
              << dDim << "x" << kDim << ") is only valid for FP8/BF8";
+    if (!isInt8 && hwtranspose::isInt8OnlyLdsTransposeGeometry(dDim, kDim))
+      return emitOpError("double-rate MFMA geometry (")
+             << dDim << "x" << kDim << ") is only valid for INT8";
   }
   return success();
 }

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -2373,12 +2373,12 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
     int64_t kDim = cfg.getKDim();
     if (!is16Bit && hwtranspose::isF16OnlyLdsTransposeGeometry(dDim, kDim))
       return emitOpError("MFMA geometry (")
-             << dDim << "x" << kDim << ") is not supported for FP8/BF8/INT8";
+             << dDim << "x" << kDim << ") is only valid for F16/BF16";
     if (!isFp8 && hwtranspose::isFp8OnlyLdsTransposeGeometry(dDim, kDim))
-      return emitOpError("quad-rate MFMA geometry (")
+      return emitOpError("MFMA geometry (")
              << dDim << "x" << kDim << ") is only valid for FP8/BF8";
     if (!isInt8 && hwtranspose::isInt8OnlyLdsTransposeGeometry(dDim, kDim))
-      return emitOpError("double-rate MFMA geometry (")
+      return emitOpError("MFMA geometry (")
              << dDim << "x" << kDim << ") is only valid for INT8";
   }
   return success();

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -2365,7 +2365,7 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
                          "live in workgroup (LDS) memory");
     bool isFp8 = hwtranspose::isFp8Type(destElemType);
     bool is16Bit = destElemType.isF16() || destElemType.isBF16();
-    bool isInt8 = destElemType.isInteger(8);
+    bool isInt8 = hwtranspose::isInt8Type(destElemType);
     if (!is16Bit && !isFp8 && !isInt8)
       return emitOpError("ldsTransposeConfig only supports f16, bf16, "
                          "f8E4M3FN, f8E5M2, or i8 destination element types");

--- a/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
+++ b/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
@@ -60,13 +60,9 @@ static bool isSupportedElementType(Type t) {
          isa<Float8E5M2Type>(t) || t.isInteger(8);
 }
 
-// Check if element type is INT8 (i8). INT8 uses ds_read_tr8_b64 like FP8/BF8
-// but maps to mfma_i32_*_i8 instructions.
-static bool isInt8Type(Type t) { return t.isInteger(8); }
-
 // Check if element type uses ds_read_tr8_b64 (8 elements per thread).
-// True for FP8 (E4M3FN), BF8 (E5M2), and INT8. isFp8Type is provided by
-// LdsTransposeLoad.h (mlir::rock::hwtranspose).
+// True for FP8 (E4M3FN), BF8 (E5M2), and INT8. isFp8Type / isInt8Type are
+// provided by LdsTransposeLoad.h (mlir::rock::hwtranspose).
 static bool uses8BitTransposeLoad(Type t) {
   return isFp8Type(t) || isInt8Type(t);
 }
@@ -542,7 +538,7 @@ static Value computePanelFinalOffset(PatternRewriter &b, Location loc,
 // Computes the final LDS offset and emits a hardware LDS transpose load
 // instruction:
 // - ds_read_tr16_b64 for f16/bf16: returns vector<4>
-// - ds_read_tr8_b64 for fp8/bf8: returns vector<8>
+// - ds_read_tr8_b64 for fp8/bf8/i8: returns vector<8>
 //
 // The final offset is computed as: final_offset = k_base * ldsStride + m_base
 // where ldsStride depends on the operand (mPerBlock for A, nPerBlock for B).
@@ -555,10 +551,12 @@ static Value computePanelFinalOffset(PatternRewriter &b, Location loc,
 //   kBase        - K dimension base offset for this panel
 //   mBase        - M/N dimension base offset for this panel
 //   ldsStride    - Stride between K rows in LDS (mPerBlock or nPerBlock)
-//   panelVecType - Result type (vector<4> for f16/bf16, vector<8> for fp8/bf8)
+//   panelVecType - Result type (vector<4> for f16/bf16,
+//                  vector<8> for fp8/bf8/i8)
 //
 // Returns:
-//   The loaded panel vector (vector<4> for f16/bf16, vector<8> for fp8/bf8)
+//   The loaded panel vector (vector<4> for f16/bf16,
+//   vector<8> for fp8/bf8/i8)
 //===----------------------------------------------------------------------===//
 static Value emitPanelLoad(PatternRewriter &b, Location loc, Value rawSrc,
                            Value kBase, Value mBase, Value ldsStride,
@@ -580,12 +578,12 @@ static Value emitPanelLoad(PatternRewriter &b, Location loc, Value rawSrc,
 // Extracts individual elements from loaded panel vectors and writes them
 // sequentially to the destination buffer. Panel vector width depends on the
 // element type:
-//   - f16/bf16:  vector<4>  (ds_read_tr16_b64)
-//   - fp8/bf8:   vector<8>  (ds_read_tr8_b64)
+//   - f16/bf16:    vector<4>  (ds_read_tr16_b64)
+//   - fp8/bf8/i8:  vector<8>  (ds_read_tr8_b64)
 //
 // Parameters:
 //   panelVectors - Array of loaded panel vectors (vector<4> for f16/bf16,
-//                  vector<8> for fp8/bf8)
+//                  vector<8> for fp8/bf8/i8)
 //   dest         - Destination memref (rank-1, scalar layout)
 //   targetElems  - Maximum number of elements to write
 //
@@ -603,7 +601,7 @@ writePanelVectorsToDestination(PatternRewriter &b, Location loc,
   // Extract elements per vector from the actual vector type
   // Hardware instructions:
   // - ds_read_tr16_b64 returns vector<4xf16/bf16>
-  // - ds_read_tr8_b64 returns vector<8xfp8>
+  // - ds_read_tr8_b64  returns vector<8xfp8/bf8/i8>
   assert(!panelVectors.empty() && "Panel vectors array must not be empty");
   auto panelVecType = cast<VectorType>(panelVectors[0].getType());
   int64_t elementsPerVector = panelVecType.getShape()[0];
@@ -804,7 +802,8 @@ static SmallVector<Value> getBasePanelOffsets(PatternRewriter &b, Location loc,
 //   dDim - MFMA D dimension (M or N, 16 or 32)
 //   kDim - MFMA K dimension (8, 16, 32, 64, or 128)
 //   lane - Thread's lane ID within the workgroup
-//   elemType - Element type (f16, bf16, fp8, or bf8) for selecting lane mapping
+//   elemType - Element type (f16, bf16, fp8, bf8, or i8) for selecting lane
+//              mapping
 //
 // Returns:
 //   std::pair<Value, Value>:
@@ -1121,7 +1120,7 @@ static Value computeFinalMNOffset(PatternRewriter &b, Location loc,
 // Lowers threadwise_read_into with LDS transpose config into hardware transpose
 // load instructions that read from LDS in MFMA-friendly order:
 // - ds_read_tr16_b64 for f16/bf16 (returns vector<4>)
-// - ds_read_tr8_b64 for fp8/bf8 (returns vector<8>)
+// - ds_read_tr8_b64 for fp8/bf8/i8 (returns vector<8>)
 //
 // Algorithm:
 // 1. Extract config: MFMA geometry (dDim, kDim), tiling params, operand kind
@@ -1135,7 +1134,8 @@ static Value computeFinalMNOffset(PatternRewriter &b, Location loc,
 //    otherwise)
 //    - Inner: K tiles (1 load for single-rate, 2 loads for double-rate layouts)
 // 6. For each iteration: compute final LDS offset, emit LDS transpose load
-//    instruction (ds_read_tr16_b64 for f16/bf16, ds_read_tr8_b64 for fp8/bf8)
+//    instruction (ds_read_tr16_b64 for f16/bf16,
+//    ds_read_tr8_b64 for fp8/bf8/i8)
 // 7. Extract elements from panel vectors and write sequentially to destination
 //
 // Example: 16x32 layout, 1 M-tile, 2 K-tiles → 2 ds_read_tr16_b64 calls → 8
@@ -1206,14 +1206,15 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
       isFp8Type(elemType) && isFp8OnlyLdsTransposeGeometry(dDim, instrK);
 
   // Determine vector length based on element type:
-  // - f16/bf16: ds_read_tr16_b64 returns vector<4>
-  // - fp8/bf8: ds_read_tr8_b64 returns vector<8>
+  // - f16/bf16:    ds_read_tr16_b64 returns vector<4>
+  // - fp8/bf8/i8:  ds_read_tr8_b64 returns vector<8>
   int64_t vecLen = getTransposeLoadVectorLength(elemType);
   VectorType panelVecType = VectorType::get({vecLen}, elemType);
 
   // panelVectors will contain:
   // - Single-rate: 1 vector per K tile
-  // - Double-rate (f16/bf16 only): 2 vectors per K tile (low + high)
+  // - Double-rate (f16/bf16 (16,32)/(32,16) and INT8 (16,64)/(32,32)):
+  //     2 vectors per K tile (low + high half)
   // - Quad-rate (FP8 16x128 or 32x64): 4 vectors per K tile (readIdx 0-3)
   SmallVector<Value> panelVectors;
 
@@ -1290,7 +1291,9 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
         }
 
       } else if (!isDoubleRate) {
-        // SINGLE-RATE (L32x8, L16x16, or FP8/BF8): One load per K tile
+        // SINGLE-RATE: one load per K tile.
+        //   - F16/BF16 (L32x8, L16x16)
+        //   - FP8/BF8/INT8 unscaled (L32x16, L16x32)
         Value k_base =
             computePanelFinalOffset(b, loc, isDoubleRate, k_base_local,
                                     kOffsetBase, kIdx, kTileStrideVal);
@@ -1341,8 +1344,8 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
   int64_t expectedLoads = actualMnTiles * kPanels * loadsPerKTile;
 
   // Each load produces vecLen elements:
-  // - f16/bf16: 4 elements (ds_read_tr16_b64)
-  // - fp8/bf8: 8 elements (ds_read_tr8_b64)
+  // - f16/bf16:    4 elements (ds_read_tr16_b64)
+  // - fp8/bf8/i8:  8 elements (ds_read_tr8_b64)
   int64_t sliceElems = expectedLoads * vecLen;
 
   // Verify we generated the expected number of loads

--- a/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
+++ b/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
@@ -420,8 +420,10 @@ static MNTileBounds computeMNTileIterationBounds(bool doubleBuffering,
 //   return    kBlock * kStride
 //
 // For F16/BF16 double-rate (L32x16, L16x32) the caller passes kStride=8
-// (half of kMfma=16). For FP8/BF8 the caller passes kStride=8 (unscaled
-// kMfma in {16, 32}) or kStride=32 (quad-rate scaled, kMfma in {64, 128}).
+// (per-thread K coverage of the two vector<4> halves). For FP8/BF8 the
+// caller passes kStride=8 (unscaled, single vector<8> covers 8 K per
+// thread) or kStride=32 (quad-rate scaled, four vector<8> halves cover
+// 32 K per thread).
 //===----------------------------------------------------------------------===//
 static Value computeKBlockTimesStride(PatternRewriter &b, Location loc,
                                       int64_t dDim, int64_t kStride,
@@ -487,9 +489,11 @@ static Value getDoubleRateKOffsetBase(PatternRewriter &b, Location loc,
 // extraKOffset semantics depend on the layout:
 //   - Single-rate                   -> 0
 //   - F16/BF16 double-rate, low     -> 0
-//   - F16/BF16 double-rate, high    -> 4 (half of kMfma=16, vector<4>)
+//   - F16/BF16 double-rate, high    -> 4 (size of one vector<4> half,
+//                                         per thread)
 //   - INT8 double-rate, low         -> 0
-//   - INT8 double-rate, high        -> 8 (half of kMfma=32, vector<8>)
+//   - INT8 double-rate, high        -> 8 (size of one vector<8> half,
+//                                         per thread)
 //   - Quad-rate (FP8 scaled), read i-> i * 8 (i in {0,1,2,3} for 8-K chunks)
 //
 // Parameters:
@@ -690,15 +694,19 @@ static SmallVector<Value> getBasePanelOffsets(PatternRewriter &b, Location loc,
     //     contributes to mOffsetBase). For dDim == 16, blockId is the K
     //     block.
     //
+    bool isFp8 = isFp8Type(elemType);
+    bool isInt8 = isInt8Type(elemType);
     // The verifier in ThreadwiseReadIntoOp::verify already rejects every
     // (8-bit type, geometry) pair outside the supported set, so on well-
     // formed IR this assert is unreachable. Kept as defense-in-depth for
-    // misuse from C++ callers that bypass the verifier.
+    // misuse from C++ callers that bypass the verifier. The geometry must
+    // be valid, not F16-only, not FP8-only when elemType is INT8, and not
+    // INT8-only when elemType is FP8/BF8.
     assert(isValidLdsTransposeMfmaGeometry(dDim, kDim) &&
            !isF16OnlyLdsTransposeGeometry(dDim, kDim) &&
-           "Unsupported 8-bit MFMA geometry in getBasePanelOffsets");
-    bool isFp8 = isFp8Type(elemType);
-    bool isInt8 = isInt8Type(elemType);
+           !(isFp8 && isInt8OnlyLdsTransposeGeometry(dDim, kDim)) &&
+           !(isInt8 && isFp8OnlyLdsTransposeGeometry(dDim, kDim)) &&
+           "Unsupported 8-bit (type, geometry) pair in getBasePanelOffsets");
     // FP8/BF8 quad-rate (16,128) and (32,64); INT8 double-rate (16,64) and
     // (32,32). The remaining valid pair (16,32)/(32,16) is shared single-
     // rate for both FP8/BF8 and INT8.
@@ -1189,15 +1197,20 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
   // Use mPerBlock as stride for operand A, nPerBlock for operand B
   int64_t ldsStride = (operand == OperandKind::A) ? mPerBlock : nPerBlock;
 
-  // Determine if this is a double-rate or quad-rate instruction
+  // Determine if this is a double-rate or quad-rate instruction. All numbers
+  // below are per-thread element counts.
   // Double-rate (TWO ds_read calls per K tile):
-  //   - F16/BF16 (32,16) and (16,32): ds_read_tr16_b64 returns vector<4>;
-  //     two halves cover kMfma=16 (halves of size 8 each).
-  //   - INT8 (16,64) and (32,32): ds_read_tr8_b64 returns vector<8>;
-  //     two halves cover kMfma=32 (halves of size 16 each).
-  // FP8/BF8 unscaled (16,32) and (32,16) are SINGLE-RATE (one ds_read_tr8 per
-  // tile already covers kMfma=8). F16/BF16 (16,16) and (32,8) are SINGLE-RATE.
-  // Quad-rate (FP8 scaled MFMA): 16x128 and 32x64 (k_base=32, 4 reads of 8).
+  //   - F16/BF16 (32,16) and (16,32): each ds_read_tr16_b64 returns
+  //     vector<4>; two calls give 8 K elements per thread (low/high half of
+  //     4 elements each, extraKOffset for high half = 4).
+  //   - INT8 (16,64) and (32,32): each ds_read_tr8_b64 returns vector<8>;
+  //     two calls give 16 K elements per thread (low/high half of 8
+  //     elements each, extraKOffset for high half = 8).
+  // FP8/BF8 unscaled (16,32) and (32,16) are SINGLE-RATE: one ds_read_tr8
+  // already gives 8 K elements per thread. F16/BF16 (16,16) and (32,8) are
+  // SINGLE-RATE: one ds_read_tr16 gives 4 K elements per thread.
+  // Quad-rate (FP8 scaled MFMA 16x128, 32x64): FOUR ds_read_tr8 calls per
+  // K tile = 32 K elements per thread (readIdx 0..3, extraKOffset = idx * 8).
   bool isDoubleRate =
       (!uses8BitTransposeLoad(elemType) &&
        isF16DoubleRateGeometry(dDim, instrK)) ||
@@ -1304,12 +1317,16 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
         panelVectors.push_back(panelVec);
 
       } else {
-        // DOUBLE-RATE: TWO loads per K tile
-        //   - F16/BF16 (L32x16, L16x32): vector<4> per load, halves of 8 K
-        //     elements (extraKOffset for high half = 4).
-        //   - INT8    (L16x64, L32x32):  vector<8> per load, halves of 16 K
-        //     elements (extraKOffset for high half = 8).
-        // FP8/BF8 is NEVER double-rate (single ds_read_tr8_b64 covers kMfma).
+        // DOUBLE-RATE: TWO loads per K tile. All numbers below are per-
+        // thread element counts.
+        //   - F16/BF16 (L32x16, L16x32): each ds_read_tr16_b64 returns
+        //     vector<4>; two loads give 8 K elements per thread
+        //     (extraKOffset for high half = 4).
+        //   - INT8    (L16x64, L32x32):  each ds_read_tr8_b64 returns
+        //     vector<8>; two loads give 16 K elements per thread
+        //     (extraKOffset for high half = 8).
+        // FP8/BF8 is NEVER double-rate (single ds_read_tr8_b64 already
+        // covers the full per-thread K range of the unscaled MFMA).
         int64_t highHalfOffset = isInt8Type(elemType) ? 8 : 4;
         Value k_base_low =
             computePanelFinalOffset(b, loc, isDoubleRate, k_base_local,

--- a/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
+++ b/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
@@ -56,8 +56,7 @@ namespace {
 // - f8E4M3FN, f8E5M2 (OCP FP8 for gfx950): ds_read_tr8_b64 (8 elements)
 // - i8 (INT8 for gfx950): ds_read_tr8_b64 (8 elements)
 static bool isSupportedElementType(Type t) {
-  return t.isF16() || t.isBF16() || isa<Float8E4M3FNType>(t) ||
-         isa<Float8E5M2Type>(t) || t.isInteger(8);
+  return t.isF16() || t.isBF16() || isFp8Type(t) || isInt8Type(t);
 }
 
 // Check if element type uses ds_read_tr8_b64 (8 elements per thread).

--- a/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
+++ b/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
@@ -21,13 +21,14 @@
 // to the LDS transpose load operation in an accelerator-friendly layout.
 //
 // It is intended to simplify the IR generation logic and ensure
-// consistent handling of f16/bf16/fp8/bf8 matrix accelerator tile loads from
-// LDS memory.
+// consistent handling of f16/bf16/fp8/bf8/i8 matrix accelerator tile loads
+// from LDS memory.
 //
 // Supported element types:
 // - f16, bf16: uses ds_read_tr16_b64 (returns 4 elements per thread)
 // - f8E4M3FN, f8E5M2 (OCP FP8): uses ds_read_tr8_b64 (returns 8 elements per
-// thread)
+//   thread)
+// - i8 (INT8): uses ds_read_tr8_b64 (returns 8 elements per thread)
 //
 //===----------------------------------------------------------------------===//
 
@@ -53,17 +54,29 @@ namespace {
 // Check if element type is supported for LDS transpose load
 // - f16, bf16: ds_read_tr16_b64 (4 elements)
 // - f8E4M3FN, f8E5M2 (OCP FP8 for gfx950): ds_read_tr8_b64 (8 elements)
+// - i8 (INT8 for gfx950): ds_read_tr8_b64 (8 elements)
 static bool isSupportedElementType(Type t) {
   return t.isF16() || t.isBF16() || isa<Float8E4M3FNType>(t) ||
-         isa<Float8E5M2Type>(t);
+         isa<Float8E5M2Type>(t) || t.isInteger(8);
+}
+
+// Check if element type is INT8 (i8). INT8 uses ds_read_tr8_b64 like FP8/BF8
+// but maps to mfma_i32_*_i8 instructions.
+static bool isInt8Type(Type t) { return t.isInteger(8); }
+
+// Check if element type uses ds_read_tr8_b64 (8 elements per thread).
+// True for FP8 (E4M3FN), BF8 (E5M2), and INT8. isFp8Type is provided by
+// LdsTransposeLoad.h (mlir::rock::hwtranspose).
+static bool uses8BitTransposeLoad(Type t) {
+  return isFp8Type(t) || isInt8Type(t);
 }
 
 // Returns the number of elements returned by LDS transpose load instruction
 static int64_t getTransposeLoadVectorLength(Type elemType) {
   if (elemType.isF16() || elemType.isBF16()) {
     return 4; // ds_read_tr16_b64
-  } else if (isFp8Type(elemType)) {
-    return 8; // ds_read_tr8_b64
+  } else if (uses8BitTransposeLoad(elemType)) {
+    return 8; // ds_read_tr8_b64 (FP8/BF8/INT8)
   }
   llvm_unreachable("Unsupported element type for LDS transpose load");
 }
@@ -142,14 +155,22 @@ static Decision makeDecision(StringRef arch, Type elemTypeA, Type elemTypeB,
   // Reject geometry/type combinations not handled in getBasePanelOffsets:
   //   - F16/BF16 path supports: (16,16), (16,32), (32,8), (32,16)
   //   - FP8/BF8  path supports: (16,32), (32,16), (16,128), (32,64)
+  //   - INT8     path supports: (16,32), (32,16), (16,64),  (32,32)
   // Mismatched pairs would hit llvm_unreachable in getBasePanelOffsets.
   // typesCompatible() above already guarantees A and B are either identical
   // or both FP8/BF8 variants, so checking elemTypeA is sufficient.
   if (isFp8Type(elemTypeA)) {
-    if (isF16OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma))
+    if (isF16OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma) ||
+        isInt8OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma))
+      return dec;
+  } else if (isInt8Type(elemTypeA)) {
+    if (isF16OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma) ||
+        isFp8OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma))
       return dec;
   } else {
-    if (isFp8OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma))
+    // F16/BF16
+    if (isFp8OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma) ||
+        isInt8OnlyLdsTransposeGeometry(shape.mnMfma, shape.kMfma))
       return dec;
   }
 
@@ -335,7 +356,7 @@ LDSTransposeConfigAttr buildTransposeAttrFromParams(
          "MFMA geometry must be set when building transpose attributes");
   assert(isValidLdsTransposeMfmaGeometry(mfmaDDim, mfmaKDim) &&
          "Invalid MFMA geometry for LDS transpose - valid: (16,16), (16,32), "
-         "(16,128), (32,8), (32,16), (32,64)");
+         "(16,64), (16,128), (32,8), (32,16), (32,32), (32,64)");
 
   // Create structured attribute with all parameters
   return LDSTransposeConfigAttr::get(rewriter.getContext(), mfmaDDim, mfmaKDim,
@@ -425,12 +446,20 @@ static Value computeKBlockTimesStride(PatternRewriter &b, Location loc,
 //===----------------------------------------------------------------------===//
 // getDoubleRateKOffsetBase - Compute K offset base for double-rate layouts
 //
-// For F16/BF16 double-rate layouts (L32x16, L16x32), each K tile is split
-// into two loads (low and high halves). This returns the per-lane k-block
-// contribution used as the starting point for the low/high half offsets:
+// For double-rate layouts each K tile is split into two loads (low and high
+// halves). This returns the per-lane k-block contribution used as the
+// starting point for the low/high half offsets. kStride is a hardware
+// constant chosen so that the two halves cover the per-thread K range (8
+// elements for F16/BF16 vector<4> halves, 16 elements for INT8 vector<8>
+// halves):
 //
-//   - L32x16 (32x32x16): k_offset_base = ((lane / 16) / 2) * 8
-//   - L16x32 (16x16x32): k_offset_base = (lane / 16) * 8
+//   F16/BF16 (kStride = 8):
+//     - L32x16 (32x32x16): k_offset_base = ((lane / 16) / 2) * 8
+//     - L16x32 (16x16x32): k_offset_base = (lane / 16) * 8
+//
+//   INT8 (kStride = 16):
+//     - L32x32 (32x32x32_i8): k_offset_base = ((lane / 16) / 2) * 16
+//     - L16x64 (16x16x64_i8): k_offset_base = (lane / 16) * 16
 //
 // Returns nullptr for single-rate (the caller will not consume the value).
 //===----------------------------------------------------------------------===//
@@ -440,10 +469,14 @@ static Value getDoubleRateKOffsetBase(PatternRewriter &b, Location loc,
                                       Value lane) {
   if (!isDoubleRate)
     return nullptr;
-  assert(((dDim == 32 && kDim == 16) || (dDim == 16 && kDim == 32)) &&
-         "Invalid double-rate geometry - must be 32x16 or 16x32");
-  // Half of kMfma=16 is 8 for both supported double-rate geometries.
-  return computeKBlockTimesStride(b, loc, dDim, /*kStride=*/8, lane);
+  // F16/BF16 double-rate: (32,16) and (16,32), kStride = 8
+  // INT8 double-rate:     (32,32) and (16,64), kStride = 16
+  bool isInt8DoubleRate = isInt8OnlyLdsTransposeGeometry(dDim, kDim);
+  assert((isInt8DoubleRate || isF16DoubleRateGeometry(dDim, kDim)) &&
+         "Invalid double-rate geometry - must be 32x16, 16x32, 32x32, or "
+         "16x64");
+  int64_t kStride = isInt8DoubleRate ? 16 : 8;
+  return computeKBlockTimesStride(b, loc, dDim, kStride, lane);
 }
 
 //===----------------------------------------------------------------------===//
@@ -456,13 +489,16 @@ static Value getDoubleRateKOffsetBase(PatternRewriter &b, Location loc,
 //                          + extraKOffset
 //
 // extraKOffset semantics depend on the layout:
-//   - Single-rate            -> 0
-//   - Double-rate, low half  -> 0
-//   - Double-rate, high half -> 4
-//   - Quad-rate, read i      -> i * 8 (i in {0,1,2,3} for 8-K chunks)
+//   - Single-rate                   -> 0
+//   - F16/BF16 double-rate, low     -> 0
+//   - F16/BF16 double-rate, high    -> 4 (half of kMfma=16, vector<4>)
+//   - INT8 double-rate, low         -> 0
+//   - INT8 double-rate, high        -> 8 (half of kMfma=32, vector<8>)
+//   - Quad-rate (FP8 scaled), read i-> i * 8 (i in {0,1,2,3} for 8-K chunks)
 //
 // Parameters:
-//   isDoubleRate  - Whether this is a double-rate layout (L32x16, L16x32)
+//   isDoubleRate  - Whether this is a double-rate layout (L32x16, L16x32,
+//                   L32x32 INT8, L16x64 INT8)
 //   kBaseLocal    - Local K base offset from computeLDSBaseOffsets()
 //   kOffsetBase   - Double-rate K offset base (from getDoubleRateKOffsetBase);
 //                   added only when isDoubleRate is true.
@@ -626,6 +662,7 @@ writePanelVectorsToDestination(PatternRewriter &b, Location loc,
 // Supported (dDim, kDim) combinations per element type:
 //   F16 / BF16:  (16,16), (16,32), (32,8), (32,16)   -- ds_read_tr16_b64
 //   FP8 / BF8:   (16,32), (32,16), (16,128), (32,64) -- ds_read_tr8_b64
+//   INT8:        (16,32), (32,16), (16,64),  (32,32) -- ds_read_tr8_b64
 // Any other (type, geometry) combination triggers llvm_unreachable. Callers
 // must validate the (type, geometry) pair upstream (see makeDecision()).
 //
@@ -641,34 +678,56 @@ static SmallVector<Value> getBasePanelOffsets(PatternRewriter &b, Location loc,
 
   Value kOffsetBase, mOffsetBase;
 
-  if (isFp8Type(elemType)) {
-    // FP8/BF8 lane decomposition is the same across all four supported
-    // geometries; the geometries differ only in:
-    //   - kStride: 8 (unscaled, kDim in {16, 32}) vs 32 (scaled, kDim in
-    //     {64, 128}, quad-rate)
+  if (uses8BitTransposeLoad(elemType)) {
+    // FP8/BF8/INT8 share the same lane decomposition (laneInBlock/2 +
+    // mParity); the geometries differ in:
+    //   - whether the kBlock contribution is baked into kOffsetBase here
+    //     (single-rate FP8/BF8 + scaled FP8 quad-rate) or added later via
+    //     getDoubleRateKOffsetBase (INT8 double-rate (16,64) and (32,32)).
+    //   - kStride: 8 (unscaled FP8/BF8, kDim in {16, 32}) or 32 (scaled FP8
+    //     quad-rate, kDim in {64, 128}). INT8 double-rate does not bake the
+    //     kBlock here at all.
     //   - whether dDim == 32, in which case blockId splits into
     //     mBlock = blockId % 2 and kBlock = blockId / 2 (and mBlock * 16
-    //     contributes to mOffsetBase). For dDim == 16, blockId is the K block.
+    //     contributes to mOffsetBase). For dDim == 16, blockId is the K
+    //     block.
+    //
     // The verifier in ThreadwiseReadIntoOp::verify already rejects every
-    // (FP8, geometry) pair that is not in the FP8 set, so on well-formed IR
-    // this assert is unreachable. Kept as defense-in-depth for misuse from
-    // C++ callers that bypass the verifier.
+    // (8-bit type, geometry) pair outside the supported set, so on well-
+    // formed IR this assert is unreachable. Kept as defense-in-depth for
+    // misuse from C++ callers that bypass the verifier.
     assert(isValidLdsTransposeMfmaGeometry(dDim, kDim) &&
            !isF16OnlyLdsTransposeGeometry(dDim, kDim) &&
-           "Unsupported FP8 MFMA geometry in getBasePanelOffsets");
-    bool isScaledGeom = (kDim == 64 || kDim == 128);
+           "Unsupported 8-bit MFMA geometry in getBasePanelOffsets");
+    bool isFp8 = isFp8Type(elemType);
+    bool isInt8 = isInt8Type(elemType);
+    // FP8/BF8 quad-rate (16,128) and (32,64); INT8 double-rate (16,64) and
+    // (32,32). The remaining valid pair (16,32)/(32,16) is shared single-
+    // rate for both FP8/BF8 and INT8.
+    bool isFp8Scaled = isFp8 && isFp8OnlyLdsTransposeGeometry(dDim, kDim);
+    bool isInt8DoubleRate =
+        isInt8 && isInt8OnlyLdsTransposeGeometry(dDim, kDim);
     bool isWideD = (dDim == 32);
 
     Value c8 = arith::ConstantIndexOp::create(b, loc, 8);
-    int64_t kStride = isScaledGeom ? 32 : 8;
 
     Value blockId = arith::DivUIOp::create(b, loc, lane, c16);
     Value laneInBlock = arith::RemUIOp::create(b, loc, lane, c16);
     Value kLocal = arith::DivUIOp::create(b, loc, laneInBlock, c2);
     Value mParity = arith::RemUIOp::create(b, loc, laneInBlock, c2);
 
-    Value kBlockOffset = computeKBlockTimesStride(b, loc, dDim, kStride, lane);
-    kOffsetBase = arith::AddIOp::create(b, loc, kLocal, kBlockOffset);
+    if (isInt8DoubleRate) {
+      // INT8 double-rate (L16x64, L32x32): the kBlock contribution is added
+      // later via getDoubleRateKOffsetBase in computePanelFinalOffset.
+      kOffsetBase = kLocal;
+    } else {
+      // FP8/BF8 unscaled (kStride=8) or scaled quad-rate (kStride=32):
+      // kBlock contribution baked into kOffsetBase here.
+      int64_t kStride = isFp8Scaled ? 32 : 8;
+      Value kBlockOffset =
+          computeKBlockTimesStride(b, loc, dDim, kStride, lane);
+      kOffsetBase = arith::AddIOp::create(b, loc, kLocal, kBlockOffset);
+    }
 
     mOffsetBase = arith::MulIOp::create(b, loc, mParity, c8);
     if (isWideD) {
@@ -1131,15 +1190,20 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
   int64_t ldsStride = (operand == OperandKind::A) ? mPerBlock : nPerBlock;
 
   // Determine if this is a double-rate or quad-rate instruction
-  // Double-rate ONLY for (32,16) and (16,32) MFMA with F16/BF16
-  // FP8/BF8 uses ds_read_tr8_b64 which returns 8 elements, so (16,32) and
-  // (32,16) are SINGLE-RATE for FP8/BF8 (16,16) and (32,8) are always
-  // SINGLE-RATE
-  // Quad-rate for FP8 scaled MFMA: 16x128 and 32x64 (k_base=32, 4 reads of 8)
-  bool isDoubleRate = !isFp8Type(elemType) && ((dDim == 32 && instrK == 16) ||
-                                               (dDim == 16 && instrK == 32));
-  bool isQuadRate = isFp8Type(elemType) && ((dDim == 16 && instrK == 128) ||
-                                            (dDim == 32 && instrK == 64));
+  // Double-rate (TWO ds_read calls per K tile):
+  //   - F16/BF16 (32,16) and (16,32): ds_read_tr16_b64 returns vector<4>;
+  //     two halves cover kMfma=16 (halves of size 8 each).
+  //   - INT8 (16,64) and (32,32): ds_read_tr8_b64 returns vector<8>;
+  //     two halves cover kMfma=32 (halves of size 16 each).
+  // FP8/BF8 unscaled (16,32) and (32,16) are SINGLE-RATE (one ds_read_tr8 per
+  // tile already covers kMfma=8). F16/BF16 (16,16) and (32,8) are SINGLE-RATE.
+  // Quad-rate (FP8 scaled MFMA): 16x128 and 32x64 (k_base=32, 4 reads of 8).
+  bool isDoubleRate =
+      (!uses8BitTransposeLoad(elemType) &&
+       isF16DoubleRateGeometry(dDim, instrK)) ||
+      (isInt8Type(elemType) && isInt8OnlyLdsTransposeGeometry(dDim, instrK));
+  bool isQuadRate =
+      isFp8Type(elemType) && isFp8OnlyLdsTransposeGeometry(dDim, instrK);
 
   // Determine vector length based on element type:
   // - f16/bf16: ds_read_tr16_b64 returns vector<4>
@@ -1237,10 +1301,13 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
         panelVectors.push_back(panelVec);
 
       } else {
-        // DOUBLE-RATE (L32x16, L16x32 with F16/BF16 only): TWO loads per K tile
-        // Each load returns vector<4> for f16/bf16, total 8 elements per K tile
-        // Note: FP8/BF8 is NEVER double-rate (ds_read_tr8_b64 returns 8
-        // elements) Compute K offsets for low and high halves
+        // DOUBLE-RATE: TWO loads per K tile
+        //   - F16/BF16 (L32x16, L16x32): vector<4> per load, halves of 8 K
+        //     elements (extraKOffset for high half = 4).
+        //   - INT8    (L16x64, L32x32):  vector<8> per load, halves of 16 K
+        //     elements (extraKOffset for high half = 8).
+        // FP8/BF8 is NEVER double-rate (single ds_read_tr8_b64 covers kMfma).
+        int64_t highHalfOffset = isInt8Type(elemType) ? 8 : 4;
         Value k_base_low =
             computePanelFinalOffset(b, loc, isDoubleRate, k_base_local,
                                     kOffsetBase, kIdx, kTileStrideVal,
@@ -1248,7 +1315,7 @@ LogicalResult emitThreadwiseHWTranspose(PatternRewriter &b,
         Value k_base_high =
             computePanelFinalOffset(b, loc, isDoubleRate, k_base_local,
                                     kOffsetBase, kIdx, kTileStrideVal,
-                                    /*extraKOffset=*/4);
+                                    /*extraKOffset=*/highHalfOffset);
 
         // Emit low half load
         Value panelVecLow = emitPanelLoad(b, loc, rawSrc, k_base_low, m_base,

--- a/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
+++ b/mlir/lib/Dialect/Rock/utility/LdsTransposeLoad.cpp
@@ -463,8 +463,7 @@ static Value computeKBlockTimesStride(PatternRewriter &b, Location loc,
 //===----------------------------------------------------------------------===//
 static Value getDoubleRateKOffsetBase(PatternRewriter &b, Location loc,
                                       bool isDoubleRate, int64_t dDim,
-                                      [[maybe_unused]] int64_t kDim,
-                                      Value lane) {
+                                      int64_t kDim, Value lane) {
   if (!isDoubleRate)
     return nullptr;
   // F16/BF16 double-rate: (32,16) and (16,32), kStride = 8

--- a/mlir/test/Dialect/Rock/lds_transpose_error.mlir
+++ b/mlir/test/Dialect/Rock/lds_transpose_error.mlir
@@ -118,7 +118,7 @@ func.func @threadwise_read_into_fp8_with_f16_only_geometry(
     %source: memref<128xf8E4M3FN, #gpu.address_space<workgroup>>,
     %dest: memref<8xf8E4M3FN, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{MFMA geometry (16x16) is not supported for FP8/BF8/INT8}}
+  // expected-error @+1 {{MFMA geometry (16x16) is only valid for F16/BF16}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 16, kDim = 16,
@@ -139,7 +139,7 @@ func.func @threadwise_read_into_int8_with_f16_only_geometry(
     %source: memref<128xi8, #gpu.address_space<workgroup>>,
     %dest: memref<8xi8, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{MFMA geometry (32x8) is not supported for FP8/BF8/INT8}}
+  // expected-error @+1 {{MFMA geometry (32x8) is only valid for F16/BF16}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 32, kDim = 8,
@@ -160,7 +160,7 @@ func.func @threadwise_read_into_f16_with_quad_rate_geometry(
     %source: memref<128xf16, #gpu.address_space<workgroup>>,
     %dest: memref<4xf16, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{quad-rate MFMA geometry (16x128) is only valid for FP8/BF8}}
+  // expected-error @+1 {{MFMA geometry (16x128) is only valid for FP8/BF8}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 16, kDim = 128,
@@ -180,7 +180,7 @@ func.func @threadwise_read_into_int8_with_quad_rate_geometry(
     %source: memref<128xi8, #gpu.address_space<workgroup>>,
     %dest: memref<8xi8, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{quad-rate MFMA geometry (32x64) is only valid for FP8/BF8}}
+  // expected-error @+1 {{MFMA geometry (32x64) is only valid for FP8/BF8}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 32, kDim = 64,
@@ -200,7 +200,7 @@ func.func @threadwise_read_into_f16_with_int8_only_geometry(
     %source: memref<128xf16, #gpu.address_space<workgroup>>,
     %dest: memref<4xf16, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{double-rate MFMA geometry (16x64) is only valid for INT8}}
+  // expected-error @+1 {{MFMA geometry (16x64) is only valid for INT8}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 16, kDim = 64,
@@ -220,7 +220,7 @@ func.func @threadwise_read_into_fp8_with_int8_only_geometry(
     %source: memref<128xf8E5M2, #gpu.address_space<workgroup>>,
     %dest: memref<8xf8E5M2, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{double-rate MFMA geometry (32x32) is only valid for INT8}}
+  // expected-error @+1 {{MFMA geometry (32x32) is only valid for INT8}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 32, kDim = 32,

--- a/mlir/test/Dialect/Rock/lds_transpose_error.mlir
+++ b/mlir/test/Dialect/Rock/lds_transpose_error.mlir
@@ -2,13 +2,14 @@
 
 // Error case: Invalid MFMA geometry (16x8 is not valid)
 // This tests that LDSTransposeConfigAttr::verify() catches invalid MFMA
-// geometry combinations. Valid combinations are: (16,16), (16,32), (16,128), (32,8), (32,16), (32,64)
+// geometry combinations. Valid combinations are: (16,16), (16,32), (16,64),
+// (16,128), (32,8), (32,16), (32,32), (32,64)
 func.func @threadwise_read_into_invalid_mfma_geometry_16x8(
     %source: memref<128xf16, #gpu.address_space<workgroup>>,
     %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
-    // expected-error @+1 {{invalid MFMA geometry (16x8) for LDS transpose - valid combinations: (16,16), (16,32), (16,128), (32,8), (32,16), (32,64)}}
+    // expected-error @+1 {{invalid MFMA geometry (16x8) for LDS transpose - valid combinations: (16,16), (16,32), (16,64), (16,128), (32,8), (32,16), (32,32), (32,64)}}
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 16, kDim = 8,
       mPerBlock = 128, nPerBlock = 128, kPerBlock = 32,
@@ -21,16 +22,16 @@ func.func @threadwise_read_into_invalid_mfma_geometry_16x8(
 
 // -----
 
-// Error case: Invalid MFMA geometry (32x32 is not valid)
-func.func @threadwise_read_into_invalid_mfma_geometry_32x32(
+// Error case: Invalid MFMA geometry (16x256 is not valid)
+func.func @threadwise_read_into_invalid_mfma_geometry_16x256(
     %source: memref<128xf16, #gpu.address_space<workgroup>>,
     %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
-    // expected-error @+1 {{invalid MFMA geometry (32x32) for LDS transpose - valid combinations: (16,16), (16,32), (16,128), (32,8), (32,16), (32,64)}}
+    // expected-error @+1 {{invalid MFMA geometry (16x256) for LDS transpose - valid combinations: (16,16), (16,32), (16,64), (16,128), (32,8), (32,16), (32,32), (32,64)}}
     ldsTransposeConfig = #rock.lds_transpose_config<
-      dDim = 32, kDim = 32,
-      mPerBlock = 128, nPerBlock = 128, kPerBlock = 32,
+      dDim = 16, kDim = 256,
+      mPerBlock = 128, nPerBlock = 128, kPerBlock = 256,
       mPerWave = 64, nPerWave = 64,
       doubleBuffering = false, isOperandA = true
     >
@@ -46,7 +47,7 @@ func.func @threadwise_read_into_invalid_mfma_geometry_8x8(
     %dest: memref<8xf16, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
   rock.threadwise_read_into {
-    // expected-error @+1 {{invalid MFMA geometry (8x8) for LDS transpose - valid combinations: (16,16), (16,32), (16,128), (32,8), (32,16), (32,64)}}
+    // expected-error @+1 {{invalid MFMA geometry (8x8) for LDS transpose - valid combinations: (16,16), (16,32), (16,64), (16,128), (32,8), (32,16), (32,32), (32,64)}}
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 8, kDim = 8,
       mPerBlock = 128, nPerBlock = 128, kPerBlock = 32,
@@ -78,6 +79,27 @@ func.func @threadwise_read_into_kperblock_not_divisible(
 
 // -----
 
+// Error case: kPerBlock not divisible by kDim, INT8 double-rate (32x32).
+// Exercises the divisibility check on an INT8-only geometry so that the
+// path is covered for kDim=32 as well.
+func.func @threadwise_read_into_kperblock_not_divisible_int8(
+    %source: memref<128xi8, #gpu.address_space<workgroup>>,
+    %dest: memref<16xi8, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  rock.threadwise_read_into {
+    // expected-error @+1 {{kPerBlock (50) must be divisible by kDim (32)}}
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 32, kDim = 32,
+      mPerBlock = 128, nPerBlock = 128, kPerBlock = 50,
+      mPerWave = 64, nPerWave = 64,
+      doubleBuffering = false, isOperandA = true
+    >
+  } [] (%source) [] -> %dest : memref<128xi8, #gpu.address_space<workgroup>> -> memref<16xi8, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
 // Error case: LDS transpose load not supported on gfx942
 module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx942"} {
   func.func @lds_transpose_load_unsupported_arch(%src: memref<128x256xf16, #gpu.address_space<workgroup>>, %i: index, %j: index) -> vector<4xf16> {
@@ -91,12 +113,12 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx942"} {
 
 // Error case: FP8 destination with F16-only geometry (16x16).
 // FP8/BF8 only support quad-rate geometries (16x128, 32x64) and the standard
-// (16,32) / (32,16) shared with F16, never the F16-only (16,16) / (32,8).
+// (16,32) / (32,16) shared with F16/INT8, never the F16-only (16,16) / (32,8).
 func.func @threadwise_read_into_fp8_with_f16_only_geometry(
     %source: memref<128xf8E4M3FN, #gpu.address_space<workgroup>>,
     %dest: memref<8xf8E4M3FN, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{MFMA geometry (16x16) is not supported for FP8/BF8}}
+  // expected-error @+1 {{MFMA geometry (16x16) is not supported for FP8/BF8/INT8}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 16, kDim = 16,
@@ -110,9 +132,30 @@ func.func @threadwise_read_into_fp8_with_f16_only_geometry(
 
 // -----
 
-// Error case: F16 destination with quad-rate geometry (16x128).
+// Error case: INT8 destination with F16-only geometry (32x8).
+// F16-only geometries (16,16) / (32,8) are not used by any FP8/BF8/INT8 MFMA
+// instruction.
+func.func @threadwise_read_into_int8_with_f16_only_geometry(
+    %source: memref<128xi8, #gpu.address_space<workgroup>>,
+    %dest: memref<8xi8, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  // expected-error @+1 {{MFMA geometry (32x8) is not supported for FP8/BF8/INT8}}
+  rock.threadwise_read_into {
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 32, kDim = 8,
+      mPerBlock = 128, nPerBlock = 128, kPerBlock = 16,
+      mPerWave = 64, nPerWave = 64,
+      doubleBuffering = false, isOperandA = true
+    >
+  } [] (%source) [] -> %dest : memref<128xi8, #gpu.address_space<workgroup>> -> memref<8xi8, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+// Error case: F16 destination with quad-rate FP8 geometry (16x128).
 // Quad-rate geometries (16x128, 32x64) are FP8/BF8 only and must not be used
-// with 16-bit element types.
+// with 16-bit or INT8 element types.
 func.func @threadwise_read_into_f16_with_quad_rate_geometry(
     %source: memref<128xf16, #gpu.address_space<workgroup>>,
     %dest: memref<4xf16, #gpu.address_space<private>>)
@@ -131,13 +174,73 @@ func.func @threadwise_read_into_f16_with_quad_rate_geometry(
 
 // -----
 
+// Error case: INT8 destination with quad-rate FP8 geometry (32x64).
+// Quad-rate geometries are FP8/BF8 only.
+func.func @threadwise_read_into_int8_with_quad_rate_geometry(
+    %source: memref<128xi8, #gpu.address_space<workgroup>>,
+    %dest: memref<8xi8, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  // expected-error @+1 {{quad-rate MFMA geometry (32x64) is only valid for FP8/BF8}}
+  rock.threadwise_read_into {
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 32, kDim = 64,
+      mPerBlock = 128, nPerBlock = 128, kPerBlock = 64,
+      mPerWave = 64, nPerWave = 64,
+      doubleBuffering = false, isOperandA = true
+    >
+  } [] (%source) [] -> %dest : memref<128xi8, #gpu.address_space<workgroup>> -> memref<8xi8, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+// Error case: F16 destination with INT8-only double-rate geometry (16x64).
+// Double-rate geometries (16,64) and (32,32) are INT8 only.
+func.func @threadwise_read_into_f16_with_int8_only_geometry(
+    %source: memref<128xf16, #gpu.address_space<workgroup>>,
+    %dest: memref<4xf16, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  // expected-error @+1 {{double-rate MFMA geometry (16x64) is only valid for INT8}}
+  rock.threadwise_read_into {
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 16, kDim = 64,
+      mPerBlock = 128, nPerBlock = 128, kPerBlock = 64,
+      mPerWave = 64, nPerWave = 64,
+      doubleBuffering = false, isOperandA = true
+    >
+  } [] (%source) [] -> %dest : memref<128xf16, #gpu.address_space<workgroup>> -> memref<4xf16, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+// Error case: FP8 destination with INT8-only double-rate geometry (32x32).
+// Double-rate geometries (16,64) and (32,32) are INT8 only.
+func.func @threadwise_read_into_fp8_with_int8_only_geometry(
+    %source: memref<128xf8E5M2, #gpu.address_space<workgroup>>,
+    %dest: memref<8xf8E5M2, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  // expected-error @+1 {{double-rate MFMA geometry (32x32) is only valid for INT8}}
+  rock.threadwise_read_into {
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 32, kDim = 32,
+      mPerBlock = 128, nPerBlock = 128, kPerBlock = 32,
+      mPerWave = 64, nPerWave = 64,
+      doubleBuffering = false, isOperandA = true
+    >
+  } [] (%source) [] -> %dest : memref<128xf8E5M2, #gpu.address_space<workgroup>> -> memref<8xf8E5M2, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
 // Error case: unsupported destination element type (f32).
-// ldsTransposeConfig only supports f16, bf16, f8E4M3FN, or f8E5M2.
+// ldsTransposeConfig only supports f16, bf16, f8E4M3FN, f8E5M2, or i8.
 func.func @threadwise_read_into_unsupported_dest_type(
     %source: memref<128xf32, #gpu.address_space<workgroup>>,
     %dest: memref<4xf32, #gpu.address_space<private>>)
     attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
-  // expected-error @+1 {{ldsTransposeConfig only supports f16, bf16, f8E4M3FN, or f8E5M2 destination element types}}
+  // expected-error @+1 {{ldsTransposeConfig only supports f16, bf16, f8E4M3FN, f8E5M2, or i8 destination element types}}
   rock.threadwise_read_into {
     ldsTransposeConfig = #rock.lds_transpose_config<
       dDim = 16, kDim = 16,

--- a/mlir/test/Dialect/Rock/lowering_load_transpose_lds.mlir
+++ b/mlir/test/Dialect/Rock/lowering_load_transpose_lds.mlir
@@ -28,4 +28,11 @@ module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
     %v = rock.lds_transpose_load %src[%i, %j] : memref<64x128xf8E5M2, #gpu.address_space<workgroup>> -> vector<8xf8E5M2>
     return %v : vector<8xf8E5M2>
   }
+
+// CHECK-LABEL: func @test_load_transpose_i8
+  func.func @test_load_transpose_i8(%src: memref<128x256xi8, #gpu.address_space<workgroup>>, %i: index, %j: index) -> vector<8xi8> {
+    // CHECK: amdgpu.transpose_load %arg0[%arg1, %arg2] : memref<128x256xi8, #gpu.address_space<workgroup>> -> vector<8xi8>
+    %v = rock.lds_transpose_load %src[%i, %j] : memref<128x256xi8, #gpu.address_space<workgroup>> -> vector<8xi8>
+    return %v : vector<8xi8>
+  }
 }

--- a/mlir/test/Dialect/Rock/ops.mlir
+++ b/mlir/test/Dialect/Rock/ops.mlir
@@ -454,6 +454,16 @@ func.func @rock_lds_transpose_load_fp8_e5m2(%lds_buffer: memref<256x128xf8E5M2, 
   return
 }
 
+// CHECK-LABEL: func.func @rock_lds_transpose_load_i8
+// CHECK: rock.lds_transpose_load
+func.func @rock_lds_transpose_load_i8(%lds_buffer: memref<128x64xi8, #gpu.address_space<workgroup>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  %c0 = arith.constant 0 : index
+  %fragment = rock.lds_transpose_load %lds_buffer[%c0, %c0]
+    : memref<128x64xi8, #gpu.address_space<workgroup>> -> vector<8xi8>
+  return
+}
+
 // CHECK-LABEL: func.func @test_lds_transpose_config_attr_16x32
 // CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 16, kDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>
 func.func @test_lds_transpose_config_attr_16x32(%src: memref<8192xf16, #gpu.address_space<workgroup>>, 
@@ -589,6 +599,98 @@ func.func @test_lds_transpose_config_attr_32x64(%src: memref<2048xf8E4M3FN, #gpu
     >,
     useIndexDiffs
   } [](%src) [] -> %dest : memref<2048xf8E4M3FN, #gpu.address_space<workgroup>> -> memref<32xf8E4M3FN, #gpu.address_space<private>>
+  return
+}
+
+// CHECK-LABEL: func.func @test_lds_transpose_config_attr_16x32_i8
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 16, kDim = 32, mPerBlock = 64, nPerBlock = 64, kPerBlock = 32, mPerWave = 16, nPerWave = 64, doubleBuffering = true, isOperandA = true>
+func.func @test_lds_transpose_config_attr_16x32_i8(%src: memref<8192xi8, #gpu.address_space<workgroup>>,
+                                                    %dest: memref<8xi8, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  rock.threadwise_read_into {
+    forceUnroll,
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 16,
+      kDim = 32,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      kPerBlock = 32,
+      mPerWave = 16,
+      nPerWave = 64,
+      doubleBuffering = true,
+      isOperandA = true
+    >,
+    useIndexDiffs
+  } [](%src) [] -> %dest : memref<8192xi8, #gpu.address_space<workgroup>> -> memref<8xi8, #gpu.address_space<private>>
+  return
+}
+
+// CHECK-LABEL: func.func @test_lds_transpose_config_attr_32x16_i8
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 32, kDim = 16, mPerBlock = 64, nPerBlock = 64, kPerBlock = 16, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>
+func.func @test_lds_transpose_config_attr_32x16_i8(%src: memref<1024xi8, #gpu.address_space<workgroup>>,
+                                                    %dest: memref<8xi8, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  rock.threadwise_read_into {
+    forceUnroll,
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 32,
+      kDim = 16,
+      mPerBlock = 64,
+      nPerBlock = 64,
+      kPerBlock = 16,
+      mPerWave = 32,
+      nPerWave = 32,
+      doubleBuffering = false,
+      isOperandA = false
+    >,
+    useIndexDiffs
+  } [](%src) [] -> %dest : memref<1024xi8, #gpu.address_space<workgroup>> -> memref<8xi8, #gpu.address_space<private>>
+  return
+}
+
+// CHECK-LABEL: func.func @test_lds_transpose_config_attr_16x64_i8
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 16, kDim = 64, mPerBlock = 32, nPerBlock = 32, kPerBlock = 64, mPerWave = 16, nPerWave = 32, doubleBuffering = false, isOperandA = true>
+func.func @test_lds_transpose_config_attr_16x64_i8(%src: memref<2048xi8, #gpu.address_space<workgroup>>,
+                                                    %dest: memref<16xi8, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  rock.threadwise_read_into {
+    forceUnroll,
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 16,
+      kDim = 64,
+      mPerBlock = 32,
+      nPerBlock = 32,
+      kPerBlock = 64,
+      mPerWave = 16,
+      nPerWave = 32,
+      doubleBuffering = false,
+      isOperandA = true
+    >,
+    useIndexDiffs
+  } [](%src) [] -> %dest : memref<2048xi8, #gpu.address_space<workgroup>> -> memref<16xi8, #gpu.address_space<private>>
+  return
+}
+
+// CHECK-LABEL: func.func @test_lds_transpose_config_attr_32x32_i8
+// CHECK: ldsTransposeConfig = #rock.lds_transpose_config<dDim = 32, kDim = 32, mPerBlock = 32, nPerBlock = 32, kPerBlock = 32, mPerWave = 32, nPerWave = 32, doubleBuffering = false, isOperandA = false>
+func.func @test_lds_transpose_config_attr_32x32_i8(%src: memref<2048xi8, #gpu.address_space<workgroup>>,
+                                                    %dest: memref<16xi8, #gpu.address_space<private>>)
+    attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  rock.threadwise_read_into {
+    forceUnroll,
+    ldsTransposeConfig = #rock.lds_transpose_config<
+      dDim = 32,
+      kDim = 32,
+      mPerBlock = 32,
+      nPerBlock = 32,
+      kPerBlock = 32,
+      mPerWave = 32,
+      nPerWave = 32,
+      doubleBuffering = false,
+      isOperandA = false
+    >,
+    useIndexDiffs
+  } [](%src) [] -> %dest : memref<2048xi8, #gpu.address_space<workgroup>> -> memref<16xi8, #gpu.address_space<private>>
   return
 }
 

--- a/mlir/test/e2e/CMakeLists.txt
+++ b/mlir/test/e2e/CMakeLists.txt
@@ -51,7 +51,9 @@ if (ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED)
     PrGemmDirectToLDS
     PrLdsTransposeLoad
     PrLdsTransposeLoadFp8
+    PrLdsTransposeLoadI8
     PrLdsTransposeLoadAttention
+    PrLdsTransposeLoadAttentionI8
     PrConvDirectToLDS
     PrAttentionDirectToLDS
   )

--- a/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.cfg
+++ b/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.cfg
@@ -1,0 +1,2 @@
+if not 'lds_transpose_load' in config.features:
+    config.unsupported = True

--- a/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
@@ -1,0 +1,52 @@
+directory = "PrLdsTransposeLoadAttentionI8"
+prefix = "rocmlir-gen"
+suffix = "--operation attention --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.01 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "data type"
+values = ["i8"]
+prefix = "-t "
+
+# ============================================================================
+# Suite 1: Both K and Q use LDS transpose (transQ=true, transK=false)
+# 1 test per MFMA = 4 tests
+# ============================================================================
+[[suite]]
+name = "lds_transpose_both_i8"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,32,16,16,16,8,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 128 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,64,16,16,16,8,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,16,32,32,32,8,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,32,32,32,32,8,1,3,2,0,1"
+
+# ============================================================================
+# Suite 2: Only K uses LDS transpose (transQ=false, transK=false)
+# 2 tests per MFMA = 8 tests
+# ============================================================================
+[[suite]]
+name = "lds_transpose_k_only_i8"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=false --transK=false -perf_config attn:v3:32,32,32,32,16,16,16,8,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 128 -seq_len_k 128 -head_dim_qk 64 -head_dim_v 64 --transQ=false --transK=false -perf_config attn:v3:64,64,64,32,16,16,16,16,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 128 -head_dim_v 64 --transQ=false --transK=false -perf_config attn:v3:32,32,32,64,16,16,16,8,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=false --transK=false -perf_config attn:v3:32,32,32,16,32,32,32,8,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 128 -seq_len_k 128 -head_dim_qk 64 -head_dim_v 64 --transQ=false --transK=false -perf_config attn:v3:64,64,64,16,32,32,32,16,1,3,2,0,1"
+
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=false --transK=false -perf_config attn:v3:32,32,32,32,32,32,32,8,1,3,2,0,1"

--- a/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
@@ -9,7 +9,7 @@ prefix = "-t "
 
 # ============================================================================
 # Suite 1: Both K and Q use LDS transpose (transQ=true, transK=false)
-# 1 test per MFMA = 4 tests
+# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
 # ============================================================================
 [[suite]]
 name = "lds_transpose_both_i8"
@@ -28,7 +28,7 @@ config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=tr
 
 # ============================================================================
 # Suite 2: Only K uses LDS transpose (transQ=false, transK=false)
-# 2 tests per MFMA = 8 tests
+# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
 # ============================================================================
 [[suite]]
 name = "lds_transpose_k_only_i8"

--- a/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
@@ -26,6 +26,17 @@ config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=tr
 [[suite.test]]
 config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,32,32,32,32,8,1,3,2,0,1"
 
+# Double-rate INT8 16x64 (mfma_i32_16x16x64_i8). scheduleVersion = 4
+# (DoubleBuffer) is required because kpack = 16 < k_base = 16 is allowed only
+# under the double-buffered schedule (see MfmaInsn::isCoherentWithK).
+[[suite.test]]
+config = "-seq_len_q 128 -seq_len_k 128 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:64,64,64,32,16,16,16,16,1,4,2,0,1"
+
+# Double-rate INT8 32x32 (mfma_i32_32x32x32_i8). scheduleVersion = 4
+# (DoubleBuffer) for the same reason as above.
+[[suite.test]]
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,32,32,32,32,16,1,4,2,0,1"
+
 # ============================================================================
 # Suite 2: Only K uses LDS transpose (transQ=false, transK=false)
 # Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).

--- a/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
@@ -26,16 +26,13 @@ config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=tr
 [[suite.test]]
 config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,32,32,32,32,8,1,3,2,0,1"
 
-# Double-rate INT8 16x64 (mfma_i32_16x16x64_i8). scheduleVersion = 4
-# (DoubleBuffer) is required because kpack = 16 < k_base = 16 is allowed only
-# under the double-buffered schedule (see MfmaInsn::isCoherentWithK).
+# Double-rate INT8 16x64 (mfma_i32_16x16x64_i8).
 [[suite.test]]
-config = "-seq_len_q 128 -seq_len_k 128 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:64,64,64,32,16,16,16,16,1,4,2,0,1"
+config = "-seq_len_q 128 -seq_len_k 128 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:64,64,64,32,16,16,16,16,1,3,2,0,1"
 
-# Double-rate INT8 32x32 (mfma_i32_32x32x32_i8). scheduleVersion = 4
-# (DoubleBuffer) for the same reason as above.
+# Double-rate INT8 32x32 (mfma_i32_32x32x32_i8).
 [[suite.test]]
-config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,32,32,32,32,16,1,4,2,0,1"
+config = "-seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --transQ=true --transK=false -perf_config attn:v3:32,32,32,32,32,32,32,16,1,3,2,0,1"
 
 # ============================================================================
 # Suite 2: Only K uses LDS transpose (transQ=false, transK=false)

--- a/mlir/test/e2e/PrLdsTransposeLoadI8.cfg
+++ b/mlir/test/e2e/PrLdsTransposeLoadI8.cfg
@@ -1,0 +1,2 @@
+if not 'lds_transpose_load' in config.features:
+    config.unsupported = True

--- a/mlir/test/e2e/PrLdsTransposeLoadI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadI8.toml
@@ -1,0 +1,86 @@
+directory = "PrLdsTransposeLoadI8"
+prefix = "rocmlir-gen"
+suffix = "--operation gemm --arch %arch %random_data %pv %rocmlir_gen_flags | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+
+[[axis]]
+name = "data type"
+values = ["i8"]
+prefix = "-t "
+
+# ============================================================================
+# Suite 1: BOTH A and B use LDS transpose (transA=true, transB=false)
+# 2 tests per MFMA = 8 tests total
+# ============================================================================
+[[suite]]
+name = "lds_transpose_both_operands_i8"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=false --perf_config v4:64,64,32,32,16,16,1,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 256 -n 64 --transA=true --transB=false --perf_config v3:128,64,64,16,16,8,1,3,2,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=false --perf_config v4:64,64,64,16,16,16,1,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 256 -n 64 --transA=true --transB=false --perf_config v3:128,32,128,16,16,1,1,3,2,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 64 -n 64 --transA=true --transB=false --perf_config v4:32,128,16,32,32,32,8,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 128 -n 128 --transA=true --transB=false --perf_config v3:256,64,32,32,32,8,1,3,2,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=false --perf_config v4:64,64,32,32,32,32,1,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 256 -n 128 --transA=true --transB=false --perf_config v3:128,128,16,32,32,16,1,3,2,1,1"
+
+# ============================================================================
+# Suite 2: ONLY A uses LDS transpose (transA=true, transB=true)
+# 2 tests per MFMA = 8 tests total
+# ============================================================================
+[[suite]]
+name = "lds_transpose_A_only_i8"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 64 -n 64 --transA=true --transB=true --perf_config v4:64,64,32,32,16,16,1,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 128 -n 64 --transA=true --transB=true --perf_config v3:128,64,64,16,16,8,1,3,2,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=true --perf_config v4:64,64,64,16,16,16,1,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 64 -n 64 --transA=true --transB=true --perf_config v4:64,64,16,32,32,32,16,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 128 -n 128 --transA=true --transB=true --perf_config v3:128,128,32,32,32,8,1,3,2,1,1"
+
+# ============================================================================
+# Suite 3: ONLY B uses LDS transpose (transA=false, transB=false)
+# 2 tests per MFMA = 8 tests total
+# ============================================================================
+[[suite]]
+name = "lds_transpose_B_only_i8"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 64 -n 64 --transA=false --transB=false --perf_config v4:64,64,32,16,16,16,8,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 128 -n 64 --transA=false --transB=false --perf_config v3:128,64,64,16,16,8,1,3,2,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 128 -n 64 --transA=false --transB=false --perf_config v4:64,64,64,16,16,16,1,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 128 -n 128 --transA=false --transB=false --perf_config v3:128,128,32,32,32,16,1,3,2,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 64 -k 64 -n 64 --transA=false --transB=false --perf_config v4:64,64,32,32,32,32,1,1,4,2,0,0,1,1"
+
+[[suite.test]]
+config = "-g 1 -m 128 -k 128 -n 128 --transA=false --transB=false --perf_config v3:128,128,64,32,32,8,1,3,2,1,1"

--- a/mlir/test/e2e/PrLdsTransposeLoadI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadI8.toml
@@ -9,78 +9,105 @@ prefix = "-t "
 
 # ============================================================================
 # Suite 1: BOTH A and B use LDS transpose (transA=true, transB=false)
-# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
+# Covers all 4 INT8 MFMA geometries (dDim x kDim):
+#   - single-rate: (16, 32) and (32, 16)
+#   - double-rate: (16, 64) and (32, 32)
+# Per-test target geometry (verified from #rock.lds_transpose_config in the IR)
+# is annotated inline below.
 # ============================================================================
 [[suite]]
 name = "lds_transpose_both_operands_i8"
 
+# Geometry: (16, 32) single-rate INT8 -> mfma_i32_16x16x32_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=false --perf_config v4:64,64,32,32,16,16,1,1,4,2,0,0,1,1"
 
+# Geometry: (16, 32) single-rate INT8 -> mfma_i32_16x16x32_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 256 -n 64 --transA=true --transB=false --perf_config v3:128,64,64,16,16,8,1,3,2,1,1"
 
+# Geometry: (16, 64) double-rate INT8 -> mfma_i32_16x16x64_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=false --perf_config v4:64,64,64,16,16,16,1,1,4,2,0,0,1,1"
 
+# Geometry: (16, 64) double-rate INT8 -> mfma_i32_16x16x64_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 256 -n 64 --transA=true --transB=false --perf_config v3:128,32,128,16,16,1,1,3,2,1,1"
 
+# Geometry: (32, 32) double-rate INT8 -> mfma_i32_32x32x32_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 64 -n 64 --transA=true --transB=false --perf_config v4:32,128,16,32,32,32,8,1,4,2,0,0,1,1"
 
+# Geometry: (32, 16) single-rate INT8 -> mfma_i32_32x32x16_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 128 -n 128 --transA=true --transB=false --perf_config v3:256,64,32,32,32,8,1,3,2,1,1"
 
+# Geometry: (32, 32) double-rate INT8 -> mfma_i32_32x32x32_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=false --perf_config v4:64,64,32,32,32,32,1,1,4,2,0,0,1,1"
 
+# Geometry: (32, 32) double-rate INT8 -> mfma_i32_32x32x32_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 256 -n 128 --transA=true --transB=false --perf_config v3:128,128,16,32,32,16,1,3,2,1,1"
 
 # ============================================================================
 # Suite 2: ONLY A uses LDS transpose (transA=true, transB=true)
-# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
+# Covers all 4 INT8 MFMA geometries (dDim x kDim):
+#   - single-rate: (16, 32) and (32, 16)
+#   - double-rate: (16, 64) and (32, 32)
 # ============================================================================
 [[suite]]
 name = "lds_transpose_A_only_i8"
 
+# Geometry: (16, 32) single-rate INT8 -> mfma_i32_16x16x32_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 64 -n 64 --transA=true --transB=true --perf_config v4:64,64,32,32,16,16,1,1,4,2,0,0,1,1"
 
+# Geometry: (16, 32) single-rate INT8 -> mfma_i32_16x16x32_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 128 -n 64 --transA=true --transB=true --perf_config v3:128,64,64,16,16,8,1,3,2,1,1"
 
+# Geometry: (16, 64) double-rate INT8 -> mfma_i32_16x16x64_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 128 -n 64 --transA=true --transB=true --perf_config v4:64,64,64,16,16,16,1,1,4,2,0,0,1,1"
 
+# Geometry: (32, 32) double-rate INT8 -> mfma_i32_32x32x32_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 64 -n 64 --transA=true --transB=true --perf_config v4:64,64,16,32,32,32,16,1,4,2,0,0,1,1"
 
+# Geometry: (32, 16) single-rate INT8 -> mfma_i32_32x32x16_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 128 -n 128 --transA=true --transB=true --perf_config v3:128,128,32,32,32,8,1,3,2,1,1"
 
 # ============================================================================
 # Suite 3: ONLY B uses LDS transpose (transA=false, transB=false)
-# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
+# Covers all 4 INT8 MFMA geometries (dDim x kDim):
+#   - single-rate: (16, 32) and (32, 16)
+#   - double-rate: (16, 64) and (32, 32)
 # ============================================================================
 [[suite]]
 name = "lds_transpose_B_only_i8"
 
+# Geometry: (16, 64) double-rate INT8 -> mfma_i32_16x16x64_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 64 -n 64 --transA=false --transB=false --perf_config v4:64,64,32,16,16,16,8,1,4,2,0,0,1,1"
 
+# Geometry: (16, 32) single-rate INT8 -> mfma_i32_16x16x32_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 128 -n 64 --transA=false --transB=false --perf_config v3:128,64,64,16,16,8,1,3,2,1,1"
 
+# Geometry: (16, 64) double-rate INT8 -> mfma_i32_16x16x64_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 128 -n 64 --transA=false --transB=false --perf_config v4:64,64,64,16,16,16,1,1,4,2,0,0,1,1"
 
+# Geometry: (32, 32) double-rate INT8 -> mfma_i32_32x32x32_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 128 -n 128 --transA=false --transB=false --perf_config v3:128,128,32,32,32,16,1,3,2,1,1"
 
+# Geometry: (32, 32) double-rate INT8 -> mfma_i32_32x32x32_i8
 [[suite.test]]
 config = "-g 1 -m 64 -k 64 -n 64 --transA=false --transB=false --perf_config v4:64,64,32,32,32,32,1,1,4,2,0,0,1,1"
 
+# Geometry: (32, 16) single-rate INT8 -> mfma_i32_32x32x16_i8
 [[suite.test]]
 config = "-g 1 -m 128 -k 128 -n 128 --transA=false --transB=false --perf_config v3:128,128,64,32,32,8,1,3,2,1,1"

--- a/mlir/test/e2e/PrLdsTransposeLoadI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadI8.toml
@@ -9,7 +9,7 @@ prefix = "-t "
 
 # ============================================================================
 # Suite 1: BOTH A and B use LDS transpose (transA=true, transB=false)
-# 2 tests per MFMA = 8 tests total
+# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
 # ============================================================================
 [[suite]]
 name = "lds_transpose_both_operands_i8"
@@ -40,7 +40,7 @@ config = "-g 1 -m 128 -k 256 -n 128 --transA=true --transB=false --perf_config v
 
 # ============================================================================
 # Suite 2: ONLY A uses LDS transpose (transA=true, transB=true)
-# 2 tests per MFMA = 8 tests total
+# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
 # ============================================================================
 [[suite]]
 name = "lds_transpose_A_only_i8"
@@ -62,7 +62,7 @@ config = "-g 1 -m 128 -k 128 -n 128 --transA=true --transB=true --perf_config v3
 
 # ============================================================================
 # Suite 3: ONLY B uses LDS transpose (transA=false, transB=false)
-# 2 tests per MFMA = 8 tests total
+# Covers all 4 INT8 MFMA geometries (16x16x32, 16x16x64, 32x32x16, 32x32x32).
 # ============================================================================
 [[suite]]
 name = "lds_transpose_B_only_i8"

--- a/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
+++ b/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
@@ -1,7 +1,7 @@
 // Verify the number and shape of amdgpu.transpose_load instructions emitted
-// by the LDS-transpose fast path for the FP8/BF8 MFMA geometries on gfx950.
-// Guards against panel-loop unrolling regressions (missing or duplicated
-// loads).
+// by the LDS-transpose fast path for the FP8/BF8/INT8 MFMA geometries on
+// gfx950. Guards against panel-loop unrolling regressions (missing or
+// duplicated loads).
 
 // Unscaled 16x32 FP8 (mfma_f32_16x16x32_fp8_fp8): 8 panels.
 // RUN: rocmlir-gen --arch gfx950 --operation gemm -t fp8_fp8 \
@@ -57,3 +57,16 @@
 // UNSCALED_32x16_BF8-COUNT-4: amdgpu.transpose_load {{.*}} -> vector<8xf8E5M2>
 // UNSCALED_32x16_BF8-NOT: amdgpu.transpose_load
 // UNSCALED_32x16_BF8: amdgpu.mfma 32x32x16 {{.*}} : vector<8xf8E5M2>, vector<8xf8E5M2>, vector<16xf32>
+
+// Standard 32x16 INT8 (mfma_i32_32x32x16_i8): same topology as FP8, i8 lanes.
+// The double-rate (16,64) and (32,32) INT8 paths are exercised by the
+// e2e tests in PrLdsTransposeLoadI8.toml.
+// RUN: rocmlir-gen --arch gfx950 --operation gemm -t i8 \
+// RUN:   -g 1 -m 64 -k 32 -n 64 --transA=true --transB=false \
+// RUN:   --perf_config="v3:64,64,4,32,32,8,1,3,2,1,1" -p \
+// RUN: | rocmlir-driver --kernel-pipeline=gpu --arch gfx950 \
+// RUN: | FileCheck %s --check-prefix=STANDARD_32x16_I8
+
+// STANDARD_32x16_I8-COUNT-4: amdgpu.transpose_load {{.*}} -> vector<8xi8>
+// STANDARD_32x16_I8-NOT: amdgpu.transpose_load
+// STANDARD_32x16_I8: amdgpu.mfma 32x32x16 {{.*}} : vector<8xi8>, vector<8xi8>, vector<16xi32>

--- a/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
+++ b/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
@@ -58,6 +58,18 @@
 // UNSCALED_32x16_BF8-NOT: amdgpu.transpose_load
 // UNSCALED_32x16_BF8: amdgpu.mfma 32x32x16 {{.*}} : vector<8xf8E5M2>, vector<8xf8E5M2>, vector<16xf32>
 
+// Standard 16x32 INT8 (mfma_i32_16x16x32_i8): one ds_read_tr8_b64 per K
+// tile (vector<8xi8>), single-rate topology.
+// RUN: rocmlir-gen --arch gfx950 --operation gemm -t i8 \
+// RUN:   -g 1 -m 32 -k 32 -n 32 --transA=true --transB=false \
+// RUN:   --perf_config="v3:32,32,8,16,16,8,1,3,2,1,1" -p \
+// RUN: | rocmlir-driver --kernel-pipeline=gpu --arch gfx950 \
+// RUN: | FileCheck %s --check-prefix=STANDARD_16x32_I8
+
+// STANDARD_16x32_I8-COUNT-4: amdgpu.transpose_load {{.*}} -> vector<8xi8>
+// STANDARD_16x32_I8-NOT: amdgpu.transpose_load
+// STANDARD_16x32_I8: amdgpu.mfma 16x16x32 {{.*}} : vector<8xi8>, vector<8xi8>, vector<4xi32>
+
 // Standard 32x16 INT8 (mfma_i32_32x32x16_i8): same topology as FP8, i8 lanes.
 // RUN: rocmlir-gen --arch gfx950 --operation gemm -t i8 \
 // RUN:   -g 1 -m 64 -k 32 -n 64 --transA=true --transB=false \

--- a/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
+++ b/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
@@ -70,7 +70,7 @@
 // STANDARD_32x16_I8: amdgpu.mfma 32x32x16 {{.*}} : vector<8xi8>, vector<8xi8>, vector<16xi32>
 
 // Double-rate 16x64 INT8 (mfma_i32_16x16x64_i8): two ds_read_tr8_b64 per K
-// tile (low + high half, halves of 16 K elements each), packed into a
+// tile (low + high half, vector<8xi8> per load), packed into a
 // vector<16xi8> per MFMA operand.
 // RUN: rocmlir-gen --arch gfx950 --operation gemm -t i8 \
 // RUN:   -g 1 -m 32 -k 64 -n 32 --transA=true --transB=false \

--- a/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
+++ b/mlir/test/rocmlir-driver/lds_transpose_load_panels.mlir
@@ -59,8 +59,6 @@
 // UNSCALED_32x16_BF8: amdgpu.mfma 32x32x16 {{.*}} : vector<8xf8E5M2>, vector<8xf8E5M2>, vector<16xf32>
 
 // Standard 32x16 INT8 (mfma_i32_32x32x16_i8): same topology as FP8, i8 lanes.
-// The double-rate (16,64) and (32,32) INT8 paths are exercised by the
-// e2e tests in PrLdsTransposeLoadI8.toml.
 // RUN: rocmlir-gen --arch gfx950 --operation gemm -t i8 \
 // RUN:   -g 1 -m 64 -k 32 -n 64 --transA=true --transB=false \
 // RUN:   --perf_config="v3:64,64,4,32,32,8,1,3,2,1,1" -p \
@@ -70,3 +68,28 @@
 // STANDARD_32x16_I8-COUNT-4: amdgpu.transpose_load {{.*}} -> vector<8xi8>
 // STANDARD_32x16_I8-NOT: amdgpu.transpose_load
 // STANDARD_32x16_I8: amdgpu.mfma 32x32x16 {{.*}} : vector<8xi8>, vector<8xi8>, vector<16xi32>
+
+// Double-rate 16x64 INT8 (mfma_i32_16x16x64_i8): two ds_read_tr8_b64 per K
+// tile (low + high half, halves of 16 K elements each), packed into a
+// vector<16xi8> per MFMA operand.
+// RUN: rocmlir-gen --arch gfx950 --operation gemm -t i8 \
+// RUN:   -g 1 -m 32 -k 64 -n 32 --transA=true --transB=false \
+// RUN:   --perf_config="v3:32,32,4,16,16,16,1,3,2,1,1" -p \
+// RUN: | rocmlir-driver --kernel-pipeline=gpu --arch gfx950 \
+// RUN: | FileCheck %s --check-prefix=DOUBLE_RATE_16x64_I8
+
+// DOUBLE_RATE_16x64_I8-COUNT-4: amdgpu.transpose_load {{.*}} -> vector<8xi8>
+// DOUBLE_RATE_16x64_I8-NOT: amdgpu.transpose_load
+// DOUBLE_RATE_16x64_I8: amdgpu.mfma 16x16x64 {{.*}} : vector<16xi8>, vector<16xi8>, vector<4xi32>
+
+// Double-rate 32x32 INT8 (mfma_i32_32x32x32_i8): two ds_read_tr8_b64 per K
+// tile (low + high half), packed into a vector<16xi8> per MFMA operand.
+// RUN: rocmlir-gen --arch gfx950 --operation gemm -t i8 \
+// RUN:   -g 1 -m 64 -k 64 -n 64 --transA=true --transB=false \
+// RUN:   --perf_config="v3:64,64,4,32,32,16,1,3,2,1,1" -p \
+// RUN: | rocmlir-driver --kernel-pipeline=gpu --arch gfx950 \
+// RUN: | FileCheck %s --check-prefix=DOUBLE_RATE_32x32_I8
+
+// DOUBLE_RATE_32x32_I8-COUNT-8: amdgpu.transpose_load {{.*}} -> vector<8xi8>
+// DOUBLE_RATE_32x32_I8-NOT: amdgpu.transpose_load
+// DOUBLE_RATE_32x32_I8: amdgpu.mfma 32x32x32 {{.*}} : vector<16xi8>, vector<16xi8>, vector<16xi32>


### PR DESCRIPTION
⚠️ Do not merge until https://github.com/ROCm/rocMLIR/pull/2210 is merged - this PR depends on LDS transpose load fp8 support

## Motivation

Extends LDS transpose load optimization to support INT8 data types for GEMM and Attention kernels on gfx950. This enables hardware-accelerated transposed loads (ds_read_tr8_b64) for all INT8 MFMAs (16x16x32, 16x16x64, 32x32x16, 32x32x32), improving performance for INT8 quantized inference.

## Technical Details

- LdsTransposeLoad.cpp: Added INT8 type support, offset formulas for (16,64) and (32,32) geometries, and double-rate K-coverage logic
- AccelEmitter.cpp: Added K-dimension transformation for INT8 MFMAs with kBase=16 when kpack=1
- RockDialect.cpp/RockOps.td: Updated validation and type support for INT8 LDS transpose

## Test Plan

Added MLIR unit tests
Added E2E tests
All tests verified on gfx950 hardware with numerical correctness validation

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
