### PR TITLE
Fix i8 attention CPU reference FMA rounding and tighten E2E thresholds

### DIFF
--- a/mlir/test/e2e/AttentionVectorizationRegression.toml
+++ b/mlir/test/e2e/AttentionVectorizationRegression.toml
@@ -1,6 +1,6 @@
 directory = "AttentionVectorizationRegression"
 prefix = "rocmlir-gen"
-suffix = "--operation attention --arch %arch -pv %random_data -rand_min 0 -rand_max 1 -rand_type float %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention --arch %arch -pv %random_data -rand_min 0 -rand_max 1 -rand_type float %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.005 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "t"

--- a/mlir/test/e2e/LdsTransposeLoadAttention.toml
+++ b/mlir/test/e2e/LdsTransposeLoadAttention.toml
@@ -1,6 +1,6 @@
 directory = "LdsTransposeLoadAttention"
 prefix = "rocmlir-gen"
-suffix = "--operation attention --arch %arch -pv %constrained_float_range_random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention --arch %arch -pv %constrained_float_range_random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.005 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "data type"

--- a/mlir/test/e2e/PrAttentionBF16.toml
+++ b/mlir/test/e2e/PrAttentionBF16.toml
@@ -1,6 +1,6 @@
 directory = "PrAttentionBF16"
 prefix = "rocmlir-gen"
-suffix = "--operation attention -t bf16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention -t bf16 --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.005 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "transQ"

--- a/mlir/test/e2e/PrAttentionI8.toml
+++ b/mlir/test/e2e/PrAttentionI8.toml
@@ -1,6 +1,6 @@
 directory = "PrAttentionI8"
 prefix = "rocmlir-gen"
-suffix = "--operation attention -t i8 --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.01 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention -t i8 --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.001 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "transK"

--- a/mlir/test/e2e/PrAttentionSchedule.toml
+++ b/mlir/test/e2e/PrAttentionSchedule.toml
@@ -1,6 +1,6 @@
 directory = "PrAttentionSchedule"
 prefix = "rocmlir-gen"
-suffix = "--operation attention --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention --arch %arch -pv %random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.001 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "t"

--- a/mlir/test/e2e/PrLdsTransposeLoadAttention.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadAttention.toml
@@ -1,6 +1,6 @@
 directory = "PrLdsTransposeLoadAttention"
 prefix = "rocmlir-gen"
-suffix = "--operation attention --arch %arch -pv %constrained_float_range_random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.15 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention --arch %arch -pv %constrained_float_range_random_data %rocmlir_gen_flags -relDiff_threshold 0.3 -absDiff_threshold 0.3 -RMS_threshold 0.001 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "data type"

--- a/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
+++ b/mlir/test/e2e/PrLdsTransposeLoadAttentionI8.toml
@@ -1,6 +1,6 @@
 directory = "PrLdsTransposeLoadAttentionI8"
 prefix = "rocmlir-gen"
-suffix = "--operation attention --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.01 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
+suffix = "--operation attention --arch %arch -pv %random_data %rocmlir_gen_flags -RMS_threshold 0.001 | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s --check-prefix="
 
 [[axis]]
 name = "data type"

--- a/mlir/test/rocmlir-gen/attention-verify-i8.mlir
+++ b/mlir/test/rocmlir-gen/attention-verify-i8.mlir
@@ -2,6 +2,8 @@
 // RUN: rocmlir-gen -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-bias --operation attention --transK=true  --operation attention -t i8 --arch gfx90a:sramecc+:xnack- -pv   -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_NOSCALE
 // RUN: rocmlir-gen -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --operation attention --transK=true  --operation attention -t i8 --arch gfx90a:sramecc+:xnack- -pv   -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_NOBIAS
 // RUN: rocmlir-gen -seq_len_q 384 -seq_len_k 384 -head_dim_qk 64 -head_dim_v 64 --operation attention --transK=true  --operation attention -t i8 --arch gfx90a:sramecc+:xnack- -pv   -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_SIMPLE
