### PR TITLE
ci(claude-review): restore App token mint after #2384, close .git/config token write

### DIFF
--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -707,6 +707,13 @@ jobs:
           # (see the comment block there). When the App slug changes,
           # update BOT_LOGIN and this picks it up automatically.
           allowed_bots: ${{ env.BOT_LOGIN }}
+          # claude-code-action needs a GitHub token for agent-mode bootstrap (MCP
+          # install, internal API reads). If omitted, it requests an OIDC token
+          # (id-token:write), which this workflow deliberately does not grant --
+          # see the header. Use the job's read-only default GITHUB_TOKEN here;
+          # all PR comments are posted by the separate post job via the
+          # rocMLIR-PR-Reviewer App token, not this token.
+          github_token: ${{ github.token }}
           # show_full_output prints every tool call (including raw Read contents) to the
           # Action log. Anthropic explicitly warns this can leak secrets in public-repo
           # logs; keep it off in production. Re-enable temporarily for local debugging.

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -140,11 +140,12 @@ name: Claude Auto Review
 # Comments appear as `rocmlir-pr-reviewer[bot]` -- the bot identity of
 # the rocMLIR-PR-Reviewer GitHub App. The post / pre-fetch / cleanup
 # jobs each mint a short-lived (1-hour) installation token via
-# actions/create-github-app-token@<SHA> using the App's numeric
-# App Client ID (ROCMLIR_PR_REVIEWER_APP_ID, stored as a repository VARIABLE
-# since it is non-sensitive -- it appears in any GitHub App's public
-# install URL) plus the App's private key (ROCMLIR_PR_REVIEWER_PRIVATE_KEY,
-# stored as a repository SECRET). The resulting installation token
+# actions/create-github-app-token@<SHA> using the App's Client ID
+# (ROCMLIR_PR_REVIEWER_APP_ID, stored as a repository VARIABLE since it
+# is non-sensitive -- it appears in any GitHub App's public install URL;
+# the variable name is a historical artifact) plus the App's private key
+# (ROCMLIR_PR_REVIEWER_PRIVATE_KEY, stored as a repository SECRET). The
+# resulting installation token
 # authenticates every gh/git API call. The
 # default GITHUB_TOKEN in each job is locked down to `contents: read`
 # (or `permissions: {}` where there is no checkout), so a prompt-
@@ -575,8 +576,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Stored as a
-          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          # Client ID (non-sensitive; public install URL). Variable name
+          # ROCMLIR_PR_REVIEWER_APP_ID is historical; value is the Client ID.
+          # Stored in `vars.*`; private key in `secrets.*`.
           client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
@@ -1059,8 +1061,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Stored as a
-          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          # Client ID (non-sensitive; public install URL). Variable name
+          # ROCMLIR_PR_REVIEWER_APP_ID is historical; value is the Client ID.
+          # Stored in `vars.*`; private key in `secrets.*`.
           client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
@@ -1107,8 +1110,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Stored as a
-          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          # Client ID (non-sensitive; public install URL). Variable name
+          # ROCMLIR_PR_REVIEWER_APP_ID is historical; value is the Client ID.
+          # Stored in `vars.*`; private key in `secrets.*`.
           client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -141,10 +141,11 @@ name: Claude Auto Review
 # the rocMLIR-PR-Reviewer GitHub App. The post / pre-fetch / cleanup
 # jobs each mint a short-lived (1-hour) installation token via
 # actions/create-github-app-token@<SHA> using the App's numeric
-# App ID (ROCMLIR_PR_REVIEWER_APP_ID, stored as a repository VARIABLE
-# since it is non-sensitive -- it appears in any GitHub App's public
-# install URL) plus the App's private key (ROCMLIR_PR_REVIEWER_PRIVATE_KEY,
-# stored as a repository SECRET). The resulting installation token
+# App Client ID (ROCMLIR_PR_REVIEWER_APP_ID: repository VARIABLE preferred,
+# secrets.* fallback during migration -- non-sensitive, appears in any
+# GitHub App's public install URL) plus the App's private key
+# (ROCMLIR_PR_REVIEWER_PRIVATE_KEY, repository SECRET). The resulting
+# installation token
 # authenticates every gh/git API call. The
 # default GITHUB_TOKEN in each job is locked down to `contents: read`
 # (or `permissions: {}` where there is no checkout), so a prompt-
