### PR TITLE
[AIROCMLIR-601] [CI] Exclude test sources from Jenkins coverage reports

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1002,6 +1002,12 @@ void collectCoverageData(String profdata, String cov, String cpath) {
           --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
           --ignore-filename-regex='external/llvm-project|mlir/test/|mlir/unittests/' --format=lcov              \
           --compilation-dir ${WORKSPACE} > ./coverage_${cpath}.lcov
+       """
+}
+
+// Produce the HTML coverage report
+void produceCoverageHtml(String cov, String cpath) {
+    sh """
        ${cov} show --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver        \
           --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
           --ignore-filename-regex='external/llvm-project|mlir/test/|mlir/unittests/' -Xdemangler=llvm-cxxfilt   \
@@ -1109,6 +1115,8 @@ pipeline {
                      description: 'Compare performance against CK')
         booleanParam(name: 'runCodeCoverage', defaultValue: params.weekly || (!params.weekly && !params.nightly),
                      description: 'Collect and upload code-coverage info.')
+        booleanParam(name: 'runCoverageHtml', defaultValue: false,
+                     description: 'Also produce the HTML coverage report (llvm-cov show --format=html) and archive it as a Jenkins artifact. Off by default because the step is slow (~30+ minutes per codepath) and Codecov.io already renders coverage in its web UI; enable for offline investigations of the archived HTML.')
         string(name: 'codecovCredentialsId', defaultValue: 'codecov-token-rocmlir',
               description: 'Jenkins credential ID for the Codecov upload token. Must be a Secret text containing the token from codecov.io.')
 
@@ -2052,6 +2060,14 @@ PY
                                                                             """, returnStatus: true)
                                                                             if (uploadStatus != 0) {
                                                                                 echo "WARNING: Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked."
+                                                                            }
+                                                                        }
+                                                                        // Best-effort HTML coverage report: runs AFTER the Codecov upload so a slow/timed-out llvm-cov show cannot prevent the LCOV upload, and is bounded by its own timeout so it cannot block archiveArtifacts. Gated by the runCoverageHtml parameter for builds that only need the Codecov upload.
+                                                                        if (params.runCoverageHtml) {
+                                                                            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: 'Skipped HTML coverage report (llvm-cov show was slow or failed)') {
+                                                                                timeout(time: 45, unit: 'MINUTES') {
+                                                                                    produceCoverageHtml("${LLVM_COV}", "${CODEPATH}")
+                                                                                }
                                                                             }
                                                                         }
                                                                     }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -2053,8 +2053,10 @@ PY
                                                                             if [ -n "\${http_proxy}" ]; then
                                                                                 proxy_opt="-U \${http_proxy}"
                                                                             fi
-                                                                            ./codecov -t \${CODECOV_TOKEN} --flags "${CODEPATH}" -f ./coverage_${CODEPATH}.lcov \${proxy_opt} -Z
+                                                                            set +e
+                                                                            ./codecov -t "\${CODECOV_TOKEN}" --flags "${CODEPATH}" -f ./coverage_${CODEPATH}.lcov \${proxy_opt} -Z
                                                                             codecov_exit=\$?
+                                                                            set -e
                                                                             echo "Codecov upload exit code: \${codecov_exit}"
                                                                             exit \${codecov_exit}
                                                                             """, returnStatus: true)
@@ -2071,10 +2073,12 @@ PY
                                                                             }
                                                                         }
                                                                     }
