### PR TITLE
[URGENT] Bring back commented param sw for conv structure and perf

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1222,8 +1222,8 @@ pipeline {
                                                     }
 
                                                     stage("Parameter Sweep") {
-                                                        //parameterSweep("conv_structure")
-                                                        //parameterSweep("perf_config")
+                                                        parameterSweep("conv_structure")
+                                                        parameterSweep("perf_config")
                                                         parameterSweep(CODEPATH, "attention")
                                                         archiveArtifacts artifacts: 'build/failing_attn_configs.txt,build/failing_conv_configs.txt', allowEmptyArchive: true
                                                     }


### PR DESCRIPTION
## Motivation

It was commented out for testing purposes of Attention Parameter Sweeps and wasn't uncommented. 

## Technical Details

Uncommented 
```
                                                        parameterSweep("conv_structure")
                                                        parameterSweep("perf_config")
```

## Test Plan
No need to wait for CI checks, lets merge this asap so that all param sw steps are kicked on weekly.


## Test Result

<!-- Briefly summarize test outcomes. -

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
