### PR TITLE
Fix cpp-static-checks: build TableGen headers before clang-tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,7 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/external/llvm-project/clang/tools/clang-format:$PATH"
 
           python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py \
-            --base-commit="${{ steps.base.outputs.ref }}" \
-            --ignore-external
+            --base-commit="${{ steps.base.outputs.ref }}"
 
   format-and-lint-checks:
     name: Python format and lint checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
             -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
             -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
             -DMLIR_ENABLE_ROCM_RUNNER=1 \
@@ -112,6 +113,28 @@ jobs:
           fi
 
           ln -sf build/compile_commands.json compile_commands.json
+
+      - name: Build TableGen-generated headers
+        shell: bash
+        run: |
+          set -euo pipefail
+          # mlir-headers covers upstream MLIR + everything chained into it.
+          # The targets below are mlir-hal and rocMLIR orphan tablegen
+          # targets not hooked into mlir-headers. Any new orphan
+          # add_public_tablegen_target() declared in this repo must be
+          # added to the list below.
+          cmake --build build --target \
+            mlir-headers \
+            MHALConversionPassIncGen \
+            MLIRMHALAttrDefsIncGen \
+            MLIRMHALPassIncGen \
+            MLIRRockAttrDefsIncGen \
+            MLIRRockTuningParamAttrInterfaceIncGen \
+            MLIRRockAccelTuningParamAttrInterfaceIncGen \
+            MLIRRockPassIncGen \
+            RocMLIRConversionPassIncGen \
+            MLIRMIGraphXTypeIncGen \
+            MLIRMIGraphXPassIncGen
 
       - name: Run premerge static checks (format + tidy)
         shell: bash


### PR DESCRIPTION
## Motivation

After PR #2356 moved the C++ format/tidy premerge checks from Jenkins to GitHub Actions, the lint job stopped working on any PR whose diff transitively reaches a TableGen-generated `*.h.inc` / `*.cpp.inc` (e.g. PR #2310). The Jenkins job ran on a fully built tree where these headers existed; the GHA job only ran `cmake -S` so clang-tidy hit `file not found`.

## Technical Details

- Add a `cmake --build` step that builds `mlir-headers` plus the orphan `add_public_tablegen_target()` declarations from mlir-hal (3) and rocMLIR (7) that are not chained into `mlir-headers`. New orphan targets must be appended to this list.
- Disable precompiled headers on the lint configure to suppress spurious PCH diagnostics.

Adds ~7 minutes to the lint job wall time.

## Test Plan

Re-run the cpp-static-checks job on a known previously-failing PR (#2310).

## Test Result

- [ ] PR CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.