### PR TITLE
[AIROCMLIR-604] [DRAFT] Fix CK build/benchmarking tests in Nightly CI

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1522,7 +1522,7 @@ PY
 
                                                     if (params.checkCK && isNotNavi3x(CHIP)) {
                                                         stage("Test MLIR vs CK") {
-                                                            catchError (buildResult: null) { // This is an optional stage
+                                                            catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
                                                                 dir('composable_kernel') {
                                                                     sh 'rm -rf composable_kernel'
                                                                     getAndBuildCK('''

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1539,12 +1539,15 @@ PY
                                                                         ''', 'device_gemm_operations')
                                                                     sh '''
                                                                         # Create empty stub .a files for CK libraries we didn't build
-                                                                        # so cmake --install doesn't fail on missing files
+                                                                        # so cmake --install doesn't fail on missing library files
                                                                         grep -roh '"[^"]*\\.a"' build/ --include="cmake_install.cmake" \
                                                                             | tr -d '"' | sort -u | while read f; do
                                                                             [ -f "$f" ] || { mkdir -p "$(dirname "$f")"; ar rcs "$f"; }
                                                                         done
-                                                                        cmake --install build
+                                                                        # Tolerate install errors from example/tutorial binaries we didn't build
+                                                                        cmake --install build || true
+                                                                        # Verify the library we actually need was installed
+                                                                        test -f build/CKInstallDir/lib/libdevice_gemm_operations.a
                                                                     '''
                                                                     sh 'echo `git rev-parse HEAD`'
                                                                 }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -373,7 +373,7 @@ Map<String,String> dockerArgs() {
 }
 
 
-void buildCK(String cmakeOpts) {
+void buildCK(String cmakeOpts, String makeTarget = '') {
     sh '[ ! -d build ] || rm -rf build'
     cmakeBuild generator: 'Unix Makefiles',\
         buildDir: 'build',\
@@ -383,7 +383,7 @@ void buildCK(String cmakeOpts) {
                       -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
                      ${cmakeOpts}
                      """
-    sh 'cd build; make -j $(nproc)'
+    sh "cd build; make -j \$(nproc) ${makeTarget}"
 }
 
 void buildMIGraphX(String cmakeOpts) {
@@ -405,10 +405,10 @@ void getAndBuildMIGraphX(String cmakeOpts) {
     buildMIGraphX(cmakeOpts)
 }
 
-void getAndBuildCK(String cmakeOpts) {
+void getAndBuildCK(String cmakeOpts, String makeTarget = '') {
     git branch: params.CKBranch, poll: false,\
         url: 'https://github.com/ROCm/composable_kernel.git'
-    buildCK(cmakeOpts)
+    buildCK(cmakeOpts, makeTarget)
 }
 
 void showEnv() {
@@ -1535,8 +1535,8 @@ PY
                                                                         -DCMAKE_PREFIX_PATH="/opt/rocm"
                                                                         -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                                                         -DCMAKE_BUILD_TYPE=Release
-                                                                        -DMIOPEN_REQ_LIBS_ONLY=ON
-                                                                        ''')
+                                                                        -DBUILD_TESTING=OFF
+                                                                        ''', 'device_gemm_operations')
                                                                     sh 'cd build; make install'
                                                                     sh 'echo `git rev-parse HEAD`'
                                                                 }
@@ -1560,6 +1560,19 @@ PY
                                                                     sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
                                                                 --configs_file=${gemmToUse} \
                                                                 --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv --data-type f32 f16 i8_i8 --external-gemm-library CK"""
+
+                                                                    def attnInput = "${WORKSPACE}/mlir/utils/performance/configs/tier1-attention-configs"
+                                                                    def attnToUse = "${WORKSPACE}/build/tier1-attention-configs-ck"
+                                                                    script {
+                                                                        if (params.nightly) {
+                                                                            def runIndex = ((env.BUILD_NUMBER as int) - 1) % 5 + 1
+                                                                            splitConfigFile(attnInput, attnToUse, runIndex)
+                                                                        }
+                                                                    }
+                                                                    sh """python3 ./bin/perfRunner.py --op=attention --batch_all \
+                                                                        --configs_file=${attnToUse} \
+                                                                        --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv --external-attention-library CK"""
+
                                                                     sh 'python3 ./bin/createPerformanceReports.py ${CHIP} CK'
                                                                 }
                                                             }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1537,7 +1537,7 @@ PY
                                                                         -DCMAKE_BUILD_TYPE=Release
                                                                         -DBUILD_TESTING=OFF
                                                                         ''', 'device_gemm_operations')
-                                                                    sh 'cd build; make install'
+                                                                    sh 'cmake --install build'
                                                                     sh 'echo `git rev-parse HEAD`'
                                                                 }
                                                                 sh 'rm -f build/CMakeCache.txt'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -763,6 +763,10 @@ boolean isNotNavi3x(String chip) {
     return "${chip}" != 'gfx1100' && "${chip}" != 'gfx1101'
 }
 
+boolean isNotNavi4x(String chip) {
+    return "${chip}" != 'gfx1200' && "${chip}" != 'gfx1201'
+}
+
 void collectCoverageData(String profdata, String cov, String cpath) {
     sh """
        rm -f *.profraw
@@ -1520,18 +1524,17 @@ PY
                                                         }
                                                     }
 
-                                                    if (params.checkCK && isNotNavi3x(CHIP)) {
+                                                    if (params.checkCK && isNotNavi3x(CHIP) && isNotNavi4x(CHIP)) {
                                                         stage("Test MLIR vs CK") {
                                                             catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
                                                                 dir('composable_kernel') {
                                                                     sh 'rm -rf composable_kernel'
                                                                     getAndBuildCK('''
-                                                                        -DGPU_TARGETS=${CHIP}
+                                                                        -DGPU_ARCHS=${CHIP}
                                                                         -DCMAKE_CXX_FLAGS="-O3"
                                                                         -DCMAKE_PREFIX_PATH="/opt/rocm"
                                                                         -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                                                         -DCMAKE_BUILD_TYPE=Release
-                                                                        -DBUILD_TESTING=OFF
                                                                         ''')
                                                                     sh 'cd build; make install'
                                                                     sh 'echo `git rev-parse HEAD`'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1531,6 +1531,7 @@ PY
                                                                         -DCMAKE_PREFIX_PATH="/opt/rocm"
                                                                         -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                                                         -DCMAKE_BUILD_TYPE=Release
+                                                                        -DBUILD_TESTS=OFF
                                                                         ''')
                                                                     sh 'cd build; make install'
                                                                     sh 'echo `git rev-parse HEAD`'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1531,7 +1531,7 @@ PY
                                                                         -DCMAKE_PREFIX_PATH="/opt/rocm"
                                                                         -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                                                         -DCMAKE_BUILD_TYPE=Release
-                                                                        -DBUILD_TESTS=OFF
+                                                                        -DBUILD_TESTING=OFF
                                                                         ''')
                                                                     sh 'cd build; make install'
                                                                     sh 'echo `git rev-parse HEAD`'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1538,15 +1538,21 @@ PY
                                                                         -DBUILD_TESTING=OFF
                                                                         ''', 'device_gemm_operations')
                                                                     sh '''
-                                                                        # Create empty stub .a files for CK libraries we didn't build
-                                                                        # so cmake --install doesn't fail on missing library files
-                                                                        grep -roh '"[^"]*\\.a"' build/ --include="cmake_install.cmake" \
-                                                                            | tr -d '"' | sort -u | while read f; do
-                                                                            [ -f "$f" ] || { mkdir -p "$(dirname "$f")"; ar rcs "$f"; }
+                                                                        # Create stubs for ALL missing build artifacts (libraries, executables)
+                                                                        # so cmake --install can run to completion and install Config.cmake files
+                                                                        grep -roh '"[^"]*"' build/ --include="cmake_install.cmake" \
+                                                                            | tr -d '"' | grep '^/' | grep '/build/' | grep -v CKInstallDir \
+                                                                            | sort -u | while read f; do
+                                                                            if [ ! -e "$f" ]; then
+                                                                                mkdir -p "$(dirname "$f")"
+                                                                                case "$f" in
+                                                                                    *.a) ar rcs "$f" ;;
+                                                                                    *)   touch "$f" ;;
+                                                                                esac
+                                                                            fi
                                                                         done
-                                                                        # Tolerate install errors from example/tutorial binaries we didn't build
-                                                                        cmake --install build || true
-                                                                        # Verify the library we actually need was installed
+                                                                        cmake --install build
+                                                                        # Verify the files we actually need were installed
                                                                         test -f build/CKInstallDir/lib/libdevice_gemm_operations.a
                                                                     '''
                                                                     sh 'echo `git rev-parse HEAD`'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1537,7 +1537,15 @@ PY
                                                                         -DCMAKE_BUILD_TYPE=Release
                                                                         -DBUILD_TESTING=OFF
                                                                         ''', 'device_gemm_operations')
-                                                                    sh 'cmake --install build'
+                                                                    sh '''
+                                                                        # Create empty stub .a files for CK libraries we didn't build
+                                                                        # so cmake --install doesn't fail on missing files
+                                                                        grep -roh '"[^"]*\\.a"' build/ --include="cmake_install.cmake" \
+                                                                            | tr -d '"' | sort -u | while read f; do
+                                                                            [ -f "$f" ] || { mkdir -p "$(dirname "$f")"; ar rcs "$f"; }
+                                                                        done
+                                                                        cmake --install build
+                                                                    '''
                                                                     sh 'echo `git rev-parse HEAD`'
                                                                 }
                                                                 sh 'rm -f build/CMakeCache.txt'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1530,11 +1530,12 @@ PY
                                                                 dir('composable_kernel') {
                                                                     sh 'rm -rf composable_kernel'
                                                                     getAndBuildCK('''
-                                                                        -DGPU_ARCHS=${CHIP}
+                                                                        -DGPU_TARGETS=${CHIP}
                                                                         -DCMAKE_CXX_FLAGS="-O3"
                                                                         -DCMAKE_PREFIX_PATH="/opt/rocm"
                                                                         -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                                                         -DCMAKE_BUILD_TYPE=Release
+                                                                        -DMIOPEN_REQ_LIBS_ONLY=ON
                                                                         ''')
                                                                     sh 'cd build; make install'
                                                                     sh 'echo `git rev-parse HEAD`'

--- a/mlir/utils/performance/ck-benchmark-driver/ck-gemm-benchmark-driver.cpp
+++ b/mlir/utils/performance/ck-benchmark-driver/ck-gemm-benchmark-driver.cpp
@@ -281,14 +281,14 @@ int main(int argc, char **argv) {
     std::cout << std::string(80, '-') << "\n";
   }
 
-  // Preliminary checks
+  // Skip unsupported configs gracefully instead of failing
   if (args.dataType == benchmark::DataType::F8 && args.gemmG != 1) {
-    std::cerr << "CK does not support fp8 batched gemm!\n";
-    exit(1);
+    std::cerr << "CK does not support fp8 batched gemm, skipping.\n";
+    return 0;
   }
   if (args.dataType != args.outDataType) {
-    std::cerr << "CK does not support different input/output data types!\n";
-    exit(1);
+    std::cerr << "CK does not support different input/output data types, skipping.\n";
+    return 0;
   }
 
   size_t batchStrideA = args.gemmM * args.gemmK,

--- a/mlir/utils/performance/perfCommonUtils.py
+++ b/mlir/utils/performance/perfCommonUtils.py
@@ -45,3 +45,15 @@ class GEMMLibrary(enum.IntEnum):
             return GEMMLibrary.HIPBLASLT
         else:
             raise ValueError(f"Unknown library {name}")
+
+
+class AttentionLibrary(enum.IntEnum):
+    CK = 1
+
+    @staticmethod
+    def from_name(name: str) -> "AttentionLibrary":
+        name = name.lower()
+        if name == 'ck':
+            return AttentionLibrary.CK
+        else:
+            raise ValueError(f"Unknown attention library {name}")

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -21,7 +21,7 @@ import pandas as pd
 from hip import hip
 
 import reportUtils
-from perfCommonUtils import Operation, GEMMLibrary
+from perfCommonUtils import Operation, GEMMLibrary, AttentionLibrary
 
 # global variables.
 ROCPROF = '/opt/rocm/bin/rocprofv3'
@@ -107,6 +107,7 @@ class MLIRPaths:
     libmlir_c_runner_utils_path: str
     rocmlir_tuning_driver_path: str
     ck_gemm_benchmark_driver_path: Optional[str] = None
+    ck_atten_benchmark_driver_path: Optional[str] = None
     hipblaslt_benchmark_driver_path: Optional[str] = None
 
 
@@ -209,6 +210,7 @@ def create_paths(config_file_path, mlir_build_dir_path) -> Paths:
         mlir_bin_dir_path = (Path(mlir_build_dir_path) / 'bin').resolve()
         mlir_bin_dir = str(mlir_bin_dir_path)
         ck_gemm_benchmark_driver_location = mlir_bin_dir_path / 'ck-gemm-benchmark-driver'
+        ck_atten_benchmark_driver_location = mlir_bin_dir_path / 'ck-atten-benchmark-driver'
         hipblaslt_benchmark_driver_location = mlir_bin_dir_path / 'hipblaslt-benchmark-driver'
         llvm_bin_dir = str((Path(mlir_build_dir_path) / 'external/llvm-project/llvm/bin').resolve())
         mlir_lib_dir = str((Path(mlir_build_dir_path) / 'lib').resolve())
@@ -225,6 +227,8 @@ def create_paths(config_file_path, mlir_build_dir_path) -> Paths:
             rocmlir_tuning_driver_path=mlir_bin_dir + '/rocmlir-tuning-driver',
             ck_gemm_benchmark_driver_path=(str(ck_gemm_benchmark_driver_location)
                                            if ck_gemm_benchmark_driver_location.exists() else None),
+            ck_atten_benchmark_driver_path=(str(ck_atten_benchmark_driver_location)
+                                            if ck_atten_benchmark_driver_location.exists() else None),
             hipblaslt_benchmark_driver_path=(str(hipblaslt_benchmark_driver_location)
                                              if hipblaslt_benchmark_driver_location.exists() else
                                              None))
@@ -1683,6 +1687,70 @@ class AttentionConfiguration(PerfConfiguration):
             f"-with-attn-bias {str(self.with_attn_bias).lower()}")
 
 
+class CKAttentionConfig(AttentionConfiguration):
+    EXTERNAL_NAME = "CK"
+
+    SUPPORTED_DTYPES = {"f16", "f32", "i8"}
+
+    def _is_ck_compatible(self):
+        if self.datatype not in self.SUPPORTED_DTYPES:
+            return False
+        if self.causal:
+            return False
+        if self.return_lse:
+            return False
+        if self.split_kv != 1:
+            return False
+        if self.num_heads_q != self.num_heads_kv:
+            return False
+        return True
+
+    def _build_ck_args(self):
+        ck_group_size = self.g * self.num_heads_q
+        args = [
+            '--seq_len_q', str(self.seq_len_q),
+            '--seq_len_k', str(self.seq_len_k),
+            '--head_dim_qk', str(self.head_dim_qk),
+            '--head_dim_v', str(self.head_dim_v),
+            '-g', str(ck_group_size),
+            '-t', self.datatype,
+            '--only-matmul-flops',
+        ]
+        if self.with_attn_scale:
+            args.append('--with-attn-scale')
+        if self.with_attn_bias:
+            args.append('--with-attn-bias')
+        if self.trans_q:
+            args.append('--transQ')
+        if self.trans_k:
+            args.append('--transK')
+        if self.trans_v:
+            args.append('--transV')
+        if self.trans_o:
+            args.append('--transO')
+        return args
+
+    @classmethod
+    def benchmark_external(cls, commandline, paths: Paths, arch, num_cu, num_chiplets):
+        config = cls.from_command_line(commandline, arch, num_cu, num_chiplets)
+        if not paths.mlir_paths.ck_atten_benchmark_driver_path:
+            raise ValueError("ck-atten-benchmark-driver not built")
+
+        if not config._is_ck_compatible():
+            print(f"Skipping CK-incompatible attention config: {config!r}")
+            return config.table_entry(float('NaN'))
+
+        print(f"Running CK attention benchmark {config!r}")
+        profiler_cmd = [paths.mlir_paths.ck_atten_benchmark_driver_path] + config._build_ck_args()
+        outs, noerr = run_pipeline([profiler_cmd])
+        nanoseconds = np.nan
+        if noerr:
+            miliseconds = get_miliseconds(outs)
+            nanoseconds = miliseconds * 1e6
+
+        return config.table_entry(nanoseconds)
+
+
 class HipBLASLtGemmConfig(GemmConfiguration):
     EXTERNAL_NAME = "hipBLASLt"
 
@@ -1894,6 +1962,8 @@ def generate_performance_results(configs,
         report_file = reportUtils.PERF_REPORT_FILE['hipBLASLt']
     elif conf_class is CKGemmConfig:
         report_file = reportUtils.PERF_REPORT_FILE['CK']
+    elif conf_class is CKAttentionConfig:
+        report_file = reportUtils.PERF_REPORT_FILE['CK_attention']
     else:
         report_file = reportUtils.PERF_REPORT_FILE['MIOpen']
     df.fillna(np.nan, inplace=True)
@@ -2260,13 +2330,16 @@ def get_num_cu(chip):
 
 def found_external_tool(paths: Paths,
                         optype: Operation,
-                        gemm_library: Optional[GEMMLibrary] = None):
+                        external_lib=None):
+    if not paths.mlir_paths:
+        return False
     if optype == Operation.GEMM:
-        if not paths.mlir_paths:
+        if external_lib == GEMMLibrary.CK and not paths.mlir_paths.ck_gemm_benchmark_driver_path:
             return False
-        if gemm_library == GEMMLibrary.CK and not paths.mlir_paths.ck_gemm_benchmark_driver_path:
+        if external_lib == GEMMLibrary.HIPBLASLT and not paths.mlir_paths.hipblaslt_benchmark_driver_path:
             return False
-        if gemm_library == GEMMLibrary.HIPBLASLT and not paths.mlir_paths.hipblaslt_benchmark_driver_path:
+    elif optype == Operation.ATTENTION:
+        if external_lib == AttentionLibrary.CK and not paths.mlir_paths.ck_atten_benchmark_driver_path:
             return False
     return True
 
@@ -2377,6 +2450,11 @@ def main(args=None):
                         default="hipBLASLt",
                         help="(hipBLASLt | CK) external library to run GEMM routines")
 
+    parser.add_argument("--external-attention-library",
+                        type=str,
+                        default=None,
+                        help="(CK) external library to run attention routines")
+
     parser.add_argument(
         '--data-type',
         nargs='+',
@@ -2428,8 +2506,13 @@ def main(args=None):
         elif external_lib == GEMMLibrary.HIPBLASLT:
             conf_class = HipBLASLtGemmConfig
     elif optype == Operation.ATTENTION:
-        conf_class = AttentionConfiguration
-        external_lib = None
+        if parsed_args.external_attention_library:
+            external_lib = AttentionLibrary.from_name(parsed_args.external_attention_library)
+            if external_lib == AttentionLibrary.CK:
+                conf_class = CKAttentionConfig
+        else:
+            conf_class = AttentionConfiguration
+            external_lib = None
     elif optype == Operation.GEMM_GEMM:
         conf_class = GemmGemmConfiguration
         external_lib = None

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -7,18 +7,21 @@ from typing import Tuple, List
 PERF_REPORT_FILE = {
     'hipBLASLt': 'mlir_vs_hipblaslt_perf.csv',
     'CK': 'mlir_vs_ck_perf.csv',
+    'CK_attention': 'mlir_vs_ck_attention_perf.csv',
     'MIOpen': 'mlir_vs_miopen_perf.csv'
 }
 PERF_REPORT_FUSION_FILE = 'mlir_fusion_perf.csv'
 PERF_PLOT_REPORT_FILE = {
     'hipBLASLt': 'mlir_vs_hipblaslt_perf_for_plot.csv',
     'CK': 'mlir_vs_ck_perf_for_plot.csv',
+    'CK_attention': 'mlir_vs_ck_attention_perf_for_plot.csv',
     'MIOpen': 'mlir_vs_miopen_perf_for_plot.csv'
 }
 PERF_PLOT_REPORT_FUSION_FILE = 'mlir_fusion_perf_for_plot.csv'
 PERF_STATS_REPORT_FILE = {
     'hipBLASLt': 'mlir_vs_hipblaslt_perf_means.csv',
     'CK': 'mlir_vs_ck_perf_means.csv',
+    'CK_attention': 'mlir_vs_ck_attention_perf_means.csv',
     'MIOpen': 'mlir_vs_miopen_perf_means.csv'
 }
 PERF_STATS_REPORT_FUSION_FILE = 'mlir_fusion_perf_means.csv'


### PR DESCRIPTION
## Motivation

This PR addresses a build error that was causing the CK nightly comparison to fail, and then also makes sure that any errors are caught and noticeable to the CI (instead of always showing as green).

This implements: https://amd-hub.atlassian.net/browse/AIROCMLIR-604

## Technical Details

* Disable CK unit tests during nightly benchmark builds by adding `-DBUILD_TESTS=OFF` to the CK cmake options. The nightly pipeline only needs CK's libraries install for benchmarking (it doesn't need the CK test suite)
* Replace `catchError(buildResult: null)` with `catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE')`. The previous setting silently swallowed all failures, leaving the overall build green even when the CK stage was completely broken. With this change, the stage is marked as FAILURE (red in stage view) and the build is marked as `UNSTABLE` (yellow), making CK-related issues visible without failing the entire nightly run

## Test Plan

* Run the Nightly CI to make sure that the CK stage is now building successfully.

## Test Result

- [ ] Verify that the CK stage is running successfully and that the benchmarking artifacts are created successfully

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
