### PR TITLE
ci(claude-review): make CI-status fetch and review budget resilient

### DIFF
--- a/.claude/skills/review-rocmlir-pr/SKILL.md
+++ b/.claude/skills/review-rocmlir-pr/SKILL.md
@@ -6,26 +6,6 @@ agent: general-purpose
 allowed-tools: Read, Grep, Glob
 ---
 
-<!--
-NOTE on `allowed-tools`:
-
-This skill is invoked from a GitHub Actions workflow (.github/workflows/claude_auto_review.yml)
-that passes `--allowedTools "Skill,Read,Grep,Glob"` to claude-code-action and configures
-`--json-schema '...'` so the model's final response is captured as the action's
-`structured_output` step output. Write is intentionally absent: there is no need to
-write to disk because the workflow does not read any file Claude produced; only the
-final structured response counts.
-
-For interactive Stage-B local dry-runs, invoke the standalone Claude Code CLI with the
-broader tool set, e.g.:
-
-    claude --allowedTools "Skill,Read,Grep,Glob,Bash(gh *),Bash(jq *)" \
-           --skill review-rocmlir-pr <PR-number>
-
-Then the skill can use `gh pr view/diff/checks` itself to populate /tmp/pr/.
--->
-
-
 # rocMLIR PR Review
 
 ## IMPORTANT: Do NOT post to GitHub
@@ -34,6 +14,48 @@ This skill is **read-only**. Do NOT post any comments, reviews, or reactions. Do
 `gh pr comment`, `gh pr review`, `gh api ... -X POST/PUT/PATCH/DELETE`. Posting is the
 job of the workflow's post step, which runs in a separate job that does not have access
 to the LLM Gateway secrets.
