### PR TITLE
[AIROCMLIR-612] Lower `migraphx.convert` into linalg.generic

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -683,6 +683,27 @@ private:
 };
 } // namespace
 
+template <>
+struct GenericElementwiseTrait<migraphx::ConvertOp> {
+  static bool isValidGenericElementwiseOp(Operation *op) {
+    migraphx::ConvertOp convertOp = dyn_cast<migraphx::ConvertOp>(op);
+    assert(convertOp && "template should have unpacked a convertOp here");
+
+    Type inputType = convertOp.getInA().getType().getElementType();
+    Type outputType = convertOp.getType().getElementType();
+    return inputType.isIntOrFloat() && outputType.isIntOrFloat();
+  }
+
+  static void elementwiseBodyBuilder(OpBuilder &builder, Location loc,
+                                     ValueRange inputs) {
+    assert(inputs.size() == 2 && "only expected one input and one output");
+
+    Value casted = convertScalarToDtype(
+        builder, loc, inputs[0], inputs[1].getType(), /*isUnsignedCast=*/false);
+    linalg::YieldOp::create(builder, loc, casted);
+  }
+};
+
 // Generic elementwise precondition checks and body builders
 template <>
 struct GenericElementwiseTrait<migraphx::SigmoidOp> {
@@ -1251,6 +1272,7 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::RecipOp, linalg::ReciprocalOp>,
            ElementwiseConverter<migraphx::ErfOp, linalg::ErfOp>, ReluConverter,
            GenericElementwiseOpConverter<migraphx::WhereOp>,
+           GenericElementwiseOpConverter<migraphx::ConvertOp>,
            GenericElementwiseOpConverter<migraphx::SigmoidOp>, ReluConverter,
            ClipConverter, BroadcastConverter, MultiBroadcastConverter,
            LiteralConverter, ReshapeConverter,

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -1,11 +1,5 @@
 // RUN: rocmlir-opt --migraphx-to-linalg -verify-diagnostics %s 
 
-func.func @func_convert(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.convert'}}
-  migraphx.convert %arg0: <1x1xf32, 1x1> to <1x1xf32, 1x1>
-  func.return
-}
-
 func.func @func_unpack(%arg0: !migraphx.shaped<1x1xi8, 1x1>, %arg1: !migraphx.shaped<1x1xi8, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.unpack'}}
   %0 = migraphx.unpack %arg0 {axis = 1 : i64} : <1x1xi8, 1x1> -> <1x2xi8, 2x1>

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -357,3 +357,55 @@ func.func @func_erf_i16(%arg0: !migraphx.shaped<1x36x384x64xi16, 884736x24576x64
   %0 = migraphx.erf %arg0 : <1x36x384x64xi16, 884736x24576x64x1> -> <1x36x384x64xi16, 884736x24576x64x1>
   return %0 : !migraphx.shaped<1x36x384x64xi16, 884736x24576x64x1>
 }
+
+// -----
+
+// CHECK-LABEL: @func_convert_f16_to_f32(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}})
+// CHECK:      linalg.generic
+// CHECK:        ^bb0(%[[in:.*]]: f16, %[[out:.*]]: f32):
+// CHECK:          %[[ext:.*]] = arith.extf %[[in]] : f16 to f32
+// CHECK:          linalg.yield %[[ext]] : f32
+func.func @func_convert_f16_to_f32(%arg0: !migraphx.shaped<4x8xf16, 8x1>) -> !migraphx.shaped<4x8xf32, 8x1> {
+  %0 = migraphx.convert %arg0 : <4x8xf16, 8x1> to <4x8xf32, 8x1>
+  return %0 : !migraphx.shaped<4x8xf32, 8x1>
+}
+
+// -----
+
+// CHECK-LABEL: @func_convert_f32_to_f16(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}})
+// CHECK:      linalg.generic
+// CHECK:        ^bb0(%[[in:.*]]: f32, %[[out:.*]]: f16):
+// CHECK:          %[[trunc:.*]] = arith.truncf %[[in]] : f32 to f16
+// CHECK:          linalg.yield %[[trunc]] : f16
+func.func @func_convert_f32_to_f16(%arg0: !migraphx.shaped<4x8xf32, 8x1>) -> !migraphx.shaped<4x8xf16, 8x1> {
+  %0 = migraphx.convert %arg0 : <4x8xf32, 8x1> to <4x8xf16, 8x1>
+  return %0 : !migraphx.shaped<4x8xf16, 8x1>
+}
+
+// -----
+
+// CHECK-LABEL: @func_convert_f32_to_i32(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}})
+// CHECK:      linalg.generic
+// CHECK:        ^bb0(%[[in:.*]]: f32, %[[out:.*]]: i32):
+// CHECK:          %[[cast:.*]] = arith.fptosi %[[in]] : f32 to i32
+// CHECK:          linalg.yield %[[cast]] : i32
+func.func @func_convert_f32_to_i32(%arg0: !migraphx.shaped<4x8xf32, 8x1>) -> !migraphx.shaped<4x8xi32, 8x1> {
+  %0 = migraphx.convert %arg0 : <4x8xf32, 8x1> to <4x8xi32, 8x1>
+  return %0 : !migraphx.shaped<4x8xi32, 8x1>
+}
+
+// -----
+
+// CHECK-LABEL: @func_convert_i32_to_f32(
+// CHECK-SAME: %[[arg0:.*]]: tensor{{.*}})
+// CHECK:      linalg.generic
+// CHECK:        ^bb0(%[[in:.*]]: i32, %[[out:.*]]: f32):
+// CHECK:          %[[cast:.*]] = arith.sitofp %[[in]] : i32 to f32
+// CHECK:          linalg.yield %[[cast]] : f32
+func.func @func_convert_i32_to_f32(%arg0: !migraphx.shaped<4x8xi32, 8x1>) -> !migraphx.shaped<4x8xf32, 8x1> {
+  %0 = migraphx.convert %arg0 : <4x8xi32, 8x1> to <4x8xf32, 8x1>
+  return %0 : !migraphx.shaped<4x8xf32, 8x1>
+}


### PR DESCRIPTION
## Motivation

There is a nice helper in `arith/Utils/Utils.h` that converts from type A to type B. In the case of integer, we always **assume it is signed**. See AIROCMLIR-595

## Technical Details

Added a linalg.generic loop elementwise converter that converts type type A to type B.  The emitted IR looks like the following: 

Starting from

```mlir
func.func @func_convert_i32_to_f32(%arg0: !migraphx.shaped<4x8xi32, 8x1>) -> !migraphx.shaped<4x8xf32, 8x1> {
  %0 = migraphx.convert %arg0 : <4x8xi32, 8x1> to <4x8xf32, 8x1>
  return %0 : !migraphx.shaped<4x8xf32, 8x1>
```

to

```mlir
    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%expanded : tensor<4x8xi32>) outs(%0 : tensor<4x8xf32>) {
    ^bb0(%in: i32, %out: f32):
      %2 = arith.sitofp %in : i32 to f32
      linalg.yield %2 : f32
    } -> tensor<4x8xf32>
```

## Test Plan

Lit test

## Test Result

Passed lit test

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
