### PR TITLE
Fix benchmark report stage to use GPU-detected chip name instead of labels

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -589,11 +589,11 @@ void postProcessPerfRes(String chip) {
     archiveArtifacts artifacts: 'build/*_mlir_*.csv,build/perf-run-date', allowEmptyArchive: true, onlyIfSuccessful: true
 }
 
-//Get the GPU name of architecture
+// Get the base GPU chip name as reported by the runtime (e.g. gfx1200, gfx942).
 def get_gpu_architecture() {
     try {
         def result = sh(script: 'rocminfo', returnStdout: true).trim()
-        def arch_pattern = /Name:\s+amdgcn-amd-amdhsa--(gfx\d+\w*((:\w+[\+\-]))*)/
+        def arch_pattern = /Name:\s+amdgcn-amd-amdhsa--(gfx[0-9a-z]+)/
         def matches = (result =~ arch_pattern)
         if (matches) {
             return matches[0][1]
@@ -1622,7 +1622,8 @@ PY
                                                                     sh """python3 ./bin/perfRunner.py --op=gemm --batch_all \
                                                                 --configs_file=${gemmToUse} \
                                                                 --tuning_db=${WORKSPACE}/build/mlir_tuning_${CHIP}.tsv --data-type f32 f16 i8_i8 --external-gemm-library CK"""
-                                                                    sh 'python3 ./bin/createPerformanceReports.py ${CHIP} CK'
+                                                                    def ckChip = get_gpu_architecture()
+                                                                    sh "python3 ./bin/createPerformanceReports.py ${ckChip} CK"
                                                                 }
                                                             }
                                                         }
@@ -1631,14 +1632,16 @@ PY
                                                     stage("Create performance reports") {
                                                         dir('build') {
                                                             sh 'ls -l'
-                                                            sh 'python3 ./bin/createPerformanceReports.py ${CHIP} MIOpen'
-                                                            sh 'python3 ./bin/createPerformanceReports.py ${CHIP} hipBLASLt'
-                                                            sh 'python3 ./bin/createFusionPerformanceReports.py ${CHIP}'
-                                                            sh 'python3 ./bin/perfRegressionReport.py ${CHIP}'
-                                                            sh 'python3 ./bin/perfRegressionReport.py ${CHIP} ./oldData/${CHIP}_mlir_vs_hipblaslt_perf.csv ./${CHIP}_mlir_vs_hipblaslt_perf.csv'
+                                                            def reportChip = get_gpu_architecture()
+                                                            echo "Detected GPU chip for reports: ${reportChip} (CHIP matrix value: ${CHIP})"
+                                                            sh "python3 ./bin/createPerformanceReports.py ${reportChip} MIOpen"
+                                                            sh "python3 ./bin/createPerformanceReports.py ${reportChip} hipBLASLt"
+                                                            sh "python3 ./bin/createFusionPerformanceReports.py ${reportChip}"
+                                                            sh "python3 ./bin/perfRegressionReport.py ${reportChip}"
+                                                            sh "python3 ./bin/perfRegressionReport.py ${reportChip} ./oldData/${reportChip}_mlir_vs_hipblaslt_perf.csv ./${reportChip}_mlir_vs_hipblaslt_perf.csv"
                                                             sh 'mkdir -p reports && cp ./*.html reports'
                                                         }
-                                                        postProcessPerfRes("${CHIP}")
+                                                        postProcessPerfRes(get_gpu_architecture())
                                                     }
                                                 }
                                             }


### PR DESCRIPTION


## Motivation

The root cause is a mismatch between the Jenkins `CHIP` matrix variable and the actual GPU chip name reported by the ROCm runtime. The node has the label `gfx1201`, but `rocminfo` and `rocm_agent_enumerator` both report the GPU as `gfx1200`. 
`perfRunner.py` detects the chip via HIP at runtime and names its output files accordingly (e.g. `gfx1200_mlir_vs_miopen_perf.csv`). However, the report generation scripts (`createPerformanceReports.py`, `perfRegressionReport.py`, etc.) were receiving the `CHIP` matrix value (`gfx1201`) and looking for files named `gfx1201_mlir_vs_miopen_perf.csv`, which don't exist.


## Technical Details

**Updated the benchmark report stage** to use `get_gpu_architecture()` instead of the `${CHIP}` matrix variable for all report generation and post-processing calls:
- `createPerformanceReports.py` (MIOpen, hipBLASLt, CK)
- `createFusionPerformanceReports.py`
- `perfRegressionReport.py` (MIOpen, hipBLASLt)
- `postProcessPerfRes()` (HTML publishing and plot generation)

## Test Plan

- Run the nightly pipeline on a Navi 4x node where the label differs from the runtime-detected chip to verify the report stage completes successfully.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