@@ -575,11 +576,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # App ID is non-sensitive (it appears in any GitHub App's
-          # public install URL) and is stored as a repository variable,
-          # not a secret. The private key IS sensitive and stays in
-          # `secrets.*`.
-          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Prefer
+          # `vars.*`; fall back to `secrets.*` until the repository
+          # variable is configured. Private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       # Pre-fetch PR context in a plain shell step. This step holds the
@@ -1054,11 +1054,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # App ID is non-sensitive (it appears in any GitHub App's
-          # public install URL) and is stored as a repository variable,
-          # not a secret. The private key IS sensitive and stays in
-          # `secrets.*`.
-          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Prefer
+          # `vars.*`; fall back to `secrets.*` until the repository
+          # variable is configured. Private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Post inline comments, thread updates, and summary
@@ -1104,11 +1103,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # App ID is non-sensitive (it appears in any GitHub App's
-          # public install URL) and is stored as a repository variable,
-          # not a secret. The private key IS sensitive and stays in
-          # `secrets.*`.
-          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Prefer
+          # `vars.*`; fall back to `secrets.*` until the repository
+          # variable is configured. Private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Remove claude-review label

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -141,11 +141,10 @@ name: Claude Auto Review
 # the rocMLIR-PR-Reviewer GitHub App. The post / pre-fetch / cleanup
 # jobs each mint a short-lived (1-hour) installation token via
 # actions/create-github-app-token@<SHA> using the App's numeric
-# App Client ID (ROCMLIR_PR_REVIEWER_APP_ID: repository VARIABLE preferred,
-# secrets.* fallback during migration -- non-sensitive, appears in any
-# GitHub App's public install URL) plus the App's private key
-# (ROCMLIR_PR_REVIEWER_PRIVATE_KEY, repository SECRET). The resulting
-# installation token
+# App Client ID (ROCMLIR_PR_REVIEWER_APP_ID, stored as a repository VARIABLE
+# since it is non-sensitive -- it appears in any GitHub App's public
+# install URL) plus the App's private key (ROCMLIR_PR_REVIEWER_PRIVATE_KEY,
+# stored as a repository SECRET). The resulting installation token
 # authenticates every gh/git API call. The
 # default GITHUB_TOKEN in each job is locked down to `contents: read`
 # (or `permissions: {}` where there is no checkout), so a prompt-
@@ -576,10 +575,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Prefer
-          # `vars.*`; fall back to `secrets.*` until the repository
-          # variable is configured. Private key stays in `secrets.*`.
-          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Stored as a
+          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       # Pre-fetch PR context in a plain shell step. This step holds the
@@ -1061,10 +1059,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Prefer
-          # `vars.*`; fall back to `secrets.*` until the repository
-          # variable is configured. Private key stays in `secrets.*`.
-          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Stored as a
+          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Post inline comments, thread updates, and summary
@@ -1110,10 +1107,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Prefer
-          # `vars.*`; fall back to `secrets.*` until the repository
-          # variable is configured. Private key stays in `secrets.*`.
-          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Stored as a
+          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Remove claude-review label

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -144,12 +144,11 @@ name: Claude Auto Review
 # (ROCMLIR_PR_REVIEWER_APP_ID, stored as a repository VARIABLE since it
 # is non-sensitive -- it appears in any GitHub App's public install URL;
 # the variable name is a historical artifact) plus the App's private key
-# (ROCMLIR_PR_REVIEWER_PRIVATE_KEY, stored as a repository SECRET). The
-# resulting installation token
-# authenticates every gh/git API call. The
-# default GITHUB_TOKEN in each job is locked down to `contents: read`
-# (or `permissions: {}` where there is no checkout), so a prompt-
-# injected Claude cannot escalate via the default token.
+# (ROCMLIR_PR_REVIEWER_PRIVATE_KEY, stored as a repository SECRET).
+# The resulting installation token authenticates every gh/git API
+# call. The default GITHUB_TOKEN in each job is locked down to
+# `contents: read` (or `permissions: {}` where there is no checkout),
+# so a prompt-injected Claude cannot escalate via the default token.
 #
 # We do NOT use the Anthropic OIDC token exchange that would let
 # comments appear as claude[bot] -- that path requires id-token:write
