### PR TITLE
[AIROCMLIR-600] Lower `migraphx.transpose` into `linalg.transpose`

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -517,16 +517,19 @@ struct TransposeConverter final
 
 LogicalResult
 TransposeConverter::matchAndRewrite(migraphx::TransposeOp op, OpAdaptor adaptor,
-                ConversionPatternRewriter &rewriter) const {
+                                    ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
-  RankedTensorType outputType = dyn_cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
-  assert(outputType && "MIXRShapedToTensorConverter TypeConverter should convert this into a RankedTensorType");
+  RankedTensorType outputType =
+      dyn_cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
+  assert(outputType && "MIXRShapedToTensorConverter TypeConverter should "
+                       "convert this into a RankedTensorType");
   auto init = tensor::EmptyOp::create(rewriter, loc, outputType, {});
   SmallVector<int64_t, 4> permutation;
-  llvm::transform(op.getPermutation().getValue(), std::back_inserter(permutation), [](Attribute attr){
-      return cast<IntegerAttr>(attr).getInt();
-  });
-  auto result = linalg::TransposeOp::create(rewriter, loc, adaptor.getInput(), init, permutation);
+  llvm::transform(
+      op.getPermutation().getValue(), std::back_inserter(permutation),
+      [](Attribute attr) { return cast<IntegerAttr>(attr).getInt(); });
+  auto result = linalg::TransposeOp::create(rewriter, loc, adaptor.getInput(),
+                                            init, permutation);
   rewriter.replaceOp(op, result);
   return success();
 }

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -519,7 +519,8 @@ LogicalResult
 TransposeConverter::matchAndRewrite(migraphx::TransposeOp op, OpAdaptor adaptor,
                 ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
-  RankedTensorType outputType = op.getType().asTensor();
+  RankedTensorType outputType = dyn_cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
+  assert(outputType && "MIXRShapedToTensorConverter TypeConverter should convert this into a RankedTensorType");
   auto init = tensor::EmptyOp::create(rewriter, loc, outputType, {});
   SmallVector<int64_t, 4> permutation;
   llvm::transform(op.getPermutation().getValue(), std::back_inserter(permutation), [](Attribute attr){

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -504,8 +504,31 @@ struct ReshapeConverter final
   matchAndRewrite(migraphx::ReshapeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
+
+struct TransposeConverter final
+    : public OpConversionPattern<migraphx::TransposeOp> {
+  using OpConversionPattern<migraphx::TransposeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(migraphx::TransposeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final;
+};
 } // namespace
 
+LogicalResult
+TransposeConverter::matchAndRewrite(migraphx::TransposeOp op, OpAdaptor adaptor,
+                ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+  RankedTensorType outputType = op.getType().asTensor();
+  auto init = tensor::EmptyOp::create(rewriter, loc, outputType, {});
+  SmallVector<int64_t, 4> permutation;
+  llvm::transform(op.getPermutation().getValue(), std::back_inserter(permutation), [](Attribute attr){
+      return cast<IntegerAttr>(attr).getInt();
+  });
+  auto result = linalg::TransposeOp::create(rewriter, loc, adaptor.getInput(), init, permutation);
+  rewriter.replaceOp(op, result);
+  return success();
+}
 /// Reshape the input Value into a new RankedTensorType with newShape
 /// The input must have type RankedTensorType.
 static Value reshapeValue(ConversionPatternRewriter &rewriter, Value input,
@@ -767,8 +790,8 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ReluConverter, ClipConverter, BroadcastConverter,
            MultiBroadcastConverter, LiteralConverter, ReshapeConverter,
            BooleanElementwiseConverter<migraphx::Greater>,
-           BooleanElementwiseConverter<migraphx::Equal>, ClipConverter>(
-          converter, patterns.getContext());
+           BooleanElementwiseConverter<migraphx::Equal>, ClipConverter,
+           TransposeConverter>(converter, patterns.getContext());
 }
 
 void mlir::migraphx::populateMIGraphXFuncBoundaryToLinalgConversionPatterns(

--- a/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
@@ -147,8 +147,8 @@ struct TransposeRewritePattern : public OpRewritePattern<TransposeOp> {
   // case #0 : fold TP(NCHW2NHWC)+tosa.conv.NHWC+TP(NHWC2NCHW) back to
   //           rock.conv.NCHW
   // Pattern match start from the output transpose
-  std::enable_if_t<std::is_same_v<TransposeOp, tosa::TransposeOp> || 
-                   std::is_same_v<TransposeOp, linalg::TransposeOp>,
+  std::enable_if_t<std::is_same_v<TransposeOp, tosa::TransposeOp> ||
+                       std::is_same_v<TransposeOp, linalg::TransposeOp>,
                    LogicalResult>
   matchAndRewrite(TransposeOp top, PatternRewriter &b) const final {
     SmallVector<int64_t, 4> perms = getPermutation(top);

--- a/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -129,16 +130,28 @@ struct ExtractSliceRewritePattern
   }
 };
 
-struct TransposeRewritePattern : public OpRewritePattern<tosa::TransposeOp> {
-  using OpRewritePattern<tosa::TransposeOp>::OpRewritePattern;
+template <typename TransposeOp>
+struct TransposeRewritePattern : public OpRewritePattern<TransposeOp> {
+  using OpRewritePattern<TransposeOp>::OpRewritePattern;
+
+  SmallVector<int64_t, 4> getPermutation(linalg::TransposeOp op) const {
+    return SmallVector<int64_t, 4>(op.getPermutation());
+  }
+
+  SmallVector<int64_t, 4> getPermutation(tosa::TransposeOp op) const {
+    return llvm::map_to_vector(
+        op.getPerms(), [](int32_t val) { return static_cast<int64_t>(val); });
+  }
 
   // Fold transpose ops and convert convolution into changed layout.
   // case #0 : fold TP(NCHW2NHWC)+tosa.conv.NHWC+TP(NHWC2NCHW) back to
   //           rock.conv.NCHW
   // Pattern match start from the output transpose
-  LogicalResult matchAndRewrite(tosa::TransposeOp top,
-                                PatternRewriter &b) const final {
-    const auto perms = top.getPerms();
+  std::enable_if_t<std::is_same_v<TransposeOp, tosa::TransposeOp> || 
+                   std::is_same_v<TransposeOp, linalg::TransposeOp>,
+                   LogicalResult>
+  matchAndRewrite(TransposeOp top, PatternRewriter &b) const final {
+    SmallVector<int64_t, 4> perms = getPermutation(top);
 
     Location loc = top.getLoc();
     Value inp = top->getOperand(0);
@@ -177,8 +190,10 @@ public:
     target.addIllegalOp<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
                         tensor::ExtractSliceOp, tosa::TransposeOp>();
 
-    patterns.add<TransposeRewritePattern, CollapseShapeRewritePattern,
-                 ExpandShapeRewritePattern, ExtractSliceRewritePattern>(ctx);
+    patterns.add<TransposeRewritePattern<tosa::TransposeOp>,
+                 TransposeRewritePattern<linalg::TransposeOp>,
+                 CollapseShapeRewritePattern, ExpandShapeRewritePattern,
+                 ExtractSliceRewritePattern>(ctx);
 
     if (failed(applyPartialConversion(func, target, std::move(patterns))))
       signalPassFailure();

--- a/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/ViewToTransform.cpp
@@ -188,7 +188,8 @@ public:
 
     target.addLegalDialect<rock::RockDialect, tosa::TosaDialect>();
     target.addIllegalOp<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
-                        tensor::ExtractSliceOp, tosa::TransposeOp>();
+                        tensor::ExtractSliceOp, tosa::TransposeOp,
+                        linalg::TransposeOp>();
 
     patterns.add<TransposeRewritePattern<tosa::TransposeOp>,
                  TransposeRewritePattern<linalg::TransposeOp>,

--- a/mlir/test/Conversion/LinalgToRock/linalg-to-rock.mlir
+++ b/mlir/test/Conversion/LinalgToRock/linalg-to-rock.mlir
@@ -1,4 +1,4 @@
-// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt --linalg-to-rock --rock-view-to-transform -verify-diagnostics | FileCheck %s
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt --linalg-to-rock --rock-view-to-transform -verify-diagnostics -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_3D(
 // CHECK-NEXT: %[[zero:.*]] = rock.transform
@@ -34,3 +34,25 @@ func.func @matmul_2D(%arg0: tensor<6xf32>, %arg1: tensor<6xf32>) -> tensor<9xf32
   return %collapsed : tensor<9xf32>
 }
 
+// -----
+
+// CHECK: #map = affine_map<(d0, d1, d2) -> ((d0 * 3 + d1) * 4 + d2)>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d1, d2, d0)>
+// CHECK: #map2 = affine_map<(d0) -> (d0 floordiv 6, (d0 mod 6) floordiv 3, d0 mod 3)>
+// CHECK: #transform_map = #rock.transform_map<#map by [<Unmerge{2, 3, 4} ["exp0", "exp1", "exp2"] at [0, 1, 2] -> ["dim0"] at [0]>] bounds = [2, 3, 4] -> [24]>
+// CHECK: #transform_map1 = #rock.transform_map<#map1 by [<PassThrough ["dim2", "dim0", "dim1"] at [0, 1, 2] -> ["dim2", "dim0", "dim1"] at [2, 0, 1]>] bounds = [4, 2, 3] -> [2, 3, 4]>
+// CHECK: #transform_map2 = #rock.transform_map<#map2 by [<Merge{4, 2, 3} ["dim0"] at [0] -> ["col0", "col1", "col2"] at [0, 1, 2]>] bounds = [24] -> [4, 2, 3]>
+
+// CHECK-LABEL: func.func @transpose_3d(
+// CHECK-NEXT: %[[zero:.*]] = rock.transform %{{.*}} by #transform_map
+// CHECK-NEXT: %[[empty:.*]] = tensor.empty
+// CHECK-NEXT: %[[transposed:.*]] = rock.transform %[[zero]] by #transform_map1
+// CHECK-NEXT: %[[two:.*]] = rock.transform %[[transposed]] by #transform_map2
+// CHECK-NEXT: return %[[two]]
+func.func @transpose_3d(%arg0: tensor<24xf32>) -> tensor<24xf32> attributes {arch = "##TOKEN_ARCH##", kernel} {
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2]] output_shape [2, 3, 4] : tensor<24xf32> into tensor<2x3x4xf32>
+  %0 = tensor.empty() : tensor<4x2x3xf32>
+  %transposed = linalg.transpose ins(%expanded : tensor<2x3x4xf32>) outs(%0 : tensor<4x2x3xf32>) permutation = [2, 0, 1]
+  %collapsed = tensor.collapse_shape %transposed [[0, 1, 2]] : tensor<4x2x3xf32> into tensor<24xf32>
+  return %collapsed : tensor<24xf32>
+}

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -79,12 +79,6 @@ func.func @func_flatten(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.
   func.return
 }
 
-func.func @func_transpose(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.transpose'}}
-  migraphx.transpose %arg0 {permutation = [0, 1]}: <1x1xf32, 1x1> -> <1x1xf32, 1x1>
-  func.return
-}
-
 func.func @func_slice(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.slice'}}
   migraphx.slice %arg0 {axes = [0], ends = [1], starts = [0]}: <1x1xf32, 1x1>  -> <1x1xf32, 1x1>

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -269,3 +269,17 @@ func.func @reshape_collapse(%arg0: !migraphx.shaped<9x2x4xf32, 8x4x1>) -> !migra
   %1 = migraphx.add %0, %0 : <9x8xf32, 8x1>, <9x8xf32, 8x1> -> <9x8xf32, 8x1>
   return %1 : !migraphx.shaped<9x8xf32, 8x1>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @transpose_3d
+// CHECK-SAME: (%[[arg0:.*]]: tensor<24xf32>
+// CHECK: %[[expanded:.*]] = tensor.expand_shape %[[arg0]] {{.*}} into tensor<2x3x4xf32>
+// CHECK: %[[empty:.*]] = tensor.empty() : tensor<4x2x3xf32>
+// CHECK: %[[transposed:.*]] = linalg.transpose ins(%[[expanded]] : tensor<2x3x4xf32>) outs(%[[empty]] : tensor<4x2x3xf32>) permutation = [2, 0, 1]
+// CHECK: %[[collapsed:.*]] = tensor.collapse_shape %[[transposed]] {{.*}} : tensor<4x2x3xf32> into tensor<24xf32>
+// CHECK: return %[[collapsed]] : tensor<24xf32>
+func.func @transpose_3d(%arg0: !migraphx.shaped<2x3x4xf32, 12x4x1>) -> !migraphx.shaped<4x2x3xf32, 6x3x1> {
+  %0 = migraphx.transpose %arg0 {permutation = [2, 0, 1]} : <2x3x4xf32, 12x4x1> -> <4x2x3xf32, 6x3x1>
+  return %0 : !migraphx.shaped<4x2x3xf32, 6x3x1>
+}


### PR DESCRIPTION
## Motivation

Lower `migraphx.transpose` into `linalg.transpose`.  ~~This is stacked on top of #2265 because that PR emits linalg.transpose.~~

## Technical Details

Transfer the attribute from linalg.transpose into rock-view-to-transform. Transfer permutation attribute from migraphx.transpose into linalg.transpose. 

## Test Plan

Added e2e test. 

## Test Result

Passed e2e test.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
