### PR TITLE
[AIROCMLIR-668] Add tests for gaps in rocmlir-gen LIT coverage

### DIFF
--- a/mlir/test/rocmlir-driver/populate_padding.mlir
+++ b/mlir/test/rocmlir-driver/populate_padding.mlir
@@ -32,3 +32,12 @@
 // Padding_Two-SAME: Unmerge{32, 256, 20, 17}
 // Padding_Two-SAME: AddDim{1} ["go"]
 // Padding_Two-NEXT: rock.conv([[exp0]], [[exp1]], [[exp2]]) features = {{.*}} {dilations = [1 : index, 1 : index], filter_layout = ["g", "k", "c", "0", "1"], input_layout = ["ni", "gi", "ci", "0i", "1i"], output_layout = ["no", "go", "ko", "0o", "1o"], padding = [3 : index, 3 : index, 1 : index, 2 : index], strides = [1 : index, 1 : index]} : memref<1x256x32x1x1xf32>, memref<32x1x32x14x14xf32>, memref<32x1x256x20x17xf32>
+
+// Asymmetric depth padding for a 3-D backward-data conv: `padding_d_l != padding_d_r`
+// must propagate unchanged. In a `gkc012` layout the spatial dims map to
+// `[0=h, 1=w, 2=d]`, so the padding attribute is `[h_l, h_r, w_l, w_r, d_l, d_r]`
+// and depth-only padding lands in the trailing pair.
+// RUN: rocmlir-gen --arch gfx942 --operation conv_bwd_data -t f32 -fil_layout=gkc012 -in_layout=ngc012 -out_layout=ngk012 -batchsize=2 -groupsize=1 -in_channels=4 -out_channels=4 -in_d=4 -in_h=4 -in_w=4 -fil_d=3 -fil_h=3 -fil_w=3 --conv_stride_d=1 --conv_stride_h=1 --conv_stride_w=1 --dilation_d=1 --dilation_h=1 --dilation_w=1 --padding_d_l=2 --padding_d_r=0 --padding_h=0 --padding_w=0 | FileCheck %s --check-prefix=AsymPaddingD
+// AsymPaddingD-LABEL: func.func @rock_conv_bwd_data_gkc012_ngc012_ngk012
+// AsymPaddingD: rock.conv_bwd_data
+// AsymPaddingD-SAME: padding = [0 : index, 0 : index, 0 : index, 0 : index, 2 : index, 0 : index]

--- a/mlir/test/rocmlir-driver/populate_random_data.mlir
+++ b/mlir/test/rocmlir-driver/populate_random_data.mlir
@@ -59,3 +59,31 @@
 // RAND_FLOAT-NEXT: affine.for
 // RAND_FLOAT-NEXT: %[[val3:.*]] = func.call @randomFloatValue(%[[min]], %[[max]])
 // RAND_FLOAT-NEXT: memref.store %[[val1]]
+
+// `-rand_min_int` / `-rand_max_int` override the [-5, 5) default range for
+// integer randomness. All three GEMM args (A, B, C) should pick up the new
+// bounds: exactly three randomIntegerValue calls, all using the overridden
+// constants, and no float randomization helper anywhere.
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t i8 -out_datatype i32 -g 1 -m 32 -n 32 -k 32 -ph -rand 1 -rand_type int -rand_min_int -3 -rand_max_int 7 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_INT_BOUNDS
+// RAND_INT_BOUNDS-DAG: %[[min:.*]] = arith.constant -3 : i16
+// RAND_INT_BOUNDS-DAG: %[[max:.*]] = arith.constant 7 : i16
+// RAND_INT_BOUNDS-COUNT-3: func.call @randomIntegerValue(%[[min]], %[[max]])
+// RAND_INT_BOUNDS-NOT:     func.call @randomIntegerValue
+// RAND_INT_BOUNDS-NOT: func.func private @randomFloatValue
+
+// `-rand_type_int_for_inputs` selectively forces integer randomness on
+// specific argument indices even when `-rand_type float` is in effect.
+// Listing only index 0 leaves the other two args (B, C) as float random.
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -ph -rand 1 -rand_type float -rand_type_int_for_inputs 0 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_MIXED_ONE
+// RAND_MIXED_ONE-COUNT-1: func.call @randomIntegerValue
+// RAND_MIXED_ONE-NOT:     func.call @randomIntegerValue
+// RAND_MIXED_ONE-COUNT-2: func.call @randomFloatValue
+// RAND_MIXED_ONE-NOT:     func.call @randomFloatValue
+
+// Repeating the flag accumulates indices; with both 0 and 1 forced to int,
+// only the output remains a float-random tensor.
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -ph -rand 1 -rand_type float -rand_type_int_for_inputs 0 -rand_type_int_for_inputs 1 | rocmlir-opt -canonicalize | FileCheck %s --check-prefix=RAND_MIXED_TWO
+// RAND_MIXED_TWO-COUNT-2: func.call @randomIntegerValue
+// RAND_MIXED_TWO-NOT:     func.call @randomIntegerValue
+// RAND_MIXED_TWO-COUNT-1: func.call @randomFloatValue
+// RAND_MIXED_TWO-NOT:     func.call @randomFloatValue

