### PR TITLE
[AIROCMLIR-892] Allow pure extf output fusion on splitKV > 1 attention

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/fusionUtils.h
@@ -34,9 +34,10 @@ LogicalResult testFusionLegalityReduce(func::FuncOp func);
 // are using the v4r1 algorithm (for splitting)
 LogicalResult testFusionLegalityBwdDataConv(func::FuncOp func);
 
-// Checks whether any `rock::AttentionOp` has splitKV > 1.
-// Output fusions are not allowed with splitKV > 1 because the partial results
-// need to be combined with LSE values in a subsequent stage.
+// Checks whether any `rock::AttentionOp` has splitKV > 1. Output fusions
+// are rejected because the partial results need an LSE-based combine in a
+// subsequent stage; a pure element-wise `arith.extf` reader is the one
+// exception (lossless widening commutes with the combine).
 LogicalResult testFusionLegalityAttentionSplitKV(func::FuncOp func);
 
 // This is an overload of the `testFusionLegalitySplitK` which is more

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -288,35 +288,32 @@ LogicalResult mlir::rock::testFusionLegalityReduce(ModuleOp mod) {
   return testFusionLegalityReduce(func);
 }
 
-// A linalg.generic reader of the split-kv attention output is safe to fuse
-// when it is a pure element-wise extf of the partial: extf is widening and
-// commutes with the LSE-based combination
-//   combined = sum_i exp(L_i - L) * P_i,   with sum_i exp(L_i - L) = 1.
-// The generic must have a single input and single output, be element-wise
-// (parallel iterators, equal identity indexing maps), and its body must be
-// just `arith.extf %in` followed by `linalg.yield`.
+// Matches a single-in/single-out, identity-mapped, all-parallel
+// linalg.generic whose body is exactly `arith.extf %in` + `linalg.yield`.
+// Safe to fuse past the split-kv LSE combine because extf is a lossless
+// widening.
 static bool isPureElementwiseExtF(linalg::GenericOp genericOp) {
   if (genericOp.getNumDpsInputs() != 1 || genericOp.getNumDpsInits() != 1)
     return false;
 
-  for (utils::IteratorType it : genericOp.getIteratorTypesArray())
-    if (it != utils::IteratorType::parallel)
-      return false;
+  if (!genericOp.isAllParallelLoops())
+    return false;
 
   SmallVector<AffineMap> maps = genericOp.getIndexingMapsArray();
   if (maps.size() != 2 || !maps[0].isIdentity() || maps[0] != maps[1])
     return false;
 
-  Block &body = genericOp.getRegion().front();
-  auto bodyOps = body.without_terminator();
+  Block *body = genericOp.getBlock();
+  auto bodyOps = body->without_terminator();
   if (!llvm::hasSingleElement(bodyOps))
     return false;
 
-  auto extf = dyn_cast<arith::ExtFOp>(&*bodyOps.begin());
-  if (!extf || extf.getIn() != body.getArgument(0))
+  // Block args are inputs then inits, so arg(0) is the input bbarg.
+  auto extf = dyn_cast<ExtFOp>(&*bodyOps.begin());
+  if (!extf || extf.getIn() != body->getArgument(0))
     return false;
 
-  auto yieldOp = cast<linalg::YieldOp>(body.getTerminator());
+  auto yieldOp = cast<linalg::YieldOp>(body->getTerminator());
   return yieldOp.getValues().size() == 1 &&
          yieldOp.getValues().front() == extf.getResult();
 }
