### PR TITLE
[NFC] Remove duplicated conversion patterns

### DIFF
--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -1818,13 +1818,12 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::ErfOp, linalg::ErfOp>, ReluConverter,
            GenericElementwiseOpConverter<migraphx::WhereOp>,
            GenericElementwiseOpConverter<migraphx::ConvertOp>,
-           GenericElementwiseOpConverter<migraphx::SigmoidOp>,
-           ClipConverter, BroadcastConverter, MultiBroadcastConverter,
-           LiteralConverter, ReshapeConverter,
-           BooleanElementwiseConverter<migraphx::Greater>,
-           BooleanElementwiseConverter<migraphx::Equal>,
-           TransposeConverter, ConvConverter, SliceConverter,
-           BackwardConvConverter>(converter, patterns.getContext());
+           GenericElementwiseOpConverter<migraphx::SigmoidOp>, ClipConverter,
+           BroadcastConverter, MultiBroadcastConverter, LiteralConverter,
+           ReshapeConverter, BooleanElementwiseConverter<migraphx::Greater>,
+           BooleanElementwiseConverter<migraphx::Equal>, TransposeConverter,
+           ConvConverter, SliceConverter, BackwardConvConverter>(
+          converter, patterns.getContext());
 }
 
 void mlir::migraphx::populateMIGraphXFuncBoundaryToLinalgConversionPatterns(

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -1818,11 +1818,11 @@ void mlir::migraphx::populateMIGraphXToLinalgConversionPatterns(
            ElementwiseConverter<migraphx::ErfOp, linalg::ErfOp>, ReluConverter,
            GenericElementwiseOpConverter<migraphx::WhereOp>,
            GenericElementwiseOpConverter<migraphx::ConvertOp>,
-           GenericElementwiseOpConverter<migraphx::SigmoidOp>, ReluConverter,
+           GenericElementwiseOpConverter<migraphx::SigmoidOp>,
            ClipConverter, BroadcastConverter, MultiBroadcastConverter,
            LiteralConverter, ReshapeConverter,
            BooleanElementwiseConverter<migraphx::Greater>,
-           BooleanElementwiseConverter<migraphx::Equal>, ClipConverter,
+           BooleanElementwiseConverter<migraphx::Equal>,
            TransposeConverter, ConvConverter, SliceConverter,
            BackwardConvConverter>(converter, patterns.getContext());
 }


### PR DESCRIPTION
## Motivation

Remove duplicated conversion patterns. 

## Technical Details

ReluConverter and ClipConverter are duplicated. It would be nice to remove them for now. 

## Test Plan

N/A. There should be no functional changes. This was something that cursor caught. 

## Test Result

Done.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
