### PR TITLE
[AIROCMLIR-1042] Reject DirectToLDSDoubleBuffer attention with padded gemm1 K and >1 M block

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -2332,6 +2332,23 @@ struct GridwiseAttentionAccelRewritePattern
         loadTypeQ == GemmLoadTileType::DoubleBuffer ||
         loadTypeQ == GemmLoadTileType::DirectToLDSDoubleBuffer;
 
+    // Correctness guard for the DirectToLDSDoubleBuffer (schedule v4) path of
+    // the second attention GEMM (P*V -> O). The gemm1 M loop iterates over
+    // gemm1MBlocks (the head_dim_v tiles). When gemm1's K tile is padded
+    // (seq_len_k not a multiple of gemm1KPerBlock, recorded via prePadG0M) and
+    // that loop has more than one iteration (head_dim_v > gemm1MPerBlock), the
+    // double-buffered direct-to-LDS V load prefetches the next tile without
+    // re-zeroing the padded-K region, so P*V accumulates uninitialized LDS and
+    // O is incorrect (LSE stays correct). Reject the combination so it is
+    // reported as inapplicable instead of silently returning wrong results.
+    if (loadType == GemmLoadTileType::DirectToLDSDoubleBuffer &&
+        op.getPrePadG0M().has_value() && gemm1MBlocks > 1) {
+      return op.emitOpError(
+          "DirectToLDSDoubleBuffer schedule is unsupported for attention when "
+          "the second GEMM has a padded K tile (padded seq_len_k) and more "
+          "than one M block (head_dim_v > gemm1MPerBlock)");
+    }
+
     // Note that we dont provide nRepeats because we dont want
     // nRepeats times reg buffer to be created for B of gemm0
     // because we wont be prefetching that.

--- a/mlir/test/rocmlir-gen/attention-directtolds-doublebuffer-guard.mlir
+++ b/mlir/test/rocmlir-gen/attention-directtolds-doublebuffer-guard.mlir
@@ -1,0 +1,16 @@
+// Attention lowering must reject the DirectToLDSDoubleBuffer schedule (v4) for
+// the second GEMM (P*V -> O) when its K tile is padded (seq_len_k not a multiple
+// of gemm1KPerBlock) and head_dim_v spans more than one M block
+// (head_dim_v > gemm1MPerBlock). That combination miscompiles the O tensor by
+// reading uninitialized LDS in the double-buffered direct-to-LDS V load, so it
+// must be reported as inapplicable instead of silently returning wrong results.
+
+// Rejected: schedule v4, padded seq_len_k (20 not a multiple of gemm1KPerBlock=32),
+// and head_dim_v 48 > gemm1MPerBlock 32 (=> more than one gemm1 M block).
+// RUN: rocmlir-gen --arch gfx942:sramecc+:xnack- -operation attention -t f16 -seq_len_q 64 -seq_len_k 20 -head_dim_qk 32 -head_dim_v 48 --with-attn-scale --perf_config=attn:v3:32,32,32,8,32,32,16,4,1,4,2,2,1 | not rocmlir-driver --kernel-pipeline=applicability - 2>&1 | FileCheck %s --check-prefix=REJECT
+// REJECT: DirectToLDSDoubleBuffer schedule is unsupported for attention
+
+// Accepted: same shape with the single-stage direct-to-LDS schedule (v3) still
+// lowers, confirming the guard is specific to the double-buffered variant.
+// RUN: rocmlir-gen --arch gfx942:sramecc+:xnack- -operation attention -t f16 -seq_len_q 64 -seq_len_k 20 -head_dim_qk 32 -head_dim_v 48 --with-attn-scale --perf_config=attn:v3:32,32,32,8,32,32,16,4,1,3,2,2,1 | rocmlir-driver --kernel-pipeline=applicability - | FileCheck %s --check-prefix=OK
+// OK: func.func @rock_attention


### PR DESCRIPTION
## Motivation

The `AttentionSweeps` job on #2371 started failing on `gfx950` with a single `f16` attention configuration that fails numeric validation (large RMS, sometimes `NaN`), while every other sampled config passes.

Root cause is a compiler codegen bug, the `DirectToLDSDoubleBuffer` schedule (schedule version 4) miscompiles the second attention GEMM (`P*V -> O`) for a specific tile/shape class, silently producing an incorrect `O` tensor. Because the config still compiles and runs (no crash), the sweep reports it as a hard `FAILED`.

The goal of this PR is to make the compiler **stop emitting a known-wrong kernel** for that combination, which also unblocks the sweep, the config becomes `INVALID`/filtered instead of `FAILED`.

## Technical Details

Reproduced on `gfx950` with the failing sweep config:

```
datatype=f16, g=65, seq_len_q=12, seq_len_k=52, head_dim_qk=535, head_dim_v=290, with_attn_scale=True, return_lse=True, split_kv=1, perfconfig=attn:v3:256,256,256,8,256,128,32,4,1,4,2,2,1
```

The `O` output fails with RMS ~0.7 (often `NaN`/zeros; the exact values vary run-to-run), while `LSE` is always correct, a signature of reading uninitialized / out-of-bounds LDS in the second GEMM.

Controlled bisection over the perfconfig and the shape isolates the trigger to the co-occurrence of three conditions in the fused attention lowering (`GridwiseAttentionAccelRewritePattern`):

- schedule version 4 = `DirectToLDSDoubleBuffer` (v1/v2/v3 are all correct);
- gemm1's K tile is padded — `seq_len_k` is not a multiple of `gemm1KPerBlock` (recorded as `prePadG0M`)
- gemm1 spans more than one M block — `head_dim_v > gemm1MPerBlock` (`gemm1MBlocks > 1`).

Removing any single condition (schedule v3, a single M block, or a full K tile) produces correct results, and fully tile-aligned shapes are unaffected. In this regime the double-buffered direct-to-LDS `V` load for M blocks past the first is not re-zeroed over the padded-K region, so `P*V` accumulates garbage.

This is only reachable on `gfx950` because the offending big-tile perfconfig needs ~128 KB LDS, which fits on gfx950 but is rejected on gfx942 (64 KB max). The attention sweep samples perfconfigs (including schedule versions 1–4) at random, and the applicability check does not currently reject this combination.

**Fix** (`mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp`) in `GridwiseAttentionAccelRewritePattern`, reject `DirectToLDSDoubleBuffer` when `prePadG0M` is set and `gemm1MBlocks > 1`. The op is reported as inapplicable (`emitOpError`) instead of lowering to an incorrect kernel. The sweep then classifies it as `INVALID` and the tuner falls back to another (correct) schedule.

## Test Plan

- New lit test `mlir/test/rocmlir-gen/attention-directtolds-doublebuffer-guard.mlir` the v4 + padded-K + `head_dim_v > gemm1MPerBlock` config is rejected with the guard diagnostic, and the same shape with schedule v3 still lowers
- Local end-to-end reproduction on `gfx950` (MI350X, ROCm 7.2.4) the exact CI config's applicability now returns non-zero (so `parameterSweeps` returns `INVALID`), while schedule v3, single-M-block, full-K, and fully aligned shapes still lower and validate `[1 1 1]`
- Regression check, ran the attention lit subset with and without the change on this base. The failure sets are identical (the guard introduces no new failures)

## Test Result

- Failing `gfx950` sweep config `FAILED` -> `INVALID` (filtered)
- Control configs (schedule v3 / single M block / full K / tile-aligned) still lower and validate correctly
- New lit test passes
- No regressions across the attention lit tests
- [ ] PR CI 
- [ ] Weekly CI with parameterSweeps and attentionSweeps

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.