### PR TITLE
[AIROCMLIR-612] Lower `migraphx.where` into linalg.generic

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -112,12 +112,12 @@ def MIGraphX_ClipOp :
 
 // Note: when lowering to kernel calls, MIGraphX represents booleans as i8.
 // Keep that logic here.
-def MIGraphX_WhereOp :
-    MIGraphX_Op<"where">,
-    Arguments<(ins MIXRShapedOf<[I8, SI8, UI8]>:$cond,
-      AnyMIXRShaped:$inA,
-      AnyMIXRShaped:$inB)>,
-    Results<(outs AnyMIXRShaped:$output)> {
+def MIGraphX_WhereOp
+    : MIGraphX_Op<"where", [AllElementTypesMatch<["inA", "inB", "output"]>,
+                            AllShapesMatch<["inA", "inB", "output", "cond"]>]>,
+      Arguments<(ins MIXRShapedOf<[I8, SI8, UI8]>:$cond, AnyMIXRShaped:$inA,
+          AnyMIXRShaped:$inB)>,
+      Results<(outs AnyMIXRShaped:$output)> {
   let summary = "Elementwise select";
   let description = [{
     output[x] = cond[x] ? inA[x] : inB[x]
@@ -126,7 +126,6 @@ def MIGraphX_WhereOp :
     $cond `,` $inA `,` $inB attr-dict
     `:` type($cond) `,` type($inA) `,` type($inB) `->` type($output)
   }];
-  let hasVerifier = 1;
 }
 
 // Elementwise unary operations

--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -126,6 +126,7 @@ def MIGraphX_WhereOp :
     $cond `,` $inA `,` $inB attr-dict
     `:` type($cond) `,` type($inA) `,` type($inB) `->` type($output)
   }];
+  let hasVerifier = 1;
 }
 
 // Elementwise unary operations

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -710,6 +710,28 @@ struct GenericElementwiseTrait<migraphx::SigmoidOp> {
   }
 };
 
+template<>
+struct GenericElementwiseTrait<migraphx::WhereOp> {
+  static bool isValidGenericElementwiseOp(Operation *op) {
+    // verifier already checked for most of these cases
+    return true;
+  }
+
+  static void elementwiseBodyBuilder(OpBuilder &builder, Location loc,
+                                     ValueRange inputs) {
+  Value cond = inputs[0];
+  Value inA = inputs[1];
+  Value inB = inputs[2];
+
+  IntegerType condShape = dyn_cast<IntegerType>(cond.getType());
+  assert(condShape && "should be checked in verifier");
+  Value castedCond = convertScalarToDtype(
+      builder, loc, cond, builder.getI1Type(), /*isUnsignedCast=*/false);
+  Value result = arith::SelectOp::create(builder, loc, castedCond, inA, inB);
+  linalg::YieldOp::create(builder, loc, result);
+  }
+};
+
 template <typename ElementwiseOp>
 LogicalResult GenericElementwiseOpConverter<ElementwiseOp>::matchAndRewrite(
     ElementwiseOp op, OpAdaptor adaptor,
@@ -1230,6 +1252,7 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::TanhOp, linalg::TanhOp>,
            ElementwiseConverter<migraphx::RecipOp, linalg::ReciprocalOp>,
            ElementwiseConverter<migraphx::ErfOp, linalg::ErfOp>, ReluConverter,
+           GenericElementwiseOpConverter<migraphx::WhereOp>,
            GenericElementwiseOpConverter<migraphx::SigmoidOp>, ReluConverter,
            ClipConverter, BroadcastConverter, MultiBroadcastConverter,
            LiteralConverter, ReshapeConverter,

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -723,8 +723,6 @@ struct GenericElementwiseTrait<migraphx::WhereOp> {
     Value inA = inputs[1];
     Value inB = inputs[2];
 
-    IntegerType condShape = dyn_cast<IntegerType>(cond.getType());
-    assert(condShape && "should be checked in verifier");
     Value castedCond = convertScalarToDtype(
         builder, loc, cond, builder.getI1Type(), /*isUnsignedCast=*/false);
     Value result = arith::SelectOp::create(builder, loc, castedCond, inA, inB);

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -710,25 +710,25 @@ struct GenericElementwiseTrait<migraphx::SigmoidOp> {
   }
 };
 
-template<>
+template <>
 struct GenericElementwiseTrait<migraphx::WhereOp> {
   static bool isValidGenericElementwiseOp(Operation *op) {
-    // verifier already checked for most of these cases
+    // traits in where op already checked for most of these cases
     return true;
   }
 
   static void elementwiseBodyBuilder(OpBuilder &builder, Location loc,
                                      ValueRange inputs) {
-  Value cond = inputs[0];
-  Value inA = inputs[1];
-  Value inB = inputs[2];
+    Value cond = inputs[0];
+    Value inA = inputs[1];
+    Value inB = inputs[2];
 
-  IntegerType condShape = dyn_cast<IntegerType>(cond.getType());
-  assert(condShape && "should be checked in verifier");
-  Value castedCond = convertScalarToDtype(
-      builder, loc, cond, builder.getI1Type(), /*isUnsignedCast=*/false);
-  Value result = arith::SelectOp::create(builder, loc, castedCond, inA, inB);
-  linalg::YieldOp::create(builder, loc, result);
+    IntegerType condShape = dyn_cast<IntegerType>(cond.getType());
+    assert(condShape && "should be checked in verifier");
+    Value castedCond = convertScalarToDtype(
+        builder, loc, cond, builder.getI1Type(), /*isUnsignedCast=*/false);
+    Value result = arith::SelectOp::create(builder, loc, castedCond, inA, inB);
+    linalg::YieldOp::create(builder, loc, result);
   }
 };
 

--- a/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
+++ b/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
@@ -501,27 +501,5 @@ LogicalResult SigmoidOp::verify() {
       !getResult().getType().getElementType().isFloat()) {
     return emitOpError("only support floating point");
   }
-
-  return success();
-}
-
-LogicalResult WhereOp::verify() {
-  MIXRShapedType condType = getCond().getType();
-  MIXRShapedType inAType = getInA().getType();
-  MIXRShapedType inBType = getInB().getType();
-  MIXRShapedType resultType = getType();
-
-  if (inAType.getElementType() != inBType.getElementType() ||
-      inAType.getElementType() != resultType.getElementType()) {
-    return emitOpError(
-        "input and output types must have the same element type");
-  }
-
-  if (condType.getShape() != inAType.getShape() ||
-      condType.getShape() != inBType.getShape() ||
-      condType.getShape() != resultType.getShape()) {
-    return emitOpError("input and output types must have the same shape");
-  }
-
   return success();
 }

