### PR TITLE
Fix tosa.cast float-to-int rounding to use truncation (RTZ)

### DIFF
--- a/mlir/include/mlir/Conversion/FixTosaCastRounding/FixTosaCastRounding.h
+++ b/mlir/include/mlir/Conversion/FixTosaCastRounding/FixTosaCastRounding.h
@@ -1,0 +1,32 @@
+//===- FixTosaCastRounding.h - Fix tosa.cast rounding -----------*- C++ -*-===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Advanced Micro Devices Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_CONVERSION_FIXTOSACASTROUNDING_FIXTOSACASTROUNDING_H
+#define MLIR_CONVERSION_FIXTOSACASTROUNDING_FIXTOSACASTROUNDING_H
+
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+
+#define GEN_PASS_DECL_FIXTOSACASTROUNDINGPASS
+#include "mlir/Conversion/RocMLIRPasses.h.inc"
+
+namespace rock {
+/// FusedLoc metadata tag used to mark tosa.cast ops that want RTZ rounding.
+/// Casts from migraphx.convert carry this tag; casts from quantization do not.
+/// Read by the fix-tosa-cast-rounding pass to decide whether to strip the
+/// math.roundeven that upstream tosa-to-linalg inserts before arith.fptosi.
+constexpr llvm::StringLiteral kRtzCastLocTag("rocmlir.rtz_cast");
+} // namespace rock
+
+} // namespace mlir
+
+#endif // MLIR_CONVERSION_FIXTOSACASTROUNDING_FIXTOSACASTROUNDING_H

--- a/mlir/include/mlir/Conversion/RocMLIRPasses.h
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.h
@@ -10,6 +10,7 @@
 #define MLIR_CONVERSION_ROCMLIRPASSES_H
 
 #include "mlir/Conversion/EmulateFp8ExtTrunc/EmulateFp8ExtTrunc.h"
+#include "mlir/Conversion/FixTosaCastRounding/FixTosaCastRounding.h"
 #include "mlir/Conversion/LinalgToRock/LinalgToRock.h"
 #include "mlir/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.h"
 #include "mlir/Conversion/MIGraphXToTosa/MIGraphXToTosa.h"

--- a/mlir/include/mlir/Conversion/RocMLIRPasses.td
+++ b/mlir/include/mlir/Conversion/RocMLIRPasses.td
@@ -34,6 +34,40 @@ def ConvertRockToGPUPass : Pass<"convert-rock-to-gpu", "ModuleOp"> {
 }
 
 //===----------------------------------------------------------------------===//
