### PR TITLE
Remove strict stride multiple enforcement for expanded tensor support

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -1434,9 +1434,7 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
 
     auto transposedType = cast<RankedTensorType>(transposed.getType());
 
-    // Verify that memoryLayoutType is >= transposedType in all dimensions,
-    // and that each memory dimension is a multiple of the logical dimension.
-    // A non-multiple indicates a non-integer stride expansion factor.
+    // Verify that memoryLayoutType is >= transposedType in all dimensions.
     for (auto [memDim, transDim] : llvm::zip_equal(memoryLayoutType.getShape(),
                                                    transposedType.getShape())) {
       if (memDim < transDim)

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -1443,10 +1443,6 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
         return op.emitOpError("memory layout dimension ")
                << memDim << " is smaller than logical dimension " << transDim
                << "; this indicates invalid strides";
-      if (memDim % transDim != 0)
-        return op.emitOpError("memory layout dimension ")
-               << memDim << " is not a multiple of logical dimension "
-               << transDim << "; this indicates invalid strides";
     }
 
     transposed =

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -895,9 +895,6 @@ LogicalResult ExpandStridesOp::verify() {
     if (outDim < inDim)
       return emitOpError("output dimension ")
              << outDim << " is smaller than input dimension " << inDim;
-    if (outDim % inDim != 0)
-      return emitOpError("output dimension ")
-             << outDim << " is not a multiple of input dimension " << inDim;
   }
 
   // Verify element types match

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -887,9 +887,7 @@ LogicalResult ExpandStridesOp::verify() {
   if (inputType.getRank() != outputType.getRank())
     return emitOpError("input and output must have the same rank");
 
-  // Verify that output is >= input in all dimensions,
-  // and that each output dimension is a multiple of the input dimension.
-  // A non-multiple indicates a non-integer stride expansion factor.
+  // Verify that output is >= input in all dimensions.
   for (auto [outDim, inDim] :
        llvm::zip_equal(outputType.getShape(), inputType.getShape())) {
     if (outDim < inDim)

--- a/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa-non-contiguous-strides.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/migraphx-to-tosa-non-contiguous-strides.mlir
@@ -17,6 +17,23 @@ func.func @mlir_dot_sigmoid(%arg0: !migraphx.shaped<4x24x16xf16, 384x16x1>, %arg
 
 // -----
 
+// CHECK-LABEL: @mlir_dot_sigmoid
+func.func @mlir_dot_sigmoid(%arg0: !migraphx.shaped<4x5x16xf16, 80x16x1>, %arg1: !migraphx.shaped<4x16x24xf16, 384x24x1>) -> !migraphx.shaped<4x5x24xf16, 288x24x1> attributes {arch = "gfx1201", kernel = "mixr", num_cu = 32 : i64} {
+  // CHECK: tosa.matmul
+  // CHECK-SAME: -> tensor<4x5x24xf16>
+  %0 = migraphx.dot %arg0, %arg1 : <4x5x16xf16, 80x16x1>, <4x16x24xf16, 384x24x1> -> <4x5x24xf16, 120x24x1>
+  // CHECK: %[[SIGMOID:.*]] = tosa.sigmoid
+  // CHECK-SAME: -> tensor<4x5x24xf16>
+  %1 = migraphx.sigmoid %0 : <4x5x24xf16, 120x24x1> -> <4x5x24xf16, 288x24x1>
+  // CHECK: tosa.custom %[[SIGMOID]] {domain_name = "rocmlir", implementation_attrs = "", operator_name = "expand_strides"}
+  // CHECK-SAME: (tensor<4x5x24xf16>) -> tensor<4x12x24xf16>
+  // CHECK: tosa.reshape
+  // CHECK-SAME: -> tensor<1152xf16>
+  return %1 : !migraphx.shaped<4x5x24xf16, 288x24x1>
+}
+
+// -----
+
 // expected-error @unknown {{!migraphx.shaped type with smallest stride 2 has no supported in-memory layout}}
 // expected-error @below {{failed to legalize operation 'func.func'}}
 func.func @no_unit_stride(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) -> !migraphx.shaped<4x24x24xf16, 1152x48x2> attributes {kernel = "mixr"} {
@@ -49,14 +66,5 @@ func.func @write_to_broadcast(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) ->
 func.func @stride_too_small(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) -> !migraphx.shaped<4x24x24xf16, 576x10x1> attributes {kernel = "mixr"} {
   %0 = migraphx.sigmoid %arg0 : <4x24x24xf16, 576x24x1> -> <4x24x24xf16, 576x10x1>
   return %0 : !migraphx.shaped<4x24x24xf16, 576x10x1>
-}
-
-// -----
-
-func.func @stride_not_multiple(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) -> !migraphx.shaped<4x24x24xf16, 1200x24x1> attributes {kernel = "mixr"} {
-  // expected-error @+2 {{'migraphx.mlir.as.underlying.shape' op memory layout dimension 50 is not a multiple of logical dimension 24; this indicates invalid strides}}
-  // expected-error @+1 {{failed to legalize operation 'migraphx.mlir.as.underlying.shape'}}
-  %0 = migraphx.sigmoid %arg0 : <4x24x24xf16, 576x24x1> -> <4x24x24xf16, 1200x24x1>
-  return %0 : !migraphx.shaped<4x24x24xf16, 1200x24x1>
 }
 

--- a/mlir/test/Dialect/Rock/invalid.mlir
+++ b/mlir/test/Dialect/Rock/invalid.mlir
@@ -98,11 +98,3 @@ func.func @expand_strides_element_type_mismatch(%input: tensor<4x24x24xf16>, %ou
   return %result : tensor<4x48x24xf32>
 }
 
-// -----
-
-func.func @expand_strides_not_multiple(%input: tensor<4x24x24xf16>, %output: tensor<4x50x24xf16>) -> tensor<4x50x24xf16> {
-  // expected-error@+1 {{'rock.expand_strides' op output dimension 50 is not a multiple of input dimension 24}}
-  %result = rock.expand_strides %input into %output : tensor<4x24x24xf16> into tensor<4x50x24xf16> -> tensor<4x50x24xf16>
-  return %result : tensor<4x50x24xf16>
-}
-

--- a/mlir/test/Dialect/Rock/lowering-expand-strides.mlir
+++ b/mlir/test/Dialect/Rock/lowering-expand-strides.mlir
@@ -7,6 +7,8 @@
 #transform_map = #rock.transform_map<#map by [<Unmerge{4, 16, 24} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [4, 16, 24] -> [1536]>
 #transform_map1 = #rock.transform_map<#map1 by [<Unmerge{4, 24, 16} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [4, 24, 16] -> [1536]>
 #transform_map2 = #rock.transform_map<#map3 by [<Merge{4, 48, 24} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [4608] -> [4, 48, 24]>
+// CHECK-DAG: = #rock.transform_map<{{.*}}Slice{{.*}}0, 4, 0, 5, 0, 24{{.*}}bounds = [4, 5, 24] -> [4, 12, 24]>
+
 module {
   // CHECK-LABEL: func.func @expand_strides_basic
   func.func @expand_strides_basic(%arg0: memref<1536xf16>, %arg1: memref<1536xf16>, %arg2: memref<4608xf16>) attributes {arch = "gfx950", kernel = "mixr"} {
@@ -32,5 +34,30 @@ module {
     memref.copy %2, %arg2 : memref<4608xf16> to memref<4608xf16>
     return
   }
+
+  // CHECK-LABEL: func.func @expand_strides_non_multiple
+  func.func @expand_strides_non_multiple(%arg0: memref<320xf16>, %arg1: memref<1536xf16>, %arg2: memref<1152xf16>) attributes {arch = "gfx1201", kernel = "mixr", num_cu = 32 : i64} {
+  %cst = arith.constant 1.000000e+00 : f16
+  %0 = rock.transform %arg1 by <affine_map<(d0, d1, d2) -> ((d0 * 16 + d1) * 24 + d2)> by [<Unmerge{4, 16, 24} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [4, 16, 24] -> [1536]> : memref<1536xf16> to memref<4x16x24xf16>
+  %1 = rock.transform %arg0 by <affine_map<(d0, d1, d2) -> ((d0 * 5 + d1) * 16 + d2)> by [<Unmerge{4, 5, 16} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [4, 5, 16] -> [320]> : memref<320xf16> to memref<4x5x16xf16>
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x5x24xf16>
+  rock.gemm %alloc = %1 * %0 storeMethod =  set : memref<4x5x24xf16> = memref<4x5x16xf16> * memref<4x16x24xf16>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<4x5x24xf16>
+  linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%alloc : memref<4x5x24xf16>) outs(%alloc_0 : memref<4x5x24xf16>) {
+  ^bb0(%in: f16, %out: f16):
+    %3 = arith.negf %in : f16
+    %4 = math.exp %3 : f16
+    %5 = arith.addf %4, %cst : f16
+    %6 = arith.divf %cst, %5 : f16
+    linalg.yield %6 : f16
+  }
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<4x12x24xf16>
+  // CHECK: %[[TRANSFORM2:.*]] = rock.transform %alloc_1 {{.*}} : memref<4x12x24xf16> to memref<4x5x24xf16>
+  // CHECK: memref.copy %alloc_0, %[[TRANSFORM2]] : memref<4x5x24xf16> to memref<4x5x24xf16>
+  rock.expand_strides %alloc_0 into %alloc_1 : memref<4x5x24xf16> into memref<4x12x24xf16>
+  %2 = rock.transform %alloc_1 by <affine_map<(d0) -> (d0 floordiv 288, (d0 mod 288) floordiv 24, d0 mod 24)> by [<Merge{4, 12, 24} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [1152] -> [4, 12, 24]> : memref<4x12x24xf16> to memref<1152xf16>
+  memref.copy %2, %arg2 : memref<1152xf16> to memref<1152xf16>
+  return
+}
 }
 

--- a/mlir/test/fusion/pr-e2e/mixr-expand-strides-non-multiple.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-expand-strides-non-multiple.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-gen -fut mlir_dot_sigmoid --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_dot_sigmoid_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s 
+
+// Only ~41% of the results will be correct since the non-contiguous strides
+// in this example is the result of concating 4x5x24 and 4x7x24 (i.e.m 4x12x24).
+// This kernel is specificall dealing with making sure that the 4x5x24 elements
+// are all in the correct place in the larger tensor.
+// CHECK: relDiff = 0 : 480/1152 (41.666667%)
+
+module {
+  func.func @mlir_dot_sigmoid(%arg0: !migraphx.shaped<4x5x16xf16, 80x16x1>, %arg1: !migraphx.shaped<4x16x24xf16, 384x24x1>) -> !migraphx.shaped<4x5x24xf16, 288x24x1> attributes {arch = "gfx1201", kernel = "mixr", num_cu = 32 : i64} {
+    %0 = migraphx.dot %arg0, %arg1 : <4x5x16xf16, 80x16x1>, <4x16x24xf16, 384x24x1> -> <4x5x24xf16, 120x24x1>
+    %1 = migraphx.sigmoid %0 : <4x5x24xf16, 120x24x1> -> <4x5x24xf16, 288x24x1>
+    return %1 : !migraphx.shaped<4x5x24xf16, 288x24x1>
+  }
+}


### PR DESCRIPTION
## Motivation
This PR removes a strict check in MIGraphXToTosa that was preventing MIGraphX from compiling certain concat kernels. This implements: https://amd-hub.atlassian.net/browse/AIROCMLIR-472

## Technical Details

The `AsUnderlyingShapeConverter` was incorrectly rejecting valid non-contiguous output buffer strides. Specifically, it required that memory layout dimensions be integer multiples of the logical tensor dimensions. This failed for cases like `<4x5x24xf16, 288x24x1>` where the logical shape is 4x5x24 but the memory layout is 4x12x24. This pattern could occur when MIGraphX concatenates tensors (e.g., a 4x5x24 and 4x7x24 into a 4x12x24 buffer), where each kernel writes to a different slice of the final buffer.

## Test Plan

- PR CI

## Test Result

- [x] PR CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