--- a/mlir/test/rocmlir-gen/attention-kernel-f16.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel-f16.mlir
@@ -46,3 +46,14 @@
 // CHECK-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShapeF32]]) -> [[squareShape]]
 // CHECK-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} {acc_type = f32} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf16>, tensor<1xf16>) -> [[squareShape:tensor<.*>]]
 // CHECK: return
+
+// `--softmax_dtype` controls the type used for the softmax intermediate
+// inside `rock.attention`. The default for an f16 input kernel is f32
+// (wider than the operand type for numerical stability); requesting f16
+// collapses the intermediate to the operand type to save footprint.
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 -t f16 | FileCheck %s --check-prefix=SOFTMAX_DEFAULT_F16
+// SOFTMAX_DEFAULT_F16: rock.attention
+// SOFTMAX_DEFAULT_F16: softmaxType = f32
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 -t f16 --softmax_dtype f16 | FileCheck %s --check-prefix=SOFTMAX_F16
+// SOFTMAX_F16: rock.attention
+// SOFTMAX_F16: softmaxType = f16

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -69,3 +69,37 @@
 // CHECK_NO_SCALE-DAG: %[[softmaxTensorCast:.*]] = tosa.cast %[[softmaxTensor]] : ([[squareShape]]) -> [[squareShape]]
 // CHECK_NO_SCALE-DAG: %[[resultTensor:.*]] = tosa.matmul %[[softmaxTensorCast]], %[[valuesTensor:.*]], %{{.*}}, %{{.*}} : ([[squareShape]], [[valuesShape:tensor<.*>]], tensor<1xf32>, tensor<1xf32>) -> [[valuesShape]]
 // CHECK_NO_SCALE: return
+
+// ----
+
+// Per-tensor transpose flags. The baseline (no flag) layout is:
+//   Q in [seq_q, head_qk], K in [head_qk, seq_k],
+//   V in [seq_k, head_v],  O in [seq_q, head_v].
+// `-transQ` / `-transV` flip the trailing two dims of the corresponding
+// operand and surface a `tr` modifier on the matmul; `-transO` flips the
+// output, which surfaces a `tr` modifier on the second-gemm result inside
+// `rock.attention`.
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 128 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 64 -t f16 -transQ | FileCheck %s --enable-var-scope --check-prefix=TRANS_Q
+// TRANS_Q-LABEL: func.func @rock_attention
+// Q (flat 4096) becomes head_qk x seq_q instead of seq_q x head_qk.
+// TRANS_Q: rock.transform %{{.*}} : memref<4096xf16> to memref<1x32x128xf16>
+// TRANS_Q: rock.transform %{{.*}} : memref<8192xf16> to memref<1x32x256xf16>
+// TRANS_Q: rock.transform %{{.*}} : memref<16384xf16> to memref<1x256x64xf16>
+// TRANS_Q: rock.attention
+// TRANS_Q: qk = tr %{{.*}} * %{{.*}} : memref<1x32x128xf16>, memref<1x32x256xf16>
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 128 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 64 -t f16 -transV | FileCheck %s --enable-var-scope --check-prefix=TRANS_V
+// TRANS_V-LABEL: func.func @rock_attention
+// V (flat 16384) becomes head_v x seq_k instead of seq_k x head_v.
+// TRANS_V: rock.transform %{{.*}} : memref<4096xf16> to memref<1x128x32xf16>
+// TRANS_V: rock.transform %{{.*}} : memref<8192xf16> to memref<1x32x256xf16>
+// TRANS_V: rock.transform %{{.*}} : memref<16384xf16> to memref<1x64x256xf16>
+// TRANS_V: rock.attention
+// TRANS_V: softmax(qk) * tr %{{.*}} : memref<1x64x256xf16>
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 128 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 64 -t f16 -transO | FileCheck %s --enable-var-scope --check-prefix=TRANS_O
+// TRANS_O-LABEL: func.func @rock_attention
+// TRANS_O: rock.attention
+// O (flat 8192) becomes head_v x seq_q instead of seq_q x head_v.
+// TRANS_O: tr %{{.*}} = softmax(qk) * %{{.*}} : memref<1x256x64xf16> -> memref<1x64x128xf16>

