### PR TITLE
Paged Attention: rocMLIR backend changes

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -1141,11 +1141,13 @@ def Rock_GlobalPrefetchOp
 def Rock_GlobalLoadOp
     : Rock_Op<
           "global_load", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                          AllElementTypesMatch<["source", "result"]>]>,
+                          AllElementTypesMatch<["source", "result"]>,
+                          AttrSizedOperandSegments]>,
       Arguments<(
           ins Arg<MemRefOf<SupportedMemoryElems>, "source memory">:$source,
           I1:$valid, Variadic<Index>:$sourceCoord, UnitAttr:$needs64BitIdx,
-          UnitAttr:$canReadOffEnd)>,
+          UnitAttr:$canReadOffEnd, Optional<I64>:$pagePtr,
+          OptionalAttr<I64Attr>:$pageSize)>,
       Results<(outs AnyType:$result)> {
   let summary = "Load from global memory, applying bounds checks";
   let description = [{
@@ -1162,9 +1164,17 @@ def Rock_GlobalLoadOp
     If `canReadOffEnd` is present, then the `valid` input is ignored and the
     bounds-checked implementation of this operation is always used. This
     is used to simplify the implementation of certain utility kernels.
+
+    When `pagePtr` and `pageSize` are provided, this
+    operation loads from paged memory. The `source` memref is still used for
+    type information (element type, etc.), but the actual load uses `pagePtr`
+    as the base address. `sourceCoord[0]` is treated as the offset-in-page in
+    elements (a single flat index, not multi-dimensional coordinates).
   }];
   let assemblyFormat = [{
-    $source `[` $sourceCoord `]` `if` $valid attr-dict
+    $source `[` $sourceCoord `]` `if` $valid
+    (`paged` $pagePtr^)?
+    attr-dict
     `:` type($source) `->` type($result)
   }];
   let hasVerifier = 1;
@@ -1200,7 +1210,8 @@ def Rock_GlobalLoadToLDSOp
   }];
   let assemblyFormat = [{
     $source `[` $sourceCoord `]` 
-    `->` $dest `[` $destCoord `]`  `if` $valid attr-dict
+    `->` $dest `[` $destCoord `]`  `if` $valid
+    attr-dict
     `:` type($source) `->` type($dest)
   }];
   let hasVerifier = 1;
@@ -1302,14 +1313,21 @@ def Rock_ThreadwiseReadIntoOp
         [](::mlir::Type lhs, ::mlir::TypeRange rhs) -> bool {
           return llvm::all_of(rhs, [lhs](::mlir::Type t) { return t == lhs; });
         }
-      }]>]>,
-      Arguments<(ins Arg<MemRefOf<NativeMemoryOpTypes>, "source view">:$source,
+      }]>]> {
+
+  let arguments =
+      (ins Arg<MemRefOf<NativeMemoryOpTypes>, "source view">:$source,
           Arg<MemRefOf<NativeMemoryOpTypes>, "destination registers">:$dest,
           Variadic<VectorOfNonZeroRankOf<[I1]>>:$dynamicValidities,
           TransformMapArrayAttr:$extraViews, Variadic<Index>:$extraIndices,
           UnitAttr:$forceUnroll, UnitAttr:$useIndexDiffs,
-          OptionalAttr<Rock_LDSTransposeConfigAttr>:$ldsTransposeConfig)>,
-      Results<(outs Optional<VectorOfNonZeroRankOf<[I1]>>:$validityRecord)> {
+          OptionalAttr<Rock_LDSTransposeConfigAttr>:$ldsTransposeConfig,
+          Optional<MemRefOf<[I64]>>:$ldsPagePtrs,
+          Optional<Index>:$firstPageIndex, OptionalAttr<IndexAttr>:$pageSize,
+          OptionalAttr<IndexAttr>:$numPagesPerBatch);
+
+  let results = (outs Optional<VectorOfNonZeroRankOf<[I1]>>:$validityRecord);
+
   let summary = "Read values from transformed source into destination";
 
   let description = [{
@@ -1341,8 +1359,8 @@ def Rock_ThreadwiseReadIntoOp
     L is the length of `%dest`, V is the maximum vectorization computed
     for MAPS.
 
-    The input to extraViews: (the transforms on %source) must have the form
-    (extraIdx0, ... , extraIdxN, iteration_number)
+    The input to extraViews (the transforms on %source) must have the form
+    (extraIdx0, ... , extraIdxN, iteration_number).
 
     Primarily, extraIndices would be used to pass in tid and bid. This would need
     to have a matching view in [extraViews]source. The extraIndices could be used
@@ -1368,6 +1386,14 @@ def Rock_ThreadwiseReadIntoOp
 
     This operation is also used during fusion to represent loads from additional
     arguments like bias tensors.
+
+    When `ldsPagePtrs`, `firstPageIndex`, and `pageSize` are provided, this
+    operation reads from paged memory where data is scattered across
+    non-contiguous pages accessed via a page table. The page pointers are
+    pre-loaded into LDS by the calling code to avoid redundant global memory
+    accesses across threads. During lowering, the transform maps compute the
+    flat position for each element, determining the page index and offset
+    within page.
   }];
 
   let builders = [
@@ -1377,7 +1403,7 @@ def Rock_ThreadwiseReadIntoOp
                     "ValueRange":$extraIndices, "bool":$forceUnroll,
                     "bool":$useIndexDiffs),
                 [{
-        build($_builder, $_state, TypeRange{}, source, dest, ValueRange{}, extraViews, extraIndices, forceUnroll, useIndexDiffs, /*ldsTransposeConfig=*/nullptr);
+        build($_builder, $_state, TypeRange{}, source, dest, ValueRange{}, extraViews, extraIndices, forceUnroll, useIndexDiffs, /*ldsTransposeConfig=*/nullptr, /*ldsPagePtrs=*/Value{}, /*firstPageIndex=*/Value{}, /*pageSize=*/nullptr, /*numPagesPerBatch=*/nullptr);
       }]>,
       // Builder with explicit ldsTransposeConfig support
       OpBuilder<(ins "Value":$source, "Value":$dest, "ArrayAttr":$extraViews,
@@ -1385,7 +1411,7 @@ def Rock_ThreadwiseReadIntoOp
                     "bool":$useIndexDiffs,
                     "LDSTransposeConfigAttr":$ldsTransposeConfig),
                 [{
-        build($_builder, $_state, TypeRange{}, source, dest, ValueRange{}, extraViews, extraIndices, forceUnroll, useIndexDiffs, ldsTransposeConfig);
+        build($_builder, $_state, TypeRange{}, source, dest, ValueRange{}, extraViews, extraIndices, forceUnroll, useIndexDiffs, ldsTransposeConfig, /*ldsPagePtrs=*/Value{}, /*firstPageIndex=*/Value{}, /*pageSize=*/nullptr, /*numPagesPerBatch=*/nullptr);
       }]>,
       // Builder with validityRecord but without ldsTransposeConfig
       OpBuilder<(ins "TypeRange":$validityRecord, "Value":$source,
@@ -1393,12 +1419,22 @@ def Rock_ThreadwiseReadIntoOp
                     "ArrayAttr":$extraViews, "ValueRange":$extraIndices,
                     "bool":$forceUnroll, "bool":$useIndexDiffs),
                 [{
-        build($_builder, $_state, validityRecord, source, dest, dynamicValidities, extraViews, extraIndices, forceUnroll, useIndexDiffs, /*ldsTransposeConfig=*/nullptr);
+        build($_builder, $_state, validityRecord, source, dest, dynamicValidities, extraViews, extraIndices, forceUnroll, useIndexDiffs, /*ldsTransposeConfig=*/nullptr, /*ldsPagePtrs=*/Value{}, /*firstPageIndex=*/Value{}, /*pageSize=*/nullptr, /*numPagesPerBatch=*/nullptr);
+      }]>,
+      // Builder with validityRecord and ldsTransposeConfig
+      OpBuilder<(ins "TypeRange":$validityRecord, "Value":$source,
+                    "Value":$dest, "ValueRange":$dynamicValidities,
+                    "ArrayAttr":$extraViews, "ValueRange":$extraIndices,
+                    "bool":$forceUnroll, "bool":$useIndexDiffs,
+                    "LDSTransposeConfigAttr":$ldsTransposeConfig),
+                [{
+        build($_builder, $_state, validityRecord, source, dest, dynamicValidities, extraViews, extraIndices, forceUnroll, useIndexDiffs, ldsTransposeConfig, /*ldsPagePtrs=*/Value{}, /*firstPageIndex=*/Value{}, /*pageSize=*/nullptr, /*numPagesPerBatch=*/nullptr);
       }]>];
 
   let assemblyFormat = [{
     attr-dict $extraViews `(` $source `)` (`[` $extraIndices^ `]`)? `->` $dest
     (`if` ` ` `[` $dynamicValidities^ `]`)?
+    (`paged` $ldsPagePtrs^ `:` type($ldsPagePtrs) `[` $firstPageIndex `]`)?
     `:` type($source) `->` type($dest) (`,` type($validityRecord)^)?
   }];
   let hasVerifier = 1;
@@ -1634,7 +1670,9 @@ def Rock_BlockwiseLoadTileOp
           Rock_BlockwiseMatrixParamsAttr:$matrixParamsB, UnitAttr:$isA,
           Variadic<Index>:$sourceIndices,
           OptionalAttr<Rock_GemmFeaturesAttr>:$features, I32Attr:$blockSize,
-          RockAccelTuningParamAttrInterface:$params)> {
+          RockAccelTuningParamAttrInterface:$params,
+          Optional<MemRefOf<[I64]>>:$pageTable,
+          OptionalAttr<IndexAttr>:$pageSize)> {
   let summary =
       "Blockwise load tile from global memory to LDS and/or registers";
   let description = [{
@@ -1651,10 +1689,20 @@ def Rock_BlockwiseLoadTileOp
     `isA` determines if we are loading an A matrix or B matrix. `G`, `M` and `N` are the GEMM sizes.
     `elementTypeA` and `elementTypeB` are used to construct AccelEmitter. They are data types for the Matrix A & B of the GEMMs. 
     `elementLoadType` is the element type of the global buffer this BlockwiseLoadTileOp is trying to load. 
-    `elementType` is the elementType in the registers.  Note that it may differ from `elementLoadType` because of input fusions.  
+    `elementType` is the elementType in the registers.  Note that it may differ from `elementLoadType` because of input fusions.
+
+    For paged attention (when K/V tensors are stored in non-contiguous pages),
+    the following optional parameters enable indirect memory access:
+    - `pageTable`: The i64 page table memref containing base pointers for each page.
+      Shape is [batch, numPages, 1] where each entry is a pointer to a page.
+    - `pageSize`: Number of elements per page, used to compute page boundaries.
+    When these are provided, the lowering will compute page indices from logical
+    positions and load page pointers to resolve physical addresses.
   }];
   let assemblyFormat = [{
-    $source (`[` $sourceIndices^ `]`)? (`LDS` `->` $destLDS^)? (`->` $destRegisters^)? attr-dict
+    $source (`[` $sourceIndices^ `]`)? (`LDS` `->` $destLDS^)? (`->` $destRegisters^)?
+    (`paged` $pageTable^ `:` type($pageTable))?
+    attr-dict
     `:` type($source) (`LDS` `->` type($destLDS)^)? (`->` type($destRegisters)^)?
   }];
 

--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -304,6 +304,11 @@ SmallVector<StringRef> getStringRefsFor(ArrayRef<SmallString<8>> strings);
 // type of the block argument, otherwise it returns failure.
 FailureOr<Type> getInputFusionElementType(Value transformed);
 
+// Compute the flat position in the virtual paged space by evaluating
+// the source transforms on the given coordinates.
+FailureOr<Value> computeFlatPosition(OpBuilder &b, Location loc, Value source,
+                                     ValueRange indices);
+
 } // end namespace rock
 } // end namespace mlir
 #endif

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -2009,8 +2009,31 @@ static LogicalResult verifyGlobalLoadAndPrefetch(LoadOrPrefetch op) {
   MemRefType sourceType = op.getSource().getType();
   size_t nDims = sourceType.getRank();
 
-  if (op.getSourceCoord().size() != nDims)
+  // Check if this op has paging attributes
+  bool isPaged = false;
+  if constexpr (std::is_same_v<LoadOrPrefetch, GlobalLoadOp>) {
+    isPaged = op.getPagePtr() != nullptr;
+
+    // Verify paging attributes consistency
+    bool hasPagePtr = op.getPagePtr() != nullptr;
+    bool hasPageSize = op.getPageSize().has_value();
+    if (hasPagePtr != hasPageSize) {
+      return op.emitOpError(
+          "pagePtr and pageSize must both be set or both be unset");
+    }
+
+    if (hasPageSize && op.getPageSize().value() <= 0) {
+      return op.emitOpError("pageSize must be positive");
+    }
+  }
+
+  // For paged loads, we expect exactly 1 coordinate (flat offset-in-page)
+  if (isPaged && op.getSourceCoord().size() != 1) {
+    return op.emitOpError("Expected 1 coordinate for paged load");
+  } else if (op.getSourceCoord().size() != nDims) {
     return op.emitOpError("Expected " + Twine(nDims) + " coordinates");
+  }
+
   Attribute memSpaceAttr = sourceType.getMemorySpace();
   auto gpuMemSpaceAttr = dyn_cast_or_null<gpu::AddressSpaceAttr>(memSpaceAttr);
   if (memSpaceAttr && (!gpuMemSpaceAttr ||
@@ -2328,6 +2351,11 @@ ThreadwiseReadIntoOp::cloneWithExtraIndices(OpBuilder &builder,
 void ThreadwiseReadIntoOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   getCommonEffects(*this, effects);
+  // If this is a paged load, we also read from the LDS page pointer buffer
+  if (getLdsPagePtrs()) {
+    effects.emplace_back(MemoryEffects::Read::get(),
+                         &getLdsPagePtrsMutable()[0]);
+  }
 }
 
 LogicalResult ThreadwiseReadIntoOp::verify() {
@@ -2393,6 +2421,37 @@ LogicalResult ThreadwiseReadIntoOp::verify() {
           "in register-to-register reads produced by input fusion");
     }
   }
+
+  // Verify paged attention attributes consistency
+  bool hasLdsPagePtrs = getLdsPagePtrs() != nullptr;
+  bool hasFirstPageIndex = getFirstPageIndex() != nullptr;
+  bool hasPageSize = getPageSize().has_value();
+
+  if (hasLdsPagePtrs != hasFirstPageIndex || hasLdsPagePtrs != hasPageSize) {
+    return emitOpError(
+        "ldsPagePtrs, firstPageIndex, and pageSize must all be "
+        "set together for paged attention, or none should be set");
+  }
+
+  if (hasPageSize && getPageSize().value().getSExtValue() <= 0) {
+    return emitOpError("pageSize must be positive");
+  }
+
+  if (getNumPagesPerBatch().has_value() &&
+      getNumPagesPerBatch().value().getSExtValue() <= 0) {
+    return emitOpError("numPagesPerBatch must be positive");
+  }
+
+  if (hasLdsPagePtrs) {
+    MemRefType ldsPagePtrsType = cast<MemRefType>(getLdsPagePtrs().getType());
+    if (ldsPagePtrsType.getRank() != 1) {
+      return emitOpError("ldsPagePtrs must be a 1D memref");
+    }
+    if (!ldsPagePtrsType.getElementType().isInteger(64)) {
+      return emitOpError("ldsPagePtrs must have i64 element type");
+    }
+  }
+
   return success();
 }
 
@@ -2567,6 +2626,34 @@ LogicalResult BlockwiseLoadTileOp::verify() {
   if (!destRegisters && !singleBuffer)
     return emitOpError("destRegisters must be set unless loadType is "
                        "Default/DirectToLDSDefault");
+
+  // Verify paged attention attributes consistency
+  bool hasPageTable = getPageTable() != nullptr;
+  bool hasPageSize = getPageSize().has_value();
+
+  if (hasPageTable != hasPageSize) {
+    return emitOpError(
+        "pageTable and pageSize must both be set or both be unset");
+  }
+
+  if (hasPageSize && getPageSize().value().getSExtValue() <= 0) {
+    return emitOpError("pageSize must be positive");
+  }
+
+  if (hasPageTable) {
+    MemRefType pageTableType = cast<MemRefType>(getPageTable().getType());
+    if (pageTableType.getRank() != 3) {
+      return emitOpError(
+          "pageTable must be a 3D memref with shape [batch, numPages, 1]");
+    }
+    if (pageTableType.getShape()[2] != 1) {
+      return emitOpError(
+          "pageTable last dimension must be 1 (shape [batch, numPages, 1])");
+    }
+    if (!pageTableType.getElementType().isInteger(64)) {
+      return emitOpError("pageTable must have i64 element type");
+    }
+  }
 
   return success();
 }

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
@@ -176,6 +176,12 @@ class LoweringBlockwiseLoadTileOp final
     Value numPagesPerBatchVal =
         b.createOrFold<arith::ConstantIndexOp>(loc, numPagesPerBatch);
 
+    // Get number of batches from page table shape for bounds checking
+    auto pageTableType = cast<MemRefType>(pageTable.getType());
+    int64_t numBatches = pageTableType.getShape()[0];
+    Value numBatchesVal =
+        b.createOrFold<arith::ConstantIndexOp>(loc, numBatches);
+
     // Only threads with tid < numPagesForTile participate in loading.
     // Each such thread either loads from page table or stores 0 to its LDS
     // slot.
@@ -200,10 +206,10 @@ class LoweringBlockwiseLoadTileOp final
               arith::RemUIOp::create(outerThenBuilder, outerThenLoc,
                                      globalPageIdx, numPagesPerBatchVal);
 
-          // Check that local page index is within bounds
+          // Check that batch index is within bounds.
           Value withinTableBound = arith::CmpIOp::create(
               outerThenBuilder, outerThenLoc, arith::CmpIPredicate::ult,
-              localPageIdx, numPagesPerBatchVal);
+              batchIdx, numBatchesVal);
 
           // Select the pointer value: load from page table if in bounds, else 0
           scf::IfOp ptrIfOp = scf::IfOp::create(

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
@@ -18,6 +18,7 @@
 
 #include "GridLayoutEmitter.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -138,6 +139,98 @@ class LoweringBlockwiseLoadTileOp final
     }
 
     return std::make_pair(stageOp, isNew);
