### PR TITLE
Resolve invalid escape sequence in perf utils

### DIFF
--- a/mlir/utils/performance/perfCommonUtils.py
+++ b/mlir/utils/performance/perfCommonUtils.py
@@ -29,7 +29,7 @@ class Operation(enum.IntEnum):
             raise ValueError(f"Unknown operation type {name}")
 
 
-CORRECT_RESULT_RE = re.compile('\[1\s*1\s*1\]')
+CORRECT_RESULT_RE = re.compile(r'\[1\s*1\s*1\]')
 
 
 class GEMMLibrary(enum.IntEnum):

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -814,7 +814,7 @@ def get_conv_gemm_configurations(filename):
                 test_space = []
                 args = []
                 for arg in default_test_space.keys():
-                    """
+                    r"""
                     Next condition checks if a flag is not present in the line. Check with re.search(...)
                     ensures flags are matched exactly and not as substring.
 
@@ -856,7 +856,7 @@ def get_gemm_gemm_configurations(filename):
                 test_space = []
                 args = []
                 for arg in default_test_space.keys():
-                    """
+                    r"""
                     Next condition checks if a flag is not present in the line. Check with re.search(...)
                     ensures flags are matched exactly and not as substring.
 
@@ -907,7 +907,7 @@ def get_attn_configurations(filename):
                 test_space = []
                 args = []
                 for arg in default_test_space.keys():
-                    """
+                    r"""
                     Next condition checks if a flag is not present in the line. Check with re.search(...)
                     ensures flags are matched exactly and not as substring.
 


### PR DESCRIPTION
## Motivation

Incoming py tests reported warning:
```
=============================== warnings summary ===============================
perfRunner.py:817
  /__w/rocMLIR/rocMLIR/mlir/utils/performance/perfRunner.py:817: DeprecationWarning: invalid escape sequence '\S'
    """

perfRunner.py:859
  /__w/rocMLIR/rocMLIR/mlir/utils/performance/perfRunner.py:859: DeprecationWarning: invalid escape sequence '\S'
    """

perfRunner.py:910
  /__w/rocMLIR/rocMLIR/mlir/utils/performance/perfRunner.py:910: DeprecationWarning: invalid escape sequence '\S'
    """

perfCommonUtils.py:32
  /__w/rocMLIR/rocMLIR/mlir/utils/performance/perfCommonUtils.py:32: DeprecationWarning: invalid escape sequence '\['
    CORRECT_RESULT_RE = re.compile('\[1\s*1\s*1\]')

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
## Technical Details

Use raw string literals for the regex and inline triple-quoted regex notes to eliminate Python invalid escape sequence warnings without changing behavior.

## Test Plan

PR CI
GHA CI

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