+// FixTosaCastRoundingPass
+//===----------------------------------------------------------------------===//
+
+def FixTosaCastRoundingPass
+    : Pass<"fix-tosa-cast-rounding", "::mlir::func::FuncOp"> {
+  let summary = "Change tosa.cast float-to-int from round-to-nearest-even to "
+                "round-towards-zero";
+  let description = [{
+    The upstream tosa-to-linalg pass inserts math.roundeven before arith.fptosi
+    when lowering tosa.cast, implementing TOSA's round-to-nearest-even
+    semantics. This pass removes those math.roundeven ops so that
+    arith.fptosi's native truncation (round towards zero) is used instead,
+    matching ONNX and PyTorch cast semantics. Note that this intentionally
+    diverges from the TOSA spec; rocMLIR primarily serves ONNX/MIGraphX
+    workloads where RTZ is the expected behavior.
+
+    Only math.roundeven ops that belong to an RTZ-tagged cast lowering are
+    removed; this preserves round-to-nearest-even for quantization casts.
+    The tag is the FusedLoc metadata exposed as `mlir::rock::kRtzCastLocTag`
+    and is set by the migraphx.convert lowering in migraphx-to-tosa. Because
+    upstream tosa-to-linalg often rewrites the inner roundeven's location,
+    the tag may end up on the math.roundeven itself, on the parent
+    linalg.generic's location, or on one of the generic region's *output*
+    block-argument locations; the pass checks all three. Input block-arg
+    locations are deliberately ignored to avoid false positives when a
+    downstream generic merely consumes a previously-tagged cast result.
+    To stay safe the pass also bails on multi-output generics and on i1
+    outputs.
+  }];
+  let dependentDialects = ["func::FuncDialect", "linalg::LinalgDialect",
+                           "math::MathDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // RocmlirCustomTosaDecomposePass
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Conversion/CMakeLists.txt
+++ b/mlir/lib/Conversion/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(EmulateFp8ExtTrunc)
+add_subdirectory(FixTosaCastRounding)
 add_subdirectory(MIGraphXToTosa)
 add_subdirectory(RocmlirCustomTosaDecompose)
 add_subdirectory(RocmlirCustomTosaToLinalg)

--- a/mlir/lib/Conversion/FixTosaCastRounding/CMakeLists.txt
+++ b/mlir/lib/Conversion/FixTosaCastRounding/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_rocmlir_conversion_library(RocmlirFixTosaCastRounding
+  FixTosaCastRounding.cpp
+
+  DEPENDS
+  RocMLIRConversionPassIncGen
+)
+
+target_link_libraries(RocmlirFixTosaCastRounding
+  PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRSupport
+  MLIRArithDialect
+  MLIRFuncDialect
+  MLIRLinalgDialect
+  MLIRMathDialect
+  MLIRTransformUtils
+)

--- a/mlir/lib/Conversion/FixTosaCastRounding/FixTosaCastRounding.cpp
+++ b/mlir/lib/Conversion/FixTosaCastRounding/FixTosaCastRounding.cpp
@@ -1,0 +1,172 @@
+//===- FixTosaCastRounding.cpp - Fix tosa.cast rounding -------------------===//
+//
+// Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2026 Advanced Micro Devices Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// The upstream tosa-to-linalg pass inserts math.roundeven before arith.fptosi
+// when lowering tosa.cast from float to integer. This implements TOSA's
+// "round to nearest, ties to even" semantics.
+//
+// However, ONNX and PyTorch define float-to-int cast as truncation (round
+// towards zero), which is what arith.fptosi already does natively. Since
+// rocMLIR primarily serves ONNX/MIGraphX workloads, this pass removes the
+// math.roundeven ops to restore RTZ semantics without modifying the upstream
+// LLVM code.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/FixTosaCastRounding/FixTosaCastRounding.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_FIXTOSACASTROUNDINGPASS
+#include "mlir/Conversion/RocMLIRPasses.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+/// Returns true when `roundeven`'s result participates *exclusively* in the
+/// upstream tosa-to-linalg float-to-int cast chain. The chain has two parts:
+///   1. Float clamp: optional `arith.minimumf`/`maximumf` on the rounded
+///      value, ending at `arith.fptosi`.
+///   2. Integer saturation merge (i32 case): the rounded value also feeds
+///      `arith.cmpf` to produce an i1 mask, which feeds an `arith.select`
+///      that picks between an integer saturation constant and the
+///      `arith.fptosi` result. The merged i32 then flows to `linalg.yield`.
+///
+/// We follow both branches and accept `linalg.yield` as a terminal. Removing
+/// the `math.roundeven` is safe even for the saturation comparison: at the
+/// i32 saturation boundary (|2^31|) every f32 value is already an integer
+/// (f32 ULP is >= 1 above 2^23), so `roundeven` is a no-op there and the
+/// `arith.cmpf` result is unchanged.
+///
+/// This is intentionally strict: if any user of a value in the chain is not
+/// recognized, we return false (do not strip the `roundeven`) even when a
+/// sibling user does reach an `arith.fptosi`. This prevents miscompiles
+/// where the rounded value is also consumed by an unrelated op that depends
+/// on RNE semantics.
+static bool reachesFPToSI(math::RoundEvenOp op) {
+  SmallVector<Value, 8> worklist(op->getResults());
+  bool foundFPToSI = false;
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    for (Operation *user : v.getUsers()) {
+      if (isa<arith::FPToSIOp>(user)) {
+        foundFPToSI = true;
+        continue;
+      }
+      if (isa<linalg::YieldOp>(user))
+        continue;
+      if (isa<arith::MinimumFOp, arith::MaximumFOp, arith::CmpFOp,
+              arith::SelectOp>(user)) {
+        for (Value r : user->getResults())
+          worklist.push_back(r);
+        continue;
+      }
+      return false;
+    }
+  }
+  return foundFPToSI;
+}
+
+static bool hasRtzCastLocTag(Location loc) {
+  if (auto fused = dyn_cast<FusedLoc>(loc))
+    if (auto meta = dyn_cast_or_null<StringAttr>(fused.getMetadata()))
+      return meta.getValue() == rock::kRtzCastLocTag;
+  return false;
+}
+
+/// True when this `math.roundeven` is part of an RTZ-tagged
+/// `migraphx.convert` lowering. The tag is set on the `tosa.cast` and ends
+/// up on the parent `linalg.generic`'s loc and on its output region block
+/// argument (the one carved out from the `tensor.empty()` that this cast
+/// writes into). Upstream `tosa-to-linalg` may assign the inner
+/// `math.roundeven` a different `Location`, so we don't rely on the op's
+/// own loc alone.
+///
+/// We deliberately do NOT scan input block arguments: those inherit the
+/// loc of their incoming SSA value, and if that value comes from a
+/// previously-tagged cast the tag would propagate forward, causing this
+/// pass to wrongly strip an unrelated `math.roundeven` in a downstream
+/// generic.
+static bool isRtzTaggedCastLowering(math::RoundEvenOp op,
+                                    linalg::GenericOp generic) {
+  if (hasRtzCastLocTag(op->getLoc()) || hasRtzCastLocTag(generic.getLoc()))
+    return true;
+  return llvm::any_of(generic.getRegionOutputArgs(), [](BlockArgument arg) {
+    return hasRtzCastLocTag(arg.getLoc());
+  });
+}
+
+struct RemoveRoundEvenBeforeFPToSI
+    : public OpRewritePattern<math::RoundEvenOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(math::RoundEvenOp op,
+                                PatternRewriter &rewriter) const override {
+    auto generic = op->getParentOfType<linalg::GenericOp>();
+    if (!generic)
+      return failure();
+
+    // The RTZ-tagged cast lowering corresponds to a single tosa.cast and
+    // therefore produces exactly one integer output from the generic. Use
+    // getOutputs() rather than getResultTypes() so this still works in
+    // buffer semantics (where there are no SSA results).
+    //
+    // Bail on multi-output generics (e.g. produced by linalg fusion) to
+    // avoid stripping a math.roundeven that also feeds a sibling result --
+    // for instance an i1 yielded directly from arith.cmpf, which would
+    // silently flip if we removed the rounding.
+    //
+    // Bail on i1 outputs as well: ONNX/PyTorch float-to-bool semantics is
+    // "non-zero" rather than truncation, so removing roundeven would be
+    // unsafe even if upstream tosa-to-linalg ever emitted it for an i1
+    // cast. Today MIGraphXToTosa does not tag float-to-i1 casts, but this
+    // guard is defense-in-depth.
+    ValueRange outs = generic.getOutputs();
+    if (outs.size() != 1)
+      return failure();
+    Type outElemTy = getElementTypeOrSelf(outs[0].getType());
+    if (!isa<IntegerType>(outElemTy) || outElemTy.isInteger(1))
+      return failure();
+
+    if (!isRtzTaggedCastLowering(op, generic))
+      return failure();
+
+    if (!reachesFPToSI(op))
+      return failure();
+
+    rewriter.replaceOp(op, op.getOperand());
+    return success();
+  }
+};
+
+struct FixTosaCastRoundingPass
+    : public impl::FixTosaCastRoundingPassBase<FixTosaCastRoundingPass> {
+  using FixTosaCastRoundingPassBase::FixTosaCastRoundingPassBase;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<RemoveRoundEvenBeforeFPToSI>(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // namespace

--- a/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
+++ b/mlir/lib/Conversion/MIGraphXToTosa/MIGraphXToTosa.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "mlir/Conversion/MIGraphXToTosa/MIGraphXToTosa.h"
+#include "mlir/Conversion/FixTosaCastRounding/FixTosaCastRounding.h"
 #include "mlir/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -1313,9 +1314,28 @@ ConvertConverter::matchAndRewrite(migraphx::ConvertOp op, OpAdaptor adaptor,
         ROCK_CUSTOMOP_UNSIGNED_CAST, ROCK_CUSTOMOP_DOMAIN_NAME, "",
         adaptor.getInA());
   } else {
-    rewriter.replaceOpWithNewOp<tosa::CastOp>(
-        op, getTypeConverter()->convertType(op.getResult().getType()),
+    // Tag float-to-int casts with RTZ metadata so that fix-tosa-cast-rounding
+    // can distinguish them (want truncation) from quantization casts (want
+    // RNE). Other casts (int-to-float, int-to-int, float-to-float) don't go
+    // through math.roundeven today; tagging them serves no purpose and would
+    // risk stripping legitimate rounding if upstream tosa-to-linalg ever
+    // inserts it (e.g. for narrowing float-to-float casts).
+    //
+    // Float-to-bool is excluded explicitly: ONNX/PyTorch bool cast semantics
+    // is "non-zero" (not truncation), and upstream tosa-to-linalg lowers it
+    // via arith.cmpf une rather than roundeven+fptosi. Tagging it would be
+    // misleading and unsafe if upstream ever changes that lowering.
+    Location castLoc = op.getLoc();
+    if (isa<FloatType>(inputType) && isa<IntegerType>(outputType) &&
+        !outputType.isInteger(1))
+      castLoc =
+          FusedLoc::get(op.getContext(), {op.getLoc()},
+                        StringAttr::get(op.getContext(), rock::kRtzCastLocTag));
+    auto castOp = tosa::CastOp::create(
+        rewriter, castLoc,
+        getTypeConverter()->convertType(op.getResult().getType()),
         adaptor.getInA());
+    rewriter.replaceOp(op, castOp);
   }
   return success();
 }

