### PR TITLE
[DRAFT/TEST] Validate cpp-static-checks workflow on benign file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
           # Option X: build upstream mlir-headers + mhal 3 orphans + our 7 orphans.
           # We measure wall time so we can decide if Option X is acceptable vs.
           # Option Y (--ignore-external flag + just our 7 orphans).
-          /usr/bin/time -v cmake --build build --target \
+          # NB: /usr/bin/time is not installed in rocm/mlir container, so we use
+          # `date +%s` for plain wall-clock measurement.
+          T_START=$(date +%s)
+          cmake --build build --target \
             mlir-headers \
             MHALConversionPassIncGen \
             MLIRMHALAttrDefsIncGen \
@@ -134,7 +137,10 @@ jobs:
             RocMLIRConversionPassIncGen \
             MLIRMIGraphXTypeIncGen \
             MLIRMIGraphXPassIncGen \
-            2>&1 | tail -100
+            2>&1 | tail -200
+          T_END=$(date +%s)
+          echo "==================== TIMING RESULT ===================="
+          echo "Option X TableGen build wall time: $((T_END - T_START)) seconds"
           echo "==================== TIMING: post-build .inc inventory ===================="
           echo "Total .h.inc count:    $(find build -name '*.h.inc' 2>/dev/null | wc -l)"
           echo "Total .cpp.inc count:  $(find build -name '*.cpp.inc' 2>/dev/null | wc -l)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
             -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
             -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
             -DMLIR_ENABLE_ROCM_RUNNER=1 \
@@ -112,6 +113,35 @@ jobs:
           fi
 
           ln -sf build/compile_commands.json compile_commands.json
+
+      - name: Build all TableGen targets (Option X timing test)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          echo "==================== TIMING: full TableGen build ===================="
+          # Option X: build upstream mlir-headers + mhal 3 orphans + our 7 orphans.
+          # We measure wall time so we can decide if Option X is acceptable vs.
+          # Option Y (--ignore-external flag + just our 7 orphans).
+          /usr/bin/time -v cmake --build build --target \
+            mlir-headers \
+            MHALConversionPassIncGen \
+            MLIRMHALAttrDefsIncGen \
+            MLIRMHALPassIncGen \
+            MLIRRockAttrDefsIncGen \
+            MLIRRockTuningParamAttrInterfaceIncGen \
+            MLIRRockAccelTuningParamAttrInterfaceIncGen \
+            MLIRRockPassIncGen \
+            RocMLIRConversionPassIncGen \
+            MLIRMIGraphXTypeIncGen \
+            MLIRMIGraphXPassIncGen \
+            2>&1 | tail -100
+          echo "==================== TIMING: post-build .inc inventory ===================="
+          echo "Total .h.inc count:    $(find build -name '*.h.inc' 2>/dev/null | wc -l)"
+          echo "Total .cpp.inc count:  $(find build -name '*.cpp.inc' 2>/dev/null | wc -l)"
+          echo "BuiltinLocationAttributes.h.inc present?"
+          ls -la build/external/llvm-project/llvm/tools/mlir/include/mlir/IR/BuiltinLocationAttributes.h.inc 2>&1 || true
+          echo "Our Rock .inc files present?"
+          find build -path '*Rock*' -name '*.inc' 2>/dev/null | head -20
 
       - name: Run premerge static checks (format + tidy)
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Run premerge static checks (format + tidy)
         shell: bash
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           export PATH="/opt/rocm/llvm/bin:$PATH"
 
           # premerge-checks.py invokes `git-clang-format`; ensure it's on PATH.
@@ -128,6 +128,33 @@ jobs:
           fi
           chmod +x "$git_clang_format"
           export PATH="$GITHUB_WORKSPACE/external/llvm-project/clang/tools/clang-format:$PATH"
+
+          echo "==================== DEBUG: pre-lint environment ===================="
+          echo "--- base ref ---"
+          echo "${{ steps.base.outputs.ref }}"
+          echo "--- HEAD ---"
+          git rev-parse HEAD
+          git log -1 --format='%H %s'
+          echo "--- git diff --name-only vs base ---"
+          git diff --name-only "${{ steps.base.outputs.ref }}" || true
+          echo "--- git diff --stat vs base ---"
+          git diff --stat "${{ steps.base.outputs.ref }}" || true
+          echo "--- full git diff vs base ---"
+          git diff "${{ steps.base.outputs.ref }}" || true
+          echo "--- build/ top-level ---"
+          ls -la build/ 2>&1 | head -40 || echo "no build dir"
+          echo "--- compile_commands.json size ---"
+          wc -l compile_commands.json 2>&1 || true
+          wc -l build/compile_commands.json 2>&1 || true
+          echo "--- entry for rocmlir-opt.cpp in compile_commands ---"
+          grep -A1 'rocmlir-opt.cpp' compile_commands.json 2>&1 | head -20 || true
+          echo "--- BuiltinLocationAttributes .inc files anywhere in build/ ---"
+          find build -name 'BuiltinLocationAttributes*' 2>&1 | head -20 || true
+          echo "--- Count of .h.inc files in build/ ---"
+          find build -name '*.h.inc' 2>/dev/null | wc -l || true
+          echo "--- Sample of generated .h.inc files (first 10) ---"
+          find build -name '*.h.inc' 2>/dev/null | head -10 || true
+          echo "==================== END DEBUG ===================="
 
           python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py \
             --base-commit="${{ steps.base.outputs.ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,18 +118,13 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          echo "==================== TIMING: full TableGen build ===================="
