### PR TITLE
fix incorrect minNumCU for RDNA2 (gfx103x) in AmdArchDb

### DIFF
--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -96,7 +96,7 @@ static constexpr AmdArchInfo
     rdnaInfo(GemmFeatures::dot | GemmFeatures::atomic_fmax_f32,
              /*waveSize=*/32, /*maxWavesPerEU*/ 16, /*totalSGPRPerEU*/ 512,
              /*totalVGPRPerEU*/ 1024, /*totalSharedMemPerCU*/ 131072,
-             /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/30,
+             /*maxSharedMemPerWG*/ 65536, /*numEUPerCU=*/4, /*minNumCU=*/2,
              /*hasFp8ConversionInstrs=*/false,
              /*hasOcpFp8ConversionInstrs=*/false, /*hasScaledGemm=*/false,
              /*maxNumXCC=*/1, /*hasLdsTransposeLoad=*/false),

--- a/mlir/test/rocmlir-gen/emit-split-k-selection-likelihood.mlir
+++ b/mlir/test/rocmlir-gen/emit-split-k-selection-likelihood.mlir
@@ -1,10 +1,10 @@
-// RUN: rocmlir-gen --arch gfx90a --operation gemm -t f32  -g 1 -m 8192 -k 512  -n 8192 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX90A_1
-// RUN: rocmlir-gen --arch gfx90a --operation gemm -t f32  -g 1 -m 1024 -k 256  -n 1024 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX90A_2
-// RUN: rocmlir-gen --arch gfx90a --operation gemm -t f32  -g 1 -m 32   -k 1024 -n 64   --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX90A_3
+// RUN: rocmlir-gen --arch gfx90a --operation gemm -t f32  -g 1 -m 8192 -k 512  -n 8192 --num_cu 104 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX90A_1
+// RUN: rocmlir-gen --arch gfx90a --operation gemm -t f32  -g 1 -m 1024 -k 256  -n 1024 --num_cu 104 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX90A_2
+// RUN: rocmlir-gen --arch gfx90a --operation gemm -t f32  -g 1 -m 32   -k 1024 -n 64   --num_cu 104 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX90A_3
 
-// RUN: rocmlir-gen --arch gfx1032 --operation gemm -t f32  -g 1 -m 8192 -k 512  -n 8192 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX1032_1
-// RUN: rocmlir-gen --arch gfx1032 --operation gemm -t f32  -g 1 -m 1024 -k 256  -n 1024 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX1032_2
-// RUN: rocmlir-gen --arch gfx1032 --operation gemm -t f32  -g 1 -m 32   -k 1024 -n 64   --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX1032_3
+// RUN: rocmlir-gen --arch gfx1032 --operation gemm -t f32  -g 1 -m 8192 -k 512  -n 8192 --num_cu 30 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX1032_1
+// RUN: rocmlir-gen --arch gfx1032 --operation gemm -t f32  -g 1 -m 1024 -k 256  -n 1024 --num_cu 30 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX1032_2
+// RUN: rocmlir-gen --arch gfx1032 --operation gemm -t f32  -g 1 -m 32   -k 1024 -n 64   --num_cu 30 --emit-split-k-selection-likelihood | FileCheck %s --check-prefixes=TEST_GFX1032_3
 
 // TEST_GFX90A_1: never
 // TEST_GFX90A_2: maybe


### PR DESCRIPTION
Fixes: #2303

## Motivation

RDNA2 GPUs (gfx103x) operate in WGP mode where HIP reports half the physical CU count. The rdnaInfo preset had minNumCU=30 which caused NativeArchInfoMatchesPresetInfo unit test to fail on GPUs with fewer than 30 WGPs (e.g. RX 6700 XT reports 20, RX 6500 XT reports 8).

## Technical Details

Lower minNumCU for rdnaInfo from 30 to 2, consistent with rdna3Info. Similar fix was applied for cdna3Info in commit f4b8f2aee865.
Also updated `emit-split-k-selection-likelihood.mlir` to pin `--num_cu`  explicitly in RUN lines (`--num_cu 30` for gfx1032, `--num_cu 104` for gfx90a) to decouple the test from arch preset minNumCU defaults.

## Test Plan

Run NativeArchInfoMatchesPresetInfo unit tests on machine with RX 7900 XTX (gfx1100), RX 9070 XT (gfx1201) and RX 6700 XT (gfx1031).
`emit-split-k-selection-likelihood.mlir` test passes for all 6 configurations.

## Test Result

All 3 NativeArchInfoMatchesPresetInfo tests pass, including /2 (gfx1031) which previously failed with:
Expected: (presetInfo.minNumCU) <= (nativeInfo.minNumCU), actual: 30 vs 20

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
