### PR TITLE
[Build] Fix rocMLIR build with system GCC on ROCm 7.13 (gfx115x)

### DIFF
--- a/cmake/mlir-hal.cmake
+++ b/cmake/mlir-hal.cmake
@@ -19,6 +19,17 @@ include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
+# A malformed _GLIBCXX_USE_CXX11_ABI can arrive via add_definitions(${LLVM_DEFINITIONS}).
+# Re-assert a well-formed value on GNU-style (non-MSVC) command lines, honoring the
+# GLIBCXX_USE_CXX11_ABI option selected by HandleLLVMOptions.cmake when it is set.
+if(NOT MSVC)
+  if(DEFINED GLIBCXX_USE_CXX11_ABI AND NOT GLIBCXX_USE_CXX11_ABI)
+    set(_mhal_glibcxx_cxx11_abi 0)
+  else()
+    set(_mhal_glibcxx_cxx11_abi 1)
+  endif()
+  add_compile_options(-U_GLIBCXX_USE_CXX11_ABI -D_GLIBCXX_USE_CXX11_ABI=${_mhal_glibcxx_cxx11_abi})
+endif()
 
 add_subdirectory("${MHAL_PROJECT_DIR}" EXCLUDE_FROM_ALL)
 

--- a/external/llvm-project/llvm/lib/Target/X86/MCTargetDesc/CMakeLists.txt
+++ b/external/llvm-project/llvm/lib/Target/X86/MCTargetDesc/CMakeLists.txt
@@ -28,4 +28,4 @@ add_llvm_component_library(LLVMX86Desc
   ADD_TO_COMPONENT
   X86
   )
-set_source_files_properties(X86MCCodeEmitter.cpp PROPERTIES COMPILE_FLAGS "-O2")
+set_source_files_properties(X86MCCodeEmitter.cpp PROPERTIES COMPILE_FLAGS "-O2" SKIP_PRECOMPILE_HEADERS ON)

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -29,6 +29,17 @@ include_directories(${PROJECT_SOURCE_DIR}/mlir/include)
 include_directories(${PROJECT_BINARY_DIR}/mlir/include)
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
+# A malformed _GLIBCXX_USE_CXX11_ABI can arrive via add_definitions(${LLVM_DEFINITIONS}).
+# Re-assert a well-formed value on GNU-style (non-MSVC) command lines, honoring the
+# GLIBCXX_USE_CXX11_ABI option selected by HandleLLVMOptions.cmake when it is set.
+if(NOT MSVC)
+  if(DEFINED GLIBCXX_USE_CXX11_ABI AND NOT GLIBCXX_USE_CXX11_ABI)
+    set(_mlir_glibcxx_cxx11_abi 0)
+  else()
+    set(_mlir_glibcxx_cxx11_abi 1)
+  endif()
+  add_compile_options(-U_GLIBCXX_USE_CXX11_ABI -D_GLIBCXX_USE_CXX11_ABI=${_mlir_glibcxx_cxx11_abi})
+endif()
 
 set(LLVM_VERSION_MAJOR ${CMAKE_PROJECT_VERSION_MAJOR})
 set(LLVM_VERSION_MINOR ${CMAKE_PROJECT_VERSION_MINOR})

--- a/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
+++ b/mlir/lib/Conversion/MIGraphXToLinalg/MIGraphXToLinalg.cpp
@@ -1180,7 +1180,8 @@ struct GenericElementwiseOpConverter final
 private:
   GenericElementwiseTrait<ElementwiseOp> loweringTrait;
 };
-} // namespace
+// (anonymous namespace continues through GenericElementwiseTrait
+// specializations)
 
 template <>
 struct GenericElementwiseTrait<migraphx::ConvertOp> {
@@ -1249,6 +1250,7 @@ struct GenericElementwiseTrait<migraphx::WhereOp> {
     linalg::YieldOp::create(builder, loc, result);
   }
 };
+} // namespace
 
 template <typename ElementwiseOp>
 LogicalResult GenericElementwiseOpConverter<ElementwiseOp>::matchAndRewrite(


### PR DESCRIPTION
Three small, independent build-only fixes needed to configure and compile rocMLIR with system GCC against ROCm 7.13 (observed on gfx115x). None change runtime behavior.

The vendored `external/` change is kept in its own `[EXTERNAL]`-prefixed commit, separate from the rocMLIR changes.

### 1. X86 `MCTargetDesc` — precompiled-header mismatch (`[EXTERNAL]` commit)
`X86MCCodeEmitter.cpp` already overrides `COMPILE_FLAGS` with `-O2`. With GCC the component precompiled header is built with different flags, so GCC rejects the PCH for this one source. Marking the file `SKIP_PRECOMPILE_HEADERS ON` lets it compile without the mismatched PCH.

### 2. `_GLIBCXX_USE_CXX11_ABI` — malformed definition
On this toolchain a malformed `_GLIBCXX_USE_CXX11_ABI` definition can reach the compile line through `add_definitions(${LLVM_DEFINITIONS})`. The fix re-asserts a well-formed value, but only on GNU-style (non-MSVC) command lines, and honors the `GLIBCXX_USE_CXX11_ABI` option selected by LLVM's `HandleLLVMOptions.cmake` (defaulting to `1` when unset) rather than hard-coding it. Applied in both `mlir/CMakeLists.txt` and `cmake/mlir-hal.cmake`.

### 3. `MIGraphXToLinalg.cpp` — anonymous-namespace placement
GCC requires an explicit specialization to be declared in the same namespace as its primary template. The closing brace of the anonymous namespace sat above the `GenericElementwiseTrait` specializations, so GCC rejected them. Moving the brace below the specializations fixes the build (Clang accepted both placements).

### Impact
Build-configuration / placement only; no functional or runtime change. Helps GCC-based builds on ROCm 7.13; harmless to existing Clang-based and MSVC/clang-cl builds.
