### PR TITLE
[AIROCMLIR-537] Add fusion check for attention with splitKV > 1

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
@@ -35,8 +35,8 @@ LogicalResult testFusionLegalityReduce(func::FuncOp func);
 LogicalResult testFusionLegalityBwdDataConv(func::FuncOp func);
 
 // Checks whether any `rock::AttentionOp` has splitKV > 1.
-// Fusions are not allowed with splitKV > 1 because the partial results need
-// to be combined with LSE values in a subsequent stage.
+// Output fusions are not allowed with splitKV > 1 because the partial results
+// need to be combined with LSE values in a subsequent stage.
 LogicalResult testFusionLegalityAttentionSplitKV(func::FuncOp func);
 
 // This is an overload of the `testFusionLegalitySplitK` which is more

--- a/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
@@ -34,6 +34,11 @@ LogicalResult testFusionLegalityReduce(func::FuncOp func);
 // are using the v4r1 algorithm (for splitting)
 LogicalResult testFusionLegalityBwdDataConv(func::FuncOp func);
 
+// Checks whether any `rock::AttentionOp` has splitKV > 1.
+// Fusions are not allowed with splitKV > 1 because the partial results need
+// to be combined with LSE values in a subsequent stage.
+LogicalResult testFusionLegalityAttentionSplitKV(func::FuncOp func);
+
 // This is an overload of the `testFusionLegalitySplitK` which is more
 // convenient to use in CAPI. Given a `ModuleOp`, the function retrieve the
 // embedded `func:FuncOp` and calls the implementation
@@ -46,6 +51,10 @@ LogicalResult testFusionLegalityReduce(ModuleOp mod);
 
 // Same as above, overload of `testFusionLegalityBwdDataConv` for `ModuleOp`.
 LogicalResult testFusionLegalityBwdDataConv(ModuleOp mod);
