### PR TITLE
Changes to look for max num_chiplets

### DIFF
--- a/mlir/unittests/Dialect/Rock/AmdArchDbTests.cpp
+++ b/mlir/unittests/Dialect/Rock/AmdArchDbTests.cpp
@@ -57,7 +57,7 @@ TEST_P(NativeArchTest, NativeArchInfoMatchesPresetInfo) {
             nativeInfo.hasFp8ConversionInstrs);
   EXPECT_EQ(presetInfo.hasOcpFp8ConversionInstrs,
             nativeInfo.hasOcpFp8ConversionInstrs);
-  EXPECT_EQ(presetInfo.maxNumXCC, nativeInfo.maxNumXCC);
+  EXPECT_GE(presetInfo.maxNumXCC, nativeInfo.maxNumXCC);
 }
 
 INSTANTIATE_TEST_SUITE_P(NativeArchTests, NativeArchTest,


### PR DESCRIPTION
MI308 has 4 Chiplets. 
It can be less if it is running in SPX or some other mode. Therefore change test accordingly. 

NativeArchDB maintains "maxNumXCC" value which is 8 for gfx942. 
Currently this test fails on MI308