+  }
+
+  // Compute firstPageIdx by evaluating the composed transforms.
+  FailureOr<Value> computeFirstPageIdx(PatternRewriter &b, Location loc,
+                                       Value source, ValueRange indices,
+                                       ArrayAttr gridSubTile,
+                                       int64_t pageSize) const {
+    Value wrappedSourceForFlat = transform(b, source, gridSubTile);
+
+    // indices = [kIter, g_block, m_block, n_block, tid]
+    // Replace tid with 0 to compute the tile's starting position (origin).
+    // This gives us the flat offset of the first element in the tile,
+    // which we then divide by pageSize to get the first page index.
+    SmallVector<Value> tileOriginIndices(indices.begin(), indices.end());
+    Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
+    if (!tileOriginIndices.empty())
+      tileOriginIndices.back() = zero;
+
+    FailureOr<Value> maybeTileStartFlat =
+        computeFlatPosition(b, loc, wrappedSourceForFlat, tileOriginIndices);
+    if (failed(maybeTileStartFlat))
+      return failure();
+
+    Value pageSizeVal = b.createOrFold<arith::ConstantIndexOp>(loc, pageSize);
+    return arith::DivUIOp::create(b, loc, *maybeTileStartFlat, pageSizeVal)
+        .getResult();
+  }
+
+  // Emit the page pointer loading logic to LDS.
+  void emitPagePointerLoads(PatternRewriter &b, Location loc, Value pageTable,
+                            Value ldsPagePtrs, Value firstPageIdx,
+                            int64_t numPages, int64_t numPagesPerBatch) const {
+    Value tid = WorkitemIdOp::create(b, loc, b.getIndexType());
+    Value numPagesVal = b.createOrFold<arith::ConstantIndexOp>(loc, numPages);
+    Value numPagesPerBatchVal =
+        b.createOrFold<arith::ConstantIndexOp>(loc, numPagesPerBatch);
+
+    // Only threads with tid < numPagesForTile participate in loading.
+    // Each such thread either loads from page table or stores 0 to its LDS
+    // slot.
+    Value withinTileBound = arith::CmpIOp::create(
+        b, loc, arith::CmpIPredicate::ult, tid, numPagesVal);
+
+    scf::IfOp::create(
+        b, loc, withinTileBound,
+        [&](OpBuilder &outerThenBuilder, Location outerThenLoc) {
+          // This thread is responsible for LDS slot [tid]
+          // globalPageIdx is across all batches
+          Value globalPageIdx = arith::AddIOp::create(
+              outerThenBuilder, outerThenLoc, firstPageIdx, tid);
+
+          // Split into batch and local page indices:
+          // batchIdx = globalPageIdx / numPagesPerBatch
+          // localPageIdx = globalPageIdx % numPagesPerBatch
+          Value batchIdx =
+              arith::DivUIOp::create(outerThenBuilder, outerThenLoc,
+                                     globalPageIdx, numPagesPerBatchVal);
+          Value localPageIdx =
+              arith::RemUIOp::create(outerThenBuilder, outerThenLoc,
+                                     globalPageIdx, numPagesPerBatchVal);
+
+          // Check that local page index is within bounds
+          Value withinTableBound = arith::CmpIOp::create(
+              outerThenBuilder, outerThenLoc, arith::CmpIPredicate::ult,
+              localPageIdx, numPagesPerBatchVal);
+
+          // Select the pointer value: load from page table if in bounds, else 0
+          scf::IfOp ptrIfOp = scf::IfOp::create(
+              outerThenBuilder, outerThenLoc, withinTableBound,
+              [&](OpBuilder &thenBuilder, Location thenLoc) {
+                // Load page pointer from page table
+                Value zeroIdx =
+                    thenBuilder.createOrFold<arith::ConstantIndexOp>(thenLoc,
+                                                                     0);
+                SmallVector<Value> pageTableIndices = {batchIdx, localPageIdx,
+                                                       zeroIdx};
+                Value ptr = memref::LoadOp::create(thenBuilder, thenLoc,
+                                                   pageTable, pageTableIndices);
+                scf::YieldOp::create(thenBuilder, thenLoc, ptr);
+              },
+              [&](OpBuilder &elseBuilder, Location elseLoc) {
+                Value nullPtr = elseBuilder.createOrFold<arith::ConstantIntOp>(
+                    elseLoc, 0, 64);
+                scf::YieldOp::create(elseBuilder, elseLoc, nullPtr);
+              });
+
+          // Store the selected pointer to LDS
+          Value ptrToStore = ptrIfOp.getResult(0);
+          memref::StoreOp::create(outerThenBuilder, outerThenLoc, ptrToStore,
+                                  ldsPagePtrs, tid);
+          scf::YieldOp::create(outerThenBuilder, outerThenLoc);
+        });
   }
 
   LogicalResult matchAndRewrite(rock::BlockwiseLoadTileOp op, OpAdaptor adaptor,
@@ -266,9 +359,112 @@ class LoweringBlockwiseLoadTileOp final
     SmallVector<int64_t, 3> bidGridLengths = {G, mBlocks, nBlocks};
     SmallVector<StringRef, 3> bidGridOrder = {"g_block", "m_block", "n_block"};
 
-    // Create the stages for the blockwise load tile op
+    // Create buffer views early so we can use them for paged attention
+    // calculations
+    FailureOr<RegsAsMatrixSubTiles> maybeBufferViews;
+    if (loadType == GemmLoadTileType::BypassLDS) {
+      maybeBufferViews = accelEmitterPtr->createAccelGemmOperandTransforms(
+          b, loc, kIters, bidGridLengths, blockSize, vecDimInfo.inDPerThread,
+          dName, isKContiguousDim, false);
+    } else {
+      maybeBufferViews = getLoadRegsAsTileViews(
+          b, loc, source, dName, bidGridOrder, bidGridLengths, blockSize,
+          kPerBlock, dPerBlock, vecDimInfo.inKPerThread,
+          vecDimInfo.inDPerThread, isKContiguousDim, directToLDS);
+    }
+    if (failed(maybeBufferViews))
+      return failure();
+
+    // Handle paged attention setup
+    Value pageTable = op.getPageTable();
+    std::optional<int64_t> maybePageSize;
+    if (auto pageSizeAttr = op.getPageSizeAttr())
+      maybePageSize = pageSizeAttr.getInt();
+    bool isPagedLoad = pageTable != nullptr && maybePageSize.has_value();
+    Value ldsPagePtrs;
+    Value firstPageIdx;
+    int64_t pageSize = isPagedLoad ? *maybePageSize : 0;
+    int64_t numPagesForTile = 0;
+    int64_t numPagesPerBatch = 0;
+
+    if (isPagedLoad) {
+      // Compute maximum number of pages this tile can span
+      int64_t span = (dPerBlock - 1) * kGlobal + (kPerBlock - 1);
+      numPagesForTile = (pageSize - 1 + span) / pageSize + 1;
+
+      // Get batch count and pages per batch from page table shape
+      // [batch, numPages, 1]
+      auto pageTableType = cast<MemRefType>(pageTable.getType());
+      numPagesPerBatch = pageTableType.getShape()[1];
+
+      // Allocate LDS for page pointers as i8 byte buffer (required by
+      // ReuseLDS), then view as i64. Each i64 pointer is 8 bytes.
+      auto ldsMemorySpace =
+          b.getAttr<gpu::AddressSpaceAttr>(gpu::AddressSpace::Workgroup);
+      int64_t ldsBytesForPagePtrs = numPagesForTile * 8; // sizeof(i64) = 8
+      auto ldsPagePtrsByteType = MemRefType::get(
+          {ldsBytesForPagePtrs}, b.getI8Type(), AffineMap{}, ldsMemorySpace);
+      Value ldsPagePtrsBytes = GpuAllocOp::create(b, loc, ldsPagePtrsByteType);
+
+      // Create i64 view of the byte buffer
+      auto ldsPagePtrsViewType = MemRefType::get(
+          {numPagesForTile}, b.getI64Type(), AffineMap{}, ldsMemorySpace);
+      Value zeroOffset = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
+      ldsPagePtrs =
+          memref::ViewOp::create(b, loc, ldsPagePtrsViewType, ldsPagePtrsBytes,
+                                 zeroOffset, ValueRange{});
+    }
+
+    // Set insertion point for stage creation (inside the loop)
     if (isa<LoopLikeOpInterface>(parentOp))
       b.setInsertionPoint(op);
+
+    // For paged loads, we split into two stages:
+    // 1. PagePtrLoad: Load page pointers from page table to LDS
+    // 2. GlobalRead: Use page pointers to load actual data to LDS (or regs)
+    StageOp existingGlobalRead = nullptr;
+    if (isPagedLoad) {
+      parentOp->walk([&](StageOp op) {
+        if (op.getName() == "GlobalRead")
+          existingGlobalRead = op;
+      });
+
+      // If GlobalRead already exists, set insertion point before it
+      if (existingGlobalRead) {
+        b.setInsertionPoint(existingGlobalRead);
+      }
+
+      // Stage 1: PagePtrLoad - loads page pointers to LDS
+      auto [stagePagePtrLoad, stagePagePtrLoadNew] =
+          createOrGetStage(b, loc, "PagePtrLoad", parentOp);
+      {
+        PatternRewriter::InsertionGuard guard(b);
+        b.setInsertionPointToStart(&stagePagePtrLoad.getRegion().back());
+
+        // Compute firstPageIdx
+        FailureOr<Value> maybeFirstPageIdx = computeFirstPageIdx(
+            b, loc, source, indices, maybeBufferViews->gridSubTile, pageSize);
+        if (failed(maybeFirstPageIdx))
+          return failure();
+        Value pagePtrFirstPageIdx = *maybeFirstPageIdx;
+
+        // Load page pointers to LDS
+        emitPagePointerLoads(b, loc, pageTable, ldsPagePtrs,
+                             pagePtrFirstPageIdx, numPagesForTile,
+                             numPagesPerBatch);
+
+        if (stagePagePtrLoadNew) {
+          LDSBarrierOp::create(b, loc);
+          rock::YieldOp::create(b, loc);
+        }
+      }
+
+      // Restore insertion point after the existing GlobalRead for subsequent
+      // stages
+      if (existingGlobalRead) {
+        b.setInsertionPointAfter(existingGlobalRead);
+      }
+    }
 
     auto [stageGlobalRead, stageGlobalReadNew] =
         createOrGetStage(b, loc, "GlobalRead", parentOp);
@@ -292,19 +488,45 @@ class LoweringBlockwiseLoadTileOp final
             kPerBlock, dPerBlock, vecDimInfo.inKPerThread,
             vecDimInfo.inDPerThread, isKContiguousDim, directToLDS);
       }
-      if (failed(maybeBufferViews))
-        return failure();
+
+      // For paged loads, recompute firstPageIdx in this stage
+      // (the page pointers are already in ldsPagePtrs from PagePtrLoad stage)
+      if (isPagedLoad) {
+        FailureOr<Value> maybeFirstPageIdx = computeFirstPageIdx(
+            b, loc, source, indices, maybeBufferViews->gridSubTile, pageSize);
+        if (failed(maybeFirstPageIdx))
+          return failure();
+        firstPageIdx = *maybeFirstPageIdx;
+      }
 
       Value wrappedSource = transform(b, source, maybeBufferViews->gridSubTile);
 
-      ThreadwiseReadIntoOp::create(b, loc, vectorOfBoolShapedLike(loadBuffer),
-                                   wrappedSource, loadBuffer,
-                                   /*dynamicValidities=*/ValueRange{},
-                                   /*extraViews=*/b.getArrayAttr({}),
-                                   /*extraIndices=*/indices, forceUnroll, true,
-                                   /*ldsTransposeConfig=*/nullptr);
+      if (isPagedLoad) {
+        // Create ThreadwiseReadIntoOp with paging attributes
+        ThreadwiseReadIntoOp::create(
+            b, loc, vectorOfBoolShapedLike(loadBuffer), wrappedSource,
+            loadBuffer,
+            /*dynamicValidities=*/ValueRange{},
+            /*extraViews=*/b.getArrayAttr({}),
+            /*extraIndices=*/indices, forceUnroll, /*useIndexDiffs=*/true,
+            /*ldsTransposeConfig=*/nullptr,
+            /*ldsPagePtrs=*/ldsPagePtrs,
+            /*firstPageIndex=*/firstPageIdx,
+            /*pageSize=*/b.getIndexAttr(pageSize),
+            /*numPagesPerBatch=*/b.getIndexAttr(numPagesPerBatch));
+      } else {
+        // Standard non-paged path
+        ThreadwiseReadIntoOp::create(b, loc, vectorOfBoolShapedLike(loadBuffer),
+                                     wrappedSource, loadBuffer,
+                                     /*dynamicValidities=*/ValueRange{},
+                                     /*extraViews=*/b.getArrayAttr({}),
+                                     /*extraIndices=*/indices, forceUnroll,
+                                     true,
+                                     /*ldsTransposeConfig=*/nullptr);
+      }
 