--- a/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Pipelines/CMakeLists.txt
@@ -20,6 +20,7 @@ add_rocmlir_dialect_library(MLIRRockPipeline
   MLIRRockTransforms
   MLIRRockUtility
   MLIRUBToLLVM
+  RocmlirFixTosaCastRounding
   RocmlirCustomTosaDecompose
   RocmlirCustomTosaToLinalg
   RocmlirEmulateFp8ExtTrunc

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -97,6 +97,10 @@ void rock::buildBufferizePipeline(OpPassManager &pm,
                               /*validationOptions=*/std::nullopt,
                               /*attachTargetOptions=*/tosaOptions);
 
+  // Strip math.roundeven inserted by tosa-to-linalg for RTZ-tagged casts.
+  auto &castFixPm = pm.nest<func::FuncOp>();
+  castFixPm.addPass(createFixTosaCastRoundingPass());
+
   // convert named linalg operations into linalg generic
   LinalgMorphOpsPassOptions morphOptions;
   morphOptions.namedToCategory = false;

--- a/mlir/test/Conversion/FixTosaCastRounding/fix-tosa-cast-rounding.mlir
+++ b/mlir/test/Conversion/FixTosaCastRounding/fix-tosa-cast-rounding.mlir
@@ -1,0 +1,361 @@
+// Canary (CANARY-prefixed RUN below): without fix-tosa-cast-rounding,
+// upstream tosa-to-linalg must still emit math.roundeven for migraphx.convert
+// float-to-int. If this breaks, the pass needs revisiting.
+// RUN: rocmlir-opt -pass-pipeline="builtin.module(func.func(migraphx-to-tosa),func.func(tosa-to-linalg),func.func(fix-tosa-cast-rounding))" --split-input-file --mlir-print-debuginfo %s | FileCheck %s
+// RUN: rocmlir-opt -pass-pipeline="builtin.module(func.func(migraphx-to-tosa),func.func(tosa-to-linalg))" --split-input-file --mlir-print-debuginfo %s | FileCheck %s --check-prefix=CANARY
+
+// Positive: math.roundeven with RTZ fused loc tag feeding into fptosi
+// inside linalg.generic should be removed.
+// CHECK-LABEL: @cast_rtz_tagged
+// CHECK: linalg.generic
+// CHECK-NOT: math.roundeven
+// CHECK: arith.fptosi {{%.+}} : f32 to i32
+func.func @cast_rtz_tagged(%arg0: tensor<4xf32>) -> tensor<4xi32> {
+  %empty = tensor.empty() : tensor<4xi32>
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty : tensor<4xi32>) {
+  ^bb0(%in: f32, %out: i32):
+    %1 = math.roundeven %in : f32 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+    %2 = arith.fptosi %1 : f32 to i32
+    linalg.yield %2 : i32
+  } -> tensor<4xi32>
+  return %0 : tensor<4xi32>
+}
+
+// -----
+
+// Positive: RTZ-tagged roundeven with float clamp chain (narrowing-to-i8 path).
+// CHECK-LABEL: @cast_rtz_tagged_with_clamp
+// CHECK: linalg.generic
+// CHECK-NOT: math.roundeven
+// CHECK: arith.minimumf
+// CHECK: arith.maximumf
+// CHECK: arith.fptosi
+func.func @cast_rtz_tagged_with_clamp(%arg0: tensor<4xf16>) -> tensor<4xi8> {
+  %empty = tensor.empty() : tensor<4xi8>
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf16>) outs(%empty : tensor<4xi8>) {
+  ^bb0(%in: f16, %out: i8):
+    %1 = math.roundeven %in : f16 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+    %cst_min = arith.constant -1.280000e+02 : f16
+    %cst_max = arith.constant 1.270000e+02 : f16
+    %2 = arith.minimumf %1, %cst_max : f16
+    %3 = arith.maximumf %2, %cst_min : f16
+    %4 = arith.fptosi %3 : f16 to i8
+    linalg.yield %4 : i8
+  } -> tensor<4xi8>
+  return %0 : tensor<4xi8>
+}
+
+// -----
+
+// Positive: RTZ-tagged roundeven with the i32 saturation merge pattern that
+// upstream tosa-to-linalg emits for f32->i32. Here the rounded value feeds
+// BOTH a float clamp -> fptosi (low side) AND an arith.cmpf -> arith.select
+// that picks between an i32 saturation constant and the fptosi result. This
+// is the only test that covers the cmpf+select+yield branch of
+// reachesFPToSI; if upstream changes its lowering, this test should still
+// pin the matcher behaviour.
+// CHECK-LABEL: @cast_rtz_tagged_i32_saturate
+// CHECK: linalg.generic
+// CHECK-NOT: math.roundeven
+// CHECK: arith.maximumf %{{[^,]+}}, %{{[^ ]+}} : f32
+// CHECK: arith.fptosi %{{.*}} : f32 to i32
+// CHECK: arith.cmpf uge, %{{[^,]+}}, %{{[^ ]+}} : f32
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+func.func @cast_rtz_tagged_i32_saturate(%arg0: tensor<4xf32>) -> tensor<4xi32> {
+  %empty = tensor.empty() : tensor<4xi32>
+  %cst_min = arith.constant -2.14748365E+9 : f32
+  %cst_max = arith.constant 2.14748365E+9 : f32
+  %c_int_max = arith.constant 2147483647 : i32
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty : tensor<4xi32>) {
+  ^bb0(%in: f32, %out: i32):
+    %1 = math.roundeven %in : f32 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+    %2 = arith.maximumf %1, %cst_min : f32
+    %3 = arith.fptosi %2 : f32 to i32
+    %4 = arith.cmpf uge, %1, %cst_max : f32
+    %5 = arith.select %4, %c_int_max, %3 : i32
+    linalg.yield %5 : i32
+  } -> tensor<4xi32>
+  return %0 : tensor<4xi32>
+}
+
+// -----
+
+// Negative: RTZ-tagged roundeven whose result has a sibling user outside the
+// recognized cast chain (here arith.divf) MUST NOT be removed. The generic
+// itself only yields i32 so the integer-output guard passes; this test pins
+// the strict-matcher property of reachesFPToSI: even though one sibling user
+// (arith.fptosi) does reach the cast chain, the other (arith.divf) does not,
+// so the matcher bails to avoid silently changing the divf input from
+// `round(%in)` to `%in`.
+// CHECK-LABEL: @cast_rtz_tagged_extra_user
+// CHECK: linalg.generic
+// CHECK: math.roundeven
+// CHECK: arith.divf
+// CHECK: arith.fptosi
+func.func @cast_rtz_tagged_extra_user(%arg0: tensor<4xf32>) -> tensor<4xi32> {
+  %empty = tensor.empty() : tensor<4xi32>
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty : tensor<4xi32>) {
+  ^bb0(%in: f32, %out: i32):
+    %1 = math.roundeven %in : f32 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+    %2 = arith.fptosi %1 : f32 to i32
+    %3 = arith.divf %1, %in : f32
+    %4 = arith.fptosi %3 : f32 to i32
+    %5 = arith.addi %2, %4 : i32
+    linalg.yield %5 : i32
+  } -> tensor<4xi32>
+  return %0 : tensor<4xi32>
+}
+
+// -----
+
+// Negative: RTZ-tagged generic that yields a float result alongside the
+// int cast result. The pass requires exactly one (non-i1 integer) output
+// from the generic, so this multi-output case is rejected -- otherwise
+// removing roundeven would silently change the yielded float value from
+// `max(round(%in), c)` to `max(%in, c)`.
+// CHECK-LABEL: @cast_rtz_generic_with_float_output
+// CHECK: linalg.generic
+// CHECK: math.roundeven
+// CHECK-DAG: arith.fptosi
+// CHECK-DAG: arith.maximumf
+func.func @cast_rtz_generic_with_float_output(%arg0: tensor<4xf32>) -> (tensor<4xi32>, tensor<4xf32>) {
+  %empty_i = tensor.empty() : tensor<4xi32>
+  %empty_f = tensor.empty() : tensor<4xf32>
+  %cst = arith.constant 1.0 : f32
+  %0:2 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty_i, %empty_f : tensor<4xi32>, tensor<4xf32>) {
+  ^bb0(%in: f32, %out_i: i32, %out_f: f32):
+    %1 = math.roundeven %in : f32 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+    %2 = arith.fptosi %1 : f32 to i32
+    %3 = arith.maximumf %1, %cst : f32
+    linalg.yield %2, %3 : i32, f32
+  } -> (tensor<4xi32>, tensor<4xf32>)
+  return %0#0, %0#1 : tensor<4xi32>, tensor<4xf32>
+}
+
+// -----
+
+// Negative: RTZ-tagged generic with a sibling i1 output computed via
+// arith.cmpf on the rounded value. This is the dangerous case: every user
+// of math.roundeven is recognized by reachesFPToSI (fptosi for the i32
+// branch, cmpf for the i1 branch), so without the single-output guard the
+// pass would strip the rounding and silently flip the i1 result for any
+// %in whose RNE-rounding crosses the comparison threshold.
+// CHECK-LABEL: @cast_rtz_tagged_multi_result_i1
+// CHECK: linalg.generic
+// CHECK: math.roundeven
+// CHECK-DAG: arith.fptosi
+// CHECK-DAG: arith.cmpf
+func.func @cast_rtz_tagged_multi_result_i1(%arg0: tensor<4xf32>) -> (tensor<4xi32>, tensor<4xi1>) {
+  %empty_i32 = tensor.empty() : tensor<4xi32>
+  %empty_i1 = tensor.empty() : tensor<4xi1>
+  %cst = arith.constant 0.0 : f32
+  %0:2 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty_i32, %empty_i1 : tensor<4xi32>, tensor<4xi1>) {
+  ^bb0(%in: f32, %out_i32: i32, %out_i1: i1):
+    %1 = math.roundeven %in : f32 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+    %2 = arith.fptosi %1 : f32 to i32
+    %3 = arith.cmpf une, %1, %cst : f32
+    linalg.yield %2, %3 : i32, i1
+  } -> (tensor<4xi32>, tensor<4xi1>)
+  return %0#0, %0#1 : tensor<4xi32>, tensor<4xi1>
+}
+
+// -----
+
+// Negative: only the *input* block argument carries the RTZ tag (which can
+// happen when this generic consumes the result of a previously-tagged cast).
+// The generic itself, the math.roundeven, and the output block arg are all
+// untagged, so this generic is NOT an RTZ-tagged cast lowering and the
+// roundeven must be preserved. Without restricting the block-arg scan to
+// the output args, the matcher would wrongly strip the rounding.
+// CHECK-LABEL: @cast_rtz_input_arg_tagged_only
+// CHECK: linalg.generic
+// CHECK: math.roundeven
+// CHECK: arith.fptosi
+func.func @cast_rtz_input_arg_tagged_only(%arg0: tensor<4xf32>) -> tensor<4xi32> {
+  %empty = tensor.empty() : tensor<4xi32>
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty : tensor<4xi32>) {
+  ^bb0(%in: f32 loc(fused<"rocmlir.rtz_cast">["test":0:0]), %out: i32):
+    %1 = math.roundeven %in : f32
+    %2 = arith.fptosi %1 : f32 to i32
+    linalg.yield %2 : i32
+  } -> tensor<4xi32>
+  return %0 : tensor<4xi32>
+}
+
+// -----
+
+// Negative: RTZ-tagged single-output generic with i1 output. ONNX/PyTorch
+// float-to-bool semantics is "non-zero" rather than truncation, so even
+// though MIGraphXToTosa never tags an f32->i1 cast today, the matcher
+// rejects i1 outputs as defense-in-depth.
+// CHECK-LABEL: @cast_rtz_tagged_i1_output
+// CHECK: linalg.generic
+// CHECK: math.roundeven
+// CHECK: arith.fptosi
+func.func @cast_rtz_tagged_i1_output(%arg0: tensor<4xf32>) -> tensor<4xi1> {
+  %empty = tensor.empty() : tensor<4xi1>
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty : tensor<4xi1>) {
+  ^bb0(%in: f32, %out: i1):
+    %1 = math.roundeven %in : f32 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+    %2 = arith.fptosi %1 : f32 to i1
+    linalg.yield %2 : i1
+  } -> tensor<4xi1>
+  return %0 : tensor<4xi1>
+}
+
+// -----
+
+// Negative: math.roundeven WITHOUT RTZ tag (e.g. from quantization) must
+// NOT be removed even though it feeds into fptosi.
+// CHECK-LABEL: @cast_no_tag_quantization
+// CHECK: linalg.generic
+// CHECK: math.roundeven
+// CHECK: arith.fptosi
+func.func @cast_no_tag_quantization(%arg0: tensor<4xf32>) -> tensor<4xi32> {
+  %empty = tensor.empty() : tensor<4xi32>
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty : tensor<4xi32>) {
+  ^bb0(%in: f32, %out: i32):
+    %1 = math.roundeven %in : f32
+    %2 = arith.fptosi %1 : f32 to i32
+    linalg.yield %2 : i32
+  } -> tensor<4xi32>
+  return %0 : tensor<4xi32>
+}
+
+// -----
+
+// Negative: math.roundeven outside linalg.generic must NOT be removed.
+// CHECK-LABEL: @roundeven_outside_generic
+// CHECK: math.roundeven
+func.func @roundeven_outside_generic(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = tensor.extract %arg0[%c0] : tensor<4xf32>
+  %1 = math.roundeven %0 : f32 loc(fused<"rocmlir.rtz_cast">["test":0:0])
+  %2 = tensor.from_elements %1, %1, %1, %1 : tensor<4xf32>
+  return %2 : tensor<4xf32>
+}
+
+// -----
+
+// Negative: quantizelinear through the full MIGraphX pipeline must preserve
+// math.roundeven (quantization needs RNE, not RTZ).
+// CHECK-LABEL: @mlir_quantizelinear
+// CHECK: math.roundeven
+func.func @mlir_quantizelinear(%arg0: !migraphx.shaped<1x1x2x2xf32, 4x4x2x1>) -> !migraphx.shaped<1x1x2x2xi8, 4x4x2x1> attributes {kernel = "mixr"} {
+  %scale = migraphx.literal (dense<0.5> : tensor<1x1x2x2xf32>) : <1x1x2x2xf32, 4x4x2x1>
+  %zp = migraphx.literal (dense<0> : tensor<1x1x2x2xi8>) : <1x1x2x2xi8, 4x4x2x1>
+  %0 = migraphx.quantizelinear %arg0, %scale, %zp : <1x1x2x2xf32, 4x4x2x1>, <1x1x2x2xf32, 4x4x2x1>, !migraphx.shaped<1x1x2x2xi8, 4x4x2x1> -> <1x1x2x2xi8, 4x4x2x1>
+  return %0 : !migraphx.shaped<1x1x2x2xi8, 4x4x2x1>
+}
+
+// -----
+
+// Positive integration: migraphx.convert from f32 to i32 through full
+// pipeline. Verifies the RTZ loc tag survives migraphx-to-tosa + tosa-to-linalg
+// and fix-tosa-cast-rounding removes the math.roundeven.
+// CHECK-LABEL: @convert_f32_to_i32
+// CHECK: linalg.generic
+// CHECK-NOT: math.roundeven
+// CHECK: arith.fptosi
+// CANARY-LABEL: @convert_f32_to_i32
+// CANARY: linalg.generic
+// CANARY: math.roundeven
+// CANARY: arith.fptosi
+func.func @convert_f32_to_i32(%arg0: !migraphx.shaped<4xf32, 1>) -> !migraphx.shaped<4xi32, 1> attributes {kernel = "mixr"} {
+  %0 = migraphx.convert %arg0 : <4xf32, 1> to <4xi32, 1>
+  return %0 : !migraphx.shaped<4xi32, 1>
+}
+
+// -----
+
+// Positive integration: migraphx.convert from f16 to i8 through full pipeline
+// (exercises the clamped/saturated path).
+// CHECK-LABEL: @convert_f16_to_i8
+// CHECK: linalg.generic
+// CHECK-NOT: math.roundeven
+// CHECK: arith.fptosi
+// CANARY-LABEL: @convert_f16_to_i8
+// CANARY: linalg.generic
+// CANARY: math.roundeven
+// CANARY: arith.fptosi
+func.func @convert_f16_to_i8(%arg0: !migraphx.shaped<4xf16, 1>) -> !migraphx.shaped<4xi8, 1> attributes {kernel = "mixr"} {
+  %0 = migraphx.convert %arg0 : <4xf16, 1> to <4xi8, 1>
+  return %0 : !migraphx.shaped<4xi8, 1>
+}
+
+// -----
+
+// Negative integration: float-to-float convert is not RTZ-tagged (only
+// float-to-int casts get the tag in MIGraphXToTosa::ConvertConverter), and
+// upstream lowers it via arith.truncf without ever inserting math.roundeven.
+// CHECK-LABEL: @convert_f32_to_f16
+// CHECK-NOT: math.roundeven
+// CHECK: arith.truncf
+func.func @convert_f32_to_f16(%arg0: !migraphx.shaped<4xf32, 1>) -> !migraphx.shaped<4xf16, 1> attributes {kernel = "mixr"} {
+  %0 = migraphx.convert %arg0 : <4xf32, 1> to <4xf16, 1>
+  return %0 : !migraphx.shaped<4xf16, 1>
+}
+
+// -----
+
+// Negative integration: float-to-bool convert is excluded from RTZ tagging
+// in MIGraphXToTosa, and upstream tosa-to-linalg lowers it via arith.cmpf
+// (non-zero comparison) -- not roundeven+fptosi -- so no math.roundeven is
+// emitted at all. ONNX/PyTorch bool cast semantics is preserved.
+// CHECK-LABEL: @convert_f32_to_i1
+// CHECK-NOT: math.roundeven
+// CHECK-NOT: arith.fptosi
+// CHECK: arith.cmpf une
+func.func @convert_f32_to_i1(%arg0: !migraphx.shaped<4xf32, 1>) -> !migraphx.shaped<4xi1, 1> attributes {kernel = "mixr"} {
+  %0 = migraphx.convert %arg0 : <4xf32, 1> to <4xi1, 1>
+  return %0 : !migraphx.shaped<4xi1, 1>
+}
+
+// -----
+
+// Negative: untagged roundeven inside linalg.generic that does NOT feed
+// into fptosi must NOT be removed (e.g. standalone rounding in user code).
+// CHECK-LABEL: @roundeven_untagged_no_fptosi
+// CHECK: linalg.generic
+// CHECK: math.roundeven
+func.func @roundeven_untagged_no_fptosi(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %empty = tensor.empty() : tensor<4xf32>
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%empty : tensor<4xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = math.roundeven %in : f32
+    linalg.yield %1 : f32
+  } -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}

