### PR TITLE
Make scaled GEMM accept and emit un-broadcasted scales (#2127)

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/loweringUtils.h
@@ -34,6 +34,13 @@ class ThreadwiseReadIntoOp;
 struct ConvolutionDims;
 struct GemmSize;
 
+// Block size used for quantization in scaled GEMMs (i.e. one scale value
+// per group of `kQuantBlockSize` consecutive elements along the K dimension).
+// This corresponds to the OCP MX block size and matches the assumption baked
+// into the AMD scaled MFMA / WMMA instructions (which expect one scale per
+// group of 32 elements).
+constexpr int64_t kQuantBlockSize = 32;
+
 // This structure captures three views of
 // a register memref. Each view correspond
 // to a (strided) slice of a 2D matrix that is

--- a/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
+++ b/mlir/lib/Conversion/TosaToRock/TosaToRock.cpp
@@ -953,72 +953,6 @@ public:
   }
 };
 
-/// Broadcast scale tensor to full K dim by adding a block dimension and
-/// broadcasting it to blockSize.
-/// Scale is [batch, D, kScale] if not transposed, [batch, kScale, D] if
-/// transposed. Output is [batch, D, K] or [batch, K, D] respectively,
-/// where K = kScale * blockSize.
-static FailureOr<Value> broadcastScale(OpBuilder &b, Location loc, Value scale,
-                                       int64_t blockSize, UnitAttr transpose) {
-  auto scaleType = cast<RankedTensorType>(scale.getType());
-  ArrayRef<int64_t> scaleShape = scaleType.getShape();
-  if (scaleShape.size() != 3)
-    return emitError(loc, "scale tensor must be 3D, got rank ")
-           << scaleShape.size();
-
-  // Non-transposed: [batch, D, kScale] -> block inserted at index 3
-  // Transposed:     [batch, kScale, D] -> block inserted at index 2
-  unsigned blockIdx = transpose ? 2 : 3;
-
-  SmallVector<StringRef, 3> initDims;
-  if (transpose)
-    initDims = {"batch", "kScale", "D"};
-  else
-    initDims = {"batch", "D", "kScale"};
-
-  // Step 1: Add a "block" dimension with size 1 after kScale
-  rock::BottomUpTMBuilder addDimB(b, initDims, scaleShape, loc);
-  if (transpose) {
-    addDimB.passThrough({"batch", "kScale"});
-    addDimB.addDim("block", blockIdx, 1);
-    addDimB.passThrough({"D"}, {3}, {"D"});
-  } else {
-    addDimB.passThrough({"batch", "D", "kScale"});
-    addDimB.addDim("block", blockIdx, 1);
-  }
-  auto addDimAttr = addDimB.get();
-  scale = rock::TransformOp::create(b, loc, scale, addDimAttr);
-
-  // Step 2: Broadcast the block dimension to blockSize
-  rock::BottomUpTMBuilder broadcastB =
-      rock::BottomUpTMBuilder::above(addDimB, addDimAttr);
-  if (transpose) {
-    broadcastB.passThrough({"batch", "kScale"});
-    broadcastB.broadcast({blockIdx}, {blockSize});
-    broadcastB.passThrough({"D"}, {3}, {"D"});
-  } else {
-    broadcastB.passThrough({"batch", "D", "kScale"});
-    broadcastB.broadcast({blockIdx}, {blockSize});
-  }
-  auto broadcastAttr = broadcastB.get();
-  scale = rock::TransformOp::create(b, loc, scale, broadcastAttr);
-
-  // Step 3: Merge kScale and block into K
-  rock::BottomUpTMBuilder mergeB =
-      rock::BottomUpTMBuilder::above(broadcastB, broadcastAttr);
-  if (transpose) {
-    mergeB.passThrough("batch");
-    mergeB.merge("K", 1, {"kScale", "block"});
-    mergeB.passThrough({"D"}, {2}, {"D"});
-  } else {
-    mergeB.passThrough({"batch", "D"});
-    mergeB.merge("K", 2, {"kScale", "block"});
-  }
-  auto mergeAttr = mergeB.get();
-  Value result = rock::TransformOp::create(b, loc, scale, mergeAttr);
-  return result;
-}
-
 class MatmulTBlockScaledConverter final
     : public OpConversionPattern<tosa::MatmulTBlockScaledOp> {
 public:
@@ -1113,24 +1047,13 @@ public:
     if (failed(setSplitKAttrs(op, features, rw)))
       return failure();
 
-    // Broadcast scales to match data tensor shapes
-    // A scale: [batch, M, K/blockSize] -> [batch, M, K] if not transposed,
-    // A scale: [batch, K/blockSize, M] -> [batch, K, M] if transposed
-    // Note that B scale is already transposed by default for
-    // tosa.matmul_t_block_scaled. B scale: [batch, N, K/blockSize] -> [batch,
-    // N, K] if not transposed, B scale: [batch, K/blockSize, N] -> [batch, K,
-    // N] if transposed
-    auto brAScaleResult =
-        broadcastScale(rw, loc, aScale, blockSize, transposeAScaleFromAttr);
-    if (failed(brAScaleResult))
-      return failure();
-    Value brAScale = *brAScaleResult;
-
-    auto brBScaleResult =
-        broadcastScale(rw, loc, bScale, blockSize, transposeBScaleFromAttr);
-    if (failed(brBScaleResult))
-      return failure();
-    Value brBScale = *brBScaleResult;
+    // The rock.gemm verifier accepts scales either in their natural form
+    // (with K dim equal to matrixK / quantBlockSize) or in the legacy
+    // broadcasted form (K dim equal to matrixK). Pass through the natural
+    // form so the lowering can avoid the LDS/register cost of replicating
+    // the same scale value for every K element of a quantization block.
+    Value brAScale = aScale;
+    Value brBScale = bScale;
 
     // Scale transpose attributes:
     // TransposeRewritePattern can set transpose_a_scale and transpose_b_scale

--- a/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
+++ b/mlir/lib/Dialect/Rock/IR/RockDialect.cpp
@@ -235,9 +235,27 @@ static LogicalResult verifyScales(OpType op, Value matrix, Value scale,
                         "type Float4E2M1FNType.",
                         matrixName));
     }