+
+---
+
+## Tool budget — READ THIS BEFORE STEP 1
+
+This skill runs in one of two modes; the available tools are different in each.
+Picking the wrong tool wastes turns on permission denials and can starve the
+review of budget before it reaches the final JSON output.
+
+**CI mode (default — this is your mode if you are reading this from
+`.github/workflows/claude_auto_review.yml`).** The workflow passes
+`--allowedTools "Skill,Read,Grep,Glob"` and `--json-schema '...'` to
+claude-code-action; the final JSON answer is captured as the action's
+`structured_output`. The pre-fetched context is already on disk under
+`/tmp/pr/` (the workflow has already done all the `gh`/`jq` work for you):
+
+| File | How to access |
+|---|---|
+| `/tmp/pr/meta.json` | `Read('/tmp/pr/meta.json')` -- a few KB, read it whole. |
+| `/tmp/pr/diff.patch` | `Read('/tmp/pr/diff.patch')` -- can be tens of KB; use `Read` offset/limit to page through it, or `Grep` it for a specific path. |
+| `/tmp/pr/checks.json` | `Read('/tmp/pr/checks.json')` then scan the array yourself for entries with `bucket == "fail"` or `bucket == "cancel"`. |
+| `/tmp/pr/prev_comments.json` | `Read('/tmp/pr/prev_comments.json')` then scan for entries authored by `rocmlir-pr-reviewer[bot]` with `in_reply_to_id == null` and the marker `<!-- claude-pr-review-marker:v1 -->` in the body. |
+| PR-head source files (any path in `meta.files`) | `Read('<path>')` directly from the working directory -- the PR head is checked out there. Use `Grep`/`Glob` to navigate. |
+
+In CI mode, **do not attempt** `Bash`, `jq <something>`, `head -200 file`,
+`gh api ...`, `cat`, `find`, `curl`, `wget`, `Write`, or any other shell-style
+or write-side tool. None of these are in the allowed list and every attempt
+returns a permission denial that counts against `--max-turns`. If you find
+yourself reasoning "I should run X to extract Y", stop and reformulate as
+"I should `Read` (or `Grep`, or `Glob`) Z". Examples in this file shown
+inside code fences are documentation for the *interactive* mode (see the
+appendix at the bottom); they are never to be executed in CI.
+
+**Interactive Stage-B mode (local dry-run only).** A maintainer runs the
+standalone Claude Code CLI with a broader tool set, e.g.
+
+    claude --allowedTools "Skill,Read,Grep,Glob,Bash(gh *),Bash(jq *)" \
+           --skill review-rocmlir-pr <PR-number>
+
+In this mode `/tmp/pr/` may not be populated; pre-fetch it yourself with
+the commands in the [appendix](#appendix-interactive-stage-b-only-do-not-execute-in-ci).
+Everything in the appendix is **off-limits in CI mode**.
 
 ---
 
@@ -55,11 +77,20 @@ the workspace is on (`headRefOid` in `meta.json`):
 The PR head is checked out in the working directory, so you can `Read` source files
 directly to see them at their PR-state line numbers.
 
-```bash
-jq '{title, headRefOid, files: [.files[].path]}' /tmp/pr/meta.json
-head -200 /tmp/pr/diff.patch
-jq '[.[] | select(.bucket == "fail" or .bucket == "cancel") | .name]' /tmp/pr/checks.json
-```
+In CI mode the four files in the table above are *already populated*; the only
+thing you need to do is `Read` them. Concretely:
+
+- Start by `Read('/tmp/pr/meta.json')`. Scan the JSON yourself for `title`,
+  `headRefOid`, and `files[].path` -- the file is a few KB and `Read` returns
+  the whole content. Do not try `jq` -- it is not in your tool set.
+- `Read('/tmp/pr/diff.patch')` to see the unified diff. If the file is large
+  use `Read` with an `offset`/`limit`, or use `Grep` to jump to a specific
+  path within the patch.
+- `Read('/tmp/pr/checks.json')` and scan the array for entries whose
+  `bucket` is `"fail"` or `"cancel"`. Mention any such entries in your
+  summary so the review reflects the PR's actual CI state.
+- `Read('/tmp/pr/prev_comments.json')` to discover previous Claude comments
+  for the re-review path; see the Output section for the filter rule.
 
 ### Special case: changes under `.claude/` or `.github/scripts/`
 
@@ -90,70 +121,14 @@ This special case only applies on the workflow_dispatch path; PRs that touch
 the perimeter under the label-trigger path are blocked by Layer 3 of the
 workflow and never reach this skill.
 
-If running outside the workflow (interactive Stage B / local dry-run), pre-fetch the
-same files yourself. The workflow uses local-`git` derivations for `diff.patch` and
-`meta.files` (force-push race defense); for an interactive run those races don't
-matter, so plain `gh pr diff` / `gh pr view --json …,files` is fine and produces a
-shape compatible with the table above:
-
-```bash
-mkdir -p /tmp/pr
-gh pr view "$ARGUMENTS" --json title,body,author,baseRefName,headRefName,headRefOid,files \
-  > /tmp/pr/meta.json
-gh pr diff "$ARGUMENTS" > /tmp/pr/diff.patch
-# Mirror the workflow's REST-API path so local dry-runs surface the same
-# {name, state, bucket} shape and survive on any gh version. `gh pr checks
-# --json` was only added in gh v2.36 and has rotated its field set since
-# (the `conclusion` field went away in favour of `bucket`); the workflow's
-# self-hosted runner pool serves heterogeneous images, and at least one
-# pod ships a gh without `--json` at all, where `gh pr checks --json ... ||
-# echo '[]'` silently lost all CI signal. The two endpoints below are
-# disjoint -- /check-runs is the modern Checks API (GitHub Actions etc.),
-# /status is the legacy Commit Statuses API (some Jenkins integrations);
-# either one alone misses the other half of red CI.
-# Both endpoints are paginated -- /check-runs paginates .check_runs at
-# 30/page by default, /status paginates .statuses the same way. A PR
-# with >30 entries on either side would otherwise silently drop the
-# overflow. `state` mirrors gh's old `pr checks --json state` semantics
-# (conclusion-when-completed, status-while-pending; legacy .state for
-# /status), so the field still distinguishes SUCCESS vs FAILURE vs
-# TIMED_OUT etc. rather than always reading COMPLETED.
-SHA=$(jq -r .headRefOid /tmp/pr/meta.json)
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-gh api --paginate "repos/$REPO/commits/$SHA/check-runs" \
-  | jq -s '[.[] | .check_runs[]?] | map({
-        name: .name,
-        state: (
-          (if (.status != "completed") then .status
-           else (.conclusion // "unknown")
-           end) | ascii_upcase
-        ),
-        bucket: (
-          if (.status != "completed") then "pending"
-          elif (.conclusion == "success" or .conclusion == "neutral") then "pass"
-          elif (.conclusion == "skipped") then "skipping"
-          elif (.conclusion == "cancelled") then "cancel"
-          else "fail"
-          end)
-      })' > /tmp/pr/check_runs.json
-gh api --paginate "repos/$REPO/commits/$SHA/status" \
-  | jq -s '[.[] | .statuses[]?] | map({
-        name: .context,
-        state: ((.state // "unknown") | ascii_upcase),
-        bucket: (
-          if (.state == "pending") then "pending"
-          elif (.state == "success") then "pass"
-          else "fail"
-          end)
-      })' > /tmp/pr/statuses.json
-jq -s 'add' /tmp/pr/check_runs.json /tmp/pr/statuses.json > /tmp/pr/checks.json
-rm /tmp/pr/check_runs.json /tmp/pr/statuses.json
-gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/comments" | jq -s 'add // []' \
-  > /tmp/pr/prev_comments.json
-```
-
 Identify the changed `.cpp`, `.h`, `.td`, `.mlir`, `.py`, `CMakeLists.txt`, and `.cmake`
-files from `meta.json`. Read the ones with non-trivial diffs in full.
+files from `meta.json`. `Read` the ones with non-trivial diffs in full.
+
+> Interactive Stage-B (local dry-run only): if `/tmp/pr/` is not already populated
+> for you, the pre-fetch commands are in the [appendix at the bottom of this
+> file](#appendix-interactive-stage-b-only-do-not-execute-in-ci). **Do not run
+> them in CI** -- in CI the files are already there and your tool set does not
+> include `Bash`.
 
 ---
 
@@ -440,3 +415,76 @@ same thread.
   resulting host that fails the allow-list is rejected. Keep this list in sync
   with the prompt's Hard constraints block in
   `.github/workflows/claude_auto_review.yml`.
+
+---
+
+## Appendix: Interactive Stage B only (DO NOT execute in CI)
+
+> **Stop and reread the "Tool budget" section at the top of this file if
+> you are about to use anything below from inside the
+> `claude_auto_review.yml` workflow.** In CI mode the allowed tool set is
+> `Skill,Read,Grep,Glob` -- `Bash`, `jq`, `gh`, `head`, `cat`, `Write`
+> are all denied and every attempt counts against `--max-turns`. The
+> commands below are for a maintainer running the Claude Code CLI
+> locally to populate `/tmp/pr/` before invoking this skill.
+
+The workflow uses local-`git` derivations for `diff.patch` and `meta.files`
+(force-push race defense); for an interactive run those races don't matter,
+so plain `gh pr diff` / `gh pr view --json …,files` is fine and produces a
+shape compatible with the table at the top of this file:
+
+```bash
+mkdir -p /tmp/pr
+gh pr view "$ARGUMENTS" --json title,body,author,baseRefName,headRefName,headRefOid,files \
+  > /tmp/pr/meta.json
+gh pr diff "$ARGUMENTS" > /tmp/pr/diff.patch
+# Mirror the workflow's REST-API path so local dry-runs surface the same
+# {name, state, bucket} shape and survive on any gh version. `gh pr checks
+# --json` was only added in gh v2.36 and has rotated its field set since
+# (the `conclusion` field went away in favour of `bucket`); the workflow's
+# self-hosted runner pool serves heterogeneous images, and at least one
+# pod ships a gh without `--json` at all, where `gh pr checks --json ... ||
+# echo '[]'` silently lost all CI signal. The two endpoints below are
+# disjoint -- /check-runs is the modern Checks API (GitHub Actions etc.),
+# /status is the legacy Commit Statuses API (some Jenkins integrations);
+# either one alone misses the other half of red CI.
+# Both endpoints are paginated -- /check-runs paginates .check_runs at
+# 30/page by default, /status paginates .statuses the same way. A PR
+# with >30 entries on either side would otherwise silently drop the
+# overflow. `state` mirrors gh's old `pr checks --json state` semantics
+# (conclusion-when-completed, status-while-pending; legacy .state for
+# /status), so the field still distinguishes SUCCESS vs FAILURE vs
+# TIMED_OUT etc. rather than always reading COMPLETED.
+SHA=$(jq -r .headRefOid /tmp/pr/meta.json)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh api --paginate "repos/$REPO/commits/$SHA/check-runs" \
+  | jq -s '[.[] | .check_runs[]?] | map({
+        name: .name,
+        state: (
+          (if (.status != "completed") then .status
+           else (.conclusion // "unknown")
+           end) | ascii_upcase
+        ),
+        bucket: (
+          if (.status != "completed") then "pending"
+          elif (.conclusion == "success" or .conclusion == "neutral") then "pass"
+          elif (.conclusion == "skipped") then "skipping"
+          elif (.conclusion == "cancelled") then "cancel"
+          else "fail"
+          end)
+      })' > /tmp/pr/check_runs.json
+gh api --paginate "repos/$REPO/commits/$SHA/status" \
+  | jq -s '[.[] | .statuses[]?] | map({
+        name: .context,
+        state: ((.state // "unknown") | ascii_upcase),
+        bucket: (
+          if (.state == "pending") then "pending"
+          elif (.state == "success") then "pass"
+          else "fail"
+          end)
+      })' > /tmp/pr/statuses.json
+jq -s 'add' /tmp/pr/check_runs.json /tmp/pr/statuses.json > /tmp/pr/checks.json
+rm /tmp/pr/check_runs.json /tmp/pr/statuses.json
+gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/comments" | jq -s 'add // []' \
+  > /tmp/pr/prev_comments.json
+```

--- a/.claude/skills/review-rocmlir-pr/SKILL.md
+++ b/.claude/skills/review-rocmlir-pr/SKILL.md
@@ -49,7 +49,7 @@ the workspace is on (`headRefOid` in `meta.json`):
 |------|----------|
 | `/tmp/pr/meta.json` | `gh pr view --json title,body,author,baseRefName,headRefName` plus two locally-injected fields: `headRefOid` (set from `git rev-parse HEAD` of the pinned checkout) and `files` (an array of `{path}` objects derived from `git diff --name-only --no-renames "origin/${baseRefName}...HEAD"` against the same pinned ref range that produced `diff.patch`). |
 | `/tmp/pr/diff.patch` | `git diff "origin/${baseRefName}...HEAD"` -- the unified diff between the merge-base with the base branch and the pinned PR HEAD. Equivalent to GitHub's "Files changed" view on this SHA, but generated locally so it can never disagree with the workspace or with `meta.files` if a force-push lands mid-run. |
-| `/tmp/pr/checks.json` | `gh pr checks --json` (CI status) |
+| `/tmp/pr/checks.json` | CI status: an array of `{name, state, bucket}` shaped from `repos/.../commits/{sha}/check-runs` (modern Checks API) + `repos/.../commits/{sha}/status` (legacy Commit Statuses API) so neither category of red CI is silently missed. `bucket` is one of `pass`, `fail`, `pending`, `skipping`, `cancel`. |
 | `/tmp/pr/prev_comments.json` | All inline review comments via `gh api .../pulls/N/comments` |
 
 The PR head is checked out in the working directory, so you can `Read` source files
@@ -101,9 +101,42 @@ mkdir -p /tmp/pr
 gh pr view "$ARGUMENTS" --json title,body,author,baseRefName,headRefName,headRefOid,files \
   > /tmp/pr/meta.json
 gh pr diff "$ARGUMENTS" > /tmp/pr/diff.patch
-gh pr checks "$ARGUMENTS" --json name,state,bucket 2>/dev/null > /tmp/pr/checks.json \
-  || echo '[]' > /tmp/pr/checks.json
+# Mirror the workflow's REST-API path so local dry-runs surface the same
+# {name, state, bucket} shape and survive on any gh version. `gh pr checks
+# --json` was only added in gh v2.36 and has rotated its field set since
+# (the `conclusion` field went away in favour of `bucket`); the workflow's
+# self-hosted runner pool serves heterogeneous images, and at least one
+# pod ships a gh without `--json` at all, where `gh pr checks --json ... ||
+# echo '[]'` silently lost all CI signal. The two endpoints below are
+# disjoint -- /check-runs is the modern Checks API (GitHub Actions etc.),
+# /status is the legacy Commit Statuses API (some Jenkins integrations);
+# either one alone misses the other half of red CI.
+SHA=$(jq -r .headRefOid /tmp/pr/meta.json)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh api --paginate "repos/$REPO/commits/$SHA/check-runs" \
+  | jq -s '[.[] | .check_runs[]?] | map({
+        name: .name,
+        state: ((.status // "unknown") | ascii_upcase),
+        bucket: (
+          if (.status != "completed") then "pending"
+          elif (.conclusion == "success" or .conclusion == "neutral") then "pass"
+          elif (.conclusion == "skipped") then "skipping"
+          elif (.conclusion == "cancelled") then "cancel"
+          else "fail"
+          end)
+      })' > /tmp/pr/check_runs.json
+gh api "repos/$REPO/commits/$SHA/status" \
+  | jq '[.statuses[]? | {
+        name: .context,
+        state: ((.state // "unknown") | ascii_upcase),
+        bucket: (
+          if (.state == "pending") then "pending"
+          elif (.state == "success") then "pass"
+          else "fail"
+          end)
+      }]' > /tmp/pr/statuses.json
+jq -s 'add' /tmp/pr/check_runs.json /tmp/pr/statuses.json > /tmp/pr/checks.json
+rm /tmp/pr/check_runs.json /tmp/pr/statuses.json
 gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/comments" | jq -s 'add // []' \
   > /tmp/pr/prev_comments.json
 ```

--- a/.claude/skills/review-rocmlir-pr/SKILL.md
+++ b/.claude/skills/review-rocmlir-pr/SKILL.md
@@ -111,12 +111,23 @@ gh pr diff "$ARGUMENTS" > /tmp/pr/diff.patch
 # disjoint -- /check-runs is the modern Checks API (GitHub Actions etc.),
 # /status is the legacy Commit Statuses API (some Jenkins integrations);
 # either one alone misses the other half of red CI.
+# Both endpoints are paginated -- /check-runs paginates .check_runs at
+# 30/page by default, /status paginates .statuses the same way. A PR
+# with >30 entries on either side would otherwise silently drop the
+# overflow. `state` mirrors gh's old `pr checks --json state` semantics
+# (conclusion-when-completed, status-while-pending; legacy .state for
+# /status), so the field still distinguishes SUCCESS vs FAILURE vs
+# TIMED_OUT etc. rather than always reading COMPLETED.
 SHA=$(jq -r .headRefOid /tmp/pr/meta.json)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 gh api --paginate "repos/$REPO/commits/$SHA/check-runs" \
   | jq -s '[.[] | .check_runs[]?] | map({
         name: .name,
-        state: ((.status // "unknown") | ascii_upcase),
+        state: (
+          (if (.status != "completed") then .status
+           else (.conclusion // "unknown")
+           end) | ascii_upcase
+        ),
         bucket: (
           if (.status != "completed") then "pending"
           elif (.conclusion == "success" or .conclusion == "neutral") then "pass"
@@ -125,8 +136,8 @@ gh api --paginate "repos/$REPO/commits/$SHA/check-runs" \
           else "fail"
           end)
       })' > /tmp/pr/check_runs.json
-gh api "repos/$REPO/commits/$SHA/status" \
-  | jq '[.statuses[]? | {
+gh api --paginate "repos/$REPO/commits/$SHA/status" \
+  | jq -s '[.[] | .statuses[]?] | map({
         name: .context,
         state: ((.state // "unknown") | ascii_upcase),
         bucket: (
@@ -134,7 +145,7 @@ gh api "repos/$REPO/commits/$SHA/status" \
           elif (.state == "success") then "pass"
           else "fail"
           end)
-      }]' > /tmp/pr/statuses.json
+      })' > /tmp/pr/statuses.json
 jq -s 'add' /tmp/pr/check_runs.json /tmp/pr/statuses.json > /tmp/pr/checks.json
 rm /tmp/pr/check_runs.json /tmp/pr/statuses.json
 gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/comments" | jq -s 'add // []' \

--- a/.claude/skills/review-rocmlir-pr/SKILL.md
+++ b/.claude/skills/review-rocmlir-pr/SKILL.md
@@ -69,10 +69,10 @@ the workspace is on (`headRefOid` in `meta.json`):
 
 | File | Contents |
 |------|----------|
-| `/tmp/pr/meta.json` | `gh pr view --json title,body,author,baseRefName,headRefName` plus two locally-injected fields: `headRefOid` (set from `git rev-parse HEAD` of the pinned checkout) and `files` (an array of `{path}` objects derived from `git diff --name-only --no-renames "origin/${baseRefName}...HEAD"` against the same pinned ref range that produced `diff.patch`). |
-| `/tmp/pr/diff.patch` | `git diff "origin/${baseRefName}...HEAD"` -- the unified diff between the merge-base with the base branch and the pinned PR HEAD. Equivalent to GitHub's "Files changed" view on this SHA, but generated locally so it can never disagree with the workspace or with `meta.files` if a force-push lands mid-run. |
-| `/tmp/pr/checks.json` | CI status: an array of `{name, state, bucket}` shaped from `repos/.../commits/{sha}/check-runs` (modern Checks API) + `repos/.../commits/{sha}/status` (legacy Commit Statuses API) so neither category of red CI is silently missed. `bucket` is one of `pass`, `fail`, `pending`, `skipping`, `cancel`. |
-| `/tmp/pr/prev_comments.json` | All inline review comments via `gh api .../pulls/N/comments` |
+| `/tmp/pr/meta.json` | PR metadata: `title`, `body`, `author`, `baseRefName`, `headRefName`, plus two locally-injected fields. `headRefOid` is the SHA of the pinned checkout in the workspace (force-push defense), and `files` is an array of `{path}` objects describing the same set of changed paths that `diff.patch` covers. |
+| `/tmp/pr/diff.patch` | Unified diff between the merge-base with `baseRefName` and the pinned PR HEAD. Equivalent to GitHub's "Files changed" view for this SHA, but generated locally so it can never disagree with the workspace or with `meta.files` if a force-push lands mid-run. |
+| `/tmp/pr/checks.json` | CI status: an array of `{name, state, bucket}` covering both the modern Checks API (e.g. GitHub Actions) and the legacy Commit Statuses API (e.g. some Jenkins integrations), so neither category of red CI is silently missed. `bucket` is one of `pass`, `fail`, `pending`, `skipping`, `cancel`. |
+| `/tmp/pr/prev_comments.json` | All existing inline review comments on this PR, in the order the GitHub API returns them. |
 
 The PR head is checked out in the working directory, so you can `Read` source files
 directly to see them at their PR-state line numbers.

--- a/.claude/skills/update-pr-review/SKILL.md
+++ b/.claude/skills/update-pr-review/SKILL.md
@@ -6,24 +6,6 @@ agent: general-purpose
 allowed-tools: Read, Grep, Glob
 ---
 
-<!--
-NOTE on `allowed-tools`:
-
-In workflow context, the .github/workflows/claude_auto_review.yml step constrains the
-session to `--allowedTools "Skill,Read,Grep,Glob"` and uses `--json-schema` to capture
-the model's final response as `structured_output`. This skill never posts to GitHub
-directly; it emits structured action records as the model's final response, which the
-workflow materializes to /tmp/pr/actions.json and the post job (a separate job, no LLM
-Gateway secrets in env) consumes via raw gh api.
-
-For interactive Stage-B local dry-runs, invoke the standalone Claude Code CLI with the
-broader tool set, e.g.:
-
-    claude --allowedTools "Skill,Read,Grep,Glob,Bash(gh *),Bash(jq *)" \
-           --skill update-pr-review <PR-number>
--->
-
-
 # Update PR Review
 
 You are the second phase of a two-phase PR review pipeline. The first phase
@@ -37,20 +19,48 @@ comment in the PR's lifetime.
 
 ---
 
+## Tool budget -- READ THIS BEFORE STEP 1
+
+This skill runs in the same two modes as `review-rocmlir-pr`; the available
+tools differ in each.
+
+**CI mode (default).** The workflow passes `--allowedTools
+"Skill,Read,Grep,Glob"` and `--json-schema '...'`; your final JSON answer is
+captured as the action's `structured_output`. All the inputs you need are
+already on disk:
+
+- `Read('/tmp/pr/prev_comments.json')` to load existing inline review
+  comments (the file has been populated by the workflow's pre-fetch step,
+  with `gh api --paginate ... | jq` already done for you). Then scan the
+  JSON yourself for entries whose `user.login` is `rocmlir-pr-reviewer[bot]`
+  and whose body contains the marker `<!-- claude-pr-review-marker:v1 -->`.
+
+In CI mode, **do not attempt** `Bash`, `jq`, `gh api`, `Write`, or any
+other shell-style / write-side tool -- none of these are in the allowed
+list and every attempt returns a permission denial that counts against
+`--max-turns`. If you find yourself reasoning "I should run X to extract Y",
+stop and reformulate as "I should `Read` (or `Grep`, or `Glob`) Z".
+
+**Interactive Stage-B mode (local dry-run only).** A maintainer runs the
+standalone Claude Code CLI with a broader tool set, e.g.
+
+    claude --allowedTools "Skill,Read,Grep,Glob,Bash(gh *),Bash(jq *)" \
+           --skill update-pr-review <PR-number>
+
+In that mode `/tmp/pr/prev_comments.json` may not exist; the pre-fetch
+command is in the [appendix at the bottom of this file](#appendix-interactive-stage-b-only-do-not-execute-in-ci).
+The appendix is **off-limits in CI mode**.
+
+---
+
 ## Step 1 -- Inputs
 
 - `$ARGUMENTS` is the PR number.
 - The fresh review findings are in the conversation context above (output from the prior
   skill). Each finding has `path`, `line`, `side`, `severity`, and `body`.
-- Previous Claude inline comments are pre-loaded at `/tmp/pr/prev_comments.json`. If that
-  file is missing (interactive use outside the workflow), fetch it:
-
-  ```bash
-  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-  mkdir -p /tmp/pr
-  gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/comments" \
-    | jq -s 'add // []' > /tmp/pr/prev_comments.json
-  ```
+- Previous Claude inline comments are pre-loaded at `/tmp/pr/prev_comments.json` in CI
+  mode. Use `Read('/tmp/pr/prev_comments.json')`. If the file is missing (interactive
+  Stage-B only), pre-fetch it using the command in the appendix.
 
 From the JSON, build:
 
@@ -310,3 +320,22 @@ Rules:
 - Do NOT echo any environment variable, secret, header, or URL into any field. The
   post-job sanitizer rejects strings matching common secret patterns and fails the
   workflow.
+
+---
+
+## Appendix: Interactive Stage B only (DO NOT execute in CI)
+
+> **Stop and reread the "Tool budget" section at the top of this file if
+> you are about to use anything below from inside the
+> `claude_auto_review.yml` workflow.** In CI mode the allowed tool set is
+> `Skill,Read,Grep,Glob` -- `Bash`, `jq`, `gh` are all denied and every
+> attempt counts against `--max-turns`. The command below is for a
+> maintainer running the Claude Code CLI locally to populate
+> `/tmp/pr/prev_comments.json` before invoking this skill.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+mkdir -p /tmp/pr
+gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/comments" \
+  | jq -s 'add // []' > /tmp/pr/prev_comments.json
+```

