### PR TITLE
Add hip-python to MITuna venv

### DIFF
--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -151,5 +151,4 @@ ADD "https://raw.githubusercontent.com/ROCm/MITuna/pf-tuna-rocmlir-3/requirement
 RUN python3 -m venv /tuna-venv && . /tuna-venv/bin/activate && \
     python3 -m pip install -r tuna-requirements.txt --ignore-installed && \
     python3 -m pip install -r llvm-requirements.txt --ignore-installed && \
-    python3 -m pip install -r requirements.txt --ignore-installed && \
-    python3 -m pip install --index-url https://test.pypi.org/simple/ hip-python
+    python3 -m pip install -r requirements.txt --ignore-installed

--- a/mlir/utils/jenkins/Dockerfile
+++ b/mlir/utils/jenkins/Dockerfile
@@ -151,4 +151,5 @@ ADD "https://raw.githubusercontent.com/ROCm/MITuna/pf-tuna-rocmlir-3/requirement
 RUN python3 -m venv /tuna-venv && . /tuna-venv/bin/activate && \
     python3 -m pip install -r tuna-requirements.txt --ignore-installed && \
     python3 -m pip install -r llvm-requirements.txt --ignore-installed && \
-    python3 -m pip install -r requirements.txt --ignore-installed
+    python3 -m pip install -r requirements.txt --ignore-installed && \
+    python3 -m pip install --index-url https://test.pypi.org/simple/ hip-python

--- a/mlir/utils/tuna/tuna-script.sh
+++ b/mlir/utils/tuna/tuna-script.sh
@@ -158,9 +158,12 @@ if [ "${VIRTUAL_ENV:-}" = "" ]; then
     source /tuna-venv/bin/activate
 fi
 
-# Ensure hip-python is importable (may be missing from older Docker images).
-python3 -m pip install --index-url https://test.pypi.org/simple/ \
-    --target /tmp/hip-python-pkgs hip-python
-export PYTHONPATH="/tmp/hip-python-pkgs:${PYTHONPATH:-}"
+# Ensure hip-python is importable
+if ! python3 -c "from hip import hip" 2>/dev/null; then
+    HIP_PY_DIR=$(mktemp -d)
+    python3 -m pip install --index-url https://test.pypi.org/simple/ \
+        --target "$HIP_PY_DIR" hip-python
+    export PYTHONPATH="${HIP_PY_DIR}:${PYTHONPATH:-}"
+fi
 
 tuna_run "$OP" "$TUNING_SPACE"

--- a/mlir/utils/tuna/tuna-script.sh
+++ b/mlir/utils/tuna/tuna-script.sh
@@ -158,9 +158,9 @@ if [ "${VIRTUAL_ENV:-}" = "" ]; then
     source /tuna-venv/bin/activate
 fi
 
-# Ensure hip-python is available in the venv
-echo "which python3: $(which python3)"
-python3 -m pip install --index-url https://test.pypi.org/simple/ hip-python
-python3 -c "from hip import hip; print('hip-python import OK')"
+# Ensure hip-python is importable (may be missing from older Docker images).
+python3 -m pip install --index-url https://test.pypi.org/simple/ \
+    --target /tmp/hip-python-pkgs hip-python
+export PYTHONPATH="/tmp/hip-python-pkgs:${PYTHONPATH:-}"
 
 tuna_run "$OP" "$TUNING_SPACE"

--- a/mlir/utils/tuna/tuna-script.sh
+++ b/mlir/utils/tuna/tuna-script.sh
@@ -161,4 +161,13 @@ fi
 # Ensure hip-python is available in the venv
 python3 -m pip install --index-url https://test.pypi.org/simple/ hip-python 2>/dev/null || true
 
+# Pre-flight: exercise the same code path MITuna uses, but without 2>/dev/null,
+# so we can actually see any errors. MITuna's worker hides stderr entirely.
+echo "=== Pre-flight check of tuningRunner.py ==="
+(cd "${ROCMLIR_DIR}/build/" && python3 ./bin/tuningRunner.py -q --operation gemm \
+    --config='-t f16 -out_datatype f16 -transA false -transB false -g 1 -m 1 -n 1 -k 1' \
+    --mlir-build-dir "$(pwd)" --output=- --tflops) \
+    || echo "WARNING: tuningRunner.py pre-flight exited with code $?"
+echo "=== End pre-flight check ==="
+
 tuna_run "$OP" "$TUNING_SPACE"

--- a/mlir/utils/tuna/tuna-script.sh
+++ b/mlir/utils/tuna/tuna-script.sh
@@ -159,15 +159,8 @@ if [ "${VIRTUAL_ENV:-}" = "" ]; then
 fi
 
 # Ensure hip-python is available in the venv
-python3 -m pip install --index-url https://test.pypi.org/simple/ hip-python 2>/dev/null || true
-
-# Pre-flight: exercise the same code path MITuna uses, but without 2>/dev/null,
-# so we can actually see any errors. MITuna's worker hides stderr entirely.
-echo "=== Pre-flight check of tuningRunner.py ==="
-(cd "${ROCMLIR_DIR}/build/" && python3 ./bin/tuningRunner.py -q --operation gemm \
-    --config='-t f16 -out_datatype f16 -transA false -transB false -g 1 -m 1 -n 1 -k 1' \
-    --mlir-build-dir "$(pwd)" --output=- --tflops) \
-    || echo "WARNING: tuningRunner.py pre-flight exited with code $?"
-echo "=== End pre-flight check ==="
+echo "which python3: $(which python3)"
+python3 -m pip install --index-url https://test.pypi.org/simple/ hip-python
+python3 -c "from hip import hip; print('hip-python import OK')"
 
 tuna_run "$OP" "$TUNING_SPACE"

--- a/mlir/utils/tuna/tuna-script.sh
+++ b/mlir/utils/tuna/tuna-script.sh
@@ -158,4 +158,7 @@ if [ "${VIRTUAL_ENV:-}" = "" ]; then
     source /tuna-venv/bin/activate
 fi
 
+# Ensure hip-python is available in the venv
+python3 -m pip install --index-url https://test.pypi.org/simple/ hip-python 2>/dev/null || true
+
 tuna_run "$OP" "$TUNING_SPACE"


### PR DESCRIPTION
## Motivation

This PR fixes a issue that is impacting PR CI jobs. E.g., https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2307/14/pipeline-overview/?selected-node=793

## Technical Details

This fix updates tuna-script.sh to install `hip-python` for the MITuna venv. We currently have to install it to the tmp directory as the CI job doesn't have permissions otherwise. Note, this is only temporary until https://github.com/ROCm/rocMLIR/pull/2310 is merged in.

## Test Plan

* Passing PR CI

## Test Result

* [x] Passing PR CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