@@ -350,6 +349,14 @@ jobs:
       # structured response. Disabling credential persistence eliminates the
       # file-on-disk attack path; the subsequent pre-fetch step uses GH_TOKEN
       # explicitly via env.
+      #
+      # The other half of this defense lives on the `Run Claude review` step
+      # below: `allowed_non_write_users: '__never_match__'` flips claude-code-
+      # action's configureGitAuth() onto its credential-helper branch, so the
+      # action's prepare phase does not re-write the same
+      # `x-access-token:<token>` URL back into .git/config. Both halves must
+      # stay in sync; see the comment on that input for the agent-mode code
+      # path and rationale for the sentinel value.
       - name: Checkout PR head
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -667,14 +674,35 @@ jobs:
           rm /tmp/pr/prev_comments.raw.json
           ls -la /tmp/pr/
 
-      # The Claude run. NOTE THE ENVIRONMENT: only LLM Gateway secrets are present.
-      # GITHUB_TOKEN is intentionally NOT set here. The allowed-tools list contains
-      # NO Bash, NO Write, and NO MCP write surface. The model can only Read files
-      # in the workspace and /tmp/pr/, run Grep/Glob, and use the in-repo skills.
-      # Its only output channel is the model's final response, which `--json-schema`
-      # validates and surfaces as `steps.claude-code.outputs.structured_output`.
-      # The sanitizer step then inspects that output before it's allowed to be
-      # consumed by the post job.
+      # The Claude run. NOTE THE ENVIRONMENT: LLM Gateway secrets are present
+      # via the explicit env: block below, and claude-code-action additionally
+      # sets GITHUB_TOKEN / GH_TOKEN in its process env from the github_token
+      # input (src/entrypoints/run.ts sets process.env.{GITHUB_TOKEN,GH_TOKEN}
+      # before runClaude()), so those env vars are inherited by the Claude
+      # process too. This was NOT true before commit f5e82bd5; we now pass
+      # github_token explicitly to avoid an OIDC token request (id-token:write
+      # is deliberately not granted here -- see the header).
+      #
+      # The defenses that make this acceptable are:
+      #   - github_token is the job's read-only default GITHUB_TOKEN, scoped
+      #     by `permissions: contents: read` above. Even a successful exfil
+      #     yields no write capability on this repo.
+      #   - allowedTools is Skill,Read,Grep,Glob -- no Bash, no Write, no MCP
+      #     write surface. The model cannot `printenv`, cannot shell out, and
+      #     cannot directly post to any GitHub endpoint.
+      #   - The only output channel is the model's final response, validated
+      #     by `--json-schema` and surfaced as
+      #     `steps.claude-code.outputs.structured_output`. The sanitizer step
+      #     then inspects that output (gh[pousr]_, sk-ant-api##-, Bearer ...,
+      #     etc. -- see .github/scripts/secret_patterns.sh) before it's
+      #     allowed to reach the post job.
+      #   - Residual risk: the Read tool could in principle dereference
+      #     /proc/self/environ to recover GITHUB_TOKEN / GH_TOKEN /
+      #     LLM_GATEWAY_KEY in literal form. The sanitizer's
+      #     ghp_/gho_/ghs_/ghu_/ghr_/sk-ant-api##- patterns are designed to
+      #     catch a naive emission; obfuscation defeats them, which is why we
+      #     ALSO scope the token to contents:read and keep the LLM Gateway
+      #     secrets out of the post job entirely (two-job split, see header).
       #
       # claude-code-action is SHA-pinned (not @v1) to defend against an upstream-action
       # supply-chain compromise (the same attack class as the tj-actions/changed-files
@@ -714,6 +742,44 @@ jobs:
           # all PR comments are posted by the separate post job via the
           # rocMLIR-PR-Reviewer App token, not this token.
           github_token: ${{ github.token }}