+// RUN: rocmlir-gen -seq_len_q 16 -seq_len_k 16 -head_dim_qk 16 -head_dim_v 16 --with-attn-scale --with-attn-bias --operation attention --transK=true -t i8 --arch gfx90a:sramecc+:xnack- -pv -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_CPU_FMA_REF
+// RUN: rocmlir-gen -seq_len_q 16 -seq_len_k 16 -head_dim_qk 16 -head_dim_v 16 --with-attn-scale --with-attn-bias --operation attention --transK=false -t i8 --arch gfx90a:sramecc+:xnack- -pv -RMS_threshold 0.003 | FileCheck %s --enable-var-scope --check-prefixes=CHECK_I8_CPU_FMA_REF
 
 // CHECK_I8_FULL-LABEL: @main
 // CHECK_I8_FULL: call @rock_attention_gpu(%[[alloc0:.+]], %[[alloc1:.+]], %[[alloc2:.+]], %[[alloc3:.+]], %[[alloc4:.+]], %[[alloc5:.+]], %[[alloc6:.+]], %[[gpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<147456xf16>, memref<147456xf16>, memref<24576xf16>) -> ()
@@ -22,3 +24,24 @@
 // CHECK_I8_SIMPLE: call @rock_attention_gpu(%[[alloc0:.+]], %[[alloc1:.+]], %[[alloc2:.+]], %[[alloc3:.+]], %[[alloc4:.+]], %[[gpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<24576xf16>) -> ()
 // CHECK_I8_SIMPLE: call @host_naive_attention(%[[alloc7:.+]], %[[alloc8:.+]], %[[alloc9:.+]], %[[alloc10:.+]], %[[alloc11:.+]], %[[cpu_out:.+]]) : (memref<24576xi8>, memref<24576xi8>, memref<24576xf16>, memref<1xi8>, memref<1xf16>, memref<24576xf16>) -> ()
 // CHECK_I8_SIMPLE: call @rock_attention_verify5(%[[gpu_out]], %[[cpu_out]]) : (memref<24576xf16>, memref<24576xf16>) -> ()
+
+// CHECK_I8_CPU_FMA_REF-LABEL: func.func @rock_attention
+// CHECK_I8_CPU_FMA_REF:      %[[QK_F16:.*]] = arith.sitofp {{.*}} : i32 to f16
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[QSCALE:.*]] = arith.mulf %[[QK_F16]], {{.*}} : f16
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[ATTN_SCALE:.*]] = arith.mulf %[[QSCALE]], {{.*}} : f16
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[BIASED:.*]] = arith.addf %[[ATTN_SCALE]], {{.*}} : f16
+// CHECK_I8_CPU_FMA_REF-NEXT: linalg.yield %[[BIASED]] : f16
+// CHECK_I8_CPU_FMA_REF-LABEL: func.func @host_naive_attention
+// CHECK_I8_CPU_FMA_REF:      linalg.generic
+// CHECK_I8_CPU_FMA_REF:      ^bb0(%[[IN_I32:.*]]: i32, %[[ZERO_POINT:.*]]: i8, %[[QUANT_SCALE:.*]]: f16, %[[ATTN_SCALE_IN:.*]]: f16, %[[BIAS_IN:.*]]: f16, %{{.*}}: f32):
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[BIAS_F32:.*]] = arith.extf %[[BIAS_IN]] : f16 to f32
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[SCALE_F32:.*]] = arith.extf %[[ATTN_SCALE_IN]] : f16 to f32
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[ZERO_POINT_I32:.*]] = arith.extsi %[[ZERO_POINT]] : i8 to i32
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[QK_I32:.*]] = arith.subi %[[IN_I32]], %[[ZERO_POINT_I32]] : i32
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[QK_REF_F16:.*]] = arith.sitofp %[[QK_I32]] : i32 to f16
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[QSCALE_REF:.*]] = arith.mulf %[[QK_REF_F16]], %[[QUANT_SCALE]] : f16
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[SCORE_F32:.*]] = arith.extf %[[QSCALE_REF]] : f16 to f32
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[SCALED_F32:.*]] = arith.mulf %[[SCORE_F32]], %[[SCALE_F32]] : f32
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[BIASED_F32:.*]] = arith.addf %[[SCALED_F32]], %[[BIAS_F32]] : f32
+// CHECK_I8_CPU_FMA_REF-NEXT: %[[BIASED_F16:.*]] = arith.truncf %[[BIASED_F32]] : f32 to f16
+// CHECK_I8_CPU_FMA_REF-NEXT: arith.extf %[[BIASED_F16]] : f16 to f32

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -4332,60 +4332,87 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
   if (!prefixOffset.empty()) {
     prefixOffsetTensor = loadMaskingTensor(optionalArgIndex++);
   }