--- a/.claude/skills/update-pr-review/SKILL.md
+++ b/.claude/skills/update-pr-review/SKILL.md
@@ -30,10 +30,11 @@ captured as the action's `structured_output`. All the inputs you need are
 already on disk:
 
 - `Read('/tmp/pr/prev_comments.json')` to load existing inline review
-  comments (the file has been populated by the workflow's pre-fetch step,
-  with `gh api --paginate ... | jq` already done for you). Then scan the
-  JSON yourself for entries whose `user.login` is `rocmlir-pr-reviewer[bot]`
-  and whose body contains the marker `<!-- claude-pr-review-marker:v1 -->`.
+  comments (the file has already been populated by the workflow's
+  pre-fetch step -- all the API and JSON-shaping work is done for you).
+  Then scan the JSON yourself for entries whose `user.login` is
+  `rocmlir-pr-reviewer[bot]` and whose body contains the marker
+  `<!-- claude-pr-review-marker:v1 -->`.
 
 In CI mode, **do not attempt** `Bash`, `jq`, `gh api`, `Write`, or any
 other shell-style / write-side tool -- none of these are in the allowed

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -1244,9 +1244,15 @@ jobs:
           # (this job has no GitHub write surface), and sanitize_claude_actions.sh
           # on the structured JSON output. Doubling the turn budget doesn't
           # weaken any of these -- the worst a loop-injected attacker gets is
