### PR TITLE
ci(claude-review): read App ID from repository variable

### DIFF
--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -140,9 +140,12 @@ name: Claude Auto Review
 # Comments appear as `rocmlir-pr-reviewer[bot]` -- the bot identity of
 # the rocMLIR-PR-Reviewer GitHub App. The post / pre-fetch / cleanup
 # jobs each mint a short-lived (1-hour) installation token via
-# actions/create-github-app-token@<SHA> using the App's
-# ROCMLIR_PR_REVIEWER_APP_ID + ROCMLIR_PR_REVIEWER_PRIVATE_KEY secrets,
-# and that token is what authenticates every gh/git API call. The
+# actions/create-github-app-token@<SHA> using the App's numeric
+# App ID (ROCMLIR_PR_REVIEWER_APP_ID, stored as a repository VARIABLE
+# since it is non-sensitive -- it appears in any GitHub App's public
+# install URL) plus the App's private key (ROCMLIR_PR_REVIEWER_PRIVATE_KEY,
+# stored as a repository SECRET). The resulting installation token
+# authenticates every gh/git API call. The
 # default GITHUB_TOKEN in each job is locked down to `contents: read`
 # (or `permissions: {}` where there is no checkout), so a prompt-
 # injected Claude cannot escalate via the default token.
@@ -572,7 +575,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # App ID is non-sensitive (it appears in any GitHub App's
+          # public install URL) and is stored as a repository variable,
+          # not a secret. The private key IS sensitive and stays in
+          # `secrets.*`.
+          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       # Pre-fetch PR context in a plain shell step. This step holds the
@@ -1047,7 +1054,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # App ID is non-sensitive (it appears in any GitHub App's
+          # public install URL) and is stored as a repository variable,
+          # not a secret. The private key IS sensitive and stays in
+          # `secrets.*`.
+          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Post inline comments, thread updates, and summary
@@ -1093,7 +1104,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # App ID is non-sensitive (it appears in any GitHub App's
+          # public install URL) and is stored as a repository variable,
+          # not a secret. The private key IS sensitive and stays in
+          # `secrets.*`.
+          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Remove claude-review label

--- a/.github/workflows/claude_auto_review_fork_notify.yml
+++ b/.github/workflows/claude_auto_review_fork_notify.yml
@@ -87,7 +87,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # App ID is non-sensitive (it appears in any GitHub App's
+          # public install URL) and is stored as a repository variable,
+          # not a secret. The private key IS sensitive and stays in
+          # `secrets.*`.
+          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Post fork-PR explanation comment and remove the label

--- a/.github/workflows/claude_auto_review_perimeter_banner.yml
+++ b/.github/workflows/claude_auto_review_perimeter_banner.yml
@@ -95,7 +95,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # App ID is non-sensitive (it appears in any GitHub App's
+          # public install URL) and is stored as a repository variable,
+          # not a secret. The private key IS sensitive and stays in
+          # `secrets.*`.
+          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Detect perimeter modifications, label, banner-comment


### PR DESCRIPTION
## Summary

- Move `ROCMLIR_PR_REVIEWER_APP_ID` from `secrets.*` to `vars.*` in all three Claude PR review workflows (main review, fork notify, perimeter banner).
- GitHub App IDs are non-sensitive (they appear in public install URLs); only the private key remains in `secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY`.
- Update the security-model header comment in `claude_auto_review.yml` to document the variable vs secret split.

## Deployment (required before merge)

Create repository variable **`ROCMLIR_PR_REVIEWER_APP_ID`** (Settings → Secrets and variables → Actions → Variables) with the same numeric App ID currently stored in the secret. After verifying workflows succeed, the old `ROCMLIR_PR_REVIEWER_APP_ID` secret can be removed.

## Test plan

- [x] Confirm `ROCMLIR_PR_REVIEWER_APP_ID` repository variable exists with the correct value
- [x] Trigger `claude_auto_review_perimeter_banner` on a PR (open/sync) and verify the App token step succeeds
- [x] Apply `claude-review` on a same-repo PR and verify pre-fetch/post/cleanup jobs mint the App token
- [x] Apply `claude-review` on a fork PR and verify fork-notify posts the explanation comment


Made with [Cursor](https://cursor.com)