+  auto castTensor = [&](Value v, Type elemType) -> Value {
+    return rock::tosa::createOpAndInfer<tosa::CastOp>(builder, loc, elemType,
+                                                      v);
+  };
+  auto applyPreSoftmaxInputMask = [&](Value tensor, float neutralValue) {
+    // Scale and bias are masked before being applied to qk. Use their neutral
+    // elements so later multiplication/addition leaves masked positions
+    // unchanged.
+    if (currentSeqLenTensor)
+      tensor = maskKVCacheTosa(builder, loc, tensor, currentSeqLenTensor,
+                               neutralValue);
+    if (prefixOffsetTensor)
+      return prefixOffsetMaskingTosa(builder, loc, tensor, prefixOffsetTensor,
+                                     neutralValue);
+    if (causalMasking)
+      return causalMaskingTosa(builder, loc, tensor, neutralValue);
+    return tensor;
+  };
 
   unsigned optionalArgsCounter = 3;
   if (isQuantized) {
+    // Quantized attention starts from i32 qk accumulators. Apply the quantized
+    // zero-point/bias in i32, then round to f16 before the quant scale multiply
+    // to mirror the GPU pre-softmax arithmetic.
     auto quantBiasI8 = getTensorForBlockArg(optionalArgsCounter++);
     Value quantBiasI32 = rock::tosa::createOpAndInfer<tosa::CastOp>(
         builder, loc, IntegerType::get(ctx, 32), quantBiasI8);
     qkTensor = rock::tosa::createOpAndInfer<tosa::SubOp>(
         builder, loc, IntegerType::get(ctx, 32), qkTensor, quantBiasI32);
-    qkTensor = rock::tosa::createOpAndInfer<tosa::CastOp>(
-        builder, loc, Float16Type::get(ctx), qkTensor);
+    qkTensor = castTensor(qkTensor, Float16Type::get(ctx));
     auto quantScaleF16 = getTensorForBlockArg(optionalArgsCounter++);
     qkTensor = rock::tosa::getMulOp(builder, loc, qkTensor, quantScaleF16,
                                     Float16Type::get(ctx));
   }
 