-      if (rock::isGlobalPrefetchSupported(arch)) {
+      // Skip prefetch for paged loads - would need next tile's page pointers
+      if (rock::isGlobalPrefetchSupported(arch) && !isPagedLoad) {
         // add one to k_loop to prefetch next iteration
         SmallVector<Value> indicesNext(indices.begin(), indices.end());
         Value one = b.createOrFold<arith::ConstantIndexOp>(loc, 1);
@@ -504,7 +726,8 @@ void RockBlockwiseLoadTileToThreadwisePass::runOnOperation() {
   ConversionTarget target(ctx);
 
   target.addLegalDialect<rock::RockDialect, affine::AffineDialect,
-                         arith::ArithDialect, memref::MemRefDialect>();
+                         arith::ArithDialect, memref::MemRefDialect,
+                         scf::SCFDialect>();
   target.addIllegalOp<rock::BlockwiseLoadTileOp>();
   auto func = getOperation();
 

--- a/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ConvToGemm.cpp
@@ -338,7 +338,8 @@ struct ConvertingCopyKernelRewritePattern final
       Value loaded =
           GlobalLoadOp::create(b, loc, loadType, collapsed[0], /*valid=*/trueOp,
                                index, needs64BitIdx,
-                               /*canReadOffEnd=*/true);
+                               /*canReadOffEnd=*/true, /*pagePtr=*/Value{},
+                               /*pageSize=*/nullptr);
       Value converted = createTypeConversionOp(b, loc, loaded, storeType);
       InBoundsStoreOp::create(b, loc, converted, storeMemref, zeroIndex);
       GlobalStoreOp::create(

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/MathExtras.h"
 #include <algorithm>
 #include <memory>
 #include <sstream>
@@ -518,6 +519,22 @@ static LogicalResult commonAttentionGemmElmtGemm(
   }
   RockAccelTuningParamAttrInterface params1 =
       cast<RockAccelTuningParamAttrInterface>(op.getGemm1Params().value());
+
+  // TODO: Paged attention currently requires power-of-two tile sizes due to
+  // address calculation constraints in the paged memory access path.
+  bool isPagedAttention = keyAddresses != nullptr;
+  if (isPagedAttention) {
+    int64_t mPerBlock = params0.getMPerBlock();
+    int64_t nPerBlock = params0.getNPerBlock();
+    int64_t kPerBlock = params0.getKpackPerBlock() * params0.getKpack();
+    if (!llvm::isPowerOf2_64(mPerBlock) || !llvm::isPowerOf2_64(nPerBlock) ||
+        !llvm::isPowerOf2_64(kPerBlock)) {
+      return op.emitError("Paged attention requires power-of-two tile sizes. "
+                          "Got mPerBlock=")
+             << mPerBlock << ", nPerBlock=" << nPerBlock
+             << ", kPerBlock=" << kPerBlock;
+    }
+  }
 
   // Note: the gridwise ops take K x M and K x N, so A must be transposed if
   // it's in the natural M x K form

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -144,7 +144,8 @@ static void loadAndStoreGemmInputTile(
     const RockAccelTuningParamAttrInterface &gemmTuningParams,
     const GemmFeaturesAttr &featuresAttr,
     const BlockwiseMatrixParamsAttr &matrixParamsA,
-    const BlockwiseMatrixParamsAttr &matrixParamsB) {
+    const BlockwiseMatrixParamsAttr &matrixParamsB, Value pageTable,
+    IntegerAttr pageSizeAttr) {
   UnitAttr isA = nonKDimName == "m" ? rewriter.getUnitAttr() : nullptr;
   auto loadTypeAttr =
       GemmLoadTileTypeAttr::get(rewriter.getContext(), loadType);
@@ -156,7 +157,34 @@ static void loadAndStoreGemmInputTile(
       matrixParamsB, isA,
       ValueRange{kIter, gridCoords.g_block, gridCoords.m_block,
                  gridCoords.n_block, tid},
-      featuresAttr, rewriter.getI32IntegerAttr(blockSize), gemmTuningParams);
+      featuresAttr, rewriter.getI32IntegerAttr(blockSize), gemmTuningParams,
+      pageTable, pageSizeAttr);
+}
+
+// Helper struct to hold paged attention information
+struct PagedAttentionInfo {
+  Value pageTable;  // The i64 page table memref (input to deref op)
+  int64_t pageSize; // Number of elements per page
+};
+
+// Extract paged attention info from the addresses tensor.
+static FailureOr<PagedAttentionInfo>
+getPagedAttentionInfo(Value pagedAddresses) {
+  if (!pagedAddresses)
+    return failure();
+
+  auto derefOp = pagedAddresses.getDefiningOp<DerefOp>();
+  if (!derefOp)
+    return failure();
+
+  auto outputType = dyn_cast<MemRefType>(derefOp.getOutput().getType());
+  if (!outputType || outputType.getRank() != 3)
+    return failure();
+
+  PagedAttentionInfo info;
+  info.pageTable = derefOp.getPointers();
+  info.pageSize = outputType.getShape()[2];
+  return info;
 }
 
 static Value createLDSByteBuffer(PatternRewriter &rewriter, Location loc,
@@ -2045,6 +2073,15 @@ struct GridwiseAttentionAccelRewritePattern
     bool isPrefixCausal = isCausal && prefixOffsetTensor;
     int64_t splitKV = op.getSplitKV();
 
+    Value keyAddresses = op.getKeyAddresses();
+    Value valueAddresses = op.getValueAddresses();
+
+    // Extract paged attention info if enabled
+    FailureOr<PagedAttentionInfo> keyPageInfo =
+        getPagedAttentionInfo(keyAddresses);
+    FailureOr<PagedAttentionInfo> valuePageInfo =
+        getPagedAttentionInfo(valueAddresses);
+
     // Gemm0 out is casted to be softmaxType (if null, it's casted to elemTypeV)
     Type elemTypeSoftmax = op.getSoftmaxType().value_or(elemTypeV);
 
@@ -2092,6 +2129,18 @@ struct GridwiseAttentionAccelRewritePattern
     GemmLoadTileType loadType = maybeLoadType.value();
     bool directToLDS = loadType == GemmLoadTileType::DirectToLDSDefault ||
                        loadType == GemmLoadTileType::DirectToLDSDoubleBuffer;
+
+    // Since different lanes can have different pageIdx values (and thus
+    // different page pointers), the buffer resource would be non-uniform across
+    // the wavefront. Using a non-uniform buffer resource with DirectToLDS is
+    // undefined behavior on AMD GPUs.
+    bool isPagedAttention = succeeded(keyPageInfo) || succeeded(valuePageInfo);
+    if (isPagedAttention && directToLDS) {
+      loadType = (loadType == GemmLoadTileType::DirectToLDSDefault)
+                     ? GemmLoadTileType::Default
+                     : GemmLoadTileType::DoubleBuffer;
+      directToLDS = false;
+    }
 
     auto accelEmitterPtrGemm0 = accel::AccelEmitter::select(
         features, elemTypeQ, elemTypeK, arch, gemm0TuningParams);
@@ -2559,7 +2608,8 @@ struct GridwiseAttentionAccelRewritePattern
           rewriter, loc, inQ, /*kiter=*/zero, tid, gridCoordsGemm0LoadQ,
           ldsByteBufferQ, preAccelRegBuffersQForLoad, loadTypeQ, "n", blockSize,
           elemTypeQ, elemTypeQLoad, gemm0TuningParams, featuresAttr,
-          matrixParamsK, matrixParamsQ);
+          matrixParamsK, matrixParamsQ, /*pageTable=*/nullptr,
+          /*pageSizeAttr=*/nullptr);
     }
 
     bool dynamicMLoop = splitKV != 1 || isCausal || isKVCache;
@@ -2618,14 +2668,22 @@ struct GridwiseAttentionAccelRewritePattern
               rewriter, loc, inQ, kLoopIV, tid, gridCoordsGemm0, ldsByteBufferQ,
               preAccelRegBuffersQForLoad, loadTypeQ, "n", blockSize, elemTypeQ,
               elemTypeQLoad, gemm0TuningParams, featuresAttr, matrixParamsK,
-              matrixParamsQ);
+              matrixParamsQ, /*pageTable=*/nullptr, /*pageSizeAttr=*/nullptr);
+        }
+
+        // Get paged attention info for K if enabled
+        Value keyPageTable = nullptr;
+        IntegerAttr keyPageSizeAttr = nullptr;
+        if (succeeded(keyPageInfo)) {
+          keyPageTable = keyPageInfo->pageTable;
+          keyPageSizeAttr = rewriter.getIndexAttr(keyPageInfo->pageSize);
         }
 
         loadAndStoreGemmInputTile(
             rewriter, loc, inK, kLoopIV, tid, gridCoordsGemm0, ldsByteBufferK,
             preAccelRegBufferKForLoad, loadType, "m", blockSize, elemTypeK,
             elemTypeKLoad, gemm0TuningParams, featuresAttr, matrixParamsK,
-            matrixParamsQ);
+            matrixParamsQ, keyPageTable, keyPageSizeAttr);
 
         // Conservative barrier: Ensure all LDS writes complete
         // before MMA stage reads from LDS. RockPipelinePass will remove this
@@ -2921,12 +2979,20 @@ struct GridwiseAttentionAccelRewritePattern
 
           gridCoordsGemm1.m_block = g1MLoopIndVar;
 
+          // Get paged attention info for V if enabled
+          Value valuePageTable = nullptr;
+          IntegerAttr valuePageSizeAttr = nullptr;
+          if (succeeded(valuePageInfo)) {
+            valuePageTable = valuePageInfo->pageTable;
+            valuePageSizeAttr = rewriter.getIndexAttr(valuePageInfo->pageSize);
+          }
+
           loadAndStoreGemmInputTile(
               rewriter, loc, inV,
               /*kIter=*/mLoopIV, tid, gridCoordsGemm1, ldsByteBufferV,
               preAccelRegBufferVForLoad, loadType, "m", blockSize, elemTypeV,
               elemTypeVLoad, gemm1TuningParams, featuresAttr, matrixParamsV,
-              matrixParamsKxQ);
+              matrixParamsKxQ, valuePageTable, valuePageSizeAttr);
 
           // Conservative barrier: Ensure all LDS writes complete
           // before MMA stage reads from LDS. RockPipelinePass will remove this
@@ -3522,23 +3588,29 @@ struct GridwiseGemmAccelRewritePattern
                                 ldsByteBufferB, arrayBForLoad, loadType, "n",
                                 blockSize, elementTypeB, elementTypeBLoad,
                                 tuningParams, featuresAttr, matrixParamsA,
-                                matrixParamsB);
+                                matrixParamsB, /*pageTable=*/nullptr,
+                                /*pageSizeAttr=*/nullptr);
       loadAndStoreGemmInputTile(b, loc, matA, /*kiter=*/iv, tid, gridCoords,
                                 ldsByteBufferA, arrayAForLoad, loadType, "m",
                                 blockSize, elementTypeA, elementTypeALoad,
                                 tuningParams, featuresAttr, matrixParamsA,
-                                matrixParamsB);
+                                matrixParamsB, /*pageTable=*/nullptr,
+                                /*pageSizeAttr=*/nullptr);
       if (isScaledGemm) {
         loadAndStoreGemmInputTile(b, loc, scaleB, /*kiter=*/iv, tid, gridCoords,
                                   ldsByteBufferScaleB, arrayScaleBForLoad,
                                   loadType, "n", blockSize, elementTypeScaleB,
                                   elementTypeBLoad, tuningParams, featuresAttr,
-                                  matrixParamsA, matrixParamsB);
+                                  matrixParamsA, matrixParamsB,
+                                  /*pageTable=*/nullptr,
+                                  /*pageSizeAttr=*/nullptr);
         loadAndStoreGemmInputTile(b, loc, scaleA, /*kiter=*/iv, tid, gridCoords,
                                   ldsByteBufferScaleA, arrayScaleAForLoad,
                                   loadType, "m", blockSize, elementTypeScaleA,
                                   elementTypeALoad, tuningParams, featuresAttr,
-                                  matrixParamsA, matrixParamsB);
+                                  matrixParamsA, matrixParamsB,
+                                  /*pageTable=*/nullptr,
+                                  /*pageSizeAttr=*/nullptr);
       }
 
       // Conservative barrier: Ensure all LDS writes complete