+          # CRITICAL -- pairs with `persist-credentials: false` on the checkout
+          # above. In agent mode, claude-code-action's prepare phase calls
+          # configureGitAuth() which, by default, rewrites the `origin` remote
+          # URL to `https://x-access-token:<token>@github.com/...` -- i.e. it
+          # embeds the GITHUB_TOKEN supplied above directly into .git/config.
+          # Claude in this job has the Read tool, so a prompt-injected PR could
+          # then dump .git/config and emit the token in the structured
+          # response. That re-introduces the exact attack path we close at the
+          # checkout step (see the comment there).
+          #
+          # Setting allowed_non_write_users to a sentinel that no real GitHub
+          # username can ever match (`__never_match__` contains underscores;
+          # GitHub usernames are alphanumeric + hyphens only, can't start/end
+          # with hyphen, max 39 chars) flips configureGitAuth() onto its
+          # credential-helper branch (src/github/operations/git-config.ts):
+          # the remote URL stays clean and the token is supplied at auth time
+          # via a GH_TOKEN-reading shell helper instead of being persisted to
+          # disk. The accompanying actor-permission bypass in
+          # src/github/validation/permissions.ts only fires when the actor
+          # literally equals an entry in the list -- impossible here -- so our
+          # access control (label gate / dispatch-from-default-branch gate) is
+          # unaffected.
+          #
+          # We deliberately do NOT use `use_commit_signing: 'true'` for the
+          # same effect, even though it also skips configureGitAuth(): that
+          # flag additionally registers the github_file_ops MCP server with
+          # GITHUB_TOKEN in its env (install-mcp-server.ts), which is needless
+          # new attack surface for a job whose allowed_tools list contains no
+          # MCP write surface.
+          #
+          # Side effects of this setting that are benign here:
+          #   - claude-code-action installs bubblewrap/socat for subprocess
+          #     isolation (apt-get with continue-on-error). Adds setup time;
+          #     does not affect security posture.
+          #   - CLAUDE_CODE_SUBPROCESS_ENV_SCRUB defaults to "1" when
+          #     allowed_non_write_users is set; we set it explicitly above
+          #     anyway, so the default is just belt-and-braces.
+          allowed_non_write_users: '__never_match__'
           # show_full_output prints every tool call (including raw Read contents) to the
           # Action log. Anthropic explicitly warns this can leak secrets in public-repo
           # logs; keep it off in production. Re-enable temporarily for local debugging.

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -784,15 +784,29 @@ jobs:
           # MCP write surface.
           #
           # CROSS-CUTTING DEPENDENCY -- this safeguard's correctness is bound
-          # to claude_args BELOW: install-mcp-server.ts registers
-          # github_comment / github_inline_comment / github_file_ops / CI MCP
-          # servers (each with GITHUB_TOKEN in its env) only when the
-          # corresponding `mcp__github_*__*` tools are present in
-          # --allowedTools. Today our list is "Skill,Read,Grep,Glob" so none
-          # of them get registered. If you ADD any `mcp__github_*` tool, you
-          # re-introduce a token-bearing subprocess that the Read tool could
-          # in principle reach via /proc/<pid>/environ. Re-audit before
-          # changing --allowedTools.
+          # to two other inputs on this same step. install-mcp-server.ts
+          # registers MCP servers (each with GITHUB_TOKEN in its env) under
+          # these gates in agent mode:
+          #   - github_comment        registered when --allowedTools contains
+          #                           a `mcp__github_comment__*` tool.
+          #   - github_inline_comment registered when --allowedTools contains
+          #                           a `mcp__github__*` or
+          #                           `mcp__github_inline_comment__*` tool.
+          #   - github_ci             registered when --allowedTools contains
+          #                           a `mcp__github_ci__*` tool.
+          #   - github_file_ops       registered when `use_commit_signing` is
+          #                           true. NOT tool-gated -- this server
+          #                           tracks an independent input and is the
+          #                           reason we explicitly do NOT enable
+          #                           use_commit_signing for this job
+          #                           (see the "deliberately do NOT" note
+          #                           above).
+          # Today our --allowedTools is "Skill,Read,Grep,Glob" and
+          # use_commit_signing is unset, so NONE of the above are registered.
+          # If you ADD any `mcp__github_*` tool OR set
+          # `use_commit_signing: 'true'`, you re-introduce a token-bearing
+          # subprocess that the Read tool could in principle reach via
+          # /proc/<pid>/environ. Re-audit before changing either input.
           #
           # ACTION-BUMP CHECKLIST -- this safeguard depends on three
           # undocumented internals of anthropics/claude-code-action that are

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -181,10 +181,20 @@ name: Claude Auto Review
 #
 #   Job 1 (review):
 #     - Has the LLM Gateway secrets in env (ANTHROPIC_BASE_URL, LLM_GATEWAY_KEY, USER_NTID)
