### PR TITLE
Move claude review to self-hosted runner 

### DIFF
--- a/.claude/skills/review-rocmlir-pr/SKILL.md
+++ b/.claude/skills/review-rocmlir-pr/SKILL.md
@@ -58,7 +58,7 @@ directly to see them at their PR-state line numbers.
 ```bash
 jq '{title, headRefOid, files: [.files[].path]}' /tmp/pr/meta.json
 head -200 /tmp/pr/diff.patch
-jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name]' /tmp/pr/checks.json
+jq '[.[] | select(.bucket == "fail" or .bucket == "cancel") | .name]' /tmp/pr/checks.json
 ```
 
 ### Special case: changes under `.claude/` or `.github/scripts/`
@@ -101,7 +101,7 @@ mkdir -p /tmp/pr
 gh pr view "$ARGUMENTS" --json title,body,author,baseRefName,headRefName,headRefOid,files \
   > /tmp/pr/meta.json
 gh pr diff "$ARGUMENTS" > /tmp/pr/diff.patch
-gh pr checks "$ARGUMENTS" --json name,conclusion,state 2>/dev/null > /tmp/pr/checks.json \
+gh pr checks "$ARGUMENTS" --json name,state,bucket 2>/dev/null > /tmp/pr/checks.json \
   || echo '[]' > /tmp/pr/checks.json
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/comments" | jq -s 'add // []' \

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -668,7 +668,18 @@ jobs:
           # errors (auth/network) belong in the workflow log, uncensored. Only
           # fall back to [] if gh wrote nothing parseable to stdout (e.g. no
           # checks defined yet on this PR).
-          gh pr checks "$PR_NUMBER" --json name,conclusion,state \
+          #
+          # Field choice: `bucket` is gh's own rollup of `state` into one of
+          # {pass, fail, pending, skipping, cancel} -- it replaces the older
+          # `conclusion` field that gh removed from `pr checks --json`. We keep
+          # `state` alongside it so consumers can still distinguish, for
+          # example, a queued run (state=QUEUED, bucket=pending) from an
+          # in-progress one (state=IN_PROGRESS, bucket=pending). The review
+          # skill (.claude/skills/review-rocmlir-pr/SKILL.md) filters this file
+          # via `select(.bucket == "fail" or .bucket == "cancel")`, so any
+          # rename here MUST be mirrored in the skill or Claude silently sees
+          # an empty failing-check list and stops flagging CI regressions.
+          gh pr checks "$PR_NUMBER" --json name,state,bucket \
               --repo "$GITHUB_REPOSITORY" > /tmp/pr/checks.json \
             || true
           if ! jq empty /tmp/pr/checks.json 2>/dev/null; then

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -319,7 +319,23 @@ jobs:
       || (github.event_name == 'pull_request'
           && github.event.label.name == 'claude-review'
           && github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
+    # Must be a self-hosted runner on AMD's internal network. The LLM
+    # Gateway endpoint behind ANTHROPIC_BASE_URL resolves only via AMD's
+    # internal DNS (its A record points into RFC1918 space, 10.0.0.0/8),
+    # so GitHub-hosted ubuntu-latest runners -- which sit on public Azure
+    # egress with public DNS only -- get NXDOMAIN on the hostname AND
+    # could not route to the IP even if they had it. The SDK surfaces
+    # this as `API Error: Unable to connect to API (FailedToOpenSocket)`
+    # from inside claude-code-action's bun process. ROCm/xla uses the
+    # same gateway from `runs-on: build-only-xla` for the same reason;
+    # `build-only-rocmlir` is the rocMLIR-scoped analog.
+    #
+    # Sibling jobs (`post`, `cleanup`) deliberately stay on ubuntu-latest:
+    # neither makes outbound calls to the gateway, so neither needs
+    # internal-network access, and keeping them on hosted runners avoids
+    # putting capacity pressure on the self-hosted pool for steps that
+    # only talk to api.github.com.
+    runs-on: build-only-rocmlir
     timeout-minutes: 30
     # Once `permissions:` is specified, all unlisted scopes default to none.
     # The default GITHUB_TOKEN here ONLY needs `contents: read` for

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -754,8 +754,8 @@ jobs:
           ANTHROPIC_CUSTOM_HEADERS: |
             Ocp-Apim-Subscription-Key: ${{ secrets.LLM_GATEWAY_KEY }}
             user: ${{ secrets.USER_NTID }}
-          ANTHROPIC_MODEL: "Claude-Opus-4.6"
-          ANTHROPIC_DEFAULT_OPUS_MODEL: "Claude-Opus-4.6"
+          ANTHROPIC_MODEL: "Claude-Opus-4.7"
+          ANTHROPIC_DEFAULT_OPUS_MODEL: "Claude-Opus-4.7"
           ANTHROPIC_DEFAULT_SONNET_MODEL: "Claude-Sonnet-4.6"
           ANTHROPIC_DEFAULT_HAIKU_MODEL: "Claude-Haiku-4.5"
           # Defense-in-depth: scrub Anthropic / cloud / GitHub Actions secret env vars


### PR DESCRIPTION
Three small fixes to get `claude_auto_review.yml` working again on `develop`.

1. **Move the `review` job to `build-only-rocmlir`** — the LLM Gateway behind `ANTHROPIC_BASE_URL` resolves only via AMD-internal DNS and points at an RFC1918 address, so `ubuntu-latest` failed at the DNS layer with `FailedToOpenSocket`. `post` and `cleanup` stay on `ubuntu-latest`. Mirrors what `ROCm/xla` does for the same gateway. Validated end-to-end on the new runner via a dry-run smoketest (since reverted): DNS → TCP → TLS → HTTP all succeed in ~500ms.

2. **Track `gh`'s rename of `conclusion` → `bucket`** in `gh pr checks --json`. The old field was silently returning empty, so the review skill's failing-checks filter was always seeing zero failures. Updated in both the workflow's pre-fetch step and the consumer skill.

3. **Bump Opus to `Claude-Opus-4.7`** (both `ANTHROPIC_MODEL` and `ANTHROPIC_DEFAULT_OPUS_MODEL`). Sonnet 4.6 and Haiku 4.5 unchanged. Assumes the gateway's APIM has `Claude-Opus-4.7` registered as an operation; if not, the SDK call will surface a clean 4xx in the workflow log.

Per-commit rationale is in each commit message. No security-model changes — Layers 1/2/3 unchanged and runner-agnostic.

Made with [Cursor](https://cursor.com)