### PR TITLE
[AIROCMLIR-551] Completely support as_underlying_shape and as_logical_shape

### DIFF
--- a/mlir/include/mlir/Conversion/LinalgToRock/LinalgToRock.h
+++ b/mlir/include/mlir/Conversion/LinalgToRock/LinalgToRock.h
@@ -26,12 +26,7 @@ namespace rock {
 void populateLinalgToRockConversionPattern(RewritePatternSet &pattern,
                                            MLIRContext *context);
 
-/// A tensor.insert_slice is said to be a rock.expand_stride if it satisfies the
-/// following:
-/// - dest is a tensor.empty with a single use
-/// - all offsets are zero
-/// - all strides are one
-/// - all slice sizes are static and match the source tensor shape
+/// A tensor.insert_slice is said to be a rock.expand_strides
 bool isRockExpandStride(tensor::InsertSliceOp op);
 }
 } // namespace mlir

--- a/mlir/include/mlir/Conversion/LinalgToRock/LinalgToRock.h
+++ b/mlir/include/mlir/Conversion/LinalgToRock/LinalgToRock.h
@@ -14,6 +14,7 @@
 #define MLIR_CONVERSION_LINALGTOROCK_H
 
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -24,6 +25,13 @@ namespace mlir {
 namespace rock {
 void populateLinalgToRockConversionPattern(RewritePatternSet &pattern,
                                            MLIRContext *context);
+
+/// A tensor.insert_slice is said to be a rock.expand_stride if it satisfies the following:
+/// - dest is a tensor.empty with a single use
+/// - all offsets are zero
+/// - all strides are one
+/// - all slice sizes are static and match the source tensor shape
+bool isRockExpandStride(tensor::InsertSliceOp op);
 }
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/LinalgToRock/LinalgToRock.h
+++ b/mlir/include/mlir/Conversion/LinalgToRock/LinalgToRock.h
@@ -13,8 +13,8 @@
 #ifndef MLIR_CONVERSION_LINALGTOROCK_H
 #define MLIR_CONVERSION_LINALGTOROCK_H
 
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -26,7 +26,8 @@ namespace rock {
 void populateLinalgToRockConversionPattern(RewritePatternSet &pattern,
                                            MLIRContext *context);
 
-/// A tensor.insert_slice is said to be a rock.expand_stride if it satisfies the following:
+/// A tensor.insert_slice is said to be a rock.expand_stride if it satisfies the
+/// following:
 /// - dest is a tensor.empty with a single use
 /// - all offsets are zero
 /// - all strides are one

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -156,9 +156,9 @@ struct ExpandStrideConverter final
 };
 } // namespace
 