-          # more cost burn, which the per-PR cap on this workflow's `timeout-
-          # minutes: 30` and the LLM Gateway's per-call quota already bound.
-          # Bump further only with a corresponding bump to timeout-minutes.
+          # more cost burn, which two nested wall-clock caps already bound:
+          # this step's own `timeout-minutes: 20` (the immediate cap on the
+          # model's runtime, see the `claude-code` step above) and the
+          # review job's `timeout-minutes: 30` (the outer cap that also
+          # bounds the pre-fetch + overlay + sanitizer steps in this job),
+          # plus the LLM Gateway's per-call quota. Bump --max-turns further
+          # only with a corresponding bump to the STEP's timeout-minutes (the
+          # tighter of the two -- the job-level cap is currently slack
+          # relative to the step cap and would not be the binding limit).
           #
           # --json-schema makes claude-code-action validate the model's final response
           # against the inline schema and expose it as

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -728,28 +728,49 @@ jobs:
           #     state == "success"                               -> pass
           #     otherwise (failure, error)                       -> fail
           #
-          # No `|| true` anywhere. With `set -euo pipefail` at the
-          # top of this step, any HTTP failure / auth failure / jq
-          # failure aborts the workflow visibly -- which is the
-          # correct behaviour for "we cannot determine CI state".
-          # Silently substituting `[]` here is the exact fail-open
-          # this block exists to prevent.
+          # `state` (the per-row field, distinct from `bucket`) preserves
+          # gh's old `pr checks --json state` semantics: for /check-runs
+          # it is `conclusion` (uppercased) once the run is completed and
+          # `status` (uppercased) while it is queued / in_progress, so a
+          # consumer can still distinguish QUEUED vs IN_PROGRESS for
+          # bucket=pending and SUCCESS vs FAILURE vs TIMED_OUT vs ... for
+          # the completed buckets; for /status it is the legacy `state`
+          # (uppercased: PENDING / SUCCESS / FAILURE / ERROR). The review
+          # skill only reads `bucket`, but matching gh's old contract on
+          # `state` keeps future consumers from misclassifying a finished
+          # run because `state` would otherwise always say COMPLETED.
+          #
+          # Both endpoints are queried with `--paginate`. /check-runs
+          # paginates its `.check_runs` array at 30/page by default;
+          # /status paginates its `.statuses` array the same way. A repo
+          # with >30 entries on either side would otherwise silently drop
+          # the overflow -- the exact "miss half of red CI" failure mode
+          # this block exists to prevent, just on the other endpoint.
+          # gh emits one wrapper object per page (not a merged object),
+          # so the jq below uses `-s` to slurp and `[.[] | .X[]?]` to
+          # flatten, which is also correct for the single-page case
+          # (one wrapper slurped into a 1-element array).
+          #
+          # No `|| true` anywhere. With `set -euo pipefail` at the top of
+          # this step, any HTTP failure / auth failure / jq failure
+          # aborts the workflow visibly -- which is the correct
+          # behaviour for "we cannot determine CI state". Silently
+          # substituting `[]` here is the exact fail-open this block
+          # exists to prevent.
           commit_sha=$(jq -r .headRefOid /tmp/pr/meta.json)
           gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/check-runs" \
               > /tmp/pr/check_runs.raw.json
