### PR TITLE
[AIROCMLIR-885] Reject unlowered kernels in `rocmlir-gen --verifier=clone`

### DIFF
--- a/mlir/test/rocmlir-gen/harness-multi-output.mlir
+++ b/mlir/test/rocmlir-gen/harness-multi-output.mlir
@@ -1,0 +1,29 @@
+// `--verifier=clone` builds the host harness assuming kernels have been
+// lowered through the rock kernel pipeline. Feeding it a kernel that still
+// contains higher-level dialects (tosa / migraphx) must produce an
+// actionable error rather than silently mis-routing outputs.
+
+// RUN: sed -e 's/##ARCH##/%arch/g' %s | not rocmlir-gen -ph -rand 1 -rand_type float -fut mm_fut --verifier clone - 2>&1 | FileCheck %s
+
+module attributes {rock.arch = "##ARCH##"} {
+  func.func private @mm_fut_cpu_host(%arg0: tensor<1x256x768xf32>, %arg1: tensor<1x768x768xf32>, %arg2: tensor<1x256x768xf32>) -> (tensor<1x256x768xf32>, tensor<1x256x768xf16>) {
+    %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %0 = tosa.matmul %arg0, %arg1, %a_zp, %b_zp {acc_type = f32} : (tensor<1x256x768xf32>, tensor<1x768x768xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x256x768xf32>
+    %1 = tosa.add %0, %arg2 : (tensor<1x256x768xf32>, tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %2 = tosa.cast %1 : (tensor<1x256x768xf32>) -> tensor<1x256x768xf16>
+    return %0, %2 : tensor<1x256x768xf32>, tensor<1x256x768xf16>
+  }
+  func.func private @mm_fut(%arg0: tensor<1x256x768xf32>, %arg1: tensor<1x768x768xf32>, %arg2: tensor<1x256x768xf32>) -> (tensor<1x256x768xf32>, tensor<1x256x768xf16>) attributes {rock.kernel} {
+    %a_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %b_zp = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %0 = tosa.matmul %arg0, %arg1, %a_zp, %b_zp {acc_type = f32} : (tensor<1x256x768xf32>, tensor<1x768x768xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x256x768xf32>
+    %1 = tosa.add %0, %arg2 : (tensor<1x256x768xf32>, tensor<1x256x768xf32>) -> tensor<1x256x768xf32>
+    %2 = tosa.cast %1 : (tensor<1x256x768xf32>) -> tensor<1x256x768xf16>
+    return %0, %2 : tensor<1x256x768xf32>, tensor<1x256x768xf16>
+  }
+}
+
+// CHECK: error:
+// CHECK-SAME: --verifier=clone cannot build a host harness around a kernel that is not at the rock level
+// CHECK-SAME: run the kernel pipeline first

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -5040,6 +5040,31 @@ static LogicalResult populateHostHarnessLogic(
   bool isCPUKernel = !root0.func->hasAttr("rock.kernel");
   bool hasValidation = !validationType.empty() && !genCPUKernel.getValue();
   bool hasCloneValidation = hasValidation && (validationType == "clone");
+  // `--verifier clone` builds a host harness that allocates one buffer per
+  // kernel argument and feeds the kernel's tensor results back through the
+  // trailing args. That contract is only well-defined if the kernel is
+  // at the rock IR level, so make sure we at least have one rock op in the IR.
+  if (hasCloneValidation) {
+    for (KernelIF kernel : kernels) {
+      bool hasRockOp = false;
+      kernel.func.walk([&](Operation *op) {
+        if (isa_and_nonnull<rock::RockDialect>(op->getDialect())) {
+          hasRockOp = true;
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+      if (!hasRockOp) {
+        kernel.func.emitError()
+            << "--verifier=clone cannot build a host harness around a "
+               "kernel that is not at the rock level; run the "
+               "kernel pipeline first (e.g. `rocmlir-driver "
+               "-kernel-pipeline=highlevel`)";
+        return failure();
+      }
+    }
+  }
+
   bool hasAccel = rock::isAccel(genParams.features);
   bool heuristicValidation =
       !genVerifierKeepPerfConfig && !genParams.perfConfig.empty();


### PR DESCRIPTION
## Motivation

Backports https://github.com/ROCm/rocmlirTriton/pull/235

rocmlir-gen -ph --verifier=clone has an **undocumented prerequisite**: the input kernel must already have been lowered through the rock kernel pipeline (i.e. no tosa or migraphx ops should remain in the kernel body). All existing tests happen to feed it lowered IR by by piping through `rocmlir-driver -kernel-pipeline=highlevel` first, so the prerequisite was never surfaced anywhere. I think it lived only in the head of whoever wrote rocmlir-gen originally. 

When the prerequisite is violated (e.g. a hand-authored kernel containing TOSA/MIGraphX with multiple func.return tensor results that are not aliased by trailing arguments) the clone-harness path generates invalid IR.

## Technical Details
populateHostHarnessLogic now refuses early when `--verifier=clone` is requested and any kernel is not lowered to `rock` level IR, and emits a clear error pointing users to use `rocmlir-driver -kernel-pipeline=highlevel`. 

## Test Plan
Added mlir/test/rocmlir-gen/harness-multi-output.mlir — a negative lit test that feeds a TOSA-based multi-output kernel to rocmlir-gen -ph --verifier=clone and asserts that the tool now exits with the new error message instead of silently emitting invalid IR.

## Test Result

All test pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
