### PR TITLE
 Limit CK benchmark CI to GEMM operations

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -593,8 +593,8 @@ void installCKGemmOnly(String installDir) {
            build/composable_kernelConfigVersion.cmake \
            "\${cmake_dir}/"
 
-        gemm_export_files=(build/library/src/tensor_operation_instance/gpu/CMakeFiles/Export/*/composable_kerneldevice_gemm_operationsTargets*.cmake)
-        if [ ! -e "\${gemm_export_files[0]}" ]; then
+        mapfile -t gemm_export_files < <(find build -type f -name 'composable_kerneldevice_gemm_operationsTargets*.cmake' -print)
+        if [ "\${#gemm_export_files[@]}" -eq 0 ]; then
             echo "Could not find CK device_gemm_operations CMake export files"
             exit 1
         fi
@@ -1023,8 +1023,8 @@ boolean isNotGfx11x(String chip) {
 }
 
 boolean supportsCKBenchmark(String chip) {
-    // CK does not generate a device_gemm_operations target for these arches.
-    return isNotGfx11x(chip) && !(chip in ['gfx900', 'gfx906', 'gfx90c'])
+    // CK does not generate a device_gemm_operations target for gfx906.
+    return isNotGfx11x(chip) && "${chip}" != 'gfx906'
 }
 
 String ckFp8CmakeOptions(String chip) {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -560,6 +560,8 @@ Map<String,String> dockerArgs() {
 
 void buildCK(String cmakeOpts, String buildTarget = '') {
     sh '[ ! -d build ] || rm -rf build'
+    // CK's Unix Makefiles do not expose device_gemm_operations as a directly
+    // buildable target, while Ninja handles this target graph correctly.
     cmakeBuild generator: (buildTarget ? 'Ninja' : 'Unix Makefiles'),\
         buildDir: 'build',\
         buildType: 'Release',\
@@ -1021,12 +1023,8 @@ boolean isNotGfx11x(String chip) {
 }
 
 boolean supportsCKBenchmark(String chip) {
-    // CK filters these older targets out during configuration, so no
-    // device_gemm_operations target is generated for the benchmark driver.
-    return isNotGfx11x(chip) &&
-           "${chip}" != 'gfx900' &&
-           "${chip}" != 'gfx906' &&
-           "${chip}" != 'gfx90c'
+    // CK does not generate a device_gemm_operations target for these arches.
+    return isNotGfx11x(chip) && !(chip in ['gfx900', 'gfx906', 'gfx90c'])
 }
 
 String ckFp8CmakeOptions(String chip) {
@@ -1844,12 +1842,13 @@ PY
                                                     if (params.checkCK && supportsCKBenchmark(CHIP)) {
                                                         stage("Test MLIR vs CK") {
                                                             catchError (buildResult: null) { // This is an optional stage
+                                                                def ckInstallDir = "${WORKSPACE}/composable_kernel/build/CKInstallDir"
                                                                 dir('composable_kernel') {
                                                                     sh 'rm -rf composable_kernel'
                                                                     getAndBuildCK('''
                                                                         -DGPU_TARGETS=${CHIP}
                                                                         -DCMAKE_PREFIX_PATH="/opt/rocm"
-                                                                        -DCMAKE_INSTALL_PREFIX=${WORKSPACE}/composable_kernel/build/CKInstallDir
+                                                                        -DCMAKE_INSTALL_PREFIX=''' + ckInstallDir + '''
                                                                         -DCMAKE_BUILD_TYPE=Release
                                                                         -DBUILD_TESTING=OFF
                                                                         -DBUILD_CK_EXAMPLES=OFF
@@ -1860,12 +1859,12 @@ PY
                                                                         ''' + ckFp8CmakeOptions(CHIP) + '''
                                                                         ''',
                                                                         'device_gemm_operations')
-                                                                    installCKGemmOnly('${WORKSPACE}/composable_kernel/build/CKInstallDir')
+                                                                    installCKGemmOnly(ckInstallDir)
                                                                     sh 'echo `git rev-parse HEAD`'
                                                                 }
                                                                 sh 'rm -f build/CMakeCache.txt'
                                                                 buildProject("ck-benchmark-driver",
-                                                                            '''-DCMAKE_PREFIX_PATH=${WORKSPACE}/composable_kernel/build/CKInstallDir
+                                                                            '''-DCMAKE_PREFIX_PATH=''' + ckInstallDir + '''
                                                                                 -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
                                                                                 -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
                                                                                 -DROCMLIR_ENABLE_BENCHMARKS=ck''')

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -558,9 +558,9 @@ Map<String,String> dockerArgs() {
 }
 
 
-void buildCK(String cmakeOpts) {
+void buildCK(String cmakeOpts, String buildTarget = '') {
     sh '[ ! -d build ] || rm -rf build'
-    cmakeBuild generator: 'Unix Makefiles',\
+    cmakeBuild generator: (buildTarget ? 'Ninja' : 'Unix Makefiles'),\
         buildDir: 'build',\
         buildType: 'Release',\
         installation: 'InSearchPath',\
@@ -568,7 +568,36 @@ void buildCK(String cmakeOpts) {
                       -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
                      ${cmakeOpts}
                      """
-    sh 'cd build; make -j $(nproc)'
+    if (buildTarget) {
+        sh "cmake --build build --target ${buildTarget} --parallel \$(nproc)"
+    } else {
+        sh 'cd build; make -j $(nproc)'
+    }
+}
+
+void installCKGemmOnly(String installDir) {
+    sh """#!/usr/bin/env bash
+        set -euo pipefail
+
+        install_dir="${installDir}"
+        cmake_dir="\${install_dir}/lib/cmake/composable_kernel"
+        mkdir -p "\${install_dir}/include/ck" "\${install_dir}/lib" "\${cmake_dir}"
+
+        cp -R include/ck/. "\${install_dir}/include/ck/"
+        cp -R library/include/ck/. "\${install_dir}/include/ck/"
+        cp build/include/ck/config.h build/include/ck/version.h "\${install_dir}/include/ck/"
+        cp build/lib/libdevice_gemm_operations.a "\${install_dir}/lib/"
+        cp build/composable_kernelConfig.cmake \
+           build/composable_kernelConfigVersion.cmake \
+           "\${cmake_dir}/"
+
+        gemm_export_files=(build/library/src/tensor_operation_instance/gpu/CMakeFiles/Export/*/composable_kerneldevice_gemm_operationsTargets*.cmake)
+        if [ ! -e "\${gemm_export_files[0]}" ]; then
+            echo "Could not find CK device_gemm_operations CMake export files"
+            exit 1
+        fi
+        cp "\${gemm_export_files[@]}" "\${cmake_dir}/"
+    """
 }
 
 void buildMIGraphX(String cmakeOpts) {
@@ -591,10 +620,10 @@ void getAndBuildMIGraphX(String cmakeOpts) {
     buildMIGraphX(cmakeOpts)
 }
 
-void getAndBuildCK(String cmakeOpts) {
+void getAndBuildCK(String cmakeOpts, String buildTarget = '') {
     git branch: params.CKBranch, poll: false,\
         url: 'https://github.com/ROCm/composable_kernel.git'
-    buildCK(cmakeOpts)
+    buildCK(cmakeOpts, buildTarget)
 }
 
 void showEnv() {
@@ -989,6 +1018,15 @@ boolean shouldRunBuildAndTest(String codepath) {
 
 boolean isNotGfx11x(String chip) {
     return "${chip}" != 'gfx1100' && "${chip}" != 'gfx1101'
+}
+
+boolean supportsCKBenchmark(String chip) {
+    // CK filters these older targets out during configuration, so no
+    // device_gemm_operations target is generated for the benchmark driver.
+    return isNotGfx11x(chip) &&
+           "${chip}" != 'gfx900' &&
+           "${chip}" != 'gfx906' &&
+           "${chip}" != 'gfx90c'
 }
 
 String ckFp8CmakeOptions(String chip) {
@@ -1803,7 +1841,7 @@ PY
                                                         }
                                                     }
 
-                                                    if (params.checkCK && isNotGfx11x(CHIP)) {
+                                                    if (params.checkCK && supportsCKBenchmark(CHIP)) {
                                                         stage("Test MLIR vs CK") {
                                                             catchError (buildResult: null) { // This is an optional stage
                                                                 dir('composable_kernel') {
@@ -1817,10 +1855,12 @@ PY
                                                                         -DBUILD_CK_EXAMPLES=OFF
                                                                         -DBUILD_CK_TUTORIALS=OFF
                                                                         -DBUILD_CK_PROFILER=OFF
+                                                                        -DENABLE_CLANG_CPP_CHECKS=OFF
                                                                         ''' + ckDtypesCmakeOptions(CHIP) + '''
                                                                         ''' + ckFp8CmakeOptions(CHIP) + '''
-                                                                        ''')
-                                                                    sh 'cd build; make install'
+                                                                        ''',
+                                                                        'device_gemm_operations')
+                                                                    installCKGemmOnly('${WORKSPACE}/composable_kernel/build/CKInstallDir')
                                                                     sh 'echo `git rev-parse HEAD`'
                                                                 }
                                                                 sh 'rm -f build/CMakeCache.txt'


### PR DESCRIPTION
## Summary
- Build only CK's `device_gemm_operations` target for MLIR vs CK benchmark CI.
- Avoid compiling unrelated CK conv/reduction/contraction libraries, which makes MI100/gfx908 CK build time much shorter.
- Keep the installed CK package minimal but sufficient for `ck-benchmark-driver`.

## Test plan
- `git clang-format --diff origin/develop`
- `git diff --check -- mlir/utils/jenkins/Jenkinsfile`
- CK `gfx950` full targeted build/install/import smoke: configure 15s, build 10m36s, exit 0
- CK dry-runs for `gfx908`, `gfx90a`, `gfx942`, `gfx950`, `gfx1030`, `gfx1200`, `gfx1201`


Made with [Cursor](https://cursor.com)