### PR TITLE
[NFC] Remove `migraphx.unpack` from Linalg Conversion Testcase

### DIFF
--- a/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
+++ b/mlir/test/Conversion/MIGraphXToLinalg/migraphx-to-linalg-not-implemented.mlir
@@ -1,11 +1,5 @@
 // RUN: rocmlir-opt --migraphx-to-linalg -verify-diagnostics %s 
 
-func.func @func_unpack(%arg0: !migraphx.shaped<1x1xi8, 1x1>, %arg1: !migraphx.shaped<1x1xi8, 1x1>) {
-  // expected-error @+1{{failed to legalize operation 'migraphx.unpack'}}
-  %0 = migraphx.unpack %arg0 {axis = 1 : i64} : <1x1xi8, 1x1> -> <1x2xi8, 2x1>
-  func.return
-}
-
 func.func @func_quantizelinear(%arg0: !migraphx.shaped<1x1xf32, 1x1>, %arg1: !migraphx.shaped<1x1xf32, 1x1>) {
   // expected-error @+1{{failed to legalize operation 'migraphx.quantizelinear'}}
   migraphx.quantizelinear %arg0, %arg1: <1x1xf32, 1x1>, <1x1xf32, 1x1> -> <1x1xf32, 1x1>


### PR DESCRIPTION
## Motivation

Remove `migraphx.unpack` from from migraphx -> linalg testcase. `migraphx-to-linalg` doesn't have to handle `migraphx.unpack`. 

## Technical Details

`migraphx-to-linalg` pass should never have to handle `migraphx.unpack`. This is because `migraphx-realize-int4`  pass should have transformed it into something else before running `migraphx-to-linalg`. 

`migraphx.unpack` is marked illegal in`migraphx-realize-int4` pass. 

https://github.com/ROCm/rocMLIR/blob/430bdd7528f4f0fc197bf51320566d086a721d43/mlir/lib/Dialect/MIGraphX/Transforms/RealizeInt4.cpp#L220

and `migraphx-realize-int4` is run before `migraphx-to-linalg`

https://github.com/ROCm/rocMLIR/blob/430bdd7528f4f0fc197bf51320566d086a721d43/mlir/lib/Dialect/MIGraphX/Pipeline/Pipeline.cpp#L45-L49


## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
