### PR TITLE
[AIROCMIR-446] Lower `migraphx.greater/equal` into `linalg.generic`

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MIGraphX/IR/MIGraphX.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 
 using namespace mlir;
@@ -327,6 +328,103 @@ ReluConverter::matchAndRewrite(migraphx::ReluOp op, OpAdaptor adaptor,
   // relu(x) = max(0, x)
   auto result = linalg::MaxOp::create(rewriter, loc, {in, zero}, init);
   rewriter.replaceOp(op, result);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// elementwise boolean operator
+//===----------------------------------------------------------------------===//
+
+namespace {
+template <class MIXRBooleanOp>
+struct BooleanElementwiseConverter : public OpConversionPattern<MIXRBooleanOp> {
+  using OpConversionPattern<MIXRBooleanOp>::OpConversionPattern;
+  using OpConversionPattern<MIXRBooleanOp>::getTypeConverter;
+  using OpAdaptor = typename OpConversionPattern<MIXRBooleanOp>::OpAdaptor;
+
+  static_assert(std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
+                    std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
+                "MIXRBooleanOp only supports either equal or greater");
+  LogicalResult
+  matchAndRewrite(MIXRBooleanOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+
+  constexpr arith::CmpIPredicate getIPredicate() const;
+  constexpr arith::CmpFPredicate getFPredicate() const;
+};
+} // namespace
+
+template <class MIXRBooleanOp>
+constexpr arith::CmpIPredicate
+BooleanElementwiseConverter<MIXRBooleanOp>::getIPredicate() const {
+  static_assert(std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
+                    std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
+                "MIXRBooleanOp only supports either equal or greater");
+  if (std::is_same_v<MIXRBooleanOp, migraphx::Greater>) {
+    return arith::CmpIPredicate::sgt;
+  }
+
+  return arith::CmpIPredicate::eq;
+}
+
+template <class MIXRBooleanOp>
+constexpr arith::CmpFPredicate
+BooleanElementwiseConverter<MIXRBooleanOp>::getFPredicate() const {
+  static_assert(std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
+                    std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
+                "MIXRBooleanOp only supports either equal or greater");
+  if (std::is_same_v<MIXRBooleanOp, migraphx::Greater>) {
+    return arith::CmpFPredicate::OGT;
+  }
+
+  return arith::CmpFPredicate::OEQ;
+}
+
+template <class MIXRBooleanOp>
+LogicalResult BooleanElementwiseConverter<MIXRBooleanOp>::matchAndRewrite(
+    MIXRBooleanOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+  Value a = adaptor.getInA();
+  Value b = adaptor.getInB();
+  RankedTensorType resultType =
+      cast<RankedTensorType>(getTypeConverter()->convertType(op.getResult()));
+  int64_t rank = resultType.getRank();
+  Value emptyTensor = tensor::EmptyOp::create(rewriter, loc, resultType,
+                                              /*dynamic_sizes=*/ValueRange{});
+  SmallVector<AffineMap> indexingMaps(3, rewriter.getMultiDimIdentityMap(rank));
+  SmallVector<utils::IteratorType> iteratorTypes(rank,
+                                                 utils::IteratorType::parallel);
+
+  // the block for the linalg generic
+  auto buildLinalgInnerBlock = [&](OpBuilder &b, Location loc,
+                                   ValueRange blockArgs) {
+    Value first = blockArgs[0];
+    Value second = blockArgs[1];
+    Value cmp =
+        (first.getType().isInteger())
+            ? arith::CmpIOp::create(b, loc, getIPredicate(), first, second)
+                  .getResult()
+            : arith::CmpFOp::create(b, loc, getFPredicate(), first, second)
+                  .getResult();
+
+    Location cmpLoc = cmp.getLoc();
+    Type yieldType = resultType.getElementType();
+    // migraphx expect the result type to have the same type as the input. So we
+    // must cast the cmp result into the desired type.
+    Value result =
+        (first.getType().isInteger())
+            ? arith::ExtUIOp::create(rewriter, cmpLoc, yieldType, cmp)
+                  .getResult()
+            : arith::UIToFPOp::create(rewriter, cmpLoc, yieldType, cmp)
+                  .getResult();
+    linalg::YieldOp::create(b, loc, result);
+  };
+
+  auto genericOp = linalg::GenericOp::create(
+      rewriter, loc, resultType, ValueRange{a, b}, emptyTensor, indexingMaps,
+      iteratorTypes, buildLinalgInnerBlock);
+  rewriter.replaceOp(op, genericOp);
   return success();
 }
 
@@ -667,7 +765,9 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::TanhOp, linalg::TanhOp>,
            ElementwiseConverter<migraphx::RecipOp, linalg::ReciprocalOp>,
            ReluConverter, ClipConverter, BroadcastConverter,
-           MultiBroadcastConverter, LiteralConverter, ReshapeConverter>(
+           MultiBroadcastConverter, LiteralConverter, ReshapeConverter,
+           BooleanElementwiseConverter<migraphx::Greater>,
+           BooleanElementwiseConverter<migraphx::Equal>, ClipConverter>(
           converter, patterns.getContext());
 }
 

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -342,24 +342,27 @@ struct BooleanElementwiseConverter : public OpConversionPattern<MIXRBooleanOp> {
   using OpConversionPattern<MIXRBooleanOp>::getTypeConverter;
   using OpAdaptor = typename OpConversionPattern<MIXRBooleanOp>::OpAdaptor;
 
-  static_assert(std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
-                    std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
-                "MIXRBooleanOp only supports either equal or greater");
   LogicalResult
   matchAndRewrite(MIXRBooleanOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 
-  constexpr arith::CmpIPredicate getIPredicate() const;
-  constexpr arith::CmpFPredicate getFPredicate() const;
+  constexpr std::enable_if_t<std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
+                                 std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
+                             arith::CmpIPredicate>
+  getIPredicate() const;
+
+  constexpr std::enable_if_t<std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
+                                 std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
+                             arith::CmpFPredicate>
+  getFPredicate() const;
 };
 } // namespace
 
 template <class MIXRBooleanOp>
-constexpr arith::CmpIPredicate
+constexpr std::enable_if_t<std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
+                               std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
+                           arith::CmpIPredicate>
 BooleanElementwiseConverter<MIXRBooleanOp>::getIPredicate() const {
-  static_assert(std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
-                    std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
-                "MIXRBooleanOp only supports either equal or greater");
   if (std::is_same_v<MIXRBooleanOp, migraphx::Greater>) {
     return arith::CmpIPredicate::sgt;
   }
@@ -368,11 +371,10 @@ BooleanElementwiseConverter<MIXRBooleanOp>::getIPredicate() const {
 }
 
 template <class MIXRBooleanOp>
-constexpr arith::CmpFPredicate
+constexpr std::enable_if_t<std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
+                               std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
+                           arith::CmpFPredicate>
 BooleanElementwiseConverter<MIXRBooleanOp>::getFPredicate() const {
-  static_assert(std::is_same_v<MIXRBooleanOp, migraphx::Greater> ||
-                    std::is_same_v<MIXRBooleanOp, migraphx::Equal>,
-                "MIXRBooleanOp only supports either equal or greater");
   if (std::is_same_v<MIXRBooleanOp, migraphx::Greater>) {
     return arith::CmpFPredicate::OGT;
   }
@@ -410,14 +412,12 @@ LogicalResult BooleanElementwiseConverter<MIXRBooleanOp>::matchAndRewrite(
 
     Location cmpLoc = cmp.getLoc();
     Type yieldType = resultType.getElementType();
-    // migraphx expect the result type to have the same type as the input. So we
-    // must cast the cmp result into the desired type.
+    // migraphx expects the result type to have the same type as the input. So
+    // we must cast the cmp result into the desired type.
     Value result =
         (first.getType().isInteger())
-            ? arith::ExtUIOp::create(rewriter, cmpLoc, yieldType, cmp)
-                  .getResult()
-            : arith::UIToFPOp::create(rewriter, cmpLoc, yieldType, cmp)
-                  .getResult();
+            ? arith::ExtUIOp::create(b, cmpLoc, yieldType, cmp).getResult()
+            : arith::UIToFPOp::create(b, cmpLoc, yieldType, cmp).getResult();
     linalg::YieldOp::create(b, loc, result);
   };
 

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-boolean.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-boolean.mlir
@@ -1,0 +1,86 @@
+// RUN: rocmlir-opt -split-input-file --migraphx-to-linalg -verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: @func_greater(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor{{.*}})
+// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+// CHECK-DAG: %[[zero:.*]] = tensor.empty
+// CHECK-DAG: %[[one:.*]] = linalg.generic {{.*}} ins(%[[expanded_0]], %[[expanded]] : tensor{{.*}}) outs(%[[zero]] : tensor{{.*}}) {
+// CHECK-DAG:    ^bb0(%[[in:.*]]: i32, %[[in_1:.*]]: i32, %[[out:.*]]: i32):
+// CHECK-DAG:        %[[two:.*]] = arith.cmpi sgt, %[[in]], %[[in_1]]
+// CHECK-DAG:        %[[three:.*]] = arith.extui %[[two]] : i1 to i32
+// CHECK-DAG:        linalg.yield %[[three]]
+// CHECK-DAG: %[[collapsed:.*]] = tensor.collapse_shape %[[one]]
+// CHECK-DAG: return %[[collapsed]]
+func.func @func_greater(%arg0: !migraphx.shaped<1x1x3xi32, 3x3x1>, %arg1: !migraphx.shaped<1x1x3xi32, 3x3x1>) ->  !migraphx.shaped<1x1x3xi32, 3x3x1> attributes {kernel, arch="gfx950"} {
+  %result = migraphx.greater %arg0, %arg1: <1x1x3xi32, 3x3x1>, <1x1x3xi32, 3x3x1> -> <1x1x3xi32, 3x3x1>
+  func.return %result : !migraphx.shaped<1x1x3xi32, 3x3x1>
+}
+
+// CHECK-LABEL: @func_greater_signed(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor{{.*}})
+// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+// CHECK-DAG: %[[zero:.*]] = tensor.empty
+// CHECK-DAG: %[[one:.*]] = linalg.generic {{.*}} ins(%[[expanded_0]], %[[expanded]] : tensor{{.*}}) outs(%[[zero]] : tensor{{.*}}) {
+// CHECK-DAG:    ^bb0(%[[in:.*]]: {{.*}}, %[[in_1:.*]]: {{.*}}, %[[out:.*]]: {{.*}}):
+// CHECK-DAG:        %[[two:.*]] = arith.cmpi sgt, %[[in]], %[[in_1]]
+// CHECK-DAG:        %[[three:.*]] = arith.extui %[[two]] : i1 to i32
+// CHECK-DAG:        linalg.yield %[[three]]
+// CHECK-DAG: %[[collapsed:.*]] = tensor.collapse_shape %[[one]]
+// CHECK-DAG: return %[[collapsed]]
+func.func @func_greater_signed(%arg0: !migraphx.shaped<1x1x3xsi32, 3x3x1>, %arg1: !migraphx.shaped<1x1x3xsi32, 3x3x1>) ->  !migraphx.shaped<1x1x3xsi32, 3x3x1> attributes {kernel, arch="gfx950"} {
+  %result = migraphx.greater %arg0, %arg1: <1x1x3xsi32, 3x3x1>, <1x1x3xsi32, 3x3x1> -> <1x1x3xsi32, 3x3x1>
+  func.return %result : !migraphx.shaped<1x1x3xsi32, 3x3x1>
+}
+
+// CHECK-LABEL: @func_greater_float(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor{{.*}})
+// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+// CHECK-DAG: %[[zero:.*]] = tensor.empty
+// CHECK-DAG: %[[one:.*]] = linalg.generic {{.*}} ins(%[[expanded_0]], %[[expanded]] : tensor{{.*}}) outs(%[[zero]] : tensor{{.*}}) {
+// CHECK-DAG:    ^bb0(%[[in:.*]]: {{.*}}, %[[in_1:.*]]: {{.*}}, %[[out:.*]]: {{.*}}):
+// CHECK-DAG:        %[[two:.*]] = arith.cmpf ogt, %[[in]], %[[in_1]]
+// CHECK-DAG:        %[[three:.*]] = arith.uitofp %[[two]]
+// CHECK-DAG:        linalg.yield %[[three]]
+// CHECK-DAG: %[[collapsed:.*]] = tensor.collapse_shape %[[one]]
+// CHECK-DAG: return %[[collapsed]]
+func.func @func_greater_float(%arg0: !migraphx.shaped<1x1x3xf32, 3x3x1>, %arg1: !migraphx.shaped<1x1x3xf32, 3x3x1>) ->  !migraphx.shaped<1x1x3xf32, 3x3x1> attributes {kernel, arch="gfx950"}{
+  %result = migraphx.greater %arg0, %arg1: <1x1x3xf32, 3x3x1>, <1x1x3xf32, 3x3x1> -> <1x1x3xf32, 3x3x1>
+  func.return %result : !migraphx.shaped<1x1x3xf32, 3x3x1>
+}
+
+// CHECK-LABEL: @func_equal(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor{{.*}})
+// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+// CHECK-DAG: %[[zero:.*]] = tensor.empty
+// CHECK-DAG: %[[one:.*]] = linalg.generic {{.*}} ins(%[[expanded_0]], %[[expanded]] : tensor{{.*}}) outs(%[[zero]] : tensor{{.*}}) {
+// CHECK-DAG:    ^bb0(%[[in:.*]]: {{.*}}, %[[in_1:.*]]: {{.*}}, %[[out:.*]]: {{.*}}):
+// CHECK-DAG:        %[[two:.*]] = arith.cmpi eq, %[[in]], %[[in_1]]
+// CHECK-DAG:        %[[three:.*]] = arith.extui %[[two]] : i1 to i32
+// CHECK-DAG:        linalg.yield %[[three]]
+// CHECK-DAG: %[[collapsed:.*]] = tensor.collapse_shape %[[one]]
+// CHECK-DAG: return %[[collapsed]]
+func.func @func_equal(%arg0: !migraphx.shaped<1x1x3xi32, 3x3x1>, %arg1: !migraphx.shaped<1x1x3xi32, 3x3x1>) ->  !migraphx.shaped<1x1x3xi32, 3x3x1> attributes {kernel, arch="gfx950"}{
+  %result = migraphx.equal %arg0, %arg1: <1x1x3xi32, 3x3x1>, <1x1x3xi32, 3x3x1> -> <1x1x3xi32, 3x3x1>
+  func.return %result : !migraphx.shaped<1x1x3xi32, 3x3x1>
+}
+
+// CHECK-LABEL: @func_equal_float(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor{{.*}})
+// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+// CHECK-DAG: %[[zero:.*]] = tensor.empty
+// CHECK-DAG: %[[one:.*]] = linalg.generic {{.*}} ins(%[[expanded_0]], %[[expanded]] : tensor{{.*}}) outs(%[[zero]] : tensor{{.*}}) {
+// CHECK-DAG:    ^bb0(%[[in:.*]]: {{.*}}, %[[in_1:.*]]: {{.*}}, %[[out:.*]]: {{.*}}):
+// CHECK-DAG:        %[[two:.*]] = arith.cmpf oeq, %[[in]], %[[in_1]]
+// CHECK-DAG:        %[[three:.*]] = arith.uitofp %[[two]]
+// CHECK-DAG:        linalg.yield %[[three]]
+// CHECK-DAG: %[[collapsed:.*]] = tensor.collapse_shape %[[one]]
+// CHECK-DAG: return %[[collapsed]]
+func.func @func_equal_float(%arg0: !migraphx.shaped<1x1x3xf32, 3x3x1>, %arg1: !migraphx.shaped<1x1x3xf32, 3x3x1>) ->  !migraphx.shaped<1x1x3xf32, 3x3x1> attributes {kernel, arch="gfx950"}{
+  %result = migraphx.equal %arg0, %arg1: <1x1x3xf32, 3x3x1>, <1x1x3xf32, 3x3x1> -> <1x1x3xf32, 3x3x1>
+  func.return %result : !migraphx.shaped<1x1x3xf32, 3x3x1>
+}

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -1,17 +1,5 @@
 // RUN: rocmlir-opt --migraphx-to-linalg -verify-diagnostics %s 
 
-func.func @func_greater(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.greater'}}
-  migraphx.greater %arg0, %arg1: <1x1xf32, 1x1>, <1x1xf32, 1x1> -> <1x1xf32, 1x1>
-  func.return
-}
-
-func.func @func_equal(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.equal'}}
-  migraphx.equal %arg0, %arg1: <1x1xf32, 1x1>, <1x1xf32, 1x1> -> <1x1xf32, 1x1>
-  func.return
-}
-
 func.func @func_where(%arg0: !migraphx.shaped<1x1xi8, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>, %arg2: !migraphx.shaped<1x1xf32, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.where'}}
   migraphx.where %arg0, %arg1, %arg2: <1x1xi8, 1x1>, <1x1xf32, 1x1>, <1x1xf32, 1x1> -> <1x1xf32, 1x1>


### PR DESCRIPTION
## Motivation

Lower `migraphx.greater/equal` into `linalg.generic`. This allow the user to use `migraphx.greater` and `migraphx.equal` operations.

## Technical Details

`migraphx.greater/equal` doesn't map directly into `linalg.elementwise`. In this case, we emit a `linalg.generic` instead. Also, note that the lowering is exactly the same as tosa path. 

## Test Plan

Added a lit test. 

## Test Result

Passed lit test.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
