### PR TITLE
[AIROCMLIR-546] Fixed parser crash from invalid `!migraphx.shaped`

### DIFF
--- a/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
+++ b/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
@@ -109,6 +109,14 @@ Type MIXRShapedType::parse(AsmParser &parser) {
     parser.emitError(currentLoc, "expected `>`");
     return Type();
   }
+
+  if(shape.size() != strides.size()){
+     parser.emitError(currentLoc, "migraphx.shaped type has " + Twine(shape.size())
+                       + " elements in its shape but " + Twine(strides.size())
+                       + " strides defined");
+    return Type();
+  }
+
   return get(shape, strides, elementType);
 }
 

--- a/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
+++ b/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
@@ -110,14 +110,11 @@ Type MIXRShapedType::parse(AsmParser &parser) {
     return Type();
   }
 
-  if(shape.size() != strides.size()){
-     parser.emitError(currentLoc, "migraphx.shaped type has " + Twine(shape.size())
-                       + " elements in its shape but " + Twine(strides.size())
-                       + " strides defined");
-    return Type();
-  }
-
-  return get(shape, strides, elementType);
+  return getChecked(
+      [&]() -> InFlightDiagnostic {
+        return parser.emitError(parser.getCurrentLocation());
+      },
+      shape, strides, elementType);
 }
 
 void MIXRShapedType::print(AsmPrinter &printer) const {

--- a/mlir/test/Dialect/MIGraphX/invalid.mlir
+++ b/mlir/test/Dialect/MIGraphX/invalid.mlir
@@ -270,3 +270,17 @@ func.func @dot_result_shape_mismatch(%arg0: !migraphx.shaped<2x3x4xf16, 12x4x1>,
   %0 = migraphx.dot %arg0, %arg1 : <2x3x4xf16, 12x4x1>, <2x4x5xf16, 20x5x1> -> <2x3x4xf16, 12x4x1>
   return %0 : !migraphx.shaped<2x3x4xf16, 12x4x1>
 }
+
+// -----
+
+// expected-error @+1 {{migraphx.shaped type has 1 elements in its shape but 2 strides defined}}
+func.func @invalid_more_strides_than_shapes(%arg: !migraphx.shaped<1xf32, 1x1>)  {
+  func.return
+}
+
+// -----
+
+// expected-error @+1 {{migraphx.shaped type has 2 elements in its shape but 1 strides defined}}
+func.func @invalid_more_shapes_than_strides(%arg: !migraphx.shaped<1x1xf32, 1>)  {
+  func.return
+}


### PR DESCRIPTION

## Motivation

Running `./bin/rocmlir-opt` on the following files crashes: 

```mlir
// expected-error @+1 {{migraphx.shaped type has 1 elements in its shape but 2 strides defined}}
func.func @invalid_more_strides_than_shapes(%arg: !migraphx.shaped<1xf32, 1x1>)  {
  func.return
}

// -----

// expected-error @+1 {{migraphx.shaped type has 2 elements in its shape but 1 strides defined}}
func.func @invalid_more_shapes_than_strides(%arg: !migraphx.shaped<1x1xf32, 1>)  {
  func.return
}
```

Stack trace:

```bash
0.      Program arguments: ./bin/rocmlir-opt main.mlir --migraphx-to-linalg
1.      MLIR Parser: custom op parser 'func.func'
 #0 0x00007f8246c9ebe9 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/Unix/Signals.inc:834:11
 #1 0x00007f8246c9f10b PrintStackTraceSignalHandler(void*) /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/Unix/Signals.inc:916:1
 #2 0x00007f8246c9d01f llvm::sys::RunSignalHandlers() /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/Signals.cpp:104:5
 #3 0x00007f8246c9f7c9 SignalHandler(int, siginfo_t*, void*) /home/vhe/rocMLIR/external/llvm-project/llvm/lib/Support/Unix/Signals.inc:426:38
 #4 0x00007f82463ed520 (/lib/x86_64-linux-gnu/libc.so.6+0x42520)
 #5 0x00007f82464419fc __pthread_kill_implementation ./nptl/pthread_kill.c:44:76
 #6 0x00007f82464419fc __pthread_kill_internal ./nptl/pthread_kill.c:78:10
 #7 0x00007f82464419fc pthread_kill ./nptl/pthread_kill.c:89:10
 #8 0x00007f82463ed476 gsignal ./signal/../sysdeps/posix/raise.c:27:6
 #9 0x00007f82463d37f3 abort ./stdlib/abort.c:81:7
#10 0x00007f82463d371b _nl_load_domain ./intl/loadmsgcat.c:1177:9
#11 0x00007f82463e4e96 (/lib/x86_64-linux-gnu/libc.so.6+0x39e96)
#12 0x00007f82609c7edb mlir::migraphx::MIXRShapedType mlir::detail::StorageUserBase<mlir::migraphx::MIXRShapedType, mlir::Type, mlir::migraphx::detail::MIXRShapedTypeStorage, mlir::detail::TypeUniquer, mlir::S
hapedType::Trait>::get<llvm::ArrayRef<long>&, llvm::ArrayRef<long>&, mlir::Type&>(mlir::MLIRContext*, llvm::ArrayRef<long>&, llvm::ArrayRef<long>&, mlir::Type&) /home/vhe/rocMLIR/external/llvm-project/mlir/inc
lude/mlir/IR/StorageUniquerSupport.h:179:5
#13 0x00007f8260938559 mlir::migraphx::MIXRShapedType::get(llvm::ArrayRef<long>, llvm::ArrayRef<long>, mlir::Type) /home/vhe/rocMLIR/build-debug/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphXTypes.cpp.inc:76:1
0
#14 0x00007f82609add58 mlir::migraphx::MIXRShapedType::parse(mlir::AsmParser&) /home/vhe/rocMLIR/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp:119:10
#15 0x00007f82609af6f9 generatedTypeParser(mlir::AsmParser&, llvm::StringRef*, mlir::Type&)::$_0::operator()(llvm::StringRef, llvm::SMLoc) const /home/vhe/rocMLIR/build-debug/mlir/include/mlir/Dialect/MIGraphX
/IR/MIGraphXTypes.cpp.inc:22:15
#16 0x00007f82609af618 std::enable_if<!std::is_convertible<generatedTypeParser(mlir::AsmParser&, llvm::StringRef*, mlir::Type&)::$_0, mlir::OptionalParseResult>::value, mlir::AsmParser::KeywordSwitch<mlir::Opt
ionalParseResult>&>::type mlir::AsmParser::KeywordSwitch<mlir::OptionalParseResult>::Case<generatedTypeParser(mlir::AsmParser&, llvm::StringRef*, mlir::Type&)::$_0>(llvm::StringLiteral, generatedTypeParser(mli
r::AsmParser&, llvm::StringRef*, mlir::Type&)::$_0&&) /home/vhe/rocMLIR/external/llvm-project/mlir/include/mlir/IR/OpImplementation.h:890:34
#17 0x00007f8260938ac7 generatedTypeParser(mlir::AsmParser&, llvm::StringRef*, mlir::Type&) /home/vhe/rocMLIR/build-debug/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphXTypes.cpp.inc:21:6
#18 0x00007f826093895f mlir::migraphx::MIGraphXDialect::parseType(mlir::DialectAsmParser&) const /home/vhe/rocMLIR/build-debug/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphXTypes.cpp.inc:112:22
#19 0x00007f8247679670 mlir::detail::Parser::parseExtendedType()::$_0::operator()(llvm::StringRef, llvm::StringRef, llvm::SMLoc) const /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/DialectSymbolPa
rser.cpp:319:32
#20 0x00007f8247678817 mlir::Type parseExtendedSymbol<mlir::Type, llvm::StringMap<mlir::Type, llvm::MallocAllocator>, mlir::detail::Parser::parseExtendedType()::$_0>(mlir::detail::Parser&, mlir::AsmParserState
*, llvm::StringMap<mlir::Type, llvm::MallocAllocator>&, mlir::detail::Parser::parseExtendedType()::$_0&&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/DialectSymbolParser.cpp:248:10
#21 0x00007f82476782ad mlir::detail::Parser::parseExtendedType() /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/DialectSymbolParser.cpp:308:10
#22 0x00007f82476bc1ad mlir::detail::Parser::parseNonFunctionType() /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/TypeParser.cpp:376:12
#23 0x00007f82476bb8e4 mlir::detail::Parser::parseType() /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/TypeParser.cpp:77:10
#24 0x00007f82476a4dd7 mlir::detail::AsmParserImpl<mlir::OpAsmParser>::parseColonType(mlir::Type&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/AsmParserImpl.h:545:38
#25 0x00007f8247690529 (anonymous namespace)::CustomOpAsmParser::parseArgument(mlir::OpAsmParser::Argument&, bool, bool) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/Parser.cpp:1830:23
#26 0x00007f82476906b6 (anonymous namespace)::CustomOpAsmParser::parseOptionalArgument(mlir::OpAsmParser::Argument&, bool, bool) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/Parser.cpp:1842:14
#27 0x00007f824a6d2ff6 parseFunctionArgumentList(mlir::OpAsmParser&, bool, llvm::SmallVectorImpl<mlir::OpAsmParser::Argument>&, bool&)::$_0::operator()() const /home/vhe/rocMLIR/external/llvm-project/mlir/lib/
Interfaces/FunctionImplementation.cpp:42:34
#28 0x00007f824a6d2e85 llvm::ParseResult llvm::function_ref<llvm::ParseResult ()>::callback_fn<parseFunctionArgumentList(mlir::OpAsmParser&, bool, llvm::SmallVectorImpl<mlir::OpAsmParser::Argument>&, bool&)::$
_0>(long) /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
#29 0x00007f824769af99 llvm::function_ref<llvm::ParseResult ()>::operator()() const /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
#30 0x00007f8247687009 mlir::detail::Parser::parseCommaSeparatedList(mlir::AsmParser::Delimiter, llvm::function_ref<llvm::ParseResult ()>, llvm::StringRef) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmP
arser/Parser.cpp:138:7
#31 0x00007f82476a415f mlir::detail::AsmParserImpl<mlir::OpAsmParser>::parseCommaSeparatedList(mlir::AsmParser::Delimiter, llvm::function_ref<llvm::ParseResult ()>, llvm::StringRef) /home/vhe/rocMLIR/external/
llvm-project/mlir/lib/AsmParser/AsmParserImpl.h:329:19
#32 0x00007f824a6d203a parseFunctionArgumentList(mlir::OpAsmParser&, bool, llvm::SmallVectorImpl<mlir::OpAsmParser::Argument>&, bool&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Interfaces/FunctionImplem
entation.cpp:26:17
#33 0x00007f824a6d1f0d mlir::function_interface_impl::parseFunctionSignatureWithArguments(mlir::OpAsmParser&, bool, llvm::SmallVectorImpl<mlir::OpAsmParser::Argument>&, bool&, llvm::SmallVectorImpl<mlir::Type>
&, llvm::SmallVectorImpl<mlir::DictionaryAttr>&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Interfaces/FunctionImplementation.cpp:78:7
#34 0x00007f824a6d21b4 mlir::function_interface_impl::parseFunctionOp(mlir::OpAsmParser&, mlir::OperationState&, bool, mlir::StringAttr, llvm::function_ref<mlir::Type (mlir::Builder&, llvm::ArrayRef<mlir::Type
>, llvm::ArrayRef<mlir::Type>, mlir::function_interface_impl::VariadicFlag, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&)>, mlir::StringAttr, mlir::StringAttr) /home/vhe/rocM
LIR/external/llvm-project/mlir/lib/Interfaces/FunctionImplementation.cpp:107:7
#35 0x00007f824e8b162e mlir::func::FuncOp::parse(mlir::OpAsmParser&, mlir::OperationState&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Dialect/Func/IR/FuncOps.cpp:202:10
#36 0x00007f8260cc5bbd llvm::ParseResult llvm::detail::UniqueFunctionBase<llvm::ParseResult, mlir::OpAsmParser&, mlir::OperationState&>::CallImpl<llvm::ParseResult (*)(mlir::OpAsmParser&, mlir::OperationState&
)>(void*, mlir::OpAsmParser&, mlir::OperationState&) /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/FunctionExtras.h:213:12
#37 0x00007f82476a2d0f llvm::unique_function<llvm::ParseResult (mlir::OpAsmParser&, mlir::OperationState&)>::operator()(mlir::OpAsmParser&, mlir::OperationState&) /home/vhe/rocMLIR/external/llvm-project/llvm/i
nclude/llvm/ADT/FunctionExtras.h:365:12
#38 0x00007f82476a2cb5 llvm::ParseResult llvm::function_ref<llvm::ParseResult (mlir::OpAsmParser&, mlir::OperationState&)>::callback_fn<llvm::unique_function<llvm::ParseResult (mlir::OpAsmParser&, mlir::Operat
ionState&)>>(long, mlir::OpAsmParser&, mlir::OperationState&) /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
#39 0x00007f82476a2969 llvm::function_ref<llvm::ParseResult (mlir::OpAsmParser&, mlir::OperationState&)>::operator()(mlir::OpAsmParser&, mlir::OperationState&) const /home/vhe/rocMLIR/external/llvm-project/llv
m/include/llvm/ADT/STLFunctionalExtras.h:69:12
#40 0x00007f824768ed2e (anonymous namespace)::CustomOpAsmParser::parseOperation(mlir::OperationState&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/Parser.cpp:1609:9
#41 0x00007f824768d650 (anonymous namespace)::OperationParser::parseCustomOperation(llvm::ArrayRef<std::tuple<llvm::StringRef, unsigned int, llvm::SMLoc>>) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmP
arser/Parser.cpp:2148:19
#42 0x00007f8247689893 (anonymous namespace)::OperationParser::parseOperation() /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/Parser.cpp:1262:8
#43 0x00007f82476892ed (anonymous namespace)::TopLevelOperationParser::parse(mlir::Block*, mlir::Location) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/AsmParser/Parser.cpp:2864:20
#44 0x00007f824768918e mlir::parseAsmSourceFile(llvm::SourceMgr const&, mlir::Block*, mlir::ParserConfig const&, mlir::AsmParserState*, mlir::AsmParserCodeCompleteContext*) /home/vhe/rocMLIR/external/llvm-proj
ect/mlir/lib/AsmParser/Parser.cpp:2924:41
#45 0x00007f82587383cf mlir::parseSourceFile(std::shared_ptr<llvm::SourceMgr> const&, mlir::Block*, mlir::ParserConfig const&, mlir::LocationAttr*) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Parser/Parse
r.cpp:64:10
#46 0x00007f8261314f3f mlir::OwningOpRef<mlir::ModuleOp> mlir::detail::parseSourceFile<mlir::ModuleOp, std::shared_ptr<llvm::SourceMgr> const&>(mlir::ParserConfig const&, std::shared_ptr<llvm::SourceMgr> const
&) /home/vhe/rocMLIR/external/llvm-project/mlir/include/mlir/Parser/Parser.h:158:14
#47 0x00007f8261314e48 mlir::OwningOpRef<mlir::ModuleOp> mlir::parseSourceFile<mlir::ModuleOp>(std::shared_ptr<llvm::SourceMgr> const&, mlir::ParserConfig const&) /home/vhe/rocMLIR/external/llvm-project/mlir/i
nclude/mlir/Parser/Parser.h:188:10
#48 0x00007f8261313e9d mlir::parseSourceFileForTool(std::shared_ptr<llvm::SourceMgr> const&, mlir::ParserConfig const&, bool) /home/vhe/rocMLIR/external/llvm-project/mlir/include/mlir/Tools/ParseUtilities.h:31
:12
#49 0x00007f82612f0341 performActions(llvm::raw_ostream&, std::shared_ptr<llvm::SourceMgr> const&, mlir::MLIRContext*, mlir::MlirOptMainConfig const&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:523:16
#50 0x00007f82612f0151 processBuffer(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef, mlir::MlirOptMainConfig const&, mlir::DialectRegistry&, mlir::SourceMgrDiagnosticVerifierHandler*, llvm::ThreadPoolInterface*) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:673:12
#51 0x00007f82612efe0c mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&)::$_0::operator()(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef, llvm::raw_ostream&) const /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:762:12
#52 0x00007f82612efd16 llvm::LogicalResult llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&)>::callback_fn<mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&)::$_0>(long, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&) /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
#53 0x00007f82475a769a llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&)>::operator()(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&) const /home/vhe/rocMLIR/external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
#54 0x00007f82475a6a3a mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::MemoryBufferRef const&, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Support/ToolUtilities.cpp:30:12
#55 0x00007f82612eb7a6 mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:767:26
#56 0x00007f82612ebba5 mlir::MlirOptMain(int, char**, llvm::StringRef, llvm::StringRef, mlir::DialectRegistry&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:813:14
#57 0x00007f82612ebd78 mlir::MlirOptMain(int, char**, llvm::StringRef, mlir::DialectRegistry&) /home/vhe/rocMLIR/external/llvm-project/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:829:10
#58 0x000000000024416d main /home/vhe/rocMLIR/mlir/tools/rocmlir-opt/rocmlir-opt.cpp:54:33
#59 0x00007f82463d4d90 __libc_start_call_main ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
#60 0x00007f82463d4e40 call_init ./csu/../csu/libc-start.c:128:20
#61 0x00007f82463d4e40 __libc_start_main ./csu/../csu/libc-start.c:379:5
#62 0x0000000000244015 _start (./bin/rocmlir-opt+0x244015)
```
## Technical Details

When the number of strides and shapes doesn't match, the parser calls `get()` which crashes the entire program. We emit an error here so that it errors out instead of crashing. 

## Test Plan

Added a lit-test in `invalid.mlir`

## Test Result

Passed lit test. 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