-          gh api \
+          gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/status" \
               > /tmp/pr/statuses.raw.json
-          # `gh api --paginate` on /check-runs emits one wrapper object
-          # ({total_count, check_runs: [...]}) per page concatenated --
-          # NOT a single merged object -- so `jq -s` slurps them into an
-          # array and `[.[] | .check_runs[]?]` flattens. The same shape
-          # works for the single-page case (one wrapper object slurped
-          # into a 1-element array).
           jq -s '[.[] | .check_runs[]?] | map({
                   name: .name,
-                  state: ((.status // "unknown") | ascii_upcase),
+                  state: (
+                    (if (.status != "completed") then .status
+                     else (.conclusion // "unknown")
+                     end) | ascii_upcase
+                  ),
                   bucket: (
                     if (.status != "completed") then "pending"
                     elif (.conclusion == "success" or .conclusion == "neutral") then "pass"
@@ -759,7 +780,7 @@ jobs:
                     end)
                 })' \
               /tmp/pr/check_runs.raw.json > /tmp/pr/check_runs.json
-          jq '[.statuses[]? | {
+          jq -s '[.[] | .statuses[]?] | map({
                   name: .context,
                   state: ((.state // "unknown") | ascii_upcase),
                   bucket: (
@@ -767,7 +788,7 @@ jobs:
                     elif (.state == "success") then "pass"
                     else "fail"
                     end)
-                }]' \
+                })' \
               /tmp/pr/statuses.raw.json > /tmp/pr/statuses.json
           jq -s 'add' /tmp/pr/check_runs.json /tmp/pr/statuses.json \
               > /tmp/pr/checks.json

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -219,6 +219,25 @@ on:
         description: 'PR number to review'
         required: true
         type: number
+      # Diagnostic toggle: when true, the review job sets
+      # claude-code-action's `show_full_output: true` so every Claude tool
+      # call (Skill/Read/Grep/Glob) and any permission denial is logged
+      # uncensored. Off by default; only meaningful on the dispatch path.
+      # Use this when a review hits `error_max_turns` or otherwise fails
+      # opaquely (the SDK then logs only a one-line summary) -- the
+      # denial list and per-turn tool args are the only way to tell
+      # whether the budget went to genuine work or to the model retrying
+      # a disallowed tool. Safe to enable on this pipeline because the
+      # LLM-Gateway secrets are scrubbed from the spawned claude
+      # subprocess (CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 on the action
+      # env), so the model has no path to print them even with full
+      # output on; the only data flowing into logs is workspace file
+      # contents this public repo already exposes.
+      debug:
+        description: 'Show full claude-code-action output (diagnostics; off by default)'
+        required: false
+        type: boolean
+        default: false
 
 # Make the resolved PR number available to every job's expressions without repeating
 # the conditional. For the labeled event the number lives on the PR object; for
@@ -951,10 +970,27 @@ jobs:
           #     allowed_non_write_users is set; we set it explicitly above
           #     anyway, so the default is just belt-and-braces.
           allowed_non_write_users: '__never_match__'
-          # show_full_output prints every tool call (including raw Read contents) to the
-          # Action log. Anthropic explicitly warns this can leak secrets in public-repo
-          # logs; keep it off in production. Re-enable temporarily for local debugging.
-          show_full_output: false
+          # show_full_output prints every tool call (Skill/Read/Grep/Glob args,
+          # raw Read contents, and every permission-denied tool name) to the
+          # Action log. Anthropic warns generically that this can leak secrets
+          # in public-repo logs, but on THIS pipeline that concern is already
+          # neutralized: CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 (set on the action
+          # env above) strips the LLM-Gateway env vars from the spawned claude
+          # subprocess, so the model cannot read or print them no matter what.
+          # The remaining log content is workspace file bytes -- and this repo
+          # is public, so those bytes are not sensitive.
+          #
+          # Off by default to keep label-triggered runs quiet, but flipped on
+          # when a maintainer launches `workflow_dispatch` with `debug: true`.
+          # That is the only way to diagnose `error_max_turns` (which prints
+          # just a one-line "permission_denials_count: N" summary with full
+          # output off) and other opaque SDK failures, because failed runs do
+          # not upload claude-execution-output.json as an artifact.
+          #
+          # The expression evaluates to the literal string "true" only on the
+          # dispatch path with debug=true; on the labeled-PR path `inputs` is
+          # null and the comparison yields "false" -- production stays quiet.
+          show_full_output: ${{ inputs.debug == true }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ env.PR_NUMBER }}
@@ -1157,8 +1193,31 @@ jobs:
           # --max-turns caps agentic tool-call cycles. The April 2026 CVSS 9.4
           # "Comment and Control" CVE used loop injection ("repeat this N times") to
           # both run up cost and lengthen the window for prompt-injection drift past
