### PR TITLE
[NFC] Expand and reorganize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,17 @@
 *~
 # Merge files created by git.
 *.orig
+# Reject files created by patch.
+*.rej
 # Byte compiled python modules.
 *.pyc
 # vim swap files
 .*.sw?
 .sw?
+# Perfetto trace files (profiling output).
+*.pftrace
 #OS X specific files.
-.DS_store
+.DS_Store
 
 # Ignore the user specified CMake presets in subproject directories.
 /*/CMakeUserPresets.json
@@ -43,12 +47,36 @@ autom4te.cache
 cscope.files
 cscope.out
 autoconf/aclocal.m4
-autoconf/autom4te.cache
+# Source indexing
 /compile_commands.json
-# Visual Studio built-in CMake configuration
+/tablegen_compile_commands.yml
+# Profile data (re-include LLVM PGO test inputs in external/llvm-project/)
+*.profraw
+*.profdata
+!external/llvm-project/**/*.profraw
+!external/llvm-project/**/*.profdata
+# Environment files (may contain secrets)
+.env
+# CMake configuration
 /CMakeSettings.json
-# CLion project configuration
+CMakePresets.json
+# IDE / editor config files
 /.idea
+.gdbinit
+.dir-locals.el
+# Coding assistants' stuff
+.agents/
+/CLAUDE.md
+/instructions.md
+.claude/
+/GEMINI.md
+.gemini/
+AGENTS.md
+.codex/
+# Cursor specific files
+.cursor
+.cursorignore
+.cursorindexingignore
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
@@ -68,10 +96,21 @@ pythonenv*
 /clang/utils/analyzer/projects/*/RefScanBuildResults
 # automodapi puts generated documentation files here.
 /lldb/docs/python_api/
-.gdbinit
-/MIOpen
-.dir-locals.el
+# ccls index
 /.ccls-cache
+# Jupyter notebook checkpoints
 .ipynb_checkpoints
+# rocMLIR project-specific dependencies
+/MIOpen
 /MIOpenDeps
-CMakePresets.json
+# Plan files, scratch notes, and working documents (per workspace-hygiene rule)
+/plans/
+/scratch/
+/notes/
+# Profiling output directories (per workspace-hygiene rule)
+.rocprofv3/
+# Python virtual environments and caches
+__pycache__/
+.pytest_cache/
+.venv
+venv/


### PR DESCRIPTION
Pulls relevant entries from LLVM, IREE, and Triton .gitignore files to exclude coding-assistant artifacts, profiling output, Python caches, and working-document directories that the workspace-hygiene rule mandates, preventing accidental commits of these files.

Profile-data patterns (*.profraw, *.profdata) are unanchored to catch generated profile data anywhere in the tree, but re-include the LLVM PGO test inputs under external/llvm-project/ so the vendored subtree is unaffected by future merges.

Also fixes a duplicate (autoconf/autom4te.cache) and a case-sensitivity typo (.DS_store -> .DS_Store), and groups related entries with subsection comments for clarity.

adds `.env` into `.gitignore` as well.