--- a/mlir/test/rocmlir-gen/conv-bwd-data.mlir
+++ b/mlir/test/rocmlir-gen/conv-bwd-data.mlir
@@ -22,3 +22,36 @@
 
 // MIXED_DTYPE: func.func @rock_conv_bwd_data{{.*}}(%arg0: memref<{{[0-9]+}}xf16>, %arg1: memref<{{[0-9]+}}xf32>, %arg2: memref<{{[0-9]+}}xf16>)
 // MIXED_DTYPE: func.func @conv_bwd_data_cpu(%arg0: memref<{{[0-9]+}}xf16>, %arg1: memref<{{[0-9]+}}xf32>, %arg2: memref<{{[0-9]+}}xf16>)
+
+// Forward conv also accepts mixed (filter, input) -> output dtype combos as
+// long as the filter/input dtypes agree -- the output type can be widened
+// to f32 explicitly via `-out_dtype`.
+// RUN: rocmlir-gen --arch gfx942 --operation conv -p -fil_dtype f16 -in_dtype f16 -out_dtype f32 | FileCheck %s --check-prefix=FWD_F16_F32
+// FWD_F16_F32: func.func @rock_conv{{.*}}(%{{.*}}: memref<{{[0-9]+}}xf16>, %{{.*}}: memref<{{[0-9]+}}xf16>, %{{.*}}: memref<{{[0-9]+}}xf32>)
+// FWD_F16_F32: rock.conv(%{{.*}}, %{{.*}}, %{{.*}})
+// FWD_F16_F32-SAME: memref<{{.*}}xf16>, memref<{{.*}}xf16>, memref<{{.*}}xf32>
+// RUN: rocmlir-gen --arch gfx942 --operation conv -p -fil_dtype bf16 -in_dtype bf16 -out_dtype f32 | FileCheck %s --check-prefix=FWD_BF16_F32
+// FWD_BF16_F32: func.func @rock_conv{{.*}}(%{{.*}}: memref<{{[0-9]+}}xbf16>, %{{.*}}: memref<{{[0-9]+}}xbf16>, %{{.*}}: memref<{{[0-9]+}}xf32>)
+
+// 3-D backward-data: kernel args are ordered (filter, input, output) like the
+// forward kernel; the func returns void. With matching `padding_d/h/w` the
+// padding attribute is `[h_l, h_r, w_l, w_r, d_l, d_r]`.
+// RUN: rocmlir-gen --arch gfx942 --operation conv_bwd_data -t f32 -fil_layout=gkc012 -in_layout=ngc012 -out_layout=ngk012 -batchsize=2 -groupsize=1 -in_channels=4 -out_channels=4 -in_d=4 -in_h=4 -in_w=4 -fil_d=3 -fil_h=3 -fil_w=3 --conv_stride_d=1 --conv_stride_h=1 --conv_stride_w=1 --dilation_d=1 --dilation_h=1 --dilation_w=1 --padding_d=1 --padding_h=1 --padding_w=1 | FileCheck %s --check-prefix=BWD_DATA_3D
+// BWD_DATA_3D-LABEL: func.func @rock_conv_bwd_data_gkc012_ngc012_ngk012
+// BWD_DATA_3D-SAME: (%[[fil:.*]]: memref<432xf32>, %[[in:.*]]: memref<512xf32>, %[[out:.*]]: memref<512xf32>)
+// BWD_DATA_3D: rock.transform %[[fil]] {{.*}} : memref<432xf32> to memref<1x4x4x3x3x3xf32>
+// BWD_DATA_3D: rock.transform %[[in]] {{.*}} : memref<512xf32> to memref<2x1x4x4x4x4xf32>
+// BWD_DATA_3D: rock.conv_bwd_data
+// BWD_DATA_3D-SAME: filter_layout = ["g", "k", "c", "0", "1", "2"]
+// BWD_DATA_3D-SAME: input_layout = ["ni", "gi", "ci", "0i", "1i", "2i"]
+// BWD_DATA_3D-SAME: output_layout = ["no", "go", "ko", "0o", "1o", "2o"]
+// BWD_DATA_3D-SAME: padding = [1 : index, 1 : index, 1 : index, 1 : index, 1 : index, 1 : index]
+// BWD_DATA_3D-SAME: strides = [1 : index, 1 : index, 1 : index]
+
+// 3-D backward-weight: kernel args are ordered (filter, input, output) like the
+// other conv kernels; the func returns void.
+// RUN: rocmlir-gen --arch gfx942 --operation conv_bwd_weight -t f32 -fil_layout=gkc012 -in_layout=ngc012 -out_layout=ngk012 -batchsize=2 -groupsize=1 -in_channels=4 -out_channels=4 -in_d=4 -in_h=4 -in_w=4 -fil_d=3 -fil_h=3 -fil_w=3 --conv_stride_d=1 --conv_stride_h=1 --conv_stride_w=1 --dilation_d=1 --dilation_h=1 --dilation_w=1 --padding_d=1 --padding_h=1 --padding_w=1 | FileCheck %s --check-prefix=BWD_WEIGHT_3D
+// BWD_WEIGHT_3D-LABEL: func.func @rock_conv_bwd_weight_gkc012_ngc012_ngk012
+// BWD_WEIGHT_3D-SAME: (%[[fil:.*]]: memref<432xf32>, %[[in:.*]]: memref<512xf32>, %[[out:.*]]: memref<512xf32>)
+// BWD_WEIGHT_3D: rock.conv_bwd_weight
+// BWD_WEIGHT_3D-SAME: padding = [1 : index, 1 : index, 1 : index, 1 : index, 1 : index, 1 : index]

