### PR TITLE
[CI] Scope MIGraphX CMake failure classifier to MIGraphX stage

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -259,6 +259,11 @@ Map<String,String> classifyBuildFailure(String logText) {
         if (failedTestsSnippet.length() > 2000) failedTestsSnippet = failedTestsSnippet.substring(0, 2000) + '\n... (truncated)'
     }
 
+    // Scenario 7: MIGraphX CMake configuration failed (Build and Verify MIGraphX with MLIR)
+    if (!reason && logText.contains('Configuring incomplete, errors occurred!')) {
+        reason = 'MIGraphX: CMake configuration failed (check CMakeError.log / CMakeOutput.log)'
+    }
+
     if (!reason) reason = 'Could not match a known error pattern. See build log for details.'
 
     // Extract CODEPATH (e.g. "Matrix - CODEPATH = 'navi4x'" or "Running navi4x on")
@@ -266,7 +271,7 @@ Map<String,String> classifyBuildFailure(String logText) {
     if (cpMatch.find()) codepath = cpMatch[0][1] ?: cpMatch[0][2] ?: ''
 
     // Extract stage (last occurrence in log by position = likely failed stage)
-    def stageNames = ['SCM Checkout', 'Build and Test', 'Parameter sweeps', 'Tune MLIR kernels', 'Tune rocMLIR', 'Code coverage', 'Archive performance DB']
+    def stageNames = ['SCM Checkout', 'Build and Test', 'Parameter sweeps', 'Tune MLIR kernels', 'Tune rocMLIR', 'Code coverage', 'Archive performance DB', 'MIGraphX', 'Build and Verify MIGraphX with MLIR']
     def stageIdx = -1
     for (def name in stageNames) {
         def idx = logText.lastIndexOf(name)

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -259,8 +259,11 @@ Map<String,String> classifyBuildFailure(String logText) {
         if (failedTestsSnippet.length() > 2000) failedTestsSnippet = failedTestsSnippet.substring(0, 2000) + '\n... (truncated)'
     }
 
-    // Scenario 7: MIGraphX CMake configuration failed (Build and Verify MIGraphX with MLIR)
-    if (!reason && logText.contains('Configuring incomplete, errors occurred!')) {
+    // Scenario 7: MIGraphX CMake configuration failed.
+    // Guard with stage position to avoid misclassifying CMake failures from other stages.
+    def migraphxStagePos = logText.lastIndexOf('Build and Verify MIGraphX with MLIR')
+    def cmakeConfigErrorPos = logText.lastIndexOf('Configuring incomplete, errors occurred!')
+    if (!reason && migraphxStagePos >= 0 && cmakeConfigErrorPos > migraphxStagePos) {
         reason = 'MIGraphX: CMake configuration failed (check CMakeError.log / CMakeOutput.log)'
     }
 


### PR DESCRIPTION
## Motivation

Failure that has happened recently on CI runs was not covered as special case in `Map<String,String> classifyBuildFailure(String logText)`.

## Technical Details

Introduced MIGraphX CMake configuration failed case  in `Map<String,String> classifyBuildFailure(String logText)`.

## Test Plan

no

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
