### PR TITLE
[NFC] Remove unused operation

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -423,21 +423,6 @@ def MIGraphX_PoolingOp :
   }];
 }
 
-def MIGraphX_FlattenOp :
-    MIGraphX_Op<"flatten">,
-    Arguments<(ins AnyMIXRShaped:$input,
-                   I64Attr:$axis
-                   )>,
-	Results<(outs AnyMIXRShaped:$output)> {
-  let summary = "Flatten tensor";
-  let description = [{
-    The `migraphx.flatten` op.
-  }];
-  let assemblyFormat = [{
-    $input attr-dict `:` type($input) `->` type($output)
-  }];
-}
-
 def MIGraphX_TransposeOp :
     MIGraphX_Op<"transpose">,
     Arguments<(ins AnyMIXRShaped:$input,

--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -73,12 +73,6 @@ func.func @func_pooling(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.
   func.return
 }
 
-func.func @func_flatten(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.flatten'}}
-  migraphx.flatten %arg0 {axis = 0 : i64}: <1x1xf32, 1x1> -> <1xf32, 1>
-  func.return
-}
-
 func.func @func_slice(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.slice'}}
   migraphx.slice %arg0 {axes = [0], ends = [1], starts = [0]}: <1x1xf32, 1x1>  -> <1x1xf32, 1x1>


### PR DESCRIPTION
## Motivation

Remove unused operations.

## Technical Details

I suspect that this operation is never used for the following reasons:

There is no lowering from migraphx.flatten to the Tosa pipeline.

```bash
root@31dddf580291 ~/rocMLIR/build-release ((HEAD detached at origin/develop))$ ./bin/rocmlir-opt main.mlir  --migraphx-to-tosa
main.mlir:2:3: error: failed to legalize operation 'migraphx.flatten' that was explicitly marked illegal
  migraphx.flatten %arg0 {axis = 0 : i64}: <1x1xf32, 1x1> -> <1xf32, 1>
  ^
main.mlir:2:3: note: see current operation: %0 = "migraphx.flatten"(%arg0) <{axis = 0 : i64}> : (!migraphx.shaped<1x1xf32, 1x1>) -> !migraphx.shaped<1xf32, 1>
root@31dddf580291 ~/rocMLIR/build-release ((HEAD detached at origin/develop))$ 
```

There is no reference of `FlattenOp` in `MIGraphXToTosa.cpp`. 

I ran  `git log --oneline | grep flatten` and nothing significant seems to show up. 

```bash
root@31dddf580291 ~/rocMLIR/build-release ((HEAD detached at origin/develop))$ git log --oneline | grep flatten
c74e8539ff37 [Analysis] flatten enums for recurrence types
d00f59de80f1 [test][NewPM] Pin -flattencfg test to legacy PM
d53b4bee0ccd [LoopFlatten] Add a loop-flattening pass
9e783716a224 [llvm-libtool-darwin] Allow flattening archives
55d5e6cbe250 [flang] Remove flatten and merge upstreaming script.
42cc44fbc8dc [flang] Add script to flatten git history for llvm monorepo submission (flang-compiler/f18#854)
5c5880db2f17 [flang] Merge pull request flang-compiler/f18#868 from schweitzpgi/remove-flatten
d98cb81cd11c Handle successor's PHI node correctly when flattening CFG merges two if-regions
957380714da3 [clangd] Unfold SourceLocation flattening from findNameLoc in preparation for adding more overloads. NFC
1693b80bd567 [SimplifyCFG][NFC] Test that we fail to flatten CFG in JPEG "sign" value extend pattern
fca23d74c963 [SimplifyCFG][NFC] Test that we fail to flatten CFG after forming @llvm.umul.with.overflow
ec66bc57a879 Add helper to get flattened tuple types
```

It was introduced in this [commit ](https://github.com/ROCm/rocMLIR/pull/362/changes#diff-d0976e1f9b0e0438c3731021e53b80a93e1493f9f71382419ea1f78aac62938c)  - the inception of MIGraphX dialect and it doesn't have any testcase. 



## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
