### PR TITLE
Fix run_pipeline subprocess pipe-buffer deadlock

### DIFF
--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -5,6 +5,8 @@ from collections import OrderedDict
 import getopt
 import os
 import subprocess
+import signal
+import tempfile
 import sys
 import math
 import itertools
@@ -424,27 +426,83 @@ def get_miliseconds(output):
 
 
 def run_pipeline(proc_specs):
+    """Run a shell-style pipeline (stage[i] stdout -> stage[i+1] stdin).
+
+    Returns ``(stdout_of_last_stage, ok)``.
+
+    All pipes are drained so no stage can deadlock on a full OS pipe buffer:
+      * Each stage's stderr goes to its own temp file, so a chatty stage can
+        never block writing stderr into a PIPE that is not read until after
+        ``wait()`` (the classic pipeline deadlock -- e.g. rocprof emitting many
+        KiB of trace/stats output, or the tuning driver's benchmark logs).
+      * Every stage still uses ``stdout=PIPE`` to wire ``stage[i]`` into
+        ``stage[i+1]``, but the parent closes each intermediate read-end right
+        after wiring it, so only the final stage's stdout is read by the parent
+        -- drained with ``communicate()`` (which reads concurrently), letting
+        the whole chain make progress before any stage is reaped.
+      * Because each intermediate read-end is closed in the parent, upstream
+        stages observe EOF/SIGPIPE and exit.
+
+    Never raises: any failure to spawn or drive the pipeline is reported and
+    returned as ``(b"", False)`` so callers can rely solely on the boolean.
+    """
     procs = []
-    for proc in proc_specs:
-        prev_stdout = procs[-1].stdout if procs else subprocess.DEVNULL
-        po = subprocess.Popen(proc,
-                              stdin=prev_stdout,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
-        procs.append(po)
+    stderr_files = []
     try:
-        for p in procs:
+        for proc in proc_specs:
+            prev_stdout = procs[-1].stdout if procs else subprocess.DEVNULL
+            errf = tempfile.TemporaryFile()
+            stderr_files.append(errf)
+            po = subprocess.Popen(proc, stdin=prev_stdout, stdout=subprocess.PIPE, stderr=errf)
+            if procs:
+                # Parent no longer needs the upstream read-end.
+                procs[-1].stdout.close()
+            procs.append(po)
+
+        # Drain the last stage's stdout concurrently; this cascades demand
+        # back through the pipeline so intermediate stages can finish writing.
+        outs, _ = procs[-1].communicate()
+
+        ok = True
+        failing_idx = None
+        for idx, p in enumerate(procs):
             p.wait()
-            if p.returncode != 0:
-                raise OSError(str(p.stderr.read()))
-        outs, errs = p.communicate()
-        return outs, True
+            # A non-final stage killed by SIGPIPE (-13) just means a downstream
+            # stage exited first; the real failure (if any) is reported
+            # downstream. The final stage has no downstream reader (its stdout
+            # is drained here via communicate()), so a SIGPIPE there is a real
+            # failure and must not be swallowed.
+            allow_sigpipe = idx < len(procs) - 1 and p.returncode == -signal.SIGPIPE
+            if p.returncode != 0 and not allow_sigpipe:
+                ok = False
+                if failing_idx is None:
+                    failing_idx = idx
+
+        if not ok:
+            errf = stderr_files[failing_idx]
+            errf.seek(0)
+            err_text = errf.read().decode("utf-8", errors="replace")
+            failing = procs[failing_idx]
+            print(f"Error:  {err_text}")
+            print(f"Failing command:  {' '.join(failing.args)}")
+            print(f"Failing pipeline:  {' | '.join(' '.join(proc) for proc in proc_specs)}")
+        return outs, ok
     except Exception as err:
+        # Spawning or driving the pipeline failed (e.g. a missing executable,
+        # or an error while draining). Callers key off the returned bool rather
+        # than catching exceptions, so report context and fail gracefully
+        # instead of crashing the whole runner.
         print(f"Error:  {err}")
-        print(f"Failing command:  {' '.join(p.args)}")
-        print(f"Failing pipeline:  {' | '.join([' '.join(proc) for proc in proc_specs])}")
-        outs, errs = p.communicate()
-    return outs, False
+        print(f"Failing pipeline:  {' | '.join(' '.join(proc) for proc in proc_specs)}")
+        return b"", False
+    finally:
+        # Terminate any still-running stages so a partial pipeline can't leak
+        # processes, then release every stderr temp file.
+        for p in procs:
+            if p.poll() is None:
+                p.kill()
+        for errf in stderr_files:
+            errf.close()
 
 
 class PerfConfiguration:

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -496,11 +496,18 @@ def run_pipeline(proc_specs):
         print(f"Failing pipeline:  {' | '.join(' '.join(proc) for proc in proc_specs)}")
         return b"", False
     finally:
-        # Terminate any still-running stages so a partial pipeline can't leak
-        # processes, then release every stderr temp file.
+        # Terminate any still-running stages and reap them so a partial
+        # pipeline can't leak processes or zombies, then release every stderr
+        # temp file. wait() is a cheap no-op for stages already reaped above;
+        # the timeout keeps teardown from ever hanging.
         for p in procs:
             if p.poll() is None:
                 p.kill()
+        for p in procs:
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
         for errf in stderr_files:
             errf.close()
 


### PR DESCRIPTION
## Summary

`perfRunner.run_pipeline` builds a shell-style pipeline (`stage[i]` stdout → `stage[i+1]` stdin). It created **every** stage with `stdout=PIPE` **and** `stderr=PIPE`, then called `p.wait()` on each process (including the last) *before* draining any pipe. The OS pipe buffer is ~64 KiB: as soon as a stage writes more than that to stdout or stderr, the kernel blocks its `write()`, the process never exits, and `wait()` blocks forever. `rocprof`'s trace/stats output and the tuning driver's benchmark logs both blow past 64 KiB, so benchmark runs hang.

## Fix

Rewrite `run_pipeline` to drain correctly:

- **Each stage's stderr goes to its own temp file** — a file write never blocks on a pipe buffer, so a chatty stage can't deadlock on stderr.
- **Only the final stage's stdout is read by the parent**, drained via `communicate()` (which reads concurrently); each intermediate read-end is closed in the parent right after wiring, so upstream stages observe EOF/`SIGPIPE`.
- **`SIGPIPE` tolerance is scoped to non-final stages** (an early-exiting downstream stage is expected); a `SIGPIPE` on the final stage is a real failure and is not swallowed.
- **Fails gracefully**: any spawn/drain error is reported and returned as `(b"", False)` (callers key off the boolean), and any still-running stages are killed so a partial pipeline can't leak processes.

## Test plan

- [x] Static checks: `flake8` and `yapf` clean on the changed region (repo `.flake8` / `.style.yapf`).
- [x] Validated with a GPU-free stress test: a stage emitting 2 MiB to **both** stdout and stderr completes instantly with the fix, whereas the old implementation deadlocks (reproduced: hangs until watchdog fires). Failing-stage and missing-executable cases both return `ok=False` (the latter as `(b"", False)` without raising).
- [ ] CI perf-scripts / benchmark runs no longer hang.

## Note

Ports the same fix from the vendored rocmlirTriton copy of this script (upstream PR: ROCm/rocmlirTriton#327).

Made with [Cursor](https://cursor.com)