### PR TITLE
Disable rock.arch="native" by default for BUILD_FAT_LIBROCKCOMPILER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,13 @@ if( BUILD_FAT_LIBROCKCOMPILER )
   set(MLIR_INCLUDE_INTEGRATION_TESTS OFF CACHE BOOL "")
   set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 0 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
   set(MHAL_ENABLE_HOST_RUNNER OFF CACHE BOOL "Enable MHAL host runner")
+  # rock.arch="native" runtime detection requires linking HIP and HSA, which
+  # adds a hard DT_NEEDED on libamdhip64/libhsa-runtime64 to every consumer
+  # of the static fat library. Disable it by default for the fat-lib build
+  # so consumers (e.g. MIGraphX) do not transitively pull HIP/HSA from
+  # rocMLIR alone. Pass -DROCMLIR_ENABLE_NATIVE_ARCH=ON to opt back in.
+  set(ROCMLIR_ENABLE_NATIVE_ARCH OFF CACHE BOOL
+    "Enable rock.arch=\"native\" runtime detection (requires HIP and HSA)")
   if(NOT WIN32)
     set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "")
     # Note, this is a hack to ignore Pytorch added conda path
@@ -99,6 +106,8 @@ else()
   set(MLIR_ENABLE_ROCM_RUNNER 1 CACHE BOOL "")
   set(MLIR_INCLUDE_INTEGRATION_TESTS ON CACHE BOOL "")
   set(ROCMLIR_DRIVER_PR_E2E_TEST_ENABLED 1 CACHE BOOL "Enable build PR-triggered E2E tests for Rock driver")
+  set(ROCMLIR_ENABLE_NATIVE_ARCH ON CACHE BOOL
+    "Enable rock.arch=\"native\" runtime detection (requires HIP and HSA)")
 endif()
 
 # Pointers to external llvm build, needed here to set up rpath project-wide

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -21,8 +21,14 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 
-// HIP and HSA are not supported on Windows CI.
-#ifndef _WIN32
+// HIP and HSA are needed only by rock.arch="native" runtime detection.
+// They are pulled in only when ROCMLIR_ENABLE_NATIVE_ARCH is defined
+// (default ON for shared-lib builds, OFF for BUILD_FAT_LIBROCKCOMPILER) and
+// excluded on Windows where HIP/HSA are not supported. Keeping these
+// includes off of the fat-lib build is what prevents libamdhip64 and
+// libhsa-runtime64 from becoming a hard DT_NEEDED of librockCompiler.a's
+// consumers.
+#if !defined(_WIN32) && defined(ROCMLIR_ENABLE_NATIVE_ARCH)
 #include "hip/hip_runtime_api.h"
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
@@ -153,10 +159,11 @@ static std::tuple<StringRef, unsigned> parseArchString(StringRef arch) {
   return ret;
 }
 
