### PR TITLE
[AIROCMLIR-989] Remove dead code in mlir-hal

### DIFF
--- a/external/mlir-hal/include/mlir/Dialect/MHAL/Pipelines/Pipelines.h
+++ b/external/mlir-hal/include/mlir/Dialect/MHAL/Pipelines/Pipelines.h
@@ -26,14 +26,6 @@ namespace mhal {
 // Building and Registering.
 //===----------------------------------------------------------------------===//
 
-//===--- Graph Pipeline -----------------------------------------------===//
-struct GraphOptions : public PassPipelineOptions<GraphOptions> {
-
-  PassOptions::ListOption<std::string> targets{
-      *this, "targets",
-      desc("list of target architectures to clone kernels for")};
-};
-
 //===--- Model Pipeline ---------------------------------------------------===//
 struct PackageOptions : public PassPipelineOptions<PackageOptions> {};
 

--- a/external/mlir-hal/include/mlir/Support/SystemDevice.h
+++ b/external/mlir-hal/include/mlir/Support/SystemDevice.h
@@ -17,8 +17,6 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
 
-#include <string>
-
 namespace mlir {
 namespace mhal {
 
@@ -32,7 +30,6 @@ struct SystemDevice {
 
   LogicalResult parse(llvm::StringRef arch);
   bool isCompatible(const SystemDevice &that) const;
-  std::string getArch() const;
   void dump() const;
 
 private:

--- a/external/mlir-hal/lib/Conversion/MHALToGPU/MHALToGPU.cpp
+++ b/external/mlir-hal/lib/Conversion/MHALToGPU/MHALToGPU.cpp
@@ -59,9 +59,11 @@ static LogicalResult lowerKernelCallToGpu(PatternRewriter &rw, func::CallOp op,
   auto module = op->getParentOfType<ModuleOp>();
   MLIRContext *ctx = module.getContext();
 
+  // The only caller (KernelFuncCallRewritePattern::matchAndRewrite) already
+  // checks getGPUTarget() before dispatching here, so a GPU target is
+  // guaranteed at this point.
   auto kernelPkg = getGPUTarget(func);
-  if (!kernelPkg.has_value())
-    return rw.notifyMatchFailure(op, "no gpu target");
+  assert(kernelPkg.has_value() && "caller must ensure func has a GPU target");
 
   auto targetObj = kernelPkg->getObject();
   auto binary = targetObj.getBinary();

--- a/external/mlir-hal/lib/Dialect/MHAL/IR/MHAL.cpp
+++ b/external/mlir-hal/lib/Dialect/MHAL/IR/MHAL.cpp
@@ -27,23 +27,6 @@ void mhal::MHALDialect::initialize() {
       >();
 }
 
-//===----------------------------------------------------------------------===//
-// MHALDialect Interfaces
-//===----------------------------------------------------------------------===//
-namespace {
-struct MHALAsmDialectInterface : public OpAsmDialectInterface {
-  using OpAsmDialectInterface::OpAsmDialectInterface;
-
-  AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (isa<mhal::TargetObjectAttr>(attr)) {
-      os << "target_obj";
-      return AliasResult::OverridableAlias;
-    }
-    return AliasResult::NoAlias;
-  }
-};
-} // namespace
-
 namespace mlir {
 namespace mhal {
 

--- a/external/mlir-hal/lib/Support/SystemDevice.cpp
+++ b/external/mlir-hal/lib/Support/SystemDevice.cpp
@@ -83,25 +83,6 @@ bool SystemDevice::isCompatible(const SystemDevice &that) const {
   return matches;
 }
 
-std::string SystemDevice::getArch() const {
-  std::string arch;
-  arch.reserve(llvmTriple.size() + chip.size() + features.size() * 10);
-  if (!llvmTriple.empty()) {
-    arch = llvmTriple.str();
-    arch += ':';
-  }
-  if (!chip.empty())
-    arch += chip.str();
-
-  for (const auto &entry : features) {
-    arch += ':';
-    arch += entry.getKey().str();
-    arch += (entry.getValue() ? '+' : '-');
-  }
-
-  return arch;
-}
-
 void SystemDevice::dump() const {
   llvm::errs() << "Device(" << getDeviceTypeStr(type) << ") x " << count << "\n"
                << "\n  triple = " << llvmTriple << "\n  chip = " << chip;


### PR DESCRIPTION
## Motivation

Remove dead and unreachable code in external/mlir-hal discovered while expanding MHAL dialect lit-test coverage. These code paths could never be exercised by tests, which both inflated the coverage gap and added maintenance burden for vendored code.

## Technical Details

All changes are confined to external/mlir-hal ([EXTERNAL]), purely dead-code removal with no functional change:

- MHAL.cpp: removed the unused MHALAsmDialectInterface struct — its getAlias override was never registered on the dialect, so it could never be invoked.
- SystemDevice.{h,cpp}: removed SystemDevice::getArch() (no callers anywhere in the tree) and the now-redundant #include <string> that only existed for its return type.
- Pipelines.h: removed the unused GraphOptions struct.
- MHALToGPU.cpp: replaced a redundant runtime null-check on the kernel package with an assert — the value is guaranteed valid at that point, so the guard was unreachable.

## Test Plan

- Rebuilt the affected libraries (MLIRMHALSupport, MLIRMHALTransforms) to confirm the <string> removal does not break either consumer of the header (SystemDevice.cpp, SelectTargets.cpp).
- Ran the MHAL dialect lit test suite.

## Test Result

- Build succeeded (exit code 0) with no warnings/errors from the touched files.
- All MHAL lit tests pass; no regressions.
- [ ] PR CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
