### PR TITLE
ci(claude-review): submit a formal PR review (verdict + summary) via the Reviews API

### DIFF
--- a/.claude/skills/review-rocmlir-pr/SKILL.md
+++ b/.claude/skills/review-rocmlir-pr/SKILL.md
@@ -266,7 +266,8 @@ summary).
 
 ```json
 {
-  "summary": "Reviewed N files. Posted M inline comments (C critical, J major, K minor). Verdict: APPROVE | REQUEST_CHANGES | COMMENT.",
+  "verdict": "APPROVE",
+  "summary": "## Scope\n[1-2 sentences on what the PR does]\n\n## Findings\nNo blocking issues found.\n\n## Notes\n[optional observations]",
   "inline_comments": [
     {
       "path": "mlir/lib/Dialect/Rock/Transforms/Foo.cpp",
@@ -283,8 +284,39 @@ summary).
 
 Field rules:
 
-- `summary` -- 3-5 lines: scope of change, total counts by severity, overall verdict.
-  Do NOT restate individual findings; they go in `inline_comments`.
+- `verdict` -- one of `APPROVE`, `REQUEST_CHANGES`, `COMMENT`. Pick what
+  a human reviewer would say about the PR's current state: any Critical
+  finding -> `REQUEST_CHANGES`; zero findings -> `APPROVE`; otherwise
+  `COMMENT` unless the findings materially affect correctness/security
+  (then `REQUEST_CHANGES`). Justify the choice in `summary`. On a
+  re-review the verdict reflects the PR's CURRENT state after the
+  author's fixes -- a previously-REQUEST_CHANGES PR with everything
+  resolved gets an `APPROVE`.
+
+  The post job submits **every verdict** as `gh pr review --comment`
+  (the rendered body header shows your verdict with a "submitted as
+  COMMENT" annotation). **Do NOT change your verdict because of this** --
+  emit the honest verdict; full rationale in `CLAUDE_AUTO_REVIEW.md` §13.
+
+- `summary` -- Markdown body of the formal review. The post job prepends a
+  one-line header (verdict + finding counts); EVERYTHING else is this field.
+  Use `##` section headings; typical layout:
+
+      ## Scope        -- 1-2 sentences: what the PR does / files touched
+      ## Findings     -- one-sentence each, citing `path:line` (full bodies
+                         go in `inline_comments[]`). Zero findings: a single
+                         confirming line, e.g. "No blocking issues found."
+      ## Notes        -- (optional) spot-checks, out-of-scope observations,
+                         follow-up suggestions for a separate PR
+      ## CI status    -- (optional) non-self checks in `/tmp/pr/checks.json`
+                         with `bucket == "fail"` or `"cancel"`; the
+                         auto-review pipeline's own check is expected to be
+                         in-progress / failed and is NOT a CI failure
+
+  Target ~2000 chars (sanitizer cap is 8 KiB). Do NOT restate individual
+  findings (those go in `inline_comments[]`). Do NOT print "Verdict: ..."
+  in the body -- the post job adds that header line.
+
 - `inline_comments[].path` -- repo-relative file path, must appear in the PR diff.
 - `inline_comments[].line` -- exact line number in the PR head (`headRefOid` in
   `/tmp/pr/meta.json`); do NOT use diff-relative line numbers.
@@ -358,8 +390,10 @@ Field rules:
 - `thread_updates` -- empty `[]` for an initial review. Populated by `update-pr-review`
   on re-review runs.
 