--- a/mlir/test/rocmlir-gen/gemm-misc-options.mlir
+++ b/mlir/test/rocmlir-gen/gemm-misc-options.mlir
@@ -14,3 +14,53 @@
 // CONVOCPFP8_GFX950: amdgcn-amd-amdhsa:gfx950   {{.*}}     convfp8_fp8 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
 // RUN: rocmlir-gen --arch gfx942 --operation gemm -p --num_cu 40 --num_chiplets 20 | FileCheck %s --check-prefix=NUM_CHIPLETS
 // NUM_CHIPLETS: rock.num_chiplets = 20 : i64, rock.num_cu = 40 : i64
+
+// `--emit-tuning-key` for backward-data / backward-weight: same conv key
+// payload but with `-F 2` / `-F 4` instead of `-F 1`.
+// RUN: rocmlir-gen --arch gfx942 --operation conv_bwd_data -p -t f32 --emit-tuning-key | FileCheck %s --check-prefix=BWD_DATA_KEY
+// BWD_DATA_KEY: amdgcn-amd-amdhsa:gfx942   {{.*}}     conv -F 2 -f GNC01 -I NGC01 -O NGC01 -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
+// RUN: rocmlir-gen --arch gfx942 --operation conv_bwd_weight -p -t f32 --emit-tuning-key | FileCheck %s --check-prefix=BWD_WRW_KEY
+// BWD_WRW_KEY: amdgcn-amd-amdhsa:gfx942   {{.*}}     conv -F 4 -f GNC01 -I NGC01 -O NGC01 -n 128 -c 8 -H 32 -W 32 -k 128 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1
+
+// `-pi` (`--print-inputs`) prints every input tensor of the host harness
+// (all kernel args except the output). For a 3-arg GEMM that is A and B,
+// emitted as two `printMemrefF32` calls. `-pr` and `-pvr` are already
+// covered by populate_host_print*.mlir and the fusion E2E tests.
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -ph -pi | FileCheck %s --check-prefix=PRINT_INPUTS
+// PRINT_INPUTS-LABEL: func.func @main()
+// PRINT_INPUTS-COUNT-2: call @printMemrefF32
+// PRINT_INPUTS-NOT: call @printMemrefF32
+
+// `--print-verify-results=<level>` is forwarded to `mcpuVerifyFloat` as the
+// trailing `i8` constant in the call argument list (off=0, summary=1,
+// failure=2, always=3). Summary is the default.
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -pv | FileCheck %s --check-prefix=VERIFY_SUMMARY
+// VERIFY_SUMMARY: %[[lvl:.*]] = arith.constant 1 : i8
+// VERIFY_SUMMARY: call @mcpuVerifyFloat({{.*}}, %[[lvl]], %{{.*}}) : (memref<?xf32>, memref<?xf32>, f32, f32, f32, i8, i1, i1) -> ()
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -pv --print-verify-results=always | FileCheck %s --check-prefix=VERIFY_ALWAYS
+// VERIFY_ALWAYS: %[[lvl:.*]] = arith.constant 3 : i8
+// VERIFY_ALWAYS: call @mcpuVerifyFloat({{.*}}, %[[lvl]], %{{.*}}) : (memref<?xf32>, memref<?xf32>, f32, f32, f32, i8, i1, i1) -> ()
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -pv --print-verify-results=off | FileCheck %s --check-prefix=VERIFY_OFF
+// VERIFY_OFF: %[[lvl:.*]] = arith.constant 0 : i8
+// VERIFY_OFF: call @mcpuVerifyFloat({{.*}}, %[[lvl]], %{{.*}}) : (memref<?xf32>, memref<?xf32>, f32, f32, f32, i8, i1, i1) -> ()
+// Same flag for integer kernels. With an i32 output and an i64 CPU reference
+// the verifier helper is `mcpuVerifyInt32Int64`.
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t i8 -out_datatype i32 -g 1 -m 32 -n 32 -k 32 -pv --print-verify-results=failure | FileCheck %s --check-prefix=VERIFY_INT
+// VERIFY_INT: %[[lvl:.*]] = arith.constant 2 : i8
+// VERIFY_INT: call @mcpuVerifyInt32Int64({{.*}}, %[[lvl]]) : (memref<?xi32>, memref<?xi64>, i8) -> ()
+
+// `--device <N>` (and its `-dev` alias) registers a global constructor that
+// calls `gpu.set_default_device` with the requested device index. The
+// constructor is only emitted when the flag is actually passed.
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -ph | FileCheck %s --check-prefix=NO_DEVICE
+// NO_DEVICE-NOT: llvm.func @setDeviceCtor
+// NO_DEVICE-NOT: gpu.set_default_device
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -ph --device 1 | FileCheck %s --check-prefix=DEVICE_1
+// DEVICE_1: llvm.func @setDeviceCtor()
+// DEVICE_1: %[[idx:.*]] = arith.constant 1 : i32
+// DEVICE_1: gpu.set_default_device %[[idx]]
+// DEVICE_1: llvm.mlir.global_ctors ctors = [@setDeviceCtor], priorities = [122 : i32], data = [#llvm.zero]
+// RUN: rocmlir-gen --arch gfx942 --operation gemm -t f32 -g 1 -m 32 -n 32 -k 32 -ph -dev 2 | FileCheck %s --check-prefix=DEVICE_2
+// DEVICE_2: llvm.func @setDeviceCtor()
+// DEVICE_2: %[[idx:.*]] = arith.constant 2 : i32
+// DEVICE_2: gpu.set_default_device %[[idx]]