-          # Option X: build upstream mlir-headers + mhal 3 orphans + our 7 orphans.
-          # We measure wall time so we can decide if Option X is acceptable vs.
-          # Option Y (--ignore-external flag + just our 7 orphans).
-          # NB: /usr/bin/time is not installed in rocm/mlir container, so we use
-          # `date +%s` for plain wall-clock measurement.
+          echo "==================== TIMING: our 7 orphan TableGen targets ===================="
+          # Option Y: build ONLY our 7 rocMLIR orphan TableGen targets.
+          # External/upstream and mhal generated headers are not built; the
+          # resulting clang-tidy errors in those headers are filtered out by
+          # the --ignore-external flag passed below.
           T_START=$(date +%s)
           cmake --build build --target \
-            mlir-headers \
-            MHALConversionPassIncGen \
-            MLIRMHALAttrDefsIncGen \
-            MLIRMHALPassIncGen \
             MLIRRockAttrDefsIncGen \
             MLIRRockTuningParamAttrInterfaceIncGen \
             MLIRRockAccelTuningParamAttrInterfaceIncGen \
@@ -140,7 +135,7 @@ jobs:
             2>&1 | tail -200
           T_END=$(date +%s)
           echo "==================== TIMING RESULT ===================="
-          echo "Option X TableGen build wall time: $((T_END - T_START)) seconds"
+          echo "Option Y TableGen build wall time: $((T_END - T_START)) seconds"
           echo "==================== TIMING: post-build .inc inventory ===================="
           echo "Total .h.inc count:    $(find build -name '*.h.inc' 2>/dev/null | wc -l)"
           echo "Total .cpp.inc count:  $(find build -name '*.cpp.inc' 2>/dev/null | wc -l)"
@@ -193,7 +188,8 @@ jobs:
           echo "==================== END DEBUG ===================="
 
           python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py \
-            --base-commit="${{ steps.base.outputs.ref }}"
+            --base-commit="${{ steps.base.outputs.ref }}" \
+            --ignore-external
 
   format-and-lint-checks:
     name: Python format and lint checks

--- a/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
+++ b/mlir/lib/Dialect/Rock/IR/AmdArchDb.cpp
@@ -39,6 +39,8 @@
 using namespace mlir;
 using namespace mlir::rock;
 
