### PR TITLE
[AIROCMLIR-707] Make attentionSweeps split_kv filter device-memory-aware

### DIFF
--- a/mlir/utils/performance/attentionSweeps.py
+++ b/mlir/utils/performance/attentionSweeps.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import asyncio
-from typing import Iterable, List, TypeVar
+from typing import Iterable, List, Optional, TypeVar
 from dataclasses import replace
 from datetime import datetime, timezone
 import sys
@@ -31,6 +31,7 @@ from perfRunner import get_arch, get_num_cu, get_num_chiplets, initialize_dtypes
 from perfRunner import create_paths
 from perfRunner import find_mlir_build_dir
 from perfRunner import GFX_CHIP_RE
+from perfRunner import hip, hip_check
 from parameterSweeps import (
     Options,
     sweep_parameters,
@@ -44,6 +45,26 @@ DATA_TYPES_ATTENTION = initialize_dtypes_attn()
 BOOLS = [True, False]
 MAX_TOKENS = 64 * 64  # temporarily hardcoded
 SPLIT_KV_OPTIONS = [1, 2, 4, 8, 16, 32, 64, 128]
+# When splitKV > 1, attention materializes extra partial output/LSE buffers.
+# In the sweep generator we filter out samples with estimated splitKV extra storage
+# above a conservative budget to avoid generating configs that are likely to
+# OOM/time out late in the gen->driver->run pipeline.
+#
+# Default policy: use ~12.5% of VRAM (deviceMem/8) as a conservative budget, then
+# clamp to keep behavior stable across very small/very large devices. If device
+# memory cannot be queried, fall back to a mid-range default.
+DEFAULT_SWEEP_LIMIT_BYTES = 1536 * 1024 * 1024
+MIN_DYNAMIC_SWEEP_LIMIT_BYTES = 1024 * 1024 * 1024
+MAX_DYNAMIC_SWEEP_LIMIT_BYTES = 8192 * 1024 * 1024
+DYNAMIC_SWEEP_LIMIT_DIVISOR = 8
+DTYPE_BYTES = {
+    'f16': 2,
+    'bf16': 2,
+    'f32': 4,
+    'i8': 1,
+}
+# LSE is stored as f32 in the attention API/contracts, so 4 bytes per element.
+LSE_ELEM_BYTES = 4
 # TODO: Keep these sweep bounds and perf options in sync with attention tuning
 # search space in mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
 # (createGemmGemmTuningRangeBF).
@@ -139,6 +160,58 @@ def _within_limit(g: int, slq: int, slk: int) -> bool:
     # Checks that the total token count stays within MAX_TOKENS.
     # Used both to filter generated samples and to derive per-group seq len bounds.
     return max(slq, slk) * g <= MAX_TOKENS
+
+
+def _parse_nonnegative_int64(value: str) -> int:
+    try:
+        parsed = int(value, 10)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(str(e)) from e
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    # Bound to int64 to catch accidental huge values.
+    if parsed > (1 << 63) - 1:
+        raise argparse.ArgumentTypeError("value exceeds int64 max")
+    return parsed
+
+
+def _query_visible_device_memory_bytes() -> Optional[int]:
+    try:
+        device_count = hip_check(hip.hipGetDeviceCount())
+    except RuntimeError:
+        return None
+
+    if device_count <= 0:
+        return None
+
+    try:
+        props = hip.hipDeviceProp_t()
+        hip_check(hip.hipGetDeviceProperties(props, 0))
+    except RuntimeError:
+        return None
+
+    device_memory = getattr(props, 'totalGlobalMem', None)
+    if device_memory is None:
+        return None
+
+    try:
+        device_memory = int(device_memory)
+    except (TypeError, ValueError):
+        return None
+
+    if device_memory <= 0:
+        return None
+    return device_memory
+
+
+def _get_default_sweep_limit_bytes() -> int:
+    device_memory = _query_visible_device_memory_bytes()
+    if device_memory is None:
+        return DEFAULT_SWEEP_LIMIT_BYTES
+
+    dynamic_limit = device_memory // DYNAMIC_SWEEP_LIMIT_DIVISOR
+    return max(MIN_DYNAMIC_SWEEP_LIMIT_BYTES,
+               min(MAX_DYNAMIC_SWEEP_LIMIT_BYTES, dynamic_limit))
 
 
 def sample_attn_shape():
@@ -251,16 +324,40 @@ def sample_attention_case(instruction_set: str, flags: list[str]):
     return (sample_attn_shape(), sample_perf_config(instruction_set, flags))
 
 
-def sample_attention_batch(batch_size: int, instruction_set: str, flags: list[str]):
+def _estimate_splitkv_extra_bytes(shape_sample: tuple) -> Optional[int]:
+    dtype, g, seq_len_q, _seq_len_k, num_heads_q, _num_heads_kv, _head_dim_qk, head_dim_v, _scale, _bias, _tq, _tk, _tv, _to, _causal, return_lse, split_kv, _current_seqlen = shape_sample
+    if split_kv <= 1:
+        return 0
+
+    # DTYPE_BYTES maps the attention datatype to bytes per element so we can
+    # estimate extra storage in bytes.
+    out_elem_bytes = DTYPE_BYTES.get(dtype)
+    if out_elem_bytes is None:
+        return None
+
+    extra_factor = split_kv - 1
+    batch_heads = g * num_heads_q
+    base = batch_heads * seq_len_q
+    extra_out = base * head_dim_v * out_elem_bytes * extra_factor
+    extra_lse = base * LSE_ELEM_BYTES * extra_factor if return_lse else 0
+    return extra_out + extra_lse
+
+
+def sample_attention_batch(batch_size: int, instruction_set: str, flags: list[str],
+                           splitkv_limit_bytes: int):
     filtered_samples = []
-    filtered_out = 0
+    filtered_counts = {'max_tokens': 0, 'splitkv_extra': 0}
     for _ in range(batch_size):
         sample = sample_attention_case(instruction_set, flags)
         if _within_limit(sample[0][1], sample[0][2], sample[0][3]):  # g, slq, slk
-            filtered_samples.append(sample)
+            maybe_extra_bytes = _estimate_splitkv_extra_bytes(sample[0])
+            if maybe_extra_bytes is None or maybe_extra_bytes <= splitkv_limit_bytes:
+                filtered_samples.append(sample)
+            else:
+                filtered_counts['splitkv_extra'] += 1
         else:
-            filtered_out += 1
-    return filtered_samples, filtered_out
+            filtered_counts['max_tokens'] += 1
+    return filtered_samples, filtered_counts
 
 
 def log_failing_configs(configs: List[AttentionConfiguration], filename: str):
@@ -286,11 +383,20 @@ def run_attention_sweep(args, options, paths, chip):
         print(f"Attention codepath: {instruction_set.upper()} on {chip}")
         print(
             f"rocmlir-gen flags: {' '.join(rocmlir_gen_flags) if rocmlir_gen_flags else '(none)'}")
+    splitkv_limit_bytes = (args.splitkv_extra_bytes_limit
+                           if args.splitkv_extra_bytes_limit is not None else
+                           _get_default_sweep_limit_bytes())
+    if not args.quiet:
+        print(f"SplitKV sweep extra-storage limit: {splitkv_limit_bytes} bytes")
 
-    samples, filtered_out = sample_attention_batch(args.samples, instruction_set, rocmlir_gen_flags)
+    samples, filtered_counts = sample_attention_batch(args.samples, instruction_set, rocmlir_gen_flags,
+                                                      splitkv_limit_bytes)
+    cumulative_filtered_counts = dict(filtered_counts)
 
     if not args.quiet:
-        print(f"Filtered out {filtered_out} samples exceeding MAX_TOKENS={MAX_TOKENS}.")
+        print(f"Filtered out {filtered_counts['max_tokens']} samples exceeding MAX_TOKENS={MAX_TOKENS}.")
+        print(
+            f"Filtered out {filtered_counts['splitkv_extra']} samples exceeding splitKV extra-storage limit.")
         print(f"Proceeding with {len(samples)} initial samples.\n")
 
     passed, invalid, failing = asyncio.run(
@@ -303,7 +409,10 @@ def run_attention_sweep(args, options, paths, chip):
     while (total_passed + len(total_failing)) < args.samples:
         remaining_valid = args.samples - (total_passed + len(total_failing))
         batch_target = max(remaining_valid * 2, args.jobs if args.jobs else 1)
-        batch, _ = sample_attention_batch(batch_target, instruction_set, rocmlir_gen_flags)
+        batch, refill_filtered_counts = sample_attention_batch(batch_target, instruction_set,
+                                                               rocmlir_gen_flags, splitkv_limit_bytes)
+        cumulative_filtered_counts['max_tokens'] += refill_filtered_counts['max_tokens']
+        cumulative_filtered_counts['splitkv_extra'] += refill_filtered_counts['splitkv_extra']
         if not batch:
             continue
 
@@ -317,6 +426,11 @@ def run_attention_sweep(args, options, paths, chip):
         print(f"{'Failing Configurations':^80}\n")
         for fail in total_failing:
             print(multiline_repr(fail))
+
+    if not args.quiet:
+        print("Filtered samples summary:")
+        print(f"  - MAX_TOKENS filter: {cumulative_filtered_counts['max_tokens']}")
+        print(f"  - splitKV extra-storage filter: {cumulative_filtered_counts['splitkv_extra']}")
 
     print(f"\nPassed: {total_passed}, Invalid: {total_invalid}, Failed: {len(total_failing)}")
 
@@ -341,6 +455,13 @@ def main():
                         type=int,
                         default=600,
                         help='Per-config timeout in seconds (0 disables timeout)')
+    parser.add_argument(
+        '--splitkv-extra-bytes-limit',
+        type=_parse_nonnegative_int64,
+        default=None,
+        help=("Max allowed estimated splitKV extra temporary storage (bytes). "
+              "If unset, a device-based default is used (deviceMem/8 clamped to "
+              "[1 GiB, 8 GiB], fallback 1.5 GiB)."))
     parser.add_argument('--log-failures', action='store_true')
 
     args = parser.parse_args()


### PR DESCRIPTION
## Motivation

Some attention sweep samples with large split_kv generate very high temporary storage pressure and are currently rejected as FAIL after entering the pipeline.
This PR adds an early sweep-side prefilter so memory-heavy splitKV cases can be skipped before expensive execution, reducing wasted sweep effort while keeping existing compiler/runtime behavior unchanged.

## Technical Details

Updated mlir/utils/performance/attentionSweeps.py to add a device-memory-aware splitKV prefilter in sampling:
- Added splitKV extra-storage estimator for sampled attention shapes.
- Added default splitKV limit policy based on visible device memory:
   - deviceMem / 8, clamped to [1 GiB, 8 GiB]
   - fallback to 1.5 GiB when memory query is unavailable.
- Added CLI control:
   - --splitkv-extra-bytes-limit (non-negative int64-validated override).
Refactored sample filtering to track reasons separately:
- MAX_TOKENS filter
- splitKV extra-storage filter
- cumulative reporting across initial and refill sampling batches.
Added focused unit tests in mlir/utils/performance/tests/test_attentionSweeps.py:
- limit policy behavior (clamp/fallback),
- splitKV estimator behavior,
- per-reason filter accounting.
No compiler/verifier logic was changed in this PR; scope is limited to sweep generation/filtering behavior.

## Test Plan

- Run attentionSweeps.py through CI to validate end-to-end sweep behavior with the new splitKV prefilter.
- Confirm that memory-heavy splitKV cases are filtered before expensive execution stages.

## Test Result

- [ ] CI attention-sweep run

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
