### PR TITLE
[DRAFT/TEST] Validate PR #2398 fix on rocmlir-gen.cpp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,7 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/external/llvm-project/clang/tools/clang-format:$PATH"
 
           python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py \
-            --base-commit="${{ steps.base.outputs.ref }}" \
-            --ignore-external
+            --base-commit="${{ steps.base.outputs.ref }}"
 
   format-and-lint-checks:
     name: Python format and lint checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,17 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Restore source mtimes (so ninja respects cached build artifacts)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # actions/checkout@v4 sets every file mtime to "now", which causes
+          # ninja to treat all cached build outputs as stale. Reset each
+          # file's mtime to the last commit that touched it.
+          apt-get update -qq
+          apt-get install -y -qq git-restore-mtime
+          git restore-mtime
+
       - name: Install Python dependencies for premerge checks
         shell: bash
         run: |
@@ -66,12 +77,17 @@ jobs:
           echo "ref=$BASE_REF" >> "$GITHUB_OUTPUT"
           echo "Base ref: $BASE_REF"
 
-      - name: Cache CMake build directory (compile_commands.json generation)
+      - name: Cache CMake build directory
         uses: actions/cache@v4
         with:
-          path: |
-            build
-          key: cpp-static-checks-${{ runner.os }}-pr${{ github.event.pull_request.number }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'mlir/**/CMakeLists.txt') }}
+          path: build
+          # PR-agnostic key so cache is shared across PRs. Invalidates when
+          # CMakeLists.txt files change (i.e. when the build graph itself
+          # may have changed). Source/.td changes are handled incrementally
+          # by ninja via the restored mtimes.
+          key: cpp-static-checks-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'mlir/**/CMakeLists.txt') }}
+          restore-keys: |
+            cpp-static-checks-${{ runner.os }}-
 
       - name: Generate compile_commands.json (CMake configure)
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,25 @@ jobs:
           #
           #   1) Pre-touch every tracked file to a fixed "old" timestamp.
           #      This provides a stable floor for files that
-          #      git-restore-mtime cannot locate on the first-parent
-          #      line -- most notably the external/llvm-project subtree,
-          #      whose upstream commits enter the history through the
-          #      second parent of subtree merges and are therefore
-          #      invisible to --first-parent (~128k files in our case).
+          #      git-restore-mtime cannot locate -- most notably the
+          #      external/llvm-project subtree, whose upstream commits
+          #      enter the history through the second parent of subtree
+          #      merges and are invisible to --first-parent (~128k
+          #      files), and files modified by other real merge
+          #      commits on develop's first-parent line whose diffs
+          #      are skipped by `git whatchanged` (the underlying
+          #      command used by git-restore-mtime) without `-m`.
           #   2) Run git-restore-mtime --first-parent to set accurate
-          #      per-file last-modified times for everything that *is*
-          #      on the mainline (rocMLIR proper, .github, cmake,
-          #      external/mlir-hal, ...). This includes the source
-          #      files modified in the current PR.
+          #      per-file last-modified times for non-merge develop
+          #      commits.
+          #   3) Force-touch PR-modified files to "now". On pull_request
+          #      events actions/checkout checks out a test-merge ref
+          #      (refs/pull/N/merge) whose first parent is the base
+          #      branch; the PR's own commits sit on the second parent
+          #      line and are therefore invisible to --first-parent.
+          #      Without this step ninja would keep the cached .o for
+          #      every PR-changed source -- including .td files whose
+          #      regenerated .inc headers feed clang-tidy.
           #
           # Net effect: unchanged files (incl. the LLVM subtree) appear
           # older than the cached .o files -> ninja keeps the cache.
@@ -78,6 +87,19 @@ jobs:
           git ls-files -z | xargs -0r touch -d "2000-01-01T00:00:00Z"
           echo "Restoring mtimes for files on the first-parent line..."
           time git restore-mtime --first-parent --skip-missing --quiet
