### PR TITLE
[AIROCMLIR-612] Lower `migrpahx.erf` into `linalg.erf`

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -162,6 +162,8 @@ def MIGraphX_ErfOp :
   let description = [{
     compute gauss error function
   }];
+  let arguments = (ins MIXRShapedOf<[AnyFloat]>:$inA);
+  let results = (outs MIXRShapedOf<[AnyFloat]>:$output);
 }
 def MIGraphX_ExpOp :
     MIGraphX_ElementwiseUnaryOp<"exp">;

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -1128,9 +1128,9 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::SqrtOp, linalg::SqrtOp>,
            ElementwiseConverter<migraphx::TanhOp, linalg::TanhOp>,
            ElementwiseConverter<migraphx::RecipOp, linalg::ReciprocalOp>,
-           ElementwiseConverter<migraphx::ErfOp, linalg::ErfOp>,
-           ReluConverter, ClipConverter, BroadcastConverter,
-           MultiBroadcastConverter, LiteralConverter, ReshapeConverter,
+           ElementwiseConverter<migraphx::ErfOp, linalg::ErfOp>, ReluConverter,
+           ClipConverter, BroadcastConverter, MultiBroadcastConverter,
+           LiteralConverter, ReshapeConverter,
            BooleanElementwiseConverter<migraphx::Greater>,
            BooleanElementwiseConverter<migraphx::Equal>, ClipConverter,
            TransposeConverter, ConvConverter>(converter, patterns.getContext());

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -1128,6 +1128,7 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::SqrtOp, linalg::SqrtOp>,
            ElementwiseConverter<migraphx::TanhOp, linalg::TanhOp>,
            ElementwiseConverter<migraphx::RecipOp, linalg::ReciprocalOp>,
+           ElementwiseConverter<migraphx::ErfOp, linalg::ErfOp>,
            ReluConverter, ClipConverter, BroadcastConverter,
            MultiBroadcastConverter, LiteralConverter, ReshapeConverter,
            BooleanElementwiseConverter<migraphx::Greater>,

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -12,12 +12,6 @@ func.func @func_convert(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.
   func.return
 }
 
-func.func @func_erf(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.erf'}}
-  migraphx.erf %arg0: <1x1xf32, 1x1> -> <1x1xf32, 1x1>
-  func.return
-}
-
 func.func @func_sigmoid(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.sigmoid'}}
   migraphx.sigmoid %arg0: <1x1xf32, 1x1> -> <1x1xf32, 1x1>

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -300,3 +300,10 @@ func.func @func_erf_f16(%arg0: !migraphx.shaped<1x36x384x64xf16, 884736x24576x64
   return %0 : !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1>
 }
 
+// -----
+
+func.func @func_erf_i16(%arg0: !migraphx.shaped<1x36x384x64xi16, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xi16, 884736x24576x64x1> {
+  // expected-error @+1 {{must be !migraphx.shaped of floating-point values}}
+  %0 = migraphx.erf %arg0 : <1x36x384x64xi16, 884736x24576x64x1> -> <1x36x384x64xi16, 884736x24576x64x1>
+  return %0 : !migraphx.shaped<1x36x384x64xi16, 884736x24576x64x1>
+}

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -283,3 +283,19 @@ func.func @transpose_3d(%arg0: !migraphx.shaped<2x3x4xf32, 12x4x1>) -> !migraphx
   %0 = migraphx.transpose %arg0 {permutation = [2, 0, 1]} : <2x3x4xf32, 12x4x1> -> <4x2x3xf32, 6x3x1>
   return %0 : !migraphx.shaped<4x2x3xf32, 6x3x1>
 }
+
+// -----
+  
+// CHECK-LABEL: func.func @func_erf_f32
+// CHECK: linalg.erf
+func.func @func_erf_f32(%arg0: !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1> attributes{kernel, arch = ""} {
+  %0 = migraphx.erf %arg0 : <1x36x384x64xf32, 884736x24576x64x1> -> <1x36x384x64xf32, 884736x24576x64x1>
+  return %0 : !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1>
+}
+
+// CHECK-LABEL: func.func @func_erf_f16
+// CHECK: linalg.erf
+func.func @func_erf_f16(%arg0: !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1> attributes{kernel, arch = ""} {
+  %0 = migraphx.erf %arg0 : <1x36x384x64xf16, 884736x24576x64x1> -> <1x36x384x64xf16, 884736x24576x64x1>
+  return %0 : !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1>
+}

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -288,14 +288,15 @@ func.func @transpose_3d(%arg0: !migraphx.shaped<2x3x4xf32, 12x4x1>) -> !migraphx
   
 // CHECK-LABEL: func.func @func_erf_f32
 // CHECK: linalg.erf
-func.func @func_erf_f32(%arg0: !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1> attributes{kernel, arch = ""} {
+func.func @func_erf_f32(%arg0: !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1> {
   %0 = migraphx.erf %arg0 : <1x36x384x64xf32, 884736x24576x64x1> -> <1x36x384x64xf32, 884736x24576x64x1>
   return %0 : !migraphx.shaped<1x36x384x64xf32, 884736x24576x64x1>
 }
 
 // CHECK-LABEL: func.func @func_erf_f16
 // CHECK: linalg.erf
-func.func @func_erf_f16(%arg0: !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1> attributes{kernel, arch = ""} {
+func.func @func_erf_f16(%arg0: !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1>) -> !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1> {
   %0 = migraphx.erf %arg0 : <1x36x384x64xf16, 884736x24576x64x1> -> <1x36x384x64xf16, 884736x24576x64x1>
   return %0 : !migraphx.shaped<1x36x384x64xf16, 884736x24576x64x1>
 }
+


### PR DESCRIPTION
## Motivation

Being able to lower `migraphx.erf` into `linalg.erf`. This is a trivial elementwise operations that was missed in #2227.  

This change is going to be used in the to see what it can compile: migraphx-bindings.

## Technical Details


## Test Plan


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