--- a/mlir/test/rocmlir-gen/options.mlir
+++ b/mlir/test/rocmlir-gen/options.mlir
@@ -1,2 +1,45 @@
+// Negative tests for rocmlir-gen command-line option validation.
+
+// --kernel-repeats only valid with -ph or -pv.
 // RUN: not rocmlir-gen -operation gemm -t f32 -out_datatype f32 --arch %arch -g 1 -m 1024 -k 1024 -n 1024 -transA=False -transB=False --kernel-repeats=100 2>&1 | FileCheck %s --check-prefix=ERR_KERNEL_REPEATS
 // ERR_KERNEL_REPEATS: --kernel-repeats is only supported with host harness (-ph) or CPU validation (-pv).
+
+// --verifier=cpp is not implemented for any of the in-tree operations.
+// RUN: not rocmlir-gen --arch %arch --operation gemm -t f32 -g 1 -m 64 -k 64 -n 64 -ph --verifier=cpp 2>&1 | FileCheck %s --check-prefix=ERR_CPP_GEMM
+// ERR_CPP_GEMM: External gemm validator is not available
+
+// RUN: not rocmlir-gen --arch %arch --operation attention -t f16 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 -ph --verifier=cpp 2>&1 | FileCheck %s --check-prefix=ERR_CPP_ATTN
+// ERR_CPP_ATTN: External attention validator is not available
+
+// --verifier=clone is only valid when wrapping an existing input module.
+// RUN: not rocmlir-gen --arch %arch --operation gemm -t f32 -g 1 -m 64 -k 64 -n 64 --verifier=clone 2>&1 | FileCheck %s --check-prefix=ERR_CLONE_NO_INPUT
+// ERR_CLONE_NO_INPUT: Clone validation is not compatible with kernel generation.
+
+// --arch is mandatory; the driver must reject runs that omit it.
+// RUN: not rocmlir-gen --operation gemm -t f32 -g 1 -m 64 -k 64 -n 64 2>&1 | FileCheck %s --check-prefix=ERR_NO_ARCH
+// ERR_NO_ARCH: --arch is not set
+
+// GEMM requires -g, -m, -k, -n. The detector walks {groupsize, m, k, n} in
+// order; groupsize defaults to 1 so it passes the <=0 check, leaving `m` as
+// the first missing arg the diagnostic reports.
+// RUN: not rocmlir-gen --arch %arch --operation gemm -t f32 2>&1 | FileCheck %s --check-prefix=ERR_GEMM_MISSING
+// ERR_GEMM_MISSING: Value for: m not specified
+
+// Mixed input/filter dtypes require an explicit output dtype.
+// RUN: not rocmlir-gen --arch %arch -p -fil_dtype f16 -in_dtype f32 2>&1 | FileCheck %s --check-prefix=ERR_MIXED_DTYPE
+// ERR_MIXED_DTYPE: Missing output type for mixed input types
+
+// Flash-decoding (split_kv > 1) needs return_lse; otherwise the driver bails out.
+// RUN: not rocmlir-gen --arch %arch --operation attention -t f16 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 -split_kv 2 2>&1 | FileCheck %s --check-prefix=ERR_SPLITKV
+// ERR_SPLITKV: If split-kv > 1 (flash decoding), we need to return LSE
+
+// Attention, gemm+gemm, and conv+gemm pipelines require -t (dataTypeAlias).
+// RUN: not rocmlir-gen --arch %arch --operation attention -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 2>&1 | FileCheck %s --check-prefix=ERR_NO_DTYPE
+// ERR_NO_DTYPE: Type of the attention/gemm+gemm/conv+gemm operation is not specified
+
+// Passing both `padding_h` and `padding_h_l/r` with mismatched values logs a
+// warning. rocmlir-gen does not abort so we just match the diagnostic on stderr.
+// RUN: rocmlir-gen --arch %arch -p -padding_h 2 -padding_h_l 1 2>&1 | FileCheck %s --check-prefix=WARN_PADDING_H
+// WARN_PADDING_H: you can't use both padding_h and (padding_h_l,padding_h_r).
+// RUN: rocmlir-gen --arch %arch -p -padding_w 2 -padding_w_r 1 2>&1 | FileCheck %s --check-prefix=WARN_PADDING_W
+// WARN_PADDING_W: you can't use both padding_w and (padding_w_l,padding_w_r).