+
+// Same as above, overload for `testFusionLegalityAttentionSplitKV` for
+// `ModuleOp`.
+LogicalResult testFusionLegalityAttentionSplitKV(ModuleOp mod);
 
 // Checks whether the output fusion linalg::GenericOp is valid. Assuming a
 // split-k kernel.

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -1731,7 +1731,8 @@ RocmlirSplitKSelectionLikelihood isSplitKFaster(int64_t gDim, int64_t mDim,
 
 bool isModuleFusible(ModuleOp module, StringRef perfConfig) {
   bool fusible = succeeded(rock::testFusionLegalityReduce(module)) &&
-                 succeeded(rock::testFusionLegalityBwdDataConv(module));
+                 succeeded(rock::testFusionLegalityBwdDataConv(module)) &&
+                 succeeded(rock::testFusionLegalityAttentionSplitKV(module));
   if (!rock::isSplitKRequested(module, perfConfig))
     return fusible;
   return fusible && succeeded(rock::testFusionLegalitySplitK(module));

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -288,6 +288,25 @@ LogicalResult mlir::rock::testFusionLegalityReduce(ModuleOp mod) {
   return testFusionLegalityReduce(func);
 }
 
+LogicalResult mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
+  WalkResult walkResult =
+      func.walk([](rock::AttentionOp attnOp) -> WalkResult {
+        if (attnOp.getSplitKV() > 1)
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      });
+
+  return success(!walkResult.wasInterrupted());
+}
+
+LogicalResult mlir::rock::testFusionLegalityAttentionSplitKV(ModuleOp mod) {
+  auto funcs = mod.getOps<func::FuncOp>();
+  assert(std::distance(funcs.begin(), funcs.end()) &&
+         "expected ModuleOp containing a single func::FuncOp");
+  func::FuncOp func = *(funcs.begin());
+  return testFusionLegalityAttentionSplitKV(func);
+}
+
 LogicalResult mlir::rock::testFusionLegalityBwdDataConv(func::FuncOp func) {
   // For right now, no BwdDataConv ops are fusible
   WalkResult walkResult = func.walk([&](Operation *op) -> WalkResult {

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -290,9 +290,38 @@ LogicalResult mlir::rock::testFusionLegalityReduce(ModuleOp mod) {
 
 LogicalResult
 mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
-  WalkResult walkResult = func.walk([](rock::AttentionOp attnOp) -> WalkResult {
-    if (attnOp.getSplitKV() > 1)
-      return WalkResult::interrupt();
+  // Input fusions and fusions between the first and second gemm are allowed
+  // with splitKV > 1. Only output fusions must be prevented because the
+  // partial results need to be combined with LSE values in a subsequent stage.
+  auto analysis = BufferDependencyAnalysis(func.getOperation());
+  const auto &readersTable = analysis.getReadersTable();
+  const auto &writersTable = analysis.getWritersTable();
+
+  WalkResult walkResult = func.walk([&](rock::AttentionOp attnOp) -> WalkResult {
+    if (attnOp.getSplitKV() <= 1)
+      return WalkResult::advance();
+
+    auto attnResult = attnOp.getOutArgument()->get();
+    auto maybeAlloc = findMemrefAlloc(attnResult);
+    if (failed(maybeAlloc))
+      return WalkResult::advance();
+
+    // Reject if any linalg::GenericOp reads from the attention output
+    if (readersTable.contains(maybeAlloc.value())) {
+      for (OpOperand *op : readersTable.at(maybeAlloc.value())) {
+        if (isa<linalg::GenericOp>(op->getOwner()))
+          return WalkResult::interrupt();
+      }
+    }
+
+    // Reject if any linalg::GenericOp writes to the attention output
+    if (writersTable.contains(maybeAlloc.value())) {
+      for (OpOperand *op : writersTable.at(maybeAlloc.value())) {
+        if (isa<linalg::GenericOp>(op->getOwner()))
+          return WalkResult::interrupt();
+      }
+    }
+
     return WalkResult::advance();
   });
 

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -297,33 +297,34 @@ mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
   const auto &readersTable = analysis.getReadersTable();
   const auto &writersTable = analysis.getWritersTable();
 
-  WalkResult walkResult = func.walk([&](rock::AttentionOp attnOp) -> WalkResult {
-    if (attnOp.getSplitKV() <= 1)
-      return WalkResult::advance();
+  WalkResult walkResult =
+      func.walk([&](rock::AttentionOp attnOp) -> WalkResult {
+        if (attnOp.getSplitKV() <= 1)
+          return WalkResult::advance();
 
-    auto attnResult = attnOp.getOutArgument()->get();
-    auto maybeAlloc = findMemrefAlloc(attnResult);
-    if (failed(maybeAlloc))
-      return WalkResult::advance();
+        auto attnResult = attnOp.getOutArgument()->get();
+        auto maybeAlloc = findMemrefAlloc(attnResult);
+        if (failed(maybeAlloc))
+          return WalkResult::advance();
 
-    // Reject if any linalg::GenericOp reads from the attention output
-    if (readersTable.contains(maybeAlloc.value())) {
-      for (OpOperand *op : readersTable.at(maybeAlloc.value())) {
-        if (isa<linalg::GenericOp>(op->getOwner()))
-          return WalkResult::interrupt();
-      }
-    }
+        // Reject if any linalg::GenericOp reads from the attention output
+        if (readersTable.contains(maybeAlloc.value())) {
+          for (OpOperand *op : readersTable.at(maybeAlloc.value())) {
+            if (isa<linalg::GenericOp>(op->getOwner()))
+              return WalkResult::interrupt();
+          }
+        }
 
-    // Reject if any linalg::GenericOp writes to the attention output
-    if (writersTable.contains(maybeAlloc.value())) {
-      for (OpOperand *op : writersTable.at(maybeAlloc.value())) {
-        if (isa<linalg::GenericOp>(op->getOwner()))
-          return WalkResult::interrupt();
-      }
-    }
+        // Reject if any linalg::GenericOp writes to the attention output
+        if (writersTable.contains(maybeAlloc.value())) {
+          for (OpOperand *op : writersTable.at(maybeAlloc.value())) {
+            if (isa<linalg::GenericOp>(op->getOwner()))
+              return WalkResult::interrupt();
+          }
+        }
 
-    return WalkResult::advance();
-  });
+        return WalkResult::advance();
+      });
 
   return success(!walkResult.wasInterrupted());
 }

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -288,13 +288,13 @@ LogicalResult mlir::rock::testFusionLegalityReduce(ModuleOp mod) {
   return testFusionLegalityReduce(func);
 }
 
-LogicalResult mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
-  WalkResult walkResult =
-      func.walk([](rock::AttentionOp attnOp) -> WalkResult {
-        if (attnOp.getSplitKV() > 1)
-          return WalkResult::interrupt();
-        return WalkResult::advance();
-      });
+LogicalResult
+mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
+  WalkResult walkResult = func.walk([](rock::AttentionOp attnOp) -> WalkResult {
+    if (attnOp.getSplitKV() > 1)
+      return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
 
   return success(!walkResult.wasInterrupted());
 }

--- a/mlir/test/fusion/fusability-attention-splitkv-input-intergemm-fusion.mlir
+++ b/mlir/test/fusion/fusability-attention-splitkv-input-intergemm-fusion.mlir
@@ -1,0 +1,49 @@
+// Input fusions and fusions between the first and second gemm are allowed
+// for attention ops with splitKV > 1. Only output fusions are disallowed.
+
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - | FileCheck %s
+// CHECK: fusible:1
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+module {
+  func.func @attn_splitkv_input_and_intergemm_fusible(
+      %queries: memref<1x64x1024xf32>,
+      %keys: memref<1x64x1024xf32>,
+      %values: memref<1x1024x64xf32>,
+      %lse: memref<4x1024xf32>,
+      %scale: memref<1x64x1024xf32>,
+      %out: memref<4x1024x64xf32>
+  ) attributes {kernel, mhal.arch = "##TOKEN_ARCH##"} {
+    // Input fusion: scale the queries before feeding into attention
+    %scaled_queries = memref.alloc() {alignment = 64 : i64} : memref<1x64x1024xf32>
+    linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel", "parallel"]
+    } ins(%queries, %scale : memref<1x64x1024xf32>, memref<1x64x1024xf32>)
+      outs(%scaled_queries : memref<1x64x1024xf32>) {
+    ^bb0(%in: f32, %in_scale: f32, %result: f32):
+      %mul = arith.mulf %in, %in_scale : f32
+      linalg.yield %mul : f32
+    }
+
+    rock.attention {
+      qk = tr %scaled_queries * %keys : memref<1x64x1024xf32>, memref<1x64x1024xf32>
+      lse = %lse : memref<4x1024xf32>
+      // Inter-gemm fusion: elementwise identity between first and second gemm
+      qk = elementwise {
+      ^bb0(%in: memref<1x1024x1024xf32>, %out_ew: memref<1x1024x1024xf32>):
+        memref.copy %in, %out_ew : memref<1x1024x1024xf32> to memref<1x1024x1024xf32>
+        rock.yield
+      }
+      %out = softmax(qk) * %values : memref<1x1024x64xf32> -> memref<4x1024x64xf32>
+    } {
+      firstGemmIndices = array<i64: 0>,
+      splitKV = 4 : i32,
+      storeMethod = #rock<StoreMethod set>,
+      numHeadsKV = 1 : i32,
+      numHeadsQ = 1 : i32
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-attention-splitkv-output-fusion.mlir
+++ b/mlir/test/fusion/fusability-attention-splitkv-output-fusion.mlir
@@ -1,8 +1,9 @@
-// Fusions are not allowed for attention ops with splitKV > 1.
+// Output fusions are not allowed for attention ops with splitKV > 1.
 // With flash decoding, partial results need LSE-based corrections in a
-// subsequent stage, so no fusions should be applied to the attention kernel.
+// subsequent stage, so output fusions should not be applied to the attention
+// kernel. Input fusions and fusions between the two GEMMs are still allowed.
 
-// RUN: rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - < %s | FileCheck %s
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - | FileCheck %s
 // CHECK: fusible:0
 
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
@@ -15,14 +16,13 @@ module {
       %lse: memref<4x1024xf32>,
       %bias: memref<4x1024x64xf32>,
       %out: memref<4x1024x64xf32>
-  ) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-", features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>} {
+  ) attributes {kernel, mhal.arch = "##TOKEN_ARCH##"} {
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x1024x64xf32>
     rock.attention {
       qk = tr %queries * %keys : memref<1x64x1024xf32>, memref<1x64x1024xf32>
       lse = %lse : memref<4x1024xf32>
       %alloc = softmax(qk) * %values : memref<1x1024x64xf32> -> memref<4x1024x64xf32>
     } {
-      arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-",
       firstGemmIndices = array<i64: 0>,
       splitKV = 4 : i32,
       storeMethod = #rock<StoreMethod set>,

--- a/mlir/test/fusion/fusability-attention-splitkv-output-fusion.mlir
+++ b/mlir/test/fusion/fusability-attention-splitkv-output-fusion.mlir
@@ -1,0 +1,44 @@
+// Fusions are not allowed for attention ops with splitKV > 1.
+// With flash decoding, partial results need LSE-based corrections in a
+// subsequent stage, so no fusions should be applied to the attention kernel.
+
+// RUN: rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - < %s | FileCheck %s
+// CHECK: fusible:0
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+module {
+  func.func @attn_splitkv_not_fusible(
+      %queries: memref<1x64x1024xf32>,
+      %keys: memref<1x64x1024xf32>,
+      %values: memref<1x1024x64xf32>,
+      %lse: memref<4x1024xf32>,
+      %bias: memref<4x1024x64xf32>,
+      %out: memref<4x1024x64xf32>
+  ) attributes {kernel, mhal.arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-", features = #rock<GemmFeatures mfma|dot|atomic_add|atomic_add_f16>} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x1024x64xf32>
+    rock.attention {
+      qk = tr %queries * %keys : memref<1x64x1024xf32>, memref<1x64x1024xf32>
+      lse = %lse : memref<4x1024xf32>
+      %alloc = softmax(qk) * %values : memref<1x1024x64xf32> -> memref<4x1024x64xf32>
+    } {
+      arch = "amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack-",
+      firstGemmIndices = array<i64: 0>,
+      splitKV = 4 : i32,
+      storeMethod = #rock<StoreMethod set>,
+      numHeadsKV = 1 : i32,
+      numHeadsQ = 1 : i32
+    }
+
+    linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel", "parallel"]
+    } ins(%alloc, %bias : memref<4x1024x64xf32>, memref<4x1024x64xf32>)
+      outs(%out : memref<4x1024x64xf32>) {
+    ^bb0(%in: f32, %in_bias: f32, %result: f32):
+      %add = arith.addf %in, %in_bias : f32
+      linalg.yield %add : f32
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Motivation

This PR adds some additional fusion checks to ensure that we always return a result of `fusible: 0` for attention ops with splitKV > 1. This implements: https://amd-hub.atlassian.net/browse/AIROCMLIR-537

## Technical Details

Added a new function called `testFusionLegalityAttentionSplitKV` that make sure that fusions are disabled with `splitKV > 1`

## Test Plan

- PR CI

## Test Result

- [x] PR CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
