### PR TITLE
Fix f32 scales issue

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -643,6 +643,16 @@ LogicalResult DotConverter<DotType>::matchAndRewrite(
                            batchInfo.needsReshape, scaleA3DShape, scaleA4DShape,
                            scaleASliceSize, unbroadcastedScaleAShape);
 
+      // tosa.matmul_t_block_scaled requires scale element type f8E8M0FNU.
+      // MIGraphX may provide f32 scales, so cast if needed.
+      Type mxfpScaleType = Float8E8M0FNUType::get(rewriter.getContext());
+      if (scaleAElementType != mxfpScaleType) {
+        auto castType = cast<RankedTensorType>(scaleAUnbroadcasted.getType())
+                            .clone(mxfpScaleType);
+        scaleAUnbroadcasted = rewriter.createOrFold<tosa::CastOp>(
+            loc, castType, scaleAUnbroadcasted);
+      }
+
       // Undo broadcast on scaleB: [batch, K, N] -> [batch, K/blockSize, N]
       SmallVector<int64_t> scaleB3DShape = {batchInfo.newBatch, batchInfo.kDim,
                                             batchInfo.nDim};
@@ -662,6 +672,13 @@ LogicalResult DotConverter<DotType>::matchAndRewrite(
       SmallVector<int32_t> bTransposePerm = {0, 2, 1};
       Value bDataTransposed = rock::tosa::getTransposeOp(
           rewriter, loc, inBReshaped, bTransposePerm);
+
+      if (scaleBElementType != mxfpScaleType) {
+        auto castType = cast<RankedTensorType>(scaleBUnbroadcasted.getType())
+                            .clone(mxfpScaleType);
+        scaleBUnbroadcasted = rewriter.createOrFold<tosa::CastOp>(
+            loc, castType, scaleBUnbroadcasted);
+      }
 
       // Transpose scaleB from [batch x (K/block_size) x N] to [batch x N x
       // (K/block_size)]

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -668,17 +668,17 @@ LogicalResult DotConverter<DotType>::matchAndRewrite(
                            batchInfo.needsReshape, scaleB3DShape, scaleB4DShape,
                            scaleBSliceSize, unbroadcastedScaleBShape);
 
-      // Transpose B from [batch x K x N] to [batch x N x K]
-      SmallVector<int32_t> bTransposePerm = {0, 2, 1};
-      Value bDataTransposed = rock::tosa::getTransposeOp(
-          rewriter, loc, inBReshaped, bTransposePerm);
-
       if (scaleBElementType != mxfpScaleType) {
         auto castType = cast<RankedTensorType>(scaleBUnbroadcasted.getType())
                             .clone(mxfpScaleType);
         scaleBUnbroadcasted = rewriter.createOrFold<tosa::CastOp>(
             loc, castType, scaleBUnbroadcasted);
       }
+
+      // Transpose B from [batch x K x N] to [batch x N x K]
+      SmallVector<int32_t> bTransposePerm = {0, 2, 1};
+      Value bDataTransposed = rock::tosa::getTransposeOp(
+          rewriter, loc, inBReshaped, bTransposePerm);
 
       // Transpose scaleB from [batch x (K/block_size) x N] to [batch x N x
       // (K/block_size)]

--- a/mlir/lib/Dialect/MIGraphX/Transforms/MIGraphXTransform.cpp
+++ b/mlir/lib/Dialect/MIGraphX/Transforms/MIGraphXTransform.cpp
@@ -56,11 +56,19 @@ private:
   }
 
   // Helper function to apply scaling: converts input and scale to target type,
