### PR TITLE
Cleanup rocMLIR build warnings

### DIFF
--- a/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
+++ b/mlir/lib/Conversion/RocmlirCustomTosaDecompose/RocmlirCustomTosaDecompose.cpp
@@ -867,8 +867,8 @@ public:
     int64_t rank = inputType.getRank();
 
     // Create an empty tensor with the padded output shape
-    Value emptyDest = rewriter.create<tensor::EmptyOp>(
-        loc, outputType.getShape(), outputType.getElementType());
+    Value emptyDest = tensor::EmptyOp::create(
+        rewriter, loc, outputType.getShape(), outputType.getElementType());
 
     // Build the offsets, sizes, and strides for insert_slice
     SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
@@ -879,8 +879,8 @@ public:
     SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
 
     // Insert the input into the beginning of the padded buffer
-    Value result = rewriter.create<tensor::InsertSliceOp>(
-        loc, input, emptyDest, offsets, sizes, strides);
+    Value result = tensor::InsertSliceOp::create(
+        rewriter, loc, input, emptyDest, offsets, sizes, strides);
 
     rewriter.replaceOp(op, result);
     return success();

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -377,8 +377,8 @@ AmdArchInfo mlir::rock::lookupArchInfo(StringRef arch) {
   }
   if (major == "gfx10") {
     return llvm::StringSwitch<AmdArchInfo>(minor)
-        .Cases("11", "13", rdnaNoDotInfo)
-        .Cases("10", "12", rdnaInfo)
+        .Cases({"11", "13"}, rdnaNoDotInfo)
+        .Cases({"10", "12"}, rdnaInfo)
         // All gfx103x are the same for us
         .StartsWith("3", rdnaInfo)
         .Default(rdnaNoDotInfo);

--- a/mlir/lib/Dialect/Rock/Transforms/EmulateNarrowType.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/EmulateNarrowType.cpp
@@ -139,7 +139,7 @@ struct ExtractStridedMetadataOpMemRefViewFolder
 
     Location loc = op.getLoc();
     auto makeConst = [&](int64_t value) -> Value {
-      return rewriter.create<arith::ConstantIndexOp>(loc, value);
+      return arith::ConstantIndexOp::create(rewriter, loc, value);
     };
 
     // For memref.view, the base buffer is the source memref
@@ -158,9 +158,9 @@ struct ExtractStridedMetadataOpMemRefViewFolder
 
     // If the base buffer is needed, reinterpret cast it to the expected type
     if (!op.getBaseBuffer().use_empty()) {
-      baseBuffer = rewriter.create<memref::ReinterpretCastOp>(
-          loc, cast<MemRefType>(op.getBaseBuffer().getType()), baseBuffer, 0,
-          ArrayRef<int64_t>(), ArrayRef<int64_t>());
+      baseBuffer = memref::ReinterpretCastOp::create(
+          rewriter, loc, cast<MemRefType>(op.getBaseBuffer().getType()),
+          baseBuffer, 0, ArrayRef<int64_t>(), ArrayRef<int64_t>());
     }
 
     SmallVector<Value, 4> results = {baseBuffer, offset, size, stride};
@@ -388,10 +388,10 @@ struct GatherToLDSRewritePattern
       Value nibbleBoundConst;
 
       if (isIndexType) {
-        scaleConst = rewriter.create<arith::ConstantIndexOp>(loc, scale);
-        numBytesConst = rewriter.create<arith::ConstantIndexOp>(loc, numBytes);
+        scaleConst = arith::ConstantIndexOp::create(rewriter, loc, scale);
+        numBytesConst = arith::ConstantIndexOp::create(rewriter, loc, numBytes);
         nibbleBoundConst =
-            rewriter.create<arith::ConstantIndexOp>(loc, numNibbles);
+            arith::ConstantIndexOp::create(rewriter, loc, numNibbles);
       } else {
         unsigned indexWidth = cast<IntegerType>(indexType).getWidth();
         scaleConst =


### PR DESCRIPTION
## Motivation
This is just a small PR to clean up build warnings that happen when building rocMLIR.

## Technical Details
* rocmlirCustomTosaDecompose: Switch from `rewriter.create<tensor::EmptyOp>` -> `tensor::EmptyOp::create`
* AmdArchDb: `.Cases("a", "b", val)` → `.Cases({"a", "b"}, val)`
* EmulateNarrowType: Replace `rewriter.create` calls with `op::create`

## Test Plan

- PR CI

## Test Result

- [ ] PR CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
