### PR TITLE
[CI] Fix chronic timeouts in Jenkins Code coverage stage

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1996,7 +1996,13 @@ PY
                                                             showEnv()
                                                             // Build with profiling on, and just code-generation tests.
                                                             try {
-                                                                timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                                                // Wall-clock timeout (no `activity:`): the coverage stage has long
+                                                                // silent phases (lit buffers progress; `llvm-profdata merge` on
+                                                                // ~125 GB of *.profraw produces no output for several minutes),
+                                                                // which makes activity-based timeouts fire spuriously and the
+                                                                // Codecov upload never run. 180 min covers ~60 min tests +
+                                                                // profdata merge + three llvm-cov calls + upload with margin.
+                                                                timeout(time: 180, unit: 'MINUTES') {
                                                                     sh 'rm -f build/CMakeCache.txt'
                                                                     sh 'rm -f build/*.profraw'
                                                                     buildProject('check-rocmlir-build-only',


### PR DESCRIPTION
## Motivation

The Jenkins `Code coverage` stage in `mlir/utils/jenkins/Jenkinsfile` has been chronically failing on PR builds and merges to `develop`, but the failure has been invisible for a long time:

- The whole stage runs inside a 60-minute **activity-based** timeout.
- Two parts of the pipeline produce little or no output that Jenkins sees:
  - lit buffers progress for the duration of `ninja check-rocmlir` (~60 minutes on the coverage matrix codepaths) and only flushes at the very end.
  - `llvm-profdata merge -sparse` operates on ~125 GB of `*.profraw` and runs silently for several minutes.
- The activity timer fires before `llvm-profdata merge` finishes → `coverage_<cpath>.lcov` is never produced → the Codecov uploader never runs → `archiveArtifacts ... onlyIfSuccessful: true` skips the report/lcov/html artifacts.
- The outer `catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')` plus an inner `try { ... } catch (e) { echo "NOTE: Code coverage stage had an error or timeout: ..." }` swallow the `FlowInterruptedException` → the build is **green** and the matrix bodies show ✓ even though no LCOV reached codecov.io.

Concrete evidence collected while investigating https://github.com/ROCm/rocMLIR/pull/<PR-of-test-exclusion> (the test-exclusion change):

```
[2026-05-20T12:09:03.701Z] Total Discovered Tests: 919
[2026-05-20T12:14:07.193Z] Sending interrupt signal to process
[2026-05-20T12:14:13.284Z] Terminated
[2026-05-20T12:14:13.333Z] script returned exit code 143
                            Timeout has been exceeded
[2026-05-20T12:14:13.572Z] NOTE: Code coverage stage had an error or timeout:
[2026-05-20T12:14:13.572Z] org.jenkinsci.plugins.workflow.steps.FlowInterruptedException: Timeout has been exceeded
```

The same `FlowInterruptedException` pattern was confirmed on a recent merge to `develop` (build from 2026-05-16), so codecov.io has been displaying a stale snapshot from whichever older build last produced a successful upload. The biweekly Teams report (`.github/workflows/codecov-report.yml`) reads `totals.coverage` from that stale data.

## Technical Details

Single-line change inside the `body` stage of `collectCoverageData(...)` orchestration in `mlir/utils/jenkins/Jenkinsfile`:

```diff
-                                                                timeout(time: 60, activity: true, unit: 'MINUTES') {
+                                                                timeout(time: 180, unit: 'MINUTES') {
```

- Switch from **activity-based** to **wall-clock** timeout — removes spurious firings caused by lit's buffered output and `llvm-profdata merge`'s silent runtime.
- Bump the budget to **180 minutes**: ~60 min for `ninja check-rocmlir` + several minutes for `llvm-profdata merge` over ~125 GB + three `llvm-cov` invocations (`report`, `export`, `show`) + uploader download and upload, with comfortable margin.
- A short comment is added inline to explain why `activity:` was dropped, so this isn't reintroduced inadvertently in a future cleanup.

## Test Plan

- Codecov on PR CI

## Test Result

- [x] PR CI with Codecov

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.