### PR TITLE
Add register-only cross-lane reduction for attention

### DIFF
--- a/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
@@ -825,6 +825,43 @@ def AMDGPU_PermlaneSwapOp : AMDGPU_Op<"permlane_swap", [Pure, AllTypesMatch<["re
   let hasVerifier = 1;
 }
 
+def AMDGPU_PermlaneVarOp : AMDGPU_Op<"permlane_var",
+    [Pure, AllTypesMatch<["result", "src"]>]> {
+  let summary = "AMDGPU variable-selector permlane op (GFX12+)";
+  let description = [{
+    High-level wrapper on `rocdl.permlane16.var` and `rocdl.permlanex16.var`
+    for per-lane variable-selector permutations within a wave32 subgroup.
+
+    Supports arbitrary int/float/vector types, which will be repacked to i32
+    and one or more ROCDL intrinsic calls during lowering.
+
+    - `cross = false`: intra-row permutation (each lane in a 16-lane row reads
+      from a lane in the same row, selected by `$selector`). Maps to
+      `rocdl.permlane16.var`.
+    - `cross = true`: cross-row permutation (each lane reads from the opposite
+      16-lane row, selected by `$selector`). Maps to `rocdl.permlanex16.var`.
+
+    `$selector` is an i32 VGPR providing the per-lane source-lane index.
+
+    Example:
+    ```mlir
+    %0 = amdgpu.permlane_var %src, %sel { cross = false } : f16
+    %1 = amdgpu.permlane_var %src, %sel { cross = true } : f32
+    ```
+
+    Note: Lowering is only supported on GFX12+.
+  }];
+  let arguments = (ins AnyIntegerOrFloatOr1DVector:$src,
+                       I32:$selector,
+                       DefaultValuedAttr<BoolAttr, "false">:$cross,
+                       DefaultValuedAttr<BoolAttr, "false">:$fetch_inactive,
+                       DefaultValuedAttr<BoolAttr, "false">:$bound_ctrl);
+  let results = (outs AnyIntegerOrFloatOr1DVector:$result);
+  let assemblyFormat = [{
+    $src `,` $selector attr-dict `:` type($result)
+  }];
+}
+
 def AMDGPU_LDSBarrierOp : AMDGPU_Op<"lds_barrier"> {
   let summary = "Barrier that includes a wait for LDS memory operations.";
   let description = [{

--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -2365,25 +2365,6 @@ def ROCDL_PermlaneX16Op : ROCDL_IntrOp<"permlanex16", [], [0],
   }];
 }
 
-// PermLaneX16 variable intrinsic operation (GFX12+)
-// Each lane specifies its own source lane index via VGPR $src1,
-// enabling arbitrary per-lane cross-half-wave permutations.
-def ROCDL_PermlaneX16VarOp : ROCDL_IntrOp<"permlanex16.var", [], [], [], 1, 0,
-                                          0, 0, [3, 4], ["fi", "boundControl"]>,
-                             Arguments<(ins I32:$old, I32:$src0, I32:$src1,
-                                 I1Attr:$fi, I1Attr:$boundControl)> {
-  let results = (outs I32:$res);
-  let assemblyFormat = [{
-    attr-dict $old `,` $src0 `,` $src1 `,` $fi `,` $boundControl `:` `(` type($src0) `,` type($src1) `)` `->` type($res)
-  }];
-  let description = [{
-    Performs a variable `permlanex16` operation (GFX12+) where each lane
-    provides its own source lane index in the other half-wave via VGPR $src1.
-    Unlike the non-var version which uses SGPR group selectors, this allows
-    arbitrary per-lane cross-half permutations.
-  }];
-}
-
 class ROCDL_ConcretePair<Type elem0, Type elem1> :
   Type<And<[
     LLVM_AnyStruct.predicate,
@@ -2439,6 +2420,69 @@ def ROCDL_Permlane32SwapOp : ROCDL_IntrOp<"permlane32.swap", [], [],
     ```mlir
     // Swap lanes between groups of 32 threads.
     %res = rocdl.permlane32.swap %src, %src, 0, -1 : (i32, i32) -> !llvm.struct<(i32, i32)>
+    ```
+  }];
+}
+
+// Permlane16 variable intrinsic operation (GFX12+)
+//
+// Per-lane variable-selector intra-row (within each 16-lane row) permutation.
+// Unlike `permlane16`, the source-lane indices come from a per-lane VGPR
+// (`$src1`) rather than from immediate SGPR fields, allowing arbitrary
+// per-lane intra-row permutations.
+def ROCDL_Permlane16VarOp : ROCDL_IntrOp<"permlane16.var", [], [],
+    [], 1, 0, 0, 0,
+    [3, 4], ["fi", "boundControl"]>,
+  Arguments<(ins I32:$old, I32:$src0, I32:$src1,
+             I1Attr:$fi, I1Attr:$boundControl)> {
+  let results = (outs I32:$res);
+  let assemblyFormat = [{
+    attr-dict $old `,` $src0 `,` $src1 `,` $fi `,` $boundControl `:` functional-type(operands, $res)
+  }];
+  let description = [{
+    Performs a `permlane16.var` operation: a per-lane variable-selector
+    intra-row permutation (within each 16-lane row). Maps to
+    `llvm.amdgcn.permlane16.var`.
+
+    Each destination lane within a 16-lane row reads its value from the
+    source lane whose index is given by the corresponding per-lane entry
+    in `$src1` (a VGPR). `$fi` and `$boundControl` are immediate i1 attrs
+    matching the underlying intrinsic's modifiers.
+
+    Example:
+    ```mlir
+    %res = rocdl.permlane16.var %old, %src, %selector, false, true : (i32, i32, i32) -> i32
+    ```
+  }];
+}
+
+// PermlaneX16 variable intrinsic operation (GFX12+)
+//
+// Per-lane variable-selector cross-row permutation (each lane in row R reads
+// from a per-lane-chosen source lane in the opposite 16-lane row).
+def ROCDL_PermlaneX16VarOp : ROCDL_IntrOp<"permlanex16.var", [], [],
+    [], 1, 0, 0, 0,
+    [3, 4], ["fi", "boundControl"]>,
+  Arguments<(ins I32:$old, I32:$src0, I32:$src1,
+             I1Attr:$fi, I1Attr:$boundControl)> {
+  let results = (outs I32:$res);
+  let assemblyFormat = [{
+    attr-dict $old `,` $src0 `,` $src1 `,` $fi `,` $boundControl `:` functional-type(operands, $res)
+  }];
+  let description = [{
+    Performs a `permlanex16.var` operation: a per-lane variable-selector
+    cross-row permutation (each lane in one 16-lane row reads from a
+    per-lane-chosen source lane in the opposite row). Maps to
+    `llvm.amdgcn.permlanex16.var`.
+
+    With per-lane "identity" selectors this realises an XOR-16 swap pattern
+    in pure VALU; with arbitrary selectors it enables general per-lane
+    cross-half-wave permutations. `$fi` and `$boundControl` are immediate
+    i1 attrs matching the underlying intrinsic's modifiers.
+
+    Example:
+    ```mlir
+    %res = rocdl.permlanex16.var %old, %src, %selector, false, true : (i32, i32, i32) -> i32
     ```
   }];
 }

--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -2365,6 +2365,26 @@ def ROCDL_PermlaneX16Op : ROCDL_IntrOp<"permlanex16", [], [0],
   }];
 }
 