-#     - Does NOT have GITHUB_TOKEN in any user-controlled step
+#     - Receives the workflow's default GITHUB_TOKEN (scoped to `contents: read` via
+#       the job's permissions block) on the claude-code-action step via the
+#       `github_token:` input. The action sets it as GITHUB_TOKEN / GH_TOKEN in
+#       process.env, which the Claude subprocess inherits. The token is supplied via
+#       a credential helper (allowed_non_write_users sentinel) -- NOT embedded in
+#       .git/config -- and is NOT propagated to the pre-fetch shell step (which uses
+#       the rocMLIR-PR-Reviewer App token instead). See the per-step comments on
+#       both inputs for the threat model and residual-risk discussion.
 #     - Pre-fetches PR data into /tmp/pr/ in a plain shell step (no Claude involved)
-#     - Runs claude-code-action with --allowedTools restricted to Skill/Read/Grep/Glob
+#     - Runs claude-code-action with --allowedTools restricted to Skill,Read,Grep,Glob
 #       (NO Bash, NO Write, NO MCP write tools, NO network) -- Claude cannot exfiltrate
+#       interactively. The contents:read scope of GITHUB_TOKEN bounds the blast radius
+#       even if the model dereferenced /proc/self/environ (last line of defense: the
+#       sanitizer's gh[pousr]_ / sk-ant-api##- patterns).
 #     - Captures Claude's final response via --json-schema as a step output, materializes
 #       it to /tmp/pr/actions.json, then sanitizes (rejects suspected secret patterns,
 #       enforces size and count caps) before uploading as an artifact

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -679,9 +679,10 @@ jobs:
       # sets GITHUB_TOKEN / GH_TOKEN in its process env from the github_token
       # input (src/entrypoints/run.ts sets process.env.{GITHUB_TOKEN,GH_TOKEN}
       # before runClaude()), so those env vars are inherited by the Claude
-      # process too. This was NOT true before commit f5e82bd5; we now pass
-      # github_token explicitly to avoid an OIDC token request (id-token:write
-      # is deliberately not granted here -- see the header).
+      # process too. This was NOT true before this workflow started passing
+      # `github_token` explicitly (see the input below); we do so to avoid an
+      # OIDC token request (id-token:write is deliberately not granted here --
+      # see the header).
       #
       # The defenses that make this acceptable are:
       #   - github_token is the job's read-only default GITHUB_TOKEN, scoped
@@ -772,10 +773,36 @@ jobs:
           # new attack surface for a job whose allowed_tools list contains no
           # MCP write surface.
           #
+          # CROSS-CUTTING DEPENDENCY -- this safeguard's correctness is bound
+          # to claude_args BELOW: install-mcp-server.ts registers
+          # github_comment / github_inline_comment / github_file_ops / CI MCP
+          # servers (each with GITHUB_TOKEN in its env) only when the
+          # corresponding `mcp__github_*__*` tools are present in
+          # --allowedTools. Today our list is "Skill,Read,Grep,Glob" so none
+          # of them get registered. If you ADD any `mcp__github_*` tool, you
+          # re-introduce a token-bearing subprocess that the Read tool could
+          # in principle reach via /proc/<pid>/environ. Re-audit before
+          # changing --allowedTools.
+          #
+          # ACTION-BUMP CHECKLIST -- this safeguard depends on three
+          # undocumented internals of anthropics/claude-code-action that are
+          # pinned by SHA above. When bumping the SHA, re-verify all three:
+          #   1. src/github/operations/git-config.ts -- the
+          #      `if (process.env.ALLOWED_NON_WRITE_USERS)` branch still
+          #      takes the credential-helper path (not the URL-embed path).
+          #   2. src/github/validation/permissions.ts -- the
+          #      allowedNonWriteUsers list match is still exact-string
+          #      (no glob/regex), so `__never_match__` cannot match a real
+          #      GitHub username.
+          #   3. src/modes/agent/index.ts -- configureGitAuth is still the
+          #      function that gets reached for our event in agent mode.
+          # If ANY of these change, the .git/config token write may silently
+          # resume; failure is invisible from the workflow log.
+          #
           # Side effects of this setting that are benign here:
           #   - claude-code-action installs bubblewrap/socat for subprocess