-          # the ~15-call mark where prompt-level constraints start degrading. 15 is
-          # generous for a single-PR review; bump if the skill genuinely needs more.
+          # the ~15-call mark where prompt-level constraints start degrading.
+          #
+          # We previously set this to 15 -- which was tight even for an average
+          # rocMLIR PR and demonstrably too tight for medium-large ones. PR #2378
+          # is the worked example: 68 KB diff, 55 KB of prior reviewer comments
+          # (re-review mode walks every Claude root comment to assign
+          # Scenario A/B/C/D), 16 turns burned, 7 permission denials, and the
+          # final SDK result was `error_max_turns` -- no review posted, $4.32
+          # spent for nothing. 30 gives the skill enough headroom to read the
+          # PR-side sources, run /review-rocmlir-pr, and (in re-review mode) run
+          # /update-pr-review without falling off the cliff on bigger PRs.
+          #
+          # Why 30 is still safe vs. the "Comment and Control" loop-injection
+          # threat: the drift concern in the literature is about ATTACK
+          # progress through prompt-level constraints, not about budget per se.
+          # Our defenses against loop injection are structural, not numeric:
+          # --allowedTools "Skill,Read,Grep,Glob" (no Bash, no Write, no
+          # network, no GitHub write tools), CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1
+          # (secrets stripped from the model's subprocess), the two-job split
+          # (this job has no GitHub write surface), and sanitize_claude_actions.sh
+          # on the structured JSON output. Doubling the turn budget doesn't
+          # weaken any of these -- the worst a loop-injected attacker gets is
+          # more cost burn, which the per-PR cap on this workflow's `timeout-
+          # minutes: 30` and the LLM Gateway's per-call quota already bound.
+          # Bump further only with a corresponding bump to timeout-minutes.
           #
           # --json-schema makes claude-code-action validate the model's final response
           # against the inline schema and expose it as