--- a/mlir/test/fusion/pr-e2e/tosa-cast-rtz.cpu.mlir
+++ b/mlir/test/fusion/pr-e2e/tosa-cast-rtz.cpu.mlir
@@ -1,0 +1,22 @@
+// RUN: rocmlir-driver -host-pipeline=highlevel %s | rocmlir-gen -rand=none -ph -pr -fut test_cast_rtz - \
+// RUN: | rocmlir-driver -host-pipeline=runner \
+// RUN: | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s
+
+module {
+  // This test directly tags a tosa.cast with the RTZ FusedLoc metadata, so we
+  // can drive deterministic input values via tosa.const and check the exact
+  // numerical output. The migraphx.convert -> tosa.cast tag-insertion path
+  // is covered by the lit test in
+  // test/Conversion/FixTosaCastRounding/fix-tosa-cast-rounding.mlir.
+  //
+  // RTZ truncates toward zero: 3.5 -> 3, -3.5 -> -3 (RNE would be 4 and -4).
+  // %arg0 is a dummy input required by rocmlir-gen's host-placeholder driver
+  // (-ph); the kernel itself only consumes the tosa.const above.
+  // CHECK: Unranked Memref {{.*}}
+  // CHECK-NEXT: [2,  3,  -2,  -3,  2,  -2]
+  func.func @test_cast_rtz(%arg0: tensor<1xf32>) -> tensor<6xi32> {
+    %0 = "tosa.const"() {values = dense<[2.7, 3.5, -2.5, -3.5, 2.5, -2.7]> : tensor<6xf32>} : () -> tensor<6xf32>
+    %1 = tosa.cast %0 : (tensor<6xf32>) -> tensor<6xi32> loc(fused<"rocmlir.rtz_cast">["cast_rtz":0:0])
+    return %1 : tensor<6xi32>
+  }
+}

