### PR TITLE
[AIROCMLIR-482] Add explicit error messages to ReuseLDS

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
@@ -515,8 +515,11 @@ static LogicalResult reuseLDS(func::FuncOp &func) {
 
   // not enough LDS memory
   if (failed(checkLDSSize(func, requiredMemory))) {
+    StringAttr arch = getArchValue(func);
+    int64_t maxLDS = rock::lookupArchInfo(arch).maxSharedMemPerWG;
     return func.emitOpError("ReuseLDS requires too much LDS memory: ")
-           << requiredMemory << " bytes";
+           << requiredMemory << " bytes (hardware max for " << arch.getValue()
+           << " is " << maxLDS << " bytes)";
   }
   LLVM_DEBUG(llvm::dbgs() << "Total LDS memory needed: " << requiredMemory
                           << " bytes\n");

--- a/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
@@ -557,10 +557,10 @@ static LogicalResult reuseLDS(func::FuncOp &func) {
     GpuAllocOp newAlloc = colorAllocs[color];
 
     if (offset < 0) {
-      return func.emitOpError("ReuseLDS: negative offset");
+      return alloc.emitOpError("ReuseLDS: negative offset");
     }
     if (offset >= colorSize) {
-      return func.emitOpError("ReuseLDS: offset ")
+      return alloc.emitOpError("ReuseLDS: offset ")
              << offset << " exceeds color size " << colorSize;
     }
     auto bufferType = alloc.getOutput().getType();
@@ -568,13 +568,13 @@ static LogicalResult reuseLDS(func::FuncOp &func) {
     auto elementType = bufferType.getElementType();
     auto i8Type = rewriter.getI8Type();
     if (elementType != i8Type) {
-      return func.emitOpError("ReuseLDS: LDS buffer element type must be i8, "
-                              "but it's ")
+      return alloc.emitOpError("ReuseLDS: LDS buffer element type must be i8, "
+                               "but it's ")
              << elementType;
     }
     auto rank = bufferType.getRank();
     if (rank != 1) {
-      return func.emitOpError("ReuseLDS: rank should be 1, but it's ")
+      return alloc.emitOpError("ReuseLDS: rank should be 1, but it's ")
              << rank;
     }
 

--- a/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
@@ -574,8 +574,7 @@ static LogicalResult reuseLDS(func::FuncOp &func) {
     }
     auto rank = bufferType.getRank();
     if (rank != 1) {
-      return alloc.emitOpError("ReuseLDS: rank should be 1, but it's ")
-             << rank;
+      return alloc.emitOpError("ReuseLDS: rank should be 1, but it's ") << rank;
     }
 
     rewriter.setInsertionPointAfter(alloc);

--- a/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ReuseLDS.cpp
@@ -515,17 +515,15 @@ static LogicalResult reuseLDS(func::FuncOp &func) {
 
   // not enough LDS memory
   if (failed(checkLDSSize(func, requiredMemory))) {
-    LLVM_DEBUG(llvm::dbgs() << "ReuseLDS requires too much LDS memory: "
-                            << requiredMemory << " bytes\n");
-    return failure();
+    return func.emitOpError("ReuseLDS requires too much LDS memory: ")
+           << requiredMemory << " bytes";
   }
   LLVM_DEBUG(llvm::dbgs() << "Total LDS memory needed: " << requiredMemory
                           << " bytes\n");
 
   // Add LDS barriers
   if (failed(addLDSBarriers(rewriter, func, coloringInfo))) {
-    LLVM_DEBUG(llvm::dbgs() << "Failed while adding LDS barriers\n");
-    return failure();
+    return func.emitOpError("ReuseLDS failed while adding LDS barriers");
   }
 
   // Remove rock.live_in and rock.live_out
@@ -559,27 +557,25 @@ static LogicalResult reuseLDS(func::FuncOp &func) {
     GpuAllocOp newAlloc = colorAllocs[color];
 
     if (offset < 0) {
-      LLVM_DEBUG(llvm::dbgs() << "Negative offset\n");
-      return failure();
+      return func.emitOpError("ReuseLDS: negative offset");
     }
     if (offset >= colorSize) {
-      LLVM_DEBUG(llvm::dbgs() << "Offset is too big\n");
-      return failure();
+      return func.emitOpError("ReuseLDS: offset ")
+             << offset << " exceeds color size " << colorSize;
     }
     auto bufferType = alloc.getOutput().getType();
     auto numElements = bufferType.getNumElements();
     auto elementType = bufferType.getElementType();
     auto i8Type = rewriter.getI8Type();
     if (elementType != i8Type) {
-      LLVM_DEBUG(llvm::dbgs() << "LDS buffer element type must be i8. Element "
-                                 "type is not int8, but it's "
-                              << elementType << "\n");
-      return failure();
+      return func.emitOpError("ReuseLDS: LDS buffer element type must be i8, "
+                              "but it's ")
+             << elementType;
     }
     auto rank = bufferType.getRank();
     if (rank != 1) {
-      LLVM_DEBUG(llvm::dbgs() << "Rank should be one, it's " << rank << "\n");
-      return failure();
+      return func.emitOpError("ReuseLDS: rank should be 1, but it's ")
+             << rank;
     }
 
     rewriter.setInsertionPointAfter(alloc);

--- a/mlir/test/Dialect/Rock/lowering_reuse_lds_errors.mlir
+++ b/mlir/test/Dialect/Rock/lowering_reuse_lds_errors.mlir
@@ -30,11 +30,11 @@ func.func @rock_reuse_lds_rank_not_1() attributes{arch = "##TOKEN_ARCH##", kerne
 
 // -----
 
-// Test: ReuseLDS requires too much LDS memory
-// Two interfering allocations that total 262144 bytes, exceeding all architectures' LDS limits
-// expected-error @below {{ReuseLDS requires too much LDS memory:}}
+// Test: ReuseLDS requires too much LDS memory. In this case, two interfering
+// allocations that total 262144 bytes, exceeding gfx950's 163840 byte LDS limit
 #wg = #gpu.address_space<workgroup>
-func.func @rock_reuse_lds_too_much_lds() attributes{arch = "##TOKEN_ARCH##", kernel} {
+// expected-error @below {{ReuseLDS requires too much LDS memory: 262144 bytes (hardware max for amdgcn-amd-amdhsa:gfx950 is 163840 bytes)}}
+func.func @rock_reuse_lds_too_much_lds() attributes{arch = "amdgcn-amd-amdhsa:gfx950", kernel} {
   %0 = rock.alloc() : memref<131072xi8, #wg>
   %1 = rock.alloc() : memref<131072xi8, #wg>
   rock.live_in %0 : memref<131072xi8, #wg>

--- a/mlir/test/Dialect/Rock/lowering_reuse_lds_errors.mlir
+++ b/mlir/test/Dialect/Rock/lowering_reuse_lds_errors.mlir
@@ -1,0 +1,46 @@
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt -rock-reuse-lds -split-input-file -verify-diagnostics
+
+// Test: LDS buffer element type must be i8
+#wg = #gpu.address_space<workgroup>
+func.func @rock_reuse_lds_non_i8_type() attributes{arch = "##TOKEN_ARCH##", kernel} {
+  // expected-error @below {{ReuseLDS: LDS buffer element type must be i8, but it's 'f32'}}
+  %0 = rock.alloc() : memref<256xf32, #wg>
+  %1 = rock.alloc() : memref<256xf32, #wg>
+  rock.live_in %0 : memref<256xf32, #wg>
+  rock.live_out %0 : memref<256xf32, #wg>
+  rock.live_in %1 : memref<256xf32, #wg>
+  rock.live_out %1 : memref<256xf32, #wg>
+  return
+}
+
+// -----
+
+// Test: Rank should be 1
+#wg = #gpu.address_space<workgroup>
+func.func @rock_reuse_lds_rank_not_1() attributes{arch = "##TOKEN_ARCH##", kernel} {
+  // expected-error @below {{ReuseLDS: rank should be 1, but it's 2}}
+  %0 = rock.alloc() : memref<32x32xi8, #wg>
+  %1 = rock.alloc() : memref<32x32xi8, #wg>
+  rock.live_in %0 : memref<32x32xi8, #wg>
+  rock.live_out %0 : memref<32x32xi8, #wg>
+  rock.live_in %1 : memref<32x32xi8, #wg>
+  rock.live_out %1 : memref<32x32xi8, #wg>
+  return
+}
+
+// -----
+
+// Test: ReuseLDS requires too much LDS memory
+// Two interfering allocations that total 262144 bytes, exceeding all architectures' LDS limits
+// expected-error @below {{ReuseLDS requires too much LDS memory:}}
+#wg = #gpu.address_space<workgroup>
+func.func @rock_reuse_lds_too_much_lds() attributes{arch = "##TOKEN_ARCH##", kernel} {
+  %0 = rock.alloc() : memref<131072xi8, #wg>
+  %1 = rock.alloc() : memref<131072xi8, #wg>
+  rock.live_in %0 : memref<131072xi8, #wg>
+  rock.live_in %1 : memref<131072xi8, #wg>
+  rock.live_out %0 : memref<131072xi8, #wg>
+  rock.live_out %1 : memref<131072xi8, #wg>
+  return
+}
+


### PR DESCRIPTION
## Motivation

This PR adds explicit error messages to ReuseLDS so that we see useful errors instead of `Lowering Failed` when tuning.

Implements: https://amd-hub.atlassian.net/browse/AIROCMLIR-482

## Technical Details

Change `llvm::dbgs()` + `return failure()` to `emitOpError()` statements.

## Test Plan

- PR CI

## Test Result

- [x] PR CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