-    if (matrixType.getShape() != scaleType.getShape()) {
+    // Scales are expected to have the same non-K dimensions as the matrix.
+    // The K dimension may either match the matrix K (legacy broadcasted form)
+    // or be matrixK / kQuantBlockSize (natural form, one scale per quant
+    // block).
+    ArrayRef<int64_t> matShape = matrixType.getShape();
+    ArrayRef<int64_t> scaleShape = scaleType.getShape();
+    if (matShape.size() != scaleShape.size()) {
       return op.emitError(llvm::formatv(
           "Scale{0} shape must match matrix{0} shape.", matrixName));
+    }
+    for (size_t i = 0, e = matShape.size(); i < e; ++i) {
+      // K is dim 1 for matA (KxM after normalization) and dim 1 for matB
+      // (KxN after normalization); G is always dim 0.
+      bool isKDim = (i == 1);
+      bool kDimOk = scaleShape[i] == matShape[i] ||
+                    (matShape[i] % kQuantBlockSize == 0 &&
+                     scaleShape[i] == matShape[i] / kQuantBlockSize);
+      if (isKDim ? !kDimOk : (scaleShape[i] != matShape[i])) {
+        return op.emitError(llvm::formatv(
+            "Scale{0} shape must match matrix{0} shape.", matrixName));
+      }
     }
   }
   return success();
@@ -1177,20 +1195,37 @@ LogicalResult GemmOp::verify() {
 
     StringRef firstName = isA ? "M" : "K";
     StringRef secondName = isA ? "K" : "N";
+    // Scale's K dimension can either match the matrix K (legacy / broadcasted
+    // form) or be K / kQuantBlockSize (natural form, one scale per
+    // quantization block). Both are accepted here; the lowering canonicalizes
+    // them to the natural form.
+    auto kMatches = [](int64_t scaleK, int64_t matrixK) -> bool {
+      if (scaleK == matrixK)
+        return true;
+      if (matrixK % kQuantBlockSize == 0 &&
+          scaleK == matrixK / kQuantBlockSize)
+        return true;
+      return false;
+    };
 
-    if (second != expectedSecond)
+    bool secondOk = isA ? kMatches(second, expectedSecond)
+                        : (second == expectedSecond);
+    bool firstOk = isA ? (first == expectedFirst)
+                       : kMatches(first, expectedFirst);
+
+    if (!secondOk)
       return emitOpError() << scaleName << "'s " << secondName
                            << " dimension must match matrix "
                            << (isA ? "A" : "B") << "'s " << secondName
-                           << " dimension"
+                           << " dimension (or be K / " << kQuantBlockSize << ")"
                            << " " << scaleName << "_" << secondName.lower()
                            << " = " << second << " " << (isA ? "k_a" : "n_b")
                            << " = " << expectedSecond;
-    if (first != expectedFirst)
+    if (!firstOk)
       return emitOpError() << scaleName << "'s " << firstName
                            << " dimension must match matrix "
                            << (isA ? "A" : "B") << "'s " << firstName
-                           << " dimension"
+                           << " dimension (or be K / " << kQuantBlockSize << ")"
                            << " " << scaleName << "_" << firstName.lower()
                            << " = " << first << " " << (isA ? "m_a" : "k_b")
                            << " = " << expectedFirst;

--- a/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GemmToGridwise.cpp
@@ -726,13 +726,23 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
     auto scaleBType = cast<MemRefType>(scaleB.getType());
     scaleAShape = scaleAType.getShape();
     scaleBShape = scaleBType.getShape();
-    // keep both scales in the same layout as the matrices
-    // do transpose as necessary to achieve this. This is required to align load
-    // and store layouts with matrices.
-    bool transposeScaleA = (aShape != scaleAShape);
+    // Determine whether scales are in the K-first form already (no transpose
+    // needed) or in the D-first form (transpose needed). Scales may be in
+    // either the broadcasted form (K dim equal to matrix K) or the natural
+    // form (K dim equal to matrix K / kQuantBlockSize).
+    auto isAlreadyKFirst = [&](ArrayRef<int64_t> matShape,
+                               ArrayRef<int64_t> sShape) -> bool {
+      if (sShape[0] != matShape[0])
+        return false;
+      bool kLike = (sShape[1] == matShape[1]) ||
+                   (matShape[1] % kQuantBlockSize == 0 &&
+                    sShape[1] == matShape[1] / kQuantBlockSize);
+      return kLike && sShape[2] == matShape[2];
+    };
+    bool transposeScaleA = !isAlreadyKFirst(aShape, scaleAShape);
     scaleA =
         normalizeMatrix(scaleA, rw, loc, transposeScaleA, "gemmK", "gemmM");
-    bool transposeScaleB = (bShape != scaleBShape);
+    bool transposeScaleB = !isAlreadyKFirst(bShape, scaleBShape);
     scaleB =
         normalizeMatrix(scaleB, rw, loc, transposeScaleB, "gemmK", "gemmN");
   }
