### PR TITLE
[AIROCMLIR-505] Fixed no kernel attribute crashing `*-to-rock` passes

### DIFF
--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
@@ -54,8 +54,9 @@ void LinalgToRockPass::runOnOperation() {
   MLIRContext &ctx = getContext();
   func::FuncOp func = getOperation();
   if (!func->hasAttr("kernel")) {
-    llvm::report_fatal_error("func op does not have the kernel attribute for "
-                             "linalg-to-rock lowering");
+    func->emitError("func op does not have the kernel attribute for "
+                    "linalg-to-rock lowering");
+    return signalPassFailure();
   }
 
   ConversionTarget bodyConversionTarget(ctx);

--- a/mlir/lib/Conversion/TosaToRock/TosaToRockPass.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRockPass.cpp
@@ -38,7 +38,8 @@ public:
   void runOnOperation() override {
     auto func = getOperation();
     if (!func->hasAttr("kernel")) {
-      llvm::report_fatal_error("func op does not have the kernel attribute");
+      func->emitError("func op does not have the kernel attribute");
+      return signalPassFailure();
     }
     auto &ctx = getContext();
     // Split patterns into two stages by bufferization

--- a/mlir/test/Conversion/LinalgToRock/linalg-to-rock-invalid.mlir
+++ b/mlir/test/Conversion/LinalgToRock/linalg-to-rock-invalid.mlir
@@ -1,0 +1,6 @@
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt --linalg-to-rock -verify-diagnostics --split-input-file
+
+// expected-error @+1 {{func op does not have the kernel attribute for linalg-to-rock lowering}}
+func.func @no_kernel_attribute_test() {
+  func.return
+}

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-invalid.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-invalid.mlir
@@ -1,0 +1,6 @@
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt --tosa-to-rock -verify-diagnostics --split-input-file
+
+// expected-error @+1 {{func op does not have the kernel attribute}}
+func.func @no_kernel_attribute_test() {
+  func.return
+}


### PR DESCRIPTION
## Motivation

As a developer who handwrites a lot of mlir, it would be really nice if the tosa/linalg to rock pass errors out instead of crashing when there are no kernel attributes specified. 

Example: 

```mlir
func.func @empty(){
  func.return
}
```

Ruuning: rocmlir-opt --linalg-to-rock <filename> or rocmlir-opt --tosa-to-rock gives the following. 

```bash
LLVM ERROR: func op does not have the kernel attribute for linalg-to-rock lowering
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace and instructions to reproduce the bug.
Stack dump:
0.	Program arguments: ./bin/rocmlir-opt testing.mlir --linalg-to-rock
 #0 0x00007f1e5f633538 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/Unix/Signals.inc:834:13
 #1 0x00007f1e5f630fe3 llvm::sys::RunSignalHandlers() /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/Signals.cpp:105:18
 #2 0x00007f1e5f634261 SignalHandler(int, siginfo_t*, void*) /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/Unix/Signals.inc:426:38
 #3 0x00007f1e5efed520 (/lib/x86_64-linux-gnu/libc.so.6+0x42520)
 #4 0x00007f1e5f0419fc __pthread_kill_implementation ./nptl/pthread_kill.c:44:76
 #5 0x00007f1e5f0419fc __pthread_kill_internal ./nptl/pthread_kill.c:78:10
 #6 0x00007f1e5f0419fc pthread_kill ./nptl/pthread_kill.c:89:10
 #7 0x00007f1e5efed476 gsignal ./signal/../sysdeps/posix/raise.c:27:6
 #8 0x00007f1e5efd37f3 abort ./stdlib/abort.c:81:7
 #9 0x00007f1e5f56ece7 llvm::report_fatal_error(llvm::Twine const&, bool) /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/ErrorHandling.cpp:137:5
#10 0x00007f1e5f56eb36 (/home/vhe/rocMLIR/build-release/external/llvm-project/llvm/lib/libLLVMSupport.so.22.0git+0x16eb36)
#11 0x00007f1e6c31032d mlir::Operation::hasAttr(llvm::StringRef) /home/vhe/rocMLIR/external/llvm-project/mlir/include/mlir/IR/Operation.h:572:12
#12 0x00007f1e6c31032d (anonymous namespace)::LinalgToRockPass::runOnOperation() /home/vhe/rocMLIR/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp:59:14
#13 0x00007f1e5fed1572 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_3::operator()() const /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:0:17
#14 0x00007f1e5fed1572 void llvm::function_ref<void ()>::callback_fn<mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_3>(long) /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
#15 0x00007f1e5fed1572 llvm::function_ref<void ()>::operator()() const /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
#16 0x00007f1e5fed1572 void mlir::MLIRContext::executeAction<mlir::PassExecutionAction, mlir::Pass&>(llvm::function_ref<void ()>, llvm::ArrayRef<mlir::IRUnit>, mlir::Pass&) /home/vhe/rocMLIR/external/llvm-project/mlir/include/mlir/IR/MLIRContext.h:290:7
#17 0x00007f1e5fed1572 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:603:21
#18 0x00007f1e5fed22ca mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:682:9
#19 0x00007f1e5fed58d4 mlir::detail::OpToOpPassAdaptor::runOnOperationImpl(bool) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:881:13
#20 0x00007f1e5fed1730 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_3::operator()() const /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:610:22
#21 0x00007f1e5fed1730 void llvm::function_ref<void ()>::callback_fn<mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_3>(long) /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
#22 0x00007f1e5fed1730 llvm::function_ref<void ()>::operator()() const /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
#23 0x00007f1e5fed1730 void mlir::MLIRContext::executeAction<mlir::PassExecutionAction, mlir::Pass&>(llvm::function_ref<void ()>, llvm::ArrayRef<mlir::IRUnit>, mlir::Pass&) /home/vhe/rocMLIR/external/llvm-project/mlir/include/mlir/IR/MLIRContext.h:290:7
#24 0x00007f1e5fed1730 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:603:21
#25 0x00007f1e5fed22ca mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:682:9
#26 0x00007f1e5fed8e6c mlir::PassManager::runPasses(mlir::Operation*, mlir::AnalysisManager) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:1117:3
#27 0x00007f1e5fed8545 mlir::PassManager::run(mlir::Operation*) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Pass/Pass.cpp:1091:0
#28 0x00007f1e6c2e40e2 performActions(llvm::raw_ostream&, std::shared_ptr<llvm::SourceMgr> const&, mlir::MLIRContext*, mlir::MlirOptMainConfig const&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:591:7
#29 0x00007f1e6c2e32d8 processBuffer(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef, mlir::MlirOptMainConfig const&, mlir::DialectRegistry&, mlir::SourceMgrDiagnosticVerifierHandler*, llvm::ThreadPoolInterface*) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:673:12
#30 0x00007f1e6c2e32d8 mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&)::$_0::operator()(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef, llvm::raw_ostream&) const /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:762:12
#31 0x00007f1e6c2e32d8 llvm::LogicalResult llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&)>::callback_fn<mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&)::$_0>(long, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&) /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
#32 0x00007f1e5facd23b llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&)>::operator()(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&) const /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
#33 0x00007f1e5facd23b mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Support/ToolUtilities.cpp:30:12
#34 0x00007f1e6c2d8db6 mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:767:26
#35 0x00007f1e6c2d90e6 mlir::MlirOptMain(int, char**, llvm::StringRef, llvm::StringRef, mlir::DialectRegistry&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:813:14
#36 0x00007f1e6c2d9315 mlir::MlirOptMain(int, char**, llvm::StringRef, mlir::DialectRegistry&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:829:10
#37 0x000000000020eb45 main /home/vhe/rocMLIR/mlir/tools/rocmlir-opt/rocmlir-opt.cpp:54:33
#38 0x00007f1e5efd4d90 __libc_start_call_main ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
#39 0x00007f1e5efd4e40 call_init ./csu/../csu/libc-start.c:128:20
#40 0x00007f1e5efd4e40 __libc_start_main ./csu/../csu/libc-start.c:379:5
#41 0x000000000020e8f5 _start (./bin/rocmlir-opt+0x20e8f5)
```

## Technical Details

Added a littest

## Test Plan

Added a lit test

## Test Result

Passed lit test. 
## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