+          echo "Force-touching PR-modified files to 'now' so ninja rebuilds them..."
+          BASE_REF="origin/${{ github.base_ref }}"
+          # Fetch the base branch so the diff base resolves locally.
+          git fetch --quiet origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
+            || git fetch --quiet origin "${{ github.base_ref }}" || true
+          PR_FILES=$(git diff --name-only "$BASE_REF"...HEAD || true)
+          if [[ -n "$PR_FILES" ]]; then
+            echo "$PR_FILES" | wc -l | awk '{print "  PR-modified files: " $1}'
+            # `touch` (no -d) sets mtime to the current wall-clock time.
+            echo "$PR_FILES" | xargs -r touch
+          else
+            echo "  (no PR-modified files detected vs $BASE_REF)"
+          fi
 
       - name: Install Python dependencies for premerge checks
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,23 +46,38 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # actions/checkout@v4 sets every file mtime to "now", which causes
-          # ninja to treat all cached build outputs as stale. Reset each
-          # file's mtime to the last commit that touched it.
+          # actions/checkout@v4 sets every file mtime to "now", which makes
+          # ninja consider every cached build artifact stale. Strategy:
           #
-          # Flags:
-          #   --first-parent : follow only the mainline (skip merged side
-          #                    branches). On a repo with the large
-          #                    external/llvm-project subtree this turns a
-          #                    multi-million-commit traversal into a few-
-          #                    thousand-commit walk (seconds vs. >15 min).
-          #   --skip-missing : tolerate files present in the index but not
-          #                    touched by any first-parent commit (e.g.
-          #                    submodule-tracked content); leave their mtimes
-          #                    alone instead of erroring out.
+          #   1) Pre-touch every tracked file to a fixed "old" timestamp.
+          #      This provides a stable floor for files that
+          #      git-restore-mtime cannot locate on the first-parent
+          #      line -- most notably the external/llvm-project subtree,
+          #      whose upstream commits enter the history through the
+          #      second parent of subtree merges and are therefore
+          #      invisible to --first-parent (~128k files in our case).
+          #   2) Run git-restore-mtime --first-parent to set accurate
+          #      per-file last-modified times for everything that *is*
+          #      on the mainline (rocMLIR proper, .github, cmake,
+          #      external/mlir-hal, ...). This includes the source
+          #      files modified in the current PR.
+          #
+          # Net effect: unchanged files (incl. the LLVM subtree) appear
+          # older than the cached .o files -> ninja keeps the cache.
+          # Files actually modified in this PR appear newer than the
+          # cached .o files -> ninja rebuilds only those.
+          #
+          # --first-parent is essential: a full traversal of the LLVM
+          # subtree history takes well over 15 minutes on the runner.
+          # --skip-missing (default in 2020.09) keeps the "not found"
+          # files at the pretouched floor instead of erroring out;
+          # --quiet suppresses the ~128k WARNING lines this produces.
           apt-get update -qq
           apt-get install -y -qq git-restore-mtime
-          time git restore-mtime --first-parent --skip-missing
+          echo "Pretouching all tracked files to a fixed old timestamp..."
+          git ls-files -z | xargs -0r touch -d "2000-01-01T00:00:00Z"
+          echo "Restoring mtimes for files on the first-parent line..."
+          time git restore-mtime --first-parent --skip-missing --quiet
 
       - name: Install Python dependencies for premerge checks
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
             -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
             -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
             -DMLIR_ENABLE_ROCM_RUNNER=1 \
@@ -112,6 +113,28 @@ jobs:
           fi
 
           ln -sf build/compile_commands.json compile_commands.json
