### PR TITLE
[CI] Publish artifacts when a branch finishes

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1438,9 +1438,6 @@ PY
                                                         dir ('build') {
                                                             stash name: "MLIR-PerfDB-${params.canXdlops ? CHIP : 'vanilla'}", includes: "*.tsv"
                                                         }
-                                                        // Publish this arch's DBs immediately so they're visible without waiting for other parallel branches
-                                                        archiveArtifacts artifacts: "build/*.tsv",
-                                                            allowEmptyArchive: true, onlyIfSuccessful: false
                                                     }
                                                 }
                                             }
@@ -1450,11 +1447,13 @@ PY
                                             throw e
                                         }
                                         finally {
-                                            // Best-effort: publish any partial DBs produced before a failure/abort so unfinished branches still surface artifacts
+                                            // Publish per-arch tuning DBs as soon as this branch finishes so artifacts published without waiting for other parallel branches
                                             try {
                                                 archiveArtifacts artifacts: "build/*.tsv",
                                                     allowEmptyArchive: true, onlyIfSuccessful: false
-                                            } catch (ignored) {}
+                                            } catch (Exception archiveErr) {
+                                                echo "[CI] archiveArtifacts of tuning DBs failed: ${archiveErr.message}"
+                                            }
                                             cleanWs()
                                         }
                                     }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1438,6 +1438,9 @@ PY
                                                         dir ('build') {
                                                             stash name: "MLIR-PerfDB-${params.canXdlops ? CHIP : 'vanilla'}", includes: "*.tsv"
                                                         }
+                                                        // Publish this arch's DBs immediately so they're visible without waiting for other parallel branches
+                                                        archiveArtifacts artifacts: "build/*.tsv",
+                                                            allowEmptyArchive: true, onlyIfSuccessful: false
                                                     }
                                                 }
                                             }
@@ -1447,6 +1450,11 @@ PY
                                             throw e
                                         }
                                         finally {
+                                            // Best-effort: publish any partial DBs produced before a failure/abort so unfinished branches still surface artifacts
+                                            try {
+                                                archiveArtifacts artifacts: "build/*.tsv",
+                                                    allowEmptyArchive: true, onlyIfSuccessful: false
+                                            } catch (ignored) {}
                                             cleanWs()
                                         }
                                     }


### PR DESCRIPTION
Per-arch tuning DBs are currently only published at the end of the weekly Tuning matrix, after every parallel branch (gfx908/gfx90a/gfx942/gfx950/gfx1100/gfx1201) finishes. A single slow or failing branch hides the DBs that the rest already produced.

This adds an archiveArtifacts 'build/*.tsv' in the matrix row's finally block, so each branch publishes its own DBs as soon as it finishes independent if it is success or failure