-                                                                    archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', onlyIfSuccessful: true
                                                                 }
                                                             } catch (Exception e) {
                                                                 unstable("Code coverage stage had an error or timeout: ${e}")
+                                                            } finally {
+                                                                // Always archive whatever was produced, even on UNSTABLE / timeout / exception.
+                                                                archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', allowEmptyArchive: true
                                                             }
                                                         }
                                                     }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1996,7 +1996,13 @@ PY
                                                             showEnv()
                                                             // Build with profiling on, and just code-generation tests.
                                                             try {
-                                                                timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                                                // Wall-clock timeout (no `activity:`): the coverage stage has long
+                                                                // silent phases (lit buffers progress; `llvm-profdata merge` on
+                                                                // ~125 GB of *.profraw produces no output for several minutes),
+                                                                // which makes activity-based timeouts fire spuriously and the
+                                                                // Codecov upload never run. 180 min covers ~60 min tests +
+                                                                // profdata merge + three llvm-cov calls + upload with margin.
+                                                                timeout(time: 180, unit: 'MINUTES') {
                                                                     sh 'rm -f build/CMakeCache.txt'
                                                                     sh 'rm -f build/*.profraw'
                                                                     buildProject('check-rocmlir-build-only',

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -2036,24 +2036,22 @@ PY
                                                                     dir ('build') {
                                                                         // Run tests.
                                                                         collectCoverageData("${LLVM_PROFDATA}", "${LLVM_COV}", "${CODEPATH}")
-                                                                        // Upload to codecov. Credential ID is configurable via codecovCredentialsId (default: codecov-token-rocmlir).
-                                                                        withEnv(["CODEPATH=${CODEPATH}"]) {
-                                                                            withCredentials([string(credentialsId: params.codecovCredentialsId ?: 'codecov-token-rocmlir',
-                                                                                                variable: 'CODECOV_TOKEN')]) {
-                                                                                def uploadStatus = sh(script: '''
-                                                                                curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
-                                                                                proxy_opt=""
-                                                                                if [ -n "${http_proxy}" ]; then
-                                                                                    proxy_opt="-U ${http_proxy}"
-                                                                                fi
-                                                                                ./codecov -t ${CODECOV_TOKEN} --flags "${CODEPATH}" -f ./coverage_${CODEPATH}.lcov ${proxy_opt}
-                                                                                codecov_exit=$?
-                                                                                echo "Codecov upload exit code: ${codecov_exit}"
-                                                                                exit ${codecov_exit}
-                                                                                ''', returnStatus: true)
-                                                                                if (uploadStatus != 0) {
-                                                                                    echo "WARNING: Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked."
-                                                                                }
+                                                                        // Interpolate ${CODEPATH} via Groovy at the call site (bare CODEPATH is empty inside nested closures); shell-side vars are escaped with \$.
+                                                                        withCredentials([string(credentialsId: params.codecovCredentialsId ?: 'codecov-token-rocmlir',
+                                                                                            variable: 'CODECOV_TOKEN')]) {
+                                                                            def uploadStatus = sh(script: """
+                                                                            curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x ./codecov
+                                                                            proxy_opt=""
+                                                                            if [ -n "\${http_proxy}" ]; then
+                                                                                proxy_opt="-U \${http_proxy}"
+                                                                            fi
+                                                                            ./codecov -t \${CODECOV_TOKEN} --flags "${CODEPATH}" -f ./coverage_${CODEPATH}.lcov \${proxy_opt}
+                                                                            codecov_exit=\$?
+                                                                            echo "Codecov upload exit code: \${codecov_exit}"
+                                                                            exit \${codecov_exit}
+                                                                            """, returnStatus: true)
+                                                                            if (uploadStatus != 0) {
+                                                                                echo "WARNING: Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked."
                                                                             }
                                                                         }
                                                                     }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -2053,13 +2053,13 @@ PY
                                                                             if [ -n "\${http_proxy}" ]; then
                                                                                 proxy_opt="-U \${http_proxy}"
                                                                             fi
-                                                                            ./codecov -t \${CODECOV_TOKEN} --flags "${CODEPATH}" -f ./coverage_${CODEPATH}.lcov \${proxy_opt}
+                                                                            ./codecov -t \${CODECOV_TOKEN} --flags "${CODEPATH}" -f ./coverage_${CODEPATH}.lcov \${proxy_opt} -Z
                                                                             codecov_exit=\$?
                                                                             echo "Codecov upload exit code: \${codecov_exit}"
                                                                             exit \${codecov_exit}
                                                                             """, returnStatus: true)
                                                                             if (uploadStatus != 0) {
-                                                                                echo "WARNING: Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked."
+                                                                                unstable("Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked.")
                                                                             }
                                                                         }
                                                                         // Best-effort HTML coverage report: runs AFTER the Codecov upload so a slow/timed-out llvm-cov show cannot prevent the LCOV upload, and is bounded by its own timeout so it cannot block archiveArtifacts. Gated by the runCoverageHtml parameter for builds that only need the Codecov upload.
@@ -2074,7 +2074,7 @@ PY
                                                                     archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', onlyIfSuccessful: true
                                                                 }
                                                             } catch (Exception e) {
-                                                                echo "NOTE: Code coverage stage had an error or timeout:\n${e}"
+                                                                unstable("Code coverage stage had an error or timeout: ${e}")
                                                             }
                                                         }
                                                     }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -964,15 +964,15 @@ void collectCoverageData(String profdata, String cov, String cpath) {
        rm -f build/*.profraw
        ${cov} report --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver      \
           --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
-          --ignore-filename-regex=external/llvm-project > ./coverage_${cpath}.report
+          --ignore-filename-regex='external/llvm-project|mlir/test/|mlir/unittests/' > ./coverage_${cpath}.report
        cat ./coverage_${cpath}.report
        ${cov} export --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver      \
           --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
-          --ignore-filename-regex=external/llvm-project --format=lcov              \
+          --ignore-filename-regex='external/llvm-project|mlir/test/|mlir/unittests/' --format=lcov              \
           --compilation-dir ${WORKSPACE} > ./coverage_${cpath}.lcov
        ${cov} show --object ./bin/rocmlir-opt --object ./bin/rocmlir-driver        \
           --object ./bin/rocmlir-gen --instr-profile ./coverage.profdata           \
-          --ignore-filename-regex=external/llvm-project -Xdemangler=llvm-cxxfilt   \
+          --ignore-filename-regex='external/llvm-project|mlir/test/|mlir/unittests/' -Xdemangler=llvm-cxxfilt   \
           --format=html > ./coverage_${cpath}.html
        """
 }

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -2061,7 +2061,11 @@ PY
                                                                             exit \${codecov_exit}
                                                                             """, returnStatus: true)
                                                                             if (uploadStatus != 0) {
-                                                                                unstable("Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked.")
+                                                                                // Yellow stage but green build: don't block PR merge on Codecov hiccups.
+                                                                                catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE',
+                                                                                           message: "Codecov upload failed (exit ${uploadStatus})") {
+                                                                                    error("Codecov upload failed (exit code ${uploadStatus}). Check that credential '${params.codecovCredentialsId ?: 'codecov-token-rocmlir'}' contains a valid token from codecov.io and that the repo is linked.")
+                                                                                }
                                                                             }
                                                                         }
                                                                         // Best-effort HTML coverage report: runs AFTER the Codecov upload so a slow/timed-out llvm-cov show cannot prevent the LCOV upload, and is bounded by its own timeout so it cannot block archiveArtifacts. Gated by the runCoverageHtml parameter for builds that only need the Codecov upload.
@@ -2075,7 +2079,11 @@ PY
                                                                     }
                                                                 }
                                                             } catch (Exception e) {
-                                                                unstable("Code coverage stage had an error or timeout: ${e}")
+                                                                // Yellow stage but green build, same rationale as above.
+                                                                catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE',
+                                                                           message: 'Code coverage stage had an error or timeout') {
+                                                                    error("Code coverage stage had an error or timeout: ${e}")
+                                                                }
                                                             } finally {
                                                                 // Always archive whatever was produced, even on UNSTABLE / timeout / exception.
                                                                 archiveArtifacts artifacts: 'build/coverage*.report, build/coverage*.lcov, build/coverage*.html', allowEmptyArchive: true


### PR DESCRIPTION
## Motivation

The Codecov reports for rocMLIR (visible on [app.codecov.io/gh/ROCm/rocMLIR (https://app.codecov.io/gh/ROCm/rocMLIR)) had three independent issues that came to light while investigating [AIROCMLIR-601]:

1. **Test sources were counted as production code.** The lit test passes built into `MLIRRockTestPasses` (e.g. `mlir/test/lib/Dialect/Rock/ TestFunctionFusibility.cpp`, `TestRockMultibuffer.cpp`, …) and the gtest unit tests under `mlir/unittests/` were instrumented and reported as if they were production code. This inflated the headline percentage that the biweekly Teams report (`.github/workflows/codecov-report.yml`) publishes, added noise to per-file drilldowns, and blocked future use of Codecov as a meaningful PR gate.
2. **The Jenkins `Code coverage` stage timed out chronically and silently.** Long phases (`lit` test buffering, `llvm-profdata merge` of ~125 GB of `*.profraw`, three `llvm-cov` invocations including a slow HTML `show`) defeated the activity-based timeout, and any timeout/exception was caught and turned into a green build with no Codecov upload — so the Codecov "no report" we kept seeing was actually a silent CI failure, not a Codecov problem.
3. **Even when the stage finished, the upload script was broken and failures were hidden.** `CODEPATH` was empty inside the upload shell, the `codecov` CLI was invoked without `-Z` so it returned exit 0 even on missing files / bad tokens, and warnings were logged with `echo` instead of `unstable()`, so genuine upload failures showed up as a green build with a `WARNING` line buried in the console.

## Technical Details

All changes are in `mlir/utils/jenkins/Jenkinsfile`. No other CI / build / source files are touched.

### 1. Exclude test sources from coverage

`collectCoverageData(...)` runs three `llvm-cov` invocations: a text `report`, an LCOV `export` (the artifact uploaded to Codecov), and an HTML `show`. All three previously passed `--ignore-filename-regex=external/llvm-project`, so only upstream LLVM was filtered. The regex is extended to also drop `mlir/test/` and `mlir/unittests/`:

    --ignore-filename-regex='external/llvm-project|mlir/test/|mlir/unittests/'

A small `codecov.yml` at the repo root with the same `ignore:` list would also protect the metric for coverage uploaded from any other source (developer-local `llvm-cov`, future GitHub Actions, one-off re-uploads). Not in this PR — tracked as a follow-up.

### 2. Fix chronic timeouts in the coverage stage

Switched the parent timeout from activity-based to **wall-clock 180 min** so silent phases (lit buffering, `llvm-profdata merge`) cannot make it fire spuriously. The 180 min number is a safety ceiling — real runs are far shorter (see "Future work" below).

### 3. Fix empty `CODEPATH` in Codecov upload script 

The upload script previously referenced `${CODEPATH}` from a nested closure where the variable was empty, so the `codecov` CLI was effectively invoked as `--flags "" -f ./coverage_.lcov`. Switched to Groovy double-quoted string interpolation at the call site so `${CODEPATH}` resolves to the matrix codepath (e.g. `gfx942`, `gfx90a`).

### 4. Decouple HTML coverage report from the Codecov upload

Moved the slow `llvm-cov show --format=html` out of `collectCoverageData(...)` into a new helper `produceCoverageHtml(...)` that runs **after** the Codecov upload, wrapped in its own 45 min `timeout(...)` and `catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', ...)`. A new pipeline parameter `runCoverageHtml` (default **`false`**) toggles it on demand from the Jenkins "Build with parameters" UI, the same way `runCodeCov` already
does.

Net effect: the HTML report can no longer block or starve the Codecov upload, and the typical CI run skips it entirely.

### 5. Surface Codecov failures as UNSTABLE instead of silent success

- Pass `-Z` to the `codecov` CLI so missing files / bad tokens / network errors produce a non-zero exit code instead of a silent exit 0.
- Replace `echo "WARNING: ..."` with `unstable("...")` on upload failure.
- Replace `echo "NOTE: Code coverage stage had an error or timeout..."` with `unstable("...")` in the outer `catch (Exception)` block.

Build colour semantics: `unstable(...)` marks the build **yellow but passing** — subsequent stages, archive, and downstream jobs still run.
Coverage problems are now **visible** in the Stage View instead of hidden in the console, but they **never** turn the build red.

## Test Plan

The Jenkins `Code coverage` stage on this PR is the source of truth. Each iteration validated:

- [x] Coverage `.lcov` no longer contains entries under `mlir/test/` or `mlir/unittests/` (1).
- [x] Coverage stage runs to completion within the wall-clock budget (2).
- [x] `Codecov upload exit code: 0` is reported, and the upload is visible at https://app.codecov.io/gh/ROCm/rocMLIR/commits with the matrix flag (`gfx942` etc.) attached (3, 4).
- [x] `runCoverageHtml=false` (default) skips HTML generation; setting it to `true` produces `coverage_*.html` and archives it (4).
- [x] Forcing an upload failure (revoking the token in a scratch run) marks the build UNSTABLE / yellow with a clear message in Stage View, and does **not** turn the build red (5).

## Test Result

- [x] PR CI
- Codecov commit: https://app.codecov.io/gh/ROCm/rocMLIR/commit/5925387805e2d972fe9610bcdc5be2bde3c4bf6b

## Future work (not in this PR)

- Add a repo-root `codecov.yml` mirroring the `ignore:` list, so the filter applies to any future upload source (GitHub Actions, local re-uploads).
- Lower the 180 min wall-clock parent timeout to ~120 min after we have 2–3 clean green runs that confirm the real ceiling. Now that timeouts are explicit (yellow), tightening it is safe to do as a one-line follow-up.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

[AIROCMLIR-601]: https://amd-hub.atlassian.net/browse/AIROCMLIR-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