### PR DESCRIPTION
## Motivation

This is a port of https://github.com/ROCm/rocmlirTriton/pull/250 from rocmlirTriton.

This PR adds tests for existing rocmlir-gen features that were missing direct test coverage in our LIT tests.

## Technical Details

The following is a list of what changed relative to the rocmlirTriton version:
* Removed LIT tests for features that don't exist in rocMLIR
    * `--cpu-timers
* Updated verifier ABI differences (`gemm-misc-options.mlir`)
    * `mcpuVerifyFloat` in rocMLIR takes two trailing `i1` args, so the expected signature is now `(memref<?xf32>, memref<?xf32>, f32, f32, f32, i8, i1, i1)`
  instead of `(..., i8, i1)`
    * The integer verifier helper is `mcpuVerifyInt32Int64` with an `i64` reference operand `(memref<?xi32>, memref<?xi64>, i8)`, not `mcpuVerifyInt32Int32` / `memref<?xi32>`.
* Updated conv kernel signature & op syntax (`conv-bwd-data.mlir`)
* Updated attention output transpose (`attention-kernel.mlir`)
    * `-transO` surfaces a `tr` prefix on the second-gemm result inside `rock.attention` (`tr %N = softmax(qk) * %M : ... -> memref<1x64x128xf16>`), not an `oTransposed` attribute.

## Test Plan

* Run the PR CI

## Test Result

* [x] Passing PR CI: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2392/1/pipeline-overview/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