--- a/mlir/test/rocmlir-driver/pipelines.mlir
+++ b/mlir/test/rocmlir-driver/pipelines.mlir
@@ -173,6 +173,7 @@
 // HIGHLEVEL-NEXT:mxfp} level=none profiles={pro_int,
 // HIGHLEVEL-NEXT:pro_fp} specification_version=1.1.draft},
 // HIGHLEVEL-NEXT:func.func(tosa-to-linalg{aggressive-reduce-constant=false disable-tosa-decompositions=false}),
+// HIGHLEVEL-NEXT:func.func(fix-tosa-cast-rounding),
 // HIGHLEVEL-NEXT:func.func(tosa-to-tensor,
 // HIGHLEVEL-NEXT:tosa-to-scf,
 // HIGHLEVEL-NEXT:tosa-to-arith{include-apply-rescale=false use-32-bit=false},

--- a/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
+++ b/mlir/tools/rocmlir-lib/librockcompiler_deps.cmake
@@ -257,4 +257,5 @@ MLIRTosaToRock
 RocmlirCustomTosaDecompose
 RocmlirCustomTosaToLinalg
 RocmlirEmulateFp8ExtTrunc
+RocmlirFixTosaCastRounding
 )


### PR DESCRIPTION
## Fix tosa.cast float-to-int rounding to use truncation (RTZ)

