### PR TITLE
Add logic for detecting loops with dynamic indices in `RemoveRedundantCasts`

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/RemoveRedundantCasts.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RemoveRedundantCasts.cpp
@@ -426,6 +426,12 @@ matchSingleBlockCountedLoop(BlockArgument iv) {
       argNumber >= latchBr.getDestOperands().size())
     return failure();
 
+  // The body must be entered only from the header. Otherwise the GEP in the
+  // body could run with an `iv` outside [lowerBound, upperBound), breaking the
+  // full-coverage proof that lets us redirect the post-loop load.
+  if (body->getSinglePredecessor() != header)
+    return failure();
+
   Value latchValue = latchBr.getDestOperands()[argNumber];
   std::optional<int64_t> step = getConstantAddStep(latchValue, iv);
   if (!step || *step <= 0)

--- a/mlir/lib/Dialect/Rock/Transforms/RemoveRedundantCasts.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/RemoveRedundantCasts.cpp
@@ -52,14 +52,19 @@
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Rock/Passes.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+
+#include <optional>
 
 namespace mlir {
 namespace rock {
@@ -267,16 +272,38 @@ struct IndexRange {
   }
 };
 
-// Get the index range for a memory access. Returns an invalid range if we can't
-// determine it (dynamic indices, multi-index GEPs, etc.).
-static IndexRange getAccessRange(GEPOp gep, Type accessType) {
+struct LoopCoverage {
+  IndexRange range;
+  Block *header = nullptr;
+  Block *body = nullptr;
+};
+
+struct CountedLoopInfo {
+  Block *header = nullptr;
+  Block *body = nullptr;
+  BlockArgument iv;
+  int64_t lowerBound = 0;
+  int64_t upperBound = 0;
+  int64_t step = 0;
+};
+
+// Cache of counted-loop recognizer results keyed by induction-variable block
+// argument. The same loop iv can drive many fptrunc stores in a writer loop
+// (one per buffer), and each load+fpext pattern triggers a fresh sweep through
+// every store; without memoization we re-prove the same loop O(stores) times
+// per load+fpext pattern.
+using CountedLoopCache = DenseMap<BlockArgument, FailureOr<CountedLoopInfo>>;
+
+// Compute the per-access element count, scaled into GEP-element-type units.
+// Precondition: `gep` must be non-null. Returns nullopt if the access type
+// width is not a whole-number multiple of the GEP element type width (e.g.
+// loading a vector that doesn't tile the GEP element type cleanly).
+static std::optional<int64_t> getAccessElementCount(GEPOp gep,
+                                                    Type accessType) {
+  assert(gep && "getAccessElementCount requires a non-null GEP");
   int64_t elementCount = 1;
   if (auto vecType = dyn_cast<VectorType>(accessType))
     elementCount = vecType.getNumElements();
-
-  // No GEP means accessing at base (index 0)
-  if (!gep)
-    return {0, elementCount};
 
   // GEP indices are in units of the GEP element type. When the access type
   // differs, convert elementCount to GEP-element-type units so that ranges
@@ -287,14 +314,32 @@ static IndexRange getAccessRange(GEPOp gep, Type accessType) {
     unsigned accessBits = accessElemType.getIntOrFloatBitWidth();
     unsigned totalBits = accessBits * elementCount;
     if (gepBits == 0 || totalBits % gepBits != 0)
-      return {-1, 0};
+      return std::nullopt;
     elementCount = totalBits / gepBits;
   }
+  return elementCount;
+}
+
+// Get the index range for a memory access. Returns an invalid range if we can't
+// determine it (dynamic indices, multi-index GEPs, etc.).
+static IndexRange getAccessRange(GEPOp gep, Type accessType) {
+  // No GEP means accessing at base (index 0); element count is just the
+  // access type's lane count.
+  if (!gep) {
+    int64_t elementCount = 1;
+    if (auto vecType = dyn_cast<VectorType>(accessType))
+      elementCount = vecType.getNumElements();
+    return {0, elementCount};
+  }
+
+  std::optional<int64_t> elementCount = getAccessElementCount(gep, accessType);
+  if (!elementCount)
+    return {-1, 0}; // Invalid
 
   // Check if all indices are constant
   auto indices = gep.getIndices();
   if (indices.empty())
-    return {0, elementCount};
+    return {0, *elementCount};
 
   // We only handle single-index GEPs with constant index
   if (indices.size() != 1)
@@ -304,7 +349,159 @@ static IndexRange getAccessRange(GEPOp gep, Type accessType) {
   if (!constIdx)
     return {-1, 0}; // Invalid
 
-  return {constIdx.getInt(), elementCount};
+  return {constIdx.getInt(), *elementCount};
+}
+
+static Value getBranchOperandToBlock(Operation *terminator, Block *dest,
+                                     unsigned argNumber) {
+  auto branch = dyn_cast<BranchOpInterface>(terminator);
+  if (!branch)
+    return {};
+
+  for (unsigned i = 0, e = terminator->getNumSuccessors(); i < e; ++i) {
+    if (terminator->getSuccessor(i) != dest)
+      continue;
+    SuccessorOperands operands = branch.getSuccessorOperands(i);
+    if (argNumber >= operands.size())
+      return {};
+    return operands[argNumber];
+  }
+  return {};
+}
+
+static std::optional<int64_t> getConstantAddStep(Value value, Value base) {
+  Value step;
+  if (matchPattern(
+          value, m_Op<AddOp>(matchers::m_Val(base), matchers::m_Any(&step))) ||
+      matchPattern(value,
+                   m_Op<AddOp>(matchers::m_Any(&step), matchers::m_Val(base))))
+    return getConstantIntValue(step);
+  return std::nullopt;
+}
+
+static std::optional<int64_t> getLessThanLoopBound(ICmpOp icmp, Value iv) {
+  ICmpPredicate pred = icmp.getPredicate();
+  Value lhs = icmp.getOperand(0);
+  Value rhs = icmp.getOperand(1);
+
+  // `iv < bound`: iv on LHS, bound on RHS.
+  if (lhs == iv && (pred == ICmpPredicate::slt || pred == ICmpPredicate::ult))
+    return getConstantIntValue(rhs);
+
+  // `bound > iv`: bound on LHS, iv on RHS. Equivalent to `iv < bound`.
+  if (rhs == iv && (pred == ICmpPredicate::sgt || pred == ICmpPredicate::ugt))
+    return getConstantIntValue(lhs);
+
+  return std::nullopt;
+}
+
+// Detect the canonical single-block LLVM-CFG counted loop emitted for
+// vectorized private-buffer copies:
+//   ^header(%i):
+//     %cond = llvm.icmp "slt" %i, %upperBound
+//     llvm.cond_br %cond, ^body, ^exit
+//   ^body:
+//     ... gep %buffer[%i] ...
+//     %next = llvm.add %i, %step
+//     llvm.br ^header(%next)
+static FailureOr<CountedLoopInfo>
+matchSingleBlockCountedLoop(BlockArgument iv) {
+  Block *header = iv.getOwner();
+  auto condBr = dyn_cast<CondBrOp>(header->getTerminator());
+  if (!condBr)
+    return failure();
+
+  auto icmp = condBr.getCondition().getDefiningOp<ICmpOp>();
+  if (!icmp)
+    return failure();
+
+  std::optional<int64_t> upperBound = getLessThanLoopBound(icmp, iv);
+  if (!upperBound)
+    return failure();
+
+  Block *body = condBr.getTrueDest();
+  auto latchBr = dyn_cast<BrOp>(body->getTerminator());
+  unsigned argNumber = iv.getArgNumber();
+  if (!latchBr || latchBr.getDest() != header ||
+      argNumber >= latchBr.getDestOperands().size())
+    return failure();
+
+  Value latchValue = latchBr.getDestOperands()[argNumber];
+  std::optional<int64_t> step = getConstantAddStep(latchValue, iv);
+  if (!step || *step <= 0)
+    return failure();
+
+  std::optional<int64_t> lowerBound;
+  bool sawLatch = false;
+  for (Block *pred : header->getPredecessors()) {
+    Value incoming =
+        getBranchOperandToBlock(pred->getTerminator(), header, argNumber);
+    if (!incoming)
+      return failure();
+
+    if (pred == body) {
+      if (incoming != latchValue)
+        return failure();
+      sawLatch = true;
+      continue;
+    }
+
+    std::optional<int64_t> initialValue = getConstantIntValue(incoming);
+    if (!initialValue)
+      return failure();
+    if (lowerBound && *lowerBound != *initialValue)
+      return failure();
+    lowerBound = *initialValue;
+  }
+
+  if (!lowerBound || !sawLatch)
+    return failure();
+
+  return CountedLoopInfo{header, body, iv, *lowerBound, *upperBound, *step};
+}
+
+// Look up `iv` in the counted-loop cache, populating it on first miss by
+// running `matchSingleBlockCountedLoop`.
+static FailureOr<CountedLoopInfo>
+matchCachedCountedLoop(BlockArgument iv, CountedLoopCache &cache) {
+  auto [it, inserted] = cache.try_emplace(iv, failure());
+  if (inserted)
+    it->second = matchSingleBlockCountedLoop(iv);
+  return it->second;
+}
+
+// If the dynamic GEP is indexed by a counted loop that starts at zero, ends at
+// bufferSize, and steps by the access width, its accesses collectively cover
+// the full buffer.
+static LoopCoverage getFullCoverageLoopAccess(GEPOp gep, Type accessType,
+                                              int64_t bufferSize,
+                                              CountedLoopCache &loopCache) {
+  LoopCoverage invalid{{-1, 0}, nullptr, nullptr};
+  if (!gep || bufferSize <= 0)
+    return invalid;
+
+  auto indices = gep.getIndices();
+  if (indices.size() != 1)
+    return invalid;
+
+  auto indexValue = dyn_cast<Value>(indices[0]);
+  if (!indexValue)
+    return invalid;
+
+  auto blockArg = dyn_cast<BlockArgument>(indexValue);
+  if (!blockArg)
+    return invalid;
+
+  std::optional<int64_t> elementCount = getAccessElementCount(gep, accessType);
+  if (!elementCount || *elementCount <= 0 || bufferSize % *elementCount != 0)
+    return invalid;
+
+  FailureOr<CountedLoopInfo> loop = matchCachedCountedLoop(blockArg, loopCache);
+  if (failed(loop) || loop->body != gep->getBlock() || loop->lowerBound != 0 ||
+      loop->upperBound != bufferSize || loop->step != *elementCount)
+    return invalid;
+
+  return {{0, bufferSize}, loop->header, loop->body};
 }
 
 // Get the total size (in elements) of a buffer from its alloca.
@@ -314,11 +511,9 @@ static int64_t getBufferSize(Value buffer) {
     return -1;
 
   // Get array size (number of elements allocated)
-  Value arraySizeVal = alloca.getArraySize();
-  if (auto constOp = arraySizeVal.getDefiningOp<LLVM::ConstantOp>()) {
-    if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue()))
-      return intAttr.getInt();
-  }
+  std::optional<int64_t> arraySize = getConstantIntValue(alloca.getArraySize());
+  if (arraySize)
+    return *arraySize;
   return -1; // Dynamic or unknown size
 }
 
@@ -329,7 +524,7 @@ static int64_t getBufferSize(Value buffer) {
 static SmallVector<FPTruncStoreInfo *>
 findMatchingFPTruncStores(LoadFPExtPattern &pattern,
                           SmallVector<FPTruncStoreInfo> &storeInfos,
-                          DominanceInfo &domInfo) {
+                          DominanceInfo &domInfo, CountedLoopCache &loopCache) {
   SmallVector<FPTruncStoreInfo *> dominatingStores;
   int64_t bufferSize = getBufferSize(pattern.narrowBuffer);
 
@@ -346,14 +541,58 @@ findMatchingFPTruncStores(LoadFPExtPattern &pattern,
       continue;
     if (getScalarType(info.wideValue.getType()) != fpextElemType)
       continue;
-    if (!domInfo.dominates(info.narrowStore.getOperation(),
-                           pattern.loadOp.getOperation()))
-      continue;
 
     IndexRange storeRange =
         getAccessRange(info.narrowGep, info.narrowStore.getValue().getType());
-    if (!storeRange.isValid())
-      continue;
+    if (storeRange.isValid()) {
+      // Static index: the concrete store op must dominate the load, so every
+      // path to the load executes this store first. `getAccessRange` already
+      // tells us what part of the buffer this store covers.
+      if (!domInfo.dominates(info.narrowStore.getOperation(),
+                             pattern.loadOp.getOperation()))
+        continue;
+    } else {
+      // Dynamic index: try to prove the enclosing counted loop collectively
+      // covers the full buffer. The generated LLVM CFG often writes the narrow
+      // buffer with a counted loop and reads it in a later block:
+      //
+      //   ^store_header(%i):
+      //     cond_br %i < N, ^store_body, ^after_store_loop
+      //   ^store_body:
+      //     store %buf[%i]
+      //     br ^store_header(%i + step)
+      //   ^after_store_loop:
+      //     ...
+      //     load %buf[%j]
+      //
+      // An individual store inside the writer loop body does not
+      // instruction-dominate the later load, because CFG dominance can see the
+      // first-iteration exit path that bypasses the loop body. Instead, prove
+      // that:
+      //   (1) The loop has the canonical zero-based, constant-step shape that
+      //       tiles the whole buffer (`getFullCoverageLoopAccess`).
+      //   (2) The loop's header dominates the load block. Combined with (1)'s
+      //       single-block body that unconditionally branches back to the
+      //       header, this means every path to the load passes through the
+      //       loop, and the only way to leave the loop is the exit edge taken
+      //       after the buffer is fully written.
+      //   (3) The load is outside the loop (not in the header or body). If
+      //       the load were inside the loop, only the iterations completed
+      //       so far would have written -- partial, not full, coverage.
+      LoopCoverage coverage = getFullCoverageLoopAccess(
+          info.narrowGep, info.narrowStore.getValue().getType(), bufferSize,
+          loopCache);
+      if (!coverage.range.isValid() || !coverage.header || !coverage.body)
+        continue;
+      Block *loadBlock = pattern.loadOp->getBlock();
+      if (loadBlock == coverage.header || loadBlock == coverage.body)
+        continue;
+      if (!domInfo.dominates(coverage.header, loadBlock))
+        continue;
+      storeRange = coverage.range;
+    }
+    assert(storeRange.isValid() &&
+           "static and dynamic branches must both yield a valid range");
 
     dominatingStores.push_back(&info);
 
@@ -414,8 +653,8 @@ hasNoInterveningStores(LoadFPExtPattern &pattern,
 // Verify that a load -> fpext pattern is safe to optimize.
 static FailureOr<SmallVector<FPTruncStoreInfo *>>
 verifySafety(LoadFPExtPattern &pattern,
-             SmallVector<FPTruncStoreInfo> &storeInfos,
-             DominanceInfo &domInfo) {
+             SmallVector<FPTruncStoreInfo> &storeInfos, DominanceInfo &domInfo,
+             CountedLoopCache &loopCache) {
   // Check that the narrow buffer is an alloca
   auto narrowAlloca = pattern.narrowBuffer.getDefiningOp<AllocaOp>();
   if (!narrowAlloca) {
@@ -447,7 +686,7 @@ verifySafety(LoadFPExtPattern &pattern,
   // the optimization safe. For static indices, full-buffer coverage is
   // also required.
   SmallVector<FPTruncStoreInfo *> matchingStores =
-      findMatchingFPTruncStores(pattern, storeInfos, domInfo);
+      findMatchingFPTruncStores(pattern, storeInfos, domInfo, loopCache);
   if (matchingStores.empty()) {
     LLVM_DEBUG(llvm::dbgs()
                << "\tUNSAFE: No matching fptrunc stores found for load\n");
@@ -503,6 +742,15 @@ verifySafety(LoadFPExtPattern &pattern,
 // and all corresponding wide stores must dominate every load from that narrow
 // buffer. If no consistent selection exists, all selections are cleared so
 // that createWideBuffersAndStores will create a unified wide buffer instead.
+//
+// Known pessimism: this routine uses op-level dominance, so a pre-existing
+// parallel wide store that lives inside the same writer loop as the narrow
+// store (i.e. the dynamic-loop case admitted by `getFullCoverageLoopAccess`)
+// will fail the dominance check and be discarded. The pass remains correct in
+// that case -- `createWideBuffersAndStores` will allocate a fresh wide buffer
+// next to the narrow one -- but the original parallel wide buffer is left in
+// the IR as dead state. Reusing such a pre-existing wide store would require
+// applying the same loop-coverage reasoning here.
 static void
 selectConsistentWideBuffers(SmallVector<LoadFPExtPattern> &safePatterns,
                             DominanceInfo &domInfo) {
@@ -582,6 +830,16 @@ selectConsistentWideBuffers(SmallVector<LoadFPExtPattern> &safePatterns,
 }
 
 // Create a wide store for an fptrunc store info, using the given wide buffer.
+//
+// In the dynamic-loop case the narrow store lives inside the writer loop body,
+// so the wide store inserted here also ends up inside the body and does NOT
+// instruction-dominate the post-loop load. Correctness still holds via the
+// loop-coverage argument enforced by `findMatchingFPTruncStores`: the loop's
+// header dominates the load and the only exit edge is taken after every
+// iteration has run, so by the time the load executes every wide store has
+// executed too. The op-level dominance check performed by
+// `selectConsistentWideBuffers` is therefore only meaningful for pre-existing
+// parallel wide stores; freshly created stores intentionally bypass it.
 static void createWideStore(FPTruncStoreInfo *info, Value wideBuffer,
                             Type wideElemType, OpBuilder &builder) {
   builder.setInsertionPointAfter(info->narrowStore);
@@ -843,12 +1101,13 @@ void RockRemoveRedundantCastsPass::runOnOperation() {
 
   // Step 3: Verify safety (applicability) for each pattern
   DominanceInfo domInfo(funcOp);
+  CountedLoopCache loopCache;
   SmallVector<LoadFPExtPattern> safePatterns;
   for (auto &pattern : loadFPExtPatterns) {
     LLVM_DEBUG(llvm::dbgs()
                << "Verifying pattern: load=" << pattern.loadOp << "\n");
     FailureOr<SmallVector<FPTruncStoreInfo *>> result =
-        verifySafety(pattern, storeInfo, domInfo);
+        verifySafety(pattern, storeInfo, domInfo, loopCache);
     if (succeeded(result)) {
       pattern.matchingStores = *result;
       safePatterns.push_back(pattern);

--- a/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
+++ b/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
@@ -474,3 +474,758 @@ llvm.func @test_scalar_types() {
   llvm.return
 }
 
+// Safe case: dynamic GEPs from canonical loops cover the full buffer.
+// CHECK-LABEL: llvm.func @test_dynamic_full_coverage_loop
+llvm.func @test_dynamic_full_coverage_loop() {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):  // 2 preds: ^bb0, ^store_body
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^load_header(%zero : i32)
+
+^store_body:  // pred: ^store_header
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^load_header(%j: i32):  // 2 preds: ^store_header, ^load_body
+  %keep_loading = llvm.icmp "slt" %j, %sixteen : i32
+  llvm.cond_br %keep_loading, ^load_body, ^done
+
+^load_body:  // pred: ^load_header
+  %load_ptr = llvm.getelementptr %narrow[%j] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  %sum = llvm.fadd %extended, %wide : vector<2xf32>
+  %next_j = llvm.add %j, %two : i32
+  llvm.br ^load_header(%next_j : i32)
+
+^done:  // pred: ^load_header
+  llvm.return
+}
+
+// Reduced form of the lowered convolution epilogue from build/test.mlir. The
+// f16 buffer is populated by a zero-based counted loop, then read by a later
+// counted loop and immediately fpext'd before f32 add/relu.
+// CHECK-LABEL: llvm.func @test_reduced_convolution_epilogue_from_test_mlir
+llvm.func @test_reduced_convolution_epilogue_from_test_mlir() {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %relu_zero = llvm.mlir.constant(dense<0.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %bias = llvm.alloca %size x f32 : (i64) -> !llvm.ptr<5>
+  %out = llvm.alloca %size x f32 : (i64) -> !llvm.ptr<5>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  %wmma_acc = llvm.alloca %size x f32 : (i64) -> !llvm.ptr<5>
+  llvm.br ^bb38(%zero : i32)
+
+^bb38(%iv_store: i32):  // 2 preds: ^bb0, ^bb39
+  %keep_storing = llvm.icmp "slt" %iv_store, %sixteen : i32
+  llvm.cond_br %keep_storing, ^bb39, ^bb40
+
+^bb39:  // pred: ^bb38
+  %acc_ptr = llvm.getelementptr %wmma_acc[%iv_store] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f32
+  %acc = llvm.load %acc_ptr {alignment = 4 : i64} : !llvm.ptr<5> -> vector<2xf32>
+  %narrow_value = llvm.fptrunc %acc : vector<2xf32> to vector<2xf16>
+  %narrow_store_ptr = llvm.getelementptr %narrow[%iv_store] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %narrow_store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_store = llvm.add %iv_store, %two : i32
+  llvm.br ^bb38(%next_store : i32)
+
+^bb40:  // pred: ^bb38
+  llvm.br ^bb41(%zero : i32)
+
+^bb41(%iv_load: i32):  // 2 preds: ^bb40, ^bb42
+  %keep_loading = llvm.icmp "slt" %iv_load, %sixteen : i32
+  llvm.cond_br %keep_loading, ^bb42, ^bb43
+
+^bb42:  // pred: ^bb41
+  %narrow_load_ptr = llvm.getelementptr %narrow[%iv_load] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %narrow_load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %bias_ptr = llvm.getelementptr %bias[%iv_load] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f32
+  %bias_value = llvm.load %bias_ptr {alignment = 4 : i64} : !llvm.ptr<5> -> vector<2xf32>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  %sum = llvm.fadd %extended, %bias_value : vector<2xf32>
+  %relu = llvm.intr.maximum(%sum, %relu_zero) : (vector<2xf32>, vector<2xf32>) -> vector<2xf32>
+  %out_ptr = llvm.getelementptr %out[%iv_load] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f32
+  llvm.store %relu, %out_ptr {alignment = 4 : i64} : vector<2xf32>, !llvm.ptr<5>
+  %next_load = llvm.add %iv_load, %two : i32
+  llvm.br ^bb41(%next_load : i32)
+
+^bb43:  // pred: ^bb41
+  llvm.return
+}
+
+// Safe case: the loop guard uses the swapped form `bound > iv` (equivalent to
+// `iv < bound`). The counted-loop recognizer accepts both operand orderings.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_swapped_operand_predicate
+llvm.func @test_dynamic_loop_swapped_operand_predicate() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "sgt" %sixteen, %i : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: a bypass edge reaches the load block without going through
+// the store loop, so the loop header does not dominate the load. The pass
+// must not redirect the load to a wide buffer that may never have been
+// written.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_bypass
+llvm.func @test_dynamic_loop_bypass(%cond: i1) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.cond_br %cond, ^store_header(%zero : i32), ^bypass
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^load_block(%zero : i32)
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^bypass:
+  llvm.br ^load_block(%zero : i32)
+
+^load_block(%j: i32):
+  %load_ptr = llvm.getelementptr %narrow[%j] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the load is inside the store loop body, so at load time the
+// loop has only completed the current iteration -- partial, not full
+// coverage. The pass must not fire.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_load_in_body
+llvm.func @test_dynamic_loop_load_in_body() {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^header(%zero : i32)
+
+^header(%i: i32):
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^body, ^done
+
+^body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %load_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  %sum = llvm.fadd %extended, %wide : vector<2xf32>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^header(%next_i : i32)
+
+^done:
+  llvm.return
+}
+
+// Unsafe case: loop starts at 8 rather than 0, so the lower half of the
+// buffer is never written -- not full coverage.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_nonzero_lower_bound
+llvm.func @test_dynamic_loop_nonzero_lower_bound() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %eight = llvm.mlir.constant(8 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%eight : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the loop step (4) is larger than the vector lane count (2),
+// leaving holes between successive store tiles.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_step_exceeds_vector
+llvm.func @test_dynamic_loop_step_exceeds_vector() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %four = llvm.mlir.constant(4 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %four : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: loop upper bound is 12 while the buffer holds 16 elements;
+// the last 4 elements are never written.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_upper_bound_short
+llvm.func @test_dynamic_loop_upper_bound_short() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %twelve = llvm.mlir.constant(12 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %twelve : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: GEP is indexed by `iv + 1` rather than `iv` directly. The
+// recognizer requires the GEP index to be the loop's induction-variable
+// block argument so the per-iteration access tile is known.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_indirect_gep_index
+llvm.func @test_dynamic_loop_indirect_gep_index() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %one = llvm.mlir.constant(1 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %offset_idx = llvm.add %i, %one : i32
+  %store_ptr = llvm.getelementptr %narrow[%offset_idx] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the loop guard uses `sle`, which the recognizer intentionally
+// does not match. (Although `iv <= 14` with step 2 from 0 happens to cover
+// the same elements as `iv < 16`, keeping the recognizer to strict `<` /
+// `>` avoids reasoning about boundary conditions.)
+// CHECK-LABEL: llvm.func @test_dynamic_loop_sle_predicate
+llvm.func @test_dynamic_loop_sle_predicate() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %fourteen = llvm.mlir.constant(14 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "sle" %i, %fourteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the store loop iterates with a non-constant upper bound, so
+// the recognizer cannot determine that the loop covers the buffer.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_non_constant_upper_bound
+llvm.func @test_dynamic_loop_non_constant_upper_bound(%bound: i32) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %bound : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: loop step is non-constant. The recognizer requires a known
+// constant step to compute coverage per iteration.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_non_constant_step
+llvm.func @test_dynamic_loop_non_constant_step(%step: i32) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %step : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Safe case: unsigned-less-than (`ult`) loop guard. The recognizer accepts
+// both signed and unsigned strict less-than predicates.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_ult_predicate
+llvm.func @test_dynamic_loop_ult_predicate() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "ult" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}
+
+// Safe case: unsigned-greater-than (`ugt`) loop guard with swapped operands.
+// Equivalent to `iv ult bound`; the recognizer accepts both operand orderings
+// for the unsigned predicate.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_ugt_swapped_predicate
+llvm.func @test_dynamic_loop_ugt_swapped_predicate() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "ugt" %sixteen, %i : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the load lives inside the loop's header block (before the
+// cond_br terminator). At load time the loop may not yet have completed any
+// iteration that writes the index being loaded, so the buffer is only
+// partially covered. The pass must not fire.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_load_in_header
+llvm.func @test_dynamic_loop_load_in_header() {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^header(%zero : i32)
+
+^header(%i: i32):
+  %load_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  %sum = llvm.fadd %extended, %wide : vector<2xf32>
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^body, ^done
+
+^body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^header(%next_i : i32)
+
+^done:
+  llvm.return
+}
+
+// Unsafe case: the alloca holds 15 f16 elements but the store loop's vector
+// tile is 2 lanes wide, so the per-iteration access tile (2 elements) does
+// not divide the buffer size. The recognizer rejects this to avoid reasoning
+// about partial tiles at the buffer tail.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_buffer_not_multiple_of_tile
+llvm.func @test_dynamic_loop_buffer_not_multiple_of_tile() -> vector<2xf32> {
+  %size = llvm.mlir.constant(15 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %fifteen = llvm.mlir.constant(15 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %fifteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Safe case: the loop header has two non-body predecessors that pass the same
+// constant initial value. The recognizer accepts this since the lower bound is
+// consistent across all entry paths.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_multiple_entries_same_lower_bound
+llvm.func @test_dynamic_loop_multiple_entries_same_lower_bound(%cond: i1) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.cond_br %cond, ^path1, ^path2
+
+^path1:
+  llvm.br ^store_header(%zero : i32)
+
+^path2:
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the loop header has two non-body predecessors that pass
+// different constant initial values (0 vs 2). The recognizer requires a
+// consistent lower bound and rejects this case.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_multiple_entries_conflicting_lower_bound
+llvm.func @test_dynamic_loop_multiple_entries_conflicting_lower_bound(%cond: i1) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.cond_br %cond, ^path1, ^path2
+
+^path1:
+  llvm.br ^store_header(%zero : i32)
+
+^path2:
+  llvm.br ^store_header(%two : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Safe case (known pessimism): the writer loop body contains both the narrow
+// fptrunc store and a pre-existing parallel wide store of the same wide value.
+// `selectConsistentWideBuffers` uses op-level dominance, which rejects the
+// pre-existing in-loop wide store as a reuse candidate. The pass still
+// transforms the load correctly by allocating a fresh wide buffer next to the
+// narrow one, leaving the original pre-existing wide alloca/store in the IR
+// as dead state. Documented in `selectConsistentWideBuffers`.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_with_preexisting_wide_store
+llvm.func @test_dynamic_loop_with_preexisting_wide_store() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // The pre-existing parallel wide alloca; pessimistically left in the IR.
+  %wide_buf = llvm.alloca %size x f32 : (i64) -> !llvm.ptr<5>
+  // The pass allocates a fresh wide buffer rather than reusing %wide_buf.
+  // CHECK: llvm.alloca {{.*}} x f32
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %narrow_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %narrow_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %wide_ptr = llvm.getelementptr %wide_buf[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f32
+  llvm.store %wide, %wide_ptr {alignment = 4 : i64} : vector<2xf32>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the per-iteration access tile is wider than the loop step, so
+// successive iterations overlap rather than tile the buffer. Although the
+// union of all writes still covers [0, 16), the recognizer intentionally
+// rejects mismatched step/tile because the "last write wins" semantics that
+// keep the wide buffer in sync depend on a clean tiling.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_step_smaller_than_vector
+llvm.func @test_dynamic_loop_step_smaller_than_vector() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %one = llvm.mlir.constant(1 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %one : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Safe case: the post-loop load has no GEP at all (loads directly from the
+// alloca base pointer). The dynamic-loop coverage proof comes from the
+// writer-loop's GEP, not the load's, so the load shape is irrelevant to
+// recognizing coverage. The pass must still rewrite the load to read from a
+// fresh wide buffer.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_load_without_gep
+llvm.func @test_dynamic_loop_load_without_gep() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %loaded = llvm.load %narrow {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}

--- a/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
+++ b/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
@@ -673,6 +673,46 @@ llvm.func @test_dynamic_loop_load_in_body() {
   llvm.return
 }
 
+// Unsafe case: the loop body has a second predecessor (a block reached after
+// the loop branches back into it), so the body can execute with an `iv`
+// outside [lowerBound, upperBound). Full coverage can no longer be proven, so
+// the pass must not fire.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_body_extra_predecessor
+llvm.func @test_dynamic_loop_body_extra_predecessor(%cond: i1) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.cond_br %cond, ^reenter, ^ret
+
+^reenter:
+  llvm.br ^store_body
+
+^ret:
+  llvm.return %extended : vector<2xf32>
+}
+
 // Unsafe case: loop starts at 8 rather than 0, so the lower half of the
 // buffer is never written -- not full coverage.
 // CHECK-LABEL: llvm.func @test_dynamic_loop_nonzero_lower_bound

--- a/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
+++ b/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
@@ -515,8 +515,7 @@ llvm.func @test_dynamic_full_coverage_loop() {
   llvm.return
 }
 
-// Reduced form of the lowered convolution epilogue from build/test.mlir. The
-// f16 buffer is populated by a zero-based counted loop, then read by a later
+// The f16 buffer is populated by a zero-based counted loop, then read by a later
 // counted loop and immediately fpext'd before f32 add/relu.
 // CHECK-LABEL: llvm.func @test_reduced_convolution_epilogue_from_test_mlir
 llvm.func @test_reduced_convolution_epilogue_from_test_mlir() {

--- a/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
+++ b/mlir/test/Dialect/LLVMIR/remove-redundant-casts.mlir
@@ -1229,3 +1229,325 @@ llvm.func @test_dynamic_loop_load_without_gep() -> vector<2xf32> {
   // CHECK: llvm.load {{.*}} -> vector<2xf32>
   llvm.return %extended : vector<2xf32>
 }
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_step_first_operand
+llvm.func @test_dynamic_loop_step_first_operand() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %two, %i : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_body_cond_br_terminator
+llvm.func @test_dynamic_loop_body_cond_br_terminator() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep_storing = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep_storing, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  %recheck = llvm.icmp "slt" %next_i, %sixteen : i32
+  llvm.cond_br %recheck, ^store_header(%next_i : i32), ^after_loop
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// Unsafe case: the dynamic index into the narrow buffer is the function-
+// argument induction variable of the entry block. The recognizer's "header"
+// is then the entry block, whose terminator is `llvm.return` rather than a
+// `cond_br`, so the counted-loop match fails immediately.
+// CHECK-LABEL: llvm.func @test_dynamic_loop_iv_is_function_arg
+llvm.func @test_dynamic_loop_iv_is_function_arg(%iv: i32) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%iv] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_cond_not_icmp
+llvm.func @test_dynamic_loop_cond_not_icmp(%dyn_cond: i1) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  llvm.cond_br %dyn_cond, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_zero_step
+llvm.func @test_dynamic_loop_zero_step() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %zero : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_latch_not_add
+llvm.func @test_dynamic_loop_latch_not_add() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %neg_two = llvm.mlir.constant(-2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.sub %i, %neg_two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_non_constant_initial
+llvm.func @test_dynamic_loop_non_constant_initial(%init: i32) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%init : i32)
+
+^store_header(%i: i32):
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_dynamic_alloca_size
+llvm.func @test_dynamic_loop_dynamic_alloca_size(%dyn_size: i64) -> vector<2xf32> {
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %dyn_size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_two_buffers_shared_iv
+llvm.func @test_dynamic_loop_two_buffers_shared_iv() {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow1 = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  %narrow2 = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // Both narrow allocas are replaced by fresh wide buffers.
+  // CHECK: llvm.alloca {{.*}} x f32
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value1 = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %ptr1 = llvm.getelementptr %narrow1[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value1, %ptr1 {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %narrow_value2 = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %ptr2 = llvm.getelementptr %narrow2[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value2, %ptr2 {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr1 = llvm.getelementptr %narrow1[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded1 = llvm.load %load_ptr1 {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %ext1 = llvm.fpext %loaded1 : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  %load_ptr2 = llvm.getelementptr %narrow2[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded2 = llvm.load %load_ptr2 {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %ext2 = llvm.fpext %loaded2 : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  %sum = llvm.fadd %ext1, %ext2 : vector<2xf32>
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_header_as_second_successor
+llvm.func @test_dynamic_loop_header_as_second_successor(%cond: i1) -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  %sixteen = llvm.mlir.constant(16 : i32) : i32
+  %wide = llvm.mlir.constant(dense<1.000000e+00> : vector<2xf32>) : vector<2xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK: llvm.alloca {{.*}} x f32
+  llvm.cond_br %cond, ^preheader, ^store_header(%zero : i32)
+
+^preheader:
+  llvm.br ^store_header(%zero : i32)
+
+^store_header(%i: i32):
+  %keep = llvm.icmp "slt" %i, %sixteen : i32
+  llvm.cond_br %keep, ^store_body, ^after_loop
+
+^store_body:
+  %narrow_value = llvm.fptrunc %wide : vector<2xf32> to vector<2xf16>
+  %store_ptr = llvm.getelementptr %narrow[%i] : (!llvm.ptr<5>, i32) -> !llvm.ptr<5>, f16
+  llvm.store %narrow_value, %store_ptr {alignment = 2 : i64} : vector<2xf16>, !llvm.ptr<5>
+  %next_i = llvm.add %i, %two : i32
+  llvm.br ^store_header(%next_i : i32)
+
+^after_loop:
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.load {{.*}} -> vector<2xf32>
+  llvm.return %extended : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @test_dynamic_loop_gep_elem_bitwidth_mismatch
+llvm.func @test_dynamic_loop_gep_elem_bitwidth_mismatch() -> vector<2xf32> {
+  %size = llvm.mlir.constant(16 : i64) : i64
+  %wide3 = llvm.mlir.constant(dense<1.000000e+00> : vector<3xf32>) : vector<3xf32>
+  %narrow = llvm.alloca %size x f16 : (i64) -> !llvm.ptr<5>
+  // CHECK-NOT: llvm.alloca {{.*}} x f32
+  // GEP elem type intentionally `f32` so that vector<3xf16> (48 bits) does
+  // not tile the 32-bit element cleanly.
+  %store_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f32
+  %v3 = llvm.fptrunc %wide3 : vector<3xf32> to vector<3xf16>
+  llvm.store %v3, %store_ptr {alignment = 2 : i64} : vector<3xf16>, !llvm.ptr<5>
+  %load_ptr = llvm.getelementptr %narrow[0] : (!llvm.ptr<5>) -> !llvm.ptr<5>, f16
+  %loaded = llvm.load %load_ptr {alignment = 2 : i64} : !llvm.ptr<5> -> vector<2xf16>
+  %extended = llvm.fpext %loaded : vector<2xf16> to vector<2xf32>
+  // CHECK: llvm.fpext
+  llvm.return %extended : vector<2xf32>
+}


### PR DESCRIPTION
## Motivation

Extends `rock-remove-redundant-casts` to handle the case where a narrow (f16/bf16) private buffer is filled by a counted CFG loop and then read back and `fpext`'d in a later block. Previously the pass required every `fptrunc` store to op-dominate the load, which fails for stores nested inside a writer-loop body even when every path to the load provably executes every store. The motivating IR is the lowered convolution/attention epilogue: a counted loop writes each `vector<2xf16>` tile of a private buffer, then a later counted loop reads those tiles back through `fpext` for bias-add / ReLU. Without this change the precision-preserving wide-buffer rewrite never fires on that pattern.

## Technical Details

The new logic recognizes a canonical single-block LLVM-CFG counted loop (`icmp slt/sgt/ult/ugt` + `cond_br` header, single-body block with `add` + `br` latch) and proves a dynamic GEP indexed by its induction variable collectively tiles `[0, bufferSize)` when the loop starts at zero, ends at `bufferSize`, and steps by the per-iteration access width. `findMatchingFPTruncStores` now splits the dominance check by index kind: static indices keep the existing op-level check, while dynamic indices require (1) full-buffer coverage by the writer loop, (2) the loop header dominates the load block, and (3) the load lives outside the loop's header and body, together guaranteeing every path to the load passes through every iteration. Recognizer results are memoized per induction-variable block argument so each writer loop is proven at most once.

The transform reuses the existing wide-buffer creation path; in the dynamic case the inserted wide store lands inside the writer-loop body, which is safe via the same coverage argument and is called out in block comments on `createWideStore` and `selectConsistentWideBuffers`. 

## Test Plan

* PR CI
* Nightly CI

## Test Result

* [x] PR CI: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2378/1/pipeline-overview/
* [x] Nightly CI
  * Nightly LIT tests are passing here: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2378/2/pipeline-overview/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