+  bool fuseQuantizedScaleBias = isQuantized && hasAttnScale && hasAttnBias;
+  Value pendingScaleForFma;
   if (hasAttnScale) {
     auto scaleTensor = getTensorForBlockArg(optionalArgsCounter++);
-    if (!currentSeqLen.empty())
-      scaleTensor =
-          maskKVCacheTosa(builder, loc, scaleTensor, currentSeqLenTensor, 1.0f);
+    scaleTensor = applyPreSoftmaxInputMask(scaleTensor, 1.0f);
 
-    // Use prefix offset masking if provided, otherwise standard causal
-    if (prefixOffsetTensor)
-      scaleTensor = prefixOffsetMaskingTosa(builder, loc, scaleTensor,
-                                            prefixOffsetTensor, 1.0f);
-    else if (causalMasking)
-      scaleTensor = causalMaskingTosa(builder, loc, scaleTensor, 1.0f);
-
-    qkTensor = rock::tosa::getMulOp(
-        builder, loc, qkTensor, scaleTensor,
-        cast<ShapedType>(scaleTensor.getType()).getElementType());
+    if (fuseQuantizedScaleBias) {
+      // Defer the multiply so the bias branch can model qk * scale + bias
+      // with the same single-rounding f16 FMA used by the GPU i8 path.
+      pendingScaleForFma = scaleTensor;
+    } else {
+      qkTensor = rock::tosa::getMulOp(
+          builder, loc, qkTensor, scaleTensor,
+          cast<ShapedType>(scaleTensor.getType()).getElementType());
+    }
   }
 
   if (hasAttnBias) {
     auto biasTensor = getTensorForBlockArg(optionalArgsCounter++);
-    if (!currentSeqLen.empty())
-      biasTensor =
-          maskKVCacheTosa(builder, loc, biasTensor, currentSeqLenTensor, 0.0f);
+    biasTensor = applyPreSoftmaxInputMask(biasTensor, 0.0f);
 
-    // Use prefix offset masking if provided, otherwise standard causal
-    if (prefixOffsetTensor)
-      biasTensor = prefixOffsetMaskingTosa(builder, loc, biasTensor,
-                                           prefixOffsetTensor, 0.0f);
-    else if (causalMasking)
-      biasTensor = causalMaskingTosa(builder, loc, biasTensor, 0.0f);
-
-    qkTensor = rock::tosa::createOpAndInfer<tosa::AddOp>(
-        builder, loc, cast<ShapedType>(biasTensor.getType()).getElementType(),
-        qkTensor, biasTensor);
+    if (fuseQuantizedScaleBias) {
+      Type f32Type = builder.getF32Type();
+      // The generated GPU IR spells this as f16 mul + f16 add, but GPU lowering
+      // can fuse qk * scale + bias. Model the fused operation here with f32
+      // arithmetic followed by one f16 rounding so validation stays fair on
+      // values that would round differently if the multiply rounded to f16
+      // before adding bias.
+      assert(pendingScaleForFma && "scale tensor must be deferred for FMA");
+      qkTensor = castTensor(qkTensor, f32Type);
+      pendingScaleForFma = castTensor(pendingScaleForFma, f32Type);
+      biasTensor = castTensor(biasTensor, f32Type);
+      qkTensor = rock::tosa::getMulOp(builder, loc, qkTensor,
+                                      pendingScaleForFma, f32Type);
+      qkTensor = rock::tosa::createOpAndInfer<tosa::AddOp>(
+          builder, loc, f32Type, qkTensor, biasTensor);
+      qkTensor = castTensor(qkTensor, Float16Type::get(ctx));
+    } else {
+      qkTensor = rock::tosa::createOpAndInfer<tosa::AddOp>(
+          builder, loc, cast<ShapedType>(biasTensor.getType()).getElementType(),
+          qkTensor, biasTensor);
+    }
   }
   // cast to softmaxType
   auto softmaxType = typeFromString(softmaxDataType.getValue(), ctx);
-  qkTensor = rock::tosa::createOpAndInfer<tosa::CastOp>(builder, loc,
-                                                        softmaxType, qkTensor);
+  qkTensor = castTensor(qkTensor, softmaxType);
 
   // Apply KV-cache masking if currentSeqLen is provided
   if (currentSeqLenTensor) {


### PR DESCRIPTION
## Summary
- Fix i8 quantized attention validation by modeling fused `qk * scale + bias` in the CPU reference (f32 math + single f16 round), matching GPU lowering behavior.
- Add lit coverage in `attention-verify-i8.mlir` for the fused reference path.
- Tighten attention E2E `RMS_threshold` values validated on MI350 (i8: 0.001; f16/bf16 PR suites: 0.001–0.005).

## Test plan
- [x] `git clang-format --diff origin/develop` (clean)
- [x] GPU E2E on MI350: `PrAttentionI8`, `PrLdsTransposeLoadAttentionI8`, `PrAttentionSchedule`, `PrLdsTransposeLoadAttention`, `PrAttentionBF16`, `AttentionVectorizationRegression`, `LdsTransposeLoadAttention`
- [x] Repeated random-seed nightly runs for tightened suites
- [ ] CI premerge checks


Made with [Cursor](https://cursor.com)