+
+      - name: Build TableGen-generated headers
+        shell: bash
+        run: |
+          set -euo pipefail
+          # mlir-headers covers upstream MLIR + everything chained into it.
+          # The targets below are mlir-hal and rocMLIR orphan tablegen
+          # targets not hooked into mlir-headers. Any new orphan
+          # add_public_tablegen_target() declared in this repo must be
+          # added to the list below.
+          cmake --build build --target \
+            mlir-headers \
+            MHALConversionPassIncGen \
+            MLIRMHALAttrDefsIncGen \
+            MLIRMHALPassIncGen \
+            MLIRRockAttrDefsIncGen \
+            MLIRRockTuningParamAttrInterfaceIncGen \
+            MLIRRockAccelTuningParamAttrInterfaceIncGen \
+            MLIRRockPassIncGen \
+            RocMLIRConversionPassIncGen \
+            MLIRMIGraphXTypeIncGen \
+            MLIRMIGraphXPassIncGen
 
       - name: Run premerge static checks (format + tidy)
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,20 @@ jobs:
           # actions/checkout@v4 sets every file mtime to "now", which causes
           # ninja to treat all cached build outputs as stale. Reset each
           # file's mtime to the last commit that touched it.
+          #
+          # Flags:
+          #   --first-parent : follow only the mainline (skip merged side
+          #                    branches). On a repo with the large
+          #                    external/llvm-project subtree this turns a
+          #                    multi-million-commit traversal into a few-
+          #                    thousand-commit walk (seconds vs. >15 min).
+          #   --skip-missing : tolerate files present in the index but not
+          #                    touched by any first-parent commit (e.g.
+          #                    submodule-tracked content); leave their mtimes
+          #                    alone instead of erroring out.
           apt-get update -qq
           apt-get install -y -qq git-restore-mtime
-          git restore-mtime
+          time git restore-mtime --first-parent --skip-missing
 
       - name: Install Python dependencies for premerge checks
         shell: bash

--- a/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
+++ b/mlir/include/mlir/Dialect/Rock/IR/RockOps.td
@@ -29,6 +29,7 @@ include "mlir/Interfaces/VectorInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
 
 // Base class for Rock dialect ops.
+// NOTE: benign touch to validate incremental TableGen rebuild in CI cache test.
 class Rock_Op<string mnemonic, list<Trait> traits = []> :
     Op<Rock_Dialect, mnemonic, traits> {
   let extraClassDeclaration = [{

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -4827,8 +4827,9 @@ static void insertPrefills(func::FuncOp fut) {
 }
 
 static bool isGpuValidationSupported(const GenParams &genParams) {
-  // GPU validation is only supported for conv and gemm kernels
-  // Attention does not have a non-accel version to verify against
+  // GPU validation is only supported for conv and gemm kernels.
+  // Attention does not have a non-accel version to verify against,
+  // so it must always be validated on the CPU reference path.
   return genParams.operation.has_value() &&
          (genParams.operation == rock::KernelType::Conv ||
           genParams.operation == rock::KernelType::ConvBwdData ||

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -5702,6 +5702,8 @@ static void populateCloneHarnessLogic(ModuleOp module) {
 }
 
 int main(int argc, char **argv) {
+  // NOTE: benign touch to validate incremental rebuild + clang-tidy on cached
+  // TableGen-generated .inc headers (CI cache test).
   DialectRegistry registry;
   registerRocMLIRDialects(registry);
   // Parse pass names in main to ensure static initialization completed.


### PR DESCRIPTION
## Motivation

Verify that PR #2398 (build TableGen headers before clang-tidy) fixes
the missing `.h.inc` failure class that PR #2310 hit. This branch is
based on the PR #2398 branch and touches `rocmlir-gen.cpp`, the only
C++ file PR #2310 modified, with a benign comment change so that
`clang-tidy-diff` runs on the file and is forced to parse the full
TU (Rock dialect headers + transitively included `.inc` files).

## Test Plan

Watch the `cpp-static-checks` job:
- Green -> fix in PR #2398 is sufficient.
- Red on `file not found ... .h.inc` -> fix has a gap; expand the
  TableGen target list in PR #2398.

DRAFT: do not merge.