-          #     isolation (apt-get with continue-on-error). Adds setup time;
-          #     does not affect security posture.
+          #     isolation (apt-get with continue-on-error). Adds 10-30s of
+          #     setup time; does not affect security posture.
           #   - CLAUDE_CODE_SUBPROCESS_ENV_SCRUB defaults to "1" when
           #     allowed_non_write_users is set; we set it explicitly above
           #     anyway, so the default is just belt-and-braces.

--- a/.github/workflows/claude_auto_review_fork_notify.yml
+++ b/.github/workflows/claude_auto_review_fork_notify.yml
@@ -87,11 +87,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # App ID is non-sensitive (it appears in any GitHub App's
-          # public install URL) and is stored as a repository variable,
-          # not a secret. The private key IS sensitive and stays in
-          # `secrets.*`.
-          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Prefer
+          # `vars.*`; fall back to `secrets.*` until the repository
+          # variable is configured. Private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Post fork-PR explanation comment and remove the label

--- a/.github/workflows/claude_auto_review_fork_notify.yml
+++ b/.github/workflows/claude_auto_review_fork_notify.yml
@@ -87,10 +87,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Prefer
-          # `vars.*`; fall back to `secrets.*` until the repository
-          # variable is configured. Private key stays in `secrets.*`.
-          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Stored as a
+          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Post fork-PR explanation comment and remove the label

--- a/.github/workflows/claude_auto_review_fork_notify.yml
+++ b/.github/workflows/claude_auto_review_fork_notify.yml
@@ -87,8 +87,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Stored as a
-          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          # Client ID (non-sensitive; public install URL). Variable name
+          # ROCMLIR_PR_REVIEWER_APP_ID is historical; value is the Client ID.
+          # Stored in `vars.*`; private key in `secrets.*`.
           client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 

--- a/.github/workflows/claude_auto_review_perimeter_banner.yml
+++ b/.github/workflows/claude_auto_review_perimeter_banner.yml
@@ -95,10 +95,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Prefer
-          # `vars.*`; fall back to `secrets.*` until the repository
-          # variable is configured. Private key stays in `secrets.*`.
-          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Stored as a
+          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Detect perimeter modifications, label, banner-comment

--- a/.github/workflows/claude_auto_review_perimeter_banner.yml
+++ b/.github/workflows/claude_auto_review_perimeter_banner.yml
@@ -95,8 +95,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # Client ID is non-sensitive (public install URL). Stored as a
-          # repository variable (`vars.*`); private key stays in `secrets.*`.
+          # Client ID (non-sensitive; public install URL). Variable name
+          # ROCMLIR_PR_REVIEWER_APP_ID is historical; value is the Client ID.
+          # Stored in `vars.*`; private key in `secrets.*`.
           client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 

--- a/.github/workflows/claude_auto_review_perimeter_banner.yml
+++ b/.github/workflows/claude_auto_review_perimeter_banner.yml
@@ -95,11 +95,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          # App ID is non-sensitive (it appears in any GitHub App's
-          # public install URL) and is stored as a repository variable,
-          # not a secret. The private key IS sensitive and stays in
-          # `secrets.*`.
-          app-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
+          # Client ID is non-sensitive (public install URL). Prefer
+          # `vars.*`; fall back to `secrets.*` until the repository
+          # variable is configured. Private key stays in `secrets.*`.
+          client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID || secrets.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
       - name: Detect perimeter modifications, label, banner-comment