@@ -324,10 +321,9 @@ static bool isPureElementwiseExtF(linalg::GenericOp genericOp) {
 LogicalResult
 mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
   // Input fusions and fusions between the first and second gemm are allowed
-  // with splitKV > 1. Output fusions must be prevented because the partial
-  // results need to be combined with LSE values in a subsequent stage, except
-  // for a pure element-wise extf of the partial, which commutes with the
-  // LSE-based combination (see `isPureElementwiseExtF`).
+  // with splitKV > 1. Output fusions are rejected because the partial results
+  // need an LSE-based combine in a subsequent stage; a pure element-wise extf
+  // is the one exception (see `isPureElementwiseExtF`).
   auto analysis = BufferDependencyAnalysis(func.getOperation());
   const auto &readersTable = analysis.getReadersTable();
   const auto &writersTable = analysis.getWritersTable();
@@ -346,8 +342,8 @@ mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
         // except a pure element-wise extf.
         if (readersTable.contains(maybeAlloc.value())) {
           for (OpOperand *op : readersTable.at(maybeAlloc.value())) {
-            if (auto gen = dyn_cast<linalg::GenericOp>(op->getOwner());
-                gen && !isPureElementwiseExtF(gen))
+            if (auto genericOp = dyn_cast<linalg::GenericOp>(op->getOwner());
+                genericOp && !isPureElementwiseExtF(genericOp))
               return WalkResult::interrupt();
           }
         }

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -293,29 +293,30 @@ LogicalResult mlir::rock::testFusionLegalityReduce(ModuleOp mod) {
 // Safe to fuse past the split-kv LSE combine because extf is a lossless
 // widening.
 static bool isPureElementwiseExtF(linalg::GenericOp genericOp) {
-  if (genericOp.getNumDpsInputs() != 1 || genericOp.getNumDpsInits() != 1)
+  if (!genericOp.isSingleInputOutput())
     return false;
 
   if (!genericOp.isAllParallelLoops())
     return false;
 
+  // Both maps must be the identity (no broadcast / transpose).
   SmallVector<AffineMap> maps = genericOp.getIndexingMapsArray();
-  if (maps.size() != 2 || !maps[0].isIdentity() || maps[0] != maps[1])
+  if (!maps[0].isIdentity() || maps[0] != maps[1])
     return false;
 
+  // Body must be exactly: %ext = arith.extf %arg_in; linalg.yield %ext
   Block *body = genericOp.getBlock();
-  auto bodyOps = body->without_terminator();
-  if (!llvm::hasSingleElement(bodyOps))
+  if (body->getOperations().size() != 2) // extf + yield
     return false;
 
   // Block args are inputs then inits, so arg(0) is the input bbarg.
-  auto extf = dyn_cast<ExtFOp>(&*bodyOps.begin());
+  auto extf = dyn_cast<ExtFOp>(&body->front());
   if (!extf || extf.getIn() != body->getArgument(0))
     return false;
 
   auto yieldOp = cast<linalg::YieldOp>(body->getTerminator());
-  return yieldOp.getValues().size() == 1 &&
-         yieldOp.getValues().front() == extf.getResult();
+  return yieldOp.getNumOperands() == 1 &&
+         yieldOp->getOperand(0) == extf.getResult();
 }
 
 LogicalResult

--- a/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/fusionUtils.cpp
@@ -288,11 +288,46 @@ LogicalResult mlir::rock::testFusionLegalityReduce(ModuleOp mod) {
   return testFusionLegalityReduce(func);
 }
 
+// A linalg.generic reader of the split-kv attention output is safe to fuse
+// when it is a pure element-wise extf of the partial: extf is widening and
+// commutes with the LSE-based combination
+//   combined = sum_i exp(L_i - L) * P_i,   with sum_i exp(L_i - L) = 1.
+// The generic must have a single input and single output, be element-wise
+// (parallel iterators, equal identity indexing maps), and its body must be
+// just `arith.extf %in` followed by `linalg.yield`.
+static bool isPureElementwiseExtF(linalg::GenericOp genericOp) {
+  if (genericOp.getNumDpsInputs() != 1 || genericOp.getNumDpsInits() != 1)
+    return false;
+
+  for (utils::IteratorType it : genericOp.getIteratorTypesArray())
+    if (it != utils::IteratorType::parallel)
+      return false;
+
+  SmallVector<AffineMap> maps = genericOp.getIndexingMapsArray();
+  if (maps.size() != 2 || !maps[0].isIdentity() || maps[0] != maps[1])
+    return false;
+
+  Block &body = genericOp.getRegion().front();
+  auto bodyOps = body.without_terminator();
+  if (!llvm::hasSingleElement(bodyOps))
+    return false;
+
+  auto extf = dyn_cast<arith::ExtFOp>(&*bodyOps.begin());
+  if (!extf || extf.getIn() != body.getArgument(0))
+    return false;
+
+  auto yieldOp = cast<linalg::YieldOp>(body.getTerminator());
+  return yieldOp.getValues().size() == 1 &&
+         yieldOp.getValues().front() == extf.getResult();
+}
+
 LogicalResult
 mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
   // Input fusions and fusions between the first and second gemm are allowed
-  // with splitKV > 1. Only output fusions must be prevented because the
-  // partial results need to be combined with LSE values in a subsequent stage.
+  // with splitKV > 1. Output fusions must be prevented because the partial
+  // results need to be combined with LSE values in a subsequent stage, except
+  // for a pure element-wise extf of the partial, which commutes with the
+  // LSE-based combination (see `isPureElementwiseExtF`).
   auto analysis = BufferDependencyAnalysis(func.getOperation());
   const auto &readersTable = analysis.getReadersTable();
   const auto &writersTable = analysis.getWritersTable();
@@ -307,10 +342,12 @@ mlir::rock::testFusionLegalityAttentionSplitKV(func::FuncOp func) {
         if (failed(maybeAlloc))
           return WalkResult::advance();
 
-        // Reject if any linalg::GenericOp reads from the attention output
+        // Reject if any linalg::GenericOp reads from the attention output,
+        // except a pure element-wise extf.
         if (readersTable.contains(maybeAlloc.value())) {
           for (OpOperand *op : readersTable.at(maybeAlloc.value())) {
-            if (isa<linalg::GenericOp>(op->getOwner()))
+            if (auto gen = dyn_cast<linalg::GenericOp>(op->getOwner());
+                gen && !isPureElementwiseExtF(gen))
               return WalkResult::interrupt();
           }
         }

--- a/mlir/test/fusion/fusability-attention-splitkv-output-convert-fusion.mlir
+++ b/mlir/test/fusion/fusability-attention-splitkv-output-convert-fusion.mlir
@@ -1,0 +1,44 @@
+// A pure element-wise extf on the attention output is safe to fuse with
+// splitKV > 1: extf is widening and commutes with the LSE-based combination
+// of partial results.
+// Regression test for https://github.com/ROCm/rocMLIR/issues/2376
+
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - | FileCheck %s
+// CHECK: fusible:1
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+module {
+  func.func @attn_splitkv_output_extf_fusible(
+      %queries: memref<1x64x1024xf16>,
+      %keys: memref<1x64x1024xf16>,
+      %values: memref<1x1024x64xf16>,
+      %lse: memref<4x1024xf32>,
+      %out: memref<4x1024x64xf32>
+  ) attributes {rock.kernel, mhal.arch = "##TOKEN_ARCH##"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x1024x64xf16>
+    rock.attention {
+      qk = tr %queries * %keys : memref<1x64x1024xf16>, memref<1x64x1024xf16>
+      lse = %lse : memref<4x1024xf32>
+      %alloc = softmax(qk) * %values : memref<1x1024x64xf16> -> memref<4x1024x64xf16>
+    } {
+      firstGemmIndices = array<i64: 0>,
+      splitKV = 4 : i32,
+      storeMethod = #rock<StoreMethod set>,
+      numHeadsKV = 1 : i32,
+      numHeadsQ = 1 : i32
+    }
+
+    // Pure type widening on the attention output.
+    linalg.generic {
+      indexing_maps = [#map, #map],
+      iterator_types = ["parallel", "parallel", "parallel"]
+    } ins(%alloc : memref<4x1024x64xf16>)
+      outs(%out : memref<4x1024x64xf32>) {
+    ^bb0(%in: f16, %unused: f32):
+      %cvt = arith.extf %in : f16 to f32
+      linalg.yield %cvt : f32
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/fusability-attention-splitkv-output-extf-chain-rejection.mlir
+++ b/mlir/test/fusion/fusability-attention-splitkv-output-extf-chain-rejection.mlir
@@ -1,14 +1,14 @@
-// A pure element-wise extf on the attention output is safe to fuse with
-// splitKV > 1 (lossless widening commutes with the LSE combine).
-// Regression test for https://github.com/ROCm/rocMLIR/issues/2376
+// An extf chained with another op must NOT be fused with splitKV > 1:
+// the carve-out only allows a body that is exactly `arith.extf` + yield.
+// Regression guard for the extf carve-out (issue #2376).
 
 // RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - | FileCheck %s
-// CHECK: fusible:1
+// CHECK: fusible:0
 
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 
 module {
-  func.func @attn_splitkv_output_extf_fusible(
+  func.func @attn_splitkv_output_extf_chain_not_fusible(
       %queries: memref<1x64x1024xf16>,
       %keys: memref<1x64x1024xf16>,
       %values: memref<1x1024x64xf16>,
@@ -16,6 +16,7 @@ module {
       %out: memref<4x1024x64xf32>
   ) attributes {rock.kernel, mhal.arch = "##TOKEN_ARCH##"} {
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x1024x64xf16>
+    %scale = arith.constant 2.0 : f32
     rock.attention {
       qk = tr %queries * %keys : memref<1x64x1024xf16>, memref<1x64x1024xf16>
       lse = %lse : memref<4x1024xf32>
@@ -35,7 +36,8 @@ module {
       outs(%out : memref<4x1024x64xf32>) {
     ^bb0(%in: f16, %out_init: f32):
       %cvt = arith.extf %in : f16 to f32
-      linalg.yield %cvt : f32
+      %scaled = arith.mulf %cvt, %scale : f32
+      linalg.yield %scaled : f32
     }
     return
   }

--- a/mlir/test/fusion/fusability-attention-splitkv-output-extf-transposed-rejection.mlir
+++ b/mlir/test/fusion/fusability-attention-splitkv-output-extf-transposed-rejection.mlir
@@ -1,19 +1,20 @@
-// A pure element-wise extf on the attention output is safe to fuse with
-// splitKV > 1 (lossless widening commutes with the LSE combine).
-// Regression test for https://github.com/ROCm/rocMLIR/issues/2376
+// extf with a non-identity (transposed) indexing map must NOT be fused with
+// splitKV > 1: the LSE combine assumes the output buffer's natural layout.
+// Regression guard for the extf carve-out (issue #2376).
 
 // RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - | FileCheck %s
-// CHECK: fusible:1
+// CHECK: fusible:0
 
-#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#in_map = affine_map<(d0, d1, d2) -> (d0, d2, d1)>
+#out_map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 
 module {
-  func.func @attn_splitkv_output_extf_fusible(
+  func.func @attn_splitkv_output_extf_transposed_not_fusible(
       %queries: memref<1x64x1024xf16>,
       %keys: memref<1x64x1024xf16>,
       %values: memref<1x1024x64xf16>,
       %lse: memref<4x1024xf32>,
-      %out: memref<4x1024x64xf32>
+      %out: memref<4x64x1024xf32>
   ) attributes {rock.kernel, mhal.arch = "##TOKEN_ARCH##"} {
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x1024x64xf16>
     rock.attention {
@@ -29,10 +30,10 @@ module {
     }
 
     linalg.generic {
-      indexing_maps = [#map, #map],
+      indexing_maps = [#in_map, #out_map],
       iterator_types = ["parallel", "parallel", "parallel"]
     } ins(%alloc : memref<4x1024x64xf16>)
-      outs(%out : memref<4x1024x64xf32>) {
+      outs(%out : memref<4x64x1024xf32>) {
     ^bb0(%in: f16, %out_init: f32):
       %cvt = arith.extf %in : f16 to f32
       linalg.yield %cvt : f32

--- a/mlir/test/fusion/fusability-attention-splitkv-output-truncf-rejection.mlir
+++ b/mlir/test/fusion/fusability-attention-splitkv-output-truncf-rejection.mlir
@@ -1,0 +1,42 @@
+// truncf on the attention output must NOT be fused with splitKV > 1:
+// narrowing does not commute with the LSE combine.
+// Regression guard for the extf carve-out (issue #2376).
+
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-gen -emit-module-fusibility-for=attn:v3:32,32,32,32,32,32,16,1,1,1,2,0,1 - | FileCheck %s
+// CHECK: fusible:0
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+module {
+  func.func @attn_splitkv_output_truncf_not_fusible(
+      %queries: memref<1x64x1024xf32>,
+      %keys: memref<1x64x1024xf32>,
+      %values: memref<1x1024x64xf32>,
+      %lse: memref<4x1024xf32>,
+      %out: memref<4x1024x64xf16>
+  ) attributes {rock.kernel, mhal.arch = "##TOKEN_ARCH##"} {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x1024x64xf32>
+    rock.attention {
+      qk = tr %queries * %keys : memref<1x64x1024xf32>, memref<1x64x1024xf32>
+      lse = %lse : memref<4x1024xf32>
+      %alloc = softmax(qk) * %values : memref<1x1024x64xf32> -> memref<4x1024x64xf32>
+    } {
+      firstGemmIndices = array<i64: 0>,
+      splitKV = 4 : i32,
+      storeMethod = #rock<StoreMethod set>,
+      numHeadsKV = 1 : i32,
+      numHeadsQ = 1 : i32
+    }
+
+    linalg.generic {
+      indexing_maps = [#map, #map],
+      iterator_types = ["parallel", "parallel", "parallel"]
+    } ins(%alloc : memref<4x1024x64xf32>)
+      outs(%out : memref<4x1024x64xf16>) {
+    ^bb0(%in: f32, %out_init: f16):
+      %cvt = arith.truncf %in : f32 to f16
+      linalg.yield %cvt : f16
+    }
+    return
+  }
+}

--- a/mlir/test/fusion/pr-e2e/attention/mixr-attention-flash-decoding-3d-output-extf.mlir
+++ b/mlir/test/fusion/pr-e2e/attention/mixr-attention-flash-decoding-3d-output-extf.mlir
@@ -1,0 +1,36 @@
+// E2E regression for https://github.com/ROCm/rocMLIR/issues/2376:
+// flash-decoding attention with an output extf (f16 -> f32) on splitKV > 1.
+
+// RUN: rocmlir-gen -fut mlir_attention --arch %arch --clone-harness %s | rocmlir-driver -kernel-pipeline=migraphx,highlevel -host-pipeline=migraphx,highlevel | rocmlir-gen -ph -rand 1 -rand_type float -fut mlir_attention_wrapper -relDiff_threshold 0.0005 -RMS_threshold 0.002 --verifier clone - | rocmlir-driver -host-pipeline mhal -kernel-pipeline full | xmir-runner --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext,%linalg_test_lib_dir/libmlir_c_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_async_runtime%shlibext --entry-point-result=void | FileCheck %s
+// CHECK: [1 1 1]
+// CHECK-NEXT: [1 1 1]
+
+module {
+  func.func @mlir_attention(%arg0: !migraphx.shaped<1x256x256xf16, 65536x256x1>, %arg1: !migraphx.shaped<1x256x256xf16, 65536x256x1>, %arg2: !migraphx.shaped<1x256x256xf16, 65536x256x1>) -> (!migraphx.shaped<1x2x256x256xf32, 131072x65536x256x1>, !migraphx.shaped<1x2x256x1xf32, 512x256x1x1>) attributes {rock.kernel = "mixr"} {
+    %0 = migraphx.reshape %arg0 {dims = [1, 1, 256, 256]} : <1x256x256xf16, 65536x256x1> -> <1x1x256x256xf16, 65536x65536x256x1>
+    %1 = migraphx.multibroadcast %0 {out_dyn_dims = [], out_lens = [1, 2, 256, 256]} : <1x1x256x256xf16, 65536x65536x256x1> -> <1x2x256x256xf16, 65536x0x256x1>
+    %2 = migraphx.reshape %arg1 {dims = [1, 2, 128, 256]} : <1x256x256xf16, 65536x256x1> -> <1x2x128x256xf16, 65536x32768x256x1>
+    %3 = migraphx.transpose %2 {permutation = [0, 1, 3, 2]} : <1x2x128x256xf16, 65536x32768x256x1> -> <1x2x256x128xf16, 65536x32768x1x256>
+    %4 = migraphx.reshape %arg2 {dims = [1, 256, 2, 128]} : <1x256x256xf16, 65536x256x1> -> <1x256x2x128xf16, 65536x256x128x1>
+    %5 = migraphx.transpose %4 {permutation = [0, 2, 3, 1]} : <1x256x2x128xf16, 65536x256x128x1> -> <1x2x128x256xf16, 65536x128x1x256>
+    %6 = migraphx.dot %1, %3 : <1x2x256x256xf16, 65536x0x256x1>, <1x2x256x128xf16, 65536x32768x1x256> -> <1x2x256x128xf16, 65536x32768x128x1>
+    %7 = migraphx.convert %6 {target_type = 2 : i64} : <1x2x256x128xf16, 65536x32768x128x1> to <1x2x256x128xf32, 65536x32768x128x1>
+    %8 = migraphx.reshape %7 {dims = [1, 2, 256, 128]} : <1x2x256x128xf32, 65536x32768x128x1> -> <1x2x256x128xf32, 65536x32768x128x1>
+    %9 = migraphx.reduce_max %8 {axes = [3]} : <1x2x256x128xf32, 65536x32768x128x1> -> <1x2x256x1xf32, 512x256x1x1>
+    %10 = migraphx.reshape %9 {dims = [1, 2, 256, 1]} : <1x2x256x1xf32, 512x256x1x1> -> <1x2x256x1xf32, 512x256x1x1>
+    %11 = migraphx.multibroadcast %10 {out_dyn_dims = [], out_lens = [1, 2, 256, 128]} : <1x2x256x1xf32, 512x256x1x1> -> <1x2x256x128xf32, 512x256x1x0>
+    %12 = migraphx.sub %7, %11 : <1x2x256x128xf32, 65536x32768x128x1>, <1x2x256x128xf32, 512x256x1x0> -> <1x2x256x128xf32, 65536x32768x128x1>
+    %13 = migraphx.exp %12 : <1x2x256x128xf32, 65536x32768x128x1> -> <1x2x256x128xf32, 65536x32768x128x1>
+    %14 = migraphx.reshape %13 {dims = [1, 2, 256, 128]} : <1x2x256x128xf32, 65536x32768x128x1> -> <1x2x256x128xf32, 65536x32768x128x1>
+    %15 = migraphx.reduce_sum %14 {axes = [3]} : <1x2x256x128xf32, 65536x32768x128x1> -> <1x2x256x1xf32, 512x256x1x1>
+    %16 = migraphx.reshape %15 {dims = [1, 2, 256, 1]} : <1x2x256x1xf32, 512x256x1x1> -> <1x2x256x1xf32, 512x256x1x1>
+    %17 = migraphx.multibroadcast %16 {out_dyn_dims = [], out_lens = [1, 2, 256, 128]} : <1x2x256x1xf32, 512x256x1x1> -> <1x2x256x128xf32, 512x256x1x0>
+    %18 = migraphx.div %13, %17 : <1x2x256x128xf32, 65536x32768x128x1>, <1x2x256x128xf32, 512x256x1x0> -> <1x2x256x128xf32, 65536x32768x128x1>
+    %19 = migraphx.convert %18 {target_type = 1 : i64} : <1x2x256x128xf32, 65536x32768x128x1> to <1x2x256x128xf16, 65536x32768x128x1>
+    %20 = migraphx.dot %19, %5 : <1x2x256x128xf16, 65536x32768x128x1>, <1x2x128x256xf16, 65536x128x1x256> -> <1x2x256x256xf16, 131072x65536x256x1>
+    %21 = migraphx.convert %20 {target_type = 2 : i64} : <1x2x256x256xf16, 131072x65536x256x1> to <1x2x256x256xf32, 131072x65536x256x1>
+    %22 = migraphx.log %16 : <1x2x256x1xf32, 512x256x1x1> -> <1x2x256x1xf32, 512x256x1x1>
+    %23 = migraphx.add %10, %22 : <1x2x256x1xf32, 512x256x1x1>, <1x2x256x1xf32, 512x256x1x1> -> <1x2x256x1xf32, 512x256x1x1>
+    return %21, %23 : !migraphx.shaped<1x2x256x256xf32, 131072x65536x256x1>, !migraphx.shaped<1x2x256x1xf32, 512x256x1x1>
+  }
+}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The splitKV legality check previously rejected any linalg.generic reading the attention output, including a pure element-wise extf. 

Related to https://github.com/ROCm/rocMLIR/issues/2376.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Carve out exactly this shape (single-input, single-output, parallel identity-map linalg.generic whose body is arith.extf + yield); every other output fusion remains rejected.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Confirm that the issue has been resolved on migraphx side
- Previous + new regression tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