### Summary

- Add `fix-tosa-cast-rounding` pass that changes `tosa.cast` float-to-int semantics from round-to-nearest-even (TOSA spec) to round-towards-zero/truncation (ONNX/PyTorch spec)
- The pass runs after the upstream `tosa-to-linalg` lowering and removes the `math.roundeven` ops it inserts, letting `arith.fptosi`'s native truncation behavior take effect
- Only casts tagged by `ConvertConverter` (from `migraphx.convert`) are affected; quantization casts (from `migraphx.quantizelinear`) keep round-to-nearest-even as required by the ONNX `QuantizeLinear` spec
- No changes to `external/llvm-project`

### Motivation

The TOSA spec hardcodes round-to-nearest-even (RNE) for float-to-int casts. The upstream `tosa-to-linalg` pass faithfully implements this by inserting `math.roundeven` before `arith.fptosi`.

However, ONNX and PyTorch define float-to-int cast as **truncation** (round towards zero), matching C/NumPy `astype` semantics. Meanwhile, ONNX `QuantizeLinear` explicitly requires RNE. Since both operations flow through `tosa.cast` after `migraphx-to-tosa`, we need to distinguish them.

| ONNX op | Rounding mode | After this change |
|---|---|---|
| `Cast` (float->int) | Truncation (RTZ) | `math.roundeven` removed |
| `QuantizeLinear` | Round to nearest even (RNE) | `math.roundeven` preserved |