+// PermLaneX16 variable intrinsic operation (GFX12+)
+// Each lane specifies its own source lane index via VGPR $src1,
+// enabling arbitrary per-lane cross-half-wave permutations.
+def ROCDL_PermlaneX16VarOp : ROCDL_IntrOp<"permlanex16.var", [], [],
+    [], 1, 0, 0, 0,
+    [3, 4], ["fi", "boundControl"]>,
+  Arguments<(ins I32:$old, I32:$src0, I32:$src1,
+             I1Attr:$fi, I1Attr:$boundControl)> {
+  let results = (outs I32:$res);
+  let assemblyFormat = [{
+    attr-dict $old `,` $src0 `,` $src1 `,` $fi `,` $boundControl `:` `(` type($src0) `,` type($src1) `)` `->` type($res)
+  }];
+  let description = [{
+    Performs a variable `permlanex16` operation (GFX12+) where each lane
+    provides its own source lane index in the other half-wave via VGPR $src1.
+    Unlike the non-var version which uses SGPR group selectors, this allows
+    arbitrary per-lane cross-half permutations.
+  }];
+}
+
 class ROCDL_ConcretePair<Type elem0, Type elem1> :
   Type<And<[
     LLVM_AnyStruct.predicate,

--- a/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/external/llvm-project/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -2368,11 +2368,10 @@ def ROCDL_PermlaneX16Op : ROCDL_IntrOp<"permlanex16", [], [0],
 // PermLaneX16 variable intrinsic operation (GFX12+)
 // Each lane specifies its own source lane index via VGPR $src1,
 // enabling arbitrary per-lane cross-half-wave permutations.
-def ROCDL_PermlaneX16VarOp : ROCDL_IntrOp<"permlanex16.var", [], [],
-    [], 1, 0, 0, 0,
-    [3, 4], ["fi", "boundControl"]>,
-  Arguments<(ins I32:$old, I32:$src0, I32:$src1,
-             I1Attr:$fi, I1Attr:$boundControl)> {
+def ROCDL_PermlaneX16VarOp : ROCDL_IntrOp<"permlanex16.var", [], [], [], 1, 0,
+                                          0, 0, [3, 4], ["fi", "boundControl"]>,
+                             Arguments<(ins I32:$old, I32:$src0, I32:$src1,
+                                 I1Attr:$fi, I1Attr:$boundControl)> {
   let results = (outs I32:$res);
   let assemblyFormat = [{
     attr-dict $old `,` $src0 `,` $src1 `,` $fi `,` $boundControl `:` `(` type($src0) `,` type($src1) `)` `->` type($res)

--- a/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/external/llvm-project/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -48,6 +48,7 @@ constexpr Chipset kGfx908 = Chipset(9, 0, 8);
 constexpr Chipset kGfx90a = Chipset(9, 0, 0xa);
 constexpr Chipset kGfx942 = Chipset(9, 4, 2);
 constexpr Chipset kGfx950 = Chipset(9, 5, 0);
+constexpr Chipset kGfx1200 = Chipset(12, 0, 0);
 constexpr Chipset kGfx1250 = Chipset(12, 5, 0);
 
 // Predicates mirroring the LLVM AMDGPU `HasDot{N}Insts` features that gate
@@ -3153,6 +3154,51 @@ struct AMDGPUPermlaneLowering : public ConvertOpToLLVMPattern<PermlaneSwapOp> {
   }
 };
 
+struct AMDGPUPermlaneVarLowering
+    : public ConvertOpToLLVMPattern<PermlaneVarOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  AMDGPUPermlaneVarLowering(const LLVMTypeConverter &converter, Chipset chipset)
+      : ConvertOpToLLVMPattern<PermlaneVarOp>(converter), chipset(chipset) {}
+  Chipset chipset;
+
+  LogicalResult
+  matchAndRewrite(PermlaneVarOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (chipset < kGfx1200)
+      return op->emitOpError("permlane_var is only supported on GFX12+");
+
+    Location loc = op.getLoc();
+    Type i32 = rewriter.getI32Type();
+    Value src = adaptor.getSrc();
+    Value selector = adaptor.getSelector();
+    bool cross = op.getCross();
+    bool fi = op.getFetchInactive();
+    bool boundCtrl = op.getBoundCtrl();
+
+    SmallVector<Value> decomposed;
+    if (failed(LLVM::decomposeValue(rewriter, loc, src, i32, decomposed)))
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to decompose value to i32");
+
+    SmallVector<Value> permuted;
+    for (Value v : decomposed) {
+      Value res;
+      if (cross)
+        res = ROCDL::PermlaneX16VarOp::create(rewriter, loc, i32, v, v,
+                                              selector, fi, boundCtrl);
+      else
+        res = ROCDL::Permlane16VarOp::create(rewriter, loc, i32, v, v, selector,
+                                             fi, boundCtrl);
+      permuted.emplace_back(res);
+    }
+
+    Value result = LLVM::composeValue(rewriter, loc, permuted, src.getType());
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // In-LDS Barrier Operations
 //===----------------------------------------------------------------------===//
@@ -4416,7 +4462,8 @@ void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
            PackedScaledTruncOpLowering, PackedTrunc2xFp8OpLowering,
            PackedStochRoundFp8OpLowering, GatherToLDSOpLowering,
            GlobalLoadAsyncToLDSOpLowering, TransposeLoadOpLowering,
-           AMDGPUPermlaneLowering, AMDGPUMakeDmaBaseLowering<MakeDmaBaseOp>,
+           AMDGPUPermlaneLowering, AMDGPUPermlaneVarLowering,
+           AMDGPUMakeDmaBaseLowering<MakeDmaBaseOp>,
            AMDGPUMakeDmaBaseLowering<MakeGatherDmaBaseOp>,
            AMDGPULowerDescriptor<MakeDmaDescriptorOp>,
            AMDGPULowerDescriptor<MakeGatherDmaDescriptorOp>,

--- a/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/permlane-var.mlir
+++ b/external/llvm-project/mlir/test/Conversion/AMDGPUToROCDL/permlane-var.mlir
@@ -1,0 +1,84 @@
+// RUN: mlir-opt --convert-amdgpu-to-rocdl=chipset=gfx1200 --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: func @test_permlane_var_i32
+// CHECK-SAME: (%[[SRC:.*]]: i32, %[[SEL:.*]]: i32)
+func.func @test_permlane_var_i32(%src : i32, %sel : i32) -> i32 {
+// CHECK:  %[[RES:.*]] = rocdl.permlane16.var %[[SRC]], %[[SRC]], %[[SEL]], false, false : (i32, i32, i32) -> i32
+// CHECK:  return %[[RES]] : i32
+  %0 = amdgpu.permlane_var %src, %sel : i32
+  return %0 : i32
+}
+
+// CHECK-LABEL: func @test_permlane_var_cross_i32
+// CHECK-SAME: (%[[SRC:.*]]: i32, %[[SEL:.*]]: i32)
+func.func @test_permlane_var_cross_i32(%src : i32, %sel : i32) -> i32 {
+// CHECK:  %[[RES:.*]] = rocdl.permlanex16.var %[[SRC]], %[[SRC]], %[[SEL]], false, false : (i32, i32, i32) -> i32
+// CHECK:  return %[[RES]] : i32
+  %0 = amdgpu.permlane_var %src, %sel { cross = true } : i32
+  return %0 : i32
+}
+
+// CHECK-LABEL: func @test_permlane_var_f32
+// CHECK-SAME: (%[[SRC:.*]]: f32, %[[SEL:.*]]: i32)
+func.func @test_permlane_var_f32(%src : f32, %sel : i32) -> f32 {
+// CHECK:  %[[CAST:.*]] = llvm.bitcast %[[SRC]] : f32 to i32
+// CHECK:  %[[RES:.*]] = rocdl.permlane16.var %[[CAST]], %[[CAST]], %[[SEL]], false, false : (i32, i32, i32) -> i32
+// CHECK:  %[[RES_CAST:.*]] = llvm.bitcast %[[RES]] : i32 to f32
+// CHECK:  return %[[RES_CAST]] : f32
+  %0 = amdgpu.permlane_var %src, %sel : f32
+  return %0 : f32
+}
+
+// CHECK-LABEL: func @test_permlane_var_f16
+// CHECK-SAME: (%[[SRC:.*]]: f16, %[[SEL:.*]]: i32)
+func.func @test_permlane_var_f16(%src : f16, %sel : i32) -> f16 {
+// CHECK:  %[[CAST:.*]] = llvm.bitcast %[[SRC]] : f16 to i16
+// CHECK:  %[[ZEXT:.*]] = llvm.zext %[[CAST]] : i16 to i32
+// CHECK:  %[[RES:.*]] = rocdl.permlane16.var %[[ZEXT]], %[[ZEXT]], %[[SEL]], false, false : (i32, i32, i32) -> i32
+// CHECK:  %[[TRUNC:.*]] = llvm.trunc %[[RES]] : i32 to i16
+// CHECK:  %[[RES_CAST:.*]] = llvm.bitcast %[[TRUNC]] : i16 to f16
+// CHECK:  return %[[RES_CAST]] : f16
+  %0 = amdgpu.permlane_var %src, %sel : f16
+  return %0 : f16
+}
+
+// CHECK-LABEL: func @test_permlane_var_cross_f16
+// CHECK-SAME: (%[[SRC:.*]]: f16, %[[SEL:.*]]: i32)
+func.func @test_permlane_var_cross_f16(%src : f16, %sel : i32) -> f16 {
+// CHECK:  %[[CAST:.*]] = llvm.bitcast %[[SRC]] : f16 to i16
+// CHECK:  %[[ZEXT:.*]] = llvm.zext %[[CAST]] : i16 to i32
+// CHECK:  %[[RES:.*]] = rocdl.permlanex16.var %[[ZEXT]], %[[ZEXT]], %[[SEL]], false, false : (i32, i32, i32) -> i32
+// CHECK:  %[[TRUNC:.*]] = llvm.trunc %[[RES]] : i32 to i16
+// CHECK:  %[[RES_CAST:.*]] = llvm.bitcast %[[TRUNC]] : i16 to f16
+// CHECK:  return %[[RES_CAST]] : f16
+  %0 = amdgpu.permlane_var %src, %sel { cross = true } : f16
+  return %0 : f16
+}
+
+// CHECK-LABEL: func @test_permlane_var_4xf16
+// CHECK-SAME: (%[[SRC:.*]]: vector<4xf16>, %[[SEL:.*]]: i32)
+func.func @test_permlane_var_4xf16(%src : vector<4xf16>, %sel : i32) -> vector<4xf16> {
+// CHECK-DAG:  %[[POISON:.*]] = llvm.mlir.poison : vector<2xi32>
+// CHECK-DAG:  %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:  %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:      %[[CAST:.*]] = llvm.bitcast %[[SRC]] : vector<4xf16> to vector<2xi32>
+// CHECK:      %[[ELEM0:.*]] = llvm.extractelement %[[CAST]][%[[C0]] : i32] : vector<2xi32>
+// CHECK:      %[[ELEM1:.*]] = llvm.extractelement %[[CAST]][%[[C1]] : i32] : vector<2xi32>
+// CHECK:      %[[PERM0:.*]] = rocdl.permlane16.var %[[ELEM0]], %[[ELEM0]], %[[SEL]], false, false : (i32, i32, i32) -> i32
+// CHECK:      %[[PERM1:.*]] = rocdl.permlane16.var %[[ELEM1]], %[[ELEM1]], %[[SEL]], false, false : (i32, i32, i32) -> i32
+// CHECK:      %[[INS0:.*]] = llvm.insertelement %[[PERM0]], %[[POISON]][%[[C0]] : i32] : vector<2xi32>
+// CHECK:      %[[INS1:.*]] = llvm.insertelement %[[PERM1]], %[[INS0]][%[[C1]] : i32] : vector<2xi32>
+// CHECK:      %[[RES:.*]] = llvm.bitcast %[[INS1]] : vector<2xi32> to vector<4xf16>
+// CHECK:      return %[[RES]] : vector<4xf16>
+  %0 = amdgpu.permlane_var %src, %sel : vector<4xf16>
+  return %0 : vector<4xf16>
+}
+
+// CHECK-LABEL: func @test_permlane_var_attrs
+// CHECK-SAME: (%[[SRC:.*]]: i32, %[[SEL:.*]]: i32)
+func.func @test_permlane_var_attrs(%src : i32, %sel : i32) -> i32 {
+// CHECK:  %[[RES:.*]] = rocdl.permlanex16.var %[[SRC]], %[[SRC]], %[[SEL]], true, true : (i32, i32, i32) -> i32
+// CHECK:  return %[[RES]] : i32
+  %0 = amdgpu.permlane_var %src, %sel { cross = true, fetch_inactive = true, bound_ctrl = true } : i32
+  return %0 : i32
+}

--- a/external/llvm-project/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -1316,6 +1316,26 @@ llvm.func @rocdl.permlane32.swap(%src : i32) -> !llvm.struct<(i32, i32)> {
 
 // -----
 
+llvm.func @rocdl.permlane16.var(%src : i32) -> i32 {
+  %sel = llvm.mlir.constant(-1 : i32) : i32
+  // CHECK-LABEL: rocdl.permlane16.var
+  // CHECK: rocdl.permlane16.var %{{.*}}, %{{.*}}, %{{.*}}, false, true : (i32, i32, i32) -> i32
+  %ret = rocdl.permlane16.var %src, %src, %sel, false, true : (i32, i32, i32) -> i32
+  llvm.return %ret : i32
+}
+
+// -----
+
+llvm.func @rocdl.permlanex16.var(%src : i32) -> i32 {
+  %sel = llvm.mlir.constant(-1 : i32) : i32
+  // CHECK-LABEL: rocdl.permlanex16.var
+  // CHECK: rocdl.permlanex16.var %{{.*}}, %{{.*}}, %{{.*}}, false, true : (i32, i32, i32) -> i32
+  %ret = rocdl.permlanex16.var %src, %src, %sel, false, true : (i32, i32, i32) -> i32
+  llvm.return %ret : i32
+}
+
+// -----
+
 // CHECK-LABEL: rocdl.cvt.scale.pk8
 llvm.func @rocdl.cvt.scale.pk8(%i32: i32, %v2xi32: vector<2xi32>, %scale: i32) {
 

--- a/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/external/llvm-project/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -1444,6 +1444,22 @@ llvm.func @rocdl.permlane32.swap(%src : i32) -> !llvm.struct<(i32, i32)> {
   llvm.return %ret : !llvm.struct<(i32, i32)>
 }
 
+llvm.func @rocdl.permlane16.var(%src : i32) -> i32 {
+  %sel = llvm.mlir.constant(-1 : i32) : i32
+  // CHECK-LABEL: rocdl.permlane16.var
+  // CHECK: call i32 @llvm.amdgcn.permlane16.var(i32 %{{.*}}, i32 %{{.*}}, i32 -1, i1 false, i1 true)
+  %ret = rocdl.permlane16.var %src, %src, %sel, false, true : (i32, i32, i32) -> i32
+  llvm.return %ret : i32
+}
+
+llvm.func @rocdl.permlanex16.var(%src : i32) -> i32 {
+  %sel = llvm.mlir.constant(-1 : i32) : i32
+  // CHECK-LABEL: rocdl.permlanex16.var
+  // CHECK: call i32 @llvm.amdgcn.permlanex16.var(i32 %{{.*}}, i32 %{{.*}}, i32 -1, i1 false, i1 true)
+  %ret = rocdl.permlanex16.var %src, %src, %sel, false, true : (i32, i32, i32) -> i32
+  llvm.return %ret : i32
+}
+
 llvm.func @rocdl.wmma.fp8(%arg0 : vector<2 x i32>, %arg1 : vector<8xf32>) -> vector<8xf32> {
   // CHECK: call <8 x float> @llvm.amdgcn.wmma.f32.16x16x16.fp8.fp8.v8f32.v2i32(<2 x i32> %{{.*}}, <2 x i32> %{{.*}}, <8 x float> %{{.*}})
   %r0 = rocdl.wmma.f32.16x16x16.fp8_fp8 %arg0, %arg0, %arg1: (vector<2xi32>, vector<2xi32>, vector<8xf32>) -> vector<8xf32>

--- a/mlir/include/mlir/Dialect/Rock/Passes.td
+++ b/mlir/include/mlir/Dialect/Rock/Passes.td
@@ -118,9 +118,9 @@ def RockLinalgAlignPass : Pass<"rock-linalg-align", "::mlir::func::FuncOp"> {
 def RockBlockwiseGemmToThreadwisePass : Pass<"rock-blockwise-gemm-to-threadwise", "::mlir::func::FuncOp"> {
   let summary = "Expand blockwise gemm into threadwise gemm and clean up fusion-related shorthand";
   let dependentDialects = ["rock::RockDialect", "affine::AffineDialect",
-                           "gpu::GPUDialect", "memref::MemRefDialect",
-                           "scf::SCFDialect", "vector::VectorDialect",
-                           "ROCDL::ROCDLDialect"];
+                           "amdgpu::AMDGPUDialect", "gpu::GPUDialect",
+                           "memref::MemRefDialect", "scf::SCFDialect",
+                           "vector::VectorDialect", "ROCDL::ROCDLDialect"];
 }
 
 def RockThreadwiseGemmLoweringPass : Pass<"rock-threadwise-gemm-lowering", "::mlir::func::FuncOp"> {

--- a/mlir/include/mlir/Dialect/Rock/Passes.td
+++ b/mlir/include/mlir/Dialect/Rock/Passes.td
@@ -117,7 +117,10 @@ def RockLinalgAlignPass : Pass<"rock-linalg-align", "::mlir::func::FuncOp"> {
 
 def RockBlockwiseGemmToThreadwisePass : Pass<"rock-blockwise-gemm-to-threadwise", "::mlir::func::FuncOp"> {
   let summary = "Expand blockwise gemm into threadwise gemm and clean up fusion-related shorthand";
-  let dependentDialects = ["rock::RockDialect", "affine::AffineDialect", "gpu::GPUDialect", "memref::MemRefDialect", "scf::SCFDialect", "vector::VectorDialect"];
+  let dependentDialects = ["rock::RockDialect", "affine::AffineDialect",
+                           "gpu::GPUDialect", "memref::MemRefDialect",
+                           "scf::SCFDialect", "vector::VectorDialect",
+                           "ROCDL::ROCDLDialect"];
 }
 
 def RockThreadwiseGemmLoweringPass : Pass<"rock-threadwise-gemm-lowering", "::mlir::func::FuncOp"> {

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -1972,6 +1972,22 @@ struct BlockwiseReduceRewritePattern
               !canUseDsSwizzleBpermute_NRSmall) {
             assert(llvm::isPowerOf2_64(clusterSize) &&
                    "clusterSize must be power of 2");
+            // Correctness invariant: SubgroupReduceOp uses DPP lane-swizzle
+            // which reduces consecutive hardware lanes [0..cluster-1],
+            // [cluster..2*cluster-1], etc. Packing rtid into the low bits
+            // of tid (rtid = tid & (cluster-1)) ensures threads in the same
+            // DPP cluster hold different reduction positions (rtid) for the
+            // same non-reduction position (nrtid). This is valid because:
+            //  - clusterSize == maxActiveReductionThreads (power-of-2 gate)
+            //  - clusterSize * nrDimProd == blockSize (exact packing gate)
+            //  - threadToLDSViewTrs maps (nrtid, rtid, rIter) → LDS, and
+            //    both the initial store and DPP load use the same view.
+            // NB: this factoring is independent of tidSubTileSliceView,
+            // which controls NR-Large and early LDS-skip logic only.
+            assert(clusterSize == maxActiveReductionThreads &&
+                   "DPP cluster must equal active reduction threads");
+            assert(clusterSize * nonReductionDimSizeProduct == blockSize &&
+                   "DPP factoring requires exact thread packing");
             unsigned log2ClusterSize = llvm::Log2_64(clusterSize);
             Value shiftAmt =
                 arith::ConstantIndexOp::create(rewriter, loc, log2ClusterSize);

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -1476,10 +1476,10 @@ struct BlockwiseReduceRewritePattern
 
     // Wave32 variant (gfx950 wave32 mode / Navi4x): canUsePermlaneReduce
     // already skips the upfront LDS write+barrier; this gate additionally
-    // skips the END LDS round-trip when single-wave and !extraOut.
+    // skips the END LDS round-trip when !extraOut. partialR==2 guarantees
+    // both reduction partners are in the same wave, so multi-wave is safe.
     bool canUsePermlaneReduceLdsSkip =
-        canUsePermlaneReduce && blockSize == waveSize &&
-        !op.getExtraOutViewAttr();
+        canUsePermlaneReduce && !op.getExtraOutViewAttr();
 
     if (!canUsePermlaneReduce && !canUseSerialPermlane &&
         !canUsePermlaneSwapReduce && !canUsePermlaneInDPP_LdsSkip) {
@@ -1500,14 +1500,15 @@ struct BlockwiseReduceRewritePattern
           permlaneSwapReduce(rewriter, loc, partialReductionBuffer,
                              /*numElements=*/nrDimSize,
                              /*groupSize=*/partialR, elemType, op);
-          if (blockSize == waveSize) {
-            // Single-wave fast path: skip LDS entirely and broadcast across
-            // rDim into outputReg directly from registers.
+          if (!op.getExtraOutViewAttr()) {
+            // LDS-free path: partialR ∈ {2,4} == mTidPerWave guarantees all
+            // reduction partners are in the same wave, so multi-wave is safe.
             readReducedResultsFromPrivateBuffer(rewriter, loc,
                                                 partialReductionBuffer,
                                                 outputReg,
                                                 inputThreadSubTile2dView);
           } else {
+            // extraOut active: fall back to the full LDS round-trip.
             storePartialReductionstoLDS(
                 rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
                 inputBlockSubTile2dView, inputThreadSubTile2dView,
@@ -1524,16 +1525,18 @@ struct BlockwiseReduceRewritePattern
           int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
           permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
                                nrDimSize, waveSize, elemType, op);
-          if (blockSize == waveSize && !op.getExtraOutViewAttr()) {
-            // Single-wave fast path: skip the END LDS round-trip and
-            // broadcast across rDim into outputReg directly in registers.
+          if (!op.getExtraOutViewAttr()) {
+            // LDS-free path: after the butterfly every lane holds the fully
+            // reduced value for its own NR positions (partialR == mTidPerWave
+            // guarantees all reduction partners are in the same wave), so we
+            // broadcast directly from registers — no LDS store/barrier/read.
             readReducedResultsFromPrivateBuffer(rewriter, loc,
                                                 partialReductionBuffer,
                                                 outputReg,
                                                 inputThreadSubTile2dView);
           } else {
-            // Multi-wave (or extraOut active): final broadcast still needs
-            // LDS to redistribute results across threads in different waves.
+            // extraOut active: the extraOut read path still expects data in
+            // LDS, so fall back to the full LDS round-trip.
             storePartialReductionstoLDS(
                 rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
                 inputBlockSubTile2dView, inputThreadSubTile2dView,

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -829,6 +829,87 @@ struct BlockwiseReduceRewritePattern
                            /*swapWidth=*/32, op);
   }
 
+  // --- ds_swizzle + ds_bpermute reduction (CDNA wave64) ---
+  //
+  // Register-only cross-lane reduction for gfx908 (MI100), gfx90a (MI250),
+  // and gfx94x (MI300) using two DS permute instructions:
+  //   - ds_swizzle_b32: XOR within each 32-lane half (immediate offset, no
+  //     address computation). Used for groupSize == 4 as the first step.
+  //   - ds_bpermute_b32: XOR 32 across the two 32-lane halves. Byte address
+  //     (tid * 4) ^ 128 maps to lane (tid % 64) ^ 32 via the identity
+  //     bit 7 in byte-space == bit 5 in lane-space with 256-byte wrapping.
+  //
+  // Equivalent to permlaneSwapReduce on gfx950 but available on all CDNA.
+
+  void dsSwizzleReduceStep(ConversionPatternRewriter &rewriter, Location loc,
+                           Value buffer, int64_t numElements, Type elemType,
+                           int64_t xorDistance,
+                           BlockwiseBroadcastReduceOp op) const {
+    auto i32Type = rewriter.getI32Type();
+    // BitMode encoding: and_mask=0x1F, or_mask=0x00, xor_mask=xorDistance.
+    int32_t offsetVal = (xorDistance << 10) | 0x1F;
+    Value offset =
+        arith::ConstantIntOp::create(rewriter, loc, i32Type, offsetVal);
+
+    for (int64_t i = 0; i < numElements; i++) {
+      Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
+      Value myVal =
+          InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
+      Value myValI32 =
+          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
+      Value partnerI32 = ROCDL::DsSwizzleOp::create(rewriter, loc, i32Type,
+                                                     myValI32, offset);
+      Value partnerVal =
+          arith::BitcastOp::create(rewriter, loc, elemType, partnerI32);
+      Value reduced = createReducingOp(op, myVal, partnerVal, rewriter);
+      InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
+    }
+  }
+
+  void dsBpermuteReduceStep(ConversionPatternRewriter &rewriter, Location loc,
+                            Value buffer, int64_t numElements, Type elemType,
+                            Value tid,
+                            BlockwiseBroadcastReduceOp op) const {
+    auto i32Type = rewriter.getI32Type();
+    // byteAddr = (tid * 4) ^ 128 → hardware reads from lane (tid % 64) ^ 32.
+    Value tidI32 =
+        arith::IndexCastOp::create(rewriter, loc, i32Type, tid);
+    Value tidBytes = arith::ShLIOp::create(
+        rewriter, loc, tidI32,
+        arith::ConstantIntOp::create(rewriter, loc, i32Type, 2));
+    Value byteAddr = arith::XOrIOp::create(
+        rewriter, loc, tidBytes,
+        arith::ConstantIntOp::create(rewriter, loc, i32Type, 128));
+
+    for (int64_t i = 0; i < numElements; i++) {
+      Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
+      Value myVal =
+          InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
+      Value myValI32 =
+          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
+      Value partnerI32 = ROCDL::DsBpermuteOp::create(rewriter, loc, i32Type,
+                                                      byteAddr, myValI32);
+      Value partnerVal =
+          arith::BitcastOp::create(rewriter, loc, elemType, partnerI32);
+      Value reduced = createReducingOp(op, myVal, partnerVal, rewriter);
+      InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
+    }
+  }
+
+  // groupSize == 2: ds_bpermute only (XOR 32, cross-half).
+  // groupSize == 4: ds_swizzle (XOR 16, within-half) then ds_bpermute (XOR 32).
+  void dsSwizzleBpermuteReduce(ConversionPatternRewriter &rewriter, Location loc,
+                               Value buffer, int64_t numElements,
+                               int64_t groupSize, Type elemType, Value tid,
+                               BlockwiseBroadcastReduceOp op) const {
+    if (groupSize == 4) {
+      dsSwizzleReduceStep(rewriter, loc, buffer, numElements, elemType,
+                          /*xorDistance=*/16, op);
+    }
+    dsBpermuteReduceStep(rewriter, loc, buffer, numElements, elemType, tid,
+                         op);
+  }
+
   // This function will make a 2d view from a multi-dimensional tensors
   // where one axis needs to be reduced.
   ArrayAttr createInput2DView(Location loc, PatternRewriter &rewriter,
@@ -1441,6 +1522,21 @@ struct BlockwiseReduceRewritePattern
          (partialR == 2 || partialR == 4) &&
          blockSize <= nonReductionDimSizeProduct);
 
+    // ds_swizzle + ds_bpermute: register-only cross-lane reduction on CDNA
+    // wave64 (gfx908/MI100, gfx90a/MI250, gfx94x/MI300) via ds_swizzle_b32
+    // (XOR within each 32-lane half) and ds_bpermute_b32 (XOR 32, crossing
+    // the half-wave boundary). Same eligibility as canUsePermlaneSwapReduce
+    // but for architectures without v_permlane_swap.
+    bool hasDsSwizzleBpermute =
+        !hasPermlaneSwap && waveSize == 64 &&
+        (arch.getValue().contains("gfx908") ||
+         arch.getValue().contains("gfx90a") ||
+         arch.getValue().contains("gfx94"));
+    bool canUseDsSwizzleBpermuteReduce =
+        (has2DThreadLayout && hasDsSwizzleBpermute &&
+         (partialR == 2 || partialR == 4) &&
+         blockSize <= nonReductionDimSizeProduct);
+
     // NR-Small permlane fast-path eligibility for skipping LDS round-trips.
     //
     // Safety constraints (apply to both wave64 and wave32 variants below):
@@ -1456,23 +1552,27 @@ struct BlockwiseReduceRewritePattern
     //   - !extraOut: the extraOut path reads from LDS, so it would race
     //     against the skipped writes.
     //
-    // Wave64 variant (gfx950): partialR ∈ {2, 4}, exact thread packing
-    // (nonReductionDimSizeProduct * partialR == waveSize), reduction via
-    // v_permlane{16,32}_swap_b32.
-    bool canUsePermlaneInDPP_LdsSkip = false;
-    if (hasPermlaneSwap && waveSize == 64 && blockSize == waveSize &&
-        blockSize > nonReductionDimSizeProduct &&
-        nonReductionDimSizeProduct > 0 &&
-        llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
-        !op.getExtraOutViewAttr()) {
+    // NR-Small LDS-skip eligibility (wave64): single-wave, K == 1,
+    // partialR ∈ {2, 4}, exact packing (nrDimProd * partialR == waveSize),
+    // no extraOut. When true, BOTH the upfront and final LDS round-trips
+    // are skipped — the entire reduction stays in registers.
+    // Applies to gfx950 (permlane swap) and gfx908/gfx90a/gfx94x (ds_swizzle).
+    auto checkLdsSkipEligibility = [&](bool hasFeature) -> bool {
+      if (!hasFeature || blockSize != waveSize || waveSize != 64 ||
+          blockSize <= nonReductionDimSizeProduct ||
+          nonReductionDimSizeProduct <= 0 ||
+          !llvm::isPowerOf2_64(nonReductionDimSizeProduct) ||
+          op.getExtraOutViewAttr())
+        return false;
       int64_t r = blockSize / nonReductionDimSizeProduct;
       int64_t K = inputThreadSubTile2dShape[nrDim];
-      if ((r == 2 || r == 4) &&
-          nonReductionDimSizeProduct * r == waveSize &&
-          K == 1 && partialR == r) {
-        canUsePermlaneInDPP_LdsSkip = true;
-      }
-    }
+      return (r == 2 || r == 4) &&
+             nonReductionDimSizeProduct * r == waveSize &&
+             K == 1 && partialR == r;
+    };
+    bool canUsePermlaneInDPP_LdsSkip = checkLdsSkipEligibility(hasPermlaneSwap);
+    bool canUseDsSwizzleInDPP_LdsSkip =
+        checkLdsSkipEligibility(hasDsSwizzleBpermute);
 
     // Wave32 variant (gfx950 wave32 mode / Navi4x): canUsePermlaneReduce
     // already skips the upfront LDS write+barrier; this gate additionally
@@ -1482,7 +1582,8 @@ struct BlockwiseReduceRewritePattern
         canUsePermlaneReduce && !op.getExtraOutViewAttr();
 
     if (!canUsePermlaneReduce && !canUseSerialPermlane &&
-        !canUsePermlaneSwapReduce && !canUsePermlaneInDPP_LdsSkip) {
+        !canUsePermlaneSwapReduce && !canUseDsSwizzleBpermuteReduce &&
+        !canUsePermlaneInDPP_LdsSkip && !canUseDsSwizzleInDPP_LdsSkip) {
       storePartialReductionstoLDS(rewriter, loc, partialReductionBuffer,
                                   workspaceLDSBuffer, inputBlockSubTile2dView,
                                   inputThreadSubTile2dView, tidSubTileSliceView,
@@ -1509,6 +1610,30 @@ struct BlockwiseReduceRewritePattern
                                                 inputThreadSubTile2dView);
           } else {
             // extraOut active: fall back to the full LDS round-trip.
+            storePartialReductionstoLDS(
+                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
+                inputBlockSubTile2dView, inputThreadSubTile2dView,
+                tidSubTileSliceView, toFlatLDSView);
+            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                      outputReg, inputViewArrayAttr, axis,
+                                      partialRegTensorShape[rDim], tid,
+                                      /*withBarrier=*/true);
+          }
+        } else if (canUseDsSwizzleBpermuteReduce) {
+          // Register-only reduction via ds_swizzle + ds_bpermute
+          // (gfx908/gfx90a/gfx94x wave64). Same structure as permlane swap
+          // above: LDS-free when !extraOut, LDS fallback otherwise.
+          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
+          dsSwizzleBpermuteReduce(rewriter, loc, partialReductionBuffer,
+                                  /*numElements=*/nrDimSize,
+                                  /*groupSize=*/partialR, elemType, tid,
+                                  op);
+          if (!op.getExtraOutViewAttr()) {
+            readReducedResultsFromPrivateBuffer(rewriter, loc,
+                                                partialReductionBuffer,
+                                                outputReg,
+                                                inputThreadSubTile2dView);
+          } else {
             storePartialReductionstoLDS(
                 rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
                 inputBlockSubTile2dView, inputThreadSubTile2dView,
@@ -1731,12 +1856,22 @@ struct BlockwiseReduceRewritePattern
              maxActiveReductionThreads == 4) &&
             llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
             nonReductionDimSizeProduct * maxActiveReductionThreads == waveSize;
+        // ds_swizzle+bpermute fast-path (gfx908/gfx90a/gfx94x wave64):
+        // same eligibility as canUsePermlaneInDPP but for CDNA arches.
+        bool canUseDsSwizzleInDPP =
+            hasDsSwizzleBpermute && blockSize == waveSize &&
+            llvm::isPowerOf2_64(maxActiveReductionThreads) &&
+            (maxActiveReductionThreads == 2 ||
+             maxActiveReductionThreads == 4) &&
+            llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
+            nonReductionDimSizeProduct * maxActiveReductionThreads == waveSize;
         // The early LDS-skip prediction must remain consistent with the
         // runtime eligibility check.
         assert(!canUsePermlaneInDPP_LdsSkip || canUsePermlaneInDPP);
-        // DPP: rtid = tid % cluster. Tree/Permlane: rtid = tid / nrDimProd.
+        assert(!canUseDsSwizzleInDPP_LdsSkip || canUseDsSwizzleInDPP);
+        // DPP: rtid = tid % cluster. Tree/Permlane/DsSwizzle: rtid = tid / nrDimProd.
         Value rtid, nrtid;
-        if (canUseDPP && !canUsePermlaneInDPP) {
+        if (canUseDPP && !canUsePermlaneInDPP && !canUseDsSwizzleInDPP) {
           assert(llvm::isPowerOf2_64(clusterSize) &&
                  "clusterSize must be power of 2");
           unsigned log2ClusterSize = llvm::Log2_64(clusterSize);
@@ -1771,6 +1906,8 @@ struct BlockwiseReduceRewritePattern
         Value accReg;
         bool hasThreadwiseReduction = threadViewShape[rIterDim] > 1;
         assert(!(canUsePermlaneInDPP_LdsSkip && hasThreadwiseReduction) &&
+               "LDS-skip gate (K==1) implies rIter==1");
+        assert(!(canUseDsSwizzleInDPP_LdsSkip && hasThreadwiseReduction) &&
                "LDS-skip gate (K==1) implies rIter==1");
         if (hasThreadwiseReduction) {
           int64_t localIterVectorLen = rIterVectorLen;
@@ -1875,6 +2012,86 @@ struct BlockwiseReduceRewritePattern
           } else {
             // Leader (rtid == 0) writes the reduced value to LDS for the
             // standard readReducedResultsFromLDS broadcast path.
+            SmallVector<Value, 4> storeInits{nrtid, rtid, zeroConstantOp};
+            SmallVector<int64_t> storeBounds{1, 1, 1};
+            SmallVector<int64_t> storeStrides{1, 1, 1};
+
+            TransformingForOp storeLoop = TransformingForOp::create(
+                rewriter, loc, ArrayRef<ValueRange>(storeInits),
+                ArrayRef<Attribute>{threadToLDSViewTrs},
+                ArrayRef<int64_t>(storeBounds),
+                ArrayRef<int64_t>(storeStrides),
+                /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+            {
+              PatternRewriter::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToStart(storeLoop.getBody());
+              Block::BlockArgListType LDSCoords =
+                  storeLoop.getLowerCoords(/*domain=*/0);
+              Value zeroIdx =
+                  arith::ConstantIndexOp::create(rewriter, loc, 0);
+              Value isLeader = arith::CmpIOp::create(
+                  rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
+              scf::IfOp ifStore = scf::IfOp::create(
+                  rewriter, loc, isLeader, /*withElseRegion=*/false);
+              {
+                PatternRewriter::InsertionGuard storeGuard(rewriter);
+                rewriter.setInsertionPointToStart(ifStore.thenBlock());
+                Value valToStore = InBoundsLoadOp::create(
+                    rewriter, loc, elemType, localAccReg, zeroConstantOp);
+                InBoundsStoreOp::create(rewriter, loc, valToStore,
+                                        workspaceLDSBuffer, LDSCoords);
+              }
+            }
+            LDSBarrierOp::create(rewriter, loc);
+          }
+
+        } else if (canUseDsSwizzleInDPP) {
+          Value localAccReg = accReg;
+          if (!hasThreadwiseReduction) {
+            Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
+                                              privateMemoryAddressSpace);
+            localAccReg = GpuAllocOp::create(rewriter, loc, accRegType);
+
+            if (canUseDsSwizzleInDPP_LdsSkip) {
+              Value loadVal = InBoundsLoadOp::create(
+                  rewriter, loc, elemType, partialReductionBuffer,
+                  zeroConstantOp);
+              InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                      zeroConstantOp);
+            } else {
+              SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
+              SmallVector<int64_t> bounds{1, 1, 1};
+              SmallVector<int64_t> strides{1, 1, 1};
+
+              TransformingForOp loadLoop = TransformingForOp::create(
+                  rewriter, loc, ArrayRef<ValueRange>(inits),
+                  ArrayRef<Attribute>{threadToLDSViewTrs},
+                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+              {
+                PatternRewriter::InsertionGuard guard(rewriter);
+                rewriter.setInsertionPointToStart(loadLoop.getBody());
+                Block::BlockArgListType LDSCoords =
+                    loadLoop.getLowerCoords(/*domain=*/0);
+                Value loadVal = InBoundsLoadOp::create(
+                    rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
+                InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                        zeroConstantOp);
+              }
+            }
+          }
+
+          dsSwizzleBpermuteReduce(rewriter, loc, localAccReg,
+                                  /*numElements=*/1,
+                                  /*groupSize=*/maxActiveReductionThreads,
+                                  elemType, tid, op);
+
+          if (canUseDsSwizzleInDPP_LdsSkip) {
+            Value reduced = InBoundsLoadOp::create(
+                rewriter, loc, elemType, localAccReg, zeroConstantOp);
+            InBoundsStoreOp::create(rewriter, loc, reduced,
+                                    partialReductionBuffer, zeroConstantOp);
+          } else {
             SmallVector<Value, 4> storeInits{nrtid, rtid, zeroConstantOp};
             SmallVector<int64_t> storeBounds{1, 1, 1};
             SmallVector<int64_t> storeStrides{1, 1, 1};
@@ -2039,9 +2256,10 @@ struct BlockwiseReduceRewritePattern
             LDSBarrierOp::create(rewriter, loc);
           }
         }
-        if (canUsePermlaneInDPP_LdsSkip) {
+        if (canUsePermlaneInDPP_LdsSkip || canUseDsSwizzleInDPP_LdsSkip) {
           // END LDS-skip: broadcast from partialReductionBuffer (populated
-          // by the permlane fast-path above), bypassing the LDS round-trip.
+          // by the permlane/ds_swizzle fast-path above), bypassing the LDS
+          // round-trip.
           readReducedResultsFromPrivateBuffer(rewriter, loc,
                                               partialReductionBuffer,
                                               outputReg,

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -32,6 +32,7 @@
 #include "mlir/Dialect/Rock/utility/math.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
 
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -886,23 +887,16 @@ struct BlockwiseReduceRewritePattern
                            Value buffer, int64_t numElements, Type elemType,
                            int64_t xorDistance,
                            BlockwiseBroadcastReduceOp op) const {
-    auto i32Type = rewriter.getI32Type();
-    Type wideType = get32BitType(rewriter, elemType);
-    int32_t offsetVal = (xorDistance << 10) | 0x1F;
-    Value offset =
-        arith::ConstantIntOp::create(rewriter, loc, i32Type, offsetVal);
+    auto andMask = rewriter.getI32IntegerAttr(0x1F);
+    auto orMask = rewriter.getI32IntegerAttr(0);
+    auto xorMask = rewriter.getI32IntegerAttr(xorDistance);
 
     for (int64_t i = 0; i < numElements; i++) {
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal =
           InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
-      Value myWide = widenTo32Bit(rewriter, loc, myVal);
-      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
-      Value partnerI32 =
-          ROCDL::DsSwizzleOp::create(rewriter, loc, i32Type, myValI32, offset);
-      Value partnerWide =
-          arith::BitcastOp::create(rewriter, loc, wideType, partnerI32);
-      Value partnerVal = narrowFrom32Bit(rewriter, loc, partnerWide, elemType);
+      Value partnerVal = amdgpu::SwizzleBitModeOp::create(
+          rewriter, loc, elemType, myVal, andMask, orMask, xorMask);
       Value reduced = createReducingOp(op, myVal, partnerVal, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
     }
@@ -2358,10 +2352,11 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
   {
     ConversionTarget writeAllTarget(*ctx);
     writeAllTarget.addIllegalOp<BlockwiseBroadcastReduceOp, BlockwiseFillOp>();
-    writeAllTarget.addLegalDialect<
-        arith::ArithDialect, rock::RockDialect, memref::MemRefDialect,
-        scf::SCFDialect, vector::VectorDialect, AffineDialect, gpu::GPUDialect,
-        LLVM::LLVMDialect, ROCDL::ROCDLDialect>();
+    writeAllTarget.addLegalDialect<amdgpu::AMDGPUDialect, arith::ArithDialect,
+                                   rock::RockDialect, memref::MemRefDialect,
+                                   scf::SCFDialect, vector::VectorDialect,
+                                   AffineDialect, gpu::GPUDialect,
+                                   LLVM::LLVMDialect, ROCDL::ROCDLDialect>();
     writeAllTarget.addLegalOp<gpu::PrintfOp>();
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -738,38 +738,47 @@ struct BlockwiseReduceRewritePattern
     return {0, 0};
   }
 
-  // Widen a sub-32-bit value to 32 bits for cross-lane intrinsics that
-  // require 32-bit registers. Float types widen to f32 via arith.extf;
-  // integer types widen to i32 via arith.extsi.
-  // Returns the value unchanged if already >= 32 bits.
-  Value widenTo32Bit(ConversionPatternRewriter &rewriter, Location loc,
-                     Value val) const {
+  // Pack a scalar into i32 for cross-lane transfer. Cross-lane intrinsics
+  // only move bits, so we avoid value-converting ops (extf/truncf → v_cvt)
+  // and use bitcast+zext instead (free register ops).
+  //   32-bit float: bitcast f32 → i32
+  //   32-bit int:   identity
+  //   sub-32-bit:   bitcast fN/iN → iN, then zext iN → i32
+  Value toI32(ConversionPatternRewriter &rewriter, Location loc,
+              Value val) const {
+    auto i32Type = rewriter.getI32Type();
     Type ty = val.getType();
-    if (ty.getIntOrFloatBitWidth() >= 32)
-      return val;
-    if (ty.isIntOrIndex())
-      return arith::ExtSIOp::create(rewriter, loc, rewriter.getI32Type(), val);
-    return arith::ExtFOp::create(rewriter, loc, rewriter.getF32Type(), val);
+    unsigned bitWidth = ty.getIntOrFloatBitWidth();
+    if (bitWidth == 32) {
+      if (ty.isIntOrIndex())
+        return val;
+      return arith::BitcastOp::create(rewriter, loc, i32Type, val);
+    }
+    auto iNType = rewriter.getIntegerType(bitWidth);
+    Value asInt =
+        ty.isIntOrIndex()
+            ? val
+            : Value(arith::BitcastOp::create(rewriter, loc, iNType, val));
+    return arith::ExtUIOp::create(rewriter, loc, i32Type, asInt);
   }
 
-  // Narrow a 32-bit value back to the original sub-32-bit type.
-  // Float uses arith.truncf; integer uses arith.trunci.
-  // Returns unchanged if origType is already >= 32 bits.
-  Value narrowFrom32Bit(ConversionPatternRewriter &rewriter, Location loc,
-                        Value val, Type origType) const {
-    if (origType.getIntOrFloatBitWidth() >= 32)
-      return val;
+  // Unpack i32 back to the original element type (inverse of toI32).
+  //   32-bit float: bitcast i32 → f32
+  //   32-bit int:   identity
+  //   sub-32-bit:   trunc i32 → iN, then bitcast iN → fN/iN
+  Value fromI32(ConversionPatternRewriter &rewriter, Location loc, Value word,
+                Type origType) const {
+    unsigned bitWidth = origType.getIntOrFloatBitWidth();
+    if (bitWidth == 32) {
+      if (origType.isIntOrIndex())
+        return word;
+      return arith::BitcastOp::create(rewriter, loc, origType, word);
+    }
+    auto iNType = rewriter.getIntegerType(bitWidth);
+    Value truncated = arith::TruncIOp::create(rewriter, loc, iNType, word);
     if (origType.isIntOrIndex())
-      return arith::TruncIOp::create(rewriter, loc, origType, val);
-    return arith::TruncFOp::create(rewriter, loc, origType, val);
-  }
-
-  // The 32-bit type corresponding to elemType after widening:
-  // f32 for float types, i32 for integer types.
-  Type get32BitType(ConversionPatternRewriter &rewriter, Type elemType) const {
-    if (elemType.isIntOrIndex())
-      return rewriter.getI32Type();
-    return rewriter.getF32Type();
+      return truncated;
+    return arith::BitcastOp::create(rewriter, loc, origType, truncated);
   }
 
   // Cross-half-wave reduction via v_permlanex16_var_b32 (wave32 only).
@@ -815,34 +824,27 @@ struct BlockwiseReduceRewritePattern
     assert((swapWidth == 16 || swapWidth == 32) &&
            "permlaneSwapReduceStep only supports swap widths 16 and 32");
     auto i32Type = rewriter.getI32Type();
-    Type wideType = get32BitType(rewriter, elemType);
     auto i32PairType = LLVM::LLVMStructType::getLiteral(rewriter.getContext(),
                                                         {i32Type, i32Type});
     for (int64_t i = 0; i < numElements; i++) {
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal =
           InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
-      Value myWide = widenTo32Bit(rewriter, loc, myVal);
-      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
-      Value swapResult =
-          (swapWidth == 32)
-              ? Value(ROCDL::Permlane32SwapOp::create(
-                    rewriter, loc, i32PairType, myValI32, myValI32,
-                    /*fi=*/false, /*boundControl=*/false))
-              : Value(ROCDL::Permlane16SwapOp::create(
-                    rewriter, loc, i32PairType, myValI32, myValI32,
-                    /*fi=*/false, /*boundControl=*/false));
-      Value vdst0I32 =
-          LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 0);
-      Value vdst1I32 =
-          LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 1);
-      Value vdst0Wide =
-          arith::BitcastOp::create(rewriter, loc, wideType, vdst0I32);
-      Value vdst1Wide =
-          arith::BitcastOp::create(rewriter, loc, wideType, vdst1I32);
-      Value vdst0Narrow = narrowFrom32Bit(rewriter, loc, vdst0Wide, elemType);
-      Value vdst1Narrow = narrowFrom32Bit(rewriter, loc, vdst1Wide, elemType);
-      Value reduced = createReducingOp(op, vdst0Narrow, vdst1Narrow, rewriter);
+      Value word = toI32(rewriter, loc, myVal);
+      Value swapResult = (swapWidth == 32)
+                             ? Value(ROCDL::Permlane32SwapOp::create(
+                                   rewriter, loc, i32PairType, word, word,
+                                   /*fi=*/false, /*boundControl=*/false))
+                             : Value(ROCDL::Permlane16SwapOp::create(
+                                   rewriter, loc, i32PairType, word, word,
+                                   /*fi=*/false, /*boundControl=*/false));
+      Value vdst0 = fromI32(
+          rewriter, loc,
+          LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 0), elemType);
+      Value vdst1 = fromI32(
+          rewriter, loc,
+          LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 1), elemType);
+      Value reduced = createReducingOp(op, vdst0, vdst1, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
     }
   }
@@ -881,6 +883,7 @@ struct BlockwiseReduceRewritePattern
                            Value buffer, int64_t numElements, Type elemType,
                            int64_t xorDistance,
                            BlockwiseBroadcastReduceOp op) const {
+    auto i32Type = rewriter.getI32Type();
     auto andMask = rewriter.getI32IntegerAttr(0x1F);
     auto orMask = rewriter.getI32IntegerAttr(0);
     auto xorMask = rewriter.getI32IntegerAttr(xorDistance);
@@ -889,8 +892,10 @@ struct BlockwiseReduceRewritePattern
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal =
           InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
-      Value partnerVal = amdgpu::SwizzleBitModeOp::create(
-          rewriter, loc, elemType, myVal, andMask, orMask, xorMask);
+      Value word = toI32(rewriter, loc, myVal);
+      Value partnerWord = amdgpu::SwizzleBitModeOp::create(
+          rewriter, loc, i32Type, word, andMask, orMask, xorMask);
+      Value partnerVal = fromI32(rewriter, loc, partnerWord, elemType);
       Value reduced = createReducingOp(op, myVal, partnerVal, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
     }
@@ -900,7 +905,6 @@ struct BlockwiseReduceRewritePattern
                             Value buffer, int64_t numElements, Type elemType,
                             Value tid, BlockwiseBroadcastReduceOp op) const {
     auto i32Type = rewriter.getI32Type();
-    Type wideType = get32BitType(rewriter, elemType);
     Value tidI32 = arith::IndexCastOp::create(rewriter, loc, i32Type, tid);
     Value tidBytes = arith::ShLIOp::create(
         rewriter, loc, tidI32,
@@ -913,13 +917,10 @@ struct BlockwiseReduceRewritePattern
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal =
           InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
-      Value myWide = widenTo32Bit(rewriter, loc, myVal);
-      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
-      Value partnerI32 = ROCDL::DsBpermuteOp::create(rewriter, loc, i32Type,
-                                                     byteAddr, myValI32);
-      Value partnerWide =
-          arith::BitcastOp::create(rewriter, loc, wideType, partnerI32);
-      Value partnerVal = narrowFrom32Bit(rewriter, loc, partnerWide, elemType);
+      Value word = toI32(rewriter, loc, myVal);
+      Value partnerWord =
+          ROCDL::DsBpermuteOp::create(rewriter, loc, i32Type, byteAddr, word);
+      Value partnerVal = fromI32(rewriter, loc, partnerWord, elemType);
       Value reduced = createReducingOp(op, myVal, partnerVal, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
     }
@@ -1521,33 +1522,54 @@ struct BlockwiseReduceRewritePattern
 
     int64_t partialR = partialRegTensorShape[rDim];
 
+    // All cross-lane fast paths operate on i32 registers (permlane_swap,
+    // ds_bpermute, ds_swizzle, permlanex16_var all move 32-bit values).
+    // Cross-lane intrinsics (permlane, ds_swizzle, ds_bpermute) operate on
+    // i32. Sub-32-bit types (f16, bf16, i8, f8) are widened to 32-bit
+    // before transfer and narrowed back after; 32-bit types are bitcast
+    // to i32 directly. Types wider than 32-bit (f64, i64) are not
+    // supported here because rock.blockwise_broadcast_reduce currently
+    // rejects them at the op verifier level. If the op is ever extended
+    // to accept 64-bit types, this gate must be updated and a
+    // decomposition into two i32 halves added.
+    int64_t elemBitWidth = elemType.getIntOrFloatBitWidth();
+    bool elemSupportedByCrossLane = (elemBitWidth <= 32);
+
     // v_permlanex16_var_b32 (variable selector): gfx950, gfx12 (Navi4x).
     // NOT available on gfx11 (Navi3x) which only has the immediate form.
     bool hasPermlaneVar =
-        arch.getValue().contains("gfx950") || arch.getValue().contains("gfx12");
+        elemSupportedByCrossLane && (arch.getValue().contains("gfx950") ||
+                                     arch.getValue().contains("gfx12"));
 
     // ds_swizzle_b32 on wave32: gfx11 (RDNA3 / Navi3x). XOR=16 swaps
     // lanes 0-15 <-> 16-31, functionally identical to permlanex16_var.
     // Used as the wave32 cross-half reduction primitive when permlaneVar
     // is not available.
-    bool hasDsSwizzleWave32 =
-        !hasPermlaneVar && waveSize == 32 && arch.getValue().contains("gfx11");
+    bool hasDsSwizzleWave32 = elemSupportedByCrossLane && !hasPermlaneVar &&
+                              waveSize == 32 &&
+                              arch.getValue().contains("gfx11");
 
     auto [mTidPerWave, nTidPerWave] =
         getPerWaveThreadCounts(op.getTidSubTileSliceView());
     bool has2DThreadLayout = (mTidPerWave > 0 && nTidPerWave > 0);
 
+    // Validate that the 2D layout fully tiles the wave with no gaps
+    // or overlap. Without this, XOR-based lane swaps may pair threads
+    // that do not hold complementary reduction positions.
+    bool layoutTilesWave =
+        has2DThreadLayout && (mTidPerWave * nTidPerWave == waveSize);
+
     // === Wave32 NR-Small gates (blockSize > nrDimProd) ===
     // Cross-half-wave reduction for partialR=2 on wave32 when
-    // nTidPerWave=16 (lanes 0-15 <-> 16-31).
+    // mTidPerWave=2, nTidPerWave=16 (lanes 0-15 <-> 16-31).
     // - canUsePermlaneX16Var_NRSmall: via v_permlanex16_var (gfx950/gfx12)
     // - canUseDsSwizzleW32_NRSmall: via ds_swizzle XOR=16 (gfx11)
     bool canUsePermlaneX16Var_NRSmall =
-        (has2DThreadLayout && hasPermlaneVar && waveSize == 32 &&
-         partialR == 2 && nTidPerWave == 16);
+        (layoutTilesWave && hasPermlaneVar && waveSize == 32 && partialR == 2 &&
+         mTidPerWave == 2 && nTidPerWave == 16);
     bool canUseDsSwizzleW32_NRSmall =
-        (has2DThreadLayout && hasDsSwizzleWave32 && partialR == 2 &&
-         nTidPerWave == 16);
+        (layoutTilesWave && hasDsSwizzleWave32 && partialR == 2 &&
+         mTidPerWave == 2 && nTidPerWave == 16);
 
     // === Wave32 NR-Large gates (blockSize <= nrDimProd) ===
     // Single cross-half-wave reduction restricted to partialR == 2
@@ -1557,7 +1579,7 @@ struct BlockwiseReduceRewritePattern
     // - canUseDsSwizzleW32_NRLarge: via ds_swizzle XOR=16 (gfx11)
     bool canUsePermlaneX16Var_NRLarge = false;
     bool canUseDsSwizzleW32_NRLarge = false;
-    if (has2DThreadLayout && waveSize == 32 &&
+    if (layoutTilesWave && waveSize == 32 &&
         blockSize <= nonReductionDimSizeProduct && partialR == 2 &&
         partialR == mTidPerWave) {
       canUsePermlaneX16Var_NRLarge = hasPermlaneVar;
@@ -1570,9 +1592,13 @@ struct BlockwiseReduceRewritePattern
     // v_permlane16_swap then one v_permlane32_swap).
     // partialR == mTidPerWave freezes the MFMA layout contract: reduction
     // partners must be at lane distances 32 (2-way) or 16 (4-way).
-    bool hasPermlaneSwap = arch.getValue().contains("gfx950");
+    // Precedence: gfx950 is checked first and gets permlane_swap;
+    // the !hasPermlaneSwap guard below ensures gfx94x (which also matches
+    // the "gfx94" substring) falls into the ds_swizzle+bpermute arm instead.
+    bool hasPermlaneSwap =
+        elemSupportedByCrossLane && arch.getValue().contains("gfx950");
     bool canUsePermlaneSwap_NRLarge =
-        (has2DThreadLayout && hasPermlaneSwap && waveSize == 64 &&
+        (layoutTilesWave && hasPermlaneSwap && waveSize == 64 &&
          (partialR == 2 || partialR == 4) && partialR == mTidPerWave &&
          blockSize <= nonReductionDimSizeProduct);
 
@@ -1580,13 +1606,15 @@ struct BlockwiseReduceRewritePattern
     // wave64 (gfx908/MI100, gfx90a/MI250, gfx94x/MI300) via ds_swizzle_b32
     // (XOR within each 32-lane half) and ds_bpermute_b32 (XOR 32, crossing
     // the half-wave boundary). Same eligibility as canUsePermlaneSwap_NRLarge
-    // but for architectures without v_permlane_swap.
-    bool hasDsSwizzleBpermute = !hasPermlaneSwap && waveSize == 64 &&
+    // but for architectures without v_permlane_swap. The !hasPermlaneSwap
+    // guard prevents gfx950 from entering this arm despite matching "gfx94".
+    bool hasDsSwizzleBpermute = elemSupportedByCrossLane && !hasPermlaneSwap &&
+                                waveSize == 64 &&
                                 (arch.getValue().contains("gfx908") ||
                                  arch.getValue().contains("gfx90a") ||
                                  arch.getValue().contains("gfx94"));
     bool canUseDsSwizzleBpermute_NRLarge =
-        (has2DThreadLayout && hasDsSwizzleBpermute &&
+        (layoutTilesWave && hasDsSwizzleBpermute &&
          (partialR == 2 || partialR == 4) && partialR == mTidPerWave &&
          blockSize <= nonReductionDimSizeProduct);
 
@@ -1645,6 +1673,18 @@ struct BlockwiseReduceRewritePattern
                         "supports cross-lane intrinsics; all register-only "
                         "fast paths disabled. Check tidSubTileSliceView for "
                         "m_tid/n_tid naming.\n";
+      }
+      if (has2DThreadLayout && !layoutTilesWave) {
+        llvm::dbgs() << "BlockwiseReduce: mTidPerWave(" << mTidPerWave
+                     << ") * nTidPerWave(" << nTidPerWave << ") != waveSize("
+                     << waveSize
+                     << "); layout does not tile the wave, "
+                        "all register-only fast paths disabled.\n";
+      }
+      if (!elemSupportedByCrossLane) {
+        llvm::dbgs() << "BlockwiseReduce: elemBitWidth=" << elemBitWidth
+                     << " > 32; all register-only fast paths disabled "
+                        "(only up to 32-bit types supported).\n";
       }
     });
 

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -737,14 +737,48 @@ struct BlockwiseReduceRewritePattern
     return {0, 0};
   }
 
+  // Widen a sub-32-bit value to 32 bits for cross-lane intrinsics that
+  // require 32-bit registers. Float types widen to f32 via arith.extf;
+  // integer types widen to i32 via arith.extsi.
+  // Returns the value unchanged if already >= 32 bits.
+  Value widenTo32Bit(ConversionPatternRewriter &rewriter, Location loc,
+                     Value val) const {
+    Type ty = val.getType();
+    if (ty.getIntOrFloatBitWidth() >= 32)
+      return val;
+    if (ty.isIntOrIndex())
+      return arith::ExtSIOp::create(rewriter, loc, rewriter.getI32Type(), val);
+    return arith::ExtFOp::create(rewriter, loc, rewriter.getF32Type(), val);
+  }
+
+  // Narrow a 32-bit value back to the original sub-32-bit type.
+  // Float uses arith.truncf; integer uses arith.trunci.
+  // Returns unchanged if origType is already >= 32 bits.
+  Value narrowFrom32Bit(ConversionPatternRewriter &rewriter, Location loc,
+                        Value val, Type origType) const {
+    if (origType.getIntOrFloatBitWidth() >= 32)
+      return val;
+    if (origType.isIntOrIndex())
+      return arith::TruncIOp::create(rewriter, loc, origType, val);
+    return arith::TruncFOp::create(rewriter, loc, origType, val);
+  }
+
+  // The 32-bit type corresponding to elemType after widening:
+  // f32 for float types, i32 for integer types.
+  Type get32BitType(ConversionPatternRewriter &rewriter, Type elemType) const {
+    if (elemType.isIntOrIndex())
+      return rewriter.getI32Type();
+    return rewriter.getF32Type();
+  }
+
   // Cross-half-wave reduction via v_permlanex16_var_b32 (wave32 only).
   // Lane i exchanges with lane i+16 and reduces.
   void permlaneX16VarReduce(ConversionPatternRewriter &rewriter, Location loc,
                             Value partialReductionBuffer, Value tid,
-                            int64_t nrDimSize, int64_t waveSize,
-                            Type elemType,
+                            int64_t nrDimSize, int64_t waveSize, Type elemType,
                             BlockwiseBroadcastReduceOp op) const {
     auto i32Type = rewriter.getI32Type();
+    Type wideType = get32BitType(rewriter, elemType);
     Value lane = arith::RemUIOp::create(
         rewriter, loc, tid,
         arith::ConstantIndexOp::create(rewriter, loc, waveSize));
@@ -757,16 +791,17 @@ struct BlockwiseReduceRewritePattern
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal = InBoundsLoadOp::create(rewriter, loc, elemType,
                                            partialReductionBuffer, idx);
-      Value myValI32 =
-          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
+      Value myWide = widenTo32Bit(rewriter, loc, myVal);
+      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
       Value resultI32 = ROCDL::PermlaneX16VarOp::create(
           rewriter, loc, i32Type, myValI32, myValI32, laneIdxInHalf,
           /*fi=*/false, /*boundControl=*/false);
-      Value partnerVal =
-          arith::BitcastOp::create(rewriter, loc, elemType, resultI32);
+      Value partnerWide =
+          arith::BitcastOp::create(rewriter, loc, wideType, resultI32);
+      Value partnerVal = narrowFrom32Bit(rewriter, loc, partnerWide, elemType);
       Value reduced = createReducingOp(op, partnerVal, myVal, rewriter);
-      InBoundsStoreOp::create(rewriter, loc, reduced,
-                              partialReductionBuffer, idx);
+      InBoundsStoreOp::create(rewriter, loc, reduced, partialReductionBuffer,
+                              idx);
     }
   }
 
@@ -782,15 +817,18 @@ struct BlockwiseReduceRewritePattern
                               Value buffer, int64_t numElements, Type elemType,
                               int64_t swapWidth,
                               BlockwiseBroadcastReduceOp op) const {
+    assert((swapWidth == 16 || swapWidth == 32) &&
+           "permlaneSwapReduceStep only supports swap widths 16 and 32");
     auto i32Type = rewriter.getI32Type();
-    auto i32PairType = LLVM::LLVMStructType::getLiteral(
-        rewriter.getContext(), {i32Type, i32Type});
+    Type wideType = get32BitType(rewriter, elemType);
+    auto i32PairType = LLVM::LLVMStructType::getLiteral(rewriter.getContext(),
+                                                        {i32Type, i32Type});
     for (int64_t i = 0; i < numElements; i++) {
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal =
           InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
-      Value myValI32 =
-          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
+      Value myWide = widenTo32Bit(rewriter, loc, myVal);
+      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
       Value swapResult =
           (swapWidth == 32)
               ? Value(ROCDL::Permlane32SwapOp::create(
@@ -803,9 +841,13 @@ struct BlockwiseReduceRewritePattern
           LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 0);
       Value vdst1I32 =
           LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 1);
-      Value vdst0 = arith::BitcastOp::create(rewriter, loc, elemType, vdst0I32);
-      Value vdst1 = arith::BitcastOp::create(rewriter, loc, elemType, vdst1I32);
-      Value reduced = createReducingOp(op, vdst0, vdst1, rewriter);
+      Value vdst0Wide =
+          arith::BitcastOp::create(rewriter, loc, wideType, vdst0I32);
+      Value vdst1Wide =
+          arith::BitcastOp::create(rewriter, loc, wideType, vdst1I32);
+      Value vdst0Narrow = narrowFrom32Bit(rewriter, loc, vdst0Wide, elemType);
+      Value vdst1Narrow = narrowFrom32Bit(rewriter, loc, vdst1Wide, elemType);
+      Value reduced = createReducingOp(op, vdst0Narrow, vdst1Narrow, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
     }
   }
@@ -819,8 +861,7 @@ struct BlockwiseReduceRewritePattern
   // scalar accumulator (used by the NR-Small permlane fast-path).
   void permlaneSwapReduce(ConversionPatternRewriter &rewriter, Location loc,
                           Value buffer, int64_t numElements, int64_t groupSize,
-                          Type elemType,
-                          BlockwiseBroadcastReduceOp op) const {
+                          Type elemType, BlockwiseBroadcastReduceOp op) const {
     if (groupSize == 4) {
       permlaneSwapReduceStep(rewriter, loc, buffer, numElements, elemType,
                              /*swapWidth=*/16, op);
@@ -846,7 +887,7 @@ struct BlockwiseReduceRewritePattern
                            int64_t xorDistance,
                            BlockwiseBroadcastReduceOp op) const {
     auto i32Type = rewriter.getI32Type();
-    // BitMode encoding: and_mask=0x1F, or_mask=0x00, xor_mask=xorDistance.
+    Type wideType = get32BitType(rewriter, elemType);
     int32_t offsetVal = (xorDistance << 10) | 0x1F;
     Value offset =
         arith::ConstantIntOp::create(rewriter, loc, i32Type, offsetVal);
@@ -855,12 +896,13 @@ struct BlockwiseReduceRewritePattern
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal =
           InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
-      Value myValI32 =
-          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
-      Value partnerI32 = ROCDL::DsSwizzleOp::create(rewriter, loc, i32Type,
-                                                     myValI32, offset);
-      Value partnerVal =
-          arith::BitcastOp::create(rewriter, loc, elemType, partnerI32);
+      Value myWide = widenTo32Bit(rewriter, loc, myVal);
+      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
+      Value partnerI32 =
+          ROCDL::DsSwizzleOp::create(rewriter, loc, i32Type, myValI32, offset);
+      Value partnerWide =
+          arith::BitcastOp::create(rewriter, loc, wideType, partnerI32);
+      Value partnerVal = narrowFrom32Bit(rewriter, loc, partnerWide, elemType);
       Value reduced = createReducingOp(op, myVal, partnerVal, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
     }
@@ -868,12 +910,10 @@ struct BlockwiseReduceRewritePattern
 
   void dsBpermuteReduceStep(ConversionPatternRewriter &rewriter, Location loc,
                             Value buffer, int64_t numElements, Type elemType,
-                            Value tid,
-                            BlockwiseBroadcastReduceOp op) const {
+                            Value tid, BlockwiseBroadcastReduceOp op) const {
     auto i32Type = rewriter.getI32Type();
-    // byteAddr = (tid * 4) ^ 128 → hardware reads from lane (tid % 64) ^ 32.
-    Value tidI32 =
-        arith::IndexCastOp::create(rewriter, loc, i32Type, tid);
+    Type wideType = get32BitType(rewriter, elemType);
+    Value tidI32 = arith::IndexCastOp::create(rewriter, loc, i32Type, tid);
     Value tidBytes = arith::ShLIOp::create(
         rewriter, loc, tidI32,
         arith::ConstantIntOp::create(rewriter, loc, i32Type, 2));
@@ -885,12 +925,13 @@ struct BlockwiseReduceRewritePattern
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal =
           InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
-      Value myValI32 =
-          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
+      Value myWide = widenTo32Bit(rewriter, loc, myVal);
+      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
       Value partnerI32 = ROCDL::DsBpermuteOp::create(rewriter, loc, i32Type,
-                                                      byteAddr, myValI32);
-      Value partnerVal =
-          arith::BitcastOp::create(rewriter, loc, elemType, partnerI32);
+                                                     byteAddr, myValI32);
+      Value partnerWide =
+          arith::BitcastOp::create(rewriter, loc, wideType, partnerI32);
+      Value partnerVal = narrowFrom32Bit(rewriter, loc, partnerWide, elemType);
       Value reduced = createReducingOp(op, myVal, partnerVal, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
     }
@@ -898,16 +939,27 @@ struct BlockwiseReduceRewritePattern
 
   // groupSize == 2: ds_bpermute only (XOR 32, cross-half).
   // groupSize == 4: ds_swizzle (XOR 16, within-half) then ds_bpermute (XOR 32).
-  void dsSwizzleBpermuteReduce(ConversionPatternRewriter &rewriter, Location loc,
-                               Value buffer, int64_t numElements,
+  void dsSwizzleBpermuteReduce(ConversionPatternRewriter &rewriter,
+                               Location loc, Value buffer, int64_t numElements,
                                int64_t groupSize, Type elemType, Value tid,
                                BlockwiseBroadcastReduceOp op) const {
     if (groupSize == 4) {
       dsSwizzleReduceStep(rewriter, loc, buffer, numElements, elemType,
                           /*xorDistance=*/16, op);
     }
-    dsBpermuteReduceStep(rewriter, loc, buffer, numElements, elemType, tid,
-                         op);
+    dsBpermuteReduceStep(rewriter, loc, buffer, numElements, elemType, tid, op);
+  }
+
+  // Wave32 cross-half-wave reduction via ds_swizzle_b32 (XOR=16).
+  // Lanes 0-15 exchange with lanes 16-31 and reduce — functionally identical
+  // to permlaneX16VarReduce but uses ds_swizzle which is available on gfx11
+  // (RDNA3 / Navi3x) where v_permlanex16_var_b32 is not exposed.
+  // Only supports partialR=2 (one swap step).
+  void dsSwizzleReduceWave32(ConversionPatternRewriter &rewriter, Location loc,
+                             Value buffer, int64_t numElements, Type elemType,
+                             BlockwiseBroadcastReduceOp op) const {
+    dsSwizzleReduceStep(rewriter, loc, buffer, numElements, elemType,
+                        /*xorDistance=*/16, op);
   }
 
   // This function will make a 2d view from a multi-dimensional tensors
@@ -1348,6 +1400,8 @@ struct BlockwiseReduceRewritePattern
         invertTransforms(rewriter, loc, inputThreadSubTile2dView);
     assert(succeeded(maybeInv) &&
            "inputThreadSubTile2dView must be invertible");
+    if (failed(maybeInv))
+      return;
     ArrayAttr inputThreadSubTile2dViewInv = maybeInv.value();
 
     ArrayRef<int64_t> threadSubTile2DShape =
@@ -1361,16 +1415,16 @@ struct BlockwiseReduceRewritePattern
         rewriter, loc, ArrayRef<ValueRange>{{zero, zero}, {zero, zero}},
         ArrayRef<Attribute>{inputThreadSubTile2dViewInv,
                             rewriter.getArrayAttr({})},
-        /*bounds=*/ArrayRef<int64_t>{threadSubTile2DShape[nrDim],
-                                     threadSubTile2DShape[rDim]},
+        /*bounds=*/
+        ArrayRef<int64_t>{threadSubTile2DShape[nrDim],
+                          threadSubTile2DShape[rDim]},
         /*strides=*/ArrayRef<int64_t>{1, 1},
         /*forceUnroll=*/true, /*useIndexDiffs=*/true);
     {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(loop.getBody());
       Value iter = loop.getLowerCoords(/*domain=*/0)[0];
-      Block::BlockArgListType nrAndRCoords =
-          loop.getLowerCoords(/*domain=*/1);
+      Block::BlockArgListType nrAndRCoords = loop.getLowerCoords(/*domain=*/1);
       Value nrIdx = nrAndRCoords[nrDim];
 
       Value reducedVal = InBoundsLoadOp::create(
@@ -1479,62 +1533,77 @@ struct BlockwiseReduceRewritePattern
 
     int64_t partialR = partialRegTensorShape[rDim];
 
-    // The wave32 cross-lane reduction paths below all rely on
-    // v_permlanex16_var_b32 (variable selector form). This intrinsic is
-    // available on gfx950 (CDNA3, wave32 mode) and gfx12 (RDNA4 / Navi4x).
-    // It is NOT available on gfx11 (RDNA3 / Navi3x) -- only the immediate-
-    // selector form v_permlanex16_b32 exists there. A future ds_swizzle-based
-    // path will be added for gfx11; until then both wave32 permlane gates
-    // must be restricted to architectures that actually expose
-    // permlanex16_var.
-    bool hasPermlaneVar = arch.getValue().contains("gfx950") ||
-                          arch.getValue().contains("gfx12");
+    // === Wave32 capability flags ===
+    //
+    // v_permlanex16_var_b32 (variable selector): gfx950, gfx12 (Navi4x).
+    // NOT available on gfx11 (Navi3x) which only has the immediate form.
+    bool hasPermlaneVar =
+        arch.getValue().contains("gfx950") || arch.getValue().contains("gfx12");
 
-    // PR2-Permlane: register-only cross-half-wave reduction for partialR=2
-    // on wave32 when nTidPerWave=16 (lanes 0-15 <-> 16-31). Used in the
-    // NR-Small branch (blockSize > nrDimProd).
+    // ds_swizzle_b32 on wave32: gfx11 (RDNA3 / Navi3x). XOR=16 swaps
+    // lanes 0-15 <-> 16-31, functionally identical to permlanex16_var.
+    // Used as the wave32 cross-half reduction primitive when permlaneVar
+    // is not available.
+    bool hasDsSwizzleWave32 =
+        !hasPermlaneVar && waveSize == 32 && arch.getValue().contains("gfx11");
+
     auto [mTidPerWave, nTidPerWave] =
         getPerWaveThreadCounts(op.getTidSubTileSliceView());
     bool has2DThreadLayout = (mTidPerWave > 0 && nTidPerWave > 0);
-    bool canUsePermlaneReduce =
+
+    // === Wave32 NR-Small gates (blockSize > nrDimProd) ===
+    //
+    // Cross-half-wave reduction for partialR=2 on wave32 when
+    // nTidPerWave=16 (lanes 0-15 <-> 16-31).
+    // - canUsePermlaneX16Var_NRSmall: via v_permlanex16_var (gfx950/gfx12)
+    // - canUseDsSwizzleW32_NRSmall: via ds_swizzle XOR=16 (gfx11)
+    bool canUsePermlaneX16Var_NRSmall =
         (has2DThreadLayout && hasPermlaneVar && waveSize == 32 &&
          partialR == 2 && nTidPerWave == 16);
+    bool canUseDsSwizzleW32_NRSmall =
+        (has2DThreadLayout && hasDsSwizzleWave32 && partialR == 2 &&
+         nTidPerWave == 16);
 
-    // SerialPermlane: XOR butterfly reduction via v_permlanex16_var_b32 for
-    // blockSize <= nrDimProd on wave32. Requires power-of-2 rDimSize ==
-    // mTidPerWave. Used in the NR-Large branch.
-    bool canUseSerialPermlane = false;
-    if (has2DThreadLayout && hasPermlaneVar && waveSize == 32 &&
-        blockSize <= nonReductionDimSizeProduct) {
-      int64_t rDimSize = partialR;
-      canUseSerialPermlane = (rDimSize >= 2) &&
-                             llvm::isPowerOf2_64(rDimSize) &&
-                             (rDimSize == mTidPerWave);
+    // === Wave32 NR-Large gates (blockSize <= nrDimProd) ===
+    //
+    // Single cross-half-wave reduction restricted to partialR == 2
+    // (== mTidPerWave on WMMA wave32): one swap step is sufficient
+    // for a 2-way reduction only.
+    // - canUsePermlaneX16Var_NRLarge: via v_permlanex16_var (gfx950/gfx12)
+    // - canUseDsSwizzleW32_NRLarge: via ds_swizzle XOR=16 (gfx11)
+    bool canUsePermlaneX16Var_NRLarge = false;
+    bool canUseDsSwizzleW32_NRLarge = false;
+    if (has2DThreadLayout && waveSize == 32 &&
+        blockSize <= nonReductionDimSizeProduct && partialR == 2 &&
+        partialR == mTidPerWave) {
+      canUsePermlaneX16Var_NRLarge = hasPermlaneVar;
+      canUseDsSwizzleW32_NRLarge = hasDsSwizzleWave32;
     }
 
     // Permlane-swap: register-only cross-lane reduction on wave64 (gfx950+)
     // via v_permlane{16,32}_swap_b32. Active in NR-Large path for
     // partialR == 2 (one v_permlane32_swap step) or partialR == 4 (one
     // v_permlane16_swap then one v_permlane32_swap).
+    // partialR == mTidPerWave freezes the MFMA layout contract: reduction
+    // partners must be at lane distances 32 (2-way) or 16 (4-way).
     bool hasPermlaneSwap = arch.getValue().contains("gfx950");
-    bool canUsePermlaneSwapReduce =
+    bool canUsePermlaneSwap_NRLarge =
         (has2DThreadLayout && hasPermlaneSwap && waveSize == 64 &&
-         (partialR == 2 || partialR == 4) &&
+         (partialR == 2 || partialR == 4) && partialR == mTidPerWave &&
          blockSize <= nonReductionDimSizeProduct);
 
     // ds_swizzle + ds_bpermute: register-only cross-lane reduction on CDNA
     // wave64 (gfx908/MI100, gfx90a/MI250, gfx94x/MI300) via ds_swizzle_b32
     // (XOR within each 32-lane half) and ds_bpermute_b32 (XOR 32, crossing
-    // the half-wave boundary). Same eligibility as canUsePermlaneSwapReduce
+    // the half-wave boundary). Same eligibility as canUsePermlaneSwap_NRLarge
     // but for architectures without v_permlane_swap.
-    bool hasDsSwizzleBpermute =
-        !hasPermlaneSwap && waveSize == 64 &&
-        (arch.getValue().contains("gfx908") ||
-         arch.getValue().contains("gfx90a") ||
-         arch.getValue().contains("gfx94"));
-    bool canUseDsSwizzleBpermuteReduce =
+    bool hasDsSwizzleBpermute = !hasPermlaneSwap && waveSize == 64 &&
+                                (arch.getValue().contains("gfx908") ||
+                                 arch.getValue().contains("gfx90a") ||
+                                 arch.getValue().contains("gfx94"));
+    bool canUseDsSwizzleBpermute_NRLarge =
         (has2DThreadLayout && hasDsSwizzleBpermute &&
-         (partialR == 2 || partialR == 4) &&
+         (partialR == 2 || partialR == 4) && partialR == mTidPerWave &&
          blockSize <= nonReductionDimSizeProduct);
 
     // NR-Small permlane fast-path eligibility for skipping LDS round-trips.
@@ -1566,710 +1635,716 @@ struct BlockwiseReduceRewritePattern
         return false;
       int64_t r = blockSize / nonReductionDimSizeProduct;
       int64_t K = inputThreadSubTile2dShape[nrDim];
-      return (r == 2 || r == 4) &&
-             nonReductionDimSizeProduct * r == waveSize &&
+      return (r == 2 || r == 4) && nonReductionDimSizeProduct * r == waveSize &&
              K == 1 && partialR == r;
     };
-    bool canUsePermlaneInDPP_LdsSkip = checkLdsSkipEligibility(hasPermlaneSwap);
-    bool canUseDsSwizzleInDPP_LdsSkip =
+    bool canUsePermlaneSwap_NRSmall_LdsSkip =
+        checkLdsSkipEligibility(hasPermlaneSwap);
+    bool canUseDsSwizzleBpermute_NRSmall_LdsSkip =
         checkLdsSkipEligibility(hasDsSwizzleBpermute);
 
-    // Wave32 variant (gfx950 wave32 mode / Navi4x): canUsePermlaneReduce
-    // already skips the upfront LDS write+barrier; this gate additionally
-    // skips the END LDS round-trip when !extraOut. partialR==2 guarantees
-    // both reduction partners are in the same wave, so multi-wave is safe.
-    bool canUsePermlaneReduceLdsSkip =
-        canUsePermlaneReduce && !op.getExtraOutViewAttr();
+    // Wave32 NR-Small LDS-skip: both permlane and ds_swizzle wave32 paths
+    // skip the upfront LDS write+barrier; this gate additionally skips
+    // the END LDS round-trip when !extraOut. partialR==2 guarantees both
+    // reduction partners are in the same wave, so multi-wave is safe.
+    // K == 1 is required as a defensive guard (see wave64 LDS-skip above).
+    int64_t K = inputThreadSubTile2dShape[nrDim];
+    bool canUsePermlaneX16Var_NRSmall_LdsSkip =
+        canUsePermlaneX16Var_NRSmall && !op.getExtraOutViewAttr() && K == 1;
+    bool canUseDsSwizzleW32_NRSmall_LdsSkip =
+        canUseDsSwizzleW32_NRSmall && !op.getExtraOutViewAttr() && K == 1;
 
-    if (!canUsePermlaneReduce && !canUseSerialPermlane &&
-        !canUsePermlaneSwapReduce && !canUseDsSwizzleBpermuteReduce &&
-        !canUsePermlaneInDPP_LdsSkip && !canUseDsSwizzleInDPP_LdsSkip) {
+    LLVM_DEBUG({
+      if (!has2DThreadLayout && (hasPermlaneVar || hasPermlaneSwap ||
+                                 hasDsSwizzleBpermute || hasDsSwizzleWave32)) {
+        llvm::dbgs() << "BlockwiseReduce: has2DThreadLayout=false but arch "
+                        "supports cross-lane intrinsics; all register-only "
+                        "fast paths disabled. Check tidSubTileSliceView for "
+                        "m_tid/n_tid naming.\n";
+      }
+    });
+
+    if (!canUsePermlaneX16Var_NRSmall && !canUseDsSwizzleW32_NRSmall &&
+        !canUsePermlaneX16Var_NRLarge && !canUseDsSwizzleW32_NRLarge &&
+        !canUsePermlaneSwap_NRLarge && !canUseDsSwizzleBpermute_NRLarge &&
+        !canUsePermlaneSwap_NRSmall_LdsSkip &&
+        !canUseDsSwizzleBpermute_NRSmall_LdsSkip) {
       storePartialReductionstoLDS(rewriter, loc, partialReductionBuffer,
                                   workspaceLDSBuffer, inputBlockSubTile2dView,
                                   inputThreadSubTile2dView, tidSubTileSliceView,
                                   toFlatLDSView);
       LDSBarrierOp::create(rewriter, loc);
     }
-    // Following RAII scope will create reduction loops.
-    {
-      if (blockSize <= nonReductionDimSizeProduct) {
-        if (canUsePermlaneSwapReduce) {
-          // Register-only reduction via v_permlane{16,32}_swap_b32 (gfx950
-          // wave64). After the swap every lane holds the fully reduced
-          // value for its own nr-positions in partialReductionBuffer.
-          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
-          permlaneSwapReduce(rewriter, loc, partialReductionBuffer,
-                             /*numElements=*/nrDimSize,
-                             /*groupSize=*/partialR, elemType, op);
-          if (!op.getExtraOutViewAttr()) {
-            // LDS-free path: partialR ∈ {2,4} == mTidPerWave guarantees all
-            // reduction partners are in the same wave, so multi-wave is safe.
-            readReducedResultsFromPrivateBuffer(rewriter, loc,
-                                                partialReductionBuffer,
-                                                outputReg,
-                                                inputThreadSubTile2dView);
-          } else {
-            // extraOut active: fall back to the full LDS round-trip.
-            storePartialReductionstoLDS(
-                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
-                inputBlockSubTile2dView, inputThreadSubTile2dView,
-                tidSubTileSliceView, toFlatLDSView);
-            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                      outputReg, inputViewArrayAttr, axis,
-                                      partialRegTensorShape[rDim], tid,
-                                      /*withBarrier=*/true);
-          }
-        } else if (canUseDsSwizzleBpermuteReduce) {
-          // Register-only reduction via ds_swizzle + ds_bpermute
-          // (gfx908/gfx90a/gfx94x wave64). Same structure as permlane swap
-          // above: LDS-free when !extraOut, LDS fallback otherwise.
-          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
-          dsSwizzleBpermuteReduce(rewriter, loc, partialReductionBuffer,
-                                  /*numElements=*/nrDimSize,
-                                  /*groupSize=*/partialR, elemType, tid,
-                                  op);
-          if (!op.getExtraOutViewAttr()) {
-            readReducedResultsFromPrivateBuffer(rewriter, loc,
-                                                partialReductionBuffer,
-                                                outputReg,
-                                                inputThreadSubTile2dView);
-          } else {
-            storePartialReductionstoLDS(
-                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
-                inputBlockSubTile2dView, inputThreadSubTile2dView,
-                tidSubTileSliceView, toFlatLDSView);
-            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                      outputReg, inputViewArrayAttr, axis,
-                                      partialRegTensorShape[rDim], tid,
-                                      /*withBarrier=*/true);
-          }
-        } else if (canUseSerialPermlane) {
-          // Butterfly XOR reduction in registers via v_permlanex16_var_b32.
-          // After the butterfly, every lane in the wave holds the fully
-          // reduced value for its own nr-positions in `partialReductionBuffer`.
-          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
-          permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
-                               nrDimSize, waveSize, elemType, op);
-          if (!op.getExtraOutViewAttr()) {
-            // LDS-free path: after the butterfly every lane holds the fully
-            // reduced value for its own NR positions (partialR == mTidPerWave
-            // guarantees all reduction partners are in the same wave), so we
-            // broadcast directly from registers — no LDS store/barrier/read.
-            readReducedResultsFromPrivateBuffer(rewriter, loc,
-                                                partialReductionBuffer,
-                                                outputReg,
-                                                inputThreadSubTile2dView);
-          } else {
-            // extraOut active: the extraOut read path still expects data in
-            // LDS, so fall back to the full LDS round-trip.
-            storePartialReductionstoLDS(
-                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
-                inputBlockSubTile2dView, inputThreadSubTile2dView,
-                tidSubTileSliceView, toFlatLDSView);
-            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                      outputReg, inputViewArrayAttr, axis,
-                                      partialRegTensorShape[rDim], tid,
-                                      /*withBarrier=*/true);
-          }
-        } else {
-        ArrayAttr threadsToTensorTrs = createThreadViewForNRLargerThanThreads(
-            loc, partialRegTensorShape, blockSize, rDim, rewriter);
-        ArrayAttr threadToLDSViewTrs =
-            createLDSWorkspaceView(loc, rewriter, threadsToTensorTrs, rDim);
-        ArrayAttr threadsToLDSViewReducedTrs = createLDSWorkspaceView(
-            loc, rewriter, threadsToTensorTrs, rDim, /*makeRDimZero-*/ true);
-        ArrayRef<int64_t> threadViewShape =
-            cast<TransformMapAttr>(threadToLDSViewTrs[0]).getUpperBounds();
-        constexpr size_t nrIterDim = 1;
-        constexpr size_t rIterDim = 2;
-
-        // Note: This currently creates a bunch of dead IR because vectorization
-        // needs access to a `Value` in order to account for scalarized buffers.
-        Value threadToLDSViewed =
-            transform(rewriter, workspaceLDSBuffer, threadToLDSViewTrs);
-        VectorizationResult nrIterVectorRes =
-            getMaxVectorization(threadToLDSViewed, nrIterDim);
-        int64_t nrIterVectorLen = nrIterVectorRes.max;
-        // Create the accumulation register
-        // This will be accumulated over non-reduction iterations.
-        auto accRegType = MemRefType::get(
-            nrIterVectorLen, elemType, AffineMap{}, privateMemoryAddressSpace);
-        Value accReg = GpuAllocOp::create(rewriter, loc, accRegType);
-        {
-          PatternRewriter::InsertionGuard guard(rewriter);
-          Value nrIter;
-          if (threadViewShape[nrIterDim] > 1) {
-            AffineForOp nrIterLoop = AffineForOp::create(
-                rewriter, loc, 0, threadViewShape[nrIterDim], nrIterVectorLen);
-            // inside the loop.
-            rewriter.setInsertionPointToStart(nrIterLoop.getBody());
-            nrIter = nrIterLoop.getInductionVar();
-          } else {
-            nrIter = zeroConstantOp;
-          }
-          FillOp::create(rewriter, loc, accReg, initVal);
-          VectorizationResult rIterVectorRes =
-              getMaxVectorization(threadToLDSViewed, rIterDim);
-          int64_t rIterVectorLen = rIterVectorRes.max;
-          SmallVector<Value, 4> inits{tid, nrIter, zeroConstantOp};
-          SmallVector<int64_t> bounds{1, 1, threadViewShape[rIterDim]};
-          SmallVector<int64_t> strides{1, 1, rIterVectorLen};
-
-          TransformingForOp reductionLoop = TransformingForOp::create(
-              rewriter, loc, ArrayRef<ValueRange>{inits, inits, inits},
-              ArrayRef<Attribute>{threadToLDSViewTrs, rewriter.getArrayAttr({}),
-                                  threadsToLDSViewReducedTrs},
-              ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
-              /*forceUnroll=*/true,
-              /*useIndexDiffs=*/true);
-          {
-            PatternRewriter::InsertionGuard guard(rewriter);
-            rewriter.setInsertionPointToStart(reductionLoop.getBody());
-            Block::BlockArgListType LDSLoadCoords =
-                reductionLoop.getLowerCoords(/*domain=*/0);
-            // There are two vectorization scenarios :
-            // 1) rIterVectorLen > 1 &&  nrIterVectorLen == 1
-            //    Here we will have a load vector and accReg that is a scalar
-            //    The code in createReducingOp will vector reduce it before
-            //    doing a reducing store to accReg
-            // 2) nrIterVectorLen > 1 && rIterVectorLen == 1
-            //    Here we will have a load vector and accReg that is also a
-            //    vector The code in createReducingOp will do vector elementwise
-            //    op and store the resulting vector to accReg.
-            // NOTE: currently, LDS is viewed as [nrDim x rDim] therefore
-            // only scenario 1) is exercised. However, we'd like to keep
-            // this code compatible with both approaches for future changes.
-            Value loadVal = InBoundsLoadOp::create(
-                rewriter, loc,
-                vectorTypeOrSelf(elemType,
-                                 std::max(rIterVectorLen, nrIterVectorLen)),
-                workspaceLDSBuffer, LDSLoadCoords);
-            Value loadAcc = InBoundsLoadOp::create(
-                rewriter, loc, vectorTypeOrSelf(elemType, nrIterVectorLen),
-                accReg, zeroConstantOp);
-            Value reduced = createReducingOp(op, loadVal, loadAcc, rewriter);
-            InBoundsStoreOp::create(rewriter, loc, reduced, accReg,
-                                    zeroConstantOp);
-            // Storing the last reduction iter output directly to LDS[..., dr=0,
-            // ...]
-            Value rIterArg =
-                reductionLoop.getLowerCoords(/*domain=*/1)[rIterDim];
-            Value boundVal = arith::ConstantIndexOp::create(
-                rewriter, loc, threadViewShape[rIterDim]);
-            Value strideVal =
-                arith::ConstantIndexOp::create(rewriter, loc, rIterVectorLen);
-            Value lastIterVal =
-                arith::SubIOp::create(rewriter, loc, boundVal, strideVal);
-            Value isLastIter = arith::CmpIOp::create(
-                rewriter, loc, arith::CmpIPredicate::eq, rIterArg, lastIterVal);
-            scf::IfOp ifb = scf::IfOp::create(rewriter, loc, isLastIter,
-                                              /*withElseRegion=*/false);
-            {
-              OpBuilder thenb = ifb.getThenBodyBuilder();
-              InBoundsStoreOp::create(
-                  thenb, loc, reduced, workspaceLDSBuffer,
-                  reductionLoop.getLowerCoords(/*domain=*/2));
-            }
-          }
-        }
+    // Common pattern for all cross-lane fast paths: perform the cross-lane
+    // reduction, then either broadcast from registers (LDS-skip) or fall
+    // back to the LDS round-trip when multi-wave or extraOut is active.
+    auto emitCrossLaneReduceWithBroadcast = [&](auto crossLaneReduceFn,
+                                                bool canSkipEndLds) {
+      crossLaneReduceFn();
+      if (canSkipEndLds) {
+        readReducedResultsFromPrivateBuffer(rewriter, loc,
+                                            partialReductionBuffer, outputReg,
+                                            inputThreadSubTile2dView);
+      } else {
+        storePartialReductionstoLDS(rewriter, loc, partialReductionBuffer,
+                                    workspaceLDSBuffer, inputBlockSubTile2dView,
+                                    inputThreadSubTile2dView,
+                                    tidSubTileSliceView, toFlatLDSView);
         readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
                                   outputReg, inputViewArrayAttr, axis,
                                   partialRegTensorShape[rDim], tid,
                                   /*withBarrier=*/true);
+      }
+    };
+
+    // Following RAII scope will create reduction loops.
+    {
+      if (blockSize <= nonReductionDimSizeProduct) {
+        int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
+        bool noExtraOut = !op.getExtraOutViewAttr();
+        if (canUsePermlaneSwap_NRLarge) {
+          emitCrossLaneReduceWithBroadcast(
+              [&] {
+                permlaneSwapReduce(rewriter, loc, partialReductionBuffer,
+                                   nrDimSize, partialR, elemType, op);
+              },
+              noExtraOut);
+        } else if (canUseDsSwizzleBpermute_NRLarge) {
+          emitCrossLaneReduceWithBroadcast(
+              [&] {
+                dsSwizzleBpermuteReduce(rewriter, loc, partialReductionBuffer,
+                                        nrDimSize, partialR, elemType, tid, op);
+              },
+              noExtraOut);
+        } else if (canUsePermlaneX16Var_NRLarge) {
+          emitCrossLaneReduceWithBroadcast(
+              [&] {
+                permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
+                                     nrDimSize, waveSize, elemType, op);
+              },
+              noExtraOut);
+        } else if (canUseDsSwizzleW32_NRLarge) {
+          emitCrossLaneReduceWithBroadcast(
+              [&] {
+                dsSwizzleReduceWave32(rewriter, loc, partialReductionBuffer,
+                                      nrDimSize, elemType, op);
+              },
+              noExtraOut);
+        } else {
+          ArrayAttr threadsToTensorTrs = createThreadViewForNRLargerThanThreads(
+              loc, partialRegTensorShape, blockSize, rDim, rewriter);
+          ArrayAttr threadToLDSViewTrs =
+              createLDSWorkspaceView(loc, rewriter, threadsToTensorTrs, rDim);
+          ArrayAttr threadsToLDSViewReducedTrs = createLDSWorkspaceView(
+              loc, rewriter, threadsToTensorTrs, rDim, /*makeRDimZero-*/ true);
+          ArrayRef<int64_t> threadViewShape =
+              cast<TransformMapAttr>(threadToLDSViewTrs[0]).getUpperBounds();
+          constexpr size_t nrIterDim = 1;
+          constexpr size_t rIterDim = 2;
+
+          // Note: This currently creates a bunch of dead IR because
+          // vectorization needs access to a `Value` in order to account for
+          // scalarized buffers.
+          Value threadToLDSViewed =
+              transform(rewriter, workspaceLDSBuffer, threadToLDSViewTrs);
+          VectorizationResult nrIterVectorRes =
+              getMaxVectorization(threadToLDSViewed, nrIterDim);
+          int64_t nrIterVectorLen = nrIterVectorRes.max;
+          // Create the accumulation register
+          // This will be accumulated over non-reduction iterations.
+          auto accRegType =
+              MemRefType::get(nrIterVectorLen, elemType, AffineMap{},
+                              privateMemoryAddressSpace);
+          Value accReg = GpuAllocOp::create(rewriter, loc, accRegType);
+          {
+            PatternRewriter::InsertionGuard guard(rewriter);
+            Value nrIter;
+            if (threadViewShape[nrIterDim] > 1) {
+              AffineForOp nrIterLoop = AffineForOp::create(
+                  rewriter, loc, 0, threadViewShape[nrIterDim],
+                  nrIterVectorLen);
+              // inside the loop.
+              rewriter.setInsertionPointToStart(nrIterLoop.getBody());
+              nrIter = nrIterLoop.getInductionVar();
+            } else {
+              nrIter = zeroConstantOp;
+            }
+            FillOp::create(rewriter, loc, accReg, initVal);
+            VectorizationResult rIterVectorRes =
+                getMaxVectorization(threadToLDSViewed, rIterDim);
+            int64_t rIterVectorLen = rIterVectorRes.max;
+            SmallVector<Value, 4> inits{tid, nrIter, zeroConstantOp};
+            SmallVector<int64_t> bounds{1, 1, threadViewShape[rIterDim]};
+            SmallVector<int64_t> strides{1, 1, rIterVectorLen};
+
+            TransformingForOp reductionLoop = TransformingForOp::create(
+                rewriter, loc, ArrayRef<ValueRange>{inits, inits, inits},
+                ArrayRef<Attribute>{threadToLDSViewTrs,
+                                    rewriter.getArrayAttr({}),
+                                    threadsToLDSViewReducedTrs},
+                ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                /*forceUnroll=*/true,
+                /*useIndexDiffs=*/true);
+            {
+              PatternRewriter::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToStart(reductionLoop.getBody());
+              Block::BlockArgListType LDSLoadCoords =
+                  reductionLoop.getLowerCoords(/*domain=*/0);
+              // There are two vectorization scenarios :
+              // 1) rIterVectorLen > 1 &&  nrIterVectorLen == 1
+              //    Here we will have a load vector and accReg that is a scalar
+              //    The code in createReducingOp will vector reduce it before
+              //    doing a reducing store to accReg
+              // 2) nrIterVectorLen > 1 && rIterVectorLen == 1
+              //    Here we will have a load vector and accReg that is also a
+              //    vector The code in createReducingOp will do vector
+              //    elementwise op and store the resulting vector to accReg.
+              // NOTE: currently, LDS is viewed as [nrDim x rDim] therefore
+              // only scenario 1) is exercised. However, we'd like to keep
+              // this code compatible with both approaches for future changes.
+              Value loadVal = InBoundsLoadOp::create(
+                  rewriter, loc,
+                  vectorTypeOrSelf(elemType,
+                                   std::max(rIterVectorLen, nrIterVectorLen)),
+                  workspaceLDSBuffer, LDSLoadCoords);
+              Value loadAcc = InBoundsLoadOp::create(
+                  rewriter, loc, vectorTypeOrSelf(elemType, nrIterVectorLen),
+                  accReg, zeroConstantOp);
+              Value reduced = createReducingOp(op, loadVal, loadAcc, rewriter);
+              InBoundsStoreOp::create(rewriter, loc, reduced, accReg,
+                                      zeroConstantOp);
+              // Storing the last reduction iter output directly to LDS[...,
+              // dr=0,
+              // ...]
+              Value rIterArg =
+                  reductionLoop.getLowerCoords(/*domain=*/1)[rIterDim];
+              Value boundVal = arith::ConstantIndexOp::create(
+                  rewriter, loc, threadViewShape[rIterDim]);
+              Value strideVal =
+                  arith::ConstantIndexOp::create(rewriter, loc, rIterVectorLen);
+              Value lastIterVal =
+                  arith::SubIOp::create(rewriter, loc, boundVal, strideVal);
+              Value isLastIter =
+                  arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
+                                        rIterArg, lastIterVal);
+              scf::IfOp ifb = scf::IfOp::create(rewriter, loc, isLastIter,
+                                                /*withElseRegion=*/false);
+              {
+                OpBuilder thenb = ifb.getThenBodyBuilder();
+                InBoundsStoreOp::create(
+                    thenb, loc, reduced, workspaceLDSBuffer,
+                    reductionLoop.getLowerCoords(/*domain=*/2));
+              }
+            }
+          }
+          readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                    outputReg, inputViewArrayAttr, axis,
+                                    partialRegTensorShape[rDim], tid,
+                                    /*withBarrier=*/true);
         } // end NR-Large-Tree else
       } else {
-        if (canUsePermlaneReduce) {
-          // Register-only cross-half-wave reduction for partialR=2 via
-          // v_permlanex16_var_b32 (lanes 0-15 swap with 16-31). After the
-          // swap every lane holds the fully reduced value for its own
-          // nr-positions in partialReductionBuffer.
-          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
-          permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
-                               nrDimSize, waveSize, elemType, op);
-          if (canUsePermlaneReduceLdsSkip) {
-            // Single-wave fast path: skip the END LDS round-trip and
-            // broadcast across rDim into outputReg directly from registers.
-            readReducedResultsFromPrivateBuffer(rewriter, loc,
-                                                partialReductionBuffer,
-                                                outputReg,
-                                                inputThreadSubTile2dView);
-          } else {
-            // Multi-wave (or extraOut active): final broadcast still needs
-            // LDS to redistribute results across threads in different waves.
-            storePartialReductionstoLDS(
-                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
-                inputBlockSubTile2dView, inputThreadSubTile2dView,
-                tidSubTileSliceView, toFlatLDSView);
-            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                      outputReg, inputViewArrayAttr, axis,
-                                      partialRegTensorShape[rDim], tid,
-                                      /*withBarrier=*/true);
-          }
+        int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
+        if (canUsePermlaneX16Var_NRSmall) {
+          emitCrossLaneReduceWithBroadcast(
+              [&] {
+                permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
+                                     nrDimSize, waveSize, elemType, op);
+              },
+              canUsePermlaneX16Var_NRSmall_LdsSkip);
+        } else if (canUseDsSwizzleW32_NRSmall) {
+          emitCrossLaneReduceWithBroadcast(
+              [&] {
+                dsSwizzleReduceWave32(rewriter, loc, partialReductionBuffer,
+                                      nrDimSize, elemType, op);
+              },
+              canUseDsSwizzleW32_NRSmall_LdsSkip);
         } else {
-        // This means there are more threads than elements to be reduced.
-        ArrayAttr threadToTensorViewTrs =
-            createThreadViewforNRSmallerThanThreads(loc, partialRegTensorShape,
-                                                    blockSize, rDim, rewriter);
-        ArrayAttr threadToLDSViewTrs =
-            createLDSWorkspaceView(loc, rewriter, threadToTensorViewTrs, rDim);
-        ArrayRef<int64_t> threadViewShape =
-            cast<TransformMapAttr>(threadToLDSViewTrs[0]).getUpperBounds();
-        constexpr size_t rTidDim = 1;
-        constexpr size_t rIterDim = 2;
+          ArrayAttr threadToTensorViewTrs =
+              createThreadViewforNRSmallerThanThreads(
+                  loc, partialRegTensorShape, blockSize, rDim, rewriter);
+          ArrayAttr threadToLDSViewTrs = createLDSWorkspaceView(
+              loc, rewriter, threadToTensorViewTrs, rDim);
+          ArrayRef<int64_t> threadViewShape =
+              cast<TransformMapAttr>(threadToLDSViewTrs[0]).getUpperBounds();
+          constexpr size_t rTidDim = 1;
+          constexpr size_t rIterDim = 2;
 
-        Value threadToLDSViewed =
-            transform(rewriter, workspaceLDSBuffer, threadToLDSViewTrs);
-        VectorizationResult rIterVectorRes =
-            getMaxVectorization(threadToLDSViewed, rIterDim);
-        int64_t rIterVectorLen = rIterVectorRes.max;
+          Value threadToLDSViewed =
+              transform(rewriter, workspaceLDSBuffer, threadToLDSViewTrs);
+          VectorizationResult rIterVectorRes =
+              getMaxVectorization(threadToLDSViewed, rIterDim);
+          int64_t rIterVectorLen = rIterVectorRes.max;
 
-        // Use DPP-based subgroup reduction when all conditions are met:
-        // 1. Power-of-2 reduction threads (required by SubgroupReduceOp)
-        // 2. More than 1 reduction thread (at least 2 for cross-lane work)
-        // 3. partialR > 2: partialR is the block-level LDS reduction
-        //    dimension size (number of partial values per non-reduction
-        //    position), not the per-thread iteration count. When
-        //    partialR == 2, the cluster degenerates to size 2 with only one
-        //    reduction element per thread, so DPP setup cost is not amortized
-        //    vs the LDS-tree fallback. Threshold chosen from tuning data.
-        // 4. Reduction threads fit within a single wave
-        // 5. Exact thread packing: blockSize == clusterSize *
-        //    nonReductionDimSizeProduct. This guarantees every thread maps to
-        //    a valid (nrtid, rtid) pair, so LDS coordinates derived from them
-        //    are in-bounds.
-        // Otherwise, fall back to LDS-based tree reduction.
-        int64_t maxActiveReductionThreads = threadViewShape[rTidDim];
-        int64_t clusterSize = llvm::PowerOf2Ceil(maxActiveReductionThreads);
-        bool canUseDPP = llvm::isPowerOf2_64(maxActiveReductionThreads) &&
-                         (maxActiveReductionThreads > 1) && (partialR > 2) &&
-                         (maxActiveReductionThreads <= waveSize) &&
-                         (blockSize == maxActiveReductionThreads *
-                                           nonReductionDimSizeProduct);
-        // Permlane fast-path eligibility (gfx950 wave64): single-wave with
-        // rthreads ∈ {2, 4} and exact thread packing
-        // (nrDimProd * rthreads == waveSize). Partner lanes are 16/32 apart,
-        // so this uses the tree-style rtid layout below.
-        bool canUsePermlaneInDPP =
-            hasPermlaneSwap && waveSize == 64 && blockSize == waveSize &&
-            llvm::isPowerOf2_64(maxActiveReductionThreads) &&
-            (maxActiveReductionThreads == 2 ||
-             maxActiveReductionThreads == 4) &&
-            llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
-            nonReductionDimSizeProduct * maxActiveReductionThreads == waveSize;
-        // ds_swizzle+bpermute fast-path (gfx908/gfx90a/gfx94x wave64):
-        // same eligibility as canUsePermlaneInDPP but for CDNA arches.
-        bool canUseDsSwizzleInDPP =
-            hasDsSwizzleBpermute && blockSize == waveSize &&
-            llvm::isPowerOf2_64(maxActiveReductionThreads) &&
-            (maxActiveReductionThreads == 2 ||
-             maxActiveReductionThreads == 4) &&
-            llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
-            nonReductionDimSizeProduct * maxActiveReductionThreads == waveSize;
-        // The early LDS-skip prediction must remain consistent with the
-        // runtime eligibility check.
-        assert(!canUsePermlaneInDPP_LdsSkip || canUsePermlaneInDPP);
-        assert(!canUseDsSwizzleInDPP_LdsSkip || canUseDsSwizzleInDPP);
-        // DPP: rtid = tid % cluster. Tree/Permlane/DsSwizzle: rtid = tid / nrDimProd.
-        Value rtid, nrtid;
-        if (canUseDPP && !canUsePermlaneInDPP && !canUseDsSwizzleInDPP) {
-          assert(llvm::isPowerOf2_64(clusterSize) &&
-                 "clusterSize must be power of 2");
-          unsigned log2ClusterSize = llvm::Log2_64(clusterSize);
-          Value shiftAmt =
-              arith::ConstantIndexOp::create(rewriter, loc, log2ClusterSize);
-          Value mask =
-              arith::ConstantIndexOp::create(rewriter, loc, clusterSize - 1);
-          rtid = arith::AndIOp::create(rewriter, loc, tid, mask);
-          nrtid = arith::ShRUIOp::create(rewriter, loc, tid, shiftAmt);
-        } else {
-          if (llvm::isPowerOf2_64(nonReductionDimSizeProduct)) {
-            unsigned log2Val = llvm::Log2_64(nonReductionDimSizeProduct);
-            Value shiftAmt =
-                arith::ConstantIndexOp::create(rewriter, loc, log2Val);
-            Value mask = arith::ConstantIndexOp::create(
-                rewriter, loc, nonReductionDimSizeProduct - 1);
-            rtid = arith::ShRUIOp::create(rewriter, loc, tid, shiftAmt);
-            nrtid = arith::AndIOp::create(rewriter, loc, tid, mask);
-          } else {
-            Value nrDimSizeProductConst = arith::ConstantIndexOp::create(
-                rewriter, loc, nonReductionDimSizeProduct);
-            rtid = arith::DivSIOp::create(rewriter, loc, tid,
-                                          nrDimSizeProductConst);
-            nrtid = arith::RemSIOp::create(rewriter, loc, tid,
-                                           nrDimSizeProductConst);
-          }
-        }
-
-        // Threadwise reduction accumulator (populated only when rIterDim > 1).
-        // Under the LDS-skip gate (K == 1) rIter span is also 1, so this loop
-        // never runs on the LDS-skip path.
-        Value accReg;
-        bool hasThreadwiseReduction = threadViewShape[rIterDim] > 1;
-        assert(!(canUsePermlaneInDPP_LdsSkip && hasThreadwiseReduction) &&
-               "LDS-skip gate (K==1) implies rIter==1");
-        assert(!(canUseDsSwizzleInDPP_LdsSkip && hasThreadwiseReduction) &&
-               "LDS-skip gate (K==1) implies rIter==1");
-        if (hasThreadwiseReduction) {
-          int64_t localIterVectorLen = rIterVectorLen;
-          Type loadTypeInputReg =
-              vectorTypeOrSelf(elemType, localIterVectorLen);
-          Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
-                                            privateMemoryAddressSpace);
-          accReg = GpuAllocOp::create(rewriter, loc, accRegType);
-
-          SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
-          SmallVector<int64_t> bounds{1, 1, threadViewShape[rIterDim]};
-          SmallVector<int64_t> strides{1, 1, localIterVectorLen};
-
-          Value initVal = getReductionInitValue(op, rewriter);
-          FillOp::create(rewriter, loc, accReg, initVal);
-
-          TransformingForOp reductionLoop = TransformingForOp::create(
-              rewriter, loc, ArrayRef<ValueRange>(inits),
-              ArrayRef<Attribute>{threadToLDSViewTrs},
-              ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
-              /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-          {
-            PatternRewriter::InsertionGuard guard(rewriter);
-            rewriter.setInsertionPointToStart(reductionLoop.getBody());
-            Block::BlockArgListType LDSLoadCoords =
-                reductionLoop.getLowerCoords(/*domain=*/0);
-            Value loadVal =
-                InBoundsLoadOp::create(rewriter, loc, loadTypeInputReg,
-                                       workspaceLDSBuffer, LDSLoadCoords);
-            Value loadAcc = InBoundsLoadOp::create(rewriter, loc, elemType,
-                                                   accReg, zeroConstantOp);
-            Value reduced = createReducingOp(op, loadVal, loadAcc, rewriter);
-            InBoundsStoreOp::create(rewriter, loc, reduced, accReg,
-                                    zeroConstantOp);
-          }
-        }
-
-        if (canUsePermlaneInDPP) {
-          // Permlane fast-path (gfx950 wave64): replaces the DPP/subgroup
-          // cross-lane reduction with v_permlane{16,32}_swap_b32 over a
-          // scalar accumulator.
+          // Use DPP-based subgroup reduction when all conditions are met:
+          // 1. Power-of-2 reduction threads (required by SubgroupReduceOp)
+          // 2. More than 1 reduction thread (at least 2 for cross-lane work)
+          // 3. partialR > 2: partialR is the block-level LDS reduction
+          //    dimension size (number of partial values per non-reduction
+          //    position), not the per-thread iteration count. When
+          //    partialR == 2, the cluster degenerates to size 2 with only one
+          //    reduction element per thread, so DPP setup cost is not amortized
+          //    vs the LDS-tree fallback. Threshold chosen from tuning data.
+          // 4. Reduction threads fit within a single wave
+          // 5. Exact thread packing: blockSize == clusterSize *
+          //    nonReductionDimSizeProduct. This guarantees every thread maps to
+          //    a valid (nrtid, rtid) pair, so LDS coordinates derived from them
+          //    are in-bounds.
+          // Otherwise, fall back to LDS-based tree reduction.
+          int64_t maxActiveReductionThreads = threadViewShape[rTidDim];
+          int64_t clusterSize = llvm::PowerOf2Ceil(maxActiveReductionThreads);
+          bool canUseDPP = llvm::isPowerOf2_64(maxActiveReductionThreads) &&
+                           (maxActiveReductionThreads > 1) && (partialR > 2) &&
+                           (maxActiveReductionThreads <= waveSize) &&
+                           (blockSize == maxActiveReductionThreads *
+                                             nonReductionDimSizeProduct);
+          // Permlane fast-path eligibility (gfx950 wave64): single-wave with
+          // rthreads ∈ {2, 4} and exact thread packing
+          // (nrDimProd * rthreads == waveSize). Partner lanes are 16/32 apart,
+          // so this uses the tree-style rtid layout below.
+          bool canUsePermlaneSwap_NRSmall =
+              hasPermlaneSwap && waveSize == 64 && blockSize == waveSize &&
+              llvm::isPowerOf2_64(maxActiveReductionThreads) &&
+              (maxActiveReductionThreads == 2 ||
+               maxActiveReductionThreads == 4) &&
+              llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
+              nonReductionDimSizeProduct * maxActiveReductionThreads ==
+                  waveSize;
+          // ds_swizzle+bpermute fast-path (gfx908/gfx90a/gfx94x wave64):
+          // same eligibility as canUsePermlaneSwap_NRSmall but for CDNA arches.
+          bool canUseDsSwizzleBpermute_NRSmall =
+              hasDsSwizzleBpermute && blockSize == waveSize &&
+              llvm::isPowerOf2_64(maxActiveReductionThreads) &&
+              (maxActiveReductionThreads == 2 ||
+               maxActiveReductionThreads == 4) &&
+              llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
+              nonReductionDimSizeProduct * maxActiveReductionThreads ==
+                  waveSize;
+          // The early LDS-skip prediction must remain consistent with the
+          // runtime eligibility check.
+          assert(!canUsePermlaneSwap_NRSmall_LdsSkip ||
+                 canUsePermlaneSwap_NRSmall);
+          assert(!canUseDsSwizzleBpermute_NRSmall_LdsSkip ||
+                 canUseDsSwizzleBpermute_NRSmall);
+          // Two different tid → (rtid, nrtid) factorings are used:
           //
-          //  1. Populate localAccReg with the per-thread input value
-          //     (from accReg if threadwise-reduced, else from
-          //      partialReductionBuffer[0] under LDS-skip, else from LDS).
-          //  2. Reduce across partner groups via permlane swap.
-          //  3a. Under LDS-skip: write the result back to
-          //      partialReductionBuffer[0] for the register-only broadcast.
-          //  3b. Otherwise: leader writes to LDS so the standard
-          //      readReducedResultsFromLDS can broadcast it.
-          Value localAccReg = accReg;
-          if (!hasThreadwiseReduction) {
-            Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
-                                              privateMemoryAddressSpace);
-            localAccReg = GpuAllocOp::create(rewriter, loc, accRegType);
-
-            if (canUsePermlaneInDPP_LdsSkip) {
-              // K == 1 under the LDS-skip gate; the single value lives at
-              // partialReductionBuffer[0].
-              Value loadVal = InBoundsLoadOp::create(
-                  rewriter, loc, elemType, partialReductionBuffer,
-                  zeroConstantOp);
-              InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
-                                      zeroConstantOp);
-            } else {
-              SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
-              SmallVector<int64_t> bounds{1, 1, 1};
-              SmallVector<int64_t> strides{1, 1, 1};
-
-              TransformingForOp loadLoop = TransformingForOp::create(
-                  rewriter, loc, ArrayRef<ValueRange>(inits),
-                  ArrayRef<Attribute>{threadToLDSViewTrs},
-                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
-                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-              {
-                PatternRewriter::InsertionGuard guard(rewriter);
-                rewriter.setInsertionPointToStart(loadLoop.getBody());
-                Block::BlockArgListType LDSCoords =
-                    loadLoop.getLowerCoords(/*domain=*/0);
-                Value loadVal = InBoundsLoadOp::create(
-                    rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
-                InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
-                                        zeroConstantOp);
-              }
-            }
-          }
-
-          // After this call every lane in a partner group has the fully
-          // reduced value for its nrtid in localAccReg[0].
-          permlaneSwapReduce(rewriter, loc, localAccReg, /*numElements=*/1,
-                             /*groupSize=*/maxActiveReductionThreads, elemType,
-                             op);
-
-          if (canUsePermlaneInDPP_LdsSkip) {
-            // END LDS-skip: write into partialReductionBuffer[0] so
-            // readReducedResultsFromPrivateBuffer can broadcast from
-            // registers — no LDS write, no barrier, no LDS read.
-            Value reduced = InBoundsLoadOp::create(
-                rewriter, loc, elemType, localAccReg, zeroConstantOp);
-            InBoundsStoreOp::create(rewriter, loc, reduced,
-                                    partialReductionBuffer, zeroConstantOp);
+          // DPP path: rtid = tid % clusterSize, nrtid = tid / clusterSize.
+          //   SubgroupReduceOp uses DPP lane-swizzle within a cluster, so
+          //   consecutive lanes must be reduction partners. Packing rtid into
+          //   the low bits achieves this.
+          //
+          // Tree / permlane / ds_swizzle paths:
+          //   rtid = tid / nrDimProd, nrtid = tid % nrDimProd.
+          //   storePartialReductionstoLDS lays out data as
+          //   flat = k * nrDimProd + nrtid, so threads with the same nrtid
+          //   (consecutive in the low bits) share the same non-reduction
+          //   position. Permlane swap and ds_swizzle intrinsics exchange
+          //   lanes at fixed distances (16/32), which aligns with rtid
+          //   occupying the high bits of tid.
+          //
+          // Both factorings are correct because each path's cross-lane
+          // primitive matches its own bit layout within tid.
+          Value rtid, nrtid;
+          if (canUseDPP && !canUsePermlaneSwap_NRSmall &&
+              !canUseDsSwizzleBpermute_NRSmall) {
+            assert(llvm::isPowerOf2_64(clusterSize) &&
+                   "clusterSize must be power of 2");
+            unsigned log2ClusterSize = llvm::Log2_64(clusterSize);
+            Value shiftAmt =
+                arith::ConstantIndexOp::create(rewriter, loc, log2ClusterSize);
+            Value mask =
+                arith::ConstantIndexOp::create(rewriter, loc, clusterSize - 1);
+            rtid = arith::AndIOp::create(rewriter, loc, tid, mask);
+            nrtid = arith::ShRUIOp::create(rewriter, loc, tid, shiftAmt);
           } else {
-            // Leader (rtid == 0) writes the reduced value to LDS for the
-            // standard readReducedResultsFromLDS broadcast path.
-            SmallVector<Value, 4> storeInits{nrtid, rtid, zeroConstantOp};
-            SmallVector<int64_t> storeBounds{1, 1, 1};
-            SmallVector<int64_t> storeStrides{1, 1, 1};
-
-            TransformingForOp storeLoop = TransformingForOp::create(
-                rewriter, loc, ArrayRef<ValueRange>(storeInits),
-                ArrayRef<Attribute>{threadToLDSViewTrs},
-                ArrayRef<int64_t>(storeBounds),
-                ArrayRef<int64_t>(storeStrides),
-                /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-            {
-              PatternRewriter::InsertionGuard guard(rewriter);
-              rewriter.setInsertionPointToStart(storeLoop.getBody());
-              Block::BlockArgListType LDSCoords =
-                  storeLoop.getLowerCoords(/*domain=*/0);
-              Value zeroIdx =
-                  arith::ConstantIndexOp::create(rewriter, loc, 0);
-              Value isLeader = arith::CmpIOp::create(
-                  rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
-              scf::IfOp ifStore = scf::IfOp::create(
-                  rewriter, loc, isLeader, /*withElseRegion=*/false);
-              {
-                PatternRewriter::InsertionGuard storeGuard(rewriter);
-                rewriter.setInsertionPointToStart(ifStore.thenBlock());
-                Value valToStore = InBoundsLoadOp::create(
-                    rewriter, loc, elemType, localAccReg, zeroConstantOp);
-                InBoundsStoreOp::create(rewriter, loc, valToStore,
-                                        workspaceLDSBuffer, LDSCoords);
-              }
-            }
-            LDSBarrierOp::create(rewriter, loc);
-          }
-
-        } else if (canUseDsSwizzleInDPP) {
-          Value localAccReg = accReg;
-          if (!hasThreadwiseReduction) {
-            Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
-                                              privateMemoryAddressSpace);
-            localAccReg = GpuAllocOp::create(rewriter, loc, accRegType);
-
-            if (canUseDsSwizzleInDPP_LdsSkip) {
-              Value loadVal = InBoundsLoadOp::create(
-                  rewriter, loc, elemType, partialReductionBuffer,
-                  zeroConstantOp);
-              InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
-                                      zeroConstantOp);
+            if (llvm::isPowerOf2_64(nonReductionDimSizeProduct)) {
+              unsigned log2Val = llvm::Log2_64(nonReductionDimSizeProduct);
+              Value shiftAmt =
+                  arith::ConstantIndexOp::create(rewriter, loc, log2Val);
+              Value mask = arith::ConstantIndexOp::create(
+                  rewriter, loc, nonReductionDimSizeProduct - 1);
+              rtid = arith::ShRUIOp::create(rewriter, loc, tid, shiftAmt);
+              nrtid = arith::AndIOp::create(rewriter, loc, tid, mask);
             } else {
-              SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
-              SmallVector<int64_t> bounds{1, 1, 1};
-              SmallVector<int64_t> strides{1, 1, 1};
-
-              TransformingForOp loadLoop = TransformingForOp::create(
-                  rewriter, loc, ArrayRef<ValueRange>(inits),
-                  ArrayRef<Attribute>{threadToLDSViewTrs},
-                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
-                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-              {
-                PatternRewriter::InsertionGuard guard(rewriter);
-                rewriter.setInsertionPointToStart(loadLoop.getBody());
-                Block::BlockArgListType LDSCoords =
-                    loadLoop.getLowerCoords(/*domain=*/0);
-                Value loadVal = InBoundsLoadOp::create(
-                    rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
-                InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
-                                        zeroConstantOp);
-              }
+              Value nrDimSizeProductConst = arith::ConstantIndexOp::create(
+                  rewriter, loc, nonReductionDimSizeProduct);
+              rtid = arith::DivSIOp::create(rewriter, loc, tid,
+                                            nrDimSizeProductConst);
+              nrtid = arith::RemSIOp::create(rewriter, loc, tid,
+                                             nrDimSizeProductConst);
             }
           }
 
-          dsSwizzleBpermuteReduce(rewriter, loc, localAccReg,
-                                  /*numElements=*/1,
-                                  /*groupSize=*/maxActiveReductionThreads,
-                                  elemType, tid, op);
-
-          if (canUseDsSwizzleInDPP_LdsSkip) {
-            Value reduced = InBoundsLoadOp::create(
-                rewriter, loc, elemType, localAccReg, zeroConstantOp);
-            InBoundsStoreOp::create(rewriter, loc, reduced,
-                                    partialReductionBuffer, zeroConstantOp);
-          } else {
-            SmallVector<Value, 4> storeInits{nrtid, rtid, zeroConstantOp};
-            SmallVector<int64_t> storeBounds{1, 1, 1};
-            SmallVector<int64_t> storeStrides{1, 1, 1};
-
-            TransformingForOp storeLoop = TransformingForOp::create(
-                rewriter, loc, ArrayRef<ValueRange>(storeInits),
-                ArrayRef<Attribute>{threadToLDSViewTrs},
-                ArrayRef<int64_t>(storeBounds),
-                ArrayRef<int64_t>(storeStrides),
-                /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-            {
-              PatternRewriter::InsertionGuard guard(rewriter);
-              rewriter.setInsertionPointToStart(storeLoop.getBody());
-              Block::BlockArgListType LDSCoords =
-                  storeLoop.getLowerCoords(/*domain=*/0);
-              Value zeroIdx =
-                  arith::ConstantIndexOp::create(rewriter, loc, 0);
-              Value isLeader = arith::CmpIOp::create(
-                  rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
-              scf::IfOp ifStore = scf::IfOp::create(
-                  rewriter, loc, isLeader, /*withElseRegion=*/false);
-              {
-                PatternRewriter::InsertionGuard storeGuard(rewriter);
-                rewriter.setInsertionPointToStart(ifStore.thenBlock());
-                Value valToStore = InBoundsLoadOp::create(
-                    rewriter, loc, elemType, localAccReg, zeroConstantOp);
-                InBoundsStoreOp::create(rewriter, loc, valToStore,
-                                        workspaceLDSBuffer, LDSCoords);
-              }
-            }
-            LDSBarrierOp::create(rewriter, loc);
-          }
-
-        } else if (canUseDPP) {
-          SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
-          SmallVector<int64_t> bounds{1, 1, 1};
-          SmallVector<int64_t> strides{1, 1, 1};
-
-          gpu::AllReduceOperation gpuReduceOp;
-          ReduceMethod rMethod = op.getReduceMethod();
-          if (rMethod == ReduceMethod::Sum) {
-            gpuReduceOp = gpu::AllReduceOperation::ADD;
-          } else {
-            gpuReduceOp = isa<FloatType>(elemType)
-                              ? gpu::AllReduceOperation::MAXNUMF
-                              : gpu::AllReduceOperation::MAXSI;
-          }
-
-          TransformingForOp dppLoop = TransformingForOp::create(
-              rewriter, loc, ArrayRef<ValueRange>(inits),
-              ArrayRef<Attribute>{threadToLDSViewTrs},
-              ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
-              /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-          {
-            PatternRewriter::InsertionGuard guard(rewriter);
-            rewriter.setInsertionPointToStart(dppLoop.getBody());
-            Block::BlockArgListType LDSCoords =
-                dppLoop.getLowerCoords(/*domain=*/0);
-
-            Value valueToReduce;
-            if (hasThreadwiseReduction) {
-              valueToReduce = InBoundsLoadOp::create(rewriter, loc, elemType,
-                                                     accReg, zeroConstantOp);
-            } else {
-              valueToReduce = InBoundsLoadOp::create(
-                  rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
-            }
-
-            Value reduced = gpu::SubgroupReduceOp::create(
-                rewriter, loc, valueToReduce, gpuReduceOp, /*uniform=*/false,
-                /*cluster_size=*/std::optional<uint32_t>(clusterSize));
-
-            Value zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
-            Value isLeader = arith::CmpIOp::create(
-                rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
-
-            scf::IfOp ifStore = scf::IfOp::create(rewriter, loc, isLeader,
-                                                  /*withElseRegion=*/false);
-            {
-              PatternRewriter::InsertionGuard storeGuard(rewriter);
-              rewriter.setInsertionPointToStart(ifStore.thenBlock());
-              InBoundsStoreOp::create(rewriter, loc, reduced,
-                                      workspaceLDSBuffer, LDSCoords);
-            }
-          }
-          LDSBarrierOp::create(rewriter, loc);
-
-        } else {
-          int64_t ceilPowerOf2 =
-              llvm::PowerOf2Ceil(maxActiveReductionThreads) / 2;
+          // Threadwise reduction accumulator (populated only when rIterDim >
+          // 1). Under the LDS-skip gate (K == 1) rIter span is also 1, so this
+          // loop never runs on the LDS-skip path.
+          Value accReg;
+          bool hasThreadwiseReduction = threadViewShape[rIterDim] > 1;
+          assert(
+              !(canUsePermlaneSwap_NRSmall_LdsSkip && hasThreadwiseReduction) &&
+              "LDS-skip gate (K==1) implies rIter==1");
+          assert(!(canUseDsSwizzleBpermute_NRSmall_LdsSkip &&
+                   hasThreadwiseReduction) &&
+                 "LDS-skip gate (K==1) implies rIter==1");
           if (hasThreadwiseReduction) {
-            SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
-            SmallVector<int64_t> bounds{1, 1, 1};
-            SmallVector<int64_t> strides{1, 1, 1};
+            int64_t localIterVectorLen = rIterVectorLen;
+            Type loadTypeInputReg =
+                vectorTypeOrSelf(elemType, localIterVectorLen);
+            Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
+                                              privateMemoryAddressSpace);
+            accReg = GpuAllocOp::create(rewriter, loc, accRegType);
 
-            TransformingForOp storeLoop = TransformingForOp::create(
+            SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
+            SmallVector<int64_t> bounds{1, 1, threadViewShape[rIterDim]};
+            SmallVector<int64_t> strides{1, 1, localIterVectorLen};
+
+            Value initVal = getReductionInitValue(op, rewriter);
+            FillOp::create(rewriter, loc, accReg, initVal);
+
+            TransformingForOp reductionLoop = TransformingForOp::create(
                 rewriter, loc, ArrayRef<ValueRange>(inits),
                 ArrayRef<Attribute>{threadToLDSViewTrs},
                 ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
                 /*forceUnroll=*/true, /*useIndexDiffs=*/true);
             {
               PatternRewriter::InsertionGuard guard(rewriter);
-              rewriter.setInsertionPointToStart(storeLoop.getBody());
-              Block::BlockArgListType LDSStoreCoords =
-                  storeLoop.getLowerCoords(/*domain=*/0);
-              Value loadVal = InBoundsLoadOp::create(rewriter, loc, elemType,
+              rewriter.setInsertionPointToStart(reductionLoop.getBody());
+              Block::BlockArgListType LDSLoadCoords =
+                  reductionLoop.getLowerCoords(/*domain=*/0);
+              Value loadVal =
+                  InBoundsLoadOp::create(rewriter, loc, loadTypeInputReg,
+                                         workspaceLDSBuffer, LDSLoadCoords);
+              Value loadAcc = InBoundsLoadOp::create(rewriter, loc, elemType,
                                                      accReg, zeroConstantOp);
-              InBoundsStoreOp::create(rewriter, loc, loadVal,
-                                      workspaceLDSBuffer, LDSStoreCoords);
+              Value reduced = createReducingOp(op, loadVal, loadAcc, rewriter);
+              InBoundsStoreOp::create(rewriter, loc, reduced, accReg,
+                                      zeroConstantOp);
             }
-            LDSBarrierOp::create(rewriter, loc);
           }
 
-          int64_t treeMaxActiveThreads = maxActiveReductionThreads;
-          for (int64_t offset = ceilPowerOf2; offset >= 1;
-               offset = offset >> 1) {
-            Value offsetVal =
-                arith::ConstantIndexOp::create(rewriter, loc, offset);
-            Value rtidPlusOffsetVal =
-                arith::AddIOp::create(rewriter, loc, rtid, offsetVal);
-            Value maxActiveReductionThreadsVal = arith::ConstantIndexOp::create(
-                rewriter, loc, treeMaxActiveThreads);
-            treeMaxActiveThreads =
-                llvm::PowerOf2Ceil(treeMaxActiveThreads) >> 1;
-            Value isValid = arith::CmpIOp::create(
-                rewriter, loc, arith::CmpIPredicate::slt, rtidPlusOffsetVal,
-                maxActiveReductionThreadsVal);
-            scf::IfOp ifb = scf::IfOp::create(rewriter, loc, isValid,
-                                              /*withElseRegion=*/false);
-            {
-              OpBuilder thenb = ifb.getThenBodyBuilder();
-              SmallVector<Value, 4> firstInits{nrtid, rtid, zeroConstantOp};
-              SmallVector<Value, 4> secondInits{nrtid, rtidPlusOffsetVal,
-                                                zeroConstantOp};
-              SmallVector<int64_t> bounds{1, 1, 1};
-              SmallVector<int64_t> strides{1, 1, 1};
+          if (canUsePermlaneSwap_NRSmall) {
+            // Permlane fast-path (gfx950 wave64): replaces the DPP/subgroup
+            // cross-lane reduction with v_permlane{16,32}_swap_b32 over a
+            // scalar accumulator.
+            //
+            //  1. Populate localAccReg with the per-thread input value
+            //     (from accReg if threadwise-reduced, else from
+            //      partialReductionBuffer[0] under LDS-skip, else from LDS).
+            //  2. Reduce across partner groups via permlane swap.
+            //  3a. Under LDS-skip: write the result back to
+            //      partialReductionBuffer[0] for the register-only broadcast.
+            //  3b. Otherwise: leader writes to LDS so the standard
+            //      readReducedResultsFromLDS can broadcast it.
+            Value localAccReg = accReg;
+            if (!hasThreadwiseReduction) {
+              Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
+                                                privateMemoryAddressSpace);
+              localAccReg = GpuAllocOp::create(rewriter, loc, accRegType);
 
-              TransformingForOp reductionLoop = TransformingForOp::create(
-                  thenb, loc, ArrayRef<ValueRange>{firstInits, secondInits},
-                  ArrayRef<Attribute>{threadToLDSViewTrs, threadToLDSViewTrs},
-                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+              if (canUsePermlaneSwap_NRSmall_LdsSkip) {
+                // K == 1 under the LDS-skip gate; the single value lives at
+                // partialReductionBuffer[0].
+                Value loadVal = InBoundsLoadOp::create(rewriter, loc, elemType,
+                                                       partialReductionBuffer,
+                                                       zeroConstantOp);
+                InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                        zeroConstantOp);
+              } else {
+                SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
+                SmallVector<int64_t> bounds{1, 1, 1};
+                SmallVector<int64_t> strides{1, 1, 1};
+
+                TransformingForOp loadLoop = TransformingForOp::create(
+                    rewriter, loc, ArrayRef<ValueRange>(inits),
+                    ArrayRef<Attribute>{threadToLDSViewTrs},
+                    ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                    /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+                {
+                  PatternRewriter::InsertionGuard guard(rewriter);
+                  rewriter.setInsertionPointToStart(loadLoop.getBody());
+                  Block::BlockArgListType LDSCoords =
+                      loadLoop.getLowerCoords(/*domain=*/0);
+                  Value loadVal = InBoundsLoadOp::create(
+                      rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
+                  InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                          zeroConstantOp);
+                }
+              }
+            }
+
+            // After this call every lane in a partner group has the fully
+            // reduced value for its nrtid in localAccReg[0].
+            permlaneSwapReduce(rewriter, loc, localAccReg, /*numElements=*/1,
+                               /*groupSize=*/maxActiveReductionThreads,
+                               elemType, op);
+
+            if (canUsePermlaneSwap_NRSmall_LdsSkip) {
+              // END LDS-skip: write into partialReductionBuffer[0] so
+              // readReducedResultsFromPrivateBuffer can broadcast from
+              // registers — no LDS write, no barrier, no LDS read.
+              Value reduced = InBoundsLoadOp::create(
+                  rewriter, loc, elemType, localAccReg, zeroConstantOp);
+              InBoundsStoreOp::create(rewriter, loc, reduced,
+                                      partialReductionBuffer, zeroConstantOp);
+            } else {
+              // Leader (rtid == 0) writes the reduced value to LDS for the
+              // standard readReducedResultsFromLDS broadcast path.
+              SmallVector<Value, 4> storeInits{nrtid, rtid, zeroConstantOp};
+              SmallVector<int64_t> storeBounds{1, 1, 1};
+              SmallVector<int64_t> storeStrides{1, 1, 1};
+
+              TransformingForOp storeLoop = TransformingForOp::create(
+                  rewriter, loc, ArrayRef<ValueRange>(storeInits),
+                  ArrayRef<Attribute>{threadToLDSViewTrs},
+                  ArrayRef<int64_t>(storeBounds),
+                  ArrayRef<int64_t>(storeStrides),
                   /*forceUnroll=*/true, /*useIndexDiffs=*/true);
               {
-                PatternRewriter::InsertionGuard guard(thenb);
-                thenb.setInsertionPointToStart(reductionLoop.getBody());
-                Block::BlockArgListType firstLDSLoadCoords =
-                    reductionLoop.getLowerCoords(/*domain=*/0);
-                Value firstLoadVal = InBoundsLoadOp::create(
-                    thenb, loc, elemType, workspaceLDSBuffer,
-                    firstLDSLoadCoords);
-                Block::BlockArgListType secondLDSLoadCoords =
-                    reductionLoop.getLowerCoords(/*domain=*/1);
-                Value secondLoadVal = InBoundsLoadOp::create(
-                    thenb, loc, elemType, workspaceLDSBuffer,
-                    secondLDSLoadCoords);
-                Value reduced =
-                    createReducingOp(op, firstLoadVal, secondLoadVal, thenb);
-                InBoundsStoreOp::create(thenb, loc, reduced, workspaceLDSBuffer,
-                                        firstLDSLoadCoords);
+                PatternRewriter::InsertionGuard guard(rewriter);
+                rewriter.setInsertionPointToStart(storeLoop.getBody());
+                Block::BlockArgListType LDSCoords =
+                    storeLoop.getLowerCoords(/*domain=*/0);
+                Value zeroIdx =
+                    arith::ConstantIndexOp::create(rewriter, loc, 0);
+                Value isLeader = arith::CmpIOp::create(
+                    rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
+                scf::IfOp ifStore = scf::IfOp::create(rewriter, loc, isLeader,
+                                                      /*withElseRegion=*/false);
+                {
+                  PatternRewriter::InsertionGuard storeGuard(rewriter);
+                  rewriter.setInsertionPointToStart(ifStore.thenBlock());
+                  Value valToStore = InBoundsLoadOp::create(
+                      rewriter, loc, elemType, localAccReg, zeroConstantOp);
+                  InBoundsStoreOp::create(rewriter, loc, valToStore,
+                                          workspaceLDSBuffer, LDSCoords);
+                }
+              }
+              LDSBarrierOp::create(rewriter, loc);
+            }
+
+          } else if (canUseDsSwizzleBpermute_NRSmall) {
+            Value localAccReg = accReg;
+            if (!hasThreadwiseReduction) {
+              Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
+                                                privateMemoryAddressSpace);
+              localAccReg = GpuAllocOp::create(rewriter, loc, accRegType);
+
+              if (canUseDsSwizzleBpermute_NRSmall_LdsSkip) {
+                Value loadVal = InBoundsLoadOp::create(rewriter, loc, elemType,
+                                                       partialReductionBuffer,
+                                                       zeroConstantOp);
+                InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                        zeroConstantOp);
+              } else {
+                SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
+                SmallVector<int64_t> bounds{1, 1, 1};
+                SmallVector<int64_t> strides{1, 1, 1};
+
+                TransformingForOp loadLoop = TransformingForOp::create(
+                    rewriter, loc, ArrayRef<ValueRange>(inits),
+                    ArrayRef<Attribute>{threadToLDSViewTrs},
+                    ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                    /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+                {
+                  PatternRewriter::InsertionGuard guard(rewriter);
+                  rewriter.setInsertionPointToStart(loadLoop.getBody());
+                  Block::BlockArgListType LDSCoords =
+                      loadLoop.getLowerCoords(/*domain=*/0);
+                  Value loadVal = InBoundsLoadOp::create(
+                      rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
+                  InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                          zeroConstantOp);
+                }
+              }
+            }
+
+            dsSwizzleBpermuteReduce(rewriter, loc, localAccReg,
+                                    /*numElements=*/1,
+                                    /*groupSize=*/maxActiveReductionThreads,
+                                    elemType, tid, op);
+
+            if (canUseDsSwizzleBpermute_NRSmall_LdsSkip) {
+              Value reduced = InBoundsLoadOp::create(
+                  rewriter, loc, elemType, localAccReg, zeroConstantOp);
+              InBoundsStoreOp::create(rewriter, loc, reduced,
+                                      partialReductionBuffer, zeroConstantOp);
+            } else {
+              SmallVector<Value, 4> storeInits{nrtid, rtid, zeroConstantOp};
+              SmallVector<int64_t> storeBounds{1, 1, 1};
+              SmallVector<int64_t> storeStrides{1, 1, 1};
+
+              TransformingForOp storeLoop = TransformingForOp::create(
+                  rewriter, loc, ArrayRef<ValueRange>(storeInits),
+                  ArrayRef<Attribute>{threadToLDSViewTrs},
+                  ArrayRef<int64_t>(storeBounds),
+                  ArrayRef<int64_t>(storeStrides),
+                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+              {
+                PatternRewriter::InsertionGuard guard(rewriter);
+                rewriter.setInsertionPointToStart(storeLoop.getBody());
+                Block::BlockArgListType LDSCoords =
+                    storeLoop.getLowerCoords(/*domain=*/0);
+                Value zeroIdx =
+                    arith::ConstantIndexOp::create(rewriter, loc, 0);
+                Value isLeader = arith::CmpIOp::create(
+                    rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
+                scf::IfOp ifStore = scf::IfOp::create(rewriter, loc, isLeader,
+                                                      /*withElseRegion=*/false);
+                {
+                  PatternRewriter::InsertionGuard storeGuard(rewriter);
+                  rewriter.setInsertionPointToStart(ifStore.thenBlock());
+                  Value valToStore = InBoundsLoadOp::create(
+                      rewriter, loc, elemType, localAccReg, zeroConstantOp);
+                  InBoundsStoreOp::create(rewriter, loc, valToStore,
+                                          workspaceLDSBuffer, LDSCoords);
+                }
+              }
+              LDSBarrierOp::create(rewriter, loc);
+            }
+
+          } else if (canUseDPP) {
+            SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
+            SmallVector<int64_t> bounds{1, 1, 1};
+            SmallVector<int64_t> strides{1, 1, 1};
+
+            gpu::AllReduceOperation gpuReduceOp;
+            ReduceMethod rMethod = op.getReduceMethod();
+            if (rMethod == ReduceMethod::Sum) {
+              gpuReduceOp = gpu::AllReduceOperation::ADD;
+            } else {
+              gpuReduceOp = isa<FloatType>(elemType)
+                                ? gpu::AllReduceOperation::MAXNUMF
+                                : gpu::AllReduceOperation::MAXSI;
+            }
+
+            TransformingForOp dppLoop = TransformingForOp::create(
+                rewriter, loc, ArrayRef<ValueRange>(inits),
+                ArrayRef<Attribute>{threadToLDSViewTrs},
+                ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+            {
+              PatternRewriter::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToStart(dppLoop.getBody());
+              Block::BlockArgListType LDSCoords =
+                  dppLoop.getLowerCoords(/*domain=*/0);
+
+              Value valueToReduce;
+              if (hasThreadwiseReduction) {
+                valueToReduce = InBoundsLoadOp::create(rewriter, loc, elemType,
+                                                       accReg, zeroConstantOp);
+              } else {
+                valueToReduce = InBoundsLoadOp::create(
+                    rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
+              }
+
+              Value reduced = gpu::SubgroupReduceOp::create(
+                  rewriter, loc, valueToReduce, gpuReduceOp, /*uniform=*/false,
+                  /*cluster_size=*/std::optional<uint32_t>(clusterSize));
+
+              Value zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+              Value isLeader = arith::CmpIOp::create(
+                  rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
+
+              scf::IfOp ifStore = scf::IfOp::create(rewriter, loc, isLeader,
+                                                    /*withElseRegion=*/false);
+              {
+                PatternRewriter::InsertionGuard storeGuard(rewriter);
+                rewriter.setInsertionPointToStart(ifStore.thenBlock());
+                InBoundsStoreOp::create(rewriter, loc, reduced,
+                                        workspaceLDSBuffer, LDSCoords);
               }
             }
             LDSBarrierOp::create(rewriter, loc);
+
+          } else {
+            int64_t ceilPowerOf2 =
+                llvm::PowerOf2Ceil(maxActiveReductionThreads) / 2;
+            if (hasThreadwiseReduction) {
+              SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
+              SmallVector<int64_t> bounds{1, 1, 1};
+              SmallVector<int64_t> strides{1, 1, 1};
+
+              TransformingForOp storeLoop = TransformingForOp::create(
+                  rewriter, loc, ArrayRef<ValueRange>(inits),
+                  ArrayRef<Attribute>{threadToLDSViewTrs},
+                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+              {
+                PatternRewriter::InsertionGuard guard(rewriter);
+                rewriter.setInsertionPointToStart(storeLoop.getBody());
+                Block::BlockArgListType LDSStoreCoords =
+                    storeLoop.getLowerCoords(/*domain=*/0);
+                Value loadVal = InBoundsLoadOp::create(rewriter, loc, elemType,
+                                                       accReg, zeroConstantOp);
+                InBoundsStoreOp::create(rewriter, loc, loadVal,
+                                        workspaceLDSBuffer, LDSStoreCoords);
+              }
+              LDSBarrierOp::create(rewriter, loc);
+            }
+
+            int64_t treeMaxActiveThreads = maxActiveReductionThreads;
+            for (int64_t offset = ceilPowerOf2; offset >= 1;
+                 offset = offset >> 1) {
+              Value offsetVal =
+                  arith::ConstantIndexOp::create(rewriter, loc, offset);
+              Value rtidPlusOffsetVal =
+                  arith::AddIOp::create(rewriter, loc, rtid, offsetVal);
+              Value maxActiveReductionThreadsVal =
+                  arith::ConstantIndexOp::create(rewriter, loc,
+                                                 treeMaxActiveThreads);
+              treeMaxActiveThreads =
+                  llvm::PowerOf2Ceil(treeMaxActiveThreads) >> 1;
+              Value isValid = arith::CmpIOp::create(
+                  rewriter, loc, arith::CmpIPredicate::slt, rtidPlusOffsetVal,
+                  maxActiveReductionThreadsVal);
+              scf::IfOp ifb = scf::IfOp::create(rewriter, loc, isValid,
+                                                /*withElseRegion=*/false);
+              {
+                OpBuilder thenb = ifb.getThenBodyBuilder();
+                SmallVector<Value, 4> firstInits{nrtid, rtid, zeroConstantOp};
+                SmallVector<Value, 4> secondInits{nrtid, rtidPlusOffsetVal,
+                                                  zeroConstantOp};
+                SmallVector<int64_t> bounds{1, 1, 1};
+                SmallVector<int64_t> strides{1, 1, 1};
+
+                TransformingForOp reductionLoop = TransformingForOp::create(
+                    thenb, loc, ArrayRef<ValueRange>{firstInits, secondInits},
+                    ArrayRef<Attribute>{threadToLDSViewTrs, threadToLDSViewTrs},
+                    ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                    /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+                {
+                  PatternRewriter::InsertionGuard guard(thenb);
+                  thenb.setInsertionPointToStart(reductionLoop.getBody());
+                  Block::BlockArgListType firstLDSLoadCoords =
+                      reductionLoop.getLowerCoords(/*domain=*/0);
+                  Value firstLoadVal = InBoundsLoadOp::create(
+                      thenb, loc, elemType, workspaceLDSBuffer,
+                      firstLDSLoadCoords);
+                  Block::BlockArgListType secondLDSLoadCoords =
+                      reductionLoop.getLowerCoords(/*domain=*/1);
+                  Value secondLoadVal = InBoundsLoadOp::create(
+                      thenb, loc, elemType, workspaceLDSBuffer,
+                      secondLDSLoadCoords);
+                  Value reduced =
+                      createReducingOp(op, firstLoadVal, secondLoadVal, thenb);
+                  InBoundsStoreOp::create(thenb, loc, reduced,
+                                          workspaceLDSBuffer,
+                                          firstLDSLoadCoords);
+                }
+              }
+              LDSBarrierOp::create(rewriter, loc);
+            }
           }
-        }
-        if (canUsePermlaneInDPP_LdsSkip || canUseDsSwizzleInDPP_LdsSkip) {
-          // END LDS-skip: broadcast from partialReductionBuffer (populated
-          // by the permlane/ds_swizzle fast-path above), bypassing the LDS
-          // round-trip.
-          readReducedResultsFromPrivateBuffer(rewriter, loc,
-                                              partialReductionBuffer,
-                                              outputReg,
-                                              inputThreadSubTile2dView);
-        } else {
-          readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                    outputReg, inputViewArrayAttr, axis,
-                                    partialRegTensorShape[rDim], tid,
-                                    /*withBarrier=*/false);
-        }
+          if (canUsePermlaneSwap_NRSmall_LdsSkip ||
+              canUseDsSwizzleBpermute_NRSmall_LdsSkip) {
+            readReducedResultsFromPrivateBuffer(
+                rewriter, loc, partialReductionBuffer, outputReg,
+                inputThreadSubTile2dView);
+          } else {
+            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                      outputReg, inputViewArrayAttr, axis,
+                                      partialRegTensorShape[rDim], tid,
+                                      /*withBarrier=*/false);
+          }
         }
       }
       rewriter.eraseOp(op);
@@ -2283,11 +2358,10 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
   {
     ConversionTarget writeAllTarget(*ctx);
     writeAllTarget.addIllegalOp<BlockwiseBroadcastReduceOp, BlockwiseFillOp>();
-    writeAllTarget.addLegalDialect<arith::ArithDialect, rock::RockDialect,
-                                   memref::MemRefDialect, scf::SCFDialect,
-                                   vector::VectorDialect, AffineDialect,
-                                   gpu::GPUDialect, LLVM::LLVMDialect,
-                                   ROCDL::ROCDLDialect>();
+    writeAllTarget.addLegalDialect<
+        arith::ArithDialect, rock::RockDialect, memref::MemRefDialect,
+        scf::SCFDialect, vector::VectorDialect, AffineDialect, gpu::GPUDialect,
+        LLVM::LLVMDialect, ROCDL::ROCDLDialect>();
     writeAllTarget.addLegalOp<gpu::PrintfOp>();
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -712,9 +712,7 @@ struct BlockwiseReduceRewritePattern
     return dimProduct;
   }
 
-  // Extract per-wave thread counts from the tid slice view by looking for
-  // "m_tid" and "n_tid" named dimensions in the Merge transform that
-  // decomposes "tid". Works for both WMMA and MFMA architectures.
+  // Extract m_tid and n_tid counts from the tid slice view's Merge transform.
   static std::pair<int64_t, int64_t>
   getPerWaveThreadCounts(ArrayAttr tidSliceView) {
     if (tidSliceView.empty())
@@ -738,9 +736,8 @@ struct BlockwiseReduceRewritePattern
     return {0, 0};
   }
 
-  // Register-only cross-half-wave reduction using v_permlanex16_var_b32.
-  // Each lane exchanges its value with the corresponding lane in the other
-  // half-wave (lane i <-> lane i+16) and reduces. Requires wave32 (RDNA).
+  // Cross-half-wave reduction via v_permlanex16_var_b32 (wave32 only).
+  // Lane i exchanges with lane i+16 and reduces.
   void permlaneX16VarReduce(ConversionPatternRewriter &rewriter, Location loc,
                             Value partialReductionBuffer, Value tid,
                             int64_t nrDimSize, int64_t waveSize,
@@ -1289,14 +1286,29 @@ struct BlockwiseReduceRewritePattern
     StringAttr arch = rock::getArchValue(op);
     int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
 
-    // Permlane-reduce: register-only cross-half-wave reduction using
-    // v_permlanex16_var_b32 (GFX12+). Avoids the initial LDS store+barrier
-    // by performing reduction directly in registers before writing to LDS.
     int64_t partialR = partialRegTensorShape[rDim];
-    bool canUsePermlaneReduce =
-        (waveSize == 32 && partialR == 2);
 
-    if (!canUsePermlaneReduce) {
+    // PR2-Permlane: register-only cross-half-wave reduction for partialR=2
+    // on wave32 when nTidPerWave=16 (lanes 0-15 <-> 16-31).
+    auto [mTidPerWave, nTidPerWave] =
+        getPerWaveThreadCounts(op.getTidSubTileSliceView());
+    bool has2DThreadLayout = (mTidPerWave > 0 && nTidPerWave > 0);
+    bool canUsePermlaneReduce =
+        (has2DThreadLayout && waveSize == 32 &&
+         partialR == 2 && nTidPerWave == 16);
+
+    // SerialPermlane: XOR butterfly reduction via permlanex16_var for
+    // blockSize <= nrDimProd on wave32. Requires power-of-2 rDimSize == mTidPerWave.
+    bool canUseSerialPermlane = false;
+    if (has2DThreadLayout && waveSize == 32 &&
+        blockSize <= nonReductionDimSizeProduct) {
+      int64_t rDimSize = partialR;
+      canUseSerialPermlane = (rDimSize >= 2) &&
+                             llvm::isPowerOf2_64(rDimSize) &&
+                             (rDimSize == mTidPerWave);
+    }
+
+    if (!canUsePermlaneReduce && !canUseSerialPermlane) {
       storePartialReductionstoLDS(rewriter, loc, partialReductionBuffer,
                                   workspaceLDSBuffer, inputBlockSubTile2dView,
                                   inputThreadSubTile2dView, tidSubTileSliceView,
@@ -1306,7 +1318,9 @@ struct BlockwiseReduceRewritePattern
     // Following RAII scope will create reduction loops.
     {
       if (blockSize <= nonReductionDimSizeProduct) {
-        if (canUsePermlaneReduce) {
+        if (canUseSerialPermlane) {
+          // Butterfly reduction in registers via permlanex16_var.
+          // Uses LDS only for final broadcast.
           int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
           permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
                                nrDimSize, waveSize, elemType, op);
@@ -1425,6 +1439,20 @@ struct BlockwiseReduceRewritePattern
                                   /*withBarrier=*/true);
         } // end NR-Large-Tree else
       } else {
+        if (canUsePermlaneReduce) {
+          // Register-only reduction for partialR=2 via permlanex16_var.
+          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
+          permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
+                               nrDimSize, waveSize, elemType, op);
+          storePartialReductionstoLDS(
+              rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
+              inputBlockSubTile2dView, inputThreadSubTile2dView,
+              tidSubTileSliceView, toFlatLDSView);
+          readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                    outputReg, inputViewArrayAttr, axis,
+                                    partialRegTensorShape[rDim], tid,
+                                    /*withBarrier=*/true);
+        } else {
         // This means there are more threads than elements to be reduced.
         ArrayAttr threadToTensorViewTrs =
             createThreadViewforNRSmallerThanThreads(loc, partialRegTensorShape,
@@ -1459,15 +1487,12 @@ struct BlockwiseReduceRewritePattern
         // Otherwise, fall back to LDS-based tree reduction.
         int64_t maxActiveReductionThreads = threadViewShape[rTidDim];
         int64_t clusterSize = llvm::PowerOf2Ceil(maxActiveReductionThreads);
-        int64_t partialR = partialRegTensorShape[rDim];
         bool canUseDPP = llvm::isPowerOf2_64(maxActiveReductionThreads) &&
                          (maxActiveReductionThreads > 1) && (partialR > 2) &&
                          (maxActiveReductionThreads <= waveSize) &&
                          (blockSize == maxActiveReductionThreads *
                                            nonReductionDimSizeProduct);
-        // DPP path: contiguous threads reduce together (rtid = tid % cluster).
-        // Tree path: scattered layout (rtid = tid /
-        // nonReductionDimSizeProduct).
+        // DPP: rtid = tid % cluster. Tree: rtid = tid / nrDimProd.
         Value rtid, nrtid;
         if (canUseDPP) {
           assert(llvm::isPowerOf2_64(clusterSize) &&
@@ -1538,8 +1563,6 @@ struct BlockwiseReduceRewritePattern
           }
         }
 
-        // Cross-lane reduction: DPP path uses SubgroupReduceOp with
-        // cluster_size, tree path uses iterative LDS load/reduce/store.
         if (canUseDPP) {
           SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
           SmallVector<int64_t> bounds{1, 1, 1};
@@ -1595,7 +1618,6 @@ struct BlockwiseReduceRewritePattern
           LDSBarrierOp::create(rewriter, loc);
 
         } else {
-          // Tree reduction path: needs LDS for inter-thread communication
           int64_t ceilPowerOf2 =
               llvm::PowerOf2Ceil(maxActiveReductionThreads) / 2;
           if (hasThreadwiseReduction) {
@@ -1676,6 +1698,7 @@ struct BlockwiseReduceRewritePattern
                                   outputReg, inputViewArrayAttr, axis,
                                   partialRegTensorShape[rDim], tid,
                                   /*withBarrier=*/false);
+        }
       }
       rewriter.eraseOp(op);
       return success();

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -34,6 +34,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/AccelEmitter.h"
@@ -769,6 +770,65 @@ struct BlockwiseReduceRewritePattern
     }
   }
 
+  // One permlane-swap reduction step over a per-thread buffer (gfx950 wave64).
+  //   swapWidth == 32 -> v_permlane32_swap_b32 (lane i <-> lane i+32)
+  //   swapWidth == 16 -> v_permlane16_swap_b32 (lane i <-> lane i+16)
+  // The intrinsic returns a {vdst0, vdst1} pair that always contains
+  // {self, partner} for every lane (only the order differs across the two
+  // halves of the swap-pair). Since our reductions are commutative+associative
+  // (Sum / Max) we reduce vdst0 and vdst1 directly, avoiding the cmp+select
+  // that would otherwise be needed to identify which is the partner.
+  void permlaneSwapReduceStep(ConversionPatternRewriter &rewriter, Location loc,
+                              Value buffer, int64_t numElements, Type elemType,
+                              int64_t swapWidth,
+                              BlockwiseBroadcastReduceOp op) const {
+    auto i32Type = rewriter.getI32Type();
+    auto i32PairType = LLVM::LLVMStructType::getLiteral(
+        rewriter.getContext(), {i32Type, i32Type});
+    for (int64_t i = 0; i < numElements; i++) {
+      Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
+      Value myVal =
+          InBoundsLoadOp::create(rewriter, loc, elemType, buffer, idx);
+      Value myValI32 =
+          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
+      Value swapResult =
+          (swapWidth == 32)
+              ? Value(ROCDL::Permlane32SwapOp::create(
+                    rewriter, loc, i32PairType, myValI32, myValI32,
+                    /*fi=*/false, /*boundControl=*/false))
+              : Value(ROCDL::Permlane16SwapOp::create(
+                    rewriter, loc, i32PairType, myValI32, myValI32,
+                    /*fi=*/false, /*boundControl=*/false));
+      Value vdst0I32 =
+          LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 0);
+      Value vdst1I32 =
+          LLVM::ExtractValueOp::create(rewriter, loc, swapResult, 1);
+      Value vdst0 = arith::BitcastOp::create(rewriter, loc, elemType, vdst0I32);
+      Value vdst1 = arith::BitcastOp::create(rewriter, loc, elemType, vdst1I32);
+      Value reduced = createReducingOp(op, vdst0, vdst1, rewriter);
+      InBoundsStoreOp::create(rewriter, loc, reduced, buffer, idx);
+    }
+  }
+
+  // Register-only cross-lane reduction over `numElements` slots on gfx950+
+  // (wave64) for partner-group sizes 2 or 4:
+  //   groupSize == 2: one v_permlane32_swap (lanes 16/32 apart)
+  //   groupSize == 4: v_permlane16_swap then v_permlane32_swap
+  // After the call, every lane in a partner group holds the fully reduced
+  // value for its own nr-positions. Pass `numElements == 1` to reduce a
+  // scalar accumulator (used by the NR-Small permlane fast-path).
+  void permlaneSwapReduce(ConversionPatternRewriter &rewriter, Location loc,
+                          Value buffer, int64_t numElements, int64_t groupSize,
+                          Type elemType,
+                          BlockwiseBroadcastReduceOp op) const {
+    if (groupSize == 4) {
+      permlaneSwapReduceStep(rewriter, loc, buffer, numElements, elemType,
+                             /*swapWidth=*/16, op);
+    }
+    permlaneSwapReduceStep(rewriter, loc, buffer, numElements, elemType,
+                           /*swapWidth=*/32, op);
+  }
+
   // This function will make a 2d view from a multi-dimensional tensors
   // where one axis needs to be reduced.
   ArrayAttr createInput2DView(Location loc, PatternRewriter &rewriter,
@@ -1189,6 +1249,56 @@ struct BlockwiseReduceRewritePattern
     }
   }
 
+  // Broadcasts fully reduced per-thread values from partialReductionBuffer
+  // into outputReg, replacing the LDS write+barrier+read round-trip when
+  // every lane already holds its own reduced value (single-wave permlane
+  // fast paths). Each outputReg slot reads partialReductionBuffer at the
+  // nrDim index of its (nrIdx, rIdx) cell — the rDim coordinate is
+  // broadcasted, so multiple iter positions map to the same slot.
+  void readReducedResultsFromPrivateBuffer(
+      ConversionPatternRewriter &rewriter, Location loc,
+      Value partialReductionBuffer, TypedValue<MemRefType> outputReg,
+      ArrayAttr inputThreadSubTile2dView) const {
+    Type elemType = cast<MemRefType>(outputReg.getType()).getElementType();
+    constexpr size_t nrDim = 0;
+    constexpr size_t rDim = 1;
+
+    FailureOr<ArrayAttr> maybeInv =
+        invertTransforms(rewriter, loc, inputThreadSubTile2dView);
+    assert(succeeded(maybeInv) &&
+           "inputThreadSubTile2dView must be invertible");
+    ArrayAttr inputThreadSubTile2dViewInv = maybeInv.value();
+
+    ArrayRef<int64_t> threadSubTile2DShape =
+        getLowerShape(inputThreadSubTile2dView);
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+
+    // domain 0 (inputThreadSubTile2dViewInv): lower coord = iter, the 1D
+    //   per-thread index into outputReg.
+    // domain 1 (identity): lower coords = (nrIdx, rIdx).
+    auto loop = TransformingForOp::create(
+        rewriter, loc, ArrayRef<ValueRange>{{zero, zero}, {zero, zero}},
+        ArrayRef<Attribute>{inputThreadSubTile2dViewInv,
+                            rewriter.getArrayAttr({})},
+        /*bounds=*/ArrayRef<int64_t>{threadSubTile2DShape[nrDim],
+                                     threadSubTile2DShape[rDim]},
+        /*strides=*/ArrayRef<int64_t>{1, 1},
+        /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(loop.getBody());
+      Value iter = loop.getLowerCoords(/*domain=*/0)[0];
+      Block::BlockArgListType nrAndRCoords =
+          loop.getLowerCoords(/*domain=*/1);
+      Value nrIdx = nrAndRCoords[nrDim];
+
+      Value reducedVal = InBoundsLoadOp::create(
+          rewriter, loc, elemType, partialReductionBuffer, ValueRange{nrIdx});
+      InBoundsStoreOp::create(rewriter, loc, reducedVal, outputReg,
+                              ValueRange{iter});
+    }
+  }
+
   // Reads fully reduced results from LDS into output (and optional extra
   // output) registers. When withBarrier is true, an LDS barrier is inserted
   // before reading to ensure prior writes are visible to all threads.
@@ -1288,19 +1398,32 @@ struct BlockwiseReduceRewritePattern
 
     int64_t partialR = partialRegTensorShape[rDim];
 
+    // The wave32 cross-lane reduction paths below all rely on
+    // v_permlanex16_var_b32 (variable selector form). This intrinsic is
+    // available on gfx950 (CDNA3, wave32 mode) and gfx12 (RDNA4 / Navi4x).
+    // It is NOT available on gfx11 (RDNA3 / Navi3x) -- only the immediate-
+    // selector form v_permlanex16_b32 exists there. A future ds_swizzle-based
+    // path will be added for gfx11; until then both wave32 permlane gates
+    // must be restricted to architectures that actually expose
+    // permlanex16_var.
+    bool hasPermlaneVar = arch.getValue().contains("gfx950") ||
+                          arch.getValue().contains("gfx12");
+
     // PR2-Permlane: register-only cross-half-wave reduction for partialR=2
-    // on wave32 when nTidPerWave=16 (lanes 0-15 <-> 16-31).
+    // on wave32 when nTidPerWave=16 (lanes 0-15 <-> 16-31). Used in the
+    // NR-Small branch (blockSize > nrDimProd).
     auto [mTidPerWave, nTidPerWave] =
         getPerWaveThreadCounts(op.getTidSubTileSliceView());
     bool has2DThreadLayout = (mTidPerWave > 0 && nTidPerWave > 0);
     bool canUsePermlaneReduce =
-        (has2DThreadLayout && waveSize == 32 &&
+        (has2DThreadLayout && hasPermlaneVar && waveSize == 32 &&
          partialR == 2 && nTidPerWave == 16);
 
-    // SerialPermlane: XOR butterfly reduction via permlanex16_var for
-    // blockSize <= nrDimProd on wave32. Requires power-of-2 rDimSize == mTidPerWave.
+    // SerialPermlane: XOR butterfly reduction via v_permlanex16_var_b32 for
+    // blockSize <= nrDimProd on wave32. Requires power-of-2 rDimSize ==
+    // mTidPerWave. Used in the NR-Large branch.
     bool canUseSerialPermlane = false;
-    if (has2DThreadLayout && waveSize == 32 &&
+    if (has2DThreadLayout && hasPermlaneVar && waveSize == 32 &&
         blockSize <= nonReductionDimSizeProduct) {
       int64_t rDimSize = partialR;
       canUseSerialPermlane = (rDimSize >= 2) &&
@@ -1308,7 +1431,58 @@ struct BlockwiseReduceRewritePattern
                              (rDimSize == mTidPerWave);
     }
 
-    if (!canUsePermlaneReduce && !canUseSerialPermlane) {
+    // Permlane-swap: register-only cross-lane reduction on wave64 (gfx950+)
+    // via v_permlane{16,32}_swap_b32. Active in NR-Large path for
+    // partialR == 2 (one v_permlane32_swap step) or partialR == 4 (one
+    // v_permlane16_swap then one v_permlane32_swap).
+    bool hasPermlaneSwap = arch.getValue().contains("gfx950");
+    bool canUsePermlaneSwapReduce =
+        (has2DThreadLayout && hasPermlaneSwap && waveSize == 64 &&
+         (partialR == 2 || partialR == 4) &&
+         blockSize <= nonReductionDimSizeProduct);
+
+    // NR-Small permlane fast-path eligibility for skipping LDS round-trips.
+    //
+    // Safety constraints (apply to both wave64 and wave32 variants below):
+    //   - Single-wave only (blockSize == waveSize): cross-wave merge would
+    //     still need LDS since permlane primitives don't cross waves.
+    //   - K == 1 (K := inputThreadSubTile2dShape[nrDim]): when K > 1 the
+    //     i-th slot of partialReductionBuffer holds the value for a
+    //     DIFFERENT nr-position, not an rIter slice; substituting the LDS
+    //     read with partialReductionBuffer[i] would mix nr-positions and
+    //     produce incorrect results. With K == 1 each thread has exactly
+    //     one value (its own (nrtid, rtid) cell), and the LDS read becomes
+    //     an identity that we can replace with partialReductionBuffer[0].
+    //   - !extraOut: the extraOut path reads from LDS, so it would race
+    //     against the skipped writes.
+    //
+    // Wave64 variant (gfx950): partialR ∈ {2, 4}, exact thread packing
+    // (nonReductionDimSizeProduct * partialR == waveSize), reduction via
+    // v_permlane{16,32}_swap_b32.
+    bool canUsePermlaneInDPP_LdsSkip = false;
+    if (hasPermlaneSwap && waveSize == 64 && blockSize == waveSize &&
+        blockSize > nonReductionDimSizeProduct &&
+        nonReductionDimSizeProduct > 0 &&
+        llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
+        !op.getExtraOutViewAttr()) {
+      int64_t r = blockSize / nonReductionDimSizeProduct;
+      int64_t K = inputThreadSubTile2dShape[nrDim];
+      if ((r == 2 || r == 4) &&
+          nonReductionDimSizeProduct * r == waveSize &&
+          K == 1 && partialR == r) {
+        canUsePermlaneInDPP_LdsSkip = true;
+      }
+    }
+
+    // Wave32 variant (gfx950 wave32 mode / Navi4x): canUsePermlaneReduce
+    // already skips the upfront LDS write+barrier; this gate additionally
+    // skips the END LDS round-trip when single-wave and !extraOut.
+    bool canUsePermlaneReduceLdsSkip =
+        canUsePermlaneReduce && blockSize == waveSize &&
+        !op.getExtraOutViewAttr();
+
+    if (!canUsePermlaneReduce && !canUseSerialPermlane &&
+        !canUsePermlaneSwapReduce && !canUsePermlaneInDPP_LdsSkip) {
       storePartialReductionstoLDS(rewriter, loc, partialReductionBuffer,
                                   workspaceLDSBuffer, inputBlockSubTile2dView,
                                   inputThreadSubTile2dView, tidSubTileSliceView,
@@ -1318,20 +1492,57 @@ struct BlockwiseReduceRewritePattern
     // Following RAII scope will create reduction loops.
     {
       if (blockSize <= nonReductionDimSizeProduct) {
-        if (canUseSerialPermlane) {
-          // Butterfly reduction in registers via permlanex16_var.
-          // Uses LDS only for final broadcast.
+        if (canUsePermlaneSwapReduce) {
+          // Register-only reduction via v_permlane{16,32}_swap_b32 (gfx950
+          // wave64). After the swap every lane holds the fully reduced
+          // value for its own nr-positions in partialReductionBuffer.
+          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
+          permlaneSwapReduce(rewriter, loc, partialReductionBuffer,
+                             /*numElements=*/nrDimSize,
+                             /*groupSize=*/partialR, elemType, op);
+          if (blockSize == waveSize) {
+            // Single-wave fast path: skip LDS entirely and broadcast across
+            // rDim into outputReg directly from registers.
+            readReducedResultsFromPrivateBuffer(rewriter, loc,
+                                                partialReductionBuffer,
+                                                outputReg,
+                                                inputThreadSubTile2dView);
+          } else {
+            storePartialReductionstoLDS(
+                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
+                inputBlockSubTile2dView, inputThreadSubTile2dView,
+                tidSubTileSliceView, toFlatLDSView);
+            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                      outputReg, inputViewArrayAttr, axis,
+                                      partialRegTensorShape[rDim], tid,
+                                      /*withBarrier=*/true);
+          }
+        } else if (canUseSerialPermlane) {
+          // Butterfly XOR reduction in registers via v_permlanex16_var_b32.
+          // After the butterfly, every lane in the wave holds the fully
+          // reduced value for its own nr-positions in `partialReductionBuffer`.
           int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
           permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
                                nrDimSize, waveSize, elemType, op);
-          storePartialReductionstoLDS(
-              rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
-              inputBlockSubTile2dView, inputThreadSubTile2dView,
-              tidSubTileSliceView, toFlatLDSView);
-          readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                    outputReg, inputViewArrayAttr, axis,
-                                    partialRegTensorShape[rDim], tid,
-                                    /*withBarrier=*/true);
+          if (blockSize == waveSize && !op.getExtraOutViewAttr()) {
+            // Single-wave fast path: skip the END LDS round-trip and
+            // broadcast across rDim into outputReg directly in registers.
+            readReducedResultsFromPrivateBuffer(rewriter, loc,
+                                                partialReductionBuffer,
+                                                outputReg,
+                                                inputThreadSubTile2dView);
+          } else {
+            // Multi-wave (or extraOut active): final broadcast still needs
+            // LDS to redistribute results across threads in different waves.
+            storePartialReductionstoLDS(
+                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
+                inputBlockSubTile2dView, inputThreadSubTile2dView,
+                tidSubTileSliceView, toFlatLDSView);
+            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                      outputReg, inputViewArrayAttr, axis,
+                                      partialRegTensorShape[rDim], tid,
+                                      /*withBarrier=*/true);
+          }
         } else {
         ArrayAttr threadsToTensorTrs = createThreadViewForNRLargerThanThreads(
             loc, partialRegTensorShape, blockSize, rDim, rewriter);
@@ -1440,18 +1651,32 @@ struct BlockwiseReduceRewritePattern
         } // end NR-Large-Tree else
       } else {
         if (canUsePermlaneReduce) {
-          // Register-only reduction for partialR=2 via permlanex16_var.
+          // Register-only cross-half-wave reduction for partialR=2 via
+          // v_permlanex16_var_b32 (lanes 0-15 swap with 16-31). After the
+          // swap every lane holds the fully reduced value for its own
+          // nr-positions in partialReductionBuffer.
           int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
           permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
                                nrDimSize, waveSize, elemType, op);
-          storePartialReductionstoLDS(
-              rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
-              inputBlockSubTile2dView, inputThreadSubTile2dView,
-              tidSubTileSliceView, toFlatLDSView);
-          readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                    outputReg, inputViewArrayAttr, axis,
-                                    partialRegTensorShape[rDim], tid,
-                                    /*withBarrier=*/true);
+          if (canUsePermlaneReduceLdsSkip) {
+            // Single-wave fast path: skip the END LDS round-trip and
+            // broadcast across rDim into outputReg directly from registers.
+            readReducedResultsFromPrivateBuffer(rewriter, loc,
+                                                partialReductionBuffer,
+                                                outputReg,
+                                                inputThreadSubTile2dView);
+          } else {
+            // Multi-wave (or extraOut active): final broadcast still needs
+            // LDS to redistribute results across threads in different waves.
+            storePartialReductionstoLDS(
+                rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
+                inputBlockSubTile2dView, inputThreadSubTile2dView,
+                tidSubTileSliceView, toFlatLDSView);
+            readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                      outputReg, inputViewArrayAttr, axis,
+                                      partialRegTensorShape[rDim], tid,
+                                      /*withBarrier=*/true);
+          }
         } else {
         // This means there are more threads than elements to be reduced.
         ArrayAttr threadToTensorViewTrs =
@@ -1492,9 +1717,23 @@ struct BlockwiseReduceRewritePattern
                          (maxActiveReductionThreads <= waveSize) &&
                          (blockSize == maxActiveReductionThreads *
                                            nonReductionDimSizeProduct);
-        // DPP: rtid = tid % cluster. Tree: rtid = tid / nrDimProd.
+        // Permlane fast-path eligibility (gfx950 wave64): single-wave with
+        // rthreads ∈ {2, 4} and exact thread packing
+        // (nrDimProd * rthreads == waveSize). Partner lanes are 16/32 apart,
+        // so this uses the tree-style rtid layout below.
+        bool canUsePermlaneInDPP =
+            hasPermlaneSwap && waveSize == 64 && blockSize == waveSize &&
+            llvm::isPowerOf2_64(maxActiveReductionThreads) &&
+            (maxActiveReductionThreads == 2 ||
+             maxActiveReductionThreads == 4) &&
+            llvm::isPowerOf2_64(nonReductionDimSizeProduct) &&
+            nonReductionDimSizeProduct * maxActiveReductionThreads == waveSize;
+        // The early LDS-skip prediction must remain consistent with the
+        // runtime eligibility check.
+        assert(!canUsePermlaneInDPP_LdsSkip || canUsePermlaneInDPP);
+        // DPP: rtid = tid % cluster. Tree/Permlane: rtid = tid / nrDimProd.
         Value rtid, nrtid;
-        if (canUseDPP) {
+        if (canUseDPP && !canUsePermlaneInDPP) {
           assert(llvm::isPowerOf2_64(clusterSize) &&
                  "clusterSize must be power of 2");
           unsigned log2ClusterSize = llvm::Log2_64(clusterSize);
@@ -1523,10 +1762,13 @@ struct BlockwiseReduceRewritePattern
           }
         }
 
-        // Threadwise reduction accumulator (used by both paths when rIterDim>1)
+        // Threadwise reduction accumulator (populated only when rIterDim > 1).
+        // Under the LDS-skip gate (K == 1) rIter span is also 1, so this loop
+        // never runs on the LDS-skip path.
         Value accReg;
         bool hasThreadwiseReduction = threadViewShape[rIterDim] > 1;
-
+        assert(!(canUsePermlaneInDPP_LdsSkip && hasThreadwiseReduction) &&
+               "LDS-skip gate (K==1) implies rIter==1");
         if (hasThreadwiseReduction) {
           int64_t localIterVectorLen = rIterVectorLen;
           Type loadTypeInputReg =
@@ -1563,7 +1805,107 @@ struct BlockwiseReduceRewritePattern
           }
         }
 
-        if (canUseDPP) {
+        if (canUsePermlaneInDPP) {
+          // Permlane fast-path (gfx950 wave64): replaces the DPP/subgroup
+          // cross-lane reduction with v_permlane{16,32}_swap_b32 over a
+          // scalar accumulator.
+          //
+          //  1. Populate localAccReg with the per-thread input value
+          //     (from accReg if threadwise-reduced, else from
+          //      partialReductionBuffer[0] under LDS-skip, else from LDS).
+          //  2. Reduce across partner groups via permlane swap.
+          //  3a. Under LDS-skip: write the result back to
+          //      partialReductionBuffer[0] for the register-only broadcast.
+          //  3b. Otherwise: leader writes to LDS so the standard
+          //      readReducedResultsFromLDS can broadcast it.
+          Value localAccReg = accReg;
+          if (!hasThreadwiseReduction) {
+            Type accRegType = MemRefType::get({1}, elemType, AffineMap{},
+                                              privateMemoryAddressSpace);
+            localAccReg = GpuAllocOp::create(rewriter, loc, accRegType);
+
+            if (canUsePermlaneInDPP_LdsSkip) {
+              // K == 1 under the LDS-skip gate; the single value lives at
+              // partialReductionBuffer[0].
+              Value loadVal = InBoundsLoadOp::create(
+                  rewriter, loc, elemType, partialReductionBuffer,
+                  zeroConstantOp);
+              InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                      zeroConstantOp);
+            } else {
+              SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
+              SmallVector<int64_t> bounds{1, 1, 1};
+              SmallVector<int64_t> strides{1, 1, 1};
+
+              TransformingForOp loadLoop = TransformingForOp::create(
+                  rewriter, loc, ArrayRef<ValueRange>(inits),
+                  ArrayRef<Attribute>{threadToLDSViewTrs},
+                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+              {
+                PatternRewriter::InsertionGuard guard(rewriter);
+                rewriter.setInsertionPointToStart(loadLoop.getBody());
+                Block::BlockArgListType LDSCoords =
+                    loadLoop.getLowerCoords(/*domain=*/0);
+                Value loadVal = InBoundsLoadOp::create(
+                    rewriter, loc, elemType, workspaceLDSBuffer, LDSCoords);
+                InBoundsStoreOp::create(rewriter, loc, loadVal, localAccReg,
+                                        zeroConstantOp);
+              }
+            }
+          }
+
+          // After this call every lane in a partner group has the fully
+          // reduced value for its nrtid in localAccReg[0].
+          permlaneSwapReduce(rewriter, loc, localAccReg, /*numElements=*/1,
+                             /*groupSize=*/maxActiveReductionThreads, elemType,
+                             op);
+
+          if (canUsePermlaneInDPP_LdsSkip) {
+            // END LDS-skip: write into partialReductionBuffer[0] so
+            // readReducedResultsFromPrivateBuffer can broadcast from
+            // registers — no LDS write, no barrier, no LDS read.
+            Value reduced = InBoundsLoadOp::create(
+                rewriter, loc, elemType, localAccReg, zeroConstantOp);
+            InBoundsStoreOp::create(rewriter, loc, reduced,
+                                    partialReductionBuffer, zeroConstantOp);
+          } else {
+            // Leader (rtid == 0) writes the reduced value to LDS for the
+            // standard readReducedResultsFromLDS broadcast path.
+            SmallVector<Value, 4> storeInits{nrtid, rtid, zeroConstantOp};
+            SmallVector<int64_t> storeBounds{1, 1, 1};
+            SmallVector<int64_t> storeStrides{1, 1, 1};
+
+            TransformingForOp storeLoop = TransformingForOp::create(
+                rewriter, loc, ArrayRef<ValueRange>(storeInits),
+                ArrayRef<Attribute>{threadToLDSViewTrs},
+                ArrayRef<int64_t>(storeBounds),
+                ArrayRef<int64_t>(storeStrides),
+                /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+            {
+              PatternRewriter::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToStart(storeLoop.getBody());
+              Block::BlockArgListType LDSCoords =
+                  storeLoop.getLowerCoords(/*domain=*/0);
+              Value zeroIdx =
+                  arith::ConstantIndexOp::create(rewriter, loc, 0);
+              Value isLeader = arith::CmpIOp::create(
+                  rewriter, loc, arith::CmpIPredicate::eq, rtid, zeroIdx);
+              scf::IfOp ifStore = scf::IfOp::create(
+                  rewriter, loc, isLeader, /*withElseRegion=*/false);
+              {
+                PatternRewriter::InsertionGuard storeGuard(rewriter);
+                rewriter.setInsertionPointToStart(ifStore.thenBlock());
+                Value valToStore = InBoundsLoadOp::create(
+                    rewriter, loc, elemType, localAccReg, zeroConstantOp);
+                InBoundsStoreOp::create(rewriter, loc, valToStore,
+                                        workspaceLDSBuffer, LDSCoords);
+              }
+            }
+            LDSBarrierOp::create(rewriter, loc);
+          }
+
+        } else if (canUseDPP) {
           SmallVector<Value, 4> inits{nrtid, rtid, zeroConstantOp};
           SmallVector<int64_t> bounds{1, 1, 1};
           SmallVector<int64_t> strides{1, 1, 1};
@@ -1694,10 +2036,19 @@ struct BlockwiseReduceRewritePattern
             LDSBarrierOp::create(rewriter, loc);
           }
         }
-        readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
-                                  outputReg, inputViewArrayAttr, axis,
-                                  partialRegTensorShape[rDim], tid,
-                                  /*withBarrier=*/false);
+        if (canUsePermlaneInDPP_LdsSkip) {
+          // END LDS-skip: broadcast from partialReductionBuffer (populated
+          // by the permlane fast-path above), bypassing the LDS round-trip.
+          readReducedResultsFromPrivateBuffer(rewriter, loc,
+                                              partialReductionBuffer,
+                                              outputReg,
+                                              inputThreadSubTile2dView);
+        } else {
+          readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                    outputReg, inputViewArrayAttr, axis,
+                                    partialRegTensorShape[rDim], tid,
+                                    /*withBarrier=*/false);
+        }
         }
       }
       rewriter.eraseOp(op);
@@ -1714,7 +2065,8 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
     writeAllTarget.addLegalDialect<arith::ArithDialect, rock::RockDialect,
                                    memref::MemRefDialect, scf::SCFDialect,
                                    vector::VectorDialect, AffineDialect,
-                                   gpu::GPUDialect, ROCDL::ROCDLDialect>();
+                                   gpu::GPUDialect, LLVM::LLVMDialect,
+                                   ROCDL::ROCDLDialect>();
     writeAllTarget.addLegalOp<gpu::PrintfOp>();
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -779,7 +779,6 @@ struct BlockwiseReduceRewritePattern
                             int64_t nrDimSize, int64_t waveSize, Type elemType,
                             BlockwiseBroadcastReduceOp op) const {
     auto i32Type = rewriter.getI32Type();
-    Type wideType = get32BitType(rewriter, elemType);
     Value lane = arith::RemUIOp::create(
         rewriter, loc, tid,
         arith::ConstantIndexOp::create(rewriter, loc, waveSize));
@@ -792,14 +791,9 @@ struct BlockwiseReduceRewritePattern
       Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value myVal = InBoundsLoadOp::create(rewriter, loc, elemType,
                                            partialReductionBuffer, idx);
-      Value myWide = widenTo32Bit(rewriter, loc, myVal);
-      Value myValI32 = arith::BitcastOp::create(rewriter, loc, i32Type, myWide);
-      Value resultI32 = ROCDL::PermlaneX16VarOp::create(
-          rewriter, loc, i32Type, myValI32, myValI32, laneIdxInHalf,
-          /*fi=*/false, /*boundControl=*/false);
-      Value partnerWide =
-          arith::BitcastOp::create(rewriter, loc, wideType, resultI32);
-      Value partnerVal = narrowFrom32Bit(rewriter, loc, partnerWide, elemType);
+      Value partnerVal = amdgpu::PermlaneVarOp::create(
+          rewriter, loc, elemType, myVal, laneIdxInHalf,
+          /*cross=*/true, /*fetch_inactive=*/false, /*bound_ctrl=*/false);
       Value reduced = createReducingOp(op, partnerVal, myVal, rewriter);
       InBoundsStoreOp::create(rewriter, loc, reduced, partialReductionBuffer,
                               idx);
@@ -1527,8 +1521,6 @@ struct BlockwiseReduceRewritePattern
 
     int64_t partialR = partialRegTensorShape[rDim];
 
-    // === Wave32 capability flags ===
-    //
     // v_permlanex16_var_b32 (variable selector): gfx950, gfx12 (Navi4x).
     // NOT available on gfx11 (Navi3x) which only has the immediate form.
     bool hasPermlaneVar =
@@ -1546,7 +1538,6 @@ struct BlockwiseReduceRewritePattern
     bool has2DThreadLayout = (mTidPerWave > 0 && nTidPerWave > 0);
 
     // === Wave32 NR-Small gates (blockSize > nrDimProd) ===
-    //
     // Cross-half-wave reduction for partialR=2 on wave32 when
     // nTidPerWave=16 (lanes 0-15 <-> 16-31).
     // - canUsePermlaneX16Var_NRSmall: via v_permlanex16_var (gfx950/gfx12)
@@ -1559,7 +1550,6 @@ struct BlockwiseReduceRewritePattern
          nTidPerWave == 16);
 
     // === Wave32 NR-Large gates (blockSize <= nrDimProd) ===
-    //
     // Single cross-half-wave reduction restricted to partialR == 2
     // (== mTidPerWave on WMMA wave32): one swap step is sufficient
     // for a 2-way reduction only.

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -34,6 +34,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Rock/IR/AccelEmitter.h"
 #include "mlir/Dialect/Rock/utility/LdsTransposeLoad.h"
@@ -711,6 +712,66 @@ struct BlockwiseReduceRewritePattern
     return dimProduct;
   }
 
+  // Extract per-wave thread counts from the tid slice view by looking for
+  // "m_tid" and "n_tid" named dimensions in the Merge transform that
+  // decomposes "tid". Works for both WMMA and MFMA architectures.
+  static std::pair<int64_t, int64_t>
+  getPerWaveThreadCounts(ArrayAttr tidSliceView) {
+    if (tidSliceView.empty())
+      return {0, 0};
+    TransformMapAttr firstMap = cast<TransformMapAttr>(tidSliceView[0]);
+    for (TransformAttr tr : firstMap.getOps()) {
+      if (tr.getType() != TransformType::Merge)
+        continue;
+      ArrayRef<StringRef> lowerNames = tr.getLowerNames();
+      ArrayRef<int64_t> params = tr.getParams();
+      int64_t mTid = 0, nTid = 0;
+      for (auto [name, param] : llvm::zip(lowerNames, params)) {
+        if (name == "m_tid")
+          mTid = param;
+        else if (name == "n_tid")
+          nTid = param;
+      }
+      if (mTid > 0 && nTid > 0)
+        return {mTid, nTid};
+    }
+    return {0, 0};
+  }
+
+  // Register-only cross-half-wave reduction using v_permlanex16_var_b32.
+  // Each lane exchanges its value with the corresponding lane in the other
+  // half-wave (lane i <-> lane i+16) and reduces. Requires wave32 (RDNA).
+  void permlaneX16VarReduce(ConversionPatternRewriter &rewriter, Location loc,
+                            Value partialReductionBuffer, Value tid,
+                            int64_t nrDimSize, int64_t waveSize,
+                            Type elemType,
+                            BlockwiseBroadcastReduceOp op) const {
+    auto i32Type = rewriter.getI32Type();
+    Value lane = arith::RemUIOp::create(
+        rewriter, loc, tid,
+        arith::ConstantIndexOp::create(rewriter, loc, waveSize));
+    Value laneI32 = arith::IndexCastOp::create(rewriter, loc, i32Type, lane);
+    Value laneIdxInHalf = arith::AndIOp::create(
+        rewriter, loc, laneI32,
+        arith::ConstantIntOp::create(rewriter, loc, i32Type, 15));
+
+    for (int64_t i = 0; i < nrDimSize; i++) {
+      Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
+      Value myVal = InBoundsLoadOp::create(rewriter, loc, elemType,
+                                           partialReductionBuffer, idx);
+      Value myValI32 =
+          arith::BitcastOp::create(rewriter, loc, i32Type, myVal);
+      Value resultI32 = ROCDL::PermlaneX16VarOp::create(
+          rewriter, loc, i32Type, myValI32, myValI32, laneIdxInHalf,
+          /*fi=*/false, /*boundControl=*/false);
+      Value partnerVal =
+          arith::BitcastOp::create(rewriter, loc, elemType, resultI32);
+      Value reduced = createReducingOp(op, partnerVal, myVal, rewriter);
+      InBoundsStoreOp::create(rewriter, loc, reduced,
+                              partialReductionBuffer, idx);
+    }
+  }
+
   // This function will make a 2d view from a multi-dimensional tensors
   // where one axis needs to be reduced.
   ArrayAttr createInput2DView(Location loc, PatternRewriter &rewriter,
@@ -1228,16 +1289,36 @@ struct BlockwiseReduceRewritePattern
     StringAttr arch = rock::getArchValue(op);
     int64_t waveSize = rock::lookupArchInfo(arch).waveSize;
 
-    storePartialReductionstoLDS(rewriter, loc, partialReductionBuffer,
-                                workspaceLDSBuffer, inputBlockSubTile2dView,
-                                inputThreadSubTile2dView, tidSubTileSliceView,
-                                toFlatLDSView);
-    LDSBarrierOp::create(rewriter, loc);
+    // Permlane-reduce: register-only cross-half-wave reduction using
+    // v_permlanex16_var_b32 (GFX12+). Avoids the initial LDS store+barrier
+    // by performing reduction directly in registers before writing to LDS.
+    int64_t partialR = partialRegTensorShape[rDim];
+    bool canUsePermlaneReduce =
+        (waveSize == 32 && partialR == 2);
+
+    if (!canUsePermlaneReduce) {
+      storePartialReductionstoLDS(rewriter, loc, partialReductionBuffer,
+                                  workspaceLDSBuffer, inputBlockSubTile2dView,
+                                  inputThreadSubTile2dView, tidSubTileSliceView,
+                                  toFlatLDSView);
+      LDSBarrierOp::create(rewriter, loc);
+    }
     // Following RAII scope will create reduction loops.
     {
       if (blockSize <= nonReductionDimSizeProduct) {
-        // This means there aren't enough threads to do a parallel reduction
-        // each individual thread could do its own reduction.
+        if (canUsePermlaneReduce) {
+          int64_t nrDimSize = inputThreadSubTile2dShape[nrDim];
+          permlaneX16VarReduce(rewriter, loc, partialReductionBuffer, tid,
+                               nrDimSize, waveSize, elemType, op);
+          storePartialReductionstoLDS(
+              rewriter, loc, partialReductionBuffer, workspaceLDSBuffer,
+              inputBlockSubTile2dView, inputThreadSubTile2dView,
+              tidSubTileSliceView, toFlatLDSView);
+          readReducedResultsFromLDS(rewriter, loc, op, workspaceLDSBuffer,
+                                    outputReg, inputViewArrayAttr, axis,
+                                    partialRegTensorShape[rDim], tid,
+                                    /*withBarrier=*/true);
+        } else {
         ArrayAttr threadsToTensorTrs = createThreadViewForNRLargerThanThreads(
             loc, partialRegTensorShape, blockSize, rDim, rewriter);
         ArrayAttr threadToLDSViewTrs =
@@ -1342,6 +1423,7 @@ struct BlockwiseReduceRewritePattern
                                   outputReg, inputViewArrayAttr, axis,
                                   partialRegTensorShape[rDim], tid,
                                   /*withBarrier=*/true);
+        } // end NR-Large-Tree else
       } else {
         // This means there are more threads than elements to be reduced.
         ArrayAttr threadToTensorViewTrs =
@@ -1609,7 +1691,7 @@ void RockLowerBlockwiseGemmToThreadwisePass::runOnOperation() {
     writeAllTarget.addLegalDialect<arith::ArithDialect, rock::RockDialect,
                                    memref::MemRefDialect, scf::SCFDialect,
                                    vector::VectorDialect, AffineDialect,
-                                   gpu::GPUDialect>();
+                                   gpu::GPUDialect, ROCDL::ROCDLDialect>();
     writeAllTarget.addLegalOp<gpu::PrintfOp>();
     RewritePatternSet writeAllPatterns(ctx);
     writeAllPatterns

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -1953,41 +1953,42 @@ struct BlockwiseReduceRewritePattern
           //
           // DPP path: rtid = tid % clusterSize, nrtid = tid / clusterSize.
           //   SubgroupReduceOp uses DPP lane-swizzle within a cluster, so
-          //   consecutive lanes must be reduction partners. Packing rtid into
-          //   the low bits achieves this.
+          //   consecutive lanes must be reduction partners. Packing rtid
+          //   into the low bits achieves this.
           //
           // Tree / permlane / ds_swizzle paths:
           //   rtid = tid / nrDimProd, nrtid = tid % nrDimProd.
-          //   storePartialReductionstoLDS lays out data as
-          //   flat = k * nrDimProd + nrtid, so threads with the same nrtid
-          //   (consecutive in the low bits) share the same non-reduction
-          //   position. Permlane swap and ds_swizzle intrinsics exchange
-          //   lanes at fixed distances (16/32), which aligns with rtid
-          //   occupying the high bits of tid.
+          //   Permlane swap and ds_swizzle intrinsics exchange lanes at
+          //   fixed distances (16/32), which aligns with rtid occupying
+          //   the high bits of tid.
           //
-          // Both factorings are correct because each path's cross-lane
-          // primitive matches its own bit layout within tid.
+          // The DPP factoring differs from tidSubTileSliceView's mapping
+          // of tid, which storePartialReductionstoLDS uses to place each
+          // thread's partial into flat LDS. This is correct because:
+          //  - Both the store (via toFlatLDSView) and the DPP read (via
+          //    threadToLDSViewTrs) address the same row-major flat LDS
+          //    array: flat = nrDim * rDimSize + rDim.
+          //  - The store writes one value per (nrDim, rDim) slot using
+          //    coords from tidSubTileSliceView; the DPP read accesses
+          //    fixed flat positions via (nrtid, rtid, rIter) coords.
+          //  - The DPP read does not assume which thread stored a given
+          //    slot — it simply reads the value at each flat address.
+          //  - Complete coverage is guaranteed: tidSubTileSliceView covers
+          //    all rDim positions and the iter subtile covers all nrDim
+          //    positions, so every (nrDim, rDim) slot is written by at
+          //    least one thread with valid (in-bounds) data.
+          //    The DPP read covers every rDim position per nrtid row
+          //    (clusterSize * rDimPerRThread == rDimSize).
           Value rtid, nrtid;
           if (canUseDPP && !canUsePermlaneSwap_NRSmall &&
               !canUseDsSwizzleBpermute_NRSmall) {
             assert(llvm::isPowerOf2_64(clusterSize) &&
                    "clusterSize must be power of 2");
-            // Correctness invariant: SubgroupReduceOp uses DPP lane-swizzle
-            // which reduces consecutive hardware lanes [0..cluster-1],
-            // [cluster..2*cluster-1], etc. Packing rtid into the low bits
-            // of tid (rtid = tid & (cluster-1)) ensures threads in the same
-            // DPP cluster hold different reduction positions (rtid) for the
-            // same non-reduction position (nrtid). This is valid because:
-            //  - clusterSize == maxActiveReductionThreads (power-of-2 gate)
-            //  - clusterSize * nrDimProd == blockSize (exact packing gate)
-            //  - threadToLDSViewTrs maps (nrtid, rtid, rIter) → LDS, and
-            //    both the initial store and DPP load use the same view.
-            // NB: this factoring is independent of tidSubTileSliceView,
-            // which controls NR-Large and early LDS-skip logic only.
-            assert(clusterSize == maxActiveReductionThreads &&
-                   "DPP cluster must equal active reduction threads");
-            assert(clusterSize * nonReductionDimSizeProduct == blockSize &&
-                   "DPP factoring requires exact thread packing");
+            // The DPP read uses threadToLDSViewTrs with (nrtid, rtid, rIter)
+            // coords — a different decomposition of the same flat array
+            // that the store populated via tidSubTileSliceView.
+            // This is safe: the DPP read addresses fixed flat positions and
+            // does not care which thread stored each value.
             unsigned log2ClusterSize = llvm::Log2_64(clusterSize);
             Value shiftAmt =
                 arith::ConstantIndexOp::create(rewriter, loc, log2ClusterSize);

--- a/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/Transforms/CMakeLists.txt
@@ -72,6 +72,7 @@ add_rocmlir_dialect_library(MLIRRockTransforms
   MLIRRockUtility
   MLIRExecutionEngineUtils
   MLIRSCFTransforms
+  MLIRAMDGPUDialect
   MLIRAMDGPUUtils
   MLIRSCFToControlFlow
   MLIRSupport

--- a/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/cdna/attention_cross_lane_ds_swizzle.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/cdna/attention_cross_lane_ds_swizzle.mlir
@@ -1,0 +1,39 @@
+// Verify ds_swizzle + ds_bpermute cross-lane reduction for f16/i8 attention
+// on CDNA wave64 (gfx908/MI100, gfx90a/MI250, gfx942/MI300).
+// Two partialR variants:
+//   partialR=4 (mfma 16x16): ds_swizzle(XOR 16) + ds_bpermute(XOR 32)
+//   partialR=2 (mfma 32x32): ds_bpermute(XOR 32) only
+// Each case checks IR intrinsics and correctness [1 1 1].
+// Problem: g=1 q=77 k=77 d=64.
+
+// --- f16 partialR=4: ds_swizzle + ds_bpermute ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_F16_4WAY_IR
+// CHECK_F16_4WAY_IR-DAG: amdgpu.swizzle_bitmode
+// CHECK_F16_4WAY_IR-DAG: rocdl.ds_bpermute
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_F16_4WAY
+// CHECK_F16_4WAY: [1 1 1]
+
+// --- f16 partialR=2: ds_bpermute only ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,4,32,32,32,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_F16_2WAY_IR
+// CHECK_F16_2WAY_IR: rocdl.ds_bpermute
+// CHECK_F16_2WAY_IR-NOT: amdgpu.swizzle_bitmode
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,4,32,32,32,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_F16_2WAY
+// CHECK_F16_2WAY: [1 1 1]
+
+// --- i8 partialR=4: ds_swizzle + ds_bpermute ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,8,16,16,16,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_I8_4WAY_IR
+// CHECK_I8_4WAY_IR-DAG: amdgpu.swizzle_bitmode
+// CHECK_I8_4WAY_IR-DAG: rocdl.ds_bpermute
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,8,16,16,16,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_I8_4WAY
+// CHECK_I8_4WAY: [1 1 1]
+
+// --- i8 partialR=2: ds_bpermute only ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,8,32,32,32,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_I8_2WAY_IR
+// CHECK_I8_2WAY_IR: rocdl.ds_bpermute
+// CHECK_I8_2WAY_IR-NOT: amdgpu.swizzle_bitmode
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,8,32,32,32,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_I8_2WAY
+// CHECK_I8_2WAY: [1 1 1]

--- a/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/cdna/attention_cross_lane_permlane_swap.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/cdna/attention_cross_lane_permlane_swap.mlir
@@ -1,0 +1,38 @@
+// Verify permlane-swap cross-lane reduction for f16/i8 attention on gfx950.
+// Two partialR variants:
+//   partialR=4 (mfma 16x16): v_permlane16_swap + v_permlane32_swap
+//   partialR=2 (mfma 32x32): v_permlane32_swap only
+// Each case checks IR intrinsics and correctness [1 1 1].
+// Problem: g=1 q=77 k=77 d=64.
+
+// --- f16 partialR=4: permlane16_swap + permlane32_swap ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_F16_4WAY_IR
+// CHECK_F16_4WAY_IR-DAG: rocdl.permlane16.swap
+// CHECK_F16_4WAY_IR-DAG: rocdl.permlane32.swap
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_F16_4WAY
+// CHECK_F16_4WAY: [1 1 1]
+
+// --- f16 partialR=2: permlane32_swap only ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,4,32,32,32,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_F16_2WAY_IR
+// CHECK_F16_2WAY_IR: rocdl.permlane32.swap
+// CHECK_F16_2WAY_IR-NOT: rocdl.permlane16.swap
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,4,32,32,32,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_F16_2WAY
+// CHECK_F16_2WAY: [1 1 1]
+
+// --- i8 partialR=4: permlane16_swap + permlane32_swap ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,8,16,16,16,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_I8_4WAY_IR
+// CHECK_I8_4WAY_IR-DAG: rocdl.permlane16.swap
+// CHECK_I8_4WAY_IR-DAG: rocdl.permlane32.swap
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,8,16,16,16,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_I8_4WAY
+// CHECK_I8_4WAY: [1 1 1]
+
+// --- i8 partialR=2: permlane32_swap only ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,8,32,32,32,4,1,2,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_I8_2WAY_IR
+// CHECK_I8_2WAY_IR: rocdl.permlane32.swap
+// CHECK_I8_2WAY_IR-NOT: rocdl.permlane16.swap
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:32,32,32,8,32,32,32,4,1,2,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_I8_2WAY
+// CHECK_I8_2WAY: [1 1 1]

--- a/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/cdna/lit.local.cfg
+++ b/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/cdna/lit.local.cfg
@@ -1,2 +1,8 @@
 if not (hasattr(config, 'arch_support_mfma') and config.arch_support_mfma):
   config.unsupported = True
+
+if hasattr(config, 'arch') and config.arch:
+    if 'gfx950' in config.arch:
+        config.excludes = ['attention_cross_lane_ds_swizzle.mlir']
+    else:
+        config.excludes = ['attention_cross_lane_permlane_swap.mlir']

--- a/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/rdna/attention_cross_lane_ds_swizzle_w32.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/rdna/attention_cross_lane_ds_swizzle_w32.mlir
@@ -1,0 +1,18 @@
+// Verify ds_swizzle wave32 cross-lane reduction for f16/i8 attention on
+// RDNA3 (gfx11xx). Uses ds_swizzle_b32 XOR=16 to swap lanes 0-15 <-> 16-31.
+// Each case checks: (1) amdgpu.swizzle_bitmode in IR, (2) correctness [1 1 1].
+// Problem: g=1 q=77 k=77 d=64.
+
+// --- f16 ds_swizzle wave32 ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_F16_IR
+// CHECK_F16_IR: amdgpu.swizzle_bitmode
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_F16
+// CHECK_F16: [1 1 1]
+
+// --- i8 ds_swizzle wave32 ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_I8_IR
+// CHECK_I8_IR: amdgpu.swizzle_bitmode
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_I8
+// CHECK_I8: [1 1 1]

--- a/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/rdna/attention_cross_lane_permlane_var.mlir
+++ b/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/rdna/attention_cross_lane_permlane_var.mlir
@@ -1,0 +1,18 @@
+// Verify permlanex16_var cross-lane reduction for f16/i8 attention on
+// RDNA4 (gfx12xx). Uses v_permlanex16_var_b32 with cross=true.
+// Each case checks: (1) amdgpu.permlane_var in IR, (2) correctness [1 1 1].
+// Problem: g=1 q=77 k=77 d=64.
+
+// --- f16 permlanex16_var ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_F16_IR
+// CHECK_F16_IR: amdgpu.permlane_var {{.*}} {cross = true}
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_F16
+// CHECK_F16: [1 1 1]
+
+// --- i8 permlanex16_var ---
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" | rocmlir-driver --kernel-pipeline=gpu | FileCheck %s --check-prefix=CHECK_I8_IR
+// CHECK_I8_IR: amdgpu.permlane_var {{.*}} {cross = true}
+
+// RUN: rocmlir-gen --arch %arch --operation attention -t i8 -num_heads_q 1 -seq_len_q 77 -seq_len_k 77 -head_dim_qk 64 -head_dim_v 64 --perf_config "attn:v3:16,16,16,4,16,16,16,4,1,1,2,0,1" -rand 1 -rand_type int -pv -relDiff_threshold 0.02 -RMS_threshold 0.015 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix=CHECK_I8
+// CHECK_I8: [1 1 1]

--- a/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/rdna/lit.local.cfg
+++ b/mlir/test/Dialect/Rock/integration/reduce/blockwise_reduce/rdna/lit.local.cfg
@@ -1,2 +1,8 @@
 if not (hasattr(config, 'arch_support_wmma') and config.arch_support_wmma):
   config.unsupported = True
+
+if hasattr(config, 'arch') and config.arch:
+    if 'gfx12' in config.arch:
+        config.excludes = ['attention_cross_lane_ds_swizzle_w32.mlir']
+    else:
+        config.excludes = ['attention_cross_lane_permlane_var.mlir']

--- a/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
+++ b/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
@@ -1,0 +1,987 @@
+// RUN: rocmlir-opt -rock-blockwise-gemm-to-threadwise -split-input-file %s | FileCheck %s --check-prefixes=CHECK
+
+#map4 = affine_map<(d0, d1) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 * 8 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 8, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [256, 32] -> [1, 8, 2, 16, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 8, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 8, 2, 16, 4, 1, 8] -> [64, 128]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 128] -> [128, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 8, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [256] -> [1, 8, 2, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{8, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 8, 2, 16] -> [2, 128]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 128] -> [2, 128]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 128] -> [2, 128]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 128] -> [128, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx1201 (RDNA4 wave32): NR-Small PermlaneX16Var LDS-skip path
+// m_tid=2, n_tid=16, blockSize=256 > nrDimProd=64 => NR-Small
+// partialR=2, K=1 => canUsePermlaneX16Var_NRSmall_LdsSkip
+
+// CHECK-LABEL: func @test_permlane_nrsmall_ldsskip_gfx1201
+
+// Threadwise partial reduction loop
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-half-wave reduction via permlanex16_var
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK-NEXT: rocdl.permlanex16.var
+// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK-NEXT: arith.maxnumf
+
+// No LDS barriers (full LDS-skip path)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback to output
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf32, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlane_nrsmall_ldsskip_gfx1201(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<256xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1201",
+               block_size = 256 : i32, grid_size = 36 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 256 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<256xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16, d1 floordiv 16, (d1 mod 16) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 * 4 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 16, (d0 mod 16) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 4, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 2, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [128, 64] -> [1, 4, 2, 16, 4, 2, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{2, 4, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 4, 2, 16, 4, 2, 8] -> [64, 128]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 128] -> [128, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 4, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [128] -> [1, 4, 2, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{4, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 4, 2, 16] -> [2, 64]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 64] -> [2, 64]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 64] -> [2, 64]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 64] -> [64, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 2, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [64] -> [4, 2, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 2, 8] -> [32, 2]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{2} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 2] -> [2, 32]>
+
+// gfx1201 (RDNA4 wave32): NR-Large PermlaneX16Var path
+// m_tid=2, n_tid=16, blockSize=128 <= nrDimProd=128 => NR-Large
+// partialR=2 == mTidPerWave=2 => canUsePermlaneX16Var_NRLarge
+
+// CHECK-LABEL: func @test_permlane_nrlarge_gfx1201
+
+// Threadwise partial reduction loop
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-half-wave reduction via permlanex16_var (2 elements in nrDim)
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK-NEXT: rocdl.permlanex16.var
+// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK-NEXT: arith.maxnumf
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK-NEXT: rocdl.permlanex16.var
+// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK-NEXT: arith.maxnumf
+
+// No LDS barriers (register-only path)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback to output
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlane_nrlarge_gfx1201(
+    %input_reg : memref<64xf32, #gpu.address_space<private>>,
+    %output_reg : memref<64xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<256xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1201",
+               block_size = 128 : i32, grid_size = 36 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 128 : i32} : memref<64xf32, #gpu.address_space<private>> using memref<256xf32, #gpu.address_space<workgroup>> into memref<64xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 8 + d6) * 2 + d2, (d5 * 8 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 8, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [256, 32] -> [1, 8, 2, 16, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 8, 2} ["rep_i", "wave_m", "item_i", "m_tid"] at [4, 0, 6, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 8, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 8, 2, 16, 4, 1, 8] -> [64, 128]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 128] -> [128, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 8, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [256] -> [1, 8, 2, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{8, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 8, 2, 16] -> [2, 128]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 128] -> [2, 128]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 128] -> [2, 128]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 128] -> [128, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx1100 (RDNA3 wave32): NR-Small DsSwizzle XOR=16 LDS-skip path
+// m_tid=2, n_tid=16, blockSize=256 > nrDimProd => NR-Small
+// gfx11 lacks permlanex16_var => ds_swizzle XOR=16
+// partialR=2, K=1 => canUseDsSwizzleW32_NRSmall_LdsSkip
+
+// CHECK-LABEL: func @test_dsswizzle_nrsmall_ldsskip_gfx1100
+
+// Threadwise partial reduction
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-half-wave reduction via ds_swizzle (XOR=16)
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK-NEXT: rocdl.ds_swizzle %{{.*}}
+// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK-NEXT: arith.maxnumf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsswizzle_nrsmall_ldsskip_gfx1100(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<256xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1100",
+               block_size = 256 : i32, grid_size = 36 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 256 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<256xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16, d1 floordiv 16, (d1 mod 16) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 8 + d6) * 2 + d2, (d5 * 4 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 16, (d0 mod 16) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 4, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 2, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [128, 64] -> [1, 4, 2, 16, 4, 2, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 8, 2} ["rep_i", "wave_m", "item_i", "m_tid"] at [4, 0, 6, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2, 4, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 4, 2, 16, 4, 2, 8] -> [64, 128]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 128] -> [128, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 4, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [128] -> [1, 4, 2, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{4, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 4, 2, 16] -> [2, 64]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 64] -> [2, 64]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 64] -> [2, 64]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 64] -> [64, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 2, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [64] -> [4, 2, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 2, 8] -> [32, 2]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{2} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 2] -> [2, 32]>
+
+// gfx1100 (RDNA3 wave32): NR-Large DsSwizzle XOR=16 path
+// m_tid=2, n_tid=16, blockSize=128 <= nrDimProd=128 => NR-Large
+// gfx11 lacks permlanex16_var => ds_swizzle XOR=16
+// partialR=2 == mTidPerWave=2 => canUseDsSwizzleW32_NRLarge
+
+// CHECK-LABEL: func @test_dsswizzle_nrlarge_gfx1100
+
+// Threadwise partial reduction
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-half-wave reduction via ds_swizzle (2 elements)
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK-NEXT: rocdl.ds_swizzle
+// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK-NEXT: arith.maxnumf
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK-NEXT: rocdl.ds_swizzle
+// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK-NEXT: arith.maxnumf
+
+// No LDS barriers
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsswizzle_nrlarge_gfx1100(
+    %input_reg : memref<64xf32, #gpu.address_space<private>>,
+    %output_reg : memref<64xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<256xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1100",
+               block_size = 128 : i32, grid_size = 36 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 128 : i32} : memref<64xf32, #gpu.address_space<private>> using memref<256xf32, #gpu.address_space<workgroup>> into memref<64xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx942 (CDNA3 wave64): NR-Small DsSwizzleBpermute LDS-skip, SUM
+// m_tid=2, n_tid=32, blockSize=64 == waveSize (single wave)
+// partialR=2, K=1 => canUseDsSwizzleBpermute_NRSmall_LdsSkip
+// groupSize=2 => only ds_bpermute (XOR 32), no ds_swizzle step
+
+// CHECK-LABEL: func @test_dsbpermute_nrsmall_ldsskip_sum_gfx942
+
+// Threadwise partial reduction loop (sum)
+// CHECK: rock.transforming_for
+// CHECK: arith.addf
+
+// Cross-half-wave reduction via ds_bpermute (XOR 32)
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.addf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf32, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsbpermute_nrsmall_ldsskip_sum_gfx942(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx950 (CDNA4 wave64): NR-Small PermlaneSwap LDS-skip, SUM
+// m_tid=2, n_tid=32, blockSize=64 == waveSize (single wave)
+// partialR=2, K=1 => canUsePermlaneSwap_NRSmall_LdsSkip
+// groupSize=2 => only permlane32_swap (cross-half)
+
+// CHECK-LABEL: func @test_permlaneswap_nrsmall_ldsskip_sum_gfx950
+
+// Threadwise partial reduction loop (sum)
+// CHECK: rock.transforming_for
+// CHECK: arith.addf
+
+// Cross-half-wave reduction via permlane32_swap
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.permlane32.swap
+// CHECK: llvm.extractvalue
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.addf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf32, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlaneswap_nrsmall_ldsskip_sum_gfx950(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx950",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 16, d0 mod 16, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 4 + d2) * 8 + d6, (d5 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 4 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{2, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 16] -> [1, 1, 4, 16, 2, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{2, 1, 4, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16, 2, 1, 8] -> [64, 16]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 16] -> [64, 16]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 16] -> [64, 16]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 16] -> [16, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 4, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 4} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16] -> [4, 16]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{4} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [4, 16] -> [16, 4]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{2, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [16] -> [2, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{2, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 1, 8] -> [16, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [16, 1] -> [16, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{16} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [16, 1] -> [16, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [16, 1] -> [1, 16]>
+
+// gfx942 (CDNA3 wave64): NR-Small DsSwizzleBpermute LDS-skip, partialR=4
+// m_tid=4, n_tid=16, blockSize=64 == waveSize (single wave)
+// partialR=4, K=1 => canUseDsSwizzleBpermute_NRSmall_LdsSkip
+// groupSize=4 => ds_swizzle XOR=16 (within-half) + ds_bpermute XOR=32 (cross-half)
+
+// CHECK-LABEL: func @test_dsbpermute_nrsmall_ldsskip_r4_sum_gfx942
+
+// Threadwise partial reduction (sum)
+// CHECK: rock.transforming_for
+// CHECK: arith.addf
+
+// Step 1: within-half reduction via ds_swizzle (XOR 16)
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.ds_swizzle
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.addf
+
+// Step 2: cross-half reduction via ds_bpermute (XOR 32)
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.addf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf32, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsbpermute_nrsmall_ldsskip_r4_sum_gfx942(
+    %input_reg : memref<16xf32, #gpu.address_space<private>>,
+    %output_reg : memref<16xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<16xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<16xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 16, d0 mod 16, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 4 + d2) * 8 + d6, (d5 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 4 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{2, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 16] -> [1, 1, 4, 16, 2, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{2, 1, 4, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16, 2, 1, 8] -> [64, 16]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 16] -> [64, 16]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 16] -> [64, 16]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 16] -> [16, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 4, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 4} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16] -> [4, 16]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{4} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [4, 16] -> [16, 4]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{2, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [16] -> [2, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{2, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 1, 8] -> [16, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [16, 1] -> [16, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{16} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [16, 1] -> [16, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [16, 1] -> [1, 16]>
+
+// gfx950 (CDNA4 wave64): NR-Small PermlaneSwap LDS-skip, partialR=4
+// m_tid=4, n_tid=16, blockSize=64 == waveSize (single wave)
+// partialR=4, K=1 => canUsePermlaneSwap_NRSmall_LdsSkip
+// groupSize=4 => permlane16_swap (within-half) + permlane32_swap (cross-half)
+
+// CHECK-LABEL: func @test_permlaneswap_nrsmall_ldsskip_r4_sum_gfx950
+
+// Threadwise partial reduction (sum)
+// CHECK: rock.transforming_for
+// CHECK: arith.addf
+
+// Step 1: within-half reduction via permlane16_swap
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.permlane16.swap
+// CHECK: llvm.extractvalue
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.addf
+
+// Step 2: cross-half reduction via permlane32_swap
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.permlane32.swap
+// CHECK: llvm.extractvalue
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.addf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf32, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlaneswap_nrsmall_ldsskip_r4_sum_gfx950(
+    %input_reg : memref<16xf32, #gpu.address_space<private>>,
+    %output_reg : memref<16xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx950",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<16xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<16xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 16, (d1 mod 16) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 16, (d0 mod 16) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 2, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 64] -> [1, 1, 2, 32, 4, 2, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{2, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 2, 8] -> [64, 64]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 2, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [64] -> [4, 2, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 2, 8] -> [32, 2]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{2} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 2] -> [2, 32]>
+
+// gfx942 (CDNA3 wave64): NR-Large DsSwizzleBpermute, partialR=2
+// m_tid=2, n_tid=32, blockSize=64 <= nrDimProd=64 => NR-Large
+// partialR=2 => canUseDsSwizzleBpermute_NRLarge
+// groupSize=2 => only ds_bpermute (XOR 32), applied to 2 elements
+
+// CHECK-LABEL: func @test_dsbpermute_nrlarge_r2_gfx942
+
+// Threadwise partial reduction
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-lane reduction: ds_bpermute on 2 nrDim elements
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.maxnumf
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.maxnumf
+
+// No LDS barriers
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsbpermute_nrlarge_r2_gfx942(
+    %input_reg : memref<64xf32, #gpu.address_space<private>>,
+    %output_reg : memref<64xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<128xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<64xf32, #gpu.address_space<private>> using memref<128xf32, #gpu.address_space<workgroup>> into memref<64xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 16, (d1 mod 16) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 16, (d0 mod 16) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 2, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 64] -> [1, 1, 2, 32, 4, 2, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{2, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 2, 8] -> [64, 64]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 2, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [64] -> [4, 2, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 2, 8] -> [32, 2]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{2} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 2] -> [32, 2]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 2] -> [2, 32]>
+
+// gfx950 (CDNA4 wave64): NR-Large PermlaneSwap, partialR=2
+// m_tid=2, n_tid=32, blockSize=64 <= nrDimProd=64 => NR-Large
+// partialR=2 => canUsePermlaneSwap_NRLarge
+// groupSize=2 => only permlane32_swap, applied to 2 elements
+
+// CHECK-LABEL: func @test_permlaneswap_nrlarge_r2_gfx950
+
+// Threadwise partial reduction
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-lane reduction: permlane32_swap on 2 nrDim elements
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.permlane32.swap
+// CHECK: llvm.extractvalue
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.maxnumf
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.permlane32.swap
+// CHECK: llvm.extractvalue
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.maxnumf
+
+// No LDS barriers
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlaneswap_nrlarge_r2_gfx950(
+    %input_reg : memref<64xf32, #gpu.address_space<private>>,
+    %output_reg : memref<64xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<128xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx950",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<64xf32, #gpu.address_space<private>> using memref<128xf32, #gpu.address_space<workgroup>> into memref<64xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 16, d0 mod 16, d1 floordiv 32, (d1 mod 32) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 4 + d2) * 8 + d6, (d5 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 4 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 32, (d0 mod 32) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{2, 4, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 64] -> [1, 1, 4, 16, 2, 4, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{2, 1, 4, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{4, 1, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16, 2, 4, 8] -> [64, 64]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 4, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 4} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16] -> [4, 16]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{4} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [4, 16] -> [16, 4]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{2, 4, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [64] -> [2, 4, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{2, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{4} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 4, 8] -> [16, 4]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [16, 4] -> [16, 4]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{16} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{4} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [16, 4] -> [16, 4]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [16, 4] -> [4, 16]>
+
+// gfx942 (CDNA3 wave64): NR-Large DsSwizzleBpermute, partialR=4
+// m_tid=4, n_tid=16, blockSize=64 <= nrDimProd=64 => NR-Large
+// partialR=4 => canUseDsSwizzleBpermute_NRLarge
+// groupSize=4 => ds_swizzle (XOR 16) + ds_bpermute (XOR 32), each on 4 elements
+
+// CHECK-LABEL: func @test_dsbpermute_nrlarge_r4_gfx942
+
+// Threadwise partial reduction
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Step 1: ds_swizzle XOR=16 on 4 nrDim elements
+// CHECK: rocdl.ds_swizzle
+// CHECK: arith.maxnumf
+// CHECK: rocdl.ds_swizzle
+// CHECK: arith.maxnumf
+// CHECK: rocdl.ds_swizzle
+// CHECK: arith.maxnumf
+// CHECK: rocdl.ds_swizzle
+// CHECK: arith.maxnumf
+
+// Step 2: ds_bpermute XOR=32 on 4 nrDim elements
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.maxnumf
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.maxnumf
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.maxnumf
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.maxnumf
+
+// No LDS barriers
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsbpermute_nrlarge_r4_gfx942(
+    %input_reg : memref<64xf32, #gpu.address_space<private>>,
+    %output_reg : memref<64xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<256xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<64xf32, #gpu.address_space<private>> using memref<256xf32, #gpu.address_space<workgroup>> into memref<64xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 16, d0 mod 16, d1 floordiv 32, (d1 mod 32) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 4 + d2) * 8 + d6, (d5 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 4 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 32, (d0 mod 32) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{2, 4, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 64] -> [1, 1, 4, 16, 2, 4, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{2, 1, 4, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{4, 1, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16, 2, 4, 8] -> [64, 64]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 4, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 4} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16] -> [4, 16]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{4} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [4, 16] -> [16, 4]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{2, 4, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [64] -> [2, 4, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{2, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{4} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 4, 8] -> [16, 4]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [16, 4] -> [16, 4]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{16} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{4} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [16, 4] -> [16, 4]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [16, 4] -> [4, 16]>
+
+// gfx950 (CDNA4 wave64): NR-Large PermlaneSwap, partialR=4
+// m_tid=4, n_tid=16, blockSize=64 <= nrDimProd=64 => NR-Large
+// partialR=4 => canUsePermlaneSwap_NRLarge
+// groupSize=4 => permlane16_swap + permlane32_swap, each on 4 elements
+
+// CHECK-LABEL: func @test_permlaneswap_nrlarge_r4_gfx950
+
+// Threadwise partial reduction
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Step 1: permlane16_swap on 4 nrDim elements
+// CHECK: rocdl.permlane16.swap
+// CHECK: arith.maxnumf
+// CHECK: rocdl.permlane16.swap
+// CHECK: arith.maxnumf
+// CHECK: rocdl.permlane16.swap
+// CHECK: arith.maxnumf
+// CHECK: rocdl.permlane16.swap
+// CHECK: arith.maxnumf
+
+// Step 2: permlane32_swap on 4 nrDim elements
+// CHECK: rocdl.permlane32.swap
+// CHECK: arith.maxnumf
+// CHECK: rocdl.permlane32.swap
+// CHECK: arith.maxnumf
+// CHECK: rocdl.permlane32.swap
+// CHECK: arith.maxnumf
+// CHECK: rocdl.permlane32.swap
+// CHECK: arith.maxnumf
+
+// No LDS barriers
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlaneswap_nrlarge_r4_gfx950(
+    %input_reg : memref<64xf32, #gpu.address_space<private>>,
+    %output_reg : memref<64xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<256xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx950",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<64xf32, #gpu.address_space<private>> using memref<256xf32, #gpu.address_space<workgroup>> into memref<64xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 16, d0 mod 16, d1 floordiv 16, (d1 mod 16) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 4 + d2) * 8 + d6, (d5 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 4 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 16, (d0 mod 16) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{2, 2, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 4, 16, 2, 2, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{2, 1, 4, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{2, 1, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16, 2, 2, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 4, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 4} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16] -> [4, 16]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{4} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [4, 16] -> [16, 4]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{2, 2, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [2, 2, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{2, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 2, 8] -> [16, 2]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [16, 2] -> [16, 2]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{16} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{2} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [16, 2] -> [16, 2]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [16, 2] -> [2, 16]>
+
+// gfx942 (CDNA3 wave64): NR-Small DsSwizzleBpermute WITHOUT LDS-skip
+// m_tid=4, n_tid=16, blockSize=64 > nrDimProd=32 => NR-Small
+// K=2 => LDS-skip disabled, ds_bpermute emitted with LDS barriers
+
+// CHECK-LABEL: func @test_dsbpermute_nrsmall_noldsskip_gfx942
+
+// Upfront LDS barrier
+// CHECK: rock.lds_barrier
+
+// Cross-lane reduction via ds_bpermute (groupSize=2, 1 element)
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.maxnumf
+
+// LDS barrier after leader write
+// CHECK: rock.lds_barrier
+
+// Final readback from LDS to output via threadwise_read_into
+// CHECK: rock.threadwise_read_into
+// CHECK: return
+
+func.func @test_dsbpermute_nrsmall_noldsskip_gfx942(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<128xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<128xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 16, d0 mod 16, d1 floordiv 16, (d1 mod 16) floordiv 8, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 4 + d2) * 8 + d6, (d5 + d1) * 16 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 16, d0 mod 16)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 4 + d2, d1 * 16 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 16, (d0 mod 16) floordiv 8, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{2, 2, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 4, 16, 2, 2, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{2, 1, 4, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{2, 1, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16, 2, 2, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 4, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 4, 16]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 4} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 4, 16] -> [4, 16]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{4} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{16} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [4, 16] -> [4, 16]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [4, 16] -> [16, 4]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{2, 2, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [2, 2, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{2, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 2, 8] -> [16, 2]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [16, 2] -> [16, 2]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{16} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{2} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [16, 2] -> [16, 2]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [16, 2] -> [2, 16]>
+
+// gfx950 (CDNA4 wave64): NR-Small PermlaneSwap WITHOUT LDS-skip
+// m_tid=4, n_tid=16, blockSize=64 > nrDimProd=32 => NR-Small
+// K=2 => LDS-skip disabled, permlane32_swap emitted with LDS barriers
+
+// CHECK-LABEL: func @test_permlaneswap_nrsmall_noldsskip_gfx950
+
+// Upfront LDS barrier
+// CHECK: rock.lds_barrier
+
+// Cross-lane reduction via permlane32_swap (groupSize=2, 1 element)
+// CHECK: rocdl.permlane32.swap
+// CHECK: arith.maxnumf
+
+// LDS barrier after leader write
+// CHECK: rock.lds_barrier
+
+// Final readback from LDS to output via threadwise_read_into
+// CHECK: rock.threadwise_read_into
+// CHECK: return
+
+func.func @test_permlaneswap_nrsmall_noldsskip_gfx950(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<128xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx950",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<128xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, d0 floordiv 64, (d0 mod 64) floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 * 2 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, d0 floordiv 64, (d0 mod 64) floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 2, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [128, 32] -> [1, 2, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 2, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 2, 2, 32, 4, 1, 8] -> [64, 64]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 64] -> [64, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 2, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [128] -> [1, 2, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{2, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 2, 2, 32] -> [2, 64]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 64] -> [2, 64]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{64} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 64] -> [2, 64]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 64] -> [64, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx942 (CDNA3 wave64): LDS-tree fallback — multi-wave, no fast-path
+// m_tid=2, n_tid=32, blockSize=128 (2 waves) > nrDimProd=64 => NR-Small
+// Multi-wave => no cross-lane fast path, falls to LDS-tree reduction
+
+// CHECK-LABEL: func @test_ldstree_fallback_multiwave_gfx942
+
+// No cross-lane intrinsics before first barrier
+// CHECK-NOT: rocdl.ds_swizzle
+// CHECK-NOT: rocdl.ds_bpermute
+// CHECK-NOT: rocdl.permlane
+
+// LDS barrier (upfront store)
+// CHECK: rock.lds_barrier
+
+// Tree reduction
+// CHECK: arith.maxnumf
+
+// LDS barrier (after tree step)
+// CHECK: rock.lds_barrier
+
+// No cross-lane intrinsics after barriers
+// CHECK-NOT: rocdl.ds_swizzle
+// CHECK-NOT: rocdl.ds_bpermute
+// CHECK-NOT: rocdl.permlane
+
+// Final readback from LDS to output via threadwise_read_into
+// CHECK: rock.threadwise_read_into
+// CHECK: return
+
+func.func @test_ldstree_fallback_multiwave_gfx942(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<128xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 128 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 128 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<128xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}

--- a/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
+++ b/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
@@ -36,9 +36,7 @@
 // CHECK: arith.maxnumf
 
 // Cross-half-wave reduction via permlanex16_var
-// CHECK: arith.bitcast %{{.*}} : f32 to i32
-// CHECK-NEXT: rocdl.permlanex16.var
-// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: amdgpu.permlane_var
 // CHECK-NEXT: arith.maxnumf
 
 // No LDS barriers (full LDS-skip path)
@@ -57,6 +55,66 @@ func.func @test_permlane_nrsmall_ldsskip_gfx1201(
     attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1201",
                block_size = 256 : i32, grid_size = 36 : i32, rock.kernel} {
   rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 256 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<256xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4f16 = affine_map<(d0, d1) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16, d1 floordiv 8, 0, d1 mod 8)>
+#map5f16 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 * 8 + d1) * 16 + d3)>
+#map6f16 = affine_map<(d0, d1) -> (d0, d1)>
+#map7f16 = affine_map<(d0, d1) -> (d1, d0)>
+#map8f16 = affine_map<(d0) -> (0, d0 floordiv 32, (d0 mod 32) floordiv 16, d0 mod 16)>
+#map9f16 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 16 + d3)>
+#map10f16 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11f16 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#tm8f16 = #rock.transform_map<#map4f16 by [<Merge{1, 8, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [256, 32] -> [1, 8, 2, 16, 4, 1, 8]>
+#tm9f16 = #rock.transform_map<#map5f16 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 8, 16} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 8, 2, 16, 4, 1, 8] -> [64, 128]>
+#tm10f16 = #rock.transform_map<#map6f16 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#tm11f16 = #rock.transform_map<#map6f16 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 128] -> [64, 128]>
+#tm12f16 = #rock.transform_map<#map7f16 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 128] -> [128, 64]>
+#tm13f16 = #rock.transform_map<#map8f16 by [<Merge{1, 8, 2, 16} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [256] -> [1, 8, 2, 16]>
+#tm14f16 = #rock.transform_map<#map9f16 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{8, 16} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 8, 2, 16] -> [2, 128]>
+#tm15f16 = #rock.transform_map<#map6f16 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 128] -> [2, 128]>
+#tm16f16 = #rock.transform_map<#map6f16 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{128} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 128] -> [2, 128]>
+#tm17f16 = #rock.transform_map<#map7f16 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 128] -> [128, 2]>
+#tm18f16 = #rock.transform_map<#map10f16 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#tm19f16 = #rock.transform_map<#map11f16 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#tm20f16 = #rock.transform_map<#map6f16 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#tm21f16 = #rock.transform_map<#map6f16 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#tm22f16 = #rock.transform_map<#map7f16 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx1201 (RDNA4 wave32): NR-Small PermlaneX16Var LDS-skip path (f16)
+// Same layout as f32 test but with f16 element type to verify
+// amdgpu.permlane_var handles sub-32-bit type decomposition correctly.
+
+// CHECK-LABEL: func @test_permlane_nrsmall_ldsskip_f16_gfx1201
+
+// Threadwise partial reduction loop
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-half-wave reduction via permlanex16_var (f16 type decomposition)
+// CHECK: amdgpu.permlane_var
+// CHECK-NEXT: arith.maxnumf
+
+// No LDS barriers (full LDS-skip path)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback to output
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf16, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlane_nrsmall_ldsskip_f16_gfx1201(
+    %input_reg : memref<32xf16, #gpu.address_space<private>>,
+    %output_reg : memref<32xf16, #gpu.address_space<private>>,
+    %ws_lds : memref<256xf16, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1201",
+               block_size = 256 : i32, grid_size = 36 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#tm8f16, #tm9f16, #tm10f16, #tm10f16, #tm11f16, #tm12f16] [#tm13f16, #tm14f16, #tm15f16, #tm15f16, #tm16f16, #tm17f16] [#tm18f16, #tm19f16, #tm20f16, #tm20f16, #tm21f16, #tm22f16] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 256 : i32} : memref<32xf16, #gpu.address_space<private>> using memref<256xf16, #gpu.address_space<workgroup>> into memref<32xf16, #gpu.address_space<private>>
   return
 }
 
@@ -98,13 +156,9 @@ func.func @test_permlane_nrsmall_ldsskip_gfx1201(
 // CHECK: arith.maxnumf
 
 // Cross-half-wave reduction via permlanex16_var (2 elements in nrDim)
-// CHECK: arith.bitcast %{{.*}} : f32 to i32
-// CHECK-NEXT: rocdl.permlanex16.var
-// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: amdgpu.permlane_var
 // CHECK-NEXT: arith.maxnumf
-// CHECK: arith.bitcast %{{.*}} : f32 to i32
-// CHECK-NEXT: rocdl.permlanex16.var
-// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: amdgpu.permlane_var
 // CHECK-NEXT: arith.maxnumf
 
 // No LDS barriers (register-only path)

--- a/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
+++ b/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
@@ -218,8 +218,10 @@ func.func @test_permlane_nrlarge_gfx1201(
 // CHECK: arith.maxnumf
 
 // Cross-half-wave reduction via amdgpu.swizzle_bitmode (XOR=16)
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
 // CHECK: amdgpu.swizzle_bitmode
-// CHECK-NEXT: arith.maxnumf
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.maxnumf
 
 // No LDS barriers (full LDS-skip)
 // CHECK-NOT: rock.lds_barrier
@@ -279,9 +281,9 @@ func.func @test_dsswizzle_nrsmall_ldsskip_gfx1100(
 
 // Cross-half-wave reduction via amdgpu.swizzle_bitmode (2 elements)
 // CHECK: amdgpu.swizzle_bitmode
-// CHECK-NEXT: arith.maxnumf
+// CHECK: arith.maxnumf
 // CHECK: amdgpu.swizzle_bitmode
-// CHECK-NEXT: arith.maxnumf
+// CHECK: arith.maxnumf
 
 // No LDS barriers
 // CHECK-NOT: rock.lds_barrier
@@ -425,6 +427,71 @@ func.func @test_permlaneswap_nrsmall_ldsskip_sum_gfx950(
     attributes{rock.arch = "amdgcn-amd-amdhsa:gfx950",
                block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
   rock.blockwise_broadcast_reduce sum [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx950 (CDNA4 wave64): NR-Small PermlaneSwap LDS-skip, f16
+// Same config as test_permlaneswap_nrsmall_ldsskip_sum_gfx950 but f16
+// to verify the bitcast f16→i16, zext i16→i32, swap, trunc i32→i16,
+// bitcast i16→f16 chain in permlaneSwapReduceStep (no v_cvt instructions).
+
+// CHECK-LABEL: func @test_permlaneswap_nrsmall_ldsskip_f16_gfx950
+
+// Threadwise partial reduction (sum, f16)
+// CHECK: rock.transforming_for
+// CHECK: arith.addf
+
+// Cross-half-wave reduction via permlane32_swap with f16 bit-packing
+// CHECK: arith.bitcast %{{.*}} : f16 to i16
+// CHECK: arith.extui %{{.*}} : i16 to i32
+// CHECK: rocdl.permlane32.swap
+// CHECK: arith.trunci %{{.*}} : i32 to i16
+// CHECK: arith.bitcast %{{.*}} : i16 to f16
+// CHECK: arith.addf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf16, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_permlaneswap_nrsmall_ldsskip_f16_gfx950(
+    %input_reg : memref<32xf16, #gpu.address_space<private>>,
+    %output_reg : memref<32xf16, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf16, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx950",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf16, #gpu.address_space<private>> using memref<64xf16, #gpu.address_space<workgroup>> into memref<32xf16, #gpu.address_space<private>>
   return
 }
 
@@ -1031,3 +1098,179 @@ func.func @test_ldstree_fallback_multiwave_gfx942(
   rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 128 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<128xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
   return
 }
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// Near-miss: gfx1030 (RDNA2 wave32) — same layout as gfx942 NR-Small
+// (m_tid=2, n_tid=32, blockSize=64) but gfx1030 does not match any
+// cross-lane arch gate (not gfx908/gfx90a/gfx94x/gfx950/gfx11/gfx12).
+// Also m_tid*n_tid=64 != 32 (waveSize), so layoutTilesWave is false.
+// Must fall back to LDS-tree reduction.
+
+// CHECK-LABEL: func @test_ldstree_fallback_unsupported_arch_gfx1030
+
+// No cross-lane intrinsics
+// CHECK-NOT: amdgpu.swizzle_bitmode
+// CHECK-NOT: rocdl.ds_bpermute
+// CHECK-NOT: rocdl.permlane
+
+// LDS barrier (upfront store)
+// CHECK: rock.lds_barrier
+
+// Tree reduction
+// CHECK: arith.maxnumf
+
+// LDS barrier (after tree step)
+// CHECK: rock.lds_barrier
+
+// No cross-lane intrinsics after barriers
+// CHECK-NOT: amdgpu.swizzle_bitmode
+// CHECK-NOT: rocdl.ds_bpermute
+// CHECK-NOT: rocdl.permlane
+
+// Final readback
+// CHECK: rock.threadwise_read_into
+// CHECK: return
+
+func.func @test_ldstree_fallback_unsupported_arch_gfx1030(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1030",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// Near-miss: wave64 layout on gfx1100 (wave32) — layout doesn't tile wave.
+// m_tid=2, n_tid=32 => product=64 != 32 (waveSize), so layoutTilesWave
+// is false. hasDsSwizzleWave32 requires layoutTilesWave, so all wave32
+// fast paths are disabled. Must fall back to LDS-tree reduction.
+
+// CHECK-LABEL: func @test_ldstree_fallback_layout_mismatch_gfx1100
+
+// No cross-lane intrinsics
+// CHECK-NOT: amdgpu.swizzle_bitmode
+// CHECK-NOT: amdgpu.permlane_var
+// CHECK-NOT: rocdl.ds_bpermute
+// CHECK-NOT: rocdl.permlane
+
+// LDS barrier (upfront store)
+// CHECK: rock.lds_barrier
+
+// Tree reduction
+// CHECK: arith.maxnumf
+
+// LDS barrier (after tree step)
+// CHECK: rock.lds_barrier
+
+// No cross-lane intrinsics after barriers
+// CHECK-NOT: amdgpu.swizzle_bitmode
+// CHECK-NOT: amdgpu.permlane_var
+// CHECK-NOT: rocdl.ds_bpermute
+// CHECK-NOT: rocdl.permlane
+
+// Final readback
+// CHECK: rock.threadwise_read_into
+// CHECK: return
+
+func.func @test_ldstree_fallback_layout_mismatch_gfx1100(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx1100",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx942 (CDNA3 wave64): f16 sub-32-bit type coverage for ds_bpermute path
+// Same config as test_dsbpermute_nrsmall_ldsskip_sum_gfx942 but with f16
+// to verify bit-packing (bitcast+zext/trunc) handles sub-32-bit types in
+// the ds_bpermute path correctly (no v_cvt instructions).
+
+// CHECK-LABEL: func @test_dsbpermute_nrsmall_ldsskip_f16_gfx942
+
+// Threadwise partial reduction (sum, f16)
+// CHECK: rock.transforming_for
+// CHECK: arith.addf
+
+// Cross-half-wave reduction via ds_bpermute with f16 bit-packing
+// CHECK: arith.bitcast %{{.*}} : f16 to i16
+// CHECK: arith.extui %{{.*}} : i16 to i32
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.trunci %{{.*}} : i32 to i16
+// CHECK: arith.bitcast %{{.*}} : i16 to f16
+// CHECK: arith.addf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf16, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsbpermute_nrsmall_ldsskip_f16_gfx942(
+    %input_reg : memref<32xf16, #gpu.address_space<private>>,
+    %output_reg : memref<32xf16, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf16, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf16, #gpu.address_space<private>> using memref<64xf16, #gpu.address_space<workgroup>> into memref<32xf16, #gpu.address_space<private>>
+  return
+}
+

--- a/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
+++ b/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
@@ -163,10 +163,8 @@ func.func @test_permlane_nrlarge_gfx1201(
 // CHECK: rock.transforming_for
 // CHECK: arith.maxnumf
 
-// Cross-half-wave reduction via ds_swizzle (XOR=16)
-// CHECK: arith.bitcast %{{.*}} : f32 to i32
-// CHECK-NEXT: rocdl.ds_swizzle %{{.*}}
-// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// Cross-half-wave reduction via amdgpu.swizzle_bitmode (XOR=16)
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK-NEXT: arith.maxnumf
 
 // No LDS barriers (full LDS-skip)
@@ -225,14 +223,10 @@ func.func @test_dsswizzle_nrsmall_ldsskip_gfx1100(
 // CHECK: rock.transforming_for
 // CHECK: arith.maxnumf
 
-// Cross-half-wave reduction via ds_swizzle (2 elements)
-// CHECK: arith.bitcast %{{.*}} : f32 to i32
-// CHECK-NEXT: rocdl.ds_swizzle
-// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// Cross-half-wave reduction via amdgpu.swizzle_bitmode (2 elements)
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK-NEXT: arith.maxnumf
-// CHECK: arith.bitcast %{{.*}} : f32 to i32
-// CHECK-NEXT: rocdl.ds_swizzle
-// CHECK-NEXT: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK-NEXT: arith.maxnumf
 
 // No LDS barriers
@@ -418,10 +412,8 @@ func.func @test_permlaneswap_nrsmall_ldsskip_sum_gfx950(
 // CHECK: rock.transforming_for
 // CHECK: arith.addf
 
-// Step 1: within-half reduction via ds_swizzle (XOR 16)
-// CHECK: arith.bitcast %{{.*}} : f32 to i32
-// CHECK: rocdl.ds_swizzle
-// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// Step 1: within-half reduction via amdgpu.swizzle_bitmode (XOR 16)
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK: arith.addf
 
 // Step 2: cross-half reduction via ds_bpermute (XOR 32)
@@ -692,14 +684,14 @@ func.func @test_permlaneswap_nrlarge_r2_gfx950(
 // CHECK: rock.transforming_for
 // CHECK: arith.maxnumf
 
-// Step 1: ds_swizzle XOR=16 on 4 nrDim elements
-// CHECK: rocdl.ds_swizzle
+// Step 1: amdgpu.swizzle_bitmode XOR=16 on 4 nrDim elements
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK: arith.maxnumf
-// CHECK: rocdl.ds_swizzle
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK: arith.maxnumf
-// CHECK: rocdl.ds_swizzle
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK: arith.maxnumf
-// CHECK: rocdl.ds_swizzle
+// CHECK: amdgpu.swizzle_bitmode
 // CHECK: arith.maxnumf
 
 // Step 2: ds_bpermute XOR=32 on 4 nrDim elements
@@ -954,7 +946,7 @@ func.func @test_permlaneswap_nrsmall_noldsskip_gfx950(
 // CHECK-LABEL: func @test_ldstree_fallback_multiwave_gfx942
 
 // No cross-lane intrinsics before first barrier
-// CHECK-NOT: rocdl.ds_swizzle
+// CHECK-NOT: amdgpu.swizzle_bitmode
 // CHECK-NOT: rocdl.ds_bpermute
 // CHECK-NOT: rocdl.permlane
 
@@ -968,7 +960,7 @@ func.func @test_permlaneswap_nrsmall_noldsskip_gfx950(
 // CHECK: rock.lds_barrier
 
 // No cross-lane intrinsics after barriers
-// CHECK-NOT: rocdl.ds_swizzle
+// CHECK-NOT: amdgpu.swizzle_bitmode
 // CHECK-NOT: rocdl.ds_bpermute
 // CHECK-NOT: rocdl.permlane
 

--- a/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
+++ b/mlir/test/Dialect/Rock/lowering_bcast_reduce_cross_lane.mlir
@@ -1274,3 +1274,182 @@ func.func @test_dsbpermute_nrsmall_ldsskip_f16_gfx942(
   return
 }
 
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx908 (MI100 wave64): NR-Small DsSwizzleBpermute LDS-skip
+// Same layout as gfx942 test — verifies ds_bpermute fast path
+// is correctly selected on the oldest supported CDNA arch.
+
+// CHECK-LABEL: func @test_dsbpermute_nrsmall_ldsskip_gfx908
+
+// Threadwise partial reduction loop
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-half-wave reduction via ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.maxnumf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf32, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsbpermute_nrsmall_ldsskip_gfx908(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx908",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx90a (MI250 wave64): NR-Small DsSwizzleBpermute LDS-skip
+// Same layout as gfx942 test — verifies ds_bpermute fast path
+// is correctly selected on MI250 (gfx90a) arch.
+
+// CHECK-LABEL: func @test_dsbpermute_nrsmall_ldsskip_gfx90a
+
+// Threadwise partial reduction loop
+// CHECK: rock.transforming_for
+// CHECK: arith.maxnumf
+
+// Cross-half-wave reduction via ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : f32 to i32
+// CHECK: rocdl.ds_bpermute
+// CHECK: arith.bitcast %{{.*}} : i32 to f32
+// CHECK: arith.maxnumf
+
+// No LDS barriers (full LDS-skip)
+// CHECK-NOT: rock.lds_barrier
+
+// Direct register readback
+// CHECK: rock.transforming_for
+// CHECK: rock.in_bounds_load %{{.*}} : memref<1xf32, #gpu.address_space<private>>
+// CHECK: rock.in_bounds_store %{{.*}} -> %arg1
+// CHECK: return
+
+func.func @test_dsbpermute_nrsmall_ldsskip_gfx90a(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx90a",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+#map4 = affine_map<(d0, d1) -> (0, 0, d0 floordiv 32, d0 mod 32, d1 floordiv 8, 0, d1 mod 8)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d0 + d4) * 2 + d2) * 8 + d6, (d5 + d1) * 32 + d3)>
+#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map7 = affine_map<(d0, d1) -> (d1, d0)>
+#map8 = affine_map<(d0) -> (0, 0, d0 floordiv 32, d0 mod 32)>
+#map9 = affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2, d1 * 32 + d3)>
+#map10 = affine_map<(d0) -> (d0 floordiv 8, 0, d0 mod 8)>
+#map11 = affine_map<(d0, d1, d2) -> (d0 * 8 + d2, d1)>
+
+#transform_map8 = #rock.transform_map<#map4 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>, <Merge{4, 1, 8} ["item"] at [1] -> ["rep_i", "rep_j", "item_i"] at [4, 5, 6]>] bounds = [64, 32] -> [1, 1, 2, 32, 4, 1, 8]>
+#transform_map9 = #rock.transform_map<#map5 by [<Unmerge{4, 1, 2, 8} ["rep_i", "wave_m", "m_tid", "item_i"] at [4, 0, 2, 6] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 1, 32} ["rep_j", "wave_n", "n_tid"] at [5, 1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32, 4, 1, 8] -> [64, 32]>
+#transform_map10 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map11 = #rock.transform_map<#map6 by [<Unmerge{64} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [64, 32] -> [64, 32]>
+#transform_map12 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [64, 32] -> [32, 64]>
+#transform_map13 = #rock.transform_map<#map8 by [<Merge{1, 1, 2, 32} ["tid"] at [0] -> ["wave_m", "wave_n", "m_tid", "n_tid"] at [0, 1, 2, 3]>] bounds = [64] -> [1, 1, 2, 32]>
+#transform_map14 = #rock.transform_map<#map9 by [<Unmerge{1, 2} ["wave_m", "m_tid"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1, 32} ["wave_n", "n_tid"] at [1, 3] -> ["gemmBlockN"] at [1]>] bounds = [1, 1, 2, 32] -> [2, 32]>
+#transform_map15 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map16 = #rock.transform_map<#map6 by [<Unmerge{2} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{32} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [2, 32] -> [2, 32]>
+#transform_map17 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [2, 32] -> [32, 2]>
+#transform_map18 = #rock.transform_map<#map10 by [<Merge{4, 1, 8} ["item"] at [0] -> ["rep_i", "rep_j", "item_i"] at [0, 1, 2]>] bounds = [32] -> [4, 1, 8]>
+#transform_map19 = #rock.transform_map<#map11 by [<Unmerge{4, 8} ["rep_i", "item_i"] at [0, 2] -> ["gemmBlockM"] at [0]>, <Unmerge{1} ["rep_j"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [4, 1, 8] -> [32, 1]>
+#transform_map20 = #rock.transform_map<#map6 by [<PassThrough ["gemmBlockM"] at [0] -> ["gemmBlockM"] at [0]>, <PassThrough ["gemmBlockN"] at [1] -> ["gemmBlockN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map21 = #rock.transform_map<#map6 by [<Unmerge{32} ["gemmBlockM"] at [0] -> ["gemmM"] at [0]>, <Unmerge{1} ["gemmBlockN"] at [1] -> ["gemmN"] at [1]>] bounds = [32, 1] -> [32, 1]>
+#transform_map22 = #rock.transform_map<#map7 by [<PassThrough ["dim1", "dim0"] at [1, 0] -> ["dim1", "dim0"] at [0, 1]>] bounds = [32, 1] -> [1, 32]>
+
+// gfx942 (CDNA3 wave64): NR-Small extraOut fallback
+// Same single-wave LDS-skip-eligible config as test_dsbpermute_nrsmall_ldsskip_sum_gfx942,
+// but with extraOut present. The extraOut path reads from LDS, so the LDS-skip
+// optimisation is disabled and the op falls back to the LDS round-trip with barriers.
+
+// CHECK-LABEL: func @test_dsbpermute_extraout_fallback_gfx942
+
+// Cross-lane reduction is still used (ds_bpermute)
+// CHECK: rocdl.ds_bpermute
+
+// LDS barriers ARE present (extraOut disables LDS-skip)
+// CHECK: rock.lds_barrier
+
+// Two threadwise_read_into: one for output, one for extraOut
+// CHECK: rock.threadwise_read_into
+// CHECK: rock.threadwise_read_into
+// CHECK: return
+
+func.func @test_dsbpermute_extraout_fallback_gfx942(
+    %input_reg : memref<32xf32, #gpu.address_space<private>>,
+    %output_reg : memref<32xf32, #gpu.address_space<private>>,
+    %extra_out : memref<32xf32, #gpu.address_space<private>>,
+    %ws_lds : memref<64xf32, #gpu.address_space<workgroup>>)
+    attributes{rock.arch = "amdgcn-amd-amdhsa:gfx942",
+               block_size = 64 : i32, grid_size = 72 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce max [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] [#transform_map13, #transform_map14, #transform_map15, #transform_map15, #transform_map16, #transform_map17] [#transform_map18, #transform_map19, #transform_map20, #transform_map20, #transform_map21, #transform_map22] %input_reg into %output_reg, [#transform_map8, #transform_map9, #transform_map10, #transform_map10, #transform_map11, #transform_map12] %extra_out using %ws_lds {axis = 1 : index, blockSize = 64 : i32} : memref<32xf32, #gpu.address_space<private>> using memref<64xf32, #gpu.address_space<workgroup>> into memref<32xf32, #gpu.address_space<private>>, memref<32xf32, #gpu.address_space<private>>
+  return
+}

--- a/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
@@ -197,3 +197,26 @@ func.func @rock_blockwise_reducesum_nr_threads_lt_blocksize(%input_reg : memref<
   rock.blockwise_broadcast_reduce sum [#inputView][#inputView_tid][#inputView_iter]%input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 20 : i32, nrDimPerThread = 4 : index} : memref<4xf32, #gpu.address_space<private>> using memref<80xf32, #gpu.address_space<workgroup>> into memref<4xf32, #gpu.address_space<private>>
   return
 }
+
+// -----
+
+// NR-Small path with non-power-of-2 nonReductionDimSizeProduct.
+// blockSize=15, nrDimProd=5, rThreads=3. Since nrDimProd=5 is not a
+// power of 2, the tid factoring must use arith.divsi / arith.remsi
+// instead of arith.shrui / arith.andi.
+
+#inputView = #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["tid"] at [0] -> ["r"] at [1]>, <PassThrough ["iter"] at [1] -> ["nr_per_bid"] at [0]>] bounds = [15, 5] -> [5, 15]>
+#inputView_tid = #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 15} ["tid"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [15] -> [1, 15]>
+#inputView_iter = #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<Merge{5, 1} ["iter"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [5] -> [5, 1]>
+
+// CHECK-LABEL: func @rock_blockwise_reducesum_nonpow2_nrdimprod
+// CHECK-DAG: %[[TID:.*]] = rock.workitem_id : index
+// CHECK: %[[RTID:.*]] = arith.divsi %[[TID]], %c5
+// CHECK: %[[NRTID:.*]] = arith.remsi %[[TID]], %c5
+// CHECK: rock.lds_barrier
+// CHECK: rock.threadwise_read_into
+
+func.func @rock_blockwise_reducesum_nonpow2_nrdimprod(%input_reg : memref<5xf32, #gpu.address_space<private>>, %output_reg : memref<5xf32, #gpu.address_space<private>>, %ws_lds : memref<75xf32, #gpu.address_space<workgroup>>) attributes{rock.arch = "##TOKEN_ARCH##", block_size = 15 : i32, grid_size = 8 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#inputView][#inputView_tid][#inputView_iter]%input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 15 : i32, nrDimPerThread = 5 : index} : memref<5xf32, #gpu.address_space<private>> using memref<75xf32, #gpu.address_space<workgroup>> into memref<5xf32, #gpu.address_space<private>>
+  return
+}

--- a/mlir/test/rocmlir-driver/pipelines.mlir
+++ b/mlir/test/rocmlir-driver/pipelines.mlir
@@ -3,6 +3,7 @@
 // RUN: rocmlir-driver -dump-pipelines -kernel-pipeline=binary -arch=gfx90a /dev/null -o /dev/null 2>&1 | sed -e 's/,/,\n/g' | FileCheck %s --check-prefix=BINARY --strict-whitespace
 // RUN: rocmlir-driver -dump-pipelines -kernel-pipeline=binary -arch=gfx942 /dev/null -o /dev/null 2>&1 | sed -e 's/,/,\n/g' | FileCheck %s --check-prefix=BINARY_MI300 --strict-whitespace
 // RUN: rocmlir-driver -dump-pipelines -kernel-pipeline=binary -arch=gfx950 /dev/null -o /dev/null 2>&1 | sed -e 's/,/,\n/g' | FileCheck %s --check-prefix=BINARY_MI350 --strict-whitespace
+// RUN: rocmlir-driver -dump-pipelines -kernel-pipeline=binary -arch=gfx1100 /dev/null -o /dev/null 2>&1 | sed -e 's/,/,\n/g' | FileCheck %s --check-prefix=BINARY_RDNA3 --strict-whitespace
 // RUN: rocmlir-driver -dump-pipelines -host-pipeline=mhal -targets=gfx90a /dev/null -o /dev/null 2>&1 | sed -e 's/,/,\n/g' | FileCheck %s --check-prefix=MHAL --match-full-lines --strict-whitespace
 // RUN: rocmlir-driver -dump-pipelines -kernel-pipeline=highlevel -arch=gfx90a /dev/null -o /dev/null 2>&1 | sed -e 's/,/,\n/g' | FileCheck %s --check-prefix=HIGHLEVEL --match-full-lines --strict-whitespace
 // RUN: rocmlir-driver -dump-pipelines -kernel-pipeline=migraphx-linalg -arch=gfx90a /dev/null -o /dev/null 2>&1 | sed -e 's/,/,\n/g' | FileCheck %s --check-prefix=LINALG --match-full-lines --strict-whitespace
@@ -148,6 +149,39 @@
 // BINARY_MI350-NEXT:gpu-module-to-binary{format=fatbin  opts= section= toolkit=},
 // BINARY_MI350-NEXT:rock-check-residency,
 // BINARY_MI350-NEXT:emulate-fp8-ext-trunc{f8-conversion-instrs=false ocpf8-conversion-instrs=false})
+
+// BINARY_RDNA3:Kernel pipeline:
+// BINARY_RDNA3-NEXT:builtin.module(strip-debuginfo,
+// BINARY_RDNA3-NEXT:gpu.module(amdgpu-emulate-atomics{chipset=gfx1100},
+// BINARY_RDNA3-NEXT:arith-emulate-unsupported-floats{source-types={f8E4M3FNUZ,
+// BINARY_RDNA3-NEXT:f8E5M2FNUZ,
+// BINARY_RDNA3-NEXT:f8E4M3FN,
+// BINARY_RDNA3-NEXT:f8E5M2,
+// BINARY_RDNA3-NEXT:f8E8M0FNU} target-type=f32},
+// BINARY_RDNA3-NEXT:arith-expand{include-bf16=false include-f4e2m1=false include-f8e8m0=true include-float-min-max=false include-flush-denormals=false},
+// BINARY_RDNA3-NEXT:convert-arith-to-amdgpu{allow-packed-f16-round-to-zero=false chipset=gfx1100 saturate-fp8-truncf=true},
+// BINARY_RDNA3-NEXT:emulate-fp8-ext-trunc{f8-conversion-instrs=false ocpf8-conversion-instrs=false},
+// BINARY_RDNA3-NEXT:expand-strided-metadata,
+// BINARY_RDNA3-NEXT:lower-affine,
+// BINARY_RDNA3-NEXT:rock-subgroup-reduce-to-dpp{chip=gfx1100},
+// BINARY_RDNA3-NEXT:convert-gpu-to-rocdl{allowed-dialects={
+// BINARY_RDNA3-DAG:vector
+// BINARY_RDNA3-DAG:memref
+// BINARY_RDNA3-DAG:cf
+// BINARY_RDNA3-DAG:math
+// BINARY_RDNA3-DAG:func
+// BINARY_RDNA3-DAG:arith
+// BINARY_RDNA3-SAME:} chipset=gfx1100 index-bitwidth=0 runtime=HIP use-bare-ptr-memref-call-conv=true},
+// BINARY_RDNA3-NEXT:rock-add-direct-to-lds-alias-info,
+// BINARY_RDNA3-NEXT:llvm.func(rock-to-rocdl{chipset=gfx1100}),
+// BINARY_RDNA3-NEXT:llvm.func(canonicalize{cse-between-iterations=false    max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true},
+// BINARY_RDNA3-NEXT:cse,
+// BINARY_RDNA3-NEXT:rock-remove-redundant-casts,
+// BINARY_RDNA3-NEXT:rock-prepare-llvm)),
+// BINARY_RDNA3-NEXT:rocdl-attach-target{O=3 abi=600 chip=gfx1100 correct-sqrt=true daz=false fast=false features= finite-only=false  module= triple=amdgcn-amd-amdhsa unsafe-math=false wave64=true},
+// BINARY_RDNA3-NEXT:gpu-module-to-binary{format=fatbin  opts= section= toolkit=},
+// BINARY_RDNA3-NEXT:rock-check-residency,
+// BINARY_RDNA3-NEXT:emulate-fp8-ext-trunc{f8-conversion-instrs=false ocpf8-conversion-instrs=false})
 
 // MHAL:MHAL package pipeline:
 // MHAL-NEXT:any(mhal-package-targets)


### PR DESCRIPTION
Resolves: https://amd-hub.atlassian.net/browse/AIROCMLIR-771

## Motivation

In the current implementation, blockwise broadcast-reduce operations with small partial reduction factors (`partialR` ∈ {2, 4}) perform cross-lane reduction through LDS (Local Data Share), even though only a simple 2-way or 4-way reduction is needed. This is suboptimal because:
- A 2-way or 4-way reduction can be done with a single register-to-register cross-lane exchange — no shared memory required.
- The LDS store → barrier → tree-reduce → barrier → readback sequence adds latency that is disproportionate to the actual work (one or two reduction steps).
- Modern AMD GPUs provide efficient cross-lane instructions (`v_permlanex16_var_b32`, `v_permlane{16,32}_swap_b32`, `ds_swizzle_b32`, `ds_bpermute_b32`) that can replace this pattern entirely, keeping the reduction in registers.
This PR replaces LDS-based reduction with register-only cross-lane intrinsics across all supported AMD GPU architectures (CDNA and RDNA), and adds transparent widening so that sub-32-bit types like f16 (common in attention kernels) also benefit from the fast path instead of falling back to the slower LDS-tree reduction.

## Technical Details

### 1. Architecture-specific cross-lane reduction helpers
Each helper implements a complete reduce step: load → widen → bitcast → intrinsic → bitcast → narrow → reduce → store.
| Helper | Intrinsic(s) | Architecture | Wave size |
|--------|-------------|--------------|-----------|
| `permlaneX16VarReduce` | `v_permlanex16_var_b32` | gfx950, gfx12 (RDNA4) | 32 |
| `dsSwizzleReduceWave32` | `ds_swizzle_b32` XOR=16 | gfx11 (RDNA3) | 32 |
| `permlaneSwapReduceStep` | `v_permlane{16,32}_swap_b32` | gfx950 (CDNA4) | 64 |
| `dsSwizzleReduceStep` | `ds_swizzle_b32` XOR within 32-lane half | gfx908, gfx90a, gfx94x (CDNA 1/2/3) | 64 |
| `dsBpermuteReduceStep` | `ds_bpermute_b32` XOR 32 cross-half | gfx908, gfx90a, gfx94x (CDNA 1/2/3) | 64 |
### 2. Sub-32-bit type widening (f16 → f32)
All cross-lane intrinsics operate on 32-bit registers. Previously, sub-32-bit types (f16) could not use the fast path and fell back to the LDS-tree reduction. Three helper functions transparently widen/narrow values around the intrinsic call:
- `widenTo32Bit()` — `arith.extf f16→f32` (or `arith.extsi` for integer types)
- `narrowFrom32Bit()` — `arith.truncf f32→f16` (or `arith.trunci` for integers)
- `get32BitType()` — returns the corresponding 32-bit type (f32 for floats, i32 for integers)
The flow for f16: `f16 → extf → f32 → bitcast → i32 → intrinsic → i32 → bitcast → f32 → truncf → f16 → reduce → store`. For f32 (already 32-bit), widen/narrow are no-ops — existing behavior is unchanged.
This is critical for **attention kernels** which use f16 throughout — without widening they fall back to LDS-tree and lose the performance benefit.
### 3. Two reduction regimes: NR-Large and NR-Small
**NR-Large** (`blockSize ≤ nrDimProd`): The reduction dimension maps entirely to intra-wave lane distances. Cross-lane reduction replaces the LDS-tree. Each thread reduces its own private buffer elements.
- Wave32: `partialR == 2 && partialR == mTidPerWave` — one cross-half-wave step
- Wave64: `partialR ∈ {2, 4} && partialR == mTidPerWave` — one or two swap steps
**NR-Small** (`blockSize > nrDimProd`): Threadwise partial reduction produces a single accumulator per thread. The cross-lane step reduces this scalar across partner lanes.
- Wave32: `partialR == 2 && nTidPerWave == 16` — one cross-half-wave step
- Wave64: `partialR ∈ {2, 4} && nrDimProd * partialR == waveSize` — full register-only path
### 4. LDS-skip optimization
When all safety conditions are met (single-wave or `partialR == mTidPerWave`, `K == 1`, no `extraOut`), **both** the upfront LDS write+barrier and the final LDS broadcast are skipped — the entire reduction stays in registers. The result is broadcast directly from `partialReductionBuffer` via `readReducedResultsFromPrivateBuffer`.
### 5. Eligibility gating
Each fast-path has explicit eligibility flags that check:
- Architecture support (`hasPermlaneVar`, `hasPermlaneSwap`, `hasDsSwizzleBpermute`, `hasDsSwizzleWave32`)
- 2D thread layout (`has2DThreadLayout` via `m_tid`/`n_tid` naming)
- Reduction geometry (`partialR`, `mTidPerWave`, `nTidPerWave`, `blockSize`, `nonReductionDimSizeProduct`)
- Safety constraints (`K == 1`, `!extraOut` for LDS-skip variants)
Configurations that don't match any fast-path fall back to the existing LDS round-trip path unchanged.

## Test Plan

### New: `lowering_bcast_reduce_cross_lane.mlir` (15 tests)
| Test | Arch | Path | Verifies |
|------|------|------|----------|
| `test_permlane_nrsmall_ldsskip_gfx1201` | RDNA4 w32 | NR-Small PermlaneX16Var LDS-skip | `rocdl.permlanex16.var`, no `lds_barrier` |
| `test_permlane_nrlarge_gfx1201` | RDNA4 w32 | NR-Large PermlaneX16Var | `rocdl.permlanex16.var`, serial XOR butterfly |
| `test_dsswizzle_nrsmall_ldsskip_gfx1100` | RDNA3 w32 | NR-Small DsSwizzle LDS-skip | `rocdl.ds_swizzle`, no `lds_barrier` |
| `test_dsswizzle_nrlarge_gfx1100` | RDNA3 w32 | NR-Large DsSwizzle | `rocdl.ds_swizzle`, serial XOR butterfly |
| `test_dsbpermute_nrsmall_ldsskip_sum_gfx942` | CDNA3 w64 | NR-Small DsSwizzle+Bpermute LDS-skip | `rocdl.ds_bpermute`, no `lds_barrier` |
| `test_permlaneswap_nrsmall_ldsskip_sum_gfx950` | CDNA4 w64 | NR-Small PermlaneSwap LDS-skip | `rocdl.permlane32.swap`, no `lds_barrier` |
| `test_dsbpermute_nrsmall_ldsskip_r4_sum_gfx942` | CDNA3 w64 | NR-Small partialR=4 | `ds_swizzle` + `ds_bpermute`, no `lds_barrier` |
| `test_permlaneswap_nrsmall_ldsskip_r4_sum_gfx950` | CDNA4 w64 | NR-Small partialR=4 | `permlane16.swap` + `permlane32.swap`, no `lds_barrier` |
| `test_dsbpermute_nrlarge_r2_gfx942` | CDNA3 w64 | NR-Large partialR=2 | `rocdl.ds_bpermute`, LDS broadcast |
| `test_permlaneswap_nrlarge_r2_gfx950` | CDNA4 w64 | NR-Large partialR=2 | `rocdl.permlane32.swap`, LDS broadcast |
| `test_dsbpermute_nrlarge_r4_gfx942` | CDNA3 w64 | NR-Large partialR=4 | `ds_swizzle` + `ds_bpermute`, LDS broadcast |
| `test_permlaneswap_nrlarge_r4_gfx950` | CDNA4 w64 | NR-Large partialR=4 | `permlane16.swap` + `permlane32.swap`, LDS broadcast |
| `test_dsbpermute_nrsmall_noldsskip_gfx942` | CDNA3 w64 | NR-Small no LDS-skip (K>1) | `rocdl.ds_bpermute`, HAS `lds_barrier` |
| `test_permlaneswap_nrsmall_noldsskip_gfx950` | CDNA4 w64 | NR-Small no LDS-skip (K>1) | `rocdl.permlane32.swap`, HAS `lds_barrier` |
| `test_ldstree_fallback_multiwave_gfx942` | CDNA3 w64 | LDS-tree fallback | No intrinsics, HAS `lds_barrier` |

## Test Result

**Both CI Pass**

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