-  // then multiplies them
+  // then multiplies them.
+  // When the scale is not f8E8M0FNU, it is first roundtripped through
+  // f8E8M0FNU (e.g. f32 -> f8E8M0FNU -> f32) so that the host decomposition
+  // matches the kernel path, which casts scales to f8E8M0FNU block exponents
+  // for tosa.matmul_t_block_scaled / rock.gemm.
   Value applyScale(PatternRewriter &rewriter, Location loc, Value input,
                    Value scale, Type targetElemType) const {
-    Value convertedInput = convertToType(rewriter, loc, input, targetElemType);
+    Type scaleElemType = cast<MIXRShapedType>(scale.getType()).getElementType();
+    Type f8E8M0Type = Float8E8M0FNUType::get(rewriter.getContext());
+    if (scaleElemType != f8E8M0Type)
+      scale = convertToType(rewriter, loc, scale, f8E8M0Type);
     Value convertedScale = convertToType(rewriter, loc, scale, targetElemType);
+    Value convertedInput = convertToType(rewriter, loc, input, targetElemType);
 
     auto shapedType = cast<MIXRShapedType>(convertedInput.getType());
     return migraphx::MulOp::create(rewriter, loc,

--- a/mlir/test/Conversion/MIGraphXToTosa/quant-dot-scaled-to-matmul-t-block-scaled.mlir
+++ b/mlir/test/Conversion/MIGraphXToTosa/quant-dot-scaled-to-matmul-t-block-scaled.mlir
@@ -95,7 +95,104 @@ func.func @quant_dot_with_scales(
 }
 
 // ============================================================================
-// TEST 5: Scaled quant_dot with perf_config attribute propagation
+// TEST 5: Scaled quant_dot with f32 scales - should cast to f8E8M0FNU and use
+//         tosa.matmul_t_block_scaled. MIGraphX allows f32 scale types.
+// ============================================================================
+// CHECK-LABEL: quant_dot_with_f32_scales
+// CHECK: tosa.cast
+// CHECK: tosa.cast
+// CHECK: tosa.matmul_t_block_scaled
+// CHECK-SAME: acc_type = f32
+// CHECK-SAME: block_size = BLOCK_SIZE_32
+func.func @quant_dot_with_f32_scales(
+    %arg0: !migraphx.shaped<1x64x128xf4E2M1FN, 8192x128x1>,
+    %arg1: !migraphx.shaped<1x128x64xf4E2M1FN, 8192x64x1>,
+    %arg2: !migraphx.shaped<1x64x4x1xf32, 256x4x1x1>,
+    %arg3: !migraphx.shaped<1x4x1x64xf32, 256x64x64x1>
+) -> !migraphx.shaped<1x64x64xf32, 4096x64x1> attributes {kernel} {
+  %0 = migraphx.multibroadcast %arg2 {out_dyn_dims = [], out_lens = [1, 64, 4, 32]}
+    : <1x64x4x1xf32, 256x4x1x1> -> <1x64x4x32xf32, 256x4x1x0>
+  %1 = migraphx.reshape %0 {dims = [1, 64, 128]}
+    : <1x64x4x32xf32, 256x4x1x0> -> <1x64x128xf32, 8192x128x1>
+  %2 = migraphx.multibroadcast %arg3 {out_dyn_dims = [], out_lens = [1, 4, 32, 64]}
+    : <1x4x1x64xf32, 256x64x64x1> -> <1x4x32x64xf32, 256x64x0x1>
+  %3 = migraphx.reshape %2 {dims = [1, 128, 64]}
+    : <1x4x32x64xf32, 256x64x0x1> -> <1x128x64xf32, 8192x64x1>
+  %4 = migraphx.quant_dot %arg0 scaled by %1, %arg1 scaled by %3
+    : <1x64x128xf4E2M1FN, 8192x128x1> scaled by !migraphx.shaped<1x64x128xf32, 8192x128x1>,
+      <1x128x64xf4E2M1FN, 8192x64x1> scaled by !migraphx.shaped<1x128x64xf32, 8192x64x1>
+    -> <1x64x64xf32, 4096x64x1>
+  return %4 : !migraphx.shaped<1x64x64xf32, 4096x64x1>
+}
+
+// ============================================================================
+// TEST 6: 2D inputs with f32 scales, transpose, multibroadcast, reshape, and
+//         add. This matches the pattern from MIGraphX that was previously
+//         failing (the "unpack_fp4" pattern).
+// ============================================================================
+// CHECK-LABEL: quant_dot_2d_f32_scales_transpose_add
+// CHECK: tosa.cast
+// CHECK: tosa.cast
+// CHECK: tosa.matmul_t_block_scaled
+// CHECK-SAME: acc_type = f32
+// CHECK-SAME: block_size = BLOCK_SIZE_32
+func.func @quant_dot_2d_f32_scales_transpose_add(
+    %arg0: !migraphx.shaped<1x2048xf4E2M1FN, 2048x1>,
+    %arg1: !migraphx.shaped<1000x2048xf4E2M1FN, 2048x1>,
+    %arg2: !migraphx.shaped<1x64x1xf32, 64x1x1>,
+    %arg3: !migraphx.shaped<64x1x1000xf32, 1x1x64>,
+    %arg4: !migraphx.shaped<1x1000xf32, 1000x1>
+) -> !migraphx.shaped<1x1000xf32, 1000x1> attributes {kernel} {
+  %0 = migraphx.transpose %arg1 {permutation = [1, 0]}
+    : <1000x2048xf4E2M1FN, 2048x1> -> <2048x1000xf4E2M1FN, 1x2048>
+  %1 = migraphx.multibroadcast %arg2 {out_dyn_dims = [], out_lens = [1, 64, 32]}
+    : <1x64x1xf32, 64x1x1> -> <1x64x32xf32, 64x1x0>
+  %2 = migraphx.reshape %1 {dims = [1, 2048]}
+    : <1x64x32xf32, 64x1x0> -> <1x2048xf32, 2048x1>
+  %3 = migraphx.multibroadcast %arg3 {out_dyn_dims = [], out_lens = [64, 32, 1000]}
+    : <64x1x1000xf32, 1x1x64> -> <64x32x1000xf32, 1x0x64>
+  %4 = migraphx.reshape %3 {dims = [2048, 1000]}
+    : <64x32x1000xf32, 1x0x64> -> <2048x1000xf32, 1000x1>
+  %5 = migraphx.quant_dot %arg0 scaled by %2, %0 scaled by %4
+    : <1x2048xf4E2M1FN, 2048x1> scaled by !migraphx.shaped<1x2048xf32, 2048x1>,
+      <2048x1000xf4E2M1FN, 1x2048> scaled by !migraphx.shaped<2048x1000xf32, 1000x1>
+    -> <1x1000xf32, 1000x1>
+  %6 = migraphx.add %5, %arg4
+    : <1x1000xf32, 1000x1>, <1x1000xf32, 1000x1> -> <1x1000xf32, 1000x1>
+  return %6 : !migraphx.shaped<1x1000xf32, 1000x1>
+}
+
+// ============================================================================
+// TEST 7: f8E8M0FNU scales should NOT produce tosa.cast (already correct type)
+// ============================================================================
+// CHECK-LABEL: quant_dot_with_f8E8M0FNU_scales_no_cast
+// CHECK-NOT: tosa.cast
+// CHECK: tosa.matmul_t_block_scaled
+// CHECK-SAME: acc_type = f32
+// CHECK-SAME: block_size = BLOCK_SIZE_32
+func.func @quant_dot_with_f8E8M0FNU_scales_no_cast(
+    %arg0: !migraphx.shaped<1x64x128xf4E2M1FN, 8192x128x1>,
+    %arg1: !migraphx.shaped<1x128x64xf4E2M1FN, 8192x64x1>,
+    %arg2: !migraphx.shaped<1x64x4x1xf8E8M0FNU, 256x4x1x1>,
+    %arg3: !migraphx.shaped<1x4x1x64xf8E8M0FNU, 256x64x64x1>
+) -> !migraphx.shaped<1x64x64xf32, 4096x64x1> attributes {kernel} {
+  %0 = migraphx.multibroadcast %arg2 {out_dyn_dims = [], out_lens = [1, 64, 4, 32]}
+    : <1x64x4x1xf8E8M0FNU, 256x4x1x1> -> <1x64x4x32xf8E8M0FNU, 256x4x1x0>
+  %1 = migraphx.reshape %0 {dims = [1, 64, 128]}
+    : <1x64x4x32xf8E8M0FNU, 256x4x1x0> -> <1x64x128xf8E8M0FNU, 8192x128x1>
+  %2 = migraphx.multibroadcast %arg3 {out_dyn_dims = [], out_lens = [1, 4, 32, 64]}
+    : <1x4x1x64xf8E8M0FNU, 256x64x64x1> -> <1x4x32x64xf8E8M0FNU, 256x64x0x1>
+  %3 = migraphx.reshape %2 {dims = [1, 128, 64]}
+    : <1x4x32x64xf8E8M0FNU, 256x64x0x1> -> <1x128x64xf8E8M0FNU, 8192x64x1>
+  %4 = migraphx.quant_dot %arg0 scaled by %1, %arg1 scaled by %3
+    : <1x64x128xf4E2M1FN, 8192x128x1> scaled by !migraphx.shaped<1x64x128xf8E8M0FNU, 8192x128x1>,
+      <1x128x64xf4E2M1FN, 8192x64x1> scaled by !migraphx.shaped<1x128x64xf8E8M0FNU, 8192x64x1>
+    -> <1x64x64xf32, 4096x64x1>
+  return %4 : !migraphx.shaped<1x64x64xf32, 4096x64x1>
+}
+
+// ============================================================================
+// TEST 8: Scaled quant_dot with perf_config attribute propagation
 // ============================================================================
 // CHECK-LABEL: quant_dot_with_scales_perf_config
 // CHECK: tosa.matmul_t_block_scaled

--- a/mlir/test/Dialect/MIGraphX/quant-dot-decompose.mlir
+++ b/mlir/test/Dialect/MIGraphX/quant-dot-decompose.mlir
@@ -47,10 +47,15 @@ func.func @quant_dot_with_both_scales_f32(
   %arg2: !migraphx.shaped<1x16x512xf32, 8192x512x1>,
   %arg3: !migraphx.shaped<1x512x16xf32, 8192x16x1>
 ) -> !migraphx.shaped<1x16x16xf32, 256x16x1> {
+  // f32 scales are roundtripped through f8E8M0FNU to match the kernel path
   // CHECK-DAG: %[[CVT_A:.*]] = migraphx.convert %[[ARG0]] : <1x16x512xf4E2M1FN, 8192x512x1> to <1x16x512xf32, 8192x512x1>
   // CHECK-DAG: %[[CVT_B:.*]] = migraphx.convert %[[ARG1]] : <1x512x16xf4E2M1FN, 8192x16x1> to <1x512x16xf32, 8192x16x1>
-  // CHECK-DAG: %[[MUL_A:.*]] = migraphx.mul %[[CVT_A]], %[[ARG2]] : <1x16x512xf32, 8192x512x1>, <1x16x512xf32, 8192x512x1> -> <1x16x512xf32, 8192x512x1>
-  // CHECK-DAG: %[[MUL_B:.*]] = migraphx.mul %[[CVT_B]], %[[ARG3]] : <1x512x16xf32, 8192x16x1>, <1x512x16xf32, 8192x16x1> -> <1x512x16xf32, 8192x16x1>
+  // CHECK-DAG: %[[SCALE_A_F8:.*]] = migraphx.convert %[[ARG2]] : <1x16x512xf32, 8192x512x1> to <1x16x512xf8E8M0FNU, 8192x512x1>
+  // CHECK-DAG: %[[SCALE_A_F32:.*]] = migraphx.convert %[[SCALE_A_F8]] : <1x16x512xf8E8M0FNU, 8192x512x1> to <1x16x512xf32, 8192x512x1>
+  // CHECK-DAG: %[[SCALE_B_F8:.*]] = migraphx.convert %[[ARG3]] : <1x512x16xf32, 8192x16x1> to <1x512x16xf8E8M0FNU, 8192x16x1>
+  // CHECK-DAG: %[[SCALE_B_F32:.*]] = migraphx.convert %[[SCALE_B_F8]] : <1x512x16xf8E8M0FNU, 8192x16x1> to <1x512x16xf32, 8192x16x1>
+  // CHECK-DAG: %[[MUL_A:.*]] = migraphx.mul %[[CVT_A]], %[[SCALE_A_F32]] : <1x16x512xf32, 8192x512x1>, <1x16x512xf32, 8192x512x1> -> <1x16x512xf32, 8192x512x1>
+  // CHECK-DAG: %[[MUL_B:.*]] = migraphx.mul %[[CVT_B]], %[[SCALE_B_F32]] : <1x512x16xf32, 8192x16x1>, <1x512x16xf32, 8192x16x1> -> <1x512x16xf32, 8192x16x1>
   // CHECK: %[[DOT:.*]] = migraphx.dot %[[MUL_A]], %[[MUL_B]] : <1x16x512xf32, 8192x512x1>, <1x512x16xf32, 8192x16x1> -> <1x16x16xf32, 256x16x1>
   // CHECK: return %[[DOT]]
   %0 = migraphx.quant_dot
@@ -103,8 +108,12 @@ func.func @quant_dot_batched(
 ) -> !migraphx.shaped<8x128x128xf32, 16384x128x1> {
   // CHECK-DAG: %[[CVT_A:.*]] = migraphx.convert %[[ARG0]] : <8x128x256xf4E2M1FN, 32768x256x1> to <8x128x256xf32, 32768x256x1>
   // CHECK-DAG: %[[CVT_B:.*]] = migraphx.convert %[[ARG1]] : <8x256x128xf4E2M1FN, 32768x128x1> to <8x256x128xf32, 32768x128x1>
-  // CHECK-DAG: %[[MUL_A:.*]] = migraphx.mul %[[CVT_A]], %[[ARG2]] : <8x128x256xf32, 32768x256x1>, <8x128x256xf32, 32768x256x1> -> <8x128x256xf32, 32768x256x1>
-  // CHECK-DAG: %[[MUL_B:.*]] = migraphx.mul %[[CVT_B]], %[[ARG3]] : <8x256x128xf32, 32768x128x1>, <8x256x128xf32, 32768x128x1> -> <8x256x128xf32, 32768x128x1>
+  // CHECK-DAG: %[[SCALE_A_F8:.*]] = migraphx.convert %[[ARG2]] : <8x128x256xf32, 32768x256x1> to <8x128x256xf8E8M0FNU, 32768x256x1>
+  // CHECK-DAG: %[[SCALE_A_F32:.*]] = migraphx.convert %[[SCALE_A_F8]] : <8x128x256xf8E8M0FNU, 32768x256x1> to <8x128x256xf32, 32768x256x1>
+  // CHECK-DAG: %[[SCALE_B_F8:.*]] = migraphx.convert %[[ARG3]] : <8x256x128xf32, 32768x128x1> to <8x256x128xf8E8M0FNU, 32768x128x1>
+  // CHECK-DAG: %[[SCALE_B_F32:.*]] = migraphx.convert %[[SCALE_B_F8]] : <8x256x128xf8E8M0FNU, 32768x128x1> to <8x256x128xf32, 32768x128x1>
+  // CHECK-DAG: %[[MUL_A:.*]] = migraphx.mul %[[CVT_A]], %[[SCALE_A_F32]] : <8x128x256xf32, 32768x256x1>, <8x128x256xf32, 32768x256x1> -> <8x128x256xf32, 32768x256x1>
+  // CHECK-DAG: %[[MUL_B:.*]] = migraphx.mul %[[CVT_B]], %[[SCALE_B_F32]] : <8x256x128xf32, 32768x128x1>, <8x256x128xf32, 32768x128x1> -> <8x256x128xf32, 32768x128x1>
   // CHECK: %[[DOT:.*]] = migraphx.dot %[[MUL_A]], %[[MUL_B]] : <8x128x256xf32, 32768x256x1>, <8x256x128xf32, 32768x128x1> -> <8x128x128xf32, 16384x128x1>
   // CHECK: return %[[DOT]]
   %0 = migraphx.quant_dot
@@ -169,6 +178,28 @@ func.func @quant_dot_with_both_scales_f8e8m0fnu_kernel(
        !migraphx.shaped<1x16x512xf8E8M0FNU, 8192x512x1>,
        !migraphx.shaped<1x512x16xf4E2M1FN, 8192x16x1> scaled by
        !migraphx.shaped<1x512x16xf8E8M0FNU, 8192x16x1>
+     -> !migraphx.shaped<1x16x16xf32, 256x16x1>
+  return %0 : !migraphx.shaped<1x16x16xf32, 256x16x1>
+}
+
+// Kernel functions with f32 scales also shouldn't get decomposed
+// CHECK-LABEL: func.func @quant_dot_with_both_scales_f32_kernel
+// CHECK-NOT: migraphx.convert
+// CHECK-NOT: migraphx.dot
+// CHECK: migraphx.quant_dot
+func.func @quant_dot_with_both_scales_f32_kernel(
+  %arg0: !migraphx.shaped<1x16x512xf4E2M1FN, 8192x512x1>,
+  %arg1: !migraphx.shaped<1x512x16xf4E2M1FN, 8192x16x1>,
+  %arg2: !migraphx.shaped<1x16x512xf32, 8192x512x1>,
+  %arg3: !migraphx.shaped<1x512x16xf32, 8192x16x1>
+) -> !migraphx.shaped<1x16x16xf32, 256x16x1> attributes {kernel} {
+  %0 = migraphx.quant_dot
+       %arg0 scaled by %arg2,
+       %arg1 scaled by %arg3
+     : !migraphx.shaped<1x16x512xf4E2M1FN, 8192x512x1> scaled by
+       !migraphx.shaped<1x16x512xf32, 8192x512x1>,
+       !migraphx.shaped<1x512x16xf4E2M1FN, 8192x16x1> scaled by
+       !migraphx.shaped<1x512x16xf32, 8192x16x1>
      -> !migraphx.shaped<1x16x16xf32, 256x16x1>
   return %0 : !migraphx.shaped<1x16x16xf32, 256x16x1>
 }

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-fp4/migraphx-quant-dot-fp4-f32-scales.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-fp4/migraphx-quant-dot-fp4-f32-scales.mlir
@@ -1,0 +1,19 @@
+// RUN: rocmlir-gen -fut mlir_quant_dot_fp4 --arch %arch --clone-harness %s | rocmlir-driver -host-pipeline=migraphx,highlevel -kernel-pipeline=migraphx,highlevel | rocmlir-gen -ph -fut mlir_quant_dot_fp4_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+
+// Same as migraphx-quant-dot-fp4.mlir but WITHOUT migraphx.convert from f32
+// to f8E8M0FNU. The f32 scales are passed directly to quant_dot, testing that
+// the MIGraphXToTosa lowering correctly casts them to f8E8M0FNU for
+// tosa.matmul_t_block_scaled.
+module {
+  func.func @mlir_quant_dot_fp4(%arg0: !migraphx.shaped<1x2048xf4E2M1FN, 2048x1>, %arg1: !migraphx.shaped<1000x2048xf4E2M1FN, 2048x1>, %arg2: !migraphx.shaped<1x64x1xf32, 64x1x1>, %arg3: !migraphx.shaped<64x1x1000xf32, 1x1x64>, %arg4: !migraphx.shaped<1x1000xf32, 1000x1>) -> !migraphx.shaped<1x1000xf32, 1000x1> {
+    %0 = migraphx.transpose %arg1 {permutation = [1, 0]} : <1000x2048xf4E2M1FN, 2048x1> -> <2048x1000xf4E2M1FN, 1x2048>
+    %1 = migraphx.multibroadcast %arg2 {out_dyn_dims = [], out_lens = [1, 64, 32]} : <1x64x1xf32, 64x1x1> -> <1x64x32xf32, 64x1x0>
+    %2 = migraphx.reshape %1 {dims = [1, 2048]} : <1x64x32xf32, 64x1x0> -> <1x2048xf32, 2048x1>
+    %3 = migraphx.multibroadcast %arg3 {out_dyn_dims = [], out_lens = [64, 32, 1000]} : <64x1x1000xf32, 1x1x64> -> <64x32x1000xf32, 1x0x64>
+    %4 = migraphx.reshape %3 {dims = [2048, 1000]} : <64x32x1000xf32, 1x0x64> -> <2048x1000xf32, 1000x1>
+    %5 = migraphx.quant_dot %arg0 scaled by %2, %0 scaled by %4 : <1x2048xf4E2M1FN, 2048x1> scaled by !migraphx.shaped<1x2048xf32, 2048x1>, <2048x1000xf4E2M1FN, 1x2048> scaled by !migraphx.shaped<2048x1000xf32, 1000x1> -> <1x1000xf32, 1000x1>
+    %6 = migraphx.add %5, %arg4 : <1x1000xf32, 1000x1>, <1x1000xf32, 1000x1> -> <1x1000xf32, 1000x1>
+    return %6 : !migraphx.shaped<1x1000xf32, 1000x1>
+  }
+}

--- a/mlir/test/fusion/pr-e2e/mixr-gemm-fp4/migraphx-quant-dot-fp4-f32-scales.mlir
+++ b/mlir/test/fusion/pr-e2e/mixr-gemm-fp4/migraphx-quant-dot-fp4-f32-scales.mlir
@@ -1,10 +1,14 @@
+// RUN: rocmlir-gen --clone-harness -arch %arch -fut mlir_quant_dot_fp4 %s | rocmlir-driver --kernel-pipeline=migraphx,highlevel,gpu,binary --arch %arch --mlir-print-ir-after=rock-threadwise-gemm-lowering -o /dev/null 2>&1 | FileCheck %s --check-prefixes=ASSEMBLY
+// ASSEMBLY: amdgpu.scaled_mfma
+
 // RUN: rocmlir-gen -fut mlir_quant_dot_fp4 --arch %arch --clone-harness %s | rocmlir-driver -host-pipeline=migraphx,highlevel -kernel-pipeline=migraphx,highlevel | rocmlir-gen -ph -fut mlir_quant_dot_fp4_wrapper --verifier clone - | rocmlir-driver -host-pipeline mhal,runner -kernel-pipeline full | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
 // CHECK: [1 1 1]
 
 // Same as migraphx-quant-dot-fp4.mlir but WITHOUT migraphx.convert from f32
 // to f8E8M0FNU. The f32 scales are passed directly to quant_dot, testing that
 // the MIGraphXToTosa lowering correctly casts them to f8E8M0FNU for
-// tosa.matmul_t_block_scaled.
+// tosa.matmul_t_block_scaled. The host-side QuantDotDecompose roundtrips f32
+// scales through f8E8M0FNU to match the kernel path's behavior.
 module {
   func.func @mlir_quant_dot_fp4(%arg0: !migraphx.shaped<1x2048xf4E2M1FN, 2048x1>, %arg1: !migraphx.shaped<1000x2048xf4E2M1FN, 2048x1>, %arg2: !migraphx.shaped<1x64x1xf32, 64x1x1>, %arg3: !migraphx.shaped<64x1x1000xf32, 1x1x64>, %arg4: !migraphx.shaped<1x1000xf32, 1000x1>) -> !migraphx.shaped<1x1000xf32, 1000x1> {
     %0 = migraphx.transpose %arg1 {permutation = [1, 0]} : <1000x2048xf4E2M1FN, 2048x1> -> <2048x1000xf4E2M1FN, 1x2048>


### PR DESCRIPTION
## Motivation

QuantDot accepts both F32 and F8E8M0FNU scale types. If migraphx passes F32 scales then we need to internally convert them to f8E8M0FNU. 

`tosa.matmul_t_block_scaled` only accepts f8E8M0FNU scales.  

Previously rocMLIR was decomposing quant_dot to do this and it used `tosa.matmul` 

```
migraphx.convert %scale : f8E8M0FNU to f32  // skipped if already in f32
migraphx.convert %a : f4E2M1FN to f32
migraphx.mul %a, %scale : f32
migraphx.dot %aScaled, %bScaled
```

It worked because it used `tosa.matmul` and then f32 to f8 conversion was handled later during https://github.com/ROCm/rocMLIR/blob/78c6db39dd6182e411359d5d8d1f865821761147/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp#L781




But now to get through `tosa.matmul_t_block_Scaled` we need to apply this conversion at MIGraphX level. 

rock conversion is also kept as we use it for testing purposes and in general can be helpful in future when we can have different dtypes for scales. 