### Approach

**How it works:**

1. `ConvertConverter` in MIGraphXToTosa tags `tosa.cast` ops from `migraphx.convert` with a `FusedLoc` metadata tag (`"rocmlir.rtz_cast"`)
2. `QuantizeLinearConverter` does NOT tag its casts -- they keep the default location
3. The upstream `tosa-to-linalg` creates `math.roundeven` ops that inherit the tagged/untagged location
4. The `fix-tosa-cast-rounding` pass (in the pipeline after `tosa-to-linalg`) only removes `math.roundeven` ops with the RTZ tag

**Why this approach over alternatives:**

- **Modify upstream `TosaToLinalg.cpp`**: Creates rebase burden on `external/llvm-project`
- **Custom TOSA op**: Requires duplicating ~90 lines of complex saturation/clamping logic across 3 code paths
- **Pre-decompose in float domain**: Adds 5 extra ops per cast to work around a rounding mode mismatch
- **Post-lowering fixup with location tagging (chosen)**: Minimal code (~80 lines), reuses all upstream saturation logic, correctly distinguishes cast vs quantization via FusedLoc metadata

### Test plan

- [x] Lit test (`mlir/test/Conversion/FixTosaCastRounding/fix-tosa-cast-rounding.mlir`):
  - Positive: RTZ-tagged roundeven removed (simple cast + clamped cast)
  - Negative: untagged roundeven preserved (simulates quantization)
  - Negative: roundeven outside `linalg.generic` preserved
  - Negative: real `migraphx.quantizelinear` through full pipeline preserves roundeven
  - Negative: untagged standalone roundeven preserved
- [x] CPU E2E test (`mlir/test/fusion/pr-e2e/tosa-cast-rtz.cpu.mlir`):
  - Runtime verification with fractional values (2.7, 3.5, -2.5, etc.) confirming truncation
  - Values chosen to distinguish RTZ from RNE
- [x] Pipeline test (`mlir/test/rocmlir-driver/pipelines.mlir`):
  - HIGHLEVEL pipeline dump includes `fix-tosa-cast-rounding`
- [x] Existing quantization tests pass unchanged:
  - `mixr-dequant-conv-quant-uint8.mlir`
  - `mixr-dequant-conv-quant-uint8-nobias.mlir`
  - `mixr-dequant-conv-quant-uint8-overflow.mlir`
  - `mixr-dequant-conv-quant-uint8-underflow.mlir`
  - `mixr-dequant-conv-quant-sint8-negative-bias.mlir`