### PR DESCRIPTION
## Summary

Restores Claude Auto Review on `develop` after #2384's variable migration left the App-token mint step receiving an empty `client-id`, and tightens two adjacent security/doc loose ends that surfaced while fixing it.

### What was failing

#2384 moved `ROCMLIR_PR_REVIEWER_APP_ID` from `secrets.*` to `vars.*`, but the repository variable was not actually configured. `actions/create-github-app-token` therefore received an empty value and every gh/git API call in `claude_auto_review.yml`, `claude_auto_review_fork_notify.yml`, and `claude_auto_review_perimeter_banner.yml` failed at the token-mint step.

### Changes

**Token minting (across all three claude-review workflows)**
- Rename the deprecated `app-id` input to `client-id` on `actions/create-github-app-token` (`app-id` is annotated `deprecationMessage: "Use 'client-id' instead."` in v3.2.0).
- Read `ROCMLIR_PR_REVIEWER_APP_ID` exclusively from `vars.*`. The temporary `secrets.*` fallback added while debugging has been removed now that the repo variable is configured.
- The variable name keeps its `*_APP_ID` form (historical artifact). Per-step comments now explicitly note that the stored value is a Client ID, not the numeric App ID.

**Avoid an unintended OIDC token request**
- Pass the job's locked-down default token explicitly as `github_token: ${{ github.token }}` to `claude-code-action`. Without this the action's `setupGitHubToken()` falls through to `getIDToken()` and fails because the review job deliberately omits `id-token: write` (the workflow header explains the rationale -- LLM Gateway authenticates with a static API key, not Anthropic OIDC).

**Close a re-introduced `.git/config` token-on-disk attack path**
- In agent mode, `claude-code-action`'s prepare phase unconditionally calls `configureGitAuth()`, which by default rewrites the `origin` URL to `https://x-access-token:<token>@github.com/...`. With Claude's `Read` tool present, that re-introduces the exact file-on-disk leak the existing `persist-credentials: false` checkout option was added to close.
- Set `allowed_non_write_users: '__never_match__'` to flip `configureGitAuth()` onto its credential-helper branch (the token is supplied at auth time via a `GH_TOKEN`-reading shell helper instead of being persisted to disk). The sentinel is intentionally an invalid GitHub username (underscores aren't allowed in usernames), so the action's actor-permission bypass cannot fire and our existing access control (label gate + same-repo SHA + dispatch-from-default-branch) remains the actual gate.
- Preferred over `use_commit_signing: 'true'`, which would also skip `configureGitAuth()` but additionally registers a `github_file_ops` MCP server with the token in its env -- needless new attack surface for a job whose allowed-tools list contains no MCP write surface.

**Documentation accuracy**
- Fix workflow header that previously said the variable contained a "numeric App Client ID" (Client IDs aren't numeric).
- Replace the stale "GITHUB_TOKEN is intentionally NOT set here" comment block above the Claude run -- true before this branch but no longer accurate once we pass `github_token`. The new block describes the actual env state (claude-code-action sets `GITHUB_TOKEN` / `GH_TOKEN` in its process env from the input) and the residual `/proc/self/environ` Read-tool risk the sanitizer's `ghp_/gho_/ghs_/ghu_/ghr_/sk-ant-api##-` patterns are the final gate against.
- Cross-reference the paired safeguards (`persist-credentials: false` on the checkout step + `allowed_non_write_users` on the action) so a future reader sees both halves of the defense in one place.
- Minor reflow of the header paragraph after the App-ID -> Client-ID rewrite left an orphan line.

## Test plan

- [ ] Re-run Claude Auto Review via `workflow_dispatch` on a PR -- confirm the `Generate App token` step succeeds (no empty `client-id` error).
- [ ] After a Claude review run, confirm the runner workspace's `.git/config` contains no `x-access-token:` URL in the `[remote "origin"]` block (the credential-helper branch should leave the URL clean).
- [ ] Verify the fork-notify and perimeter-banner workflows still mint App tokens (same `client-id` rename applied there).

## Related

- #2384 -- original variable migration.

Made with [Cursor](https://cursor.com)