-// native arch is not supported in Windows, which lacks both HSA and
-// HIP libraries during CI. For more information check:
-// https://github.com/ROCm/rocMLIR/pull/1790
-#ifndef _WIN32
+// rock.arch="native" needs HIP and HSA, so the implementation is gated on
+// ROCMLIR_ENABLE_NATIVE_ARCH (default OFF for BUILD_FAT_LIBROCKCOMPILER) and
+// on a non-Windows host (HIP/HSA are not supported on Windows CI; see PR
+// #1790 for the original Windows context).
+#if !defined(_WIN32) && defined(ROCMLIR_ENABLE_NATIVE_ARCH)
 namespace {
 
 template <typename LHS, typename RHS>
@@ -350,17 +357,19 @@ AmdArchInfo nativeArchInfo(unsigned deviceId = 0) {
 
 } // anonymous namespace
 
-#endif // _WIN32
+#endif // !_WIN32 && ROCMLIR_ENABLE_NATIVE_ARCH
 
 AmdArchInfo mlir::rock::lookupArchInfo(StringRef arch) {
   // Keep this implementation in sync with
   // mlir/test/lit.site.cfg.py.in:set_arch_features()
   auto [chip, deviceId] = parseArchString(arch);
   if (chip == "native") {
-#ifdef _WIN32
-    llvm_unreachable("native arch lookup is not supported on Windows");
-#else
+#if !defined(_WIN32) && defined(ROCMLIR_ENABLE_NATIVE_ARCH)
     return nativeArchInfo(deviceId);
+#else
+    llvm_unreachable("rock.arch=\"native\" is not available in this build "
+                     "(requires ROCMLIR_ENABLE_NATIVE_ARCH=ON and a "
+                     "non-Windows host)");
 #endif
   }
   StringRef minor = chip.take_back(2);

--- a/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Rock/IR/CMakeLists.txt
@@ -47,10 +47,13 @@ target_link_libraries(MLIRRockOps
   MLIRLinalgTransformOps
   )
 
-# ROCm on Windows does not support HSA.
-# Also HIP is not supported on our CI,
-# so we cannot use either of them.
-if (NOT WIN32)
+# rock.arch="native" runtime detection in AmdArchDb.cpp is the only thing
+# in MLIRRockOps that needs HIP and HSA at link time. Gating that behind
+# ROCMLIR_ENABLE_NATIVE_ARCH lets BUILD_FAT_LIBROCKCOMPILER consumers (e.g.
+# MIGraphX, which always passes a real arch like "gfx942") avoid a hard
+# DT_NEEDED on libamdhip64/libhsa-runtime64 from rocMLIR. Windows is also
+# excluded because HIP/HSA are not supported there.
+if (NOT WIN32 AND ROCMLIR_ENABLE_NATIVE_ARCH)
   # From: https://github.com/ROCm/rocMLIR/blob/b6c726a324d2807494f770ed915af0e54cc6cb3f/external/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt#L414
   find_package(hip REQUIRED PATHS ${ROCM_PATH})
   # We do need both of these. One is for linking, to get the HIP
@@ -65,4 +68,7 @@ if (NOT WIN32)
   # From: https://github.com/ROCm/rocm-systems/blob/c53bdb9643afc2ef943fd25113a1c704d39aa6b4/projects/rocminfo/CMakeLists.txt
   find_package(hsa-runtime64 1.0 REQUIRED)
   target_link_libraries(MLIRRockOps PUBLIC hsa-runtime64::hsa-runtime64)
+
+  # Tell AmdArchDb.cpp to compile in the HIP/HSA-backed nativeArchInfo path.
+  target_compile_definitions(obj.MLIRRockOps PRIVATE ROCMLIR_ENABLE_NATIVE_ARCH=1)
 endif()

--- a/mlir/tools/rocmlir-lib/CMakeLists.txt
+++ b/mlir/tools/rocmlir-lib/CMakeLists.txt
@@ -116,7 +116,13 @@ if(BUILD_FAT_LIBROCKCOMPILER)
     add_custom_target(__generate_fat_library DEPENDS ${full_output_path})
     add_dependencies(${LIBRARY_NAME} __generate_fat_library)
 
-    target_link_libraries(${LIBRARY_NAME} INTERFACE hsa-runtime64::hsa-runtime64)
+    # Only propagate hsa-runtime64 to consumers when the fat archive actually
+    # contains code that calls into HSA (rock.arch="native" path). Otherwise
+    # consumers (e.g. MIGraphX) inherit a redundant DT_NEEDED on
+    # libhsa-runtime64 even though no symbols are referenced from rocMLIR.
+    if (ROCMLIR_ENABLE_NATIVE_ARCH)
+      target_link_libraries(${LIBRARY_NAME} INTERFACE hsa-runtime64::hsa-runtime64)
+    endif()
     target_link_libraries(${LIBRARY_NAME}
         INTERFACE
             $<BUILD_INTERFACE:${full_output_path}>
@@ -187,7 +193,12 @@ if(BUILD_FAT_LIBROCKCOMPILER)
       INCLUDES DESTINATION include/${package_name} ${ARG_EXTRA_INCLUDES}
     )
 
-    if(NOT WIN32)
+    # Only declare hsa-runtime64 as a hard find_dependency() of the exported
+    # rocMLIR config when the fat archive actually links HSA (i.e. rock.arch=
+    # "native" is enabled). With ROCMLIR_ENABLE_NATIVE_ARCH=OFF the static
+    # archive contains no HSA symbols, so there is no reason to force every
+    # find_package(rocMLIR) consumer to also resolve hsa-runtime64.
+    if(NOT WIN32 AND ROCMLIR_ENABLE_NATIVE_ARCH)
         set(DEPENDS_HSA DEPENDS hsa-runtime64)
     endif()
 

--- a/mlir/unittests/Dialect/Rock/CMakeLists.txt
+++ b/mlir/unittests/Dialect/Rock/CMakeLists.txt
@@ -9,7 +9,11 @@ set(ROCK_UNITTEST_SOURCES
   ParamLookupTableTests.cpp
 )
 
-if(NOT WIN32)
+# AmdArchDbTests directly includes hip/hip_runtime_api.h and exercises
+# lookupArchInfo("native:N"), so it can only be built when the native-arch
+# path is compiled in. Skip on Windows (no HIP/HSA) and whenever
+# ROCMLIR_ENABLE_NATIVE_ARCH is OFF (e.g. BUILD_FAT_LIBROCKCOMPILER).
+if(NOT WIN32 AND ROCMLIR_ENABLE_NATIVE_ARCH)
   list(APPEND ROCK_UNITTEST_SOURCES AmdArchDbTests.cpp)
 endif()
 


### PR DESCRIPTION



## Motivation

The rock.arch="native" runtime detection in AmdArchDb.cpp is the only code path in librockCompiler that needs HIP and HSA at link time. With the fat library, those undefined symbols force every consumer (e.g. MIGraphX) to DT_NEEDED libamdhip64 / libhsa-runtime64 via rocMLIR, which in turn lets libamdhip64 dlopen libamd_comgr at runtime even when the consumer only ever passes a concrete arch like "gfx942" to rocMLIR.

`libamd_comgr` depends on  `libLLVM`. Therefore it causes two different LLVM libs active in the same process which leads to runtime crash.

## Technical Details

Add a new ROCMLIR_ENABLE_NATIVE_ARCH cache option (default OFF for the fat lib build, ON for the shared-lib build) that gates:

- find_package(hip)/find_package(hsa-runtime64) and the corresponding target_link_libraries on MLIRRockOps
- the HIP/HSA includes and the nativeArchInfo namespace in AmdArchDb.cpp, with lookupArchInfo now reporting a clear llvm_unreachable when the "native" arch is requested in a build that doesn't support it
- the AmdArchDbTests unit test, which directly includes hip_runtime_api.h
- the hsa-runtime64 INTERFACE_LINK_LIBRARIES propagation and the find_dependency(hsa-runtime64) entry in the exported rocMLIRConfig.cmake, so consumers no longer pick up HSA via rocMLIR when there is no HSA in the static archive

Users that still want native-arch detection with the fat lib can opt back in explicitly with -DROCMLIR_ENABLE_NATIVE_ARCH=ON.

## Test Plan

Tested on the TheRock nightly builds with MIGraphX. Crash due to multiple LLVM is  not happening and all tests are passing both on rocMLIR and also on MIGraphX side. 
