### PR TITLE
Fix Jenkins Test MLIR vs CK stage and CK FP8 consumer mismatch

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -991,6 +991,25 @@ boolean isNotGfx11x(String chip) {
     return "${chip}" != 'gfx1100' && "${chip}" != 'gfx1101'
 }
 
+String ckFp8CmakeOptions(String chip) {
+    if ("${chip}" == 'gfx942') {
+        return '''
+                                                                        -DCK_USE_FNUZ_FP8=ON
+                                                                        -DCMAKE_CXX_FLAGS="-O3 -DCK_USE_FNUZ_FP8=1"
+                                                                        '''
+    }
+    if ("${chip}" == 'gfx950' || "${chip}".startsWith('gfx12')) {
+        return '''
+                                                                        -DCK_USE_OCP_FP8=ON
+                                                                        -DCK_TILE_USE_OCP_FP8=ON
+                                                                        -DCMAKE_CXX_FLAGS="-O3 -DCK_USE_OCP_FP8=1 -DCK_TILE_USE_OCP_FP8=1"
+                                                                        '''
+    }
+    return '''
+                                                                        -DCMAKE_CXX_FLAGS="-O3"
+                                                                        '''
+}
+
 void collectCoverageData(String profdata, String cov, String cpath) {
     sh """
        rm -f *.profraw
@@ -1778,10 +1797,14 @@ PY
                                                                     sh 'rm -rf composable_kernel'
                                                                     getAndBuildCK('''
                                                                         -DGPU_TARGETS=${CHIP}
-                                                                        -DCMAKE_CXX_FLAGS="-O3"
                                                                         -DCMAKE_PREFIX_PATH="/opt/rocm"
                                                                         -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
                                                                         -DCMAKE_BUILD_TYPE=Release
+                                                                        -DBUILD_TESTING=OFF
+                                                                        -DBUILD_CK_EXAMPLES=OFF
+                                                                        -DBUILD_CK_TUTORIALS=OFF
+                                                                        -DBUILD_CK_PROFILER=OFF
+                                                                        ''' + ckFp8CmakeOptions(CHIP) + '''
                                                                         ''')
                                                                     sh 'cd build; make install'
                                                                     sh 'echo `git rev-parse HEAD`'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1009,6 +1009,20 @@ String ckFp8CmakeOptions(String chip) {
                                                                         '''
 }
 
+String ckDtypesCmakeOptions(String chip) {
+    // The MLIR vs CK perf configs exercise f16/f32 GEMM, with int8 available
+    // for the CK GEMM driver. Restricting DTYPES avoids building unused CK
+    // operation instances on older arches such as gfx908.
+    if ("${chip}".startsWith('gfx94') || "${chip}" == 'gfx950' || "${chip}".startsWith('gfx12')) {
+        return '''
+                                                                        -DDTYPES="fp8;bf8;fp16;fp32;int8"
+                                                                        '''
+    }
+    return '''
+                                                                        -DDTYPES="fp16;fp32;int8"
+                                                                        '''
+}
+
 void collectCoverageData(String profdata, String cov, String cpath) {
     sh """
        rm -f *.profraw
@@ -1803,6 +1817,7 @@ PY
                                                                         -DBUILD_CK_EXAMPLES=OFF
                                                                         -DBUILD_CK_TUTORIALS=OFF
                                                                         -DBUILD_CK_PROFILER=OFF
+                                                                        ''' + ckDtypesCmakeOptions(CHIP) + '''
                                                                         ''' + ckFp8CmakeOptions(CHIP) + '''
                                                                         ''')
                                                                     sh 'cd build; make install'

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -992,16 +992,15 @@ boolean isNotGfx11x(String chip) {
 }
 
 String ckFp8CmakeOptions(String chip) {
-    if ("${chip}" == 'gfx942') {
+    // CK auto-derives CK_USE_*_FP8 from GPU_TARGETS, so we only force the
+    // numeric macro values via CMAKE_CXX_FLAGS to keep CK's `#if` checks correct.
+    if ("${chip}".startsWith('gfx94')) {
         return '''
-                                                                        -DCK_USE_FNUZ_FP8=ON
                                                                         -DCMAKE_CXX_FLAGS="-O3 -DCK_USE_FNUZ_FP8=1"
                                                                         '''
     }
     if ("${chip}" == 'gfx950' || "${chip}".startsWith('gfx12')) {
         return '''
-                                                                        -DCK_USE_OCP_FP8=ON
-                                                                        -DCK_TILE_USE_OCP_FP8=ON
                                                                         -DCMAKE_CXX_FLAGS="-O3 -DCK_USE_OCP_FP8=1 -DCK_TILE_USE_OCP_FP8=1"
                                                                         '''
     }

--- a/mlir/utils/performance/ck-benchmark-driver/CMakeLists.txt
+++ b/mlir/utils/performance/ck-benchmark-driver/CMakeLists.txt
@@ -8,6 +8,21 @@ if (composable_kernel_FOUND)
   add_library(ck-common INTERFACE IMPORTED)
   target_link_libraries(ck-common INTERFACE ${LIBS})
   target_compile_options(ck-common INTERFACE "-std=c++17")
+  get_target_property(CK_INCLUDE_DIRS composable_kernel::device_gemm_operations
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  foreach(CK_INCLUDE_DIR ${CK_INCLUDE_DIRS})
+    if(EXISTS "${CK_INCLUDE_DIR}/ck/config.h")
+      file(READ "${CK_INCLUDE_DIR}/ck/config.h" CK_CONFIG_H)
+      if(CK_CONFIG_H MATCHES "#define CK_USE_OCP_FP8[ \t]+(ON|1)")
+        target_compile_definitions(ck-common INTERFACE CK_USE_OCP_FP8=1
+                                                       CK_USE_FNUZ_FP8=0)
+      elseif(CK_CONFIG_H MATCHES "#define CK_USE_FNUZ_FP8[ \t]+(ON|1)")
+        target_compile_definitions(ck-common INTERFACE CK_USE_OCP_FP8=0
+                                                       CK_USE_FNUZ_FP8=1)
+      endif()
+      break()
+    endif()
+  endforeach()
 
   add_executable(ck-gemm-benchmark-driver EXCLUDE_FROM_ALL ck-gemm-benchmark-driver.cpp)
   target_link_libraries(ck-gemm-benchmark-driver PRIVATE ck-common)

--- a/mlir/utils/performance/ck-benchmark-driver/CMakeLists.txt
+++ b/mlir/utils/performance/ck-benchmark-driver/CMakeLists.txt
@@ -10,19 +10,28 @@ if (composable_kernel_FOUND)
   target_compile_options(ck-common INTERFACE "-std=c++17")
   get_target_property(CK_INCLUDE_DIRS composable_kernel::device_gemm_operations
                       INTERFACE_INCLUDE_DIRECTORIES)
+  set(CK_FP8_MODE "")
   foreach(CK_INCLUDE_DIR ${CK_INCLUDE_DIRS})
     if(EXISTS "${CK_INCLUDE_DIR}/ck/config.h")
       file(READ "${CK_INCLUDE_DIR}/ck/config.h" CK_CONFIG_H)
       if(CK_CONFIG_H MATCHES "#define CK_USE_OCP_FP8[ \t]+(ON|1)")
         target_compile_definitions(ck-common INTERFACE CK_USE_OCP_FP8=1
                                                        CK_USE_FNUZ_FP8=0)
+        set(CK_FP8_MODE "OCP")
       elseif(CK_CONFIG_H MATCHES "#define CK_USE_FNUZ_FP8[ \t]+(ON|1)")
         target_compile_definitions(ck-common INTERFACE CK_USE_OCP_FP8=0
                                                        CK_USE_FNUZ_FP8=1)
+        set(CK_FP8_MODE "FNUZ")
       endif()
       break()
     endif()
   endforeach()
+  if(CK_FP8_MODE)
+    message(STATUS "CK benchmark driver: detected ${CK_FP8_MODE} FP8 from ck/config.h")
+  else()
+    message(STATUS "CK benchmark driver: no FP8 mode set in ck/config.h; "
+                   "using CK defaults for ck::f8_t")
+  endif()
 
   add_executable(ck-gemm-benchmark-driver EXCLUDE_FROM_ALL ck-gemm-benchmark-driver.cpp)
   target_link_libraries(ck-gemm-benchmark-driver PRIVATE ck-common)


### PR DESCRIPTION
## Summary
- Skip CK tests/examples/tutorials/profiler in the Jenkins CK build to avoid unrelated linker failures.
- Select FNUZ FP8 for gfx942, OCP FP8 for gfx950/gfx12*, and no FP8 flags on other arches.
- Propagate installed CK FP8 mode from `config.h` to `ck-benchmark-driver` to fix symbol mismatches.

## Test plan
- [x] CK configure checks for gfx908, gfx942, gfx950
- [x] CK install + ck-benchmark-driver build on gfx950
- [x] MLIR vs CK perf smoke + report generation on gfx950


Made with [Cursor](https://cursor.com)