-bool mlir::rock::isRockExpandStride(tensor::InsertSliceOp op){
+bool mlir::rock::isRockExpandStride(tensor::InsertSliceOp op) {
   auto emptyOp = op.getDest().getDefiningOp<tensor::EmptyOp>();
-  if (!emptyOp){
+  if (!emptyOp) {
     return false;
   }
 
@@ -168,10 +168,14 @@ bool mlir::rock::isRockExpandStride(tensor::InsertSliceOp op){
   if (!srcType)
     return false;
 
-  bool isExpandStride = llvm::all_of(op.getStaticOffsets(), [](int64_t offset) { return offset == 0; }) &&
-    llvm::all_of(op.getStaticStrides(), [](int64_t stride) { return stride == 1; }) &&
-    llvm::none_of(op.getStaticSizes(),
-        [](int64_t s) { return s == ShapedType::kDynamic; }) && op.getStaticSizes() == srcType.getShape();
+  bool isExpandStride =
+      llvm::all_of(op.getStaticOffsets(),
+                   [](int64_t offset) { return offset == 0; }) &&
+      llvm::all_of(op.getStaticStrides(),
+                   [](int64_t stride) { return stride == 1; }) &&
+      llvm::none_of(op.getStaticSizes(),
+                    [](int64_t s) { return s == ShapedType::kDynamic; }) &&
+      op.getStaticSizes() == srcType.getShape();
   return isExpandStride;
 }
 
@@ -182,7 +186,7 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
   /// for expanding the strides. We are matching the following IR
   /// %empty = tensor.empty() : ....
   /// %inserted_slice = tensor.insert_slice %actual_data into %empty ...
-  if(!rock::isRockExpandStride(op)){
+  if (!rock::isRockExpandStride(op)) {
     return failure();
   }
   auto tensorEmpty =

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -163,10 +163,8 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
   /// The linalg-to-rock passes emits the following expression
   /// for expanding the strides. We are matching the following IR
-  /// clang-format off
   /// %empty = tensor.empty() : ....
   /// %inserted_slice = tensor.insert_slice %actual_data into %empty ...
-  /// clang-format on
   auto tensorEmpty =
       dyn_cast<tensor::EmptyOp>(op.getOperand(1).getDefiningOp());
   if (!tensorEmpty || !tensorEmpty->hasOneUse()) {

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -199,7 +199,8 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
   auto expandOp = rock::ExpandStridesOp::create(rewriter, loc, op.getType(),
                                                 adaptor.getSource(), alloc);
   rewriter.replaceOp(op, expandOp);
-  assert(tensorEmpty->hasOneUse() && "rock expand strides tensor should only have one use");
+  assert(tensorEmpty->hasOneUse() &&
+         "rock expand strides tensor should only have one use");
   // rewriter.eraseOp(tensorEmpty);
   return success();
 }

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -156,6 +156,25 @@ struct ExpandStrideConverter final
 };
 } // namespace
 
+bool mlir::rock::isRockExpandStride(tensor::InsertSliceOp op){
+  auto emptyOp = op.getDest().getDefiningOp<tensor::EmptyOp>();
+  if (!emptyOp){
+    return false;
+  }
+
+  // Require statically known slice sizes that exactly match the
+  // source tensor shape.
+  auto srcType = dyn_cast<RankedTensorType>(op.getSource().getType());
+  if (!srcType)
+    return false;
+
+  bool isExpandStride = llvm::all_of(op.getStaticOffsets(), [](int64_t offset) { return offset == 0; }) &&
+    llvm::all_of(op.getStaticStrides(), [](int64_t stride) { return stride == 1; }) &&
+    llvm::none_of(op.getStaticSizes(),
+        [](int64_t s) { return s == ShapedType::kDynamic; }) && op.getStaticSizes() == srcType.getShape();
+  return isExpandStride;
+}
+
 LogicalResult ExpandStrideConverter::matchAndRewrite(
     tensor::InsertSliceOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
@@ -163,32 +182,12 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
   /// for expanding the strides. We are matching the following IR
   /// %empty = tensor.empty() : ....
   /// %inserted_slice = tensor.insert_slice %actual_data into %empty ...
+  if(!rock::isRockExpandStride(op)){
+    return failure();
+  }
   auto tensorEmpty =
       dyn_cast<tensor::EmptyOp>(op.getOperand(1).getDefiningOp());
-  if (!tensorEmpty || !tensorEmpty->hasOneUse()) {
-    return failure();
-  }
-
-  // Require statically known slice sizes that exactly match the
-  // source tensor shape.
-  auto srcType = dyn_cast<RankedTensorType>(op.getSource().getType());
-  if (!srcType){
-    return failure();
-  }
-
-  // into rock.expand_strides, but only in the exact expand-strides shape:
-  // - dest is a tensor.empty with a single use
-  // - all offsets are zero
-  // - all strides are one
-  // - all slice sizes are static and match the source tensor shape
-  bool isExpandStride = llvm::all_of(op.getStaticOffsets(), [](int64_t offset) { return offset == 0; }) &&
-    llvm::all_of(op.getStaticStrides(), [](int64_t stride) { return stride == 1; }) &&
-    llvm::none_of(op.getStaticSizes(),
-        [](int64_t s) { return s == ShapedType::kDynamic; }) && op.getStaticSizes() == srcType.getShape();
-
-  if(!isExpandStride){
-    return failure();
-  }
+  assert(tensorEmpty && "Should have been checked by isRockExpandStride");
 
   Location loc = op.getLoc();
   auto alloc = bufferization::AllocTensorOp::create(

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -189,7 +189,7 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
   if (!rock::isRockExpandStride(op)) {
     return failure();
   }
-  auto tensorEmpty =
+  tensor::EmptyOp tensorEmpty =
       dyn_cast<tensor::EmptyOp>(op.getOperand(1).getDefiningOp());
   assert(tensorEmpty && "Should have been checked by isRockExpandStride");
 
@@ -199,7 +199,8 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
   auto expandOp = rock::ExpandStridesOp::create(rewriter, loc, op.getType(),
                                                 adaptor.getSource(), alloc);
   rewriter.replaceOp(op, expandOp);
-  rewriter.eraseOp(tensorEmpty);
+  assert(tensorEmpty->hasOneUse() && "rock expand strides tensor should only have one use");
+  // rewriter.eraseOp(tensorEmpty);
   return success();
 }
 

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -139,8 +139,53 @@ LogicalResult MatmulConverter<LinalgMatOp>::matchAndRewrite(
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// shape related changes
+//===----------------------------------------------------------------------===//
+namespace {
+struct ExpandStrideConverter final
+    : public OpConversionPattern<tensor::InsertSliceOp> {
+  using OpConversionPattern<tensor::InsertSliceOp>::OpConversionPattern;
+  using OpConversionPattern<tensor::InsertSliceOp>::getTypeConverter;
+  using OpAdaptor =
+      typename OpConversionPattern<tensor::InsertSliceOp>::OpAdaptor;
+
+  LogicalResult match(tensor::InsertSliceOp op) const;
+
+  LogicalResult
+  matchAndRewrite(tensor::InsertSliceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+} // namespace
+
+LogicalResult ExpandStrideConverter::matchAndRewrite(
+    tensor::InsertSliceOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  /// The linalg-to-rock passes emits the following expression
+  /// for expanding the strides. We are matching the following IR
+  /// clang-format off
+  /// %empty = tensor.empty() : ....
+  /// %inserted_slice = tensor.insert_slice %actual_data into %empty ...
+  /// clang-format on
+  auto tensorEmpty =
+      dyn_cast<tensor::EmptyOp>(op.getOperand(1).getDefiningOp());
+  if (!tensorEmpty || !tensorEmpty->hasOneUse()) {
+    return failure();
+  }
+
+  Location loc = op.getLoc();
+  auto alloc = bufferization::AllocTensorOp::create(
+      rewriter, loc, tensorEmpty.getResult().getType(), {});
+  auto expandOp = rock::ExpandStridesOp::create(rewriter, loc, op.getType(),
+                                                adaptor.getSource(), alloc);
+  rewriter.replaceOp(op, expandOp);
+  rewriter.eraseOp(tensorEmpty);
+  return success();
+}
+
 void mlir::rock::populateLinalgToRockConversionPattern(
     RewritePatternSet &pattern, MLIRContext *context) {
   pattern.add<MatmulConverter<linalg::BatchMatmulOp>,
-              MatmulConverter<linalg::MatmulOp>>(context);
+              MatmulConverter<linalg::MatmulOp>, ExpandStrideConverter>(
+      context);
 }

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -150,8 +150,6 @@ struct ExpandStrideConverter final
   using OpAdaptor =
       typename OpConversionPattern<tensor::InsertSliceOp>::OpAdaptor;
 
-  LogicalResult match(tensor::InsertSliceOp op) const;
-
   LogicalResult
   matchAndRewrite(tensor::InsertSliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -157,35 +157,16 @@ struct ExpandStrideConverter final
 } // namespace
 
 bool mlir::rock::isRockExpandStride(tensor::InsertSliceOp op) {
-  auto emptyOp = op.getDest().getDefiningOp<tensor::EmptyOp>();
-  if (!emptyOp || !emptyOp->hasOneUse()) {
-    return false;
-  }
-
-  // Require statically known slice sizes that exactly match the
-  // source tensor shape.
-  auto srcType = dyn_cast<RankedTensorType>(op.getSource().getType());
-  if (!srcType)
-    return false;
-
-  bool isExpandStride =
-      llvm::all_of(op.getStaticOffsets(),
-                   [](int64_t offset) { return offset == 0; }) &&
-      llvm::all_of(op.getStaticStrides(),
-                   [](int64_t stride) { return stride == 1; }) &&
-      llvm::none_of(op.getStaticSizes(),
-                    [](int64_t s) { return s == ShapedType::kDynamic; }) &&
-      op.getStaticSizes() == srcType.getShape();
-  return isExpandStride;
+  return op->hasAttr("rock.is_expand_strides") &&
+         isa<tensor::EmptyOp>(op.getOperand(1).getDefiningOp());
 }
 
 LogicalResult ExpandStrideConverter::matchAndRewrite(
     tensor::InsertSliceOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  /// The linalg-to-rock passes emits the following expression
-  /// for expanding the strides. We are matching the following IR
-  /// %empty = tensor.empty() : ....
-  /// %inserted_slice = tensor.insert_slice %actual_data into %empty ...
+  // The migraphx-to-linalg passes emits the rock.is_expand_stride attribute
+  // to indicate that the insert_slice is an expand_stride. In that case, we
+  // transform it into a rock.expand_strides.
   if (!rock::isRockExpandStride(op)) {
     return failure();
   }
@@ -199,9 +180,6 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
   auto expandOp = rock::ExpandStridesOp::create(rewriter, loc, op.getType(),
                                                 adaptor.getSource(), alloc);
   rewriter.replaceOp(op, expandOp);
-  assert(tensorEmpty->hasOneUse() &&
-         "rock expand strides tensor should only have one use");
-  // rewriter.eraseOp(tensorEmpty);
   return success();
 }
 

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -158,7 +158,7 @@ struct ExpandStrideConverter final
 
 bool mlir::rock::isRockExpandStride(tensor::InsertSliceOp op) {
   auto emptyOp = op.getDest().getDefiningOp<tensor::EmptyOp>();
-  if (!emptyOp) {
+  if (!emptyOp || !emptyOp->hasOneUse()) {
     return false;
   }
 

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRock.cpp
@@ -169,6 +169,27 @@ LogicalResult ExpandStrideConverter::matchAndRewrite(
     return failure();
   }
 
+  // Require statically known slice sizes that exactly match the
+  // source tensor shape.
+  auto srcType = dyn_cast<RankedTensorType>(op.getSource().getType());
+  if (!srcType){
+    return failure();
+  }
+
+  // into rock.expand_strides, but only in the exact expand-strides shape:
+  // - dest is a tensor.empty with a single use
+  // - all offsets are zero
+  // - all strides are one
+  // - all slice sizes are static and match the source tensor shape
+  bool isExpandStride = llvm::all_of(op.getStaticOffsets(), [](int64_t offset) { return offset == 0; }) &&
+    llvm::all_of(op.getStaticStrides(), [](int64_t stride) { return stride == 1; }) &&
+    llvm::none_of(op.getStaticSizes(),
+        [](int64_t s) { return s == ShapedType::kDynamic; }) && op.getStaticSizes() == srcType.getShape();
+
+  if(!isExpandStride){
+    return failure();
+  }
+
   Location loc = op.getLoc();
   auto alloc = bufferization::AllocTensorOp::create(
       rewriter, loc, tensorEmpty.getResult().getType(), {});

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
@@ -38,31 +38,11 @@ static void populateLinalgToRockDialectConversion(ConversionTarget &target) {
                          rock::RockDialect, bufferization::BufferizationDialect,
                          math::MathDialect>();
 
-  // tensor.insert_slice with operand of one tensor.empty op can be expanded
-  // into rock.expand_strides
+  // a tensor.insert_slice oculd be a rock expand stride, and in that case
+  // we expand it into a rock.expand_stride
   target.addDynamicallyLegalOp<tensor::InsertSliceOp>(
       [](tensor::InsertSliceOp op) -> std::optional<bool> {
-        auto emptyOp = op.getDest().getDefiningOp<tensor::EmptyOp>();
-        if (!emptyOp){
-          return true;
-        }
-
-        // Require statically known slice sizes that exactly match the
-        // source tensor shape.
-        auto srcType = dyn_cast<RankedTensorType>(op.getSource().getType());
-        if (!srcType)
-          return true;
-
-        // into rock.expand_strides, but only in the exact expand-strides shape:
-        // - dest is a tensor.empty with a single use
-        // - all offsets are zero
-        // - all strides are one
-        // - all slice sizes are static and match the source tensor shape
-        bool isExpandStride = llvm::all_of(op.getStaticOffsets(), [](int64_t offset) { return offset == 0; }) &&
-          llvm::all_of(op.getStaticStrides(), [](int64_t stride) { return stride == 1; }) &&
-          llvm::none_of(op.getStaticSizes(),
-                  [](int64_t s) { return s == ShapedType::kDynamic; }) && op.getStaticSizes() == srcType.getShape();
-        return !isExpandStride;
+        return !rock::isRockExpandStride(op); 
       });
 
   // We only allow Linalg operations that are elementwise. Fusion is supported

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
@@ -38,7 +38,7 @@ static void populateLinalgToRockDialectConversion(ConversionTarget &target) {
                          rock::RockDialect, bufferization::BufferizationDialect,
                          math::MathDialect>();
 
-  // a tensor.insert_slice oculd be a rock expand stride, and in that case
+  // a tensor.insert_slice could be a rock expand stride, and in that case
   // we expand it into a rock.expand_stride
   target.addDynamicallyLegalOp<tensor::InsertSliceOp>(
       [](tensor::InsertSliceOp op) -> std::optional<bool> {

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
@@ -42,7 +42,7 @@ static void populateLinalgToRockDialectConversion(ConversionTarget &target) {
   // we expand it into a rock.expand_stride
   target.addDynamicallyLegalOp<tensor::InsertSliceOp>(
       [](tensor::InsertSliceOp op) -> std::optional<bool> {
-        return !rock::isRockExpandStride(op); 
+        return !rock::isRockExpandStride(op);
       });
 
   // We only allow Linalg operations that are elementwise. Fusion is supported

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
@@ -38,6 +38,14 @@ static void populateLinalgToRockDialectConversion(ConversionTarget &target) {
                          rock::RockDialect, bufferization::BufferizationDialect,
                          math::MathDialect>();
 
+  // tensor.insert_slice with operand of one tensor.empty op can be expanded
+  // into rock.expand_strides
+  target.addDynamicallyLegalOp<tensor::InsertSliceOp>(
+      [](tensor::InsertSliceOp op) -> std::optional<bool> {
+        auto emptyOp = op.getDest().getDefiningOp<tensor::EmptyOp>();
+        return !(emptyOp && emptyOp->hasOneUse());
+      });
+
   // We only allow Linalg operations that are elementwise. Fusion is supported
   // via linalg.generic when it is an elementwise operation. Elementwise
   // operations would be converted into linalg.generic in later passes

--- a/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
+++ b/mlir/lib/Conversion/LinalgToRock/LinalgToRockPass.cpp
@@ -43,7 +43,26 @@ static void populateLinalgToRockDialectConversion(ConversionTarget &target) {
   target.addDynamicallyLegalOp<tensor::InsertSliceOp>(
       [](tensor::InsertSliceOp op) -> std::optional<bool> {
         auto emptyOp = op.getDest().getDefiningOp<tensor::EmptyOp>();
-        return !(emptyOp && emptyOp->hasOneUse());
+        if (!emptyOp){
+          return true;
+        }
+
+        // Require statically known slice sizes that exactly match the
+        // source tensor shape.
+        auto srcType = dyn_cast<RankedTensorType>(op.getSource().getType());
+        if (!srcType)
+          return true;
+
+        // into rock.expand_strides, but only in the exact expand-strides shape:
+        // - dest is a tensor.empty with a single use
+        // - all offsets are zero
+        // - all strides are one
+        // - all slice sizes are static and match the source tensor shape
+        bool isExpandStride = llvm::all_of(op.getStaticOffsets(), [](int64_t offset) { return offset == 0; }) &&
+          llvm::all_of(op.getStaticStrides(), [](int64_t stride) { return stride == 1; }) &&
+          llvm::none_of(op.getStaticSizes(),
+                  [](int64_t s) { return s == ShapedType::kDynamic; }) && op.getStaticSizes() == srcType.getShape();
+        return !isExpandStride;
       });
 
   // We only allow Linalg operations that are elementwise. Fusion is supported

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -116,10 +116,10 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
 
     assert(llvm::none_of(llvm::zip_equal(slicingShape, inputType.getShape()),
                          [](auto val) {
-                           auto [slice_dim, input_dim] = val;
-                           return slice_dim > input_dim;
+                           auto [sliceDim, inputDim] = val;
+                           return sliceDim > inputDim;
                          }) &&
-           "this should have been checked the verifier as the memory layout "
+           "this should have been checked by the verifier as the memory layout "
            "must be greater than the logical layout");
 
     RankedTensorType sliceType = resultType.clone(slicingShape);
@@ -130,9 +130,9 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
                     [&](int64_t size) { return rewriter.getIndexAttr(size); });
     SmallVector<OpFoldResult, 4> strides(sliceType.getRank(),
                                          rewriter.getIndexAttr(1));
-    return tensor::ExtractSliceOp::create(rewriter, loc, input, offset, sizes,
-                                          strides)
-        .getResult();
+    tensor::ExtractSliceOp extractOp = tensor::ExtractSliceOp::create(
+        rewriter, loc, input, offset, sizes, strides);
+    return extractOp.getResult();
   };
 
   /// Broadcast along dimensions whose stride is 0 to reach the full logical
@@ -246,9 +246,10 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
     for (int64_t dim : inputType.getShape())
       sizes.push_back(rewriter.getIndexAttr(dim));
     SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
-    return tensor::InsertSliceOp::create(rewriter, loc, input, empty, offsets,
-                                         sizes, strides)
-        .getResult();
+    tensor::InsertSliceOp insertSlice = tensor::InsertSliceOp::create(
+        rewriter, loc, input, empty, offsets, sizes, strides);
+    insertSlice->setAttr("rock.is_expand_strides", rewriter.getUnitAttr());
+    return insertSlice.getResult();
   };
 
   /// Collapse the N-D memory layout tensor into the flat underlying shape.

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -177,6 +177,13 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
       dyn_cast<RankedTensorType>(getTypeConverter()->convertType(resultType));
   if (!resultTensorType)
     return op.emitOpError("unsupported conversion to underlying shape");
+
+  // Trivial case, the input tensor is the target memory layout tensor
+  if (inTensorType == resultTensorType){
+    rewriter.replaceOp(op, in);
+    return success();
+  }
+
   SmallVector<int64_t, 4> permutation;
   // This is the permutation that reorderd strides into the order they'd be in
   // in a standard shape. So, applying it to a logically-shaped tensor gets
@@ -245,7 +252,6 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
   std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
   auto reshape = tensor::CollapseShapeOp::create(
       rewriter, loc, resultTensorType, transposed, reassociationIndex);
-
   rewriter.replaceOp(op, reshape);
   return success();
 }

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -21,8 +21,6 @@
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/Statistic.h"
 
 using namespace mlir;
 
@@ -65,7 +63,7 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
 
   // reshape into memory layout type
   RankedTensorType memoryType = inType.asMemoryLayoutTensor();
-  if (result.getType() != inType.asMemoryLayoutTensor()) {
+  if (result.getType() != memoryType) {
     SmallVector<ReassociationIndices, 4> reassociationIndex(
         1, ReassociationIndices(memoryType.getRank(), 0));
     std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
@@ -112,8 +110,10 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
 
   RankedTensorType transposedType =
       dyn_cast<RankedTensorType>(result.getType());
+  if (!transposedType) {
+    return op.emitError("cannot get RankedTensorType from result type");
+  }
   if (transposedType.getShape() != ArrayRef(slicingShape)) {
-    SmallVector<int64_t, 4> starts(permutation.size(), 0);
     RankedTensorType sliceType = resultType.clone(slicingShape);
     SmallVector<OpFoldResult, 4> offset(sliceType.getRank(),
                                         rewriter.getIndexAttr(0));
@@ -169,6 +169,8 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
   RankedTensorType memoryLayoutType = resultType.asMemoryLayoutTensor();
   Value in = adaptor.getIn();
   RankedTensorType inTensorType = dyn_cast<RankedTensorType>(in.getType());
+  if (!inTensorType)
+    return op.emitError("cannot get RankedTensorType from input");
   if (!memoryLayoutType || !in)
     return op.emitOpError(
         "output or input type has strides that cannot be represented");

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -232,8 +232,8 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
          llvm::enumerate(memoryLayoutType.getShape(), inputType.getShape())) {
       if (memDim < inDim) {
         return op.emitOpError("memory layout dimension ")
-            << memDim << " is smaller than logical dimension " << inDim
-            << "; this indicates invalid strides";
+               << memDim << " is smaller than logical dimension " << inDim
+               << "; this indicates invalid strides";
       }
     }
 

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -59,10 +59,10 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
   Location loc = op.getLoc();
   migraphx::MIXRShapedType inType = op.getIn().getType();
   RankedTensorType resultType = op.getOut().getType();
+  RankedTensorType memoryType = inType.asMemoryLayoutTensor();
 
   /// Expand a flat/underlying value into the N-D memory layout tensor.
   auto expandToMemoryLayout = [&](Value input) -> Value {
-    RankedTensorType memoryType = inType.asMemoryLayoutTensor();
     if (input.getType() == memoryType)
       return input;
     SmallVector<ReassociationIndices, 4> reassociationIndex(
@@ -75,20 +75,24 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
   /// Invert the stride permutation to transpose from memory order back to
   /// logical order.
   auto transposeToLogicalOrder = [&](Value input) -> Value {
-    SmallVector<int64_t, 4> inversePermutation, permutation, transposedShape;
+    SmallVector<int64_t, 4> inversePermutation;
     inType.getStridePermutation(inversePermutation);
     size_t nDims = inversePermutation.size();
+    bool hasTranspose =
+        !llvm::equal(llvm::seq<int64_t>(nDims), inversePermutation);
+    if (!hasTranspose)
+      return input;
+
+    // Calculating the transposed shape and permutation
+    SmallVector<int64_t, 4> permutation, transposedShape;
     permutation.resize_for_overwrite(nDims);
     transposedShape.resize_for_overwrite(nDims);
     RankedTensorType inputType = cast<RankedTensorType>(input.getType());
-    bool hasTranspose = false;
     for (auto [to, from] : llvm::enumerate(inversePermutation)) {
       permutation[from] = to;
       transposedShape[from] = inputType.getShape()[to];
-      hasTranspose |= (from != static_cast<int32_t>(to));
     }
-    if (!hasTranspose)
-      return input;
+
     Value init = tensor::EmptyOp::create(rewriter, loc, transposedShape,
                                          inputType.getElementType())
                      .getResult();
@@ -106,12 +110,22 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
         dim = 1;
     }
     RankedTensorType inputType = cast<RankedTensorType>(input.getType());
-    if (inputType.getShape() == ArrayRef(slicingShape))
+    if (inputType.getShape() == ArrayRef(slicingShape)) {
       return input;
+    }
+
+    assert(llvm::none_of(llvm::zip_equal(slicingShape, inputType.getShape()),
+                         [](auto val) {
+                           auto [slice_dim, input_dim] = val;
+                           return slice_dim > input_dim;
+                         }) &&
+           "this should have been checked the verifier as the memory layout "
+           "must be greater than the logical layout");
+
     RankedTensorType sliceType = resultType.clone(slicingShape);
     SmallVector<OpFoldResult, 4> offset(sliceType.getRank(),
-                                        rewriter.getIndexAttr(0));
-    SmallVector<OpFoldResult, 4> sizes;
+                                        rewriter.getIndexAttr(0)),
+        sizes;
     llvm::transform(sliceType.getShape(), std::back_inserter(sizes),
                     [&](int64_t size) { return rewriter.getIndexAttr(size); });
     SmallVector<OpFoldResult, 4> strides(sliceType.getRank(),
@@ -140,8 +154,8 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
         1, ReassociationIndices(linalgInputShape.size(), 0));
     std::iota(reassociationOne[0].begin(), reassociationOne[0].end(), 0);
     std::iota(reassociationTwo[0].begin(), reassociationTwo[0].end(), 0);
-    input = tensor::CollapseShapeOp::create(rewriter, loc, input,
-                                            reassociationOne);
+    input =
+        tensor::CollapseShapeOp::create(rewriter, loc, input, reassociationOne);
     input = tensor::ExpandShapeOp::create(
         rewriter, loc,
         RankedTensorType::get(linalgInputShape, resultType.getElementType()),
@@ -153,14 +167,17 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
         .getResult()[0];
   };
 
-  Value result = transposeToLogicalOrder(expandToMemoryLayout(adaptor.getIn()));
+  Value result = expandToMemoryLayout(adaptor.getIn());
+  result = transposeToLogicalOrder(result);
 
   if (result.getType() == resultType) {
     rewriter.replaceOp(op, result);
     return success();
   }
 
-  result = tryBroadcast(tryExtractSlice(result));
+  // handle long stride/broadcasting here
+  result = tryExtractSlice(result);
+  result = tryBroadcast(result);
 
   rewriter.replaceOp(op, result);
   return success();
@@ -217,18 +234,18 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
           "writing to tensors with broadcasts is unsupported");
     RankedTensorType inputType = cast<RankedTensorType>(input.getType());
     bool hasErroredOut = false;
-    if (llvm::any_of(llvm::enumerate(memoryLayoutType.getShape(),
-                                     inputType.getShape()),
-                     [&](auto data) {
-                       auto [index, memDim, inDim] = data;
-                       if (!hasErroredOut && memDim < inDim) {
-                         hasErroredOut = true;
-                         op.emitOpError("memory layout dimension ")
-                             << memDim << " is smaller than logical dimension "
-                             << inDim << "; this indicates invalid strides";
-                       }
-                       return memDim < inDim;
-                     }))
+    if (llvm::any_of(
+            llvm::enumerate(memoryLayoutType.getShape(), inputType.getShape()),
+            [&](auto data) {
+              auto [index, memDim, inDim] = data;
+              if (!hasErroredOut && memDim < inDim) {
+                hasErroredOut = true;
+                op.emitOpError("memory layout dimension ")
+                    << memDim << " is smaller than logical dimension " << inDim
+                    << "; this indicates invalid strides";
+              }
+              return memDim < inDim;
+            }))
       return failure();
     auto empty =
         tensor::EmptyOp::create(rewriter, loc, memoryLayoutType.getShape(),
@@ -239,8 +256,9 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
     for (int64_t dim : inputType.getShape())
       sizes.push_back(rewriter.getIndexAttr(dim));
     SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
-    return tensor::InsertSliceOp::create(rewriter, loc, input, empty,
-                                               offsets, sizes, strides).getResult();
+    return tensor::InsertSliceOp::create(rewriter, loc, input, empty, offsets,
+                                         sizes, strides)
+        .getResult();
   };
 
   /// Collapse the N-D memory layout tensor into the flat underlying shape.

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -21,6 +21,8 @@
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/RockTypes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Statistic.h"
 
 using namespace mlir;
 
@@ -53,60 +55,199 @@ struct AsLogicalShapeOpConverter final
 };
 } // namespace
 
-/// Checking to see if the permutation vector is like (0, 1, 2, 3, 4, 5, ...)
-static bool isPermutationStandardForm(ArrayRef<int64_t> permutation) {
-  SmallVector<int64_t, 4> increasingVec(permutation.size(), 0);
-  std::iota(increasingVec.begin(), increasingVec.end(), 0);
-  return llvm::equal(permutation, increasingVec);
-}
-
 LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
     migraphx::AsLogicalShapeOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
   migraphx::MIXRShapedType inType = op.getIn().getType();
   RankedTensorType resultType = op.getOut().getType();
-  Value in = adaptor.getIn(); // The shape we are casting from
+  Value result = adaptor.getIn(); // The shape we are casting from
 
-  SmallVector<int64_t, 4> permutation;
-  inType.getStridePermutation(permutation);
-  if (isPermutationStandardForm(permutation)) {
+  // reshape into memory layout type
+  RankedTensorType memoryType = inType.asMemoryLayoutTensor();
+  if (result.getType() != inType.asMemoryLayoutTensor()) {
     SmallVector<ReassociationIndices, 4> reassociationIndex(
-        1, ReassociationIndices(resultType.getRank(), 0));
+        1, ReassociationIndices(memoryType.getRank(), 0));
     std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
-    auto newShape = tensor::ExpandShapeOp::create(rewriter, loc, resultType, in,
-                                                  reassociationIndex);
-    rewriter.replaceOp(op, newShape);
+    result = tensor::ExpandShapeOp::create(rewriter, loc, memoryType, result,
+                                           reassociationIndex);
+  }
+
+  // This is the permutation that reorders the strides into standard shape.
+  // Equivalently, it is the permutation that, when applied to a standard
+  // shape, produces its in-memory layout. So, to get back to standard/logical
+  // shape, we need to invert it.
+  SmallVector<int64_t, 4> inversePermutation, permutation, transposedShape;
+  inType.getStridePermutation(inversePermutation);
+  size_t nDims = inversePermutation.size();
+  permutation.resize_for_overwrite(nDims);
+  transposedShape.resize_for_overwrite(nDims);
+  bool hasTranspose = false;
+  for (auto [to, from] : llvm::enumerate(inversePermutation)) {
+    permutation[from] = to;
+    transposedShape[from] = memoryType.getShape()[to];
+    hasTranspose |= (from != static_cast<int32_t>(to));
+  }
+
+  if (hasTranspose) {
+    Value init = tensor::EmptyOp::create(rewriter, loc, transposedShape,
+                                         memoryType.getElementType())
+                     .getResult();
+    result =
+        linalg::TransposeOp::create(rewriter, loc, result, init, permutation)
+            .getResult()[0];
+  }
+
+  if (result.getType() == resultType) {
+    rewriter.replaceOp(op, result);
     return success();
   }
 
-  return op.emitError(
-      "input shape is non standard or broadcast; cannot convert this shape");
+  SmallVector<int64_t, 4> slicingShape(resultType.getShape());
+  for (auto [dim, stride] :
+       llvm::zip_equal(slicingShape, inType.getStrides())) {
+    if (stride == 0)
+      dim = 1;
+  }
+
+  RankedTensorType transposedType =
+      dyn_cast<RankedTensorType>(result.getType());
+  if (transposedType.getShape() != ArrayRef(slicingShape)) {
+    SmallVector<int64_t, 4> starts(permutation.size(), 0);
+    RankedTensorType sliceType = resultType.clone(slicingShape);
+    SmallVector<OpFoldResult, 4> offset(sliceType.getRank(),
+                                        rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult, 4> sizes;
+    llvm::transform(sliceType.getShape(), std::back_inserter(sizes),
+                    [&](int64_t size) { return rewriter.getIndexAttr(size); });
+    SmallVector<OpFoldResult, 4> strides(sliceType.getRank(),
+                                         rewriter.getIndexAttr(1));
+    result = tensor::ExtractSliceOp::create(rewriter, loc, result, offset,
+                                            sizes, strides)
+                 .getResult();
+  }
+
+  if (result.getType() != resultType) {
+    SmallVector<int64_t, 4> linalgInputShape, broadcastDimension;
+    for (auto [index, stride, shape] :
+         llvm::enumerate(inType.getStrides(), inType.getShape())) {
+      if (stride != 0) {
+        linalgInputShape.push_back(shape);
+      } else {
+        broadcastDimension.push_back(index);
+      }
+    }
+
+    SmallVector<ReassociationIndices, 4> reassocationOne(
+        1, ReassociationIndices(resultType.getRank(), 0));
+    SmallVector<ReassociationIndices, 4> reassocationTwo(
+        1, ReassociationIndices(linalgInputShape.size(), 0));
+    std::iota(reassocationOne[0].begin(), reassocationOne[0].end(), 0);
+    std::iota(reassocationTwo[0].begin(), reassocationTwo[0].end(), 0);
+    result =
+        tensor::CollapseShapeOp::create(rewriter, loc, result, reassocationOne);
+    result = tensor::ExpandShapeOp::create(
+        rewriter, loc,
+        RankedTensorType::get(linalgInputShape, resultType.getElementType()),
+        result, reassocationTwo);
+    auto init = tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
+                                        resultType.getElementType());
+    result = linalg::BroadcastOp::create(rewriter, loc, result, init,
+                                         broadcastDimension)
+                 .getResult()[0];
+  }
+
+  rewriter.replaceOp(op, result);
+  return success();
 }
 
 LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
     migraphx::AsUnderlyingShapeOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
+  migraphx::MIXRShapedType resultType = op.getOut().getType();
+  RankedTensorType memoryLayoutType = resultType.asMemoryLayoutTensor();
   Value in = adaptor.getIn();
-  migraphx::MIXRShapedType resultType = op.getResult().getType();
-  auto resultTensorType =
-      cast<RankedTensorType>(getTypeConverter()->convertType(resultType));
+  RankedTensorType inTensorType = dyn_cast<RankedTensorType>(in.getType());
+  if (!memoryLayoutType || !in)
+    return op.emitOpError(
+        "output or input type has strides that cannot be represented");
 
+  RankedTensorType resultTensorType =
+      dyn_cast<RankedTensorType>(getTypeConverter()->convertType(resultType));
+  if (!resultTensorType)
+    return op.emitOpError("unsupported conversion to underlying shape");
   SmallVector<int64_t, 4> permutation;
+  // This is the permutation that reorderd strides into the order they'd be in
+  // in a standard shape. So, applying it to a logically-shaped tensor gets
+  // you the tensor in in-memory layout.
   resultType.getStridePermutation(permutation);
-  if (isPermutationStandardForm(permutation)) {
-    SmallVector<ReassociationIndices, 4> reassociationIndex(
-        1, ReassociationIndices(resultType.getRank(), 0));
-    std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
-    auto reshape = tensor::CollapseShapeOp::create(
-        rewriter, loc, resultTensorType, in, reassociationIndex);
-    rewriter.replaceOp(op, reshape);
-    return success();
+
+  Value transposed = in;
+  if (!llvm::is_sorted(permutation)) {
+    SmallVector<int64_t, 4> transposedShape;
+    llvm::transform(permutation, std::back_inserter(transposedShape),
+                    [&](int64_t permutation) {
+                      return inTensorType.getShape()[permutation];
+                    });
+
+    auto init = tensor::EmptyOp::create(rewriter, loc, transposedShape,
+                                        inTensorType.getElementType())
+                    .getResult();
+    transposed =
+        linalg::TransposeOp::create(rewriter, loc, in, init, permutation)
+            .getResult()[0];
   }
 
-  return op.emitError(
-      "input shape is non standard or broadcast; cannot convert this shape");
+  if (transposed.getType() != memoryLayoutType) {
+    // Check for broadcasts, which we don't support.
+    if (resultType.hasBroadcast()) {
+      return op.emitOpError(
+          "writing to tensors with broadcasts is unsupported");
+    }
+
+    // Verify that memoryLayoutType is >= transposedType in all dimensions.
+    RankedTensorType transposedType =
+        cast<RankedTensorType>(transposed.getType());
+    if (llvm::any_of(llvm::enumerate(memoryLayoutType.getShape(),
+                                     transposedType.getShape()),
+                     [&](auto data) {
+                       auto [index, memDim, transDim] = data;
+                       if (memDim < transDim) {
+                         op.emitOpError("memory layout dimension ")
+                             << memDim << " is smaller than logical dimension "
+                             << transDim << "; this indicates invalid strides";
+                       }
+                       return memDim < transDim;
+                     })) {
+      return failure();
+    }
+
+    auto empty =
+        tensor::EmptyOp::create(rewriter, loc, memoryLayoutType.getShape(),
+                                memoryLayoutType.getElementType());
+    int64_t rank = transposedType.getRank();
+    SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> sizes;
+    for (int64_t dim : transposedType.getShape())
+      sizes.push_back(rewriter.getIndexAttr(dim));
+    SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
+    transposed = tensor::InsertSliceOp::create(rewriter, loc, transposed, empty,
+                                               offsets, sizes, strides);
+  }
+
+  // collapsed shape in the end
+  assert(transposed.getType() == memoryLayoutType &&
+         "we should have either insert a slice to match the memory layout or "
+         "the transposed shape is the memory layout");
+  SmallVector<ReassociationIndices, 4> reassociationIndex(
+      1, ReassociationIndices(resultType.getRank(), 0));
+  std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
+  auto reshape = tensor::CollapseShapeOp::create(
+      rewriter, loc, resultTensorType, transposed, reassociationIndex);
+
+  rewriter.replaceOp(op, reshape);
+  return success();
 }
 
 namespace {

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -188,14 +188,9 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
   migraphx::MIXRShapedType resultType = op.getOut().getType();
-  RankedTensorType memoryLayoutType = resultType.asMemoryLayoutTensor();
   Value in = adaptor.getIn();
-  RankedTensorType inTensorType = dyn_cast<RankedTensorType>(in.getType());
-  if (!inTensorType)
-    return op.emitError("cannot get RankedTensorType from input");
-  if (!memoryLayoutType || !in)
-    return op.emitOpError(
-        "output or input type has strides that cannot be represented");
+  RankedTensorType memoryLayoutType = resultType.asMemoryLayoutTensor();
+  RankedTensorType inTensorType = cast<RankedTensorType>(in.getType());
 
   RankedTensorType resultTensorType =
       dyn_cast<RankedTensorType>(getTypeConverter()->convertType(resultType));
@@ -233,20 +228,15 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
       return op.emitOpError(
           "writing to tensors with broadcasts is unsupported");
     RankedTensorType inputType = cast<RankedTensorType>(input.getType());
-    bool hasErroredOut = false;
-    if (llvm::any_of(
-            llvm::enumerate(memoryLayoutType.getShape(), inputType.getShape()),
-            [&](auto data) {
-              auto [index, memDim, inDim] = data;
-              if (!hasErroredOut && memDim < inDim) {
-                hasErroredOut = true;
-                op.emitOpError("memory layout dimension ")
-                    << memDim << " is smaller than logical dimension " << inDim
-                    << "; this indicates invalid strides";
-              }
-              return memDim < inDim;
-            }))
-      return failure();
+    for (auto [index, memDim, inDim] :
+         llvm::enumerate(memoryLayoutType.getShape(), inputType.getShape())) {
+      if (memDim < inDim) {
+        return op.emitOpError("memory layout dimension ")
+            << memDim << " is smaller than logical dimension " << inDim
+            << "; this indicates invalid strides";
+      }
+    }
+
     auto empty =
         tensor::EmptyOp::create(rewriter, loc, memoryLayoutType.getShape(),
                                 memoryLayoutType.getElementType());

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -59,61 +59,55 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
   Location loc = op.getLoc();
   migraphx::MIXRShapedType inType = op.getIn().getType();
   RankedTensorType resultType = op.getOut().getType();
-  Value result = adaptor.getIn(); // The shape we are casting from
 
-  // reshape into memory layout type
-  RankedTensorType memoryType = inType.asMemoryLayoutTensor();
-  if (result.getType() != memoryType) {
+  /// Expand a flat/underlying value into the N-D memory layout tensor.
+  auto expandToMemoryLayout = [&](Value input) -> Value {
+    RankedTensorType memoryType = inType.asMemoryLayoutTensor();
+    if (input.getType() == memoryType)
+      return input;
     SmallVector<ReassociationIndices, 4> reassociationIndex(
         1, ReassociationIndices(memoryType.getRank(), 0));
     std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
-    result = tensor::ExpandShapeOp::create(rewriter, loc, memoryType, result,
-                                           reassociationIndex);
-  }
+    return tensor::ExpandShapeOp::create(rewriter, loc, memoryType, input,
+                                         reassociationIndex);
+  };
 
-  // This is the permutation that reorders the strides into standard shape.
-  // Equivalently, it is the permutation that, when applied to a standard
-  // shape, produces its in-memory layout. So, to get back to standard/logical
-  // shape, we need to invert it.
-  SmallVector<int64_t, 4> inversePermutation, permutation, transposedShape;
-  inType.getStridePermutation(inversePermutation);
-  size_t nDims = inversePermutation.size();
-  permutation.resize_for_overwrite(nDims);
-  transposedShape.resize_for_overwrite(nDims);
-  bool hasTranspose = false;
-  for (auto [to, from] : llvm::enumerate(inversePermutation)) {
-    permutation[from] = to;
-    transposedShape[from] = memoryType.getShape()[to];
-    hasTranspose |= (from != static_cast<int32_t>(to));
-  }
-
-  if (hasTranspose) {
+  /// Invert the stride permutation to transpose from memory order back to
+  /// logical order.
+  auto transposeToLogicalOrder = [&](Value input) -> Value {
+    SmallVector<int64_t, 4> inversePermutation, permutation, transposedShape;
+    inType.getStridePermutation(inversePermutation);
+    size_t nDims = inversePermutation.size();
+    permutation.resize_for_overwrite(nDims);
+    transposedShape.resize_for_overwrite(nDims);
+    RankedTensorType inputType = cast<RankedTensorType>(input.getType());
+    bool hasTranspose = false;
+    for (auto [to, from] : llvm::enumerate(inversePermutation)) {
+      permutation[from] = to;
+      transposedShape[from] = inputType.getShape()[to];
+      hasTranspose |= (from != static_cast<int32_t>(to));
+    }
+    if (!hasTranspose)
+      return input;
     Value init = tensor::EmptyOp::create(rewriter, loc, transposedShape,
-                                         memoryType.getElementType())
+                                         inputType.getElementType())
                      .getResult();
-    result =
-        linalg::TransposeOp::create(rewriter, loc, result, init, permutation)
-            .getResult()[0];
-  }
+    return linalg::TransposeOp::create(rewriter, loc, input, init, permutation)
+        .getResult()[0];
+  };
 
-  if (result.getType() == resultType) {
-    rewriter.replaceOp(op, result);
-    return success();
-  }
-
-  SmallVector<int64_t, 4> slicingShape(resultType.getShape());
-  for (auto [dim, stride] :
-       llvm::zip_equal(slicingShape, inType.getStrides())) {
-    if (stride == 0)
-      dim = 1;
-  }
-
-  RankedTensorType transposedType =
-      dyn_cast<RankedTensorType>(result.getType());
-  if (!transposedType) {
-    return op.emitError("cannot get RankedTensorType from result type");
-  }
-  if (transposedType.getShape() != ArrayRef(slicingShape)) {
+  /// Extract the logical slice when the memory layout is larger than the
+  /// logical shape (broadcast dimensions are collapsed to size 1).
+  auto tryExtractSlice = [&](Value input) -> Value {
+    SmallVector<int64_t, 4> slicingShape(resultType.getShape());
+    for (auto [dim, stride] :
+         llvm::zip_equal(slicingShape, inType.getStrides())) {
+      if (stride == 0)
+        dim = 1;
+    }
+    RankedTensorType inputType = cast<RankedTensorType>(input.getType());
+    if (inputType.getShape() == ArrayRef(slicingShape))
+      return input;
     RankedTensorType sliceType = resultType.clone(slicingShape);
     SmallVector<OpFoldResult, 4> offset(sliceType.getRank(),
                                         rewriter.getIndexAttr(0));
@@ -122,40 +116,51 @@ LogicalResult AsLogicalShapeOpConverter::matchAndRewrite(
                     [&](int64_t size) { return rewriter.getIndexAttr(size); });
     SmallVector<OpFoldResult, 4> strides(sliceType.getRank(),
                                          rewriter.getIndexAttr(1));
-    result = tensor::ExtractSliceOp::create(rewriter, loc, result, offset,
-                                            sizes, strides)
-                 .getResult();
-  }
+    return tensor::ExtractSliceOp::create(rewriter, loc, input, offset, sizes,
+                                          strides)
+        .getResult();
+  };
 
-  if (result.getType() != resultType) {
-    SmallVector<int64_t, 4> linalgInputShape, broadcastDimension;
+  /// Broadcast along dimensions whose stride is 0 to reach the full logical
+  /// shape.
+  auto tryBroadcast = [&](Value input) -> Value {
+    if (input.getType() == resultType)
+      return input;
+    SmallVector<int64_t, 4> linalgInputShape, broadcastDimensions;
     for (auto [index, stride, shape] :
          llvm::enumerate(inType.getStrides(), inType.getShape())) {
-      if (stride != 0) {
+      if (stride != 0)
         linalgInputShape.push_back(shape);
-      } else {
-        broadcastDimension.push_back(index);
-      }
+      else
+        broadcastDimensions.push_back(index);
     }
-
-    SmallVector<ReassociationIndices, 4> reassocationOne(
+    SmallVector<ReassociationIndices, 4> reassociationOne(
         1, ReassociationIndices(resultType.getRank(), 0));
-    SmallVector<ReassociationIndices, 4> reassocationTwo(
+    SmallVector<ReassociationIndices, 4> reassociationTwo(
         1, ReassociationIndices(linalgInputShape.size(), 0));
-    std::iota(reassocationOne[0].begin(), reassocationOne[0].end(), 0);
-    std::iota(reassocationTwo[0].begin(), reassocationTwo[0].end(), 0);
-    result =
-        tensor::CollapseShapeOp::create(rewriter, loc, result, reassocationOne);
-    result = tensor::ExpandShapeOp::create(
+    std::iota(reassociationOne[0].begin(), reassociationOne[0].end(), 0);
+    std::iota(reassociationTwo[0].begin(), reassociationTwo[0].end(), 0);
+    input = tensor::CollapseShapeOp::create(rewriter, loc, input,
+                                            reassociationOne);
+    input = tensor::ExpandShapeOp::create(
         rewriter, loc,
         RankedTensorType::get(linalgInputShape, resultType.getElementType()),
-        result, reassocationTwo);
+        input, reassociationTwo);
     auto init = tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
                                         resultType.getElementType());
-    result = linalg::BroadcastOp::create(rewriter, loc, result, init,
-                                         broadcastDimension)
-                 .getResult()[0];
+    return linalg::BroadcastOp::create(rewriter, loc, input, init,
+                                       broadcastDimensions)
+        .getResult()[0];
+  };
+
+  Value result = transposeToLogicalOrder(expandToMemoryLayout(adaptor.getIn()));
+
+  if (result.getType() == resultType) {
+    rewriter.replaceOp(op, result);
+    return success();
   }
+
+  result = tryBroadcast(tryExtractSlice(result));
 
   rewriter.replaceOp(op, result);
   return success();
@@ -180,84 +185,80 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
   if (!resultTensorType)
     return op.emitOpError("unsupported conversion to underlying shape");
 
-  // Trivial case, the input tensor is the target memory layout tensor
   if (inTensorType == resultTensorType) {
     rewriter.replaceOp(op, in);
     return success();
   }
 
-  SmallVector<int64_t, 4> permutation;
-  // This is the permutation that reorderd strides into the order they'd be in
-  // in a standard shape. So, applying it to a logically-shaped tensor gets
-  // you the tensor in in-memory layout.
-  resultType.getStridePermutation(permutation);
-
-  Value transposed = in;
-  if (!llvm::is_sorted(permutation)) {
+  /// Transpose from logical order to memory layout order.
+  auto transposeToMemoryOrder = [&](Value input) -> Value {
+    SmallVector<int64_t, 4> permutation;
+    resultType.getStridePermutation(permutation);
+    if (llvm::is_sorted(permutation))
+      return input;
+    RankedTensorType inputType = cast<RankedTensorType>(input.getType());
     SmallVector<int64_t, 4> transposedShape;
     llvm::transform(permutation, std::back_inserter(transposedShape),
-                    [&](int64_t permutation) {
-                      return inTensorType.getShape()[permutation];
-                    });
-
+                    [&](int64_t p) { return inputType.getShape()[p]; });
     auto init = tensor::EmptyOp::create(rewriter, loc, transposedShape,
-                                        inTensorType.getElementType())
+                                        inputType.getElementType())
                     .getResult();
-    transposed =
-        linalg::TransposeOp::create(rewriter, loc, in, init, permutation)
-            .getResult()[0];
-  }
+    return linalg::TransposeOp::create(rewriter, loc, input, init, permutation)
+        .getResult()[0];
+  };
 
-  if (transposed.getType() != memoryLayoutType) {
-    // Check for broadcasts, which we don't support.
-    if (resultType.hasBroadcast()) {
+  /// Pad via insert_slice when the transposed shape is smaller than the
+  /// memory layout (e.g. due to stride-based padding).
+  auto tryInsertSlice = [&](Value input) -> FailureOr<Value> {
+    if (input.getType() == memoryLayoutType)
+      return input;
+    if (resultType.hasBroadcast())
       return op.emitOpError(
           "writing to tensors with broadcasts is unsupported");
-    }
-
-    // Verify that memoryLayoutType is >= transposedType in all dimensions.
-    RankedTensorType transposedType =
-        cast<RankedTensorType>(transposed.getType());
+    RankedTensorType inputType = cast<RankedTensorType>(input.getType());
     bool hasErroredOut = false;
     if (llvm::any_of(llvm::enumerate(memoryLayoutType.getShape(),
-                                     transposedType.getShape()),
+                                     inputType.getShape()),
                      [&](auto data) {
-                       auto [index, memDim, transDim] = data;
-                       // We only want to emit this error one time
-                       if (!hasErroredOut && memDim < transDim) {
+                       auto [index, memDim, inDim] = data;
+                       if (!hasErroredOut && memDim < inDim) {
                          hasErroredOut = true;
                          op.emitOpError("memory layout dimension ")
                              << memDim << " is smaller than logical dimension "
-                             << transDim << "; this indicates invalid strides";
+                             << inDim << "; this indicates invalid strides";
                        }
-                       return memDim < transDim;
-                     })) {
+                       return memDim < inDim;
+                     }))
       return failure();
-    }
-
     auto empty =
         tensor::EmptyOp::create(rewriter, loc, memoryLayoutType.getShape(),
                                 memoryLayoutType.getElementType());
-    int64_t rank = transposedType.getRank();
+    int64_t rank = inputType.getRank();
     SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> sizes;
-    for (int64_t dim : transposedType.getShape())
+    for (int64_t dim : inputType.getShape())
       sizes.push_back(rewriter.getIndexAttr(dim));
     SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
-    transposed = tensor::InsertSliceOp::create(rewriter, loc, transposed, empty,
-                                               offsets, sizes, strides);
-  }
+    return tensor::InsertSliceOp::create(rewriter, loc, input, empty,
+                                               offsets, sizes, strides).getResult();
+  };
 
-  // collapsed shape in the end
-  assert(transposed.getType() == memoryLayoutType &&
-         "we should have either insert a slice to match the memory layout or "
-         "the transposed shape is the memory layout");
-  SmallVector<ReassociationIndices, 4> reassociationIndex(
-      1, ReassociationIndices(resultType.getRank(), 0));
-  std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
-  auto reshape = tensor::CollapseShapeOp::create(
-      rewriter, loc, resultTensorType, transposed, reassociationIndex);
-  rewriter.replaceOp(op, reshape);
+  /// Collapse the N-D memory layout tensor into the flat underlying shape.
+  auto collapseToUnderlying = [&](Value input) -> Value {
+    assert(input.getType() == memoryLayoutType &&
+           "expected memory layout type before collapsing");
+    SmallVector<ReassociationIndices, 4> reassociationIndex(
+        1, ReassociationIndices(resultType.getRank(), 0));
+    std::iota(reassociationIndex[0].begin(), reassociationIndex[0].end(), 0);
+    return tensor::CollapseShapeOp::create(rewriter, loc, resultTensorType,
+                                           input, reassociationIndex);
+  };
+
+  FailureOr<Value> result = tryInsertSlice(transposeToMemoryOrder(in));
+  if (failed(result))
+    return failure();
+
+  rewriter.replaceOp(op, collapseToUnderlying(*result));
   return success();
 }
 

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -181,7 +181,7 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
     return op.emitOpError("unsupported conversion to underlying shape");
 
   // Trivial case, the input tensor is the target memory layout tensor
-  if (inTensorType == resultTensorType){
+  if (inTensorType == resultTensorType) {
     rewriter.replaceOp(op, in);
     return success();
   }
@@ -218,11 +218,14 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
     // Verify that memoryLayoutType is >= transposedType in all dimensions.
     RankedTensorType transposedType =
         cast<RankedTensorType>(transposed.getType());
+    bool hasErroredOut = false;
     if (llvm::any_of(llvm::enumerate(memoryLayoutType.getShape(),
                                      transposedType.getShape()),
                      [&](auto data) {
                        auto [index, memDim, transDim] = data;
-                       if (memDim < transDim) {
+                       // We only want to emit this error one time 
+                       if (!hasErroredOut && memDim < transDim) {
+                         hasErroredOut = true;
                          op.emitOpError("memory layout dimension ")
                              << memDim << " is smaller than logical dimension "
                              << transDim << "; this indicates invalid strides";

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -223,7 +223,7 @@ LogicalResult AsUnderlyingShapeConverter::matchAndRewrite(
                                      transposedType.getShape()),
                      [&](auto data) {
                        auto [index, memDim, transDim] = data;
-                       // We only want to emit this error one time 
+                       // We only want to emit this error one time
                        if (!hasErroredOut && memDim < transDim) {
                          hasErroredOut = true;
                          op.emitOpError("memory layout dimension ")

--- a/mlir/test/Conversion/LinalgToRock/linalg-to-rock-expand-strides.mlir
+++ b/mlir/test/Conversion/LinalgToRock/linalg-to-rock-expand-strides.mlir
@@ -1,0 +1,56 @@
+// RUN:  sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt --linalg-to-rock -verify-diagnostics -split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @mlir_dot_log
+// CHECK-SAME: (%[[arg0:.*]]: tensor<1536xf16>, %[[arg1:.*]]: tensor<1536xf16>)
+func.func @mlir_dot_log(%arg0: tensor<1536xf16>, %arg1: tensor<1536xf16>) -> tensor<4608xf16> attributes {kernel, arch="##TOKEN_ARCH##"} {
+  //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+  //   CHECK: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+  %expanded = tensor.expand_shape %arg1 [[0, 1, 2]] output_shape [4, 16, 24] : tensor<1536xf16> into tensor<4x16x24xf16>
+  %expanded_0 = tensor.expand_shape %arg0 [[0, 1, 2]] output_shape [4, 24, 16] : tensor<1536xf16> into tensor<4x24x16xf16>
+  //   CHECK: %[[cst:.*]] = arith.constant dense<0.000000e+00> : tensor<4x24x24xf16>
+  %cst = arith.constant dense<0.000000e+00> : tensor<4x24x24xf16>
+  //   CHECK: %[[alloc:.*]] = bufferization.alloc_tensor() : tensor<4x24x24xf16>
+  //   CHECK: %[[gemm:.*]] = rock.gemm %[[alloc]] = %[[expanded_0]] * %[[expanded]]{{.*}}storeMethod
+  %0 = linalg.batch_matmul ins(%expanded_0, %expanded : tensor<4x24x16xf16>, tensor<4x16x24xf16>) outs(%cst : tensor<4x24x24xf16>) -> tensor<4x24x24xf16>
+  //   CHECK: %[[empty:.*]] = tensor.empty() : tensor<4x24x24xf16>
+  //   CHECK: %[[log:.*]] = linalg.log ins(%[[gemm]]{{.*}}) outs(%[[empty]]{{.*}}) -> tensor<4x24x24xf16>
+  %1 = tensor.empty() : tensor<4x24x24xf16>
+  %2 = linalg.log ins(%0 : tensor<4x24x24xf16>) outs(%1 : tensor<4x24x24xf16>) -> tensor<4x24x24xf16>
+  //   CHECK: %[[alloc2:.*]] = bufferization.alloc_tensor() : tensor<4x48x24xf16>
+  //   CHECK: %[[expand:.*]] = rock.expand_strides %[[log]] into %[[alloc2]]
+  %3 = tensor.empty() : tensor<4x48x24xf16>
+  %inserted_slice = tensor.insert_slice %2 into %3[0, 0, 0] [4, 24, 24] [1, 1, 1] : tensor<4x24x24xf16> into tensor<4x48x24xf16>
+  //   CHECK: %[[collapsed:.*]] = tensor.collapse_shape %[[expand]]
+  //   CHECK: return %[[collapsed]]
+  %collapsed = tensor.collapse_shape %inserted_slice [[0, 1, 2]] : tensor<4x48x24xf16> into tensor<4608xf16>
+  return %collapsed : tensor<4608xf16>
+}
+
+// -----
+
+
+// CHECK-LABEL: func.func @mlir_dot_log
+// CHECK-SAME: (%[[arg0:.*]]: tensor<320xf16>, %[[arg1:.*]]: tensor<1536xf16>)
+func.func @mlir_dot_log(%arg0: tensor<320xf16>, %arg1: tensor<1536xf16>) -> tensor<1152xf16> attributes {kernel, arch="##TOKEN_ARCH##"} {
+  //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+  //   CHECK: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+  %expanded = tensor.expand_shape %arg1 [[0, 1, 2]] output_shape [4, 16, 24] : tensor<1536xf16> into tensor<4x16x24xf16>
+  %expanded_0 = tensor.expand_shape %arg0 [[0, 1, 2]] output_shape [4, 5, 16] : tensor<320xf16> into tensor<4x5x16xf16>
+  //   CHECK: %[[cst:.*]] = arith.constant dense<0.000000e+00> : tensor<4x5x24xf16>
+  %cst = arith.constant dense<0.000000e+00> : tensor<4x5x24xf16>
+  //   CHECK: %[[alloc:.*]] = bufferization.alloc_tensor() : tensor<4x5x24xf16>
+  //   CHECK: %[[gemm:.*]] = rock.gemm %[[alloc]] = %[[expanded_0]] * %[[expanded]]{{.*}}storeMethod
+  %0 = linalg.batch_matmul ins(%expanded_0, %expanded : tensor<4x5x16xf16>, tensor<4x16x24xf16>) outs(%cst : tensor<4x5x24xf16>) -> tensor<4x5x24xf16>
+  //   CHECK: %[[empty:.*]] = tensor.empty() : tensor<4x5x24xf16>
+  //   CHECK: %[[log:.*]] = linalg.log ins(%[[gemm]]{{.*}}) outs(%[[empty]]{{.*}}) -> tensor<4x5x24xf16>
+  %1 = tensor.empty() : tensor<4x5x24xf16>
+  %2 = linalg.log ins(%0 : tensor<4x5x24xf16>) outs(%1 : tensor<4x5x24xf16>) -> tensor<4x5x24xf16>
+  //   CHECK: %[[alloc2:.*]] = bufferization.alloc_tensor() : tensor<4x12x24xf16>
+  //   CHECK: %[[expand:.*]] = rock.expand_strides %[[log]] into %[[alloc2]]
+  %3 = tensor.empty() : tensor<4x12x24xf16>
+  %inserted_slice = tensor.insert_slice %2 into %3[0, 0, 0] [4, 5, 24] [1, 1, 1] : tensor<4x5x24xf16> into tensor<4x12x24xf16>
+  //   CHECK: %[[collapsed:.*]] = tensor.collapse_shape %[[expand]]
+  //   CHECK: return %[[collapsed]]
+  %collapsed = tensor.collapse_shape %inserted_slice [[0, 1, 2]] : tensor<4x12x24xf16> into tensor<1152xf16>
+  return %collapsed : tensor<1152xf16>
+}

--- a/mlir/test/Conversion/LinalgToRock/linalg-to-rock-expand-strides.mlir
+++ b/mlir/test/Conversion/LinalgToRock/linalg-to-rock-expand-strides.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: func.func @mlir_dot_log
 // CHECK-SAME: (%[[arg0:.*]]: tensor<1536xf16>, %[[arg1:.*]]: tensor<1536xf16>)
-func.func @mlir_dot_log(%arg0: tensor<1536xf16>, %arg1: tensor<1536xf16>) -> tensor<4608xf16> attributes {kernel, arch="##TOKEN_ARCH##"} {
+func.func @mlir_dot_log(%arg0: tensor<1536xf16>, %arg1: tensor<1536xf16>) -> tensor<4608xf16> attributes {rock.kernel, rock.arch="##TOKEN_ARCH##"} {
   //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
   //   CHECK: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
   %expanded = tensor.expand_shape %arg1 [[0, 1, 2]] output_shape [4, 16, 24] : tensor<1536xf16> into tensor<4x16x24xf16>
@@ -31,7 +31,7 @@ func.func @mlir_dot_log(%arg0: tensor<1536xf16>, %arg1: tensor<1536xf16>) -> ten
 
 // CHECK-LABEL: func.func @mlir_dot_log
 // CHECK-SAME: (%[[arg0:.*]]: tensor<320xf16>, %[[arg1:.*]]: tensor<1536xf16>)
-func.func @mlir_dot_log(%arg0: tensor<320xf16>, %arg1: tensor<1536xf16>) -> tensor<1152xf16> attributes {kernel, arch="##TOKEN_ARCH##"} {
+func.func @mlir_dot_log(%arg0: tensor<320xf16>, %arg1: tensor<1536xf16>) -> tensor<1152xf16> attributes {rock.kernel, rock.arch="##TOKEN_ARCH##"} {
   //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
   //   CHECK: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
   %expanded = tensor.expand_shape %arg1 [[0, 1, 2]] output_shape [4, 16, 24] : tensor<1536xf16> into tensor<4x16x24xf16>

--- a/mlir/test/Conversion/LinalgToRock/linalg-to-rock-expand-strides.mlir
+++ b/mlir/test/Conversion/LinalgToRock/linalg-to-rock-expand-strides.mlir
@@ -19,7 +19,7 @@ func.func @mlir_dot_log(%arg0: tensor<1536xf16>, %arg1: tensor<1536xf16>) -> ten
   //   CHECK: %[[alloc2:.*]] = bufferization.alloc_tensor() : tensor<4x48x24xf16>
   //   CHECK: %[[expand:.*]] = rock.expand_strides %[[log]] into %[[alloc2]]
   %3 = tensor.empty() : tensor<4x48x24xf16>
-  %inserted_slice = tensor.insert_slice %2 into %3[0, 0, 0] [4, 24, 24] [1, 1, 1] : tensor<4x24x24xf16> into tensor<4x48x24xf16>
+  %inserted_slice = tensor.insert_slice %2 into %3[0, 0, 0] [4, 24, 24] [1, 1, 1] {rock.is_expand_strides}: tensor<4x24x24xf16> into tensor<4x48x24xf16>
   //   CHECK: %[[collapsed:.*]] = tensor.collapse_shape %[[expand]]
   //   CHECK: return %[[collapsed]]
   %collapsed = tensor.collapse_shape %inserted_slice [[0, 1, 2]] : tensor<4x48x24xf16> into tensor<4608xf16>
@@ -48,7 +48,7 @@ func.func @mlir_dot_log(%arg0: tensor<320xf16>, %arg1: tensor<1536xf16>) -> tens
   //   CHECK: %[[alloc2:.*]] = bufferization.alloc_tensor() : tensor<4x12x24xf16>
   //   CHECK: %[[expand:.*]] = rock.expand_strides %[[log]] into %[[alloc2]]
   %3 = tensor.empty() : tensor<4x12x24xf16>
-  %inserted_slice = tensor.insert_slice %2 into %3[0, 0, 0] [4, 5, 24] [1, 1, 1] : tensor<4x5x24xf16> into tensor<4x12x24xf16>
+  %inserted_slice = tensor.insert_slice %2 into %3[0, 0, 0] [4, 5, 24] [1, 1, 1] {rock.is_expand_strides} : tensor<4x5x24xf16> into tensor<4x12x24xf16>
   //   CHECK: %[[collapsed:.*]] = tensor.collapse_shape %[[expand]]
   //   CHECK: return %[[collapsed]]
   %collapsed = tensor.collapse_shape %inserted_slice [[0, 1, 2]] : tensor<4x12x24xf16> into tensor<1152xf16>

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-non-contiguous-stride.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-non-contiguous-stride.mlir
@@ -1,7 +1,5 @@
 // RUN: rocmlir-opt -split-input-file --migraphx-to-linalg -verify-diagnostics %s | FileCheck %s
 
-// testcase taken from migraphx-to-tosa-non-contiguous-strides.mlir
-
 // CHECK-LABEL: func.func @mlir_dot_log(
 func.func @mlir_dot_log(%arg0: !migraphx.shaped<4x24x16xf16, 384x16x1>, %arg1: !migraphx.shaped<4x16x24xf16, 384x24x1>) -> !migraphx.shaped<4x24x24xf16, 1152x24x1> attributes {kernel = "mixr"} {
   // CHECK: linalg.batch_matmul ins

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-non-contiguous-stride.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-non-contiguous-stride.mlir
@@ -1,0 +1,64 @@
+// RUN: rocmlir-opt -split-input-file --migraphx-to-linalg -verify-diagnostics %s | FileCheck %s
+
+// testcase taken from migraphx-to-tosa-non-contiguous-strides.mlir
+
+// CHECK-LABEL: func.func @mlir_dot_log(
+func.func @mlir_dot_log(%arg0: !migraphx.shaped<4x24x16xf16, 384x16x1>, %arg1: !migraphx.shaped<4x16x24xf16, 384x24x1>) -> !migraphx.shaped<4x24x24xf16, 1152x24x1> attributes {kernel = "mixr"} {
+  // CHECK: linalg.batch_matmul ins
+  // CHECK-SAME: -> tensor<4x24x24xf16>
+  %0 = migraphx.dot %arg0, %arg1 : <4x24x16xf16, 384x16x1>, <4x16x24xf16, 384x24x1> -> <4x24x24xf16, 576x24x1>
+  // CHECK: %[[LOG:.*]] = linalg.log ins{{.*}} -> tensor<4x24x24xf16>
+  %1 = migraphx.log %0 : <4x24x24xf16, 576x24x1> -> <4x24x24xf16, 1152x24x1>
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<4x48x24xf16>
+  // CHECK: tensor.insert_slice %[[LOG]] into %[[EMPTY]]
+  return %1 : !migraphx.shaped<4x24x24xf16, 1152x24x1>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @mlir_dot_log
+func.func @mlir_dot_log(%arg0: !migraphx.shaped<4x5x16xf16, 80x16x1>, %arg1: !migraphx.shaped<4x16x24xf16, 384x24x1>) -> !migraphx.shaped<4x5x24xf16, 288x24x1> attributes {arch = "gfx1201", kernel = "mixr", num_cu = 32 : i64} {
+  // CHECK: linalg.batch_matmul ins{{.*}}-> tensor<4x5x24xf16>
+  %0 = migraphx.dot %arg0, %arg1 : <4x5x16xf16, 80x16x1>, <4x16x24xf16, 384x24x1> -> <4x5x24xf16, 120x24x1>
+  // CHECK: %[[LOG:.*]] = linalg.log ins{{.*}}-> tensor<4x5x24xf16>
+  %1 = migraphx.log %0 : <4x5x24xf16, 120x24x1> -> <4x5x24xf16, 288x24x1>
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<4x12x24xf16>
+  // CHECK: tensor.insert_slice %[[LOG]] into %[[EMPTY]]
+  return %1 : !migraphx.shaped<4x5x24xf16, 288x24x1>
+}
+
+// -----
+
+// expected-error @unknown {{!migraphx.shaped type with smallest stride 2 has no supported in-memory layout}}
+// expected-error @below {{failed to legalize operation 'func.func'}}
+func.func @no_unit_stride(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) -> !migraphx.shaped<4x24x24xf16, 1152x48x2> attributes {kernel = "mixr"} {
+  %0 = migraphx.log %arg0 : <4x24x24xf16, 576x24x1> -> <4x24x24xf16, 1152x48x2>
+  return %0 : !migraphx.shaped<4x24x24xf16, 1152x48x2>
+}
+
+// -----
+
+// expected-error @unknown {{!migraphx.shaped type can't be laid out in memory when the stride 1000 at index 0 being smaller than the product of previous lengths 2400}}
+// expected-error @below {{failed to legalize operation 'func.func'}}
+func.func @stride_not_divisible(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) -> !migraphx.shaped<4x24x24xf16, 1000x100x1> attributes {kernel = "mixr"} {
+  %0 = migraphx.log %arg0 : <4x24x24xf16, 576x24x1> -> <4x24x24xf16, 1000x100x1>
+  return %0 : !migraphx.shaped<4x24x24xf16, 1000x100x1>
+}
+
+// -----
+
+func.func @write_to_broadcast(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) -> !migraphx.shaped<4x24x24xf16, 0x24x1> attributes {kernel = "mixr"} {
+  // expected-error @+2 {{'migraphx.mlir.as.underlying.shape' op writing to tensors with broadcasts is unsupported}}
+  // expected-error @+1 {{failed to legalize operation 'migraphx.mlir.as.underlying.shape'}}
+  %0 = migraphx.log %arg0 : <4x24x24xf16, 576x24x1> -> <4x24x24xf16, 0x24x1>
+  return %0 : !migraphx.shaped<4x24x24xf16, 0x24x1>
+}
+
+// -----
+
+// expected-error @unknown {{!migraphx.shaped type can't be laid out in memory when the stride 576 at index 0 does not evenly divide the previous stride 10}}
+// expected-error @below {{failed to legalize operation 'func.func'}}
+func.func @stride_too_small(%arg0: !migraphx.shaped<4x24x24xf16, 576x24x1>) -> !migraphx.shaped<4x24x24xf16, 576x10x1> attributes {kernel = "mixr"} {
+  %0 = migraphx.log %arg0 : <4x24x24xf16, 576x24x1> -> <4x24x24xf16, 576x10x1>
+  return %0 : !migraphx.shaped<4x24x24xf16, 576x10x1>
+}

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -425,7 +425,7 @@ func.func @transposed(%arg0: !migraphx.shaped<4x3xf32, 1x4>) -> !migraphx.shaped
   %op = migraphx.floor %arg0 : <4x3xf32, 1x4> -> <4x3xf32, 1x4>
   // CHECK: %[[FLOOR:.*]] = linalg.floor ins{{.*}} -> tensor<4x3xf32>
   // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<3x4xf32>
-  // CHECK: linalg.transpose ins(%[[FLOOR]] : tensor{{.*}}) outs(%3 : tensor{{.*}}) permutation = [1, 0] 
+  // CHECK: linalg.transpose ins(%[[FLOOR]] : tensor{{.*}}) outs(%[[EMPTY]] : tensor{{.*}}) permutation = [1, 0] 
   func.return %op : !migraphx.shaped<4x3xf32, 1x4>
 }
 
@@ -437,7 +437,7 @@ func.func @broadcast(%arg0: !migraphx.shaped<4x3xf32, 1x0>, %arg1: !migraphx.sha
   // CHECK-DAG:     %[[collapsed:.*]] = tensor.collapse_shape %[[expanded_0]]
   // CHECK-DAG:     %[[expanded_1:.*]] = tensor.expand_shape %[[collapsed]]
   // CHECK-DAG:     %[[zero:.*]] = tensor.empty() : tensor<4x3xf32>
-  // CHECK-DAG:     %[[broadcasted:.*]] = linalg.broadcast ins(%[[expanded_1]] : tensor<4xf32>) outs(%[[zero]] : tensor<4x3xf32>) dimensions = [1] 
+  // CHECK-DAG:     %[[broadcasted:.*]] = linalg.broadcast ins(%[[expanded_1]] : tensor<4xf32>) outs(%[[zero]] : tensor<4x3xf32>) dimensions = [1]
   %op = migraphx.sub %arg0, %arg1 : <4x3xf32, 1x0>, <4x3xf32, 3x1> -> <4x3xf32, 3x1>
   // CHECK-DAG:     %[[one:.*]] = tensor.empty() : tensor<4x3xf32>
   // CHECK-DAG:     %[[two:.*]] = linalg.sub ins(%[[broadcasted]], %[[expanded]] : tensor<4x3xf32>, tensor<4x3xf32>) outs(%[[one]] : tensor<4x3xf32>) -> tensor<4x3xf32>

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -507,3 +507,10 @@ func.func @scalar(%arg0: !migraphx.shaped<1xf32, 0>) -> !migraphx.shaped<1xf32, 
   //   CHECK: %[[FLOOR:.*]] = linalg.floor ins(%[[arg0]]{{.*}}) -> tensor<1xf32>
   func.return %op : !migraphx.shaped<1xf32, 0>
 }
+
+// CHECK-LABEL: mlir_dot_sigmoid
+func.func @mlir_dot_sigmoid(%arg0: !migraphx.shaped<4x5x16xf16, 80x16x1>, %arg1: !migraphx.shaped<4x16x24xf16, 384x24x1>) -> !migraphx.shaped<4x5x24xf16, 288x24x1> attributes {arch = "gfx1201", kernel = "mixr", num_cu = 32 : i64} {
+  %0 = migraphx.dot %arg0, %arg1 : <4x5x16xf16, 80x16x1>, <4x16x24xf16, 384x24x1> -> <4x5x24xf16, 120x24x1>
+  %1 = migraphx.sigmoid %0 : <4x5x24xf16, 120x24x1> -> <4x5x24xf16, 288x24x1>
+  return %1 : !migraphx.shaped<4x5x24xf16, 288x24x1>
+}

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -189,10 +189,8 @@ func.func @literal_splat_f32() -> !migraphx.shaped<4x3xf32, 3x1> {
 }
 
 // CHECK-LABEL: @literal(
-// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}})
 // CHECK-DAG:  %[[cst:.*]] = arith.constant dense<1.000000e+00> : tensor<16xf32>
-// CHECK-DAG:  %[[collapsed:.*]] = tensor.collapse_shape %[[cst]]
-// CHECK-DAG:  return %[[collapsed]]
+// CHECK-DAG:  return %[[cst]]
 func.func @literal(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %cst = migraphx.literal (dense<1.0> : tensor<16xf32>) : <16xf32, 1>
   return %cst : !migraphx.shaped<16xf32, 1>

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -1,5 +1,6 @@
 // RUN: rocmlir-opt -split-input-file --migraphx-to-linalg %s -verify-diagnostics  | FileCheck %s
 
+
 // CHECK-LABEL: func_sub
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor
 // CHECK-DAG: linalg.sub ins(%[[arg0]], %[[arg1]] {{.*}})
@@ -96,6 +97,8 @@ func.func @func_tanh(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16x
   return %0 : !migraphx.shaped<16xf32, 1>
 }
 
+// -----
+
 // CHECK-LABEL: func_recip
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
 // CHECK-DAG: linalg.reciprocal ins(%[[arg0]] {{.*}})
@@ -103,6 +106,8 @@ func.func @func_recip(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16
   %0 = migraphx.recip %arg0: <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
 }
+
+// -----
 
 // CHECK-LABEL: func_relu(
 // CHECK-SAME: %[[arg0:.*]]: tensor
@@ -116,7 +121,6 @@ func.func @func_relu(%arg0: !migraphx.shaped<123x234xf32, 234x1>) -> !migraphx.s
   %arg1 = migraphx.relu %arg0: <123x234xf32, 234x1> -> <123x234xf32, 234x1>
   func.return %arg1: !migraphx.shaped<123x234xf32, 234x1>
 }
-
 // testcase from mixr-to-tosa-ops.mlir
 
 // CHECK-LABEL: @clip_i32(
@@ -412,4 +416,96 @@ func.func @func_slice1(%arg0: !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x
 func.func @func_slice2(%arg0: !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1>) -> !migraphx.shaped<1x12x100x64xf32, 76800x6400x64x1> attributes{kernel, arch = ""} {
   %0 = migraphx.slice %arg0 {axes = [1, 2], ends = [12, 284], starts = [0, 184]} : <1x36x384x64xf32, 884736x24576x64x1> -> <1x12x100x64xf32, 76800x6400x64x1>
   return %0 : !migraphx.shaped<1x12x100x64xf32, 76800x6400x64x1>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @transposed(
+func.func @transposed(%arg0: !migraphx.shaped<4x3xf32, 1x4>) -> !migraphx.shaped<4x3xf32, 1x4> {
+  %op = migraphx.floor %arg0 : <4x3xf32, 1x4> -> <4x3xf32, 1x4>
+  // CHECK: %[[FLOOR:.*]] = linalg.floor ins{{.*}} -> tensor<4x3xf32>
+  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<3x4xf32>
+  // CHECK: linalg.transpose ins(%[[FLOOR]] : tensor{{.*}}) outs(%3 : tensor{{.*}}) permutation = [1, 0] 
+  func.return %op : !migraphx.shaped<4x3xf32, 1x4>
+}
+
+// CHECK-LABEL:func.func @broadcast(
+// CHECK-SAME:    %[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor
+// CHECK-DAG:     %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+// CHECK-DAG:     %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+func.func @broadcast(%arg0: !migraphx.shaped<4x3xf32, 1x0>, %arg1: !migraphx.shaped<4x3xf32, 3x1>) -> !migraphx.shaped<4x3xf32, 3x1> {
+  // CHECK-DAG:     %[[collapsed:.*]] = tensor.collapse_shape %[[expanded_0]]
+  // CHECK-DAG:     %[[expanded_1:.*]] = tensor.expand_shape %[[collapsed]]
+  // CHECK-DAG:     %[[zero:.*]] = tensor.empty() : tensor<4x3xf32>
+  // CHECK-DAG:     %[[broadcasted:.*]] = linalg.broadcast ins(%[[expanded_1]] : tensor<4xf32>) outs(%[[zero]] : tensor<4x3xf32>) dimensions = [1] 
+  %op = migraphx.sub %arg0, %arg1 : <4x3xf32, 1x0>, <4x3xf32, 3x1> -> <4x3xf32, 3x1>
+  // CHECK-DAG:     %[[one:.*]] = tensor.empty() : tensor<4x3xf32>
+  // CHECK-DAG:     %[[two:.*]] = linalg.sub ins(%[[broadcasted]], %[[expanded]] : tensor<4x3xf32>, tensor<4x3xf32>) outs(%[[one]] : tensor<4x3xf32>) -> tensor<4x3xf32>
+  func.return %op : !migraphx.shaped<4x3xf32, 3x1>
+}
+
+// CHECK-LABEL: func.func @sliced
+// CHECK-SAME: (%[[arg0:.*]]: tensor<20xf32>, %[[arg1:.*]]: tensor<12xf32>
+func.func @sliced(%arg0: !migraphx.shaped<4x3xf32, 5x1>, %arg1: !migraphx.shaped<4x3xf32, 3x1>) -> !migraphx.shaped<4x3xf32, 3x1> {
+  //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+  //   CHECK: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+  //   CHECK: %[[extracted_slice:.*]] = tensor.extract_slice %[[expanded_0]]
+  %op = migraphx.sub %arg0, %arg1 : <4x3xf32, 5x1>, <4x3xf32, 3x1> -> <4x3xf32, 3x1>
+  //   CHECK: %[[zero:.*]] = tensor.empty() : tensor<4x3xf32>
+  //   CHECK: %[[one:.*]] = linalg.sub ins(%[[extracted_slice]], %[[expanded]]
+  func.return %op : !migraphx.shaped<4x3xf32, 3x1>
+}
+
+// CHECK-LABEL: func.func @everything
+// CHECK-SAME: (%[[arg0:.*]]: tensor<30xf32>, %[[arg1:.*]]: tensor<60xf32>
+// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
+// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
+func.func @everything(%arg0: !migraphx.shaped<4x3x5xf32, 1x0x6>, %arg1: !migraphx.shaped<4x3x5xf32, 15x5x1>) -> !migraphx.shaped<4x3x5xf32, 15x5x1> {
+  // CHECK-DAG: %[[transposed:.*]] = linalg.transpose ins(%[[expanded_0]]{{.*}}) outs({{.*}}) permutation = [1, 2, 0]
+  // CHECK-DAG: %[[extracted_slice:.*]] = tensor.extract_slice %[[transposed]]
+  // CHECK-DAG: %[[collapsed:.*]] = tensor.collapse_shape %[[extracted_slice]]
+  // CHECK-DAG: %[[expanded_1:.*]] = tensor.expand_shape %[[collapsed]]
+  // CHECK-DAG: %[[broadcasted:.*]] = linalg.broadcast ins(%[[expanded_1]] : tensor<4x5xf32>) outs({{.*}} : tensor<4x3x5xf32>) dimensions = [1]
+  %op = migraphx.sub %arg0, %arg1 : <4x3x5xf32, 1x0x6>, <4x3x5xf32, 15x5x1> -> <4x3x5xf32, 15x5x1>
+  // CHECK-DAG: %[[result:.*]] = linalg.sub ins(%[[broadcasted]], %[[expanded]] : tensor<4x3x5xf32>, tensor<4x3x5xf32>) outs({{.*}} : tensor<4x3x5xf32>) -> tensor<4x3x5xf32>
+  func.return %op : !migraphx.shaped<4x3x5xf32, 15x5x1>
+}
+
+// CHECK-LABEL: func.func @matchingLogicalTypes
+// CHECK-SAME: (%[[arg0:.*]]: tensor<9xf32>
+func.func @matchingLogicalTypes(%arg0: !migraphx.shaped<3x3xf32, 1x3>) -> !migraphx.shaped<3x3xf32, 1x3> {
+  //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg0]]
+  //   CHECK: %[[transposed:.*]] = linalg.transpose ins(%[[expanded]] : tensor<3x3xf32>) outs({{.*}}) permutation = [1, 0]
+  %op = migraphx.floor %arg0 : <3x3xf32, 1x3> -> <3x3xf32, 1x3>
+  //   CHECK: %[[FLOOR:.*]] = linalg.floor ins(%[[transposed]]{{.*}}) -> tensor<3x3xf32>
+  //   CHECK: linalg.transpose ins(%[[FLOOR]] : tensor<3x3xf32>) outs({{.*}}) permutation = [1, 0]
+  func.return %op : !migraphx.shaped<3x3xf32, 1x3>
+}
+
+// CHECK-LABEL: func.func @transposeWithUnitDims
+// CHECK-SAME: (%[[arg0:.*]]: tensor<9xf32>
+func.func @transposeWithUnitDims(%arg0: !migraphx.shaped<3x1x3xf32, 1x3x3>) -> !migraphx.shaped<3x1x3xf32, 1x3x3> {
+  //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg0]]
+  //   CHECK: %[[transposed:.*]] = linalg.transpose ins(%[[expanded]] : tensor<3x1x3xf32>) outs({{.*}}) permutation = [2, 1, 0]
+  %op = migraphx.floor %arg0 : <3x1x3xf32, 1x3x3> -> <3x1x3xf32, 1x3x3>
+  //   CHECK: %[[FLOOR:.*]] = linalg.floor ins(%[[transposed]]{{.*}}) -> tensor<3x1x3xf32>
+  //   CHECK: linalg.transpose ins(%[[FLOOR]] : tensor<3x1x3xf32>) outs({{.*}}) permutation = [2, 1, 0]
+  func.return %op : !migraphx.shaped<3x1x3xf32, 1x3x3>
+}
+
+// CHECK-LABEL: func.func @needStableSort
+// CHECK-SAME: (%[[arg0:.*]]: tensor<3xf32>
+func.func @needStableSort(%arg0: !migraphx.shaped<3x1x1xf32, 1x1x1>) -> !migraphx.shaped<3x1x1xf32, 1x1x1> {
+  //   CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg0]]
+  %op = migraphx.floor %arg0 : <3x1x1xf32, 1x1x1> -> <3x1x1xf32, 1x1x1>
+  //   CHECK: %[[FLOOR:.*]] = linalg.floor ins(%[[expanded]]{{.*}}) -> tensor<3x1x1xf32>
+  func.return %op : !migraphx.shaped<3x1x1xf32, 1x1x1>
+}
+
+// CHECK-LABEL: func.func @scalar
+// CHECK-SAME: (%[[arg0:.*]]: tensor<1xf32>
+func.func @scalar(%arg0: !migraphx.shaped<1xf32, 0>) -> !migraphx.shaped<1xf32, 0> {
+  %op = migraphx.floor %arg0 : <1xf32, 0> -> <1xf32, 0>
+  //   CHECK: %[[FLOOR:.*]] = linalg.floor ins(%[[arg0]]{{.*}}) -> tensor<1xf32>
+  func.return %op : !migraphx.shaped<1xf32, 0>
 }

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -2,9 +2,7 @@
 
 // CHECK-LABEL: func_sub
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor
-// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.sub ins(%[[expanded_0]], %[[expanded]] {{.*}})
+// CHECK-DAG: linalg.sub ins(%[[arg0]], %[[arg1]] {{.*}})
 func.func @func_sub(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.sub %arg0, %arg1 : <16xf32, 1>, <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -12,9 +10,7 @@ func.func @func_sub(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shaped<
 
 // CHECK-LABEL: func_mul
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor
-// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.mul ins(%[[expanded_0]], %[[expanded]] {{.*}})
+// CHECK-DAG: linalg.mul ins(%[[arg0]], %[[arg1]] {{.*}})
 func.func @func_mul(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.mul %arg0, %arg1 : <16xf32, 1>, <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -22,9 +18,7 @@ func.func @func_mul(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shaped<
 
 // CHECK-LABEL: func_div
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor
-// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.div ins(%[[expanded_0]], %[[expanded]] {{.*}})
+// CHECK-DAG: linalg.div ins(%[[arg0]], %[[arg1]] {{.*}})
 func.func @func_div(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.div %arg0, %arg1 : <16xf32, 1>, <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -32,9 +26,7 @@ func.func @func_div(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shaped<
 
 // CHECK-LABEL: func_power
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}, %[[arg1:.*]]: tensor
-// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg1]]
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.powf ins(%[[expanded_0]], %[[expanded]] {{.*}})
+// CHECK-DAG: linalg.powf ins(%[[arg0]], %[[arg1]] {{.*}})
 func.func @func_power(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.pow %arg0, %arg1 : <16xf32, 1>, <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -42,8 +34,7 @@ func.func @func_power(%arg0: !migraphx.shaped<16xf32, 1>, %arg1: !migraphx.shape
 
 // CHECK-LABEL: func_abs
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.abs ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.abs ins(%[[arg0]] {{.*}})
 func.func @func_abs(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.abs %arg0 : <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -51,8 +42,7 @@ func.func @func_abs(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf
 
 // CHECK-LABEL: func_ceil
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.ceil ins(%[[expanded]] {{.*}})
+// CHECK-DAG: linalg.ceil ins(%[[arg0]] {{.*}})
 func.func @func_ceil(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.ceil %arg0: <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -60,8 +50,7 @@ func.func @func_ceil(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16x
 
 // CHECK-LABEL: func_exp
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.exp ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.exp ins(%[[arg0]] {{.*}})
 func.func @func_exp(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.exp %arg0 : <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -69,8 +58,7 @@ func.func @func_exp(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf
 
 // CHECK-LABEL: func_floor
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.floor ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.floor ins(%[[arg0]] {{.*}})
 func.func @func_floor(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.floor %arg0 : <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -78,8 +66,7 @@ func.func @func_floor(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16
 
 // CHECK-LABEL: func_log
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.log ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.log ins(%[[arg0]] {{.*}})
 func.func @func_log(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.log %arg0: <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -87,8 +74,7 @@ func.func @func_log(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf
 
 // CHECK-LABEL: func_neg
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.negf ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.negf ins(%[[arg0]] {{.*}})
 func.func @func_neg(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.neg %arg0: <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -96,8 +82,7 @@ func.func @func_neg(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf
 
 // CHECK-LABEL: func_sqrt
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.sqrt ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.sqrt ins(%[[arg0]] {{.*}})
 func.func @func_sqrt(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.sqrt %arg0: <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -105,8 +90,7 @@ func.func @func_sqrt(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16x
 
 // CHECK-LABEL: func_tanh
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.tanh ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.tanh ins(%[[arg0]] {{.*}})
 func.func @func_tanh(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.tanh %arg0: <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>
@@ -114,8 +98,7 @@ func.func @func_tanh(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16x
 
 // CHECK-LABEL: func_recip
 // CHECK-SAME: (%[[arg0:.*]]: tensor{{.*}}
-// CHECK-DAG: %[[expanded_0:.*]] = tensor.expand_shape %[[arg0]]
-// CHECK-DAG: linalg.reciprocal ins(%[[expanded_0]] {{.*}})
+// CHECK-DAG: linalg.reciprocal ins(%[[arg0]] {{.*}})
 func.func @func_recip(%arg0: !migraphx.shaped<16xf32, 1>) -> !migraphx.shaped<16xf32, 1> {
   %0 = migraphx.recip %arg0: <16xf32, 1> -> <16xf32, 1>
   return %0 : !migraphx.shaped<16xf32, 1>

--- a/mlir/test/fusion/pr-e2e/mixr-non-contiguous-strides-sub.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-non-contiguous-strides-sub.mlir
@@ -1,0 +1,15 @@
+// RUN: rocmlir-gen -fut mlir_dot_log --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel -targets %arch | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_dot_log_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full -targets %arch | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s 
+
+// Only half of the results will be correct since the non-contiguous strides
+// in this example means that about half of the memory is uninitialized.
+// CHECK: relDiff = 0 : 2304/4608 (50.000000%)
+
+module {
+  func.func @mlir_dot_log(%arg0: !migraphx.shaped<4x24x16xf16, 384x16x1>, %arg1: !migraphx.shaped<4x16x24xf16, 384x24x1>) -> !migraphx.shaped<4x24x24xf16, 1152x24x1>  {
+    %0 = migraphx.dot %arg0, %arg1 : <4x24x16xf16, 384x16x1>, <4x16x24xf16, 384x24x1> -> <4x24x24xf16, 576x24x1>
+    %1 = migraphx.sub %0, %0 : <4x24x24xf16, 576x24x1>,<4x24x24xf16, 576x24x1> -> <4x24x24xf16, 1152x24x1>
+    return %1 : !migraphx.shaped<4x24x24xf16, 1152x24x1>
+  }
+}
+
+


### PR DESCRIPTION
## Motivation

Being able to support transposed memory layout, long strides in both as_underlying_shape and as_logical_shape. 

Furthermore, in `as_underlying_shape`, broadcasting is supported.

## Technical Details

This one PR essentially implements these two commits: #2198 , [this one](https://github.com/rocm/rocmlir/commit/61116258d7c1b). 

as_logical_shape is implemented as the following:

1. Reshape from flat memory layout to memory layout 
2. Check the stride permutation, and invert it to match the logical shape
3. If the memory layout tensor is "greater in dimension" than the logical dimension, it means that we have a long stride layout so we emit tensor.extract_from_slice to get the logical shape
4. Broadcast if needed

as_underlying_shape is implemented as the following: 

1. Reshape to memory based on stride permutation 
2. If there are long strides, we emit a tensor.insert_slice with a tensor.empty_op 
3. If there is broadcasting, we error out. 

## Test Plan

Added e2e and lit test. 

## Test Result

Passed both e2e and lit test. 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
