### PR TITLE
Add rdnaWaves occupancy filter to greedy tuning phases 1 and 2

### DIFF
--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -269,6 +269,8 @@ static void createGemmGemmTuningRangeGreedyPhase1(
   std::mt19937 rng(seed);
   int64_t waveSize =
       rock::lookupArchInfo(rock::getArchValue(gemmGemmOp)).waveSize;
+  bool isWmma = archInfo.isWmma(gemmGemmOp);
+  int64_t numEUPerCU = archInfo.numEUPerCU;
 
   int64_t outputSwizzle{2}, wavesPerEU{0};
   for (uint32_t gemm0MPerBlock : params[0]) {
@@ -301,6 +303,13 @@ static void createGemmGemmTuningRangeGreedyPhase1(
           uint32_t gemmSchedule = params[5][rng() % params[5].size()];
           uint32_t splitKFactor =
               optimalSplitKFactors[rng() % optimalSplitKFactors.size()];
+
+          if (isWmma) {
+            int64_t rdnaWaves = (gemm0MPerBlock / gemmMPerWave) *
+                                (gemm0NPerBlock / gemmNPerWave);
+            if (rdnaWaves < numEUPerCU)
+              continue;
+          }
 
           auto gemmGemmParams = GemmGemmParamsAttr::get(
               gemmGemmOp.getContext(), gemm0MPerBlock, gemm1MPerBlock,
@@ -335,6 +344,7 @@ createGemmGemmTuningRangeGreedyPhase2(TuningParamSet *newSpace,
   bool isWmma = archInfo.isWmma(gemmGemmOp);
   int64_t waveSize =
       rock::lookupArchInfo(rock::getArchValue(gemmGemmOp)).waveSize;
+  int64_t numEUPerCU = archInfo.numEUPerCU;
   int64_t outputSwizzle{2}, wavesPerEU{0};
   OpBuilder b(gemmGemmOp.getContext());
 
@@ -356,6 +366,12 @@ createGemmGemmTuningRangeGreedyPhase2(TuningParamSet *newSpace,
   for (uint32_t gemmKPerBlock : validRangeGemmGemmParams[2]) {
     for (uint32_t gemmMPerWave : mPerWaveRange) {
       for (uint32_t gemmNPerWave : nPerWaveRange) {
+        if (isWmma) {
+          int64_t rdnaWaves =
+              (gemm0MPerBlock / gemmMPerWave) * (gemm0NPerBlock / gemmNPerWave);
+          if (rdnaWaves < numEUPerCU)
+            continue;
+        }
         for (uint32_t gemmMnPerXdl : validRangeGemmGemmParams[3]) {
           for (uint32_t gemmKPack : validRangeGemmGemmParams[4]) {
             for (int64_t splitKFactor : optimalSplitKFactors) {


### PR DESCRIPTION
Resolves: https://amd-hub.atlassian.net/browse/AIROCMLIR-613

## Motivation

Greedy tuning for attention kernels on RDNA targets was significantly slower than exhaustive tuning — approximately 13x slower. This is the opposite of the expected behavior, as greedy tuning is designed to be faster than exhaustive by exploring a smarter subset of the search space. On CDNA targets, greedy was already faster than exhaustive, so this issue was RDNA-specific.

The root cause was a missing rdnaWaves occupancy filter in the greedy tuning code path. The exhaustive tuning path (createGemmGemmTuningRangeBF) already filters out configurations where the number of waves per workgroup is less than numEUPerCU for WMMA (RDNA's matrix math accelerator). 

## Technical Details

Added the existing rdnaWaves >= numEUPerCU filter to greedy tuning Phase 1 and Phase 2 in RockTuningImpl.cpp:

Phase 1 (createGemmGemmTuningRangeGreedyPhase1): Added isWmma and numEUPerCU variables, and a check that skips randomly sampled configurations where (gemm0MPerBlock / gemmMPerWave) * (gemm0NPerBlock / gemmNPerWave) < numEUPerCU.

Phase 2 (createGemmGemmTuningRangeGreedyPhase2): Added the same rdnaWaves check in the mPerWave/nPerWave loop, placed before the inner loops for early pruning.

-  33.5x speedup over old greedy

- 2.6x faster than exhaustive (as greedy should be)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

**TFlops performance:**

| Comparison | Wins | Neutral | Losses | Geo Mean |
|---|---|---|---|---|
| New Greedy vs Exhaustive | 34 | 3 | 8 | **+9.4%** |

The new greedy not only runs faster but also finds better configurations than exhaustive in a lot of cases, because it still explores non-power-of-2 tile sizes that exhaustive does not cover, while no longer wasting time on configurations with insufficient wave occupancy.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
