### PR TITLE
[CODECOV] Ensure coverage data is uploaded successfully 

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -882,7 +882,7 @@ pipeline {
                      description: 'Compare performance against CK')
         booleanParam(name: 'runCodeCoverage', defaultValue: params.weekly || (!params.weekly && !params.nightly),
                      description: 'Collect and upload code-coverage info.')
-        string(name: 'codecovCredentialsId', defaultValue: 'codecov-token',
+        string(name: 'codecovCredentialsId', defaultValue: 'codecov-token-rocmlir',
               description: 'Jenkins credential ID for the Codecov upload token. Must be a Secret text containing the token from codecov.io.')
 
         // choose the codepath for testing
@@ -1777,9 +1777,9 @@ PY
                                                                     dir ('build') {
                                                                         // Run tests.
                                                                         collectCoverageData("${LLVM_PROFDATA}", "${LLVM_COV}", "${CODEPATH}")
-                                                                        // Upload to codecov. Credential ID is configurable via codecovCredentialsId (default: codecov-token).
+                                                                        // Upload to codecov. Credential ID is configurable via codecovCredentialsId (default: codecov-token-rocmlir).
                                                                         withEnv(["CODEPATH=${CODEPATH}"]) {
-                                                                            withCredentials([string(credentialsId: params.codecovCredentialsId ?: 'codecov-token',
+                                                                            withCredentials([string(credentialsId: params.codecovCredentialsId ?: 'codecov-token-rocmlir',
                                                                                                 variable: 'CODECOV_TOKEN')]) {
                                                                                 def uploadStatus = sh(script: '''
                                                                                 curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
@@ -1793,7 +1793,7 @@ PY
                                                                                 exit ${codecov_exit}
                                                                                 ''', returnStatus: true)
                                                                                 if (uploadStatus != 0) {
-                                                                                    echo "WARNING: Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token'}' contains a valid token from codecov.io and that the repo is linked."
+                                                                                    echo "WARNING: Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked."
                                                                                 }
                                                                             }
                                                                         }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -242,7 +242,7 @@ Map<String,String> classifyBuildFailure(String logText) {
         failureList = logText.substring(summaryStart, summaryEnd).trim()
         if (failureList.length() > 2000) failureList = failureList.substring(0, 2000) + '\n... (truncated)'
     }
-     //trigger codecov test as initial commit in pr - DONT MERGE, REMOVE THIS COMMENT, ...
+
     // Scenario 5: HIP no device (hipErrorNoDevice)
     if (!reason && logText.contains('RuntimeError: hipError_t.hipErrorNoDevice')) {
         reason = 'HIP: no device (hipErrorNoDevice)'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -242,7 +242,7 @@ Map<String,String> classifyBuildFailure(String logText) {
         failureList = logText.substring(summaryStart, summaryEnd).trim()
         if (failureList.length() > 2000) failureList = failureList.substring(0, 2000) + '\n... (truncated)'
     }
-
+     //trigger codecov test as initial commit in pr - DONT MERGE, REMOVE THIS COMMENT, ...
     // Scenario 5: HIP no device (hipErrorNoDevice)
     if (!reason && logText.contains('RuntimeError: hipError_t.hipErrorNoDevice')) {
         reason = 'HIP: no device (hipErrorNoDevice)'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -882,6 +882,8 @@ pipeline {
                      description: 'Compare performance against CK')
         booleanParam(name: 'runCodeCoverage', defaultValue: params.weekly || (!params.weekly && !params.nightly),
                      description: 'Collect and upload code-coverage info.')
+        string(name: 'codecovCredentialsId', defaultValue: 'codecov-token',
+              description: 'Jenkins credential ID for the Codecov upload token. Must be a Secret text containing the token from codecov.io.')
 
         // choose the codepath for testing
         choice(name: 'codepath',
@@ -1775,18 +1777,24 @@ PY
                                                                     dir ('build') {
                                                                         // Run tests.
                                                                         collectCoverageData("${LLVM_PROFDATA}", "${LLVM_COV}", "${CODEPATH}")
-cd                                                                        // Upload to codecov. Pass CODEPATH into shell so it expands in the upload command.
+                                                                        // Upload to codecov. Credential ID is configurable via codecovCredentialsId (default: codecov-token).
                                                                         withEnv(["CODEPATH=${CODEPATH}"]) {
-                                                                            withCredentials([string(credentialsId: 'codecov-token-rocmlir',
+                                                                            withCredentials([string(credentialsId: params.codecovCredentialsId ?: 'codecov-token',
                                                                                                 variable: 'CODECOV_TOKEN')]) {
-                                                                                sh '''
+                                                                                def uploadStatus = sh(script: '''
                                                                                 curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
                                                                                 proxy_opt=""
                                                                                 if [ -n "${http_proxy}" ]; then
                                                                                     proxy_opt="-U ${http_proxy}"
                                                                                 fi
                                                                                 ./codecov -t ${CODECOV_TOKEN} --flags "${CODEPATH}" -f ./coverage_${CODEPATH}.lcov ${proxy_opt}
-                                                                                '''
+                                                                                codecov_exit=$?
+                                                                                echo "Codecov upload exit code: ${codecov_exit}"
+                                                                                exit ${codecov_exit}
+                                                                                ''', returnStatus: true)
+                                                                                if (uploadStatus != 0) {
+                                                                                    echo "WARNING: Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token'}' contains a valid token from codecov.io and that the repo is linked."
+                                                                                }
                                                                             }
                                                                         }
                                                                     }


### PR DESCRIPTION
## Motivation

We did not upload code coverage data for months since some tests were failing, our token on codecov expired, ..
In previous PRs we fixed the failing tests and this PR fixes the issues related to usage of recently added CODECOV token to our Jenkins 
## Technical Details

I've generated new token on codecov.io, we've provided it to our Jenkins Admins, they have set it and I've changed in Jenkinsfile that we use the new one. Apart from that I added checks to ensure that the data is uploaded correctly to CODECOV.

## Test Plan

1. CODECOV data is uploaded on codecov.io
2. CODECOV writes Codecov Report as a comment on GH PR

## Test Result

DONE ✅

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