-If the PR is genuinely good, return an empty `inline_comments: []` and an APPROVE
-summary. The "Resolved" path in `update-pr-review` only works if reviews are honest.
+If the PR is genuinely good, return an empty `inline_comments: []`, an
+`APPROVE` verdict, and a short summary confirming you found no blocking
+issues. The "Resolved" path in `update-pr-review` only works if reviews are
+honest.
 
 If `update-pr-review` will run after this skill (the workflow detects this when
 `/tmp/pr/prev_comments.json` contains prior root comments where `user.login` is

--- a/.claude/skills/update-pr-review/SKILL.md
+++ b/.claude/skills/update-pr-review/SKILL.md
@@ -254,17 +254,19 @@ For each fresh finding `f` NOT in `handled_fresh`:
 
 ## Step 3 -- Output schema
 
-Return a single JSON object with a `summary` string and two arrays
-(`inline_comments` and `thread_updates`) AS YOUR FINAL RESPONSE. All three top-level
-fields are REQUIRED by the validating schema -- never omit `summary`, even if it
-ends up being a short note like "no inline findings; reconciled N existing threads".
-The workflow uses claude-code-action's `--json-schema` flag to validate the response
-and capture it as `structured_output`; do not write to a file. Use this exact
-schema -- the post script depends on it:
+Return a single JSON object with a `verdict` string, a `summary` string, and two
+arrays (`inline_comments` and `thread_updates`) AS YOUR FINAL RESPONSE. All four
+top-level fields are REQUIRED by the validating schema -- never omit `summary`
+or `verdict`, even if the summary ends up being a short note like "no inline
+findings; reconciled N existing threads". The workflow uses claude-code-action's
+`--json-schema` flag to validate the response and capture it as
+`structured_output`; do not write to a file. Use this exact schema -- the post
+script depends on it:
 
 ```json
 {
-  "summary": "<3-5 line top-level summary written by the review skill>",
+  "verdict": "APPROVE",
+  "summary": "<Markdown body written by the review skill, with `##` sections>",
   "inline_comments": [
     {
       "path": "mlir/lib/Dialect/Rock/Foo.cpp",
@@ -295,6 +297,14 @@ schema -- the post script depends on it:
 ```
 
 Rules:
+- `verdict` MUST be one of `APPROVE`, `REQUEST_CHANGES`, `COMMENT`, reflecting
+  the PR's CURRENT state after the author's fixes (same decision rule as
+  `/review-rocmlir-pr`). The post job submits every verdict as `--comment`;
+  emit the honest verdict.
+- `summary` MUST be Markdown formatted with `##` sections per the
+  `review-rocmlir-pr` contract -- pass through the upstream `summary`
+  unchanged unless the reconciliation outcome materially affects what should
+  be said. If you do edit it, keep the section structure.
 - `inline_comments` MUST contain only Scenario E findings. Findings handled in Step 2
   (Scenarios A/B/C, plus D's regression sub-case) MUST NOT appear here -- those all
   emit `thread_updates`, never an `inline_comments` entry.

--- a/.github/scripts/post_claude_review.sh
+++ b/.github/scripts/post_claude_review.sh
@@ -325,16 +325,24 @@ post_review() {
 
   # Counts are over the FINAL inline_comments (post-reconciliation), so
   # on a re-review they reflect only genuinely-new (Scenario E) findings.
-  # Switch the header label to "New findings" when thread_updates is
-  # non-empty so `Findings: 0` on a fully-fixed re-review can't be
-  # misread as "the PR was always clean".
-  local critical major minor total findings_label
+  # The header label switches to "New findings" on any re-review run,
+  # sourced from `is_re_review` on meta.json (set by the pre-fetch step
+  # using the exact same filter the prompt's Step 1 uses: prior root
+  # comments by BOT_LOGIN carrying the marker). The earlier heuristic of
+  # `thread_updates.length > 0` misread the steady-state of an unfixed
+  # PR: when every prior thread was dedup-gated AND no genuinely-new
+  # findings emerged, both arrays are [] and `Findings: 0` would read as
+  # "the PR was always clean" -- exactly the misread this switch exists
+  # to prevent. Defaulting to `false` if the field is absent (e.g. a
+  # workflow rollback between runs) preserves the prior behaviour.
+  local critical major minor total findings_label is_re_review
   critical=$(jq '[.inline_comments[] | select(.severity == "Critical")] | length' "$ACTIONS_FILE")
   major=$(jq    '[.inline_comments[] | select(.severity == "Major")]    | length' "$ACTIONS_FILE")
   minor=$(jq    '[.inline_comments[] | select(.severity == "Minor")]    | length' "$ACTIONS_FILE")
   total=$((critical + major + minor))
+  is_re_review=$(jq -r '.is_re_review // false' "$META_FILE")
   findings_label="Findings"
-  if (( $(jq '.thread_updates | length' "$ACTIONS_FILE") > 0 )); then
+  if [[ "$is_re_review" == "true" ]]; then
     findings_label="New findings"
   fi
 

--- a/.github/scripts/post_claude_review.sh
+++ b/.github/scripts/post_claude_review.sh
@@ -54,7 +54,7 @@ META_FILE="${PR_DIR}/meta.json"
 MARKER='<!-- claude-pr-review-marker:v1 -->'
 
 # Per-action sub-markers, appended on REPLIES only (root inline comments and
-# the top-level summary do not get one -- those carry only MARKER). The
+# the formal-review body do not get one -- those carry only MARKER). The
 # update-pr-review skill's Step 1 uses these sub-markers to disambiguate the
 # kind ("resolve" vs "clarify") of OUR own previous replies on a thread when
 # computing the dedup gate. Without a sub-marker, the skill has to fall back
@@ -79,8 +79,8 @@ with_marker_and_action() {
 
 # Tracks whether ANY non-skippable failure happened during posting. We do not exit on
 # the first failure -- a single bad inline comment must not lose the other postings or
-# the summary. Instead we record it here and exit non-zero at the end so the GitHub
-# Actions job fails visibly.
+# the formal review. Instead we record it here and exit non-zero at the end so the
+# GitHub Actions job fails visibly.
 HAD_FAILURE=0
 
 : "${GH_TOKEN:?GH_TOKEN must be set}"
@@ -277,25 +277,75 @@ post_thread_updates() {
   echo "::endgroup::"
 }
 
-post_summary() {
-  local summary
-  summary=$(jq -r '.summary' "$ACTIONS_FILE")
-  if [[ -z "$summary" || "$summary" == "null" ]]; then
-    echo "::warning::No summary in actions.json; skipping top-level comment"
-    return 0
+post_review() {
+  # Submit a formal pull-request review via `gh pr review --comment`.
+  # Runs after post_inline_comments / post_thread_updates so the inline
+  # comments exist when the review is submitted; they are NOT batched
+  # into the review's `comments[]` array (a per-comment 422 would fail
+  # the whole batched review atomically).
+  #
+  # Security policy: every verdict is submitted as `--comment` so the
+  # bot's reviews stay advisory -- a bot `--approve` would satisfy
+  # branch protection, and a bot `--request-changes` becomes a sticky
+  # merge block with no automated recovery (the bug github/gh-aw#27655
+  # + PR #27662 had to solve). No runtime opt-in; full threat model in
+  # CLAUDE_AUTO_REVIEW.md §13.
+  local verdict summary
+  verdict=$(jq -r '.verdict // empty' "$ACTIONS_FILE")
+  summary=$(jq -r '.summary // empty' "$ACTIONS_FILE")
+
+  # `downgrade_note` is appended to the body header so a maintainer sees
+  # both the model's verdict and the fact that it was submitted as
+  # COMMENT. `COMMENT` is the no-op case (model verdict matches event).
+  local downgrade_note=""
+  case "$verdict" in
+    APPROVE|REQUEST_CHANGES)
+      downgrade_note=" -- submitted as COMMENT (automated reviews are advisory)"
+      ;;
+    COMMENT) ;;
+    *)
+      # Sanitizer already validates the enum; reaching here means the
+      # sanitizer was bypassed or the schema regressed. Do NOT echo
+      # the raw value (model-controlled).
+      echo "::error::post_review: unknown .verdict in actions.json; sanitizer should have rejected this"
+      HAD_FAILURE=1
+      return 0
+      ;;
+  esac
+
+  # Counts are over the FINAL inline_comments (post-reconciliation), so
+  # on a re-review they reflect only genuinely-new (Scenario E) findings.
+  # Switch the header label to "New findings" when thread_updates is
+  # non-empty so `Findings: 0` on a fully-fixed re-review can't be
+  # misread as "the PR was always clean".
+  local critical major minor total findings_label
+  critical=$(jq '[.inline_comments[] | select(.severity == "Critical")] | length' "$ACTIONS_FILE")
+  major=$(jq    '[.inline_comments[] | select(.severity == "Major")]    | length' "$ACTIONS_FILE")
+  minor=$(jq    '[.inline_comments[] | select(.severity == "Minor")]    | length' "$ACTIONS_FILE")
+  total=$((critical + major + minor))
+  findings_label="Findings"
+  if (( $(jq '.thread_updates | length' "$ACTIONS_FILE") > 0 )); then
+    findings_label="New findings"
   fi
 
-  echo "::group::Posting top-level summary"
-  # Use --body-file so multiline content with shell metacharacters is safe.
-  # Append the marker so a future re-review can attribute this top-level
-  # comment to us as well (not strictly required for the inline-comment
-  # detection logic, but kept consistent across every body we post).
+  # Body header is computed here (deterministic, no model input). The
+  # body that follows is the model's `summary` (## Scope / ## Findings
+  # / ## Notes / ## CI status per the skill). Marker for attribution.
   local tmp
   tmp=$(mktemp)
-  printf '%s\n\n%s\n' "$summary" "$MARKER" > "$tmp"
-  if ! gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$tmp" 2>/tmp/summary_err; then
-    echo "::error::Failed to post top-level summary"
-    cat /tmp/summary_err
+  {
+    printf '**Verdict:** %s%s &nbsp;\xc2\xb7&nbsp; **%s:** %d (%d Critical, %d Major, %d Minor)\n' \
+        "$verdict" "$downgrade_note" "$findings_label" "$total" "$critical" "$major" "$minor"
+    printf '\n---\n\n'
+    printf '%s\n' "$summary"
+    printf '\n%s\n' "$MARKER"
+  } > "$tmp"
+
+  echo "::group::Submitting formal review (verdict=${verdict}; submitted as COMMENT; ${total} new inline comments tallied)"
+  if ! gh pr review "$PR_NUMBER" --repo "$REPO" --comment --body-file "$tmp" \
+       2>/tmp/review_err; then
+    echo "::error::Failed to submit review on PR #${PR_NUMBER}"
+    cat /tmp/review_err
     HAD_FAILURE=1
   fi
   rm -f "$tmp"
@@ -304,7 +354,7 @@ post_summary() {
 
 post_inline_comments
 post_thread_updates
-post_summary
+post_review
 
 if (( HAD_FAILURE != 0 )); then
   echo "::error::One or more posting actions failed; see logs above."

--- a/.github/scripts/post_claude_review.sh
+++ b/.github/scripts/post_claude_review.sh
@@ -296,7 +296,10 @@ post_review() {
 
   # `downgrade_note` is appended to the body header so a maintainer sees
   # both the model's verdict and the fact that it was submitted as
-  # COMMENT. `COMMENT` is the no-op case (model verdict matches event).
+  # COMMENT. The bot always submits as COMMENT; a model verdict of
+  # COMMENT therefore needs no annotation (the body header would
+  # otherwise read `Verdict: COMMENT -- submitted as COMMENT` which is
+  # just noise).
   local downgrade_note=""
   case "$verdict" in
     APPROVE|REQUEST_CHANGES)
@@ -308,6 +311,13 @@ post_review() {
       # sanitizer was bypassed or the schema regressed. Do NOT echo
       # the raw value (model-controlled).
       echo "::error::post_review: unknown .verdict in actions.json; sanitizer should have rejected this"
+      # `return 0` (not 1) for two reasons: (a) we MUST skip the body-
+      # build / submit below -- otherwise the bypassed bad verdict
+      # would land verbatim in the rendered review header (the very
+      # leak this defensive arm exists to prevent); (b) failures are
+      # propagated via HAD_FAILURE so a single bad action doesn't
+      # abort the other postings, with the script exiting non-zero at
+      # the end.
       HAD_FAILURE=1
       return 0
       ;;

--- a/.github/scripts/sanitize_claude_actions.sh
+++ b/.github/scripts/sanitize_claude_actions.sh
@@ -63,6 +63,72 @@ if ! jq -e . "$ACTIONS_FILE" >/dev/null; then
   exit 1
 fi
 
+# Verdict must be one of the three allowed strings. The action's
+# --json-schema already enforces this; the re-check here is
+# defense-in-depth against a schema regression. Do NOT echo the raw
+# .verdict value: this sanitizer runs in the secret-bearing review
+# job and a prompt-injected payload could place a secret-shaped
+# string in .verdict, which would land in Actions logs before the
+# secret-pattern scan layer below gets to catch it.
+verdict=$(jq -r '.verdict // empty' "$ACTIONS_FILE")
+case "$verdict" in
+  APPROVE|REQUEST_CHANGES|COMMENT) ;;
+  *)
+    echo "::error::actions.json has missing or invalid .verdict; must be APPROVE, REQUEST_CHANGES, or COMMENT (raw value not printed -- model-controlled content, see CLAUDE_AUTO_REVIEW.md secret-redaction policy)"
+    exit 1
+    ;;
+esac
+
+# Summary must be a non-empty string. The action's --json-schema enforces
+# `type: string` + `minLength: 1`; the re-check here is defense-in-depth
+# against a schema regression. The post script prepends a body header
+# (verdict + finding counts) and appends the marker, bracketing the
+# summary, so an empty / missing / non-string summary would still
+# produce a structurally non-empty body -- but a review whose model-
+# authored portion is missing or malformed is meaningless and a strong
+# signal that something is wrong upstream. Fail closed.
+#
+# `jq -e` exits non-zero when the filter result is false, null, or
+# empty, so the combined predicate rejects: missing key, null,
+# non-string type (number / boolean / array / object), and empty
+# string. This matches the schema's `{type: "string", minLength: 1}`
+# constraint exactly.
+if ! jq -e '.summary | type == "string" and length > 0' "$ACTIONS_FILE" >/dev/null; then
+  echo "::error::actions.json .summary must be a non-empty string (--json-schema type:string + minLength:1 should have rejected this)"
+  exit 1
+fi
+
+# Defense-in-depth: every other field that the later byte-length /
+# fence / marker scans dereference as a string must actually BE a
+# string (or null, for optional fields). The schema enforces `type:
+# "string"` on each; the re-check here closes the same redaction-
+# bypass class as the verdict / summary checks above:
+#
+#   If a schema regression slipped, say, an object into
+#   inline_comments[].body, the later `utf8bytelength` scan would
+#   error with `jq: error (at ...): object ({"hidden":"sk-secret...
+#   only strings have UTF-8 byte length` -- jq truncates the value
+#   at ~10 characters, but that partial-secret prefix would land in
+#   the public Actions log before the secret-pattern scan ever ran.
+#   The `test` / `contains` / `split` operations in the suggestion-
+#   contract, body-field fence-guard, and marker-spoof checks have
+#   the same property.
+#
+# Predicate: every value of the stream must be null (optional fields
+# missing) or a string. `jq -e` exits non-zero on false / null /
+# empty, failing the sanitizer with a fixed-text error so no model-
+# controlled content reaches the log.
+if ! jq -e '
+  all(
+    ( .inline_comments[]?.body,
+      .inline_comments[]?.suggestion,
+      .thread_updates[]?.body );
+    . == null or type == "string")
+' "$ACTIONS_FILE" >/dev/null; then
+  echo "::error::actions.json has a non-string value in inline_comments[].body, inline_comments[].suggestion, or thread_updates[].body (--json-schema type:string should have rejected this; raw value not printed -- model-controlled content)"
+  exit 1
+fi
+
 # Count caps. The action's --json-schema validates that these are arrays;
 # we only need to bound their length here.
 inline_count=$(jq '.inline_comments | length' "$ACTIONS_FILE")

--- a/.github/scripts/tests/test_sanitize.sh
+++ b/.github/scripts/tests/test_sanitize.sh
@@ -80,7 +80,8 @@ print_fail_blob() {
 make_blob() {
     local body_file="$1" out="$2"
     jq -nR --rawfile body "$body_file" \
-        '{summary:"x",
+        '{verdict:"COMMENT",
+          summary:"x",
           inline_comments:[],
           thread_updates:[{type:"clarify",
                            claude_comment_id:1,
@@ -297,6 +298,339 @@ echo
 echo "--- Diagnostic-redaction (rejected hostname must not leak in stderr) ---"
 run_redact_check "URL diag redacted host"   'http://supersecret-evil-host-12345.com/x'             "supersecret-evil-host-12345"
 run_redact_check "pct-host diag redacted"   'http://supersecret-evil-host-12345%65xyz.com/x'       "supersecret-evil-host-12345"
+
+echo
+echo "--- Verdict field validation (formal review state) ---"
+# Sanitizer re-checks the enum even though --json-schema does too,
+# as defense-in-depth against a schema regression.
+run_verdict_reject() {
+    local name="$1" verdict_jq="$2" want="$3"
+    local json="$TMP_DIR/in.json"
+    # Build a payload with the given verdict expression. `--argjson verdict ...`
+    # lets us pass either a string ("APPROVE") or `null` / a wrong-type value.
+    if [[ "$verdict_jq" == "OMIT" ]]; then
+        jq -n '{summary:"x", inline_comments:[], thread_updates:[]}' > "$json"
+    else
+        jq -n --argjson verdict "$verdict_jq" \
+            '{verdict:$verdict, summary:"x", inline_comments:[], thread_updates:[]}' \
+            > "$json"
+    fi
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && echo "$out" | grep -qE "$want"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  reject  %-44s rc=%d\n' "$name" "$rc"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("verdict-reject:$name")
+        printf '  FAIL  reject  %-44s rc=%d want=/%s/\n' "$name" "$rc" "$want"
+        print_fail_blob "$out"
+    fi
+}
+run_verdict_accept() {
+    local name="$1" verdict="$2"
+    local json="$TMP_DIR/in.json"
+    jq -n --arg verdict "$verdict" \
+        '{verdict:$verdict, summary:"x", inline_comments:[], thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -eq 0 ]]; then
+        PASS=$((PASS + 1))
+        printf '  PASS  accept  verdict=%s\n' "$verdict"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("verdict-accept:$name")
+        printf '  FAIL  accept  verdict=%s rc=%d\n' "$verdict" "$rc"
+        print_fail_blob "$out"
+    fi
+}
+run_verdict_reject "verdict missing"        'OMIT'                  "missing or invalid .verdict"
+run_verdict_reject "verdict null"           'null'                  "missing or invalid .verdict"
+run_verdict_reject "verdict empty string"   '""'                    "missing or invalid .verdict"
+run_verdict_reject "verdict wrong enum"     '"approve"'             "missing or invalid .verdict"
+run_verdict_reject "verdict freeform"       '"LGTM"'                "missing or invalid .verdict"
+run_verdict_reject "verdict integer"        '0'                     "missing or invalid .verdict"
+run_verdict_accept "verdict APPROVE"        "APPROVE"
+run_verdict_accept "verdict REQUEST_CHANGES" "REQUEST_CHANGES"
+run_verdict_accept "verdict COMMENT"        "COMMENT"
+
+# Verdict is model-controlled and the sanitizer runs in the
+# secret-bearing review job; assert the raw value never leaks to
+# stderr on the rejection path.
+run_verdict_redact_check() {
+    local name="$1" verdict_jq="$2" needle="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson verdict "$verdict_jq" \
+        '{verdict:$verdict, summary:"x", inline_comments:[], thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && ! echo "$out" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  redact  verdict %-30s (substr "%s" not in stderr)\n' "$name" "$needle"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("verdict-redact:$name")
+        printf '  FAIL  redact  verdict %s rc=%d (substr "%s" leaked)\n' "$name" "$rc" "$needle"
+        print_fail_blob "$out"
+    fi
+}
+run_verdict_redact_check "secret-shaped"    '"sk-secret-xyzzy-12345"' "sk-secret-xyzzy-12345"
+run_verdict_redact_check "host-shaped"      '"supersecret-evil-host"' "supersecret-evil-host"
+
+echo
+echo "--- Summary field validation (non-empty string contract) ---"
+# Sanitizer re-checks .summary is a non-empty string even though the
+# action's --json-schema enforces type:string + minLength:1, as
+# defense-in-depth against a schema regression. The predicate rejects
+# missing key, null, non-string types, and empty string -- matching
+# the schema constraint exactly.
+run_summary_reject() {
+    local name="$1" summary_jq="$2" want="$3"
+    local json="$TMP_DIR/in.json"
+    if [[ "$summary_jq" == "OMIT" ]]; then
+        jq -n '{verdict:"COMMENT", inline_comments:[], thread_updates:[]}' > "$json"
+    else
+        jq -n --argjson summary "$summary_jq" \
+            '{verdict:"COMMENT", summary:$summary, inline_comments:[], thread_updates:[]}' \
+            > "$json"
+    fi
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && echo "$out" | grep -qE "$want"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  reject  %-44s rc=%d\n' "$name" "$rc"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("summary-reject:$name")
+        printf '  FAIL  reject  %-44s rc=%d want=/%s/\n' "$name" "$rc" "$want"
+        print_fail_blob "$out"
+    fi
+}
+run_summary_reject "summary missing"        'OMIT'                  "must be a non-empty string"
+run_summary_reject "summary null"           'null'                  "must be a non-empty string"
+run_summary_reject "summary empty string"   '""'                    "must be a non-empty string"
+run_summary_reject "summary integer"        '42'                    "must be a non-empty string"
+run_summary_reject "summary boolean"        'true'                  "must be a non-empty string"
+run_summary_reject "summary array"          '["a","b"]'             "must be a non-empty string"
+run_summary_reject "summary object"         '{"k":"v"}'             "must be a non-empty string"
+# Accept case: any non-empty string passes.
+run_summary_accept() {
+    local name="$1" summary_jq="$2"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson summary "$summary_jq" \
+        '{verdict:"COMMENT", summary:$summary, inline_comments:[], thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -eq 0 ]]; then
+        PASS=$((PASS + 1))
+        printf '  PASS  accept  %s\n' "$name"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("summary-accept:$name")
+        printf '  FAIL  accept  %s rc=%d\n' "$name" "$rc"
+        print_fail_blob "$out"
+    fi
+}
+run_summary_accept "summary single char"    '"x"'
+run_summary_accept "summary multi-line md"  '"## Scope\nfoo\n\n## Findings\nNone."'
+
+# Summary is model-controlled and the sanitizer runs in the secret-
+# bearing review job; assert that secret-shaped content nested inside
+# a non-string summary never leaks to stderr on the rejection path.
+# Today this holds trivially because the rejection error is fixed
+# text -- the pin is here so a future maintainer who "helpfully" adds
+# the summary value to the diagnostic catches it via a CI failure.
+run_summary_redact_check() {
+    local name="$1" summary_jq="$2" needle="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson summary "$summary_jq" \
+        '{verdict:"COMMENT", summary:$summary, inline_comments:[], thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && ! echo "$out" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  redact  summary %-30s (substr "%s" not in stderr)\n' "$name" "$needle"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("summary-redact:$name")
+        printf '  FAIL  redact  summary %s rc=%d (substr "%s" leaked)\n' "$name" "$rc" "$needle"
+        print_fail_blob "$out"
+    fi
+}
+run_summary_redact_check "secret in object value" '{"hidden":"sk-secret-leak-12345"}' "sk-secret-leak-12345"
+run_summary_redact_check "secret in array"        '["sk-secret-leak-67890"]'         "sk-secret-leak-67890"
+run_summary_redact_check "host-shaped in key"     '{"evil-host-domain":"x"}'         "evil-host-domain"
+
+echo
+echo "--- Field-type defense-in-depth (non-string string fields) ---"
+# The sanitizer re-checks that inline_comments[].body, inline_comments[].
+# suggestion, and thread_updates[].body are strings (or null, for optional
+# fields) even though the action's --json-schema enforces type:string on
+# each. The re-check closes the same redaction-bypass class as the
+# verdict/summary type checks: a schema regression that slipped a non-
+# string through would otherwise reach `utf8bytelength` / `test` /
+# `contains` / `split` in later scans, and jq's error message includes
+# the value (truncated at ~10 chars) -- partial-secret-leaking on
+# stderr before the secret-pattern layer ever runs.
+
+# Build a payload with a single inline_comments entry whose .body is the
+# raw JSON expression supplied by the caller (--argjson, so the value
+# round-trips with its declared type intact).
+run_ic_body_reject() {
+    local name="$1" body_jq="$2" want="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson v "$body_jq" \
+        '{verdict:"COMMENT", summary:"x",
+          inline_comments:[{path:"f.cpp",line:1,side:"RIGHT",severity:"Major",body:$v}],
+          thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && echo "$out" | grep -qE "$want"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  reject  %-44s rc=%d\n' "$name" "$rc"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("ic-body-reject:$name")
+        printf '  FAIL  reject  %-44s rc=%d want=/%s/\n' "$name" "$rc" "$want"
+        print_fail_blob "$out"
+    fi
+}
+run_ic_body_reject "ic.body integer"        '42'                                "non-string value"
+run_ic_body_reject "ic.body boolean"        'true'                              "non-string value"
+run_ic_body_reject "ic.body array"          '["a","b"]'                         "non-string value"
+run_ic_body_reject "ic.body object"         '{"k":"v"}'                         "non-string value"
+
+# Same shape, but exercises inline_comments[].suggestion. Body is fixed
+# to a valid string so the new check is the only gate that can fire.
+run_ic_sugg_reject() {
+    local name="$1" sugg_jq="$2" want="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson v "$sugg_jq" \
+        '{verdict:"COMMENT", summary:"x",
+          inline_comments:[{path:"f.cpp",line:1,side:"RIGHT",severity:"Major",
+                            body:"ok",suggestion:$v}],
+          thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && echo "$out" | grep -qE "$want"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  reject  %-44s rc=%d\n' "$name" "$rc"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("ic-sugg-reject:$name")
+        printf '  FAIL  reject  %-44s rc=%d want=/%s/\n' "$name" "$rc" "$want"
+        print_fail_blob "$out"
+    fi
+}
+run_ic_sugg_reject "ic.suggestion integer"  '42'                                "non-string value"
+run_ic_sugg_reject "ic.suggestion array"    '["return foo();"]'                 "non-string value"
+run_ic_sugg_reject "ic.suggestion object"   '{"code":"return foo();"}'          "non-string value"
+
+# Same shape on a clarify thread_update body. (For resolve / resolve_
+# with_reaction the schema does not carry a body field, so a non-string
+# body there is the same regression shape but only this fixture exercises
+# the user-facing clarify path.)
+run_tu_body_reject() {
+    local name="$1" body_jq="$2" want="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson v "$body_jq" \
+        '{verdict:"COMMENT", summary:"x", inline_comments:[],
+          thread_updates:[{type:"clarify",claude_comment_id:1,body:$v}]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && echo "$out" | grep -qE "$want"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  reject  %-44s rc=%d\n' "$name" "$rc"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("tu-body-reject:$name")
+        printf '  FAIL  reject  %-44s rc=%d want=/%s/\n' "$name" "$rc" "$want"
+        print_fail_blob "$out"
+    fi
+}
+run_tu_body_reject "tu.body integer"        '42'                                "non-string value"
+run_tu_body_reject "tu.body array"          '["clarification"]'                 "non-string value"
+run_tu_body_reject "tu.body object"         '{"k":"clarification"}'             "non-string value"
+
+# Redaction: secret-shaped content nested inside a non-string string-
+# field must never leak to stderr on the rejection path. This pins the
+# fixed-text contract on the new defense-in-depth check the same way
+# the summary-redact tests above pin it on the summary check; a future
+# maintainer who "helpfully" adds the offending value to the
+# diagnostic catches it via a CI failure.
+run_ic_body_redact_check() {
+    local name="$1" body_jq="$2" needle="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson v "$body_jq" \
+        '{verdict:"COMMENT", summary:"x",
+          inline_comments:[{path:"f.cpp",line:1,side:"RIGHT",severity:"Major",body:$v}],
+          thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && ! echo "$out" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  redact  ic.body %-30s (substr "%s" not in stderr)\n' "$name" "$needle"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("ic-body-redact:$name")
+        printf '  FAIL  redact  ic.body %s rc=%d (substr "%s" leaked)\n' "$name" "$rc" "$needle"
+        print_fail_blob "$out"
+    fi
+}
+run_ic_body_redact_check "secret in object"  '{"hidden":"sk-secret-bodyleak-11111"}' "sk-secret-bodyleak-11111"
+run_ic_body_redact_check "secret in array"   '["sk-secret-bodyleak-22222"]'          "sk-secret-bodyleak-22222"
+
+run_ic_sugg_redact_check() {
+    local name="$1" sugg_jq="$2" needle="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson v "$sugg_jq" \
+        '{verdict:"COMMENT", summary:"x",
+          inline_comments:[{path:"f.cpp",line:1,side:"RIGHT",severity:"Major",
+                            body:"ok",suggestion:$v}],
+          thread_updates:[]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && ! echo "$out" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  redact  ic.suggestion %-24s (substr "%s" not in stderr)\n' "$name" "$needle"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("ic-sugg-redact:$name")
+        printf '  FAIL  redact  ic.suggestion %s rc=%d (substr "%s" leaked)\n' "$name" "$rc" "$needle"
+        print_fail_blob "$out"
+    fi
+}
+run_ic_sugg_redact_check "secret in object" '{"k":"sk-secret-suggleak-33333"}' "sk-secret-suggleak-33333"
+
+run_tu_body_redact_check() {
+    local name="$1" body_jq="$2" needle="$3"
+    local json="$TMP_DIR/in.json"
+    jq -n --argjson v "$body_jq" \
+        '{verdict:"COMMENT", summary:"x", inline_comments:[],
+          thread_updates:[{type:"clarify",claude_comment_id:1,body:$v}]}' \
+        > "$json"
+    local out rc
+    out=$(bash "$SANITIZER" "$json" 2>&1) || rc=$? && rc=${rc:-0}
+    if [[ $rc -ne 0 ]] && ! echo "$out" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1))
+        printf '  PASS  redact  tu.body %-30s (substr "%s" not in stderr)\n' "$name" "$needle"
+    else
+        FAIL=$((FAIL + 1))
+        FAIL_NAMES+=("tu-body-redact:$name")
+        printf '  FAIL  redact  tu.body %s rc=%d (substr "%s" leaked)\n' "$name" "$rc" "$needle"
+        print_fail_blob "$out"
+    fi
+}
+run_tu_body_redact_check "secret in array"  '["sk-secret-threadleak-44444"]'   "sk-secret-threadleak-44444"
 
 echo
 echo "--- Negative cases: legitimate content must be accepted ---"

--- a/.github/workflows/CLAUDE_AUTO_REVIEW.md
+++ b/.github/workflows/CLAUDE_AUTO_REVIEW.md
@@ -396,9 +396,12 @@ three verdicts as `gh pr review --comment` (advisory). No runtime opt-in.
 Full threat model + rationale: [§13](#13-security-measures-summary).
 
 **Review body layout** (built by `post_claude_review.sh`, NOT the model):
+the exact byte sequence the script writes, including the `&nbsp;`
+entities around the middle-dot separator (the rendered review on
+GitHub displays these as non-breaking spaces).
 
 ```markdown
-**Verdict:** APPROVE -- submitted as COMMENT (automated reviews are advisory)  ·  **Findings:** N (C Critical, J Major, K Minor)
+**Verdict:** REQUEST_CHANGES -- submitted as COMMENT (automated reviews are advisory) &nbsp;·&nbsp; **Findings:** 3 (1 Critical, 1 Major, 1 Minor)
 
 ---
 
@@ -406,6 +409,11 @@ Full threat model + rationale: [§13](#13-security-measures-summary).
 
 <!-- claude-pr-review-marker:v1 -->
 ```
+
+The `-- submitted as COMMENT (...)` annotation appears whenever the
+model's verdict is `APPROVE` or `REQUEST_CHANGES`; for a model
+`verdict: COMMENT` it is omitted (the submitted event and the model's
+intent already coincide). Numbers shown are illustrative.
 
 On a re-review run the header label switches from `**Findings:**` to
 `**New findings:**` so a maintainer reading `New findings: 0` on a

--- a/.github/workflows/CLAUDE_AUTO_REVIEW.md
+++ b/.github/workflows/CLAUDE_AUTO_REVIEW.md
@@ -58,7 +58,13 @@ When a maintainer applies the `claude-review` label to a pull request, an LLM
 - **inline review comments** anchored to specific `file:line` positions,
 - optional one-click **commit suggestions**,
 - **thread updates** on re-review (resolve / clarify / react), and
-- a **top-level summary** comment.
+- a **formal pull-request review** carrying the model's verdict and a
+  structured Markdown summary. **The bot's reviews are purely advisory:
+  every verdict (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) is submitted
+  as a `--comment` event**, so the model's assessment is surfaced in the
+  rendered body header without affecting the merge gate. See
+  [§8 / Job 2](#job-2--post-has-write-no-secrets) for how the review is
+  rendered and [§13](#13-security-measures-summary) for the threat model.
 
 The label is **consumed by each label-triggered same-repo run** — the `cleanup`
 job removes it when the review finishes (§8). `workflow_dispatch` is an
@@ -174,7 +180,7 @@ flowchart TD
     end
 
     review -.->|calls| gateway["LLM Gateway<br/>(internal network)"]
-    post -.->|comments via App token| gh["GitHub API"]
+    post -.->|comments + formal review<br/>via App token| gh["GitHub API"]
 ```
 
 The split into separate workflow files is deliberate: the two **companion**
@@ -309,7 +315,8 @@ sequenceDiagram
     R->>A: upload actions.json + meta.json
     A-->>P: download artifact
     P->>GH: mint App token
-    P->>GH: post inline comments, thread updates, summary
+    P->>GH: post inline comments + thread updates
+    P->>GH: submit formal review (verdict + summary, always as COMMENT event)
     C->>GH: (always on label path) remove 'claude-review' label
 ```
 
@@ -346,7 +353,7 @@ through the App token, which never enters the model's environment.
 | **Checkout default branch** (sparse, scripts only) | The post script must be the **trusted** version, never the PR's. Under `pull_request` the default checkout ref would be the PR merge — so this pins explicitly to the default branch. |
 | **Download artifact** | The validated `actions.json` + `meta.json`. |
 | **Mint App token** | Each job mints its own (job outputs aren't encrypted, so tokens are never passed between jobs). |
-| **Post** | Runs `post_claude_review.sh`: posts inline comments (anchored to `headRefOid` from `meta.json`), thread updates, and the summary. A single bad inline comment is recorded but doesn't abort the rest; the job exits non-zero at the end if anything failed. A 422 "line not part of the diff" is the one soft-skip. |
+| **Post** | Runs `post_claude_review.sh`: posts inline comments (anchored to `headRefOid` from `meta.json`), thread updates, and a **formal pull-request review** carrying the verdict + summary. A single bad inline comment is recorded but doesn't abort the rest; the job exits non-zero at the end if anything failed. A 422 "line not part of the diff" is the one soft-skip. |
 
 **Permissions:** `contents: read` (for the script checkout) — all writes via
 the App token. No gateway secret is present in this job at all.
@@ -366,8 +373,57 @@ Every posted body gets the `<!-- claude-pr-review-marker:v1 -->` marker
 appended; replies additionally get an action sub-marker
 (`<!-- claude-pr-review-action:resolve -->` / `:clarify -->`) so the next
 re-review can tell *which kind* of reply was ours (§11). Inline comments use
-`POST /pulls/{n}/comments`; replies use `…/comments/{id}/replies`; the summary
-is a top-level issue comment via `gh pr comment`.
+`POST /pulls/{n}/comments`; replies use `…/comments/{id}/replies`; the
+verdict + summary use the Reviews API (covered below).
+
+**How the formal review is submitted.** The verdict + summary go through
+`POST /pulls/{n}/reviews` (`gh pr review --comment --body-file <summary>`) —
+the same endpoint a human reviewer's "Comment" button hits, so they appear
+as a `Commented` entry in the PR's reviews list rather than as a top-level
+issue comment in the conversation thread. Inline comments are deliberately
+NOT batched into the review's `comments[]` array (see "What's NOT batched"
+below). The bot only submits the `COMMENT` event (see "COMMENT-only
+submission" below).
+
+**The verdict** is the model's honest assessment of the PR's current state —
+any Critical → `REQUEST_CHANGES`; zero findings → `APPROVE`; otherwise
+`COMMENT`, unless the findings materially affect correctness/security (then
+`REQUEST_CHANGES`). Full rule (with re-review semantics) lives in the
+`/review-rocmlir-pr` skill; see also [§12.2](#122-the-structured-output-contract).
+
+**COMMENT-only submission (unconditional).** The post script submits all
+three verdicts as `gh pr review --comment` (advisory). No runtime opt-in.
+Full threat model + rationale: [§13](#13-security-measures-summary).
+
+**Review body layout** (built by `post_claude_review.sh`, NOT the model):
+
+```markdown
+**Verdict:** APPROVE -- submitted as COMMENT (automated reviews are advisory)  ·  **Findings:** N (C Critical, J Major, K Minor)
+
+---
+
+<model's structured Markdown summary -- ## Scope / ## Findings / ## Notes / ## CI status>
+
+<!-- claude-pr-review-marker:v1 -->
+```
+
+On a re-review run the header label switches from `**Findings:**` to
+`**New findings:**` (detected by `thread_updates` being non-empty) so a
+maintainer reading `New findings: 0` on a fully-fixed PR does not
+misread it as "the PR was always clean" — the count is over Scenario-E
+genuinely-new findings, with resolved/clarified threads from prior
+runs not included.
+
+**What's NOT batched into the review submission.** The Reviews API allows
+`POST /pulls/{n}/reviews` to also carry an inline `comments[]` array, which
+would group every inline comment under the same review event in the PR UI.
+We deliberately keep inline comments as separate `POST /pulls/{n}/comments`
+calls because a single bad comment line in a batched review fails the
+WHOLE review submission atomically, losing the verdict + summary along
+with the bad comment. The per-comment soft-skip on 422 "line not part of
+the diff" depends on per-comment isolation. Batched submission is a
+possible future improvement once the review skill pre-validates that every
+comment line is in the diff.
 
 ### Job 3 — `cleanup` (removes the label on the label path)
 
@@ -427,7 +483,8 @@ is posted, never a partial or unvetted result:
 | Model emits no `structured_output` (or non-JSON) | The materialize step errors → `review` fails → no artifact. |
 | Sanitizer rejects (exit 1/2/3) | `review` fails → no artifact uploaded. |
 | `review` job fails for any reason | `post` is skipped (`needs: review`), so **nothing is posted**. |
-| A single inline comment fails to post | Recorded; the rest of the comments + summary still post; `post` exits non-zero at the end so the failure is visible. |
+| A single inline comment fails to post | Recorded; the rest of the comments, thread updates, and the formal review still post; `post` exits non-zero at the end so the failure is visible. |
+| Formal review submission fails (`gh pr review` non-zero) | Inline comments and thread updates still posted; the verdict is lost for this run; `post` exits non-zero so the missing review is visible. Reapply `claude-review` to retry once the underlying cause (transient 5xx, App permission drift, etc.) is fixed. |
 | Anything above | On label-triggered same-repo runs, `cleanup` still runs (`if: always()`) and removes the label, so the PR is immediately re-triggerable. |
 
 So a sanitizer catch or a flaky run never leaks a half-vetted review: the worst
@@ -528,8 +585,15 @@ automatically by `fork_notify` as a comment on the PR):
 `sanitize_claude_actions.sh` is the **last gate** before the model's output
 leaves the secret-bearing job. `claude-code-action`'s `--json-schema` already
 validated the outer JSON shape; the sanitizer adds what the schema can't
-express. It exits `1` (malformed/bad fields), `2` (suspected secret / bad
-URL), or `3` (size/count cap exceeded).
+express (URL allow-list, secret patterns, byte/count caps, conditional
+field requirements, marker anti-spoof) **and** re-checks the schema-
+expressible string-typed and enum-valued fields (`verdict`, `summary`,
+`inline_comments[].body` / `.suggestion`, `thread_updates[].body`) as
+defense-in-depth — if a future schema regression slipped a non-string
+through, the later byte-length / fence / pattern scans would error on it
+and jq's error message would partially leak the value (truncated to
+~10 chars on stderr). It exits `1` (malformed/bad fields), `2` (suspected
+secret / bad URL), or `3` (size/count cap exceeded).
 
 The caps it enforces (overridable via env vars of the same name) are:
 
@@ -714,7 +778,12 @@ untrusted PR data with its own directives:
    `github-actions[bot]` (wrong/legacy identities).
 5. **Step 2 — run `/review-rocmlir-pr`**; **Step 3 — run `/update-pr-review`**
    (re-review only) to reconcile against prior comments; **Step 4 — emit the
-   single JSON object** described below and nothing else.
+   single JSON object** described below and nothing else, including the
+   `verdict` (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) that appears in the
+   rendered body header (the submitted `gh pr review` event is hardcoded to
+   `--comment`; see [§8 / Job 2](#job-2--post-has-write-no-secrets)) and the
+   `## Scope` / `## Findings` / `## Notes` / `## CI status` Markdown sections
+   that become the review body.
 6. **Hard constraints** — the model-facing mirror of the sanitizer: no
    secrets/env-var names/values/headers; only `github.com`/`*.github.com`/
    `*.githubusercontent.com` URLs (with the full enumeration of rejected URL
@@ -734,10 +803,11 @@ The model's final message must be a single JSON object (validated by
 
 ```json
 {
-  "summary": "...",
+  "verdict": "APPROVE",
+  "summary": "## Scope\n...Markdown body with ## sections...",
   "inline_comments": [
-    { "path": "...", "line": 142, "side": "RIGHT",
-      "severity": "Critical|Major|Minor", "body": "...",
+    { "path": "mlir/lib/Foo.cpp", "line": 142, "side": "RIGHT",
+      "severity": "Major", "body": "...",
       "suggestion": "optional verbatim single-line replacement" }
   ],
   "thread_updates": [
@@ -748,11 +818,34 @@ The model's final message must be a single JSON object (validated by
 }
 ```
 
+The example is a valid JSON shape template; replace every value with
+content appropriate to the PR. The legal values for each enum-typed field
+are documented in the bullet list below (and enforced by `--json-schema`):
+
+- `verdict` is the model's *intended* review event (`APPROVE` /
+  `REQUEST_CHANGES` / `COMMENT`); the schema and sanitizer both reject
+  other values. The post job submits **every verdict** as
+  `gh pr review --comment` (advisory reviews; see
+  [§13](#13-security-measures-summary)) and surfaces the model's verdict
+  in the rendered body header. Decision rule + re-review semantics live in
+  the `/review-rocmlir-pr` skill; [§8 / Job 2](#job-2--post-has-write-no-secrets)
+  has the architectural summary and body-layout example.
+- `summary` is well-structured Markdown (`## Scope`, `## Findings`,
+  `## Notes`, `## CI status` -- see the skill for the layout). The post
+  job prepends a deterministic one-line header showing verdict + finding
+  counts; the model's `summary` is the body that follows. Do NOT prefix
+  the body with `Verdict:` — that would render as a duplicate of the
+  header.
 - `side` is `"RIGHT"` only (head-file line numbers); `LEFT` is unsupported.
 - `suggestion` must be a single line with no `` ``` `` fence (it's wrapped in a
   `suggestion` fence by the post script).
 - Initial review: `thread_updates: []`. Re-review: the reconciliation skill
-  populates `thread_updates` and only-genuinely-new `inline_comments`.
+  populates `thread_updates` and only-genuinely-new `inline_comments`, and
+  picks the verdict based on the PR's CURRENT state after fixes — the same
+  way a human reviewer would behave. The post job submits every verdict as
+  `--comment` (see [§8 / Job 2](#job-2--post-has-write-no-secrets)
+  "COMMENT-only submission"), so there is no sticky `CHANGES_REQUESTED`
+  state to supersede between runs.
 
 ---
 
@@ -763,6 +856,7 @@ The model's final message must be a single JSON object (validated by
 | Two-job split (secrets vs write) | A prompt-injected model can't both read a secret and write it out. |
 | `--allowedTools Skill,Read,Grep,Glob` | No Bash/Write/network/MCP-write → no interactive exfil or GitHub write from the model. |
 | `contents: read` default token + App token for writes | Even if the read-only token leaks, it grants no write capability. |
+| **COMMENT-only submission (unconditional)** | A prompt-injected or simply mistaken model can emit `verdict: "APPROVE"` on a PR that should not be approved, or `verdict: "REQUEST_CHANGES"` on a PR with no real findings. The sanitizer validates the enum but cannot validate review correctness. Letting `APPROVE` through to `gh pr review --approve` would tick a real "approving review" slot that branch protection counts toward "require N approving reviews", turning the pipeline into a self-sufficient merge-gate bypass. Letting `REQUEST_CHANGES` through to `gh pr review --request-changes` is the other half of the same problem: GitHub does NOT clear a `CHANGES_REQUESTED` review when the same reviewer later submits a `COMMENT` review, so a stale block from one run combined with no `--approve` path on the next run would leave fixed PRs wedged indefinitely until a maintainer manually dismisses them (this is exactly what [github/gh-aw#27655](https://github.com/github/gh-aw/issues/27655) + [PR #27662](https://github.com/github/gh-aw/pull/27662) had to solve for the same class of tool). `post_claude_review.sh` resolves both at once: it submits EVERY verdict as `--comment` (a "left a review with no decision" event that satisfies no approval rule and leaves no sticky state), and surfaces both the model's verdict and the submitted event in the rendered body header. **No runtime opt-in.** Keeping this as a single hardcoded rule means there is no env var, repo variable, or workflow input that a misconfiguration could flip; changing the policy requires a PR to `post_claude_review.sh` and goes through the perimeter audit ([§6](#6-the-three-layer-defense-model)). |
 | `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` | Subprocesses can't see the gateway secrets. |
 | SHA-pinned checkout | TOCTOU force-push race between label and checkout. |
 | `persist-credentials: false` + credential-helper git-auth | Token never written to `.git/config` where Read could dump it. |
@@ -808,6 +902,11 @@ CLI, shown below). The names must match what the workflows reference.
 | `ROCMLIR_PR_REVIEWER_PRIVATE_KEY` | secret | The PEM **private key** of the bot GitHub App (step 14.2). |
 | `ROCMLIR_PR_REVIEWER_APP_ID` | **variable** | The bot App's **Client ID** (non-sensitive; it appears in the App's public install URL). The variable name is historical — its value is the Client ID, not the numeric App ID. |
 
+There is **no runtime variable** to change the bot's review submission
+event. [COMMENT-only submission](#13-security-measures-summary) is
+hardcoded in `post_claude_review.sh`. To change it on a port, see
+[§16 item 8](#16-porting-to-another-project).
+
 > The `anthropic_api_key` input on the Claude step is a hardcoded placeholder
 > (`sk-ant-dummy-gateway-key`), **not** a secret — it's required by the action's
 > schema but unused when `ANTHROPIC_BASE_URL` is set.
@@ -851,7 +950,7 @@ The pipeline posts under a dedicated App identity (§11) rather than
 1. **Create the App** at **Settings → Developer settings → GitHub Apps → New
    GitHub App** (org-level if the repo is in an org). Set repository
    **permissions**:
-   - **Pull requests: Read & write** — post inline comments, replies, reactions.
+   - **Pull requests: Read & write** — post inline comments, replies, reactions, **and submit formal pull-request reviews** (`POST /pulls/{n}/reviews`, the endpoint behind `gh pr review --comment`). The same `pull_requests: write` scope covers all four; no separate "reviews" toggle exists. (The pipeline submits only `COMMENT` events; see [§13](#13-security-measures-summary).)
    - **Issues: Read & write** — add/remove labels (labels live on the issues API).
    - **Contents: Read-only** — read repo content via the token.
    - **Metadata: Read-only** — mandatory baseline.
@@ -903,7 +1002,11 @@ configure, as a repo admin:
 ### 14.6 Verify
 
 Open a small same-repo PR, apply `claude-review`, and confirm: the `review`
-job runs on your runner, `post` comments appear under your bot identity, and
+job runs on your runner, inline comments and any thread updates appear under
+your bot identity, a **formal review** with the `Commented` event shows up
+in the PR's reviews list with the structured-Markdown body (the body header
+prints the model's verdict — `APPROVE` / `REQUEST_CHANGES` / `COMMENT` —
+along with the "submitted as COMMENT" annotation for the first two), and
 `cleanup` removes the label. For a fork PR you should instead see the
 `fork_notify` comment (§9.1).
 
@@ -939,6 +1042,7 @@ env vars can't reference a single source. When you change one, update all:
 | URL allow-list hosts | `ALLOWED_HOST_RE` in the sanitizer; prompt "Hard constraints"; skill "Rules". |
 | `bucket` CI-status values | Pre-fetch jq in `claude_auto_review.yml`; the review skill's filter. |
 | Output JSON schema | `--json-schema` in `claude_auto_review.yml`; sanitizer checks; both skills. |
+| `verdict` enum (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) | `--json-schema` enum in `claude_auto_review.yml`; sanitizer's verdict check; verdict→annotation case in `post_claude_review.sh`'s `post_review` (the submitted `gh pr review` event is hardcoded to `--comment`; the case selects only the body-header annotation); both skills' output-schema sections. The **COMMENT-only submission policy** is intentionally NOT a sync point — it lives only in `post_claude_review.sh`'s `post_review` (no env var, no workflow input, no repo variable) so a misconfiguration cannot flip it. |
 | Pinned action SHAs | `claude-code-action`, `create-github-app-token`, `checkout`, `upload/download-artifact` — re-verify internals on bump (esp. the credential-helper branch behind `allowed_non_write_users`). |
 
 ---
@@ -982,6 +1086,12 @@ alone do not protect the secrets** (see [§5](#5-trigger-model-pull_request-vs-p
 **7. URL allow-list.** If your review bodies legitimately link to a non-GitHub
 host, add it to `ALLOWED_HOST_RE` in the sanitizer **and** the prompt's "Hard
 constraints" block — keep the two in sync.
+
+**8. COMMENT-only submission.** Every verdict is submitted as `--comment`;
+there is no runtime opt-in (see [§13](#13-security-measures-summary)). Keep
+it as-is unless your repo has a deliberate process for treating bot reviews
+as merge-gate decisions — if you enable real `--request-changes` events,
+implement the gh-aw#27662 supersede step (see §13) as well.
 
 ---
 

--- a/.github/workflows/CLAUDE_AUTO_REVIEW.md
+++ b/.github/workflows/CLAUDE_AUTO_REVIEW.md
@@ -408,11 +408,17 @@ Full threat model + rationale: [§13](#13-security-measures-summary).
 ```
 
 On a re-review run the header label switches from `**Findings:**` to
-`**New findings:**` (detected by `thread_updates` being non-empty) so a
-maintainer reading `New findings: 0` on a fully-fixed PR does not
-misread it as "the PR was always clean" — the count is over Scenario-E
-genuinely-new findings, with resolved/clarified threads from prior
-runs not included.
+`**New findings:**` so a maintainer reading `New findings: 0` on a
+fully-fixed PR does not misread it as "the PR was always clean" — the
+count is over Scenario-E genuinely-new findings, with resolved /
+clarified threads from prior runs not included. The switch is driven
+by `meta.json#.is_re_review`, computed in the pre-fetch step using the
+same `BOT_LOGIN + marker + root-comment` filter the prompt's Step 1
+uses. **Do not derive this from `thread_updates.length`** — every
+Scenario A/B/C/D's dedup gate (and Scenario D's "still present, no
+human reply, last bot reply was clarify/null" silent-skip) can produce
+a re-review run whose `thread_updates` is `[]`, and a length-based
+heuristic would mislabel the body header on those.
 
 **What's NOT batched into the review submission.** The Reviews API allows
 `POST /pulls/{n}/reviews` to also carry an inline `comments[]` array, which
@@ -1041,6 +1047,7 @@ env vars can't reference a single source. When you change one, update all:
 | Default-branch diff baseline | Layer-3 block (`git diff`); perimeter banner (Compare API). |
 | URL allow-list hosts | `ALLOWED_HOST_RE` in the sanitizer; prompt "Hard constraints"; skill "Rules". |
 | `bucket` CI-status values | Pre-fetch jq in `claude_auto_review.yml`; the review skill's filter. |
+| `is_re_review` filter (BOT_LOGIN + marker + root-comment) | Pre-fetch jq that writes `meta.json#.is_re_review` in `claude_auto_review.yml`; the prompt's Step 1 N-count. Both filters must stay byte-for-byte identical so the post job's `Findings:` vs `New findings:` header label can't drift from the model's initial-vs-re-review-mode decision. |
 | Output JSON schema | `--json-schema` in `claude_auto_review.yml`; sanitizer checks; both skills. |
 | `verdict` enum (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) | `--json-schema` enum in `claude_auto_review.yml`; sanitizer's verdict check; verdict→annotation case in `post_claude_review.sh`'s `post_review` (the submitted `gh pr review` event is hardcoded to `--comment`; the case selects only the body-header annotation); both skills' output-schema sections. The **COMMENT-only submission policy** is intentionally NOT a sync point — it lives only in `post_claude_review.sh`'s `post_review` (no env var, no workflow input, no repo variable) so a misconfiguration cannot flip it. |
 | Pinned action SHAs | `claude-code-action`, `create-github-app-token`, `checkout`, `upload/download-artifact` — re-verify internals on bump (esp. the credential-helper branch behind `allowed_non_write_users`). |

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -42,10 +42,9 @@ on:
 env:
   PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
   # Bot identity for every comment this pipeline posts (the rocMLIR-PR-Reviewer
-  # GitHub App). This literal is duplicated in the prompt heredoc, the
-  # perimeter-banner workflow (EXPECTED_AUTHOR), and both .claude/skills/* files
-  # because Markdown and cross-workflow env vars can't reference this var. When
-  # the App slug changes, update all of them -- see the sync table in doc §15.
+  # GitHub App). Mirrored in the prompt heredoc, perimeter-banner's
+  # EXPECTED_AUTHOR, and both .claude/skills/* files (Markdown / cross-workflow
+  # env vars can't reference this var). See sync table in doc §15.
   BOT_LOGIN: 'rocmlir-pr-reviewer[bot]'
 
 # Cancel an in-flight review for the same PR if a new label/dispatch event
@@ -308,8 +307,7 @@ jobs:
           # Scrub secret env vars from any subprocess the model spawns.
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
-          # Required by the input schema but unused when ANTHROPIC_BASE_URL is
-          # set; this is a placeholder, not a secret.
+          # Placeholder, not a secret -- required by the action's schema, unused when ANTHROPIC_BASE_URL is set. See doc §14.1.
           anthropic_api_key: "sk-ant-dummy-gateway-key"
           # Which bot identity's prior comments count as "ours". Sourced from
           # BOT_LOGIN (workflow env); update there. See doc §11, §15.
@@ -318,17 +316,12 @@ jobs:
           # an OIDC (id-token:write) request. All PR writes go through the App
           # token in the post job, not this token.
           github_token: ${{ github.token }}
-          # CRITICAL -- pairs with persist-credentials:false on the checkout. A
-          # sentinel that no real GitHub username can match flips the action's
-          # configureGitAuth() onto its credential-helper branch, so the token
-          # is NOT embedded in .git/config (where the Read tool could dump it).
-          # The actor-permission bypass tied to this list can't fire (no real
-          # user equals the sentinel). Do NOT use use_commit_signing for the
-          # same effect -- it registers a token-bearing MCP server. Adding any
-          # mcp__github_* tool or use_commit_signing re-introduces a
-          # token-bearing subprocess; re-audit first. On a claude-code-action
-          # SHA bump, re-verify the credential-helper branch still holds. Full
-          # threat model and action-bump checklist in doc §8, §15.
+          # CRITICAL -- pairs with persist-credentials:false. A non-matching
+          # sentinel forces the credential-helper git-auth path so the token
+          # is NOT embedded in .git/config. Do NOT switch to use_commit_signing
+          # or add mcp__github_* tools (both re-introduce a token-bearing
+          # process). On a claude-code-action SHA bump, re-verify the
+          # credential-helper branch still holds. See doc §8, §15.
           allowed_non_write_users: '__never_match__'
           # Log every tool call / permission denial. Off by default; on for
           # workflow_dispatch debug=true to diagnose error_max_turns. Safe --
@@ -440,22 +433,45 @@ jobs:
             step output -- if you produce anything else, the action fails the run.
 
               {
-                "summary": "...",
+                "verdict": "APPROVE",
+                "summary": "...Markdown body...",
                 "inline_comments": [
-                  { "path": "...", "line": N, "side": "RIGHT",
-                    "severity": "Critical|Major|Minor", "body": "...",
+                  { "path": "...", "line": 1, "side": "RIGHT",
+                    "severity": "Major", "body": "...",
                     "suggestion": "...optional verbatim replacement for the single line at `line`..." }
                 ],
                 "thread_updates": [
-                  { "type": "resolve",                "claude_comment_id": N },
-                  { "type": "resolve_with_reaction", "claude_comment_id": N,
-                    "human_reply_id": N },
-                  { "type": "clarify",                "claude_comment_id": N,
+                  { "type": "resolve",                "claude_comment_id": 1 },
+                  { "type": "resolve_with_reaction", "claude_comment_id": 1,
+                    "human_reply_id": 1 },
+                  { "type": "clarify",                "claude_comment_id": 1,
                     "body": "..." }
                 ]
               }
 
+            The example above is a SHAPE template, not the final answer; replace
+            every value with content appropriate to this PR. The legal values for
+            `verdict`, `severity`, and `type` are exhaustively enumerated below
+            (and the `--json-schema` flag rejects anything else). Earlier
+            iterations of this prompt used `"foo" | "bar" | "baz"` shorthand
+            inside the example, which is NOT valid JSON -- a model that copied
+            it verbatim would fail schema validation and the run would abort
+            with no review posted.
+
             For initial reviews (N == 0): thread_updates is [].
+
+            `verdict` is your honest assessment (`APPROVE` /
+            `REQUEST_CHANGES` / `COMMENT`). The post job submits every
+            verdict as `--comment` (advisory; the body header shows
+            your verdict). **Emit the honest verdict; do NOT downgrade.**
+            Full decision rule: see the `/review-rocmlir-pr` skill.
+
+            `summary` is the Markdown body of the formal review (the post
+            job prepends a one-line header with verdict + finding counts;
+            everything else is `summary`). Use `## Scope` / `## Findings`
+            / `## Notes` / `## CI status` sections; target ~2000 chars;
+            do NOT restate individual findings or print "Verdict: ..." in
+            the body. Full layout in the `/review-rocmlir-pr` skill.
 
             `inline_comments[].side` MUST be the literal string "RIGHT". The
             schema's enum is ["RIGHT"] only -- emitting "LEFT" (or anything
@@ -574,7 +590,7 @@ jobs:
           claude_args: |
             --allowedTools "Skill,Read,Grep,Glob"
             --max-turns 30
-            --json-schema '{"type":"object","required":["summary","inline_comments","thread_updates"],"properties":{"summary":{"type":"string"},"inline_comments":{"type":"array","items":{"type":"object","required":["path","line","side","severity","body"],"properties":{"path":{"type":"string","minLength":1},"line":{"type":"integer","minimum":1},"side":{"type":"string","enum":["RIGHT"]},"severity":{"type":"string","enum":["Critical","Major","Minor"]},"body":{"type":"string","minLength":1},"suggestion":{"type":"string","minLength":1,"pattern":"^[^\\r\\n]*$"}}}},"thread_updates":{"type":"array","items":{"type":"object","required":["type","claude_comment_id"],"properties":{"type":{"type":"string","enum":["resolve","resolve_with_reaction","clarify"]},"claude_comment_id":{"type":"integer"},"human_reply_id":{"type":"integer"},"body":{"type":"string"}}}}}}'
+            --json-schema '{"type":"object","required":["verdict","summary","inline_comments","thread_updates"],"properties":{"verdict":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","COMMENT"]},"summary":{"type":"string","minLength":1},"inline_comments":{"type":"array","items":{"type":"object","required":["path","line","side","severity","body"],"properties":{"path":{"type":"string","minLength":1},"line":{"type":"integer","minimum":1},"side":{"type":"string","enum":["RIGHT"]},"severity":{"type":"string","enum":["Critical","Major","Minor"]},"body":{"type":"string","minLength":1},"suggestion":{"type":"string","minLength":1,"pattern":"^[^\\r\\n]*$"}}}},"thread_updates":{"type":"array","items":{"type":"object","required":["type","claude_comment_id"],"properties":{"type":{"type":"string","enum":["resolve","resolve_with_reaction","clarify"]},"claude_comment_id":{"type":"integer"},"human_reply_id":{"type":"integer"},"body":{"type":"string"}}}}}}'
           settings: |
             {
               "hasCompletedOnboarding": true
@@ -665,7 +681,7 @@ jobs:
           client-id: ${{ vars.ROCMLIR_PR_REVIEWER_APP_ID }}
           private-key: ${{ secrets.ROCMLIR_PR_REVIEWER_PRIVATE_KEY }}
 
-      - name: Post inline comments, thread updates, and summary
+      - name: Post inline comments, thread updates, and submit review
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ env.PR_NUMBER }}

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -282,6 +282,31 @@ jobs:
           jq -s 'add // []' /tmp/pr/prev_comments.raw.json \
             > /tmp/pr/prev_comments.json
           rm /tmp/pr/prev_comments.raw.json
+
+          # Stash `is_re_review` on meta.json so the post job can pick the
+          # correct `Findings:` vs `New findings:` body-header label without
+          # depending on `thread_updates.length > 0`. That heuristic misses
+          # the steady state of an unfixed PR: on a re-run where every
+          # prior thread is dedup-gated (Scenario D non-regression -- still
+          # present, no new human reply, last bot reply was clarify/null;
+          # plus Scenarios A/B/C suppressed by their respective dedup
+          # gates) the model emits inline_comments == [] AND thread_updates
+          # == [], which the heuristic would label as `Findings: 0` and
+          # invite a maintainer to misread it as "the PR was always clean"
+          # -- exactly what the New-findings: switch is meant to prevent.
+          # The filter must match the prompt's Step 1 exactly (BOT_LOGIN +
+          # marker + root-comment), so a future change to either has to
+          # update both. The marker literal mirrors MARKER in
+          # post_claude_review.sh; see the sync row in doc §15.
+          re_review_count=$(jq --arg bot "$BOT_LOGIN" '
+            [.[] | select(
+              .user.login == $bot
+              and (.body | contains("<!-- claude-pr-review-marker:v1 -->"))
+              and (.in_reply_to_id == null)
+            )] | length' /tmp/pr/prev_comments.json)
+          jq --argjson n "$re_review_count" '.is_re_review = ($n > 0)' \
+            /tmp/pr/meta.json > /tmp/pr/meta.tmp
+          mv /tmp/pr/meta.tmp /tmp/pr/meta.json
           ls -la /tmp/pr/
 
       # The Claude run. LLM gateway secrets are in env (below); the action also


### PR DESCRIPTION
## Summary

Switch the bot's overall review from a stand-alone issue comment to a **formal pull-request review** (`gh pr review --comment`) carrying a new `verdict` field (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) plus the Markdown summary.

Every verdict is unconditionally submitted as `--comment` (advisory). This prevents the bot from ever ticking a branch-protection approving-review slot or leaving a sticky `CHANGES_REQUESTED` block (the [`gh-aw#27655`](https://github.com/github/gh-aw/issues/27655) / [PR #27662](https://github.com/github/gh-aw/pull/27662) wedge). The model's verdict is preserved in a computed body header. Full rationale in `CLAUDE_AUTO_REVIEW.md` §13.

Also adds defense-in-depth sanitizer re-checks (`verdict` enum, `summary` non-empty string, every string-typed field really is a string or null) to close a redaction-bypass class where a schema regression could partially leak values via `jq`'s truncated error message.

## Test plan

- [x] Sanitizer fixture suite: **148/148 PASS** (121 → 148, +27 covering verdict / summary / field-type / redaction).
- [x] End-to-end smoke with stubbed `gh`: COMMENT initial, APPROVE re-review with all 3 thread-update types, REQUEST_CHANGES + suggestion fence, bad-verdict defensive arm, 422 soft-skip, 500 hard-failure resilience.
- [x] `shellcheck` clean on the modified scripts.
- [ ] CI: validate on first `claude-review` label after merge.