--- a/mlir/lib/Dialect/Rock/Transforms/LowerRockReduce.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/LowerRockReduce.cpp
@@ -169,7 +169,8 @@ LogicalResult ReduceRewritePattern::matchAndRewrite(
     Value isValid = outLoop.getValidity(/*domain=*/0);
     GlobalLoadOp loadVal =
         GlobalLoadOp::create(rewriter, loc, vectorType, op.getIn(), isValid,
-                             loadCoords, needs64BitIdx);
+                             loadCoords, needs64BitIdx, /*canReadOffEnd=*/false,
+                             /*pagePtr=*/Value{}, /*pageSize=*/nullptr);
     auto privateMemoryAddressSpace = rewriter.getAttr<gpu::AddressSpaceAttr>(
         gpu::GPUDialect::getPrivateAddressSpace());
     Value loadedReg = GpuAllocOp::create(

--- a/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
@@ -57,8 +57,15 @@ struct InterferenceData {
   SmallVector<GpuAllocOp> allocs;
   SmallVector<LiveInOp> liveIns;
   SmallVector<LiveOutOp> liveOuts;
+  // Interference graph for graph coloring (prevents same-color assignment)
   llvm::SmallDenseMap<GpuAllocOp, llvm::SetVector<GpuAllocOp>>
       interferenceGraph;
+  // "Hard" interference: buffers accessed by the same operation.
+  // These can't be merged into the same allocation even at different offsets,
+  // because the second AnnotateLiveness pass would see an op that both reads
+  // and writes to the same allocation.
+  llvm::SmallDenseMap<GpuAllocOp, llvm::SetVector<GpuAllocOp>>
+      sameOpInterference;
 };
 
 struct GraphColoringInfo {
@@ -158,6 +165,41 @@ graphColoring(const InterferenceData &interferenceData) {
   // Then, we can generate more than one GpuAllocOp and improve
   // aliasing issues.
   // This might be removed in the future if aliasing issues are solved.
+
+  // Build a map from color to allocs that have that color
+  llvm::SmallDenseMap<int64_t, SmallVector<GpuAllocOp>> colorToAllocs;
+  for (GpuAllocOp alloc : sortedAllocs) {
+    for (int64_t color : graphColoringInfo.colorAssignment[alloc]) {
+      colorToAllocs[color].push_back(alloc);
+    }
+  }
+
+  // Helper to check if merging srcColor into dstColor would put buffers
+  // that are accessed by the same operation into the same allocation.
+  // Same-op interference must also prevent color merging.
+  auto wouldViolateSameOpInterference = [&](int64_t srcColor,
+                                            int64_t dstColor) -> bool {
+    if (!colorToAllocs.contains(srcColor) || !colorToAllocs.contains(dstColor))
+      return false;
+
+    for (GpuAllocOp srcAlloc : colorToAllocs[srcColor]) {
+      for (GpuAllocOp dstAlloc : colorToAllocs[dstColor]) {
+        if (srcAlloc == dstAlloc)
+          continue;
+        // Check if these allocs have same-op interference
+        if (interferenceData.sameOpInterference.contains(srcAlloc) &&
+            interferenceData.sameOpInterference.at(srcAlloc).contains(
+                dstAlloc)) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "Preventing color merge due to same-op interference: "
+                     << srcAlloc << " and " << dstAlloc << "\n");
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
   llvm::SmallDenseMap<int64_t, SetVector<int64_t>> colorsToMerge;
   llvm::SmallDenseMap<int64_t, int64_t> oldColorToNew;
   for (GpuAllocOp alloc : sortedAllocs) {
@@ -167,6 +209,9 @@ graphColoring(const InterferenceData &interferenceData) {
       int64_t newColor = oldColorToNew[firstColor];
       // assign all the colors of the current 'alloc' to newColor
       for (int64_t color : graphColoringInfo.colorAssignment[alloc]) {
+        // Skip if merging would violate same-op interference
+        if (wouldViolateSameOpInterference(color, newColor))
+          continue;
         oldColorToNew[color] = newColor;
         colorsToMerge[newColor].insert(color);
       }
@@ -176,12 +221,18 @@ graphColoring(const InterferenceData &interferenceData) {
            llvm::enumerate(graphColoringInfo.colorAssignment[alloc])) {
         // merge all non-first colors with the first one
         if (i > 0) {
+          // Skip if merging would violate same-op interference
+          if (wouldViolateSameOpInterference(color, firstColor))
+            continue;
           oldColorToNew[color] = firstColor;
           colorsToMerge[firstColor].insert(color);
           // if the current 'color' has merged some colors,
           // merge its colors to 'firstColor'
           if (colorsToMerge.contains(color)) {
             for (int64_t otherColor : colorsToMerge[color]) {
+              // Skip if merging would violate same-op interference
+              if (wouldViolateSameOpInterference(otherColor, firstColor))
+                continue;
               oldColorToNew[otherColor] = firstColor;
               colorsToMerge[firstColor].insert(otherColor);
             }

--- a/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/SugarToLoops.cpp
@@ -31,6 +31,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
@@ -1174,6 +1175,52 @@ Value selectDataIf4b(Location loc, PatternRewriter &b,
   return b.createOrFold<vector::ExtractOp>(loc, loadedVec, lsb);
 }
 
+// Create a buffer resource (V#) from a raw page pointer for paged loads.
+// The page pointer is an i64 containing the raw address. Returns a pointer in
+// address space 8 suitable for buffer operations.
+static Value createBufferResourceFromPagePtr(PatternRewriter &b, Location loc,
+                                             Value pagePtr,
+                                             int64_t pageSizeBytes,
+                                             StringRef arch) {
+  // Convert i64 page pointer to LLVM pointer (global address space = 1)
+  auto ptrType = LLVM::LLVMPointerType::get(b.getContext(), /*addressSpace=*/1);
+  Value ptr = LLVM::IntToPtrOp::create(b, loc, ptrType, pagePtr);
+
+  // Create buffer resource (V#)
+  // Buffer descriptor flags (from AMDGPUToROCDL.cpp::makeBufferRsrc):
+  //   bits 0-11:  dst sel (ignored by loads)
+  //   bits 12-14: data format (must be nonzero, 7=float)
+  //   bits 15-18: num format (must be nonzero, 4=32bit)
+  //   bit 19:     nested heap (0)
+  //   bit 20:     behavior on unmap (0 = return 0)
+  //   bits 21-22: index stride for swizzles (N/A)
+  //   bit 23:     add thread ID (0)
+  //   bit 24:     reserved, must be 1 on RDNA, 0 on CDNA
+  //   bits 25-26: reserved (0)
+  //   bit 27:     non-volatile (CDNA only)
+  //   bits 28-29: OOB select (RDNA only: 2=none, 3=bounds check)
+  //   bits 30-31: type (must be 0)
+  bool isRDNA = arch.starts_with("gfx10") || arch.starts_with("gfx11") ||
+                arch.starts_with("gfx12");
+
+  Value stride = b.createOrFold<LLVM::ConstantOp>(loc, b.getI16Type(),
+                                                  b.getI16IntegerAttr(0));
+  Value numRecords = b.createOrFold<LLVM::ConstantOp>(
+      loc, b.getI64Type(), b.getI64IntegerAttr(pageSizeBytes));
+
+  uint32_t flags = (7 << 12) | (4 << 15); // base: data format + num format
+  if (isRDNA) {
+    flags |= (1 << 24); // RDNA reserved bit
+    flags |= (3 << 28); // OOB select = 3 (bounds check enabled)
+  }
+  Value flagsVal = b.createOrFold<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                                    b.getI32IntegerAttr(flags));
+
+  auto rsrcType = LLVM::LLVMPointerType::get(b.getContext(), /*addrSpace=*/8);
+  return ROCDL::MakeBufferRsrcOp::create(b, loc, rsrcType, ptr, stride,
+                                         numRecords, flagsVal);
+}
+
 struct GlobalPrefetchRewritePattern
     : public OpRewritePattern<GlobalPrefetchOp> {
   using OpRewritePattern<GlobalPrefetchOp>::OpRewritePattern;
@@ -1202,6 +1249,116 @@ struct GlobalLoadRewritePattern : public OpRewritePattern<GlobalLoadOp> {
     Value source = op.getSource();
     Value valid = op.getValid();
 
+    // Check if this is a paged load
+    Value pagePtr = op.getPagePtr();
+    bool isPagedLoad = pagePtr != nullptr;
+
+    if (isPagedLoad) {
+      // Paged load path: use ROCDL intrinsics directly
+      Type originalLoadedType = op.getResult().getType();
+      Type loadedType = originalLoadedType;
+      MemRefType srcType = cast<MemRefType>(source.getType());
+      Type elemType = srcType.getElementType();
+      int64_t elemBytes = elemType.getIntOrFloatBitWidth() / 8;
+
+      // Get page size in elements and convert to bytes
+      int64_t pageSizeElems = op.getPageSizeAttr().getInt();
+      int64_t pageSizeBytes = pageSizeElems * elemBytes;
+
+      // Get architecture for buffer flags
+      StringRef arch = rock::getArchValue(op);
+
+      // Create buffer resource from page pointer
+      Value rsrc =
+          createBufferResourceFromPagePtr(b, loc, pagePtr, pageSizeBytes, arch);
+
+      // coords[0] is offset-in-page in elements (single flat index)
+      // Convert to bytes for the buffer load
+      Value offsetInPageElems = op.getSourceCoord()[0];
+      Value elemBytesVal =
+          b.createOrFold<arith::ConstantIndexOp>(loc, elemBytes);
+      Value offsetBytes =
+          arith::MulIOp::create(b, loc, offsetInPageElems, elemBytesVal);
+      Value offsetI32 =
+          arith::IndexCastOp::create(b, loc, b.getI32Type(), offsetBytes);
+
+      // soffset (scalar offset) is 0
+      Value soffset = b.createOrFold<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                                       b.getI32IntegerAttr(0));
+      // aux flags: 0 for basic loads
+      Value aux = b.createOrFold<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                                   b.getI32IntegerAttr(0));
+
+      // Handle validity with conditional load
+      llvm::APInt validConst = APInt::getZero(1);
+      bool isAlwaysValid =
+          matchPattern(valid, m_ConstantInt(&validConst)) && validConst.isOne();
+
+      if (!isAlwaysValid) {
+        // Emit conditional load with validity check
+        auto guard =
+            scf::IfOp::create(b, loc, originalLoadedType, valid, true, true);
+
+        // Else branch: return zeros
+        b.setInsertionPointToEnd(guard.getBody(1));
+        Value zeroes = createZeroConstantOp(b, loc, originalLoadedType);
+        scf::YieldOp::create(b, loc, zeroes);
+
+        // Then branch: perform the load
+        b.setInsertionPointToEnd(guard.getBody(0));
+
+        Value loaded = createZeroConstantOp(b, loc, loadedType);
+        perHardwareOp(loadedType, [&](int64_t offset, Type thisOpTy) {
+          Value offsetConst =
+              b.createOrFold<arith::ConstantIndexOp>(loc, offset);
+          Value thisOffsetI32 = offsetI32;
+          if (offset != 0) {
+            Value offsetI32Const = b.createOrFold<arith::ConstantIntOp>(
+                loc, offset * elemBytes, 32);
+            thisOffsetI32 =
+                arith::AddIOp::create(b, loc, offsetI32, offsetI32Const);
+          }
+          Value thisLoad = ROCDL::RawPtrBufferLoadOp::create(
+              b, loc, thisOpTy, rsrc, thisOffsetI32, soffset, aux,
+              /*alias_scopes=*/nullptr, /*noalias_scopes=*/nullptr,
+              /*tbaa=*/nullptr);
+          if (isa<VectorType>(loadedType))
+            loaded = b.createOrFold<InsertSliceOp>(loc, loadedType, thisLoad,
+                                                   loaded, offsetConst);
+          else
+            loaded = thisLoad;
+        });
+        scf::YieldOp::create(b, loc, loaded);
+        b.replaceOp(op, guard.getResult(0));
+      } else {
+        // Always valid: emit load directly
+        Value loaded = createZeroConstantOp(b, loc, loadedType);
+        perHardwareOp(loadedType, [&](int64_t offset, Type thisOpTy) {
+          Value offsetConst =
+              b.createOrFold<arith::ConstantIndexOp>(loc, offset);
+          Value thisOffsetI32 = offsetI32;
+          if (offset != 0) {
+            Value offsetI32Const = b.createOrFold<arith::ConstantIntOp>(
+                loc, offset * elemBytes, 32);
+            thisOffsetI32 =
+                arith::AddIOp::create(b, loc, offsetI32, offsetI32Const);
+          }
+          Value thisLoad = ROCDL::RawPtrBufferLoadOp::create(
+              b, loc, thisOpTy, rsrc, thisOffsetI32, soffset, aux,
+              /*alias_scopes=*/nullptr, /*noalias_scopes=*/nullptr,
+              /*tbaa=*/nullptr);
+          if (isa<VectorType>(loadedType))
+            loaded = b.createOrFold<InsertSliceOp>(loc, loadedType, thisLoad,
+                                                   loaded, offsetConst);
+          else
+            loaded = thisLoad;
+        });
+        b.replaceOp(op, loaded);
+      }
+      return success();
+    }
+
+    // Non-paged load path (existing code)
     Type loadedType;
     SmallVector<Value> coords;
     std::tie(coords, loadedType) = getCoordsAndType(b, op);

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -687,6 +687,18 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
   StringAttr arch = getArchValue(op);
   auto archInfo = rock::lookupArchInfo(arch);
 
+  // Check if this is a paged load
+  Value ldsPagePtrs = adaptor.getLdsPagePtrs();
+  Value firstPageIdx = adaptor.getFirstPageIndex();
+  std::optional<int64_t> pageSize;
+  if (auto pageSizeAttr = op.getPageSizeAttr())
+    pageSize = pageSizeAttr.getInt();
+  std::optional<int64_t> numPagesPerBatch;
+  if (auto numPagesPerBatchAttr = op.getNumPagesPerBatchAttr())
+    numPagesPerBatch = numPagesPerBatchAttr.getInt();
+  bool isPagedLoad = ldsPagePtrs && firstPageIdx && pageSize.has_value() &&
+                     numPagesPerBatch.has_value();
+
   int64_t numValues = dstBufferType.getNumElements();
   bool hwDirectToLDS128b, hwDirectToLDS32b;
   if (isGlobalToLDS) {
@@ -842,9 +854,74 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
 
     if (srcAddrSpace == gpu::AddressSpace::Global &&
         dstAddrSpace == gpu::AddressSpace::Private) {
-      Value loaded = GlobalLoadOp::create(b, loc, loadType, buffer, validity,
-                                          loadLoop.getLowerCoords(/*domain=*/0),
-                                          needs64BitIdx);
+      Value loaded;
+      if (isPagedLoad) {
+        // For paged loads, domain 0 transforms already include the paging
+        // transform which maps to [batch, pageIdx, offsetInPage].
+        // getLowerCoords(0) returns these coordinates directly.
+        ValueRange sourceCoords = loadLoop.getLowerCoords(/*domain=*/0);
+
+        // sourceCoords has shape [batch, pageIdx, offsetInPage]
+        // batch (index 0) is needed to compute global page index.
+        // pageIdx (index 1) is local within the batch.
+        // offsetInPage (index 2) is the offset within the page.
+        assert(sourceCoords.size() >= 3 &&
+               "Expected at least 3 coords for paged source");
+        Value batchIdx = sourceCoords[0];
+        Value localPageIdx = sourceCoords[1];
+        Value offsetInPage = sourceCoords[2];
+
+        // Convert local page index to global:
+        // globalPageIdx = batch * numPagesPerBatch + localPageIdx
+        Value numPagesPerBatchVal =
+            b.createOrFold<arith::ConstantIndexOp>(loc, *numPagesPerBatch);
+        Value batchOffset =
+            arith::MulIOp::create(b, loc, batchIdx, numPagesPerBatchVal);
+        Value globalPageIdx =
+            arith::AddIOp::create(b, loc, batchOffset, localPageIdx);
+
+        // Compute LDS index: globalPageIdx - firstPageIdx
+        // This gives the offset into the LDS page pointer array
+        Value ldsPageIdx =
+            arith::SubIOp::create(b, loc, globalPageIdx, firstPageIdx);
+
+        // Clamp to [0, numPagesForTile-1] to prevent LDS out-of-bounds
+        MemRefType ldsType = cast<MemRefType>(ldsPagePtrs.getType());
+        int64_t numPagesForTile = ldsType.getShape()[0];
+        Value maxValidIdx =
+            b.createOrFold<arith::ConstantIndexOp>(loc, numPagesForTile - 1);
+        Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
+        Value clampedLow = arith::MaxSIOp::create(b, loc, ldsPageIdx, zero);
+        Value clampedIdx =
+            arith::MinSIOp::create(b, loc, clampedLow, maxValidIdx);
+
+        Value pagePtr = memref::LoadOp::create(b, loc, ldsPagePtrs, clampedIdx);
+
+        // Additional validity check: page pointer must not be null.
+        // This handles cases where:
+        // 1. The clamped index points to an LDS slot that was initialized to 0
+        //    (because the page was beyond page table bounds)
+        // 2. The original ldsPageIdx was out of range (clamping was applied)
+        Value zeroI64 = b.createOrFold<arith::ConstantIntOp>(loc, 0, 64);
+        Value pagePtrValid = arith::CmpIOp::create(
+            b, loc, arith::CmpIPredicate::ne, pagePtr, zeroI64);
+        Value combinedValidity =
+            arith::AndIOp::create(b, loc, validity, pagePtrValid);
+
+        // Emit GlobalLoadOp with paging attributes
+        // Pass single flat offset (offsetInPage in elements)
+        loaded = GlobalLoadOp::create(
+            b, loc, loadType, buffer, combinedValidity,
+            ValueRange{offsetInPage}, needs64BitIdx, /*canReadOffEnd=*/false,
+            pagePtr, b.getI64IntegerAttr(*pageSize));
+      } else {
+        // Non-paged load path
+        loaded = GlobalLoadOp::create(
+            b, loc, loadType, buffer, validity,
+            loadLoop.getLowerCoords(/*domain=*/0), needs64BitIdx,
+            /*canReadOffEnd=*/false,
+            /*pagePtr=*/Value{}, /*pageSize=*/nullptr);
+      }
       InBoundsStoreOp::create(b, loc, loaded, dest, destIndex);
     } else if (isGlobalToLDS) {
       int64_t loadTypeByteWidth = getByteWidth(loadType);
@@ -891,9 +968,11 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
       // LDS index is wavefront-uniform as that is needed by load to LDS
       // instruction
       ldsIndex = arith::AddIOp::create(b, loc, ldsIndex, ldsIndexWave);
+
       GlobalLoadToLDSOp::create(b, loc, buffer, dest, validity, directToLDSType,
                                 loadLoop.getLowerCoords(/*domain=*/0),
-                                ValueRange{ldsIndex}, needs64BitIdx);
+                                ValueRange{ldsIndex}, needs64BitIdx,
+                                /*canReadOffEnd=*/false);
     } else {
       if (needs64BitIdx)
         return b.notifyMatchFailure(

--- a/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ThreadwiseGemmLowering.cpp
@@ -885,7 +885,13 @@ LogicalResult ThreadwiseReadIntoRewritePattern::matchAndRewrite(
         Value ldsPageIdx =
             arith::SubIOp::create(b, loc, globalPageIdx, firstPageIdx);
 
-        // Clamp to [0, numPagesForTile-1] to prevent LDS out-of-bounds
+        // Clamp to [0, numPagesForTile-1] to prevent LDS out-of-bounds.
+        // We use signed max/min operations intentionally: if globalPageIdx <
+        // firstPageIdx, the subtraction underflows and produces a bit pattern
+        // that represents a negative value in two's complement. Using signed
+        // comparison correctly detects this underflow and clamps to 0. Unsigned
+        // comparison would treat the underflowed value as a large positive
+        // number, failing to clamp it.
         MemRefType ldsType = cast<MemRefType>(ldsPagePtrs.getType());
         int64_t numPagesForTile = ldsType.getShape()[0];
         Value maxValidIdx =

--- a/mlir/lib/Dialect/Rock/Transforms/TransformToMemref.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/TransformToMemref.cpp
@@ -207,7 +207,15 @@ struct TransformRewritePattern : public OpRewritePattern<TransformOp> {
             }
           }
         }
-        // Fall back to the last non-empty group
+
+        // Fall back to the last non-empty group. This is semantically correct
+        // because:
+        // 1. AddDim always creates dimensions of size 1
+        // 2. Size-1 dimensions can be grouped with any source dimension without
+        //    changing reshape semantics (product of dimension sizes is
+        //    preserved)
+        // 3. The subsequent sort ensures contiguity, which is required by
+        //    expand_shape
         if (!found) {
           for (int srcDim = merges.size() - 1; srcDim >= 0; srcDim--) {
             if (!merges[srcDim].empty()) {

--- a/mlir/lib/Dialect/Rock/Transforms/TransformToMemref.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/TransformToMemref.cpp
@@ -70,14 +70,81 @@ struct TransformRewritePattern : public OpRewritePattern<TransformOp> {
   using OpRewritePattern<TransformOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(TransformOp op,
                                 PatternRewriter &b) const override {
-    auto src = cast<TypedValue<ShapedType>>(op.getOperand());
-    auto srcShape = src.getType().getShape();
-    auto res = cast<TypedValue<ShapedType>>(op.getResult());
-    auto resShape = res.getType().getShape();
+    auto src = cast<TypedValue<MemRefType>>(op.getOperand());
+    MemRefType srcType = src.getType();
+    ArrayRef<int64_t> srcShape = srcType.getShape();
+    auto res = cast<TypedValue<MemRefType>>(op.getResult());
+    MemRefType resType = res.getType();
+    ArrayRef<int64_t> resShape = resType.getShape();
 
+    // First, check if this is a Slice-only transform (possibly with
+    // PassThrough). These need special handling via memref.subview.
+    bool hasSlice = false;
+    bool hasOtherTransforms = false;
+    for (auto tattr : op.getTransform().getOps()) {
+      switch (tattr.getType()) {
+      case rock::TransformType::Slice:
+        hasSlice = true;
+        break;
+      case rock::TransformType::PassThrough:
+        // PassThrough is compatible with Slice
+        break;
+      default:
+        hasOtherTransforms = true;
+        break;
+      }
+    }
+
+    // Handle Slice-only case (possibly with PassThrough)
+    if (hasSlice && !hasOtherTransforms && srcShape.size() == resShape.size()) {
+      // Build subview parameters
+      SmallVector<OpFoldResult> offsets(srcShape.size());
+      SmallVector<OpFoldResult> sizes(srcShape.size());
+      SmallVector<OpFoldResult> strides(srcShape.size());
+
+      // Initialize with identity (offset=0, size=result dim, stride=1)
+      for (size_t i = 0; i < srcShape.size(); i++) {
+        offsets[i] = b.getIndexAttr(0);
+        sizes[i] = b.getIndexAttr(resShape[i]);
+        strides[i] = b.getIndexAttr(1);
+      }
+
+      // Apply Slice parameters
+      for (auto tattr : op.getTransform().getOps()) {
+        if (tattr.getType() == rock::TransformType::Slice) {
+          ArrayRef<int64_t> params = tattr.getParams();
+          ArrayRef<uint32_t> upperDims = tattr.getUpperDims();
+          // Slice params are [start0, end0, start1, end1, ...]
+          for (size_t i = 0; i < upperDims.size(); i++) {
+            int64_t start = params[i * 2];
+            int64_t end = params[i * 2 + 1];
+            uint32_t dim = upperDims[i];
+            offsets[dim] = b.getIndexAttr(start);
+            sizes[dim] = b.getIndexAttr(end - start);
+          }
+        }
+      }
+
+      auto subview = memref::SubViewOp::create(b, op.getLoc(), src, offsets,
+                                               sizes, strides);
+
+      // The subview result type may have a different layout than the expected
+      // result type. Use memref.cast if needed.
+      if (subview.getType() != resType) {
+        b.replaceOpWithNewOp<memref::CastOp>(op, resType, subview);
+      } else {
+        b.replaceOp(op, subview.getResult());
+      }
+      return success();
+    }
+
+    // Handle expand/collapse shape transforms
     bool expanded = resShape.size() > srcShape.size();
     SmallVector<ReassociationIndices> merges(expanded ? srcShape.size()
                                                       : resShape.size());
+
+    // Track AddDim result dimensions (for expanded case) to incorporate later
+    SmallVector<uint32_t> addDimResultDims;
 
     // only converts simple expand/collapse form
     for (auto tattr : op.getTransform().getOps()) {
@@ -97,9 +164,19 @@ struct TransformRewritePattern : public OpRewritePattern<TransformOp> {
       case rock::TransformType::Slice:
       case rock::TransformType::Embed:
       case rock::TransformType::Broadcast:
-      case rock::TransformType::AddDim:
       case rock::TransformType::ConstDim:
         return failure(); // Unsupported
+      case rock::TransformType::AddDim:
+        // AddDim adds a dimension of size 1 that doesn't exist in source.
+        // For expand_shape, we can handle this by including the AddDim
+        // dimension in a source dimension's reassociation group.
+        // Only supported when expanding (adding dimensions).
+        if (!expanded)
+          return failure();
+        // Track the result dimension for later incorporation
+        for (auto outDim : outDims)
+          addDimResultDims.push_back(outDim);
+        break;
       case rock::TransformType::Unmerge:
       case rock::TransformType::Merge: {
         auto inDim = inDims[0];
@@ -109,6 +186,44 @@ struct TransformRewritePattern : public OpRewritePattern<TransformOp> {
         break;
       }
       }
+    }
+
+    // If we have AddDim dimensions to incorporate (in expanded case)
+    if (!addDimResultDims.empty()) {
+      // For each AddDim result dimension, find an adjacent source dimension's
+      // merge group to add it to. An AddDim at result index d should be grouped
+      // with a source dimension whose merge group contains an adjacent result
+      // index (d-1 or d+1).
+      for (auto addDimIdx : addDimResultDims) {
+        bool found = false;
+        // First, try to find a merge group containing an adjacent result dim
+        for (size_t srcDim = 0; srcDim < merges.size() && !found; srcDim++) {
+          for (int32_t idx : merges[srcDim]) {
+            if (idx == static_cast<int32_t>(addDimIdx) - 1 ||
+                idx == static_cast<int32_t>(addDimIdx) + 1) {
+              merges[srcDim].push_back(addDimIdx);
+              found = true;
+              break;
+            }
+          }
+        }
+        // Fall back to the last non-empty group
+        if (!found) {
+          for (int srcDim = merges.size() - 1; srcDim >= 0; srcDim--) {
+            if (!merges[srcDim].empty()) {
+              merges[srcDim].push_back(addDimIdx);
+              found = true;
+              break;
+            }
+          }
+        }
+        if (!found)
+          return failure(); // No suitable group found
+      }
+
+      // Sort each reassociation group (required by expand_shape)
+      for (auto &group : merges)
+        llvm::sort(group);
     }
 
     if (srcShape == resShape) {

--- a/mlir/lib/Dialect/Rock/Transforms/TransformToMemref.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/TransformToMemref.cpp
@@ -61,6 +61,88 @@ struct RockTransformToMemrefPass
   void runOnOperation() override;
 };
 
+// Try to lower a Slice-only transform to memref.subview.
+// Slice transforms require separate handling from the expand/collapse path
+// because they represent fundamentally different operations:
+// - Slice: Extracts a contiguous subset of the memref starting at an offset.
+//   This maps naturally to `memref.subview` which supports offsets and sizes.
+// - Expand/Collapse (Merge, Unmerge, AddDim): These only change how dimensions
+//   are grouped/split, without changing the data range. They map to
+//   `memref.expand_shape` / `memref.collapse_shape` which do not support
+//   offsets.
+//
+// Because of this fundamental difference, Slice cannot be combined with
+// expand/collapse transforms in a single lowering. We handle Slice-only
+// transforms here via subview, and let the expand/collapse path handle
+// reshape-only transforms.
+static LogicalResult tryLowerSliceToSubview(TransformOp op,
+                                            PatternRewriter &b,
+                                            TypedValue<MemRefType> src,
+                                            MemRefType resType,
+                                            ArrayRef<int64_t> srcShape,
+                                            ArrayRef<int64_t> resShape) {
+  // Check if this is a Slice-only transform (possibly with PassThrough).
+  bool hasSlice = false;
+  bool hasOtherTransforms = false;
+  for (auto tattr : op.getTransform().getOps()) {
+    switch (tattr.getType()) {
+    case rock::TransformType::Slice:
+      hasSlice = true;
+      break;
+    case rock::TransformType::PassThrough:
+      // PassThrough is compatible with Slice
+      break;
+    default:
+      hasOtherTransforms = true;
+      break;
+    }
+  }
+
+  // Only handle pure Slice transforms where rank is preserved.
+  if (!hasSlice || hasOtherTransforms || srcShape.size() != resShape.size())
+    return failure();
+
+  // Build subview parameters
+  SmallVector<OpFoldResult> offsets(srcShape.size());
+  SmallVector<OpFoldResult> sizes(srcShape.size());
+  SmallVector<OpFoldResult> strides(srcShape.size());
+
+  // Initialize with identity (offset=0, size=result dim, stride=1)
+  for (size_t i = 0; i < srcShape.size(); i++) {
+    offsets[i] = b.getIndexAttr(0);
+    sizes[i] = b.getIndexAttr(resShape[i]);
+    strides[i] = b.getIndexAttr(1);
+  }
+
+  // Apply Slice parameters
+  for (auto tattr : op.getTransform().getOps()) {
+    if (tattr.getType() == rock::TransformType::Slice) {
+      ArrayRef<int64_t> params = tattr.getParams();
+      ArrayRef<uint32_t> upperDims = tattr.getUpperDims();
+      // Slice params are [start0, end0, start1, end1, ...]
+      for (size_t i = 0; i < upperDims.size(); i++) {
+        int64_t start = params[i * 2];
+        int64_t end = params[i * 2 + 1];
+        uint32_t dim = upperDims[i];
+        offsets[dim] = b.getIndexAttr(start);
+        sizes[dim] = b.getIndexAttr(end - start);
+      }
+    }
+  }
+
+  auto subview =
+      memref::SubViewOp::create(b, op.getLoc(), src, offsets, sizes, strides);
+
+  // The subview result type may have a different layout than the expected
+  // result type. Use memref.cast if needed.
+  if (subview.getType() != resType) {
+    b.replaceOpWithNewOp<memref::CastOp>(op, resType, subview);
+  } else {
+    b.replaceOp(op, subview.getResult());
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // TransformOp conversion to MemRef
 //   This is needed for init kernels that don't fold rock.transform into
@@ -77,66 +159,10 @@ struct TransformRewritePattern : public OpRewritePattern<TransformOp> {
     MemRefType resType = res.getType();
     ArrayRef<int64_t> resShape = resType.getShape();
 
-    // First, check if this is a Slice-only transform (possibly with
-    // PassThrough). These need special handling via memref.subview.
-    bool hasSlice = false;
-    bool hasOtherTransforms = false;
-    for (auto tattr : op.getTransform().getOps()) {
-      switch (tattr.getType()) {
-      case rock::TransformType::Slice:
-        hasSlice = true;
-        break;
-      case rock::TransformType::PassThrough:
-        // PassThrough is compatible with Slice
-        break;
-      default:
-        hasOtherTransforms = true;
-        break;
-      }
-    }
-
-    // Handle Slice-only case (possibly with PassThrough)
-    if (hasSlice && !hasOtherTransforms && srcShape.size() == resShape.size()) {
-      // Build subview parameters
-      SmallVector<OpFoldResult> offsets(srcShape.size());
-      SmallVector<OpFoldResult> sizes(srcShape.size());
-      SmallVector<OpFoldResult> strides(srcShape.size());
-
-      // Initialize with identity (offset=0, size=result dim, stride=1)
-      for (size_t i = 0; i < srcShape.size(); i++) {
-        offsets[i] = b.getIndexAttr(0);
-        sizes[i] = b.getIndexAttr(resShape[i]);
-        strides[i] = b.getIndexAttr(1);
-      }
-
-      // Apply Slice parameters
-      for (auto tattr : op.getTransform().getOps()) {
-        if (tattr.getType() == rock::TransformType::Slice) {
-          ArrayRef<int64_t> params = tattr.getParams();
-          ArrayRef<uint32_t> upperDims = tattr.getUpperDims();
-          // Slice params are [start0, end0, start1, end1, ...]
-          for (size_t i = 0; i < upperDims.size(); i++) {
-            int64_t start = params[i * 2];
-            int64_t end = params[i * 2 + 1];
-            uint32_t dim = upperDims[i];
-            offsets[dim] = b.getIndexAttr(start);
-            sizes[dim] = b.getIndexAttr(end - start);
-          }
-        }
-      }
-
-      auto subview = memref::SubViewOp::create(b, op.getLoc(), src, offsets,
-                                               sizes, strides);
-
-      // The subview result type may have a different layout than the expected
-      // result type. Use memref.cast if needed.
-      if (subview.getType() != resType) {
-        b.replaceOpWithNewOp<memref::CastOp>(op, resType, subview);
-      } else {
-        b.replaceOp(op, subview.getResult());
-      }
+    // Try Slice-only lowering first
+    if (succeeded(tryLowerSliceToSubview(op, b, src, resType, srcShape,
+                                         resShape)))
       return success();
-    }
 
     // Handle expand/collapse shape transforms
     bool expanded = resShape.size() > srcShape.size();
@@ -196,7 +222,6 @@ struct TransformRewritePattern : public OpRewritePattern<TransformOp> {
       // index (d-1 or d+1).
       for (auto addDimIdx : addDimResultDims) {
         bool found = false;
-        // First, try to find a merge group containing an adjacent result dim
         for (size_t srcDim = 0; srcDim < merges.size() && !found; srcDim++) {
           for (int32_t idx : merges[srcDim]) {
             if (idx == static_cast<int32_t>(addDimIdx) - 1 ||
@@ -208,25 +233,8 @@ struct TransformRewritePattern : public OpRewritePattern<TransformOp> {
           }
         }
 
-        // Fall back to the last non-empty group. This is semantically correct
-        // because:
-        // 1. AddDim always creates dimensions of size 1
-        // 2. Size-1 dimensions can be grouped with any source dimension without
-        //    changing reshape semantics (product of dimension sizes is
-        //    preserved)
-        // 3. The subsequent sort ensures contiguity, which is required by
-        //    expand_shape
-        if (!found) {
-          for (int srcDim = merges.size() - 1; srcDim >= 0; srcDim--) {
-            if (!merges[srcDim].empty()) {
-              merges[srcDim].push_back(addDimIdx);
-              found = true;
-              break;
-            }
-          }
-        }
         if (!found)
-          return failure(); // No suitable group found
+          return failure(); // AddDim not adjacent to any group
       }
 
       // Sort each reassociation group (required by expand_shape)

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -8,6 +8,8 @@
 
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -2679,4 +2681,81 @@ FailureOr<Type> mlir::rock::getInputFusionElementType(Value transformed) {
   }
 
   return shapedTy.getElementType();
+}
+
+FailureOr<Value> mlir::rock::computeFlatPosition(OpBuilder &b, Location loc,
+                                                 Value source,
+                                                 ValueRange indices) {
+  // Walk the transform chain on source to collect TransformMapAttrs.
+  // Stop at rock.deref, we only want transforms in the virtual address space,
+  // not the underlying page table structure.
+  SmallVector<TransformMapAttr> sourceTransforms;
+  Value baseSource = source;
+  while (auto transformOp = baseSource.getDefiningOp<TransformOp>()) {
+    if (transformOp.getInput().getDefiningOp<DerefOp>()) {
+      break;
+    }
+    sourceTransforms.push_back(transformOp.getTransform());
+    baseSource = transformOp.getInput();
+  }
+
+  // Start with the input coordinates (indices from the op).
+  // The transforms may expect more dimensions (e.g., iter=0 for tile origin).
+  SmallVector<Value> currentCoords(indices.begin(), indices.end());
+
+  // Pad with zeros if the first transform expects more inputs than we have.
+  // This handles the case where gridSubTile expects (indices..., iter)
+  // and we want to evaluate at iter=0 for the tile's starting position.
+  if (!sourceTransforms.empty()) {
+    AffineMap firstMap = sourceTransforms[0].getMap().getAffineMap();
+    Value zero = b.createOrFold<arith::ConstantIndexOp>(loc, 0);
+    while (currentCoords.size() < firstMap.getNumInputs()) {
+      currentCoords.push_back(zero);
+    }
+  }
+
+  // Evaluate transforms in order (outermost first, then inner)
+  // to get the flat position. Each transform maps upper -> lower coords.
+  for (auto [idx, transform] : llvm::enumerate(sourceTransforms)) {
+    AffineMap map = transform.getMap().getAffineMap();
+    if (map.getNumInputs() != currentCoords.size())
+      return failure();
+    std::optional<SmallVector<Value>> transformed =
+        affine::expandAffineMap(b, loc, map, currentCoords);
+    if (!transformed)
+      return failure();
+    currentCoords = std::move(*transformed);
+  }
+
+  if (currentCoords.empty())
+    return failure();
+
+  // If we have a single coordinate, return it directly.
+  if (currentCoords.size() == 1)
+    return currentCoords.back();
+
+  // For multi-dimensional coordinates (e.g., [batch, total] for paged memory),
+  // compute the row-major flattened position across all dimensions.
+  // We need the shape of the baseSource to compute strides.
+  auto baseType = dyn_cast<MemRefType>(baseSource.getType());
+  if (!baseType ||
+      baseType.getRank() != static_cast<int64_t>(currentCoords.size()))
+    return failure();
+
+  ArrayRef<int64_t> shape = baseType.getShape();
+
+  // Compute flat position: sum of coord[i] * product(shape[i+1:])
+  Value flatPos = currentCoords.back();
+  for (int i = static_cast<int>(currentCoords.size()) - 2; i >= 0; --i) {
+    // Compute stride for dimension i (product of all dimensions after i)
+    int64_t stride = 1;
+    for (size_t j = i + 1; j < shape.size(); ++j) {
+      stride *= shape[j];
+    }
+    Value strideVal = b.createOrFold<arith::ConstantIndexOp>(loc, stride);
+    Value term = arith::MulIOp::create(b, loc, currentCoords[i], strideVal);
+    flatPos = arith::AddIOp::create(b, loc, flatPos, term);
+  }
+
+  return flatPos;
 }

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -907,3 +907,176 @@ func.func @gridwise_attn_wavespereu_outputswizzle(%arg0: memref<1474560xf16>, %a
   } {blockSize = 128 : i32, enableSoftmax = false, firstGemmIndices = array<i64: 0>, splitKV = 1 : i32, gridSize = 512 : i32, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 0, 0, 0, 1, 0>, params0 = #rock.accel_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 8, mPerWave = 32, nPerWave = 16, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 1, wavesPerEU = 4, gridGroupSize = 0, forceUnroll = true>, params1 = #rock.accel_gemm_params<kpackPerBlock = 4, mPerBlock = 128, nPerBlock = 32, kpack = 8, mPerWave = 128, nPerWave = 16, mnPerXdl = 16, splitKFactor = 4, scheduleVersion = 1, outputSwizzle = 1, wavesPerEU = 4, gridGroupSize = 0, forceUnroll = true>, storeMethod = #rock<StoreMethod atomic_add>} : memref<4x512x4096xf16>, memref<4x512x1024xf16>, memref<4x1024x384xf16>, memref<4x4096x384xf16>
   return
 }
+
+// -----
+
+#accel_gemm_params = #rock.accel_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 1, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0, forceUnroll = true>
+#map = affine_map<(d0, d1, d2, d3) -> ((d1 * 18 + d2) * 64 + d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>
+#map2 = affine_map<(d0, d1, d2) -> (d1 * 64 + d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map4 = affine_map<(d0, d1) -> (0, 0, d1)>
+#map5 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map7 = affine_map<(d0, d1) -> (d0, d1 floordiv 8192, d1 mod 8192)>
+#map8 = affine_map<(d0, d1, d2, d3, d4) -> (d0, (d1 * 4096 + d3) * 64 + d4)>
+#map9 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, 0, d3, d4)>
+#map10 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4, d3)>
+#map11 = affine_map<(d0, d1, d2) -> (0, d0, d1, d2)>
+#map12 = affine_map<(d0, d1, d2) -> (0, d0 floordiv 7, d0 mod 7, d1, d2)>
+#map13 = affine_map<(d0, d1, d2, d3) -> (((d0 * 1500 + d1) * 14 + d2) * 64 + d3)>
+#map14 = affine_map<(d0, d1) -> (d1)>
+#map15 = affine_map<(d0, d1) -> (d0, 0)>
+#map16 = affine_map<(d0) -> (0, d0)>
+#map17 = affine_map<(d0, d1, d2, d3, d4) -> ((d0 * 2 + d1) * 7 + d2, d3, d4)>
+#map18 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#map19 = affine_map<(d0, d1, d2) -> (0, d0, 0, d1, d2)>
+#map20 = affine_map<(d0, d1, d2) -> (d0, d2, d1)>
+#map21 = affine_map<(d0, d1, d2, d3) -> (d0 * 7 + d3, d1, d2)>
+#map22 = affine_map<(d0, d1, d2) -> (d0, d1, d2 floordiv 7, d2 mod 7)>
+#map23 = affine_map<(d0, d1) -> (d0 * 7 + d1)>
+#map24 = affine_map<(d0, d1) -> (d0, d1)>
+#map25 = affine_map<(d0) -> (d0, 0)>
+#map26 = affine_map<(d0, d1, d2, d3, d4) -> (d0 * 7 + d3 + d1, d2, d4)>
+#map27 = affine_map<(d0, d1, d2) -> (d0, 0, d1 floordiv 7, d1 mod 7, d2)>
+#map28 = affine_map<(d0, d1, d2, d3) -> (d2 * 4096 + d3)>
+#map29 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, d3)>
+#map30 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#transform_map = #rock.transform_map<#map by [<Unmerge{1500, 18, 64} ["exp1", "exp2", "exp3"] at [1, 2, 3] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 1500, 18, 64] -> [1728000]>
+#transform_map1 = #rock.transform_map<#map1 by [<PassThrough ["dim0", "dim2", "dim1", "dim3"] at [0, 1, 2, 3] -> ["dim0", "dim2", "dim1", "dim3"] at [0, 2, 1, 3]>] bounds = [1, 18, 1500, 64] -> [1, 1500, 18, 64]>
+#transform_map2 = #rock.transform_map<#map2 by [<Unmerge{16, 64} ["exp1", "exp2"] at [1, 2] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 16, 64] -> [1024]>
+#transform_map3 = #rock.transform_map<#map3 by [<Slice{0, 1, 0, 1, 0, 64} ["dim0_sliced", "dim1_sliced", "dim2_sliced"] at [0, 1, 2] -> ["dim0", "dim1", "dim2"] at [0, 1, 2]>] bounds = [1, 1, 64] -> [1, 16, 64]>
+#transform_map4 = #rock.transform_map<#map4 by [<Merge{1, 1} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>] bounds = [1, 64] -> [1, 1, 64]>
+#transform_map5 = #rock.transform_map<#map5 by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <Unmerge{64} ["exp1"] at [1] -> ["dim1"] at [1]>, <AddDim{1} ["unit2"] at [2] -> [] at []>] bounds = [1, 64, 1] -> [1, 64]>
+#transform_map6 = #rock.transform_map<#map6 by [<Slice{0, 1, 0, 14, 0, 1500, 0, 64} ["dim0_sliced", "dim1_sliced", "dim2_sliced", "dim3_sliced"] at [0, 1, 2, 3] -> ["dim0", "dim1", "dim2", "dim3"] at [0, 1, 2, 3]>] bounds = [1, 14, 1500, 64] -> [1, 18, 1500, 64]>
+#transform_map7 = #rock.transform_map<#map7 by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <Merge{64, 8192} ["dim1"] at [1] -> ["col1", "col2"] at [1, 2]>] bounds = [1, 524288] -> [1, 64, 8192]>
+#transform_map8 = #rock.transform_map<#map8 by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <Unmerge{2, 4096, 64} ["exp1", "exp3", "exp4"] at [1, 3, 4] -> ["dim1"] at [1]>, <AddDim{1} ["unit2"] at [2] -> [] at []>] bounds = [1, 2, 1, 4096, 64] -> [1, 524288]>
+#transform_map9 = #rock.transform_map<#map9 by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>, <PassThrough ["dim3"] at [3] -> ["dim3"] at [3]>, <PassThrough ["dim4"] at [4] -> ["dim4"] at [4]>] bounds = [1, 2, 7, 4096, 64] -> [1, 2, 1, 4096, 64]>
+#transform_map10 = #rock.transform_map<#map10 by [<PassThrough ["dim0", "dim1", "dim2", "dim4", "dim3"] at [0, 1, 2, 3, 4] -> ["dim0", "dim1", "dim2", "dim4", "dim3"] at [0, 1, 2, 4, 3]>] bounds = [1, 2, 1, 64, 4096] -> [1, 2, 1, 4096, 64]>
+#transform_map11 = #rock.transform_map<#map9 by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [1]>, <Broadcast{1} ["dim2"] at [2] -> ["dim2"] at [2]>, <PassThrough ["dim3"] at [3] -> ["dim3"] at [3]>, <PassThrough ["dim4"] at [4] -> ["dim4"] at [4]>] bounds = [1, 2, 7, 64, 4096] -> [1, 2, 1, 64, 4096]>
+#transform_map12 = #rock.transform_map<#map11 by [<Merge{1, 14} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>] bounds = [14, 1500, 64] -> [1, 14, 1500, 64]>
+#transform_map13 = #rock.transform_map<#map12 by [<Merge{1, 2, 7} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [3]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [4]>] bounds = [14, 64, 4096] -> [1, 2, 7, 64, 4096]>
+#transform_map14 = #rock.transform_map<#map12 by [<Merge{1, 2, 7} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [3]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [4]>] bounds = [14, 4096, 64] -> [1, 2, 7, 4096, 64]>
+#transform_map15 = #rock.transform_map<#map13 by [<Unmerge{1, 1500, 14, 64} ["col0", "col1", "col2", "col3"] at [0, 1, 2, 3] -> ["dim0"] at [0]>] bounds = [1, 1500, 14, 64] -> [1344000]>
+#transform_map16 = #rock.transform_map<#map1 by [<PassThrough ["dim0", "dim2", "dim1", "dim3"] at [0, 2, 1, 3] -> ["dim0", "dim2", "dim1", "dim3"] at [0, 1, 2, 3]>] bounds = [1, 14, 1500, 64] -> [1, 1500, 14, 64]>
+#transform_map17 = #rock.transform_map<#map11 by [<Merge{14} ["dim0"] at [0] -> ["exp1"] at [1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>, <ConstDim{0, 1} [] at [] -> ["unit0"] at [0]>] bounds = [14, 1500, 64] -> [1, 14, 1500, 64]>
+#transform_map18 = #rock.transform_map<#map14 by [<Unmerge{1} ["exp1"] at [1] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 1] -> [1]>
+#transform_map19 = #rock.transform_map<#map15 by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <Broadcast{1} ["dim1"] at [1] -> ["dim1"] at [1]>] bounds = [1, 14] -> [1, 1]>
+#transform_map20 = #rock.transform_map<#map16 by [<Merge{1, 14} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>] bounds = [14] -> [1, 14]>
+#transform_map21 = #rock.transform_map<#map17 by [<Unmerge{1, 2, 7} ["batch", "num_heads", "repeat"] at [0, 1, 2] -> ["group"] at [0]>, <PassThrough ["dim0", "dim1"] at [3, 4] -> ["dim0", "dim1"] at [1, 2]>] bounds = [1, 2, 7, 64, 4096] -> [14, 64, 4096]>
+#transform_map22 = #rock.transform_map<#map18 by [<Slice{0, 1} ["repeat"] at [2] -> ["repeat"] at [2]>, <PassThrough ["batch", "num_heads", "dim0", "dim1"] at [0, 1, 3, 4] -> ["batch", "num_heads", "dim0", "dim1"] at [0, 1, 3, 4]>] bounds = [1, 2, 1, 64, 4096] -> [1, 2, 7, 64, 4096]>
+#transform_map23 = #rock.transform_map<#map19 by [<Merge{1, 2, 1} ["group"] at [0] -> ["batch", "num_heads", "repeat"] at [0, 1, 2]>, <PassThrough ["dim0", "dim1"] at [1, 2] -> ["dim0", "dim1"] at [3, 4]>] bounds = [2, 64, 4096] -> [1, 2, 1, 64, 4096]>
+#transform_map24 = #rock.transform_map<#map17 by [<Unmerge{1, 2, 7} ["batch", "num_heads", "repeat"] at [0, 1, 2] -> ["group"] at [0]>, <PassThrough ["dim0", "dim1"] at [3, 4] -> ["dim0", "dim1"] at [1, 2]>] bounds = [1, 2, 7, 4096, 64] -> [14, 4096, 64]>
+#transform_map25 = #rock.transform_map<#map18 by [<Slice{0, 1} ["repeat"] at [2] -> ["repeat"] at [2]>, <PassThrough ["batch", "num_heads", "dim0", "dim1"] at [0, 1, 3, 4] -> ["batch", "num_heads", "dim0", "dim1"] at [0, 1, 3, 4]>] bounds = [1, 2, 1, 4096, 64] -> [1, 2, 7, 4096, 64]>
+#transform_map26 = #rock.transform_map<#map19 by [<Merge{1, 2, 1} ["group"] at [0] -> ["batch", "num_heads", "repeat"] at [0, 1, 2]>, <PassThrough ["dim0", "dim1"] at [1, 2] -> ["dim0", "dim1"] at [3, 4]>] bounds = [2, 4096, 64] -> [1, 2, 1, 4096, 64]>
+#transform_map27 = #rock.transform_map<#map20 by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [14, 64, 1500] -> [14, 1500, 64]>
+#transform_map28 = #rock.transform_map<#map21 by [<Unmerge{2, 7} ["gemmG", "numRepeats"] at [0, 3] -> ["gemmG"] at [0]>, <PassThrough ["seqLen", "headDim"] at [2, 1] -> ["seqLen", "headDim"] at [2, 1]>] bounds = [2, 64, 1500, 7] -> [14, 64, 1500]>
+#transform_map29 = #rock.transform_map<#map22 by [<Merge{1500, 7} ["seqLen"] at [2] -> ["seqLen", "numRepeats"] at [2, 3]>, <PassThrough ["gemmG", "headDim"] at [0, 1] -> ["gemmG", "headDim"] at [0, 1]>] bounds = [2, 64, 10500] -> [2, 64, 1500, 7]>
+#transform_map30 = #rock.transform_map<#map23 by [<Unmerge{2, 7} ["gemmG", "numRepeats"] at [0, 1] -> ["gemmG"] at [0]>] bounds = [2, 7] -> [14]>
+#transform_map31 = #rock.transform_map<#map24 by [<Slice{0, 1} ["numRepeats"] at [1] -> ["numRepeats"] at [1]>, <PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>] bounds = [2, 1] -> [2, 7]>
+#transform_map32 = #rock.transform_map<#map25 by [<Merge{2, 1} ["seqLen"] at [0] -> ["gemmG", "numRepeats"] at [0, 1]>] bounds = [2] -> [2, 1]>
+#transform_map33 = #rock.transform_map<#map26 by [<Unmerge{2, 7, 1} ["gemmG", "numRepeats", "splitKV"] at [0, 3, 1] -> ["gemmG"] at [0]>, <PassThrough ["seqLen", "headDim"] at [2, 4] -> ["seqLen", "headDim"] at [1, 2]>] bounds = [2, 1, 1500, 7, 64] -> [14, 1500, 64]>
+#transform_map34 = #rock.transform_map<#map27 by [<Merge{1500, 7} ["seqLen"] at [1] -> ["seqLen", "numRepeats"] at [2, 3]>, <Merge{2, 1} ["gemmG"] at [0] -> ["gemmG", "splitKV"] at [0, 1]>, <PassThrough ["headDim"] at [2] -> ["headDim"] at [4]>] bounds = [2, 10500, 64] -> [2, 1, 1500, 7, 64]>
+#transform_map35 = #rock.transform_map<#map3 by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K"] at [1] -> ["gemm0K"] at [1]>, <Pad{0, 28} ["gemm0NPad"] at [2] -> ["gemm0N"] at [2]>] bounds = [2, 64, 10528] -> [2, 64, 10500]>
+#transform_map36 = #rock.transform_map<#map3 by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <Pad{0, 28} ["gemm1NPad"] at [1] -> ["gemm1N"] at [1]>, <PassThrough ["gemm1M"] at [2] -> ["gemm1M"] at [2]>] bounds = [2, 10528, 64] -> [2, 10500, 64]>
+#transform_map37 = #rock.transform_map<#map28 by [<Unmerge{1500, 4096} ["exp2", "exp3"] at [2, 3] -> ["dim0"] at [0]>, <AddDim{1} ["unit0"] at [0] -> [] at []>, <AddDim{1} ["unit1"] at [1] -> [] at []>] bounds = [1, 1, 1500, 4096] -> [6144000]>
+#transform_map38 = #rock.transform_map<#map29 by [<PassThrough ["dim0"] at [0] -> ["dim0"] at [0]>, <Broadcast{1} ["dim1"] at [1] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [2]>, <PassThrough ["dim3"] at [3] -> ["dim3"] at [3]>] bounds = [1, 14, 1500, 4096] -> [1, 1, 1500, 4096]>
+#transform_map39 = #rock.transform_map<#map30 by [<Unmerge{14} ["exp1"] at [1] -> ["dim0"] at [0]>, <PassThrough ["dim1"] at [2] -> ["dim1"] at [1]>, <PassThrough ["dim2"] at [3] -> ["dim2"] at [2]>, <AddDim{1} ["unit0"] at [0] -> [] at []>] bounds = [1, 14, 1500, 4096] -> [14, 1500, 4096]>
+#transform_map40 = #rock.transform_map<#map11 by [<Merge{1, 14} ["dim0"] at [0] -> ["col0", "col1"] at [0, 1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>] bounds = [14, 1500, 4096] -> [1, 14, 1500, 4096]>
+#transform_map41 = #rock.transform_map<#map11 by [<Merge{14} ["dim0"] at [0] -> ["exp1"] at [1]>, <PassThrough ["dim1"] at [1] -> ["dim1"] at [2]>, <PassThrough ["dim2"] at [2] -> ["dim2"] at [3]>, <ConstDim{0, 1} [] at [] -> ["unit0"] at [0]>] bounds = [14, 1500, 4096] -> [1, 14, 1500, 4096]>
+module {
+  // CHECK-LABEL: func.func @mlir_slice_reshape_add_slice_div_greater_convert
+  func.func @mlir_slice_reshape_add_slice_div_greater_convert_where_convert_reshape_slice_reshape_add_slice_convert_where_convert_reshape_slice_unsqueeze_reshape_unsqueeze_transpose_reshape_dot_mul_where_broadcast_greater_convert_where_convert_reshape_reduce_max_reshape_sub_exp_reshape_reduce_sum_reshape_div_convert_dot_transpose_reshape(%arg0: memref<1024xi64>, %arg1: memref<1024xi64>, %arg2: memref<1xi32>, %arg3: memref<6144000xi8>, %arg4: memref<1728000xf16>, %arg5: memref<1344000xf16>) attributes {arch = "gfx942", block_size = 64 : i32, features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16|direct_to_lds_32b>, grid_size = 658 : i32, kernel = "mixr", num_cu = 32 : i64} {
+    %cst = arith.constant 0xFC00 : f16
+    %cst_0 = arith.constant 1.250000e-01 : f16
+    %c0_i8 = arith.constant 0 : i8
+    %0 = rock.transform %arg4 by #transform_map : memref<1728000xf16> to memref<1x1500x18x64xf16>
+    %1 = rock.transform %0 by #transform_map1 : memref<1x1500x18x64xf16> to memref<1x18x1500x64xf16>
+    %2 = rock.transform %arg1 by #transform_map2 : memref<1024xi64> to memref<1x16x64xi64>
+    %3 = rock.transform %arg0 by #transform_map2 : memref<1024xi64> to memref<1x16x64xi64>
+    %4 = rock.transform %3 by #transform_map3 : memref<1x16x64xi64> to memref<1x1x64xi64>
+    %5 = rock.transform %4 by #transform_map4 : memref<1x1x64xi64> to memref<1x64xi64>
+    %6 = rock.transform %5 by #transform_map5 : memref<1x64xi64> to memref<1x64x1xi64>
+    // CHECK-DAG: rock.deref %{{.+}} : memref<1x64x1xi64> -> memref<1x64x8192xf16>
+    %7 = rock.deref %6 : memref<1x64x1xi64> -> memref<1x64x8192xf16>
+    %8 = rock.transform %2 by #transform_map3 : memref<1x16x64xi64> to memref<1x1x64xi64>
+    %9 = rock.transform %8 by #transform_map4 : memref<1x1x64xi64> to memref<1x64xi64>
+    %10 = rock.transform %9 by #transform_map5 : memref<1x64xi64> to memref<1x64x1xi64>
+    // CHECK-DAG: rock.deref %{{.+}} : memref<1x64x1xi64> -> memref<1x64x8192xf16>
+    %11 = rock.deref %10 : memref<1x64x1xi64> -> memref<1x64x8192xf16>
+    %12 = rock.transform %1 by #transform_map6 : memref<1x18x1500x64xf16> to memref<1x14x1500x64xf16>
+    %13 = rock.transform %7 by #transform_map7 : memref<1x64x8192xf16> to memref<1x524288xf16>
+    %14 = rock.transform %13 by #transform_map8 : memref<1x524288xf16> to memref<1x2x1x4096x64xf16>
+    %15 = rock.transform %14 by #transform_map9 : memref<1x2x1x4096x64xf16> to memref<1x2x7x4096x64xf16>
+    %16 = rock.transform %11 by #transform_map7 : memref<1x64x8192xf16> to memref<1x524288xf16>
+    %17 = rock.transform %16 by #transform_map8 : memref<1x524288xf16> to memref<1x2x1x4096x64xf16>
+    %18 = rock.transform %17 by #transform_map10 : memref<1x2x1x4096x64xf16> to memref<1x2x1x64x4096xf16>
+    %19 = rock.transform %18 by #transform_map11 : memref<1x2x1x64x4096xf16> to memref<1x2x7x64x4096xf16>
+    %20 = rock.transform %12 by #transform_map12 : memref<1x14x1500x64xf16> to memref<14x1500x64xf16>
+    %21 = rock.transform %19 by #transform_map13 : memref<1x2x7x64x4096xf16> to memref<14x64x4096xf16>
+    %22 = rock.transform %15 by #transform_map14 : memref<1x2x7x4096x64xf16> to memref<14x4096x64xf16>
+    %alloc = memref.alloc() : memref<1344000xf16>
+    %23 = rock.transform %alloc by #transform_map15 : memref<1344000xf16> to memref<1x1500x14x64xf16>
+    %24 = rock.transform %23 by #transform_map16 : memref<1x1500x14x64xf16> to memref<1x14x1500x64xf16>
+    %25 = rock.transform %24 by #transform_map17 : memref<1x14x1500x64xf16> to memref<14x1500x64xf16>
+    %26 = rock.transform %arg2 by #transform_map18 : memref<1xi32> to memref<1x1xi32>
+    %27 = rock.transform %26 by #transform_map19 : memref<1x1xi32> to memref<1x14xi32>
+    %28 = rock.transform %27 by #transform_map20 : memref<1x14xi32> to memref<14xi32>
+    %29 = rock.transform %21 by #transform_map21 : memref<14x64x4096xf16> to memref<1x2x7x64x4096xf16>
+    %30 = rock.transform %29 by #transform_map22 : memref<1x2x7x64x4096xf16> to memref<1x2x1x64x4096xf16>
+    %31 = rock.transform %30 by #transform_map23 : memref<1x2x1x64x4096xf16> to memref<2x64x4096xf16>
+    %32 = rock.transform %22 by #transform_map24 : memref<14x4096x64xf16> to memref<1x2x7x4096x64xf16>
+    %33 = rock.transform %32 by #transform_map25 : memref<1x2x7x4096x64xf16> to memref<1x2x1x4096x64xf16>
+    %34 = rock.transform %33 by #transform_map26 : memref<1x2x1x4096x64xf16> to memref<2x4096x64xf16>
+    %35 = rock.transform %20 by #transform_map27 : memref<14x1500x64xf16> to memref<14x64x1500xf16>
+    %36 = rock.transform %35 by #transform_map28 : memref<14x64x1500xf16> to memref<2x64x1500x7xf16>
+    %37 = rock.transform %36 by #transform_map29 : memref<2x64x1500x7xf16> to memref<2x64x10500xf16>
+    %38 = rock.transform %28 by #transform_map30 : memref<14xi32> to memref<2x7xi32>
+    %39 = rock.transform %38 by #transform_map31 : memref<2x7xi32> to memref<2x1xi32>
+    %40 = rock.transform %39 by #transform_map32 : memref<2x1xi32> to memref<2xi32>
+    %41 = rock.transform %25 by #transform_map33 : memref<14x1500x64xf16> to memref<2x1x1500x7x64xf16>
+    %42 = rock.transform %41 by #transform_map34 : memref<2x1x1500x7x64xf16> to memref<2x10500x64xf16>
+    %43 = rock.transform %37 by #transform_map35 : memref<2x64x10500xf16> to memref<2x64x10528xf16>
+    %44 = rock.transform %42 by #transform_map36 : memref<2x10500x64xf16> to memref<2x10528x64xf16>
+    // CHECK-DAG: %[[C8192:.+]] = arith.constant 8192 : index
+    // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : index
+    // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+    // CHECK: scf.for
+    // CHECK: arith.divui %{{.+}}, %[[C8192]] : index
+    // CHECK: %[[WID_K:.+]] = rock.workitem_id : index
+    // CHECK: %[[SHOULD_LOAD_K:.+]] = arith.cmpi ult, %[[WID_K]], %[[C2]] : index
+    // CHECK: scf.if %[[SHOULD_LOAD_K]] {
+    // CHECK:   arith.addi %{{.+}}, %[[WID_K]] : index
+    // CHECK:   arith.divui %{{.+}}, %[[C64]] : index
+    // CHECK:   arith.remui %{{.+}}, %[[C64]] : index
+    // CHECK:   scf.if
+    // CHECK:     memref.load %{{.+}} : memref<1x64x1xi64>
+    // CHECK:     memref.store %{{.+}}, %{{.+}} : memref<{{.+}}xi64, #gpu.address_space<workgroup>>
+    // CHECK: rock.lds_barrier
+    // CHECK: rock.threadwise_read_into {{{.*}}pageSize = 8192 : index{{.*}}}
+    // CHECK-SAME: paged %{{.+}} : memref<{{.+}}xi64, #gpu.address_space<workgroup>>
+    // CHECK: rock.threadwise_read_into {{{.*}}pageSize = 8192 : index{{.*}}}
+    // CHECK-SAME: paged %{{.+}} : memref<{{.+}}xi64, #gpu.address_space<workgroup>>
+    rock.gridwise_attention_accel(%43, %31, %34, %arg3, %40, %11, %7, %44) preSoftmaxOps = {
+    ^bb0(%arg6: memref<6144000xi8>, %arg7: memref<14x1500x4096xf16>, %arg8: memref<1x14x1500x4096xf16>):
+      %45 = rock.transform %arg6 by #transform_map37 : memref<6144000xi8> to memref<1x1x1500x4096xi8>
+      %46 = rock.transform %45 by #transform_map38 : memref<1x1x1500x4096xi8> to memref<1x14x1500x4096xi8>
+      %47 = rock.transform %arg7 by #transform_map39 : memref<14x1500x4096xf16> to memref<1x14x1500x4096xf16>
+      %48 = rock.transform %46 by #transform_map40 : memref<1x14x1500x4096xi8> to memref<14x1500x4096xi8>
+      %49 = rock.transform %47 by #transform_map40 : memref<1x14x1500x4096xf16> to memref<14x1500x4096xf16>
+      %alloc_1 = memref.alloc() : memref<1x14x1500x4096xf16>
+      %50 = rock.transform %alloc_1 by #transform_map41 : memref<1x14x1500x4096xf16> to memref<14x1500x4096xf16>
+      linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel"]} ins(%48, %49 : memref<14x1500x4096xi8>, memref<14x1500x4096xf16>) outs(%50 : memref<14x1500x4096xf16>) attrs =  {rock.majorTensorNumber = 1 : index} {
+      ^bb0(%in: i8, %in_2: f16, %out: f16):
+        %51 = arith.mulf %in_2, %cst_0 : f16
+        %52 = arith.cmpi ne, %in, %c0_i8 : i8
+        %53 = arith.select %52, %cst, %51 : f16
+        linalg.yield %53 : f16
+      }
+      memref.copy %alloc_1, %arg8 : memref<1x14x1500x4096xf16> to memref<1x14x1500x4096xf16>
+      rock.yield
+    } {blockSize = 64 : i32, firstGemmIndices = array<i64: 1>, gridSize = 658 : i32, numRepeatsGQA = 7 : index, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0, 1, 1, 1, 0>, params0 = #accel_gemm_params, params1 = #accel_gemm_params, prePadG0N = 10500 : index, softmaxType = f32, splitKV = 1 : i32, storeMethod = #rock<StoreMethod set>} : memref<2x64x10528xf16>, memref<2x64x4096xf16>, memref<2x4096x64xf16>, memref<6144000xi8>, memref<2xi32>, memref<1x64x8192xf16>, memref<1x64x8192xf16>, memref<2x10528x64xf16>
+    memref.copy %alloc, %arg5 : memref<1344000xf16> to memref<1344000xf16>
+    return
+  }
+}

--- a/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/gridwise_attention_accel_lowering.mlir
@@ -1080,3 +1080,4 @@ module {
     return
   }
 }
+

--- a/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
@@ -551,4 +551,60 @@ func.func @load_4bit_vector_boundary_case(%mem: memref<4294967295xi4>) -> vector
         : memref<4294967295xi4> -> vector<3xi4>
     return %ret : vector<3xi4>
 }
+
+// CHECK-LABEL: func.func @load_paged_scalar
+// CHECK-SAME: (%[[mem:.*]]: memref<1x64x8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
+func.func @load_paged_scalar(%mem: memref<1x64x8192xf16>, %pagePtr: i64, %offset: index) -> f16 attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
+    %true = arith.constant true
+    // Paged load converts page ptr to llvm.ptr, creates buffer resource, and loads
+    // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(16384 : i64) : i64
+    // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
+    // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
+    // CHECK: rocdl.raw.ptr.buffer.load %[[rsrc]]
+    %ret = rock.global_load %mem[%offset] if %true paged %pagePtr {pageSize = 8192 : i64}
+        : memref<1x64x8192xf16> -> f16
+    return %ret : f16
+}
+
+// CHECK-LABEL: func.func @load_paged_vector
+// CHECK-SAME: (%[[mem:.*]]: memref<1x64x8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
+func.func @load_paged_vector(%mem: memref<1x64x8192xf16>, %pagePtr: i64, %offset: index) -> vector<2xf16> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
+    %true = arith.constant true
+    // Paged vector load converts page ptr to llvm.ptr, creates buffer resource, and loads
+    // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(16384 : i64) : i64
+    // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
+    // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
+    // CHECK: rocdl.raw.ptr.buffer.load %[[rsrc]]
+    %ret = rock.global_load %mem[%offset] if %true paged %pagePtr {pageSize = 8192 : i64}
+        : memref<1x64x8192xf16> -> vector<2xf16>
+    return %ret : vector<2xf16>
+}
+
+// CHECK-LABEL: func.func @load_paged_vector_maybe_oob
+// CHECK-SAME: (%[[mem:.*]]: memref<1x64x8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index, %[[valid:.*]]: i1)
+func.func @load_paged_vector_maybe_oob(%mem: memref<1x64x8192xf16>, %pagePtr: i64, %offset: index, %valid: i1) -> vector<2xf16> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
+    // Paged load with validity check - scf.if guards the buffer load
+    // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(16384 : i64) : i64
+    // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
+    // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
+    // CHECK: scf.if %[[valid]]
+    // CHECK:   rocdl.raw.ptr.buffer.load %[[rsrc]]
+    %ret = rock.global_load %mem[%offset] if %valid paged %pagePtr {pageSize = 8192 : i64}
+        : memref<1x64x8192xf16> -> vector<2xf16>
+    return %ret : vector<2xf16>
+}
+
+// CHECK-LABEL: func.func @load_paged_vector_large_page
+// CHECK-SAME: (%[[mem:.*]]: memref<1x64x16384xf32>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
+func.func @load_paged_vector_large_page(%mem: memref<1x64x16384xf32>, %pagePtr: i64, %offset: index) -> vector<4xf32> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
+    %true = arith.constant true
+    // Larger page size (16384 elements * 4 bytes = 65536 bytes)
+    // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(65536 : i64) : i64
+    // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
+    // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
+    // CHECK: rocdl.raw.ptr.buffer.load %[[rsrc]]
+    %ret = rock.global_load %mem[%offset] if %true paged %pagePtr {pageSize = 16384 : i64}
+        : memref<1x64x16384xf32> -> vector<4xf32>
+    return %ret : vector<4xf32>
+}
 }

--- a/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
+++ b/mlir/test/Dialect/Rock/lowering_global_load_store.mlir
@@ -553,58 +553,54 @@ func.func @load_4bit_vector_boundary_case(%mem: memref<4294967295xi4>) -> vector
 }
 
 // CHECK-LABEL: func.func @load_paged_scalar
-// CHECK-SAME: (%[[mem:.*]]: memref<1x64x8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
-func.func @load_paged_scalar(%mem: memref<1x64x8192xf16>, %pagePtr: i64, %offset: index) -> f16 attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
+// CHECK-SAME: (%[[mem:.*]]: memref<8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
+func.func @load_paged_scalar(%mem: memref<8192xf16>, %pagePtr: i64, %offset: index) -> f16 attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
     %true = arith.constant true
-    // Paged load converts page ptr to llvm.ptr, creates buffer resource, and loads
     // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(16384 : i64) : i64
     // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
     // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
     // CHECK: rocdl.raw.ptr.buffer.load %[[rsrc]]
     %ret = rock.global_load %mem[%offset] if %true paged %pagePtr {pageSize = 8192 : i64}
-        : memref<1x64x8192xf16> -> f16
+        : memref<8192xf16> -> f16
     return %ret : f16
 }
 
 // CHECK-LABEL: func.func @load_paged_vector
-// CHECK-SAME: (%[[mem:.*]]: memref<1x64x8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
-func.func @load_paged_vector(%mem: memref<1x64x8192xf16>, %pagePtr: i64, %offset: index) -> vector<2xf16> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
+// CHECK-SAME: (%[[mem:.*]]: memref<8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
+func.func @load_paged_vector(%mem: memref<8192xf16>, %pagePtr: i64, %offset: index) -> vector<2xf16> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
     %true = arith.constant true
-    // Paged vector load converts page ptr to llvm.ptr, creates buffer resource, and loads
     // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(16384 : i64) : i64
     // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
     // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
     // CHECK: rocdl.raw.ptr.buffer.load %[[rsrc]]
     %ret = rock.global_load %mem[%offset] if %true paged %pagePtr {pageSize = 8192 : i64}
-        : memref<1x64x8192xf16> -> vector<2xf16>
+        : memref<8192xf16> -> vector<2xf16>
     return %ret : vector<2xf16>
 }
 
 // CHECK-LABEL: func.func @load_paged_vector_maybe_oob
-// CHECK-SAME: (%[[mem:.*]]: memref<1x64x8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index, %[[valid:.*]]: i1)
-func.func @load_paged_vector_maybe_oob(%mem: memref<1x64x8192xf16>, %pagePtr: i64, %offset: index, %valid: i1) -> vector<2xf16> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
-    // Paged load with validity check - scf.if guards the buffer load
+// CHECK-SAME: (%[[mem:.*]]: memref<8192xf16>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index, %[[valid:.*]]: i1)
+func.func @load_paged_vector_maybe_oob(%mem: memref<8192xf16>, %pagePtr: i64, %offset: index, %valid: i1) -> vector<2xf16> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
     // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(16384 : i64) : i64
     // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
     // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
     // CHECK: scf.if %[[valid]]
     // CHECK:   rocdl.raw.ptr.buffer.load %[[rsrc]]
     %ret = rock.global_load %mem[%offset] if %valid paged %pagePtr {pageSize = 8192 : i64}
-        : memref<1x64x8192xf16> -> vector<2xf16>
+        : memref<8192xf16> -> vector<2xf16>
     return %ret : vector<2xf16>
 }
 
 // CHECK-LABEL: func.func @load_paged_vector_large_page
-// CHECK-SAME: (%[[mem:.*]]: memref<1x64x16384xf32>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
-func.func @load_paged_vector_large_page(%mem: memref<1x64x16384xf32>, %pagePtr: i64, %offset: index) -> vector<4xf32> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
+// CHECK-SAME: (%[[mem:.*]]: memref<16384xf32>, %[[pagePtr:.*]]: i64, %[[offset:.*]]: index)
+func.func @load_paged_vector_large_page(%mem: memref<16384xf32>, %pagePtr: i64, %offset: index) -> vector<4xf32> attributes {arch = "amdgcn-amd-amdhsa:gfx942"} {
     %true = arith.constant true
-    // Larger page size (16384 elements * 4 bytes = 65536 bytes)
     // CHECK-DAG: %[[pageSizeBytes:.*]] = llvm.mlir.constant(65536 : i64) : i64
     // CHECK: %[[ptr:.*]] = llvm.inttoptr %[[pagePtr]] : i64 to !llvm.ptr<1>
     // CHECK: %[[rsrc:.*]] = rocdl.make.buffer.rsrc %[[ptr]], %{{.*}}, %[[pageSizeBytes]], %{{.*}} : <1> to <8>
     // CHECK: rocdl.raw.ptr.buffer.load %[[rsrc]]
     %ret = rock.global_load %mem[%offset] if %true paged %pagePtr {pageSize = 16384 : i64}
-        : memref<1x64x16384xf32> -> vector<4xf32>
+        : memref<16384xf32> -> vector<4xf32>
     return %ret : vector<4xf32>
 }
 }

--- a/mlir/test/Dialect/Rock/toblockwise_attention_accel_lowering.mlir
+++ b/mlir/test/Dialect/Rock/toblockwise_attention_accel_lowering.mlir
@@ -208,3 +208,27 @@ func.func @gridwise_attn_schedulev2(%arg0: memref<1x384x64xf32>, %arg1: memref<1
   } : memref<1x64x384xf32>, memref<1x64x384xf32>, memref<1x384x64xf32>, memref<1x384x64xf32>
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @paged_attention_disables_direct_to_lds
+// CHECK-NOT: DirectToLDSDefault
+// CHECK: rock.blockwise_load_tile
+// CHECK-SAME: loadType = #rock<GemmLoadTileType Default>
+func.func @paged_attention_disables_direct_to_lds(%arg0: memref<1x64x384xf16>, %arg1: memref<1x64x384xf16>, %arg2: memref<1x384x64xf16>, %arg3: memref<1x384x64xf16>, %pageTable: memref<1x64x1xi64>) attributes {block_size = 64 : i32, features = #rock<GemmFeatures mfma|dot|atomic_add|direct_to_lds_128b>, grid_size = 24 : i32, kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx950:sramecc+:xnack-"} {
+  %0 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> (d0, d2, d1)> by [<PassThrough ["gemmG"] at [0] -> ["gemmG"] at [0]>, <PassThrough ["gemm0K", "gemm0M"] at [1, 2] -> ["gemm0K", "gemm0M"] at [2, 1]>] bounds = [1, 64, 384] -> [1, 384, 64]> : memref<1x64x384xf16> to memref<1x64x384xf16>
+  %keyAddrs = rock.deref %pageTable : memref<1x64x1xi64> -> memref<1x64x8192xf16>
+  %valueAddrs = rock.deref %pageTable : memref<1x64x1xi64> -> memref<1x64x8192xf16>
+  rock.gridwise_attention_accel(%0, %arg1, %arg2, %keyAddrs, %valueAddrs, %arg3) preSoftmaxOps = {} {
+    blockSize = 64 : i32,
+    gridSize = 24 : i32,
+    params0 = #rock.accel_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 3, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0, forceUnroll = true>,
+    params1 = #rock.accel_gemm_params<kpackPerBlock = 32, mPerBlock = 32, nPerBlock = 32, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 16, splitKFactor = 1, scheduleVersion = 3, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0, forceUnroll = true>,
+    firstGemmIndices = array<i64: 0>,
+    splitKV = 1 : i32,
+    storeMethod = #rock<StoreMethod set>,
+    operand_segment_sizes = array<i32: 1, 1, 1, 0, 0, 0, 1, 1, 1, 0>
+  } : memref<1x64x384xf16>, memref<1x64x384xf16>, memref<1x384x64xf16>, memref<1x64x8192xf16>, memref<1x64x8192xf16>, memref<1x384x64xf16>
+  return
+}
+


### PR DESCRIPTION
## Motivation

This PR implements the backend/lowering pipeline for paged attention in rocMLIR. The changes enable efficient tiled loading from non-contiguous paged memory by passing page table information through each lowering stage, culminating in ROCDL.raw_ptr_buffer_load instructions that load directly from page pointers.

Implements: https://amd-hub.atlassian.net/browse/AIROCMLIR-42

## Technical Details
Overview of the flow:
```
rock.attention (with keyAddresses/valueAddresses)
       │
       ▼
rock.gridwise_attention_accel (extracts page table from rock.deref)
       │
       ▼
rock.blockwise_load_tile (with pageTable + pageSize)
       │
       ├──► Stage: PagePtrLoad (load page pointers to LDS)
       │
       └──► Stage: GlobalRead (with ldsPagePtrs + firstPageIndex)
                   │
                   ▼
            rock.threadwise_read_into (with paging attributes)
                   │
                   ▼
            rock.global_load (with pagePtr + pageSize)
                   │
                   ▼
            ROCDL.raw_ptr_buffer_load (final HW instruction)
```
1. GridwiseGemmToBlockwise
  * Extracts paging info from `rock.deref` ops
  * Disabled DirectToLDS for paged loads (ticket for future implementation work: https://amd-hub.atlassian.net/browse/AIROCMLIR-464)
  * Appends page attributes to BlockwiseLoadTile ops
2. BlockwiseLoadTileToThreadwise
  * Splits the load into two stages for paged loads:
    * `PagePtrLoad`
      * Compute the firstPageIdx by evaluating transforms to get the tile's starting flat position
      * Allocates LDS buffer for page pointers
      * Each thread loads one page pointer from the global page table to LDS
      * Issues LDS barrier to synchronize before `GlobalRead` stage
    * `GlobalRead`: Creates `ThreadwiseReadInto` op with paging attributes
3. ThreadwiseGemmLowering
  * Transform maps produce coordinates in [batch, pageIdx, offsetInPage] form
  * Computes LDS page index: globalPageIdx - firstPageIdx
  * Loads page pointer from LDS with bounds clamping
  * Adds validity check for null pointers (pages beyond table bounds)
  * Emits GlobalLoadOp with pagePtr and pageSize attributes
4. SugarToLoops
  * Creates buffer resource (V#) from raw page pointer using ROCDL.make.buffer.rsrc
  * Converts i64 pointer to LLVM pointer type
  * Sets appropriate buffer descriptor flags (RDNA vs CDNA)
  * Uses page size as numRecords for bounds checking
  * Emits ROCDL.raw_ptr_buffer_load with:
  * Buffer resource from page pointer
  * Offset within page (in bytes)
  * Validity-guarded conditional load (scf.if)
## Test Plan

- PR CI

## Test Result

- [ ] PR CI

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
