### PR TITLE
Bump CMake from 3.23.3 to 3.28.3 in Dockerfile

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -35,8 +35,8 @@ RUN echo 'install build dependencies'; \
         # shell users
         less vim
 
-# Install cmake 3.23+ from source.
-RUN wget --no-verbose -O /cmake.sh https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3-linux-x86_64.sh; \
+# Install cmake 3.28+ from source.
+RUN wget --no-verbose -O /cmake.sh https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.sh; \
     chmod +x /cmake.sh; \
     mkdir -p /etc/cmake; \
     /cmake.sh --prefix=/etc/cmake --skip-license; \


### PR DESCRIPTION
This change is a prerequisite for https://github.com/ROCm/rocMLIR/pull/2328.

## Motivation

The MIGraphX CMake configuration step fails when building against ROCm 7.2 with the following error:
CMake Error at /opt/rocm/lib/cmake/hipblaslt/hipblaslt-config.cmake:10 (block):
  Unknown CMake command "block".

## Technical Details

ROCm 7.2 ships a hipblaslt-config.cmake that uses the block() CMake command, which was introduced in CMake 3.25. Our Dockerfile installed CMake 3.23.3, which does not recognize this command, causing the MIGraphX configuration to fail.
Bump CMake from 3.23.3 to 3.28.3 in the Dockerfile. This version fully supports the block() command and is backward-compatible with all existing build configurations (rocMLIR minimum requirement is CMake 3.20).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tested locally by building the Docker image and running find_package(hipblaslt) with CMake 3.28.3 inside the container,  configuration completes successfully.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
