### PR TITLE
[NFC] Add migraphx.yield terminator op

### DIFF
--- a/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
+++ b/mlir/include/mlir/Dialect/MIGraphX/IR/MIGraphX.td
@@ -613,6 +613,19 @@ def MIGraphX_ReduceMaxOp
   }];
 }
 
+// Yield operation for MIGraphX regions
+def MIGraphX_YieldOp : MIGraphX_Op<"yield", [Pure, Terminator]>,
+                       Arguments<(ins Optional<AnyType>:$value)> {
+  let summary = "Terminator for MIGraphX regions";
+  let description = [{
+    Terminates a region in a MIGraphX operation (e.g., the preSoftmaxBody
+    of migraphx.attention), yielding a value back to the enclosing op.
+  }];
+  let builders = [OpBuilder<
+      (ins), [{ build($_builder, $_state, /*value=*/Value()); }]>];
+  let assemblyFormat = "($value^ `:` type($value))? attr-dict";
+}
+
 //--------- Execution layer Ops
 def MIGraphX_CodeObjOp :
     MIGraphX_Op<"code_object">,

--- a/mlir/test/Dialect/MIGraphX/yield.mlir
+++ b/mlir/test/Dialect/MIGraphX/yield.mlir
@@ -1,0 +1,20 @@
+// RUN: rocmlir-opt --allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK-LABEL: func.func @migraphx_yield_no_value
+// CHECK: migraphx.yield
+func.func @migraphx_yield_no_value() {
+  "test.container"() ({
+    migraphx.yield
+  }) : () -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @migraphx_yield_with_value
+// CHECK: migraphx.yield %{{.*}} : !migraphx.shaped<2x64x256xf16, 16384x256x1>
+func.func @migraphx_yield_with_value(
+    %arg0: !migraphx.shaped<2x64x256xf16, 16384x256x1>) {
+  "test.container"() ({
+    migraphx.yield %arg0 : !migraphx.shaped<2x64x256xf16, 16384x256x1>
+  }) : () -> ()
+  return
+}


### PR DESCRIPTION
Add a region terminator op for the MIGraphX dialect. This op will be used by migraphx.attention to yield values from its preSoftmaxBody region. 