@@ -769,10 +779,27 @@ GemmRewritePattern::matchAndRewrite(GemmOp op, GemmOpAdaptor adaptor,
   b = padMatrix(b, rw, loc, "gemmK", extraPad.k, "gemmN", extraPad.n);
   c = padMatrix(c, rw, loc, "gemmM", extraPad.m, "gemmN", extraPad.n);
   if (scaleA && scaleB) {
+    // Scales are either in the natural form (K dim = matrixK / kQuantBlockSize)
+    // or in the legacy broadcasted form (K dim = matrixK). When in natural
+    // form the K-direction padding has to be scaled down by the quantization
+    // block size since each scale value covers `kQuantBlockSize` elements
+    // along K of the matrix.
+    int64_t matK = aShape[1];
+    int64_t scaleAK =
+        cast<MemRefType>(scaleA.getType()).getShape()[1];
+    bool scalesAreBroadcast = (scaleAK == matK);
+    int64_t scaleKPad = scalesAreBroadcast
+                            ? extraPad.k
+                            : (extraPad.k / kQuantBlockSize);
+    if (!scalesAreBroadcast && (extraPad.k % kQuantBlockSize != 0))
+      return op.emitError(
+          "K padding for scaled GEMM must be a multiple of the quantization "
+          "block size");
+
     scaleA =
-        padMatrix(scaleA, rw, loc, "gemmK", extraPad.k, "gemmM", extraPad.m);
+        padMatrix(scaleA, rw, loc, "gemmK", scaleKPad, "gemmM", extraPad.m);
     scaleB =
-        padMatrix(scaleB, rw, loc, "gemmK", extraPad.k, "gemmN", extraPad.n);
+        padMatrix(scaleB, rw, loc, "gemmK", scaleKPad, "gemmN", extraPad.n);
     auto scaleAType = cast<MemRefType>(scaleA.getType());
     auto scaleBType = cast<MemRefType>(scaleB.getType());
     scaleAShape = scaleAType.getShape();
@@ -902,24 +929,50 @@ GemmRewritePattern::arrangeSplitKTransform(OpBuilder &builder, GemmOp op,
   }
 
   const int64_t origK = cast<MemRefType>(a.getType()).getShape()[1];
-  int64_t kPad = 0;
+  // For scaled GEMMs, split-K division must not cut a quantization block.
+  // For broadcasted scales the K padding must be a multiple of
+  // lcm(splitKFactor, kQuantBlockSize). For natural-form (un-broadcasted)
+  // scales, additionally each split's K must be a multiple of
+  // kQuantBlockSize, so the padded K must be a multiple of
+  // splitKFactor * kQuantBlockSize.
+  bool scalesInNaturalForm = false;
   if (scaleA && scaleB) {
-    // Hard code block size to 32 for now.
-    // for the scaleGEMMs, split-K division needs to happen such that it doesn't
-    // cut in the middle of the a block
-    // TODO: Use AmdArchDbInfo to populate blockSize
-    int64_t blockSize = 32;
-    int64_t lcm = math_util::lcm(splitKFactor, blockSize);
-    kPad = lcm - math_util::mod_1_to_n(origK, lcm);
-  } else {
-    kPad = splitKFactor - math_util::mod_1_to_n(origK, splitKFactor);
+    int64_t scaleAK = cast<MemRefType>(scaleA.getType()).getShape()[1];
+    scalesInNaturalForm = (scaleAK != origK);
   }
+  int64_t kAlign;
+  if (scaleA && scaleB) {
+    kAlign = scalesInNaturalForm ? (splitKFactor * kQuantBlockSize)
+                                 : math_util::lcm(splitKFactor,
+                                                  static_cast<int64_t>(
+                                                      kQuantBlockSize));
+  } else {
+    kAlign = splitKFactor;
+  }
+  int64_t kPad = kAlign - math_util::mod_1_to_n(origK, kAlign);
 
   a = padMatrix(a, builder, loc, "gemmK", kPad, "gemmM", 0);
   b = padMatrix(b, builder, loc, "gemmK", kPad, "gemmN", 0);
+
+  // Determine if scales are in broadcasted or natural form so we can scale the
+  // K-direction padding/splitting appropriately.
+  int64_t scaleKPad = 0;
+  bool scalesAreBroadcast = false;
   if (scaleA && scaleB) {
-    scaleA = padMatrix(scaleA, builder, loc, "gemmK", kPad, "gemmM", 0);
-    scaleB = padMatrix(scaleB, builder, loc, "gemmK", kPad, "gemmN", 0);
+    int64_t matKAfterPad = cast<MemRefType>(a.getType()).getShape()[1];
+    int64_t scaleKBeforePad =
+        cast<MemRefType>(scaleA.getType()).getShape()[1];
+    scalesAreBroadcast = (scaleKBeforePad == origK);
+    if (scalesAreBroadcast) {
+      scaleKPad = kPad;
+    } else {
+      // Natural form: matK = scaleK * kQuantBlockSize, so the scale's K
+      // padding is the matrix K padding divided by kQuantBlockSize.
+      scaleKPad = kPad / kQuantBlockSize;
+    }
+    (void)matKAfterPad;
+    scaleA = padMatrix(scaleA, builder, loc, "gemmK", scaleKPad, "gemmM", 0);
+    scaleB = padMatrix(scaleB, builder, loc, "gemmK", scaleKPad, "gemmN", 0);
   }
 
   // perform coordinate transformations
@@ -936,20 +989,33 @@ GemmRewritePattern::arrangeSplitKTransform(OpBuilder &builder, GemmOp op,
     Value &out;
     SmallVector<StringRef> inputDimNames;
     ArrayRef<int64_t> inputShape;
+    int64_t splitK;
+    int64_t kPerSplit;
   };
 
   llvm::SmallVector<GemmOperandsData, 4> gemmOperands{
-      {a, aNew, {"gemmG", "gemmK", "gemmM"}, aShape},
-      {b, bNew, {"gemmG", "gemmK", "gemmN"}, bShape}};
+      {a, aNew, {"gemmG", "gemmK", "gemmM"}, aShape, splitKFactor,
+       K / splitKFactor},
+      {b, bNew, {"gemmG", "gemmK", "gemmN"}, bShape, splitKFactor,
+       K / splitKFactor}};
   if (scaleA && scaleB) {
     ArrayRef<int64_t> scaleAShape =
         cast<MemRefType>(scaleA.getType()).getShape();
     ArrayRef<int64_t> scaleBShape =
         cast<MemRefType>(scaleB.getType()).getShape();
-    gemmOperands.push_back(
-        {scaleA, scaleANew, {"gemmG", "gemmK", "gemmM"}, scaleAShape});
-    gemmOperands.push_back(
-        {scaleB, scaleBNew, {"gemmG", "gemmK", "gemmN"}, scaleBShape});
+    int64_t scaleK = scaleAShape[1];
+    gemmOperands.push_back({scaleA,
+                            scaleANew,
+                            {"gemmG", "gemmK", "gemmM"},
+                            scaleAShape,
+                            splitKFactor,
+                            scaleK / splitKFactor});
+    gemmOperands.push_back({scaleB,
+                            scaleBNew,
+                            {"gemmG", "gemmK", "gemmN"},
+                            scaleBShape,
+                            splitKFactor,
+                            scaleK / splitKFactor});
   }
   for (auto &gemmOperand : gemmOperands) {
     // Prepare matrix A and B - i.e.,
@@ -970,7 +1036,7 @@ GemmRewritePattern::arrangeSplitKTransform(OpBuilder &builder, GemmOp op,
     unmergeTransform.passThrough({"gemmG", preservedDimName}, {0, 3},
                                  {"gemmG", preservedDimName});
     unmergeTransform.unmerge({"gemmKSplit", "gemmK"}, {1, 2}, "gemmK",
-                             {splitKFactor, K / splitKFactor});
+                             {gemmOperand.splitK, gemmOperand.kPerSplit});
 
     auto unmergeTransformAttr = unmergeTransform.get();
 

--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -3319,15 +3319,71 @@ struct GridwiseGemmAccelRewritePattern
                                 ? elementTypeB
                                 : maybeElementTypeBLoad.value();
     auto destType = op.getC().getType().getElementType();
-    auto scaleA = op.getScaleA();
-    auto scaleB = op.getScaleB();
+    Value scaleA = op.getScaleA();
+    Value scaleB = op.getScaleB();
     bool hasScaleA = scaleA != nullptr;
     bool hasScaleB = scaleB != nullptr;
     bool isScaledGemm = hasScaleA && hasScaleB;
     auto elementTypeScaleA =
-        isScaledGemm ? scaleA.getType().getElementType() : nullptr;
+        isScaledGemm
+            ? cast<MemRefType>(scaleA.getType()).getElementType()
+            : nullptr;
     auto elementTypeScaleB =
-        isScaledGemm ? scaleB.getType().getElementType() : nullptr;
+        isScaledGemm
+            ? cast<MemRefType>(scaleB.getType()).getElementType()
+            : nullptr;
+
+    // If scales are provided in their natural form (K dim equal to matrixK /
+    // kQuantBlockSize) re-broadcast them along the K axis so the existing
+    // LDS/load pipeline can handle them uniformly as if they had matrix
+    // shape. The amdgpu.scaled_mfma op only consumes the first scale value
+    // along this broadcasted dimension so the result is identical, while the
+    // hand-written user IR no longer needs to do the broadcast itself.
+    auto broadcastScaleAlongK =
+        [&](Value scale, ArrayRef<int64_t> matShape) -> Value {
+      auto scaleType = cast<MemRefType>(scale.getType());
+      ArrayRef<int64_t> scaleShape = scaleType.getShape();
+      if (scaleShape == matShape)
+        return scale;
+      assert(scaleShape.size() == matShape.size() &&
+             "scale rank must match matrix rank");
+      assert(matShape[1] % scaleShape[1] == 0 &&
+             "matrix K must be a multiple of scale K");
+      int64_t blockFactor = matShape[1] / scaleShape[1];
+      assert(blockFactor == kQuantBlockSize &&
+             "scale K must be matK / kQuantBlockSize");
+      // (G, kScale, D)
+      // 1) addDim "block" with size 1 next to kScale -> (G, kScale, block, D)
+      // 2) broadcast the new dim from 1 to blockFactor
+      // 3) merge (kScale, block) -> K
+      SmallVector<StringRef, 3> initDims = {"gemmG", "gemmKScale", "gemmD"};
+      BottomUpTMBuilder addDim(b, initDims, scaleShape, op.getLoc());
+      addDim.passThrough({"gemmG", "gemmKScale"}, {0, 1},
+                         {"gemmG", "gemmKScale"});
+      addDim.addDim("gemmKBlock", 2, 1);
+      addDim.passThrough({"gemmD"}, {3}, {"gemmD"});
+      auto addDimAttr = addDim.get();
+      Value v = TransformOp::create(b, op.getLoc(), scale, addDimAttr);
+      auto bc = BottomUpTMBuilder::above(addDim, addDimAttr);
+      bc.passThrough({"gemmG", "gemmKScale"}, {0, 1},
+                     {"gemmG", "gemmKScale"});
+      bc.broadcast({2}, {blockFactor});
+      bc.passThrough({"gemmD"}, {3}, {"gemmD"});
+      auto bcAttr = bc.get();
+      v = TransformOp::create(b, op.getLoc(), v, bcAttr);
+      auto mg = BottomUpTMBuilder::above(bc, bcAttr);
+      mg.passThrough({"gemmG"}, {0}, {"gemmG"});
+      mg.merge("gemmK", 1, {"gemmKScale", "gemmKBlock"});
+      mg.passThrough({"gemmD"}, {2}, {"gemmD"});
+      auto mgAttr = mg.get();
+      return TransformOp::create(b, op.getLoc(), v, mgAttr);
+    };
+    if (isScaledGemm) {
+      ArrayRef<int64_t> aShapeForBroadcast = op.getA().getType().getShape();
+      ArrayRef<int64_t> bShapeForBroadcast = op.getB().getType().getShape();
+      scaleA = broadcastScaleAlongK(scaleA, aShapeForBroadcast);
+      scaleB = broadcastScaleAlongK(scaleB, bShapeForBroadcast);
+    }
 
     // Get 'features' from arch
     StringRef arch = rock::getArchValue(op);

--- a/mlir/test/Conversion/TosaToRock/tosa-to-rock-matmul-t-block-scaled.mlir
+++ b/mlir/test/Conversion/TosaToRock/tosa-to-rock-matmul-t-block-scaled.mlir
@@ -2,7 +2,7 @@
 
 module attributes {mhal.arch = "amdgcn-amd-amdhsa:gfx950"} {
 // CHECK-LABEL: @test_matmul_t_block_scaled_basic
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 // Test basic tosa.matmul_t_block_scaled lowering to rock.gemm with scales
 // A: [1, 128, 256] f4, A_scale: [1, 128, 8] f8 (K/32 = 256/32 = 8)
@@ -20,7 +20,7 @@ func.func @test_matmul_t_block_scaled_basic(%a_data: tensor<1x128x256xf4E2M1FN>,
 }
 
 // CHECK-LABEL: @test_matmul_t_block_scaled_batched
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_batched(%a_data: tensor<4x128x256xf4E2M1FN>, 
@@ -35,7 +35,7 @@ func.func @test_matmul_t_block_scaled_batched(%a_data: tensor<4x128x256xf4E2M1FN
 }
 
 // CHECK-LABEL: @test_matmul_t_block_scaled_large_k
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_large_k(%a_data: tensor<1x64x512xf4E2M1FN>, 
@@ -55,7 +55,7 @@ func.func @test_matmul_t_block_scaled_large_k(%a_data: tensor<1x64x512xf4E2M1FN>
 // This should result in rock.gemm with `tr` on A data
 // A scale is NOT transposed (no transpose on scale input)
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_a
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = tr %{{.*}} scaled by %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_a(%a_data: tensor<1x256x256xf4E2M1FN>, 
@@ -79,7 +79,7 @@ func.func @test_matmul_t_block_scaled_transpose_a(%a_data: tensor<1x256x256xf4E2
 // Note: B data transpose is independent of B scale transpose. B scale remains in its
 // default transposed state (matching matmul_t_block_scaled's B layout expectation)
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_b
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by %{{.*}} * %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_b(%a_data: tensor<1x128x256xf4E2M1FN>, 
@@ -101,7 +101,7 @@ func.func @test_matmul_t_block_scaled_transpose_b(%a_data: tensor<1x128x256xf4E2
 // Using symmetric shape M = K/blockSize = 8 so transpose doesn't change shape
 // A scale transpose is independent of A data transpose
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_a_scale
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by tr %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_a_scale(%a_data: tensor<1x8x256xf4E2M1FN>, 
@@ -122,7 +122,7 @@ func.func @test_matmul_t_block_scaled_transpose_a_scale(%a_data: tensor<1x8x256x
 // Using symmetric shape N = K/blockSize = 8 so transpose doesn't change shape
 // B scale transpose is independent of B data transpose
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_b_scale
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by %{{.*}} * tr %{{.*}} scaled by %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_b_scale(%a_data: tensor<1x128x256xf4E2M1FN>, 
@@ -142,7 +142,7 @@ func.func @test_matmul_t_block_scaled_transpose_b_scale(%a_data: tensor<1x128x25
 // Test transpose on both A scale and B scale
 // Both scales have symmetric shapes for valid transpose fusion
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_both_scales
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by tr %{{.*}} * tr %{{.*}} scaled by %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_both_scales(%a_data: tensor<1x8x256xf4E2M1FN>, 
@@ -163,7 +163,7 @@ func.func @test_matmul_t_block_scaled_transpose_both_scales(%a_data: tensor<1x8x
 // A data: [batch, M, K] with symmetric M=K=256
 // A scale: [batch, M, K/32] with M=256, K/32=8 -> after transpose [batch, K/32, M] = [batch, 8, 256]
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_a_data_and_scale
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = tr %{{.*}} scaled by tr %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_a_data_and_scale(%a_data: tensor<1x256x256xf4E2M1FN>, 
@@ -185,7 +185,7 @@ func.func @test_matmul_t_block_scaled_transpose_a_data_and_scale(%a_data: tensor
 // B data: [batch, N, K] with symmetric N=K=256
 // B scale pre-transpose [1, 8, 256] 
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_b_data_and_scale
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm %{{.*}} = %{{.*}} scaled by %{{.*}} * %{{.*}} scaled by %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_b_data_and_scale(%a_data: tensor<1x128x256xf4E2M1FN>, 
@@ -207,7 +207,7 @@ func.func @test_matmul_t_block_scaled_transpose_b_data_and_scale(%a_data: tensor
 // Output: [batch, M, N] = [1, 128, 512] transposed to [1, 512, 128]
 // The transpose on the output should be fused into the gemm as cTransposed
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_c
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm tr %{{.*}} = %{{.*}} scaled by %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_c(%a_data: tensor<1x128x256xf4E2M1FN>, 
@@ -225,7 +225,7 @@ func.func @test_matmul_t_block_scaled_transpose_c(%a_data: tensor<1x128x256xf4E2
 // Test output transpose combined with input transpose on A
 // A data is transposed, output is transposed
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_a_and_c
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm tr %{{.*}} = tr %{{.*}} scaled by %{{.*}} * tr %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_a_and_c(%a_data: tensor<1x256x256xf4E2M1FN>, 
@@ -243,7 +243,7 @@ func.func @test_matmul_t_block_scaled_transpose_a_and_c(%a_data: tensor<1x256x25
 
 // Test output transpose combined with B data transpose (toggles B's default transpose)
 // CHECK-LABEL: @test_matmul_t_block_scaled_transpose_b_and_c
-// CHECK: rock.transform
+// CHECK-NOT: rock.transform
 // CHECK: rock.gemm tr %{{.*}} = %{{.*}} scaled by %{{.*}} * %{{.*}} scaled by tr %{{.*}}
 
 func.func @test_matmul_t_block_scaled_transpose_b_and_c(%a_data: tensor<1x128x256xf4E2M1FN>, 

--- a/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
+++ b/mlir/test/Dialect/Rock/gemm_to_gridwise.mlir
@@ -731,3 +731,51 @@ func.func @gemm_scaled_fp4_splitk_odd(%arg0: memref<589824xf4E2M1FN>, %arg1: mem
   } : memref<3x256x256xf32> = memref<3x256x768xf4E2M1FN> scaled by memref<3x256x768xf8E8M0FNU> * memref<3x768x256xf4E2M1FN> scaled by memref<3x768x256xf8E8M0FNU>
   func.return
 }
+
+// -----
+
+// Test that the verifier and lowering accept un-broadcasted (natural form)
+// scales, where the K dimension of the scale equals matrix K / kQuantBlockSize
+// (32). The lowering should propagate the scale through padding/split-K
+// without re-broadcasting at this stage.
+
+// CHECK-LABEL: func.func @gemm_scaled_fp4_natural_form
+// CHECK-SAME: (%[[a:.*]]: memref<1x128x256xf4E2M1FN>, %[[b:.*]]: memref<1x128x512xf4E2M1FN>, %[[c:.*]]: memref<1x256x512xf32>, %[[scaleA:.*]]: memref<1x4x256xf8E8M0FNU>, %[[scaleB:.*]]: memref<1x4x512xf8E8M0FNU>)
+// CHECK-SAME: grid_size = 32 : i32
+func.func @gemm_scaled_fp4_natural_form(%a: memref<1x128x256xf4E2M1FN>, %b: memref<1x128x512xf4E2M1FN>, %c: memref<1x256x512xf32>, %scaleA: memref<1x4x256xf8E8M0FNU>, %scaleB: memref<1x4x512xf8E8M0FNU>) attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  // The scales are already in the (G, K/32, D) form so no transpose is needed
+  // and no padding is required (K is already a multiple of mPerBlock).
+  // CHECK: rock.gridwise_gemm_accel(%[[a]], %[[b]], %[[c]], %[[scaleA]], %[[scaleB]])
+  rock.gemm %c = tr %a scaled by tr %scaleA * %b scaled by %scaleB features = mfma storeMethod = set {
+    derivedBlockSize = 256 : i32,
+    gridSize = 32 : i32,
+    params = #xdlops_gemm_params0
+  } : memref<1x256x512xf32> = memref<1x128x256xf4E2M1FN> scaled by memref<1x4x256xf8E8M0FNU> * memref<1x128x512xf4E2M1FN> scaled by memref<1x4x512xf8E8M0FNU>
+  func.return
+}
+
+// -----
+
+// Test natural-form scales with split-K. The scale K dim is matK/32 = 4 and
+// splitKFactor = 2. The padded matrix K must be a multiple of
+// splitKFactor * kQuantBlockSize = 64, so K = 128 stays unchanged, and the
+// scale K = 4 splits cleanly into 2 chunks of 2.
+
+// CHECK-LABEL: func.func @gemm_scaled_fp4_natural_form_splitk
+// CHECK-SAME: (%[[a:.*]]: memref<1x128x256xf4E2M1FN>, %[[b:.*]]: memref<1x128x512xf4E2M1FN>, %[[c:.*]]: memref<1x256x512xf32> {rock.prefill = 0.000000e+00 : f32}, %[[scaleA:.*]]: memref<1x4x256xf8E8M0FNU>, %[[scaleB:.*]]: memref<1x4x512xf8E8M0FNU>)
+// CHECK-SAME: grid_size = 64 : i32
+func.func @gemm_scaled_fp4_natural_form_splitk(%a: memref<1x128x256xf4E2M1FN>, %b: memref<1x128x512xf4E2M1FN>, %c: memref<1x256x512xf32>, %scaleA: memref<1x4x256xf8E8M0FNU>, %scaleB: memref<1x4x512xf8E8M0FNU>) attributes {rock.arch = "amdgcn-amd-amdhsa:gfx950"} {
+  // Split K=128 into 2 parts (64 per split) for matrices, K=4 into 2 parts
+  // (2 per split) for scales.
+  // CHECK-DAG: rock.transform {{.*}} : memref<1x128x256xf4E2M1FN> to memref<1x2x64x256xf4E2M1FN>
+  // CHECK-DAG: rock.transform {{.*}} : memref<1x2x64x256xf4E2M1FN> to memref<2x64x256xf4E2M1FN>
+  // CHECK-DAG: rock.transform {{.*}} : memref<1x4x256xf8E8M0FNU> to memref<1x2x2x256xf8E8M0FNU>
+  // CHECK-DAG: rock.transform {{.*}} : memref<1x2x2x256xf8E8M0FNU> to memref<2x2x256xf8E8M0FNU>
+  // CHECK: rock.gridwise_gemm_accel({{.*}}) storeMethod(atomic_add) features = mfma {{.*}} : memref<2x64x256xf4E2M1FN>, memref<2x64x512xf4E2M1FN>, memref<2x256x512xf32>, memref<2x2x256xf8E8M0FNU>, memref<2x2x512xf8E8M0FNU>
+  rock.gemm %c = tr %a scaled by tr %scaleA * %b scaled by %scaleB features = mfma storeMethod = set {
+    derivedBlockSize = 256 : i32,
+    gridSize = 32 : i32,
+    params = #rock.accel_gemm_params<kpackPerBlock = 8, mPerBlock = 64, nPerBlock = 64, kpack = 1, mPerWave = 32, nPerWave = 32, mnPerXdl = 32, forceUnroll = true, splitKFactor = 2, scheduleVersion = 1, outputSwizzle = 2, wavesPerEU = 0, gridGroupSize = 0>
+  } : memref<1x256x512xf32> = memref<1x128x256xf4E2M1FN> scaled by memref<1x4x256xf8E8M0FNU> * memref<1x128x512xf4E2M1FN> scaled by memref<1x4x512xf8E8M0FNU>
+  func.return
+}

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -333,6 +333,15 @@ static llvm::cl::opt<bool> scaledGemm(
     llvm::cl::desc("Indicates whether to generate scaling gemm or not"),
     llvm::cl::value_desc("boolean"), llvm::cl::init(false));
 
+static llvm::cl::opt<bool> broadcastScales(
+    "broadcastScales",
+    llvm::cl::desc(
+        "When generating a scaled GEMM, replicate each scale value along K "
+        "to match the matrix shape (legacy behaviour). When false, scales "
+        "are passed in their natural form (K dim = matK / quantBlockSize) "
+        "and the lowering takes care of the broadcast internally."),
+    llvm::cl::value_desc("boolean"), llvm::cl::init(true));
+
 /// Backwards data convolution options
 static llvm::cl::opt<int64_t>
     usesV4R1("v4r1", llvm::cl::desc("Use V4R1 for bwd_data convolution"),
@@ -2591,15 +2600,28 @@ static func::FuncOp createGpuGemmKernel(ModuleOp module,
   Value aVal = expandedArgs[0], bVal = expandedArgs[1], cVal = expandedArgs[2];
   Value aScale = nullptr, bScale = nullptr;
   if (scaledGemm) {
-    aScale = buildBroadcastedScales(b, loc, expandedArgs[3], transposeScaleA,
-                                    /*isA=*/true);
-    bScale = buildBroadcastedScales(b, loc, expandedArgs[4], transposeScaleB,
-                                    /*isA=*/false);
+    if (broadcastScales) {
+      aScale = buildBroadcastedScales(b, loc, expandedArgs[3], transposeScaleA,
+                                      /*isA=*/true);
+      bScale = buildBroadcastedScales(b, loc, expandedArgs[4], transposeScaleB,
+                                      /*isA=*/false);
+    } else {
+      aScale = expandedArgs[3];
+      bScale = expandedArgs[4];
+    }
   }
   bool hasAccel = rock::isAccel(params.features);
   // for the non-accel path, emulate Fp4 scaled GEMMs by multiplying the scale
-  // by the matrix. This is used when doing `-pv_with_gpu`
+  // by the matrix. This is used when doing `-pv_with_gpu`. The matrix-shaped
+  // (broadcasted) form is required for the elementwise multiply, so apply the
+  // broadcast on the fly when the user opted out of it above.
   if (!hasAccel && scaledGemm) {
+    if (!broadcastScales) {
+      aScale = buildBroadcastedScales(b, loc, aScale, transposeScaleA,
+                                      /*isA=*/true);
+      bScale = buildBroadcastedScales(b, loc, bScale, transposeScaleB,
+                                      /*isA=*/false);
+    }
     if (transposeA) {
       aVal = rock::normalizeMatrix(aVal, b, loc, true, kName, mName);
       transposeA = false;


### PR DESCRIPTION
## Summary

Fixes [ROCm/rocMLIR-internal#2127](https://github.com/ROCm/rocMLIR-internal/issues/2127): scaled FP4 GEMMs no longer require their scales to be broadcasted to match the matrix shape. Instead, the dialect now accepts scales in their natural form (with K dim equal to ``matrixK / kQuantBlockSize``) and the lowering takes care of the broadcast internally.

- ``GemmOp::verify`` and the shared ``verifyScales`` helper now accept either form for ``scaleA``/``scaleB``.
- ``GemmToGridwise`` no longer assumes scales have the matrix shape: K-first detection, padding, and split-K logic each scale K-direction quantities by ``kQuantBlockSize`` when the natural form is used.
- ``GridwiseGemmToBlockwise`` re-broadcasts natural-form scales along K via ``rock.transform`` (``AddDim``/``Broadcast``/``Merge``) before the existing LDS/load pipeline runs, so downstream lowering paths are unchanged.
- ``TosaToRock`` no longer broadcasts scales when lowering ``tosa.matmul_t_block_scaled`` -- the natural form is forwarded directly, eliminating dozens of extra ops at the user-level IR.
- ``rocmlir-gen`` gains a ``--broadcastScales`` flag (default ``true`` to preserve existing kernels) so the test suite can also exercise the natural form.

## Test plan

- [x] All MLIR FileCheck tests pass: ``Dialect``, ``Conversion``, ``rocmlir-gen``, ``rocmlir-driver``, ``rocmlir-opt``.
- [x] New tests added in ``mlir/test/Dialect/Rock/gemm_to_gridwise.mlir`` for the natural-form path with and without split-K.
- [x] Updated ``mlir/test/Conversion/TosaToRock/tosa-to-rock-matmul-t-block-scaled.mlir`` to assert no broadcast ``rock.transform`` ops remain.
- [x] Verified the full pipeline (TosaToRock + GemmToGridwise + GridwiseGemmToBlockwise) lowers natural-form scales without errors on a sample input.
- [ ] Run ``GemmScaled*`` e2e tests on hardware (gfx950) to validate end-to-end correctness with both forms.

Made with [Cursor](https://cursor.com)