### PR TITLE
[AIROCMLIR-564] Lower `migraphx.reshape` using helper function

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -397,6 +397,15 @@ struct MultiBroadcastConverter final
   matchAndRewrite(migraphx::MultiBroadcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
+
+struct ReshapeConverter final
+    : public OpConversionPattern<migraphx::ReshapeOp> {
+  using OpConversionPattern<migraphx::ReshapeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(migraphx::ReshapeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final;
+};
 } // namespace
 
 /// Reshape the input Value into a new RankedTensorType with newShape
@@ -432,6 +441,20 @@ static Value reshapeValue(ConversionPatternRewriter &rewriter, Value input,
   input = tensor::ExpandShapeOp::create(rewriter, loc, resultType, input,
                                         expandReassociation);
   return input;
+}
+
+LogicalResult
+ReshapeConverter::matchAndRewrite(migraphx::ReshapeOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const {
+  Value input = adaptor.getInput();
+  ArrayAttr dims = adaptor.getDims();
+  SmallVector<int64_t, 5> newShape;
+  for (auto dim : dims) {
+    newShape.push_back(dyn_cast<IntegerAttr>(dim).getInt());
+  }
+  auto output = reshapeValue(rewriter, input, newShape);
+  rewriter.replaceOp(op, output);
+  return success();
 }
 
 LogicalResult
@@ -644,8 +667,8 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::TanhOp, linalg::TanhOp>,
            ElementwiseConverter<migraphx::RecipOp, linalg::ReciprocalOp>,
            ReluConverter, ClipConverter, BroadcastConverter,
-           MultiBroadcastConverter, LiteralConverter>(converter,
-                                                      patterns.getContext());
+           MultiBroadcastConverter, LiteralConverter, ReshapeConverter>(
+          converter, patterns.getContext());
 }
 
 void mlir::migraphx::populateMIGraphXFuncBoundaryToLinalgConversionPatterns(

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -97,12 +97,6 @@ func.func @func_transpose(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraph
   func.return
 }
 
-func.func @func_reshape(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.reshape'}}
-  migraphx.reshape %arg0 {dims = [1, 1]}: <1x1xf32, 1x1> -> <1x1xf32, 1x1>
-  func.return
-}
-
 func.func @func_slice(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.slice'}}
   migraphx.slice %arg0 {axes = [0], ends = [1], starts = [0]}: <1x1xf32, 1x1>  -> <1x1xf32, 1x1>

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -239,3 +239,33 @@ func.func @scalar_broadcast_test() -> !migraphx.shaped<2x2xf32, 2x1> {
   %sum = migraphx.add %result, %result : <2x2xf32, 0x0>, <2x2xf32, 0x0> -> <2x2xf32, 2x1>
   return %sum : !migraphx.shaped<2x2xf32, 2x1>
 }
+
+// CHECK-LABEL: @reshape_expand(
+// CHECK-SAME: %[[arg0:.*]]: tensor<72xi8>
+// CHECK-DAG:  %[[expanded:.*]] = tensor.expand_shape %[[arg0]] {{.*}} output_shape [9, 8] : tensor<72xi8> into tensor<9x8xi8>
+// CHECK-DAG:  %[[collapsed:.*]] = tensor.collapse_shape %[[expanded]] {{.*}} : tensor<9x8xi8> into tensor<72xi8>
+// CHECK-DAG:  %[[expanded_0:.*]] = tensor.expand_shape %[[collapsed]] {{.*}} output_shape [9, 2, 4] : tensor<72xi8> into tensor<9x2x4xi8>
+// CHECK-DAG:  %[[empty:.*]] = tensor.empty() : tensor<9x2x4xi8>
+// CHECK-DAG:  %[[add:.*]] = linalg.add ins(%[[expanded_0]], %[[expanded_0]] : {{.*}}) outs(%[[empty]] : {{.*}})
+// CHECK-DAG:  %[[collapsed_1:.*]] = tensor.collapse_shape %[[add]] {{.*}} : tensor<9x2x4xi8> into tensor<72xi8>
+// CHECK-DAG:  return %[[collapsed_1]]
+func.func @reshape_expand(%arg0: !migraphx.shaped<9x8xi8, 8x1>) -> !migraphx.shaped<9x2x4xi8, 8x4x1> attributes {arch = "gfx950", kernel} {
+  %0 = migraphx.reshape %arg0 {dims = [9, 2, 4]} : <9x8xi8, 8x1> -> <9x2x4xi8, 8x4x1>
+  %1 = migraphx.add %0, %0 : <9x2x4xi8, 8x4x1>, <9x2x4xi8, 8x4x1> -> <9x2x4xi8, 8x4x1>
+  return %1 : !migraphx.shaped<9x2x4xi8, 8x4x1>
+}
+
+// CHECK-LABEL: @reshape_collapse(
+// CHECK-SAME: %[[arg0:.*]]: tensor<72xf32>
+// CHECK-DAG:  %[[expanded:.*]] = tensor.expand_shape %[[arg0]] {{.*}} output_shape [9, 2, 4] : tensor<72xf32> into tensor<9x2x4xf32>
+// CHECK-DAG:  %[[collapsed:.*]] = tensor.collapse_shape %[[expanded]] {{.*}} : tensor<9x2x4xf32> into tensor<72xf32>
+// CHECK-DAG:  %[[expanded_0:.*]] = tensor.expand_shape %[[collapsed]] {{.*}} output_shape [9, 8] : tensor<72xf32> into tensor<9x8xf32>
+// CHECK-DAG:  %[[empty:.*]] = tensor.empty() : tensor<9x8xf32>
+// CHECK-DAG:  %[[add:.*]] = linalg.add ins(%[[expanded_0]], %[[expanded_0]] : {{.*}}) outs(%[[empty]] : {{.*}})
+// CHECK-DAG:  %[[collapsed_1:.*]] = tensor.collapse_shape %[[add]] {{.*}} : tensor<9x8xf32> into tensor<72xf32>
+// CHECK-DAG:  return %[[collapsed_1]]
+func.func @reshape_collapse(%arg0: !migraphx.shaped<9x2x4xf32, 8x4x1>) -> !migraphx.shaped<9x8xf32, 8x1> attributes {arch = "gfx950", kernel} {
+  %0 = migraphx.reshape %arg0 {dims = [9, 8]} : <9x2x4xf32, 8x4x1> -> <9x8xf32, 8x1>
+  %1 = migraphx.add %0, %0 : <9x8xf32, 8x1>, <9x8xf32, 8x1> -> <9x8xf32, 8x1>
+  return %1 : !migraphx.shaped<9x8xf32, 8x1>
+}


### PR DESCRIPTION
## Motivation

Being able to lower `migraphx.reshape`

## Technical Details

migraphx.reshape is lowered as the following: 

```mlir
%intermediate = tensor.collapse_shape ... // collapse shape into one dimensional
%result = tensor.expand_shape... // expand shape into the target shape
```

This is kind of a freebie from the previous PR as that PR implemented `reshapeValue` function

Note that the tosa pipeline lowers `tosa.reshape` as a expand_shape and collapse_shape as well. This is done in the `tosa-to-tensor` pass::

https://github.com/llvm/llvm-project/blob/42d07c38e22768360a66548407a28332340efb20/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp#L259-L261

## Test Plan

lit test

## Test Result

Passed lit test

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