+int unused_rock_test_variable = 99;
+
 static constexpr AmdArchInfo
     gcnInfo(GemmFeatures::none, /*waveSize=*/64,
             /*maxWavesPerEU*/ 10, /*totalSGPRPerEU*/ 512,

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -88,6 +88,7 @@ static bool testReduceFusible(MlirContext ctx) {
 }
 int main(int argc, char *argv[]) {
   // Create MLIR context and register dialects
+  int unused_test_variable =  42;
   MlirContext ctx = mlirContextCreate();
   MlirDialectRegistry registry = mlirDialectRegistryCreate();
   mlirRegisterRocMLIRDialects(registry);

--- a/mlir/test/CAPI/reduce_fusible.cpp
+++ b/mlir/test/CAPI/reduce_fusible.cpp
@@ -88,7 +88,6 @@ static bool testReduceFusible(MlirContext ctx) {
 }
 int main(int argc, char *argv[]) {
   // Create MLIR context and register dialects
-  int unused_test_variable =  42;
   MlirContext ctx = mlirContextCreate();
   MlirDialectRegistry registry = mlirDialectRegistryCreate();
   mlirRegisterRocMLIRDialects(registry);

--- a/mlir/tools/rocmlir-opt/rocmlir-opt.cpp
+++ b/mlir/tools/rocmlir-opt/rocmlir-opt.cpp
@@ -17,7 +17,7 @@
 
 using namespace mlir;
 
-int unused_test_variable =  42;
+int unused_test_variable = 42;
 
 // In test directory, no header file
 namespace mlir {

--- a/mlir/tools/rocmlir-opt/rocmlir-opt.cpp
+++ b/mlir/tools/rocmlir-opt/rocmlir-opt.cpp
@@ -17,6 +17,8 @@
 
 using namespace mlir;
 
+int unused_test_variable =  42;
+
 // In test directory, no header file
 namespace mlir {
 void registerSideEffectTestPasses();

--- a/mlir/utils/jenkins/static-checks/premerge-checks.py
+++ b/mlir/utils/jenkins/static-checks/premerge-checks.py
@@ -31,10 +31,13 @@ def get_diff(base_commit, ignore_external_files: bool) -> Tuple[bool, str]:
     command = f"git-clang-format --diff {base_commit}"
     if ignore_external_files:
         command = f"git-clang-format --diff {base_commit} $(git diff --name-only {base_commit} | grep -v '^external/')"
+    print(f"[DEBUG] git-clang-format command: {command}", flush=True)
     diff_run = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     is_diff_run_succesful = diff_run.returncode <= 1
     diff = diff_run.stdout.decode()
-    print(diff)
+    print(f"[DEBUG] git-clang-format returncode: {diff_run.returncode}", flush=True)
+    print(f"[DEBUG] git-clang-format stderr:\n{diff_run.stderr.decode()}", flush=True)
+    print(f"[DEBUG] git-clang-format stdout (the diff):\n{diff}", flush=True)
     return is_diff_run_succesful, diff
 
 
@@ -121,16 +124,22 @@ def run_clang_tidy(base_commit, ignore_config, ignore_external_files: bool = Fal
     else:
         ignore = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, [])
     cpu_count = multiprocessing.cpu_count()
-    p = subprocess.Popen([
+    cmd = [
         './external/llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py', '-p0',
-        '-quiet', '-j',
-        str(cpu_count), '-extra-arg=-std=c++17'
-    ],
+        '-j', str(cpu_count), '-extra-arg=-std=c++17'
+    ]
+    print(f"[DEBUG] clang-tidy-diff command: {cmd}", flush=True)
+    p = subprocess.Popen(cmd,
                          stdout=subprocess.PIPE,
                          stdin=subprocess.PIPE,
                          stderr=subprocess.PIPE)
     a = ''.join(diff)
-    out = p.communicate(input=a.encode())[0].decode()
+    print(f"[DEBUG] diff piped to clang-tidy-diff (len={len(a)}):\n{a}", flush=True)
+    out_bytes, err_bytes = p.communicate(input=a.encode())
+    out = out_bytes.decode()
+    print(f"[DEBUG] clang-tidy-diff returncode: {p.returncode}", flush=True)
+    print(f"[DEBUG] clang-tidy-diff stderr:\n{err_bytes.decode()}", flush=True)
+    print(f"[DEBUG] clang-tidy-diff RAW stdout (pre-filter):\n{out}", flush=True)
     # Typical finding looks like:
     # [cwd/]clang/include/clang/AST/DeclCXX.h:3058:20: error: ... [clang-diagnostic-error]
     pattern = '^([^:]*):(\\d+):(\\d+): (.*): (.*)'
@@ -167,6 +176,7 @@ def run_clang_tidy(base_commit, ignore_config, ignore_external_files: bool = Fal
                     print('clang-tidy found error:', line)
                     errors_count += 1
 
+    print(f"[DEBUG] final tally: errors_count={errors_count}, warn_count={warn_count}", flush=True)
     if errors_count + warn_count != 0:
         print('clang-tidy found {} errors and {} warnings.'.format(errors_count, warn_count))
 


### PR DESCRIPTION
## Purpose

Empirically validate that the new GitHub Actions `cpp-static-checks` job (introduced by #2356) actually reports findings when given a normal, non-broken C++ file. Decouples this question from the separate `.inc` files missing during clang-tidy parse issue observed on #2310.

## What this PR does

Adds one intentionally bad line in `mlir/test/CAPI/reduce_fusible.cpp`:

```cpp
int unused_test_variable =  42;
```

That single line triggers **three** independent linter findings:

| Tool | Finding | Why |
|---|---|---|
| `clang-format` | Double space after `=` | LLVM style |
| `clang-tidy` (`readability-identifier-naming.VariableCase`) | `unused_test_variable` is snake_case, config expects `camelBack` | `.clang-tidy` config |
| `clang-tidy` (`clang-diagnostic-unused-variable`) | Variable declared but never used | clang default warnings |

## Why this file specifically

`mlir/test/CAPI/reduce_fusible.cpp` includes only `mlir-c/` C API headers (`mlir-c/Dialect/Rock.h`, `mlir-c/RegisterRocMLIR.h`) plus `<iostream>` and `<string>`. The `mlir-c/` headers do **not** transitively pull in upstream MLIR core (`mlir/IR/Location.h` and friends), so this translation unit does not depend on TableGen-generated `.inc` files like `BuiltinLocationAttributes.h.inc`.

This means clang-tidy should be able to fully parse and analyse it even though no build step runs before linting in the workflow. Any failure here would be a workflow problem, not a missing-build-artifacts problem.

## Expected outcome

`C/C++ premerge checks` should **fail red** with three findings on the line shown above. If it instead passes green or fails with `BuiltinLocationAttributes.h.inc not found`, that tells us something different is broken and informs the next step (build step vs. `--ignore-external` vs. CMake target hookup).

## Not for merge

This is a draft solely for CI observation. Once we read the actual workflow output and decide on the right follow-up (build step in GHA, hooking our orphan TableGen targets into `mlir-headers`, or restoring `--ignore-external`), this branch will be deleted.

Signed-off-by: bogdan-petkovic <bpetkovi@amd.com>

Made with [Cursor](https://cursor.com)