@@ -1170,7 +1229,7 @@ jobs:
           # array-length-vs-element-size limits we want.
           claude_args: |
             --allowedTools "Skill,Read,Grep,Glob"
-            --max-turns 15
+            --max-turns 30
             --json-schema '{"type":"object","required":["summary","inline_comments","thread_updates"],"properties":{"summary":{"type":"string"},"inline_comments":{"type":"array","items":{"type":"object","required":["path","line","side","severity","body"],"properties":{"path":{"type":"string","minLength":1},"line":{"type":"integer","minimum":1},"side":{"type":"string","enum":["RIGHT"]},"severity":{"type":"string","enum":["Critical","Major","Minor"]},"body":{"type":"string","minLength":1},"suggestion":{"type":"string","minLength":1,"pattern":"^[^\\r\\n]*$"}}}},"thread_updates":{"type":"array","items":{"type":"object","required":["type","claude_comment_id"],"properties":{"type":{"type":"string","enum":["resolve","resolve_with_reaction","clarify"]},"claude_comment_id":{"type":"integer"},"human_reply_id":{"type":"integer"},"body":{"type":"string"}}}}}}'
           settings: |
             {

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -1020,6 +1020,35 @@ jobs:
               - /tmp/pr/checks.json        (CI status)
               - /tmp/pr/prev_comments.json (existing inline review comments)
 
+            ## Tool budget -- read this before Step 1
+
+            Your tool set in this run is exactly Skill, Read, Grep, Glob -- nothing
+            else. Bash, Write, jq, gh, head, cat, curl, wget, the GitHub MCP tools,
+            and every other write-side or shell-style tool are DENIED. Each denied
+            attempt counts against --max-turns and brings you closer to falling out
+            with no review posted.
+
+            The pre-fetch step has already done all the gh/jq work for you. To read
+            the files above, use the Read tool directly:
+              - Read('/tmp/pr/meta.json')          -- small JSON, read whole.
+              - Read('/tmp/pr/diff.patch')         -- can be tens of KB; use Read
+                                                      offset/limit or Grep for a
+                                                      specific path.
+              - Read('/tmp/pr/checks.json')        -- scan the array yourself for
+                                                      entries with bucket == "fail"
+                                                      or "cancel".
+              - Read('/tmp/pr/prev_comments.json') -- scan for the marker check
+                                                      described in Step 1.
+              - Read('<workspace-relative path>')  -- the PR head is checked out;
+                                                      read source files directly.
+
+            If you find yourself reasoning "I should run jq/head/gh to extract X",
+            stop and reformulate as "I should Read (or Grep, or Glob) X". The
+            .claude/skills/review-rocmlir-pr/SKILL.md file shows shell snippets
+            inside an appendix labelled "Interactive Stage B only (DO NOT execute
+            in CI)" -- those snippets are documentation for a maintainer running
+            the skill locally; they are NOT instructions for you in this workflow.
+
             ## Step 1 -- Decide review mode
 
             Count previous Claude root comments:

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -677,30 +677,102 @@ jobs:
             /tmp/pr/meta.json > /tmp/pr/meta.tmp
           mv /tmp/pr/meta.tmp /tmp/pr/meta.json
           rm /tmp/pr/files.json
-          # gh pr checks exits nonzero when any check is failing or pending; in
-          # that case stdout STILL contains the JSON describing those failures,
-          # which is exactly what the reviewer needs to see. Preserve stdout
-          # and ignore the rollup exit code. We do NOT swallow stderr -- real
-          # errors (auth/network) belong in the workflow log, uncensored. Only
-          # fall back to [] if gh wrote nothing parseable to stdout (e.g. no
-          # checks defined yet on this PR).
+          # Pull CI status directly from the REST API instead of via
+          # `gh pr checks --json`. `gh pr checks --json` was only added
+          # in gh v2.36 and the underlying field set has churned since
+          # (e.g. the `conclusion` field this workflow used to read was
+          # silently rotated out in favour of `bucket`). The self-hosted
+          # runner pool that hosts this job hands out pods from
+          # heterogeneous images -- at least one pod ships a gh that
+          # pre-dates `--json` entirely. On that pod the previous
+          # `gh pr checks --json ... || true; jq empty || echo '[]'`
+          # pattern silently fell through to `[]`: gh exited non-zero
+          # with "unknown flag: --json" to stderr and an empty stdout,
+          # `|| true` swallowed the exit, the empty file failed `jq
+          # empty`, and the fallback wrote `[]`. Claude then approved
+          # the PR with zero visibility into CI -- the run on PR #2386
+          # at 2026-05-28T18:17Z is the concrete proof.
           #