--- a/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
+++ b/mlir/lib/Dialect/MIGraphX/IR/MIGraphX.cpp
@@ -501,5 +501,27 @@ LogicalResult SigmoidOp::verify() {
       !getResult().getType().getElementType().isFloat()) {
     return emitOpError("only support floating point");
   }
+
+  return success();
+}
+
+LogicalResult WhereOp::verify() {
+  MIXRShapedType condType = getCond().getType();
+  MIXRShapedType inAType = getInA().getType();
+  MIXRShapedType inBType = getInB().getType();
+  MIXRShapedType resultType = getType();
+
+  if (inAType.getElementType() != inBType.getElementType() ||
+      inAType.getElementType() != resultType.getElementType()) {
+    return emitOpError(
+        "input and output types must have the same element type");
+  }
+
+  if (condType.getShape() != inAType.getShape() ||
+      condType.getShape() != inBType.getShape() ||
+      condType.getShape() != resultType.getShape()) {
+    return emitOpError("input and output types must have the same shape");
+  }
+
   return success();
 }

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -1,11 +1,5 @@
 // RUN: rocmlir-opt --migraphx-to-linalg -verify-diagnostics %s 
 
-func.func @func_where(%arg0: !migraphx.shaped<1x1xi8, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>, %arg2: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.where'}}
-  migraphx.where %arg0, %arg1, %arg2: <1x1xi8, 1x1>, <1x1xf32, 1x1>, <1x1xf32, 1x1> -> <1x1xf32, 1x1>
-  func.return
-}
-
 func.func @func_convert(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.convert'}}
   migraphx.convert %arg0: <1x1xf32, 1x1> to <1x1xf32, 1x1>

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -302,7 +302,7 @@ func.func @func_erf_f16(%arg0: !migraphx.shaped<1x36x384x64xf16, 884736x24576x64
 
 // -----
 
-// CHECK-LABEL: func.func @where
+// CHECK-LABEL: func.func @where_f32
 // CHECK: linalg.generic
 // CHECK-SAME: ins({{.*}} : tensor<64x64xi8>, tensor<64x64xf32>, tensor<64x64xf32>) outs({{.*}} : tensor<64x64xf32>)
 // CHECK: ^bb0(%[[in:.*]]: i8, %[[in_2:.*]]: f32, %[[in_3:.*]]: f32, %[[out:.*]]: f32):

--- a/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/mixr-to-linalg-ops.mlir
@@ -302,6 +302,33 @@ func.func @func_erf_f16(%arg0: !migraphx.shaped<1x36x384x64xf16, 884736x24576x64
 
 // -----
 
+// CHECK-LABEL: func.func @where
+// CHECK: linalg.generic
+// CHECK-SAME: ins({{.*}} : tensor<64x64xi8>, tensor<64x64xf32>, tensor<64x64xf32>) outs({{.*}} : tensor<64x64xf32>)
+// CHECK: ^bb0(%[[in:.*]]: i8, %[[in_2:.*]]: f32, %[[in_3:.*]]: f32, %[[out:.*]]: f32):
+// CHECK-DAG: %[[trunci:.*]] = arith.trunci %[[in]] : i8 to i1
+// CHECK-DAG: %[[select:.*]] = arith.select %[[trunci]], %[[in_2]], %[[in_3]] : f32
+// CHECK: linalg.yield %[[select]] : f32
+func.func @where_f32(%arg0: !migraphx.shaped<64x64xi8, 64x1>, %arg1: !migraphx.shaped<64x64xf32, 64x1>, %arg2: !migraphx.shaped<64x64xf32, 64x1>) -> !migraphx.shaped<64x64xf32, 64x1> {
+  %0 = migraphx.where %arg0, %arg1, %arg2 : <64x64xi8, 64x1>, <64x64xf32, 64x1>, <64x64xf32, 64x1> -> <64x64xf32, 64x1>
+  return %0 : !migraphx.shaped<64x64xf32, 64x1>
+}
+
+// CHECK-LABEL: func.func @where_broadcast
+// CHECK: linalg.generic
+// CHECK-SAME: ins({{.*}} : tensor<64x64xi8>, tensor<64x64xf16>, tensor<64x64xf16>) outs({{.*}} : tensor<64x64xf16>)
+// CHECK: ^bb0(%[[in:.*]]: i8, %[[in_3:.*]]: f16, %[[in_4:.*]]: f16, %[[out:.*]]: f16):
+// CHECK-DAG: %[[trunci:.*]] = arith.trunci %[[in]] : i8 to i1
+// CHECK-DAG: %[[select:.*]] = arith.select %[[trunci]], %[[in_3]], %[[in_4]] : f16
+// CHECK: linalg.yield %[[select]] : f16
+func.func @where_broadcast(%arg0: !migraphx.shaped<64x1xi8, 1x1>, %arg1: !migraphx.shaped<64x64xf16, 64x1>, %arg2: !migraphx.shaped<64x64xf16, 64x1>) -> !migraphx.shaped<64x64xf16, 64x1> {
+  %0 = migraphx.multibroadcast %arg0 {out_dyn_dims = [], out_lens = [64, 64]} : <64x1xi8, 1x1> -> <64x64xi8, 1x0>
+  %1 = migraphx.where %0, %arg1, %arg2 : <64x64xi8, 1x0>, <64x64xf16, 64x1>, <64x64xf16, 64x1> -> <64x64xf16, 64x1>
+  return %1 : !migraphx.shaped<64x64xf16, 64x1>
+}
+
+// -----
+
 // CHECK-LABEL: @func_sigmoid_2d_f32(
 // CHECK-SAME: %[[arg0:.*]]: tensor{{.*}})
 // CHECK-DAG:  %[[expanded:.*]] = tensor.expand_shape %[[arg0]] {{.*}} output_shape [4, 8] : tensor<32xf32> into tensor<4x8xf32>

--- a/mlir/test/Dialect/MIGraphX/invalid.mlir
+++ b/mlir/test/Dialect/MIGraphX/invalid.mlir
@@ -304,7 +304,7 @@ func.func @where_cond_not_bool(%arg0: !migraphx.shaped<4x4xf32, 4x1>, %arg1: !mi
 // -----
 
 func.func @where_mismatched_types(%arg0: !migraphx.shaped<4x4xi8, 4x1>, %arg1: !migraphx.shaped<4x4xf32, 4x1>, %arg2: !migraphx.shaped<4x4xf16, 4x1>) -> !migraphx.shaped<4x4xf32, 4x1> {
-  // expected-error @+1 {{input and output types must have the same element type}}
+  // expected-error @+1 {{op failed to verify that all of {inA, inB, output} have same element type}}
   %0 = migraphx.where %arg0, %arg1, %arg2 : <4x4xi8, 4x1>, <4x4xf32, 4x1>, <4x4xf16, 4x1> -> <4x4xf32, 4x1>
   return %0 : !migraphx.shaped<4x4xf32, 4x1>
 }
@@ -312,7 +312,7 @@ func.func @where_mismatched_types(%arg0: !migraphx.shaped<4x4xi8, 4x1>, %arg1: !
 // -----
 
 func.func @where_mismatched_shapes(%arg0: !migraphx.shaped<4x4xi8, 4x1>, %arg1: !migraphx.shaped<4x8xf32, 8x1>, %arg2: !migraphx.shaped<4x8xf32, 8x1>) -> !migraphx.shaped<4x8xf32, 8x1> {
-  // expected-error @+1 {{input and output types must have the same shape}}
+  // expected-error @+1 {{op failed to verify that all of {inA, inB, output, cond} have same shape}}
   %0 = migraphx.where %arg0, %arg1, %arg2 : <4x4xi8, 4x1>, <4x8xf32, 8x1>, <4x8xf32, 8x1> -> <4x8xf32, 8x1>
   return %0 : !migraphx.shaped<4x8xf32, 8x1>
 }

--- a/mlir/test/Dialect/MIGraphX/invalid.mlir
+++ b/mlir/test/Dialect/MIGraphX/invalid.mlir
@@ -292,3 +292,27 @@ func.func @func_sigmoid_2d_i32(%arg0: !migraphx.shaped<4x8xi32, 8x1>) -> !migrap
   %0 = migraphx.sigmoid %arg0 : <4x8xi32, 8x1> -> <4x8xi32, 8x1>
   return %0 : !migraphx.shaped<4x8xi32, 8x1>
 }
+
+// -----
+
+func.func @where_cond_not_bool(%arg0: !migraphx.shaped<4x4xf32, 4x1>, %arg1: !migraphx.shaped<4x4xf32, 4x1>, %arg2: !migraphx.shaped<4x4xf32, 4x1>) -> !migraphx.shaped<4x4xf32, 4x1> {
+  // expected-error @+1 {{'migraphx.where' op operand #0 must be !migraphx.shaped of 8-bit signless integer or 8-bit signed integer or 8-bit unsigned integer values, but got '!migraphx.shaped<4x4xf32, 4x1>'}}
+  %0 = migraphx.where %arg0, %arg1, %arg2 : <4x4xf32, 4x1>, <4x4xf32, 4x1>, <4x4xf32, 4x1> -> <4x4xf32, 4x1>
+  return %0 : !migraphx.shaped<4x4xf32, 4x1>
+}
+
+// -----
+
+func.func @where_mismatched_types(%arg0: !migraphx.shaped<4x4xi8, 4x1>, %arg1: !migraphx.shaped<4x4xf32, 4x1>, %arg2: !migraphx.shaped<4x4xf16, 4x1>) -> !migraphx.shaped<4x4xf32, 4x1> {
+  // expected-error @+1 {{input and output types must have the same element type}}
+  %0 = migraphx.where %arg0, %arg1, %arg2 : <4x4xi8, 4x1>, <4x4xf32, 4x1>, <4x4xf16, 4x1> -> <4x4xf32, 4x1>
+  return %0 : !migraphx.shaped<4x4xf32, 4x1>
+}
+
+// -----
+
+func.func @where_mismatched_shapes(%arg0: !migraphx.shaped<4x4xi8, 4x1>, %arg1: !migraphx.shaped<4x8xf32, 8x1>, %arg2: !migraphx.shaped<4x8xf32, 8x1>) -> !migraphx.shaped<4x8xf32, 8x1> {
+  // expected-error @+1 {{input and output types must have the same shape}}
+  %0 = migraphx.where %arg0, %arg1, %arg2 : <4x4xi8, 4x1>, <4x8xf32, 8x1>, <4x8xf32, 8x1> -> <4x8xf32, 8x1>
+  return %0 : !migraphx.shaped<4x8xf32, 8x1>
+}


### PR DESCRIPTION
## Motivation

Lower `migraphx.where` into `linalg.generic`. We cannot use `linalg.where` because the cond operand must be of type i1. However 

## Technical Details

The cond operand from `migraphx.where` is converted from i8 into i1. We then use `arith.select` to choose if we want the first or the second operand for `migraphx.where`.


## Test Plan

Added lit test

## Test Result

Passed E2E test 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
