### PR TITLE
 Restrict CI notifications to official jobs and improve improve failure classification

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -259,7 +259,7 @@ Map<String,String> classifyBuildFailure(String logText) {
         if (failedTestsSnippet.length() > 2000) failedTestsSnippet = failedTestsSnippet.substring(0, 2000) + '\n... (truncated)'
     }
 
-    if (!reason) reason = 'Unrecognized error'
+    if (!reason) reason = 'Could not match a known error pattern. See build log for details.'
 
     // Extract CODEPATH (e.g. "Matrix - CODEPATH = 'navi4x'" or "Running navi4x on")
     def cpMatch = logText =~ /CODEPATH\s*=\s*['"]?(\w+)['"]?|Running\s+(\w+)\s+on\s+\S+/

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -227,8 +227,8 @@ Map<String,String> classifyBuildFailure(String logText) {
         reason = 'Tune rocMLIR: errors in tuning log (check logs for details)'
     }
 
-    // Scenario 3: SCM checkout failed (max retries or channel error)
-    if (!reason && (logText.contains('ERROR: Checkout failed') || logText.contains('Maximum checkout retry attempts reached'))) {
+    // Scenario 3: SCM checkout failed (max retries, clone error, or channel error)
+    if (!reason && (logText.contains('ERROR: Checkout failed') || logText.contains('Maximum checkout retry attempts reached') || logText.contains("ERROR: Error cloning remote repo"))) {
         reason = 'SCM checkout failed (max retries or agent/channel error)'
     }
 
@@ -1842,7 +1842,8 @@ cd                                                                        // Upl
                 def logText = ''
                 if ((result == 'FAILURE' || result == 'ABORTED') && (params.nightly || params.weekly)) {
                     try {
-                        def logLines = currentBuild.rawBuild.getLog(5000)
+                        // Use large limit so early failures (e.g. SCM checkout) are included; getLog(N) may return last N lines on some setups.
+                        def logLines = currentBuild.rawBuild.getLog(100000)
                         logText = logLines.join('\n')
                         failureDetails = classifyBuildFailure(logText)
                     } catch (e) {
@@ -1852,6 +1853,13 @@ cd                                                                        // Upl
                 if (result == 'ABORTED') {
                     if (failureDetails == null) failureDetails = [:]
                     failureDetails.abortedBy = parseAbortedByFromLog(logText) ?: '—'
+                }
+                // For FAILURE/ABORTED, ensure we always have a details map so the card shows Stage/CODEPATH/Details (with fallback if classification failed).
+                if ((result == 'FAILURE' || result == 'ABORTED') && failureDetails == null) {
+                    failureDetails = [reason: 'Could not match a known error pattern. See build log for details.', codepath: '', stage: '']
+                }
+                if (failureDetails != null && !failureDetails.reason) {
+                    failureDetails.reason = 'Could not match a known error pattern. See build log for details.'
                 }
                 if ((params.nightly || params.weekly) && buildUrl && jobName) {
                     def runType = params.nightly ? 'nightly' : 'weekly'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1838,9 +1838,10 @@ cd                                                                        // Upl
                 def buildNum = env.BUILD_NUMBER ?: '?'
                 def buildUrl = env.BUILD_URL ?: ''
                 def jobName = env.JOB_NAME ?: ''
+                def isOfficialNightlyOrWeekly = (jobName == 'MLIR/mlir-nightly-all' || jobName == 'MLIR/mlir-weekly')
                 def failureDetails = null
                 def logText = ''
-                if ((result == 'FAILURE' || result == 'ABORTED') && (params.nightly || params.weekly)) {
+                if ((result == 'FAILURE' || result == 'ABORTED') && (params.nightly || params.weekly) && isOfficialNightlyOrWeekly) {
                     try {
                         // Use large limit so early failures (e.g. SCM checkout) are included; getLog(N) may return last N lines on some setups.
                         def logLines = currentBuild.rawBuild.getLog(100000)
@@ -1861,7 +1862,7 @@ cd                                                                        // Upl
                 if (failureDetails != null && !failureDetails.reason) {
                     failureDetails.reason = 'Could not match a known error pattern. See build log for details.'
                 }
-                if ((params.nightly || params.weekly) && buildUrl && jobName) {
+                if ((params.nightly || params.weekly) && isOfficialNightlyOrWeekly && buildUrl && jobName) {
                     def runType = params.nightly ? 'nightly' : 'weekly'
                     def jenkinsBase = buildUrl.replaceFirst('/job/.*', '')
                     def jobNameEncoded = jobName.replace('/', '%2F')


### PR DESCRIPTION
## Motivation

We are getting CI monitoring messages from Workflows for unofficial (PR, manual) nightly and weekly runs. Apart from that, some of known failure scenarios are not shown in message since we checked smaller part of log. We want to improve this automated CI monitoring process.

## Technical Details

-  Send webhook only for MLIR/mlir-nightly-all and MLIR/mlir-weekly (not for
  MLIR/mlir runs with nightly/weekly params used for testing).
- Increase getLog limit to 100k lines so early failures (e.g. SCM checkout)
  are included in classification.
- Classify SCM failures that log "Error cloning remote repo" in addition to
  "Checkout failed" and "Maximum checkout retry attempts reached".
- Always show Details/Stage/CODEPATH in the card for failed/aborted builds;
  use "Could not match a known error pattern. See build log for details."
  when no known pattern matches.

## Test Plan

1. Kick unofficial nightly on weekly on this PR and ensure it was not sent as notification to CI channel or CI Monitoring group
2. Other things can be tested once it's on develop.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