-          # Field choice: `bucket` is gh's own rollup of `state` into one of
-          # {pass, fail, pending, skipping, cancel} -- it replaces the older
-          # `conclusion` field that gh removed from `pr checks --json`. We keep
-          # `state` alongside it so consumers can still distinguish, for
-          # example, a queued run (state=QUEUED, bucket=pending) from an
-          # in-progress one (state=IN_PROGRESS, bucket=pending). The review
-          # skill (.claude/skills/review-rocmlir-pr/SKILL.md) filters this file
-          # via `select(.bucket == "fail" or .bucket == "cancel")`, so any
-          # rename here MUST be mirrored in the skill or Claude silently sees
-          # an empty failing-check list and stops flagging CI regressions.
-          gh pr checks "$PR_NUMBER" --json name,state,bucket \
-              --repo "$GITHUB_REPOSITORY" > /tmp/pr/checks.json \
-            || true
-          if ! jq empty /tmp/pr/checks.json 2>/dev/null; then
-            echo '[]' > /tmp/pr/checks.json
-          fi
+          # The /check-runs and /status REST endpoints below have been
+          # stable since v3 launched; gh is just used as an
+          # authenticated HTTP client via `gh api`. The response is
+          # then shaped in jq into the same `{name, state, bucket}`
+          # schema the review skill reads (see
+          # .claude/skills/review-rocmlir-pr/SKILL.md and its
+          # `select(.bucket == "fail" or .bucket == "cancel")` filter,
+          # which MUST stay in sync with the bucket values emitted
+          # here).
+          #
+          # We query BOTH endpoints because they expose disjoint
+          # things and either one alone would silently miss CI red:
+          #   - /commits/{sha}/check-runs covers everything that uses
+          #     the Checks API (GitHub Actions, App-driven check runs,
+          #     etc.). This is the predominant source of CI signal on
+          #     this repo.
+          #   - /commits/{sha}/status covers the older Commit Statuses
+          #     API (some Jenkins integrations, third-party bots that
+          #     post via status contexts). These do not appear in
+          #     /check-runs at all.
+          #
+          # bucket mapping below mirrors gh's own rollup logic (see
+          # `gh pr checks --json bucket` source):
+          #   /check-runs:
+          #     status != "completed"                            -> pending
+          #     conclusion in {success, neutral}                 -> pass
+          #     conclusion == "skipped"                          -> skipping
+          #     conclusion == "cancelled"                        -> cancel
+          #     otherwise (failure, timed_out, action_required,
+          #                startup_failure, stale, ...)          -> fail
+          #   /status:
+          #     state == "pending"                               -> pending
+          #     state == "success"                               -> pass
+          #     otherwise (failure, error)                       -> fail
+          #
+          # No `|| true` anywhere. With `set -euo pipefail` at the
+          # top of this step, any HTTP failure / auth failure / jq
+          # failure aborts the workflow visibly -- which is the
+          # correct behaviour for "we cannot determine CI state".
+          # Silently substituting `[]` here is the exact fail-open
+          # this block exists to prevent.
+          commit_sha=$(jq -r .headRefOid /tmp/pr/meta.json)
+          gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/check-runs" \
+              > /tmp/pr/check_runs.raw.json
+          gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/status" \
+              > /tmp/pr/statuses.raw.json
+          # `gh api --paginate` on /check-runs emits one wrapper object
+          # ({total_count, check_runs: [...]}) per page concatenated --
+          # NOT a single merged object -- so `jq -s` slurps them into an
+          # array and `[.[] | .check_runs[]?]` flattens. The same shape
+          # works for the single-page case (one wrapper object slurped
+          # into a 1-element array).
+          jq -s '[.[] | .check_runs[]?] | map({
+                  name: .name,
+                  state: ((.status // "unknown") | ascii_upcase),
+                  bucket: (
+                    if (.status != "completed") then "pending"
+                    elif (.conclusion == "success" or .conclusion == "neutral") then "pass"
+                    elif (.conclusion == "skipped") then "skipping"
+                    elif (.conclusion == "cancelled") then "cancel"
+                    else "fail"
+                    end)
+                })' \
+              /tmp/pr/check_runs.raw.json > /tmp/pr/check_runs.json
+          jq '[.statuses[]? | {
+                  name: .context,
+                  state: ((.state // "unknown") | ascii_upcase),
+                  bucket: (
+                    if (.state == "pending") then "pending"
+                    elif (.state == "success") then "pass"
+                    else "fail"
+                    end)
+                }]' \
+              /tmp/pr/statuses.raw.json > /tmp/pr/statuses.json
+          jq -s 'add' /tmp/pr/check_runs.json /tmp/pr/statuses.json \
+              > /tmp/pr/checks.json
+          rm /tmp/pr/check_runs.raw.json /tmp/pr/check_runs.json \
+             /tmp/pr/statuses.raw.json /tmp/pr/statuses.json
           # Write the raw API response to a tempfile FIRST, so a failed paginate
           # (network blip, 5xx, auth) hard-fails this step before jq normalizes it.
           gh api --paginate \


### PR DESCRIPTION
## Summary

Three reliability fixes for `claude_auto_review.yml`, each observed end-to-end on a real run (PR #2386 and PR #2378).

### 1. CI-status fail-open via `gh pr checks --json`

The self-hosted runner pool includes a `gh` that pre-dates `--json` on `pr checks`. Combined with `|| true` + a `jq empty` fallback, this silently produced `checks.json = []` and the review approved PR #2386 while CI was red.

**Fix:** swap `gh pr checks --json` for `gh api --paginate` against `/check-runs` (modern Checks API) and `/status` (legacy Commit Statuses API), shape both into the existing `{name, state, bucket}` schema, and drop `|| true` so a fetch failure aborts visibly instead of fail-opening. Mirror the same shape in the skill's local-dev snippet.

### 2. `error_max_turns` on medium-large PRs + opaque failures

PR #2378 burned through `--max-turns 15` with 7 permission denials and `error_max_turns`, $4.32 spent, no review posted. `show_full_output: false` made it impossible to tell which tool was being denied.

**Fix:**
- Bump `--max-turns` to 30. The defenses against loop-injection are structural (`--allowedTools "Skill,Read,Grep,Glob"`, `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1`, two-job split, output sanitizer), not the turn count -- per-call gateway quotas and the job's `timeout-minutes: 30` bound worst-case cost.
- Add a `debug` boolean input to `workflow_dispatch`, wired to `show_full_output`. Default `false` so label-triggered runs stay quiet; a maintainer can re-dispatch with `debug: true` to inspect tool-call logs when a run fails opaquely.

### 3. Root cause of those denials

Both review skills (and the workflow prompt) were nudging Claude toward `Bash` / `jq` / `gh` shapes that are not in the CI tool set. Under load the model ignored the weak "if running outside the workflow" preambles and the denials drained the budget.

**Fix:**
- Add a top-of-file **Tool budget** section to both skills naming the exact CI tool set, listing the cost of denials, and showing how to read each `/tmp/pr/*` file with `Read`.
- Replace in-CI `jq` / `head` examples with prose-form `Read`-tool instructions. Describe the data shape of each pre-fetched file rather than the `gh` / `git` command that produced it.
- Move shell snippets to an **Appendix: Interactive Stage B only (DO NOT execute in CI)** at the bottom of each skill.
- Mirror the budget banner in the workflow prompt so the rule is reinforced before Step 1.

## Test plan

- [x] `bash -n` on the inline shell parses cleanly.
- [x] `yaml.safe_load` on the workflow is valid; the new `debug` input has the expected shape.
- [x] jq transforms smoke-tested against fixtures covering every check-run conclusion, every legacy status state, multi-page pagination on both endpoints, and empty payloads.
- [x] Skill frontmatter parses; appendix anchor references resolve.
- [ ] After merge, re-dispatch PR #2378 with `debug: false`: `checks.json` non-empty and reflects red CI, no `error_max_turns`, `permission_denials_count` ~0.
- [ ] If max-turns still trips, re-dispatch with `debug: true` and inspect the tool-call log.

## Related

Follows up #2387. Addresses reviewer comments on PR #2387 about the `gh pr checks --json` exit-code handling, and on commit e5ab00a calling the budget bump a practical-only mitigation.

Made with [Cursor](https://cursor.com)