### PR TITLE
[AIROCMLIR-1042] Zero padded LDS before direct-to-LDS gather

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp
@@ -297,6 +297,29 @@ class LoweringBlockwiseLoadTileOp final
 
       Value wrappedSource = transform(b, source, maybeBufferViews->gridSubTile);
 
+      // The direct-to-LDS gather (amdgpu.gather_to_lds) drops out-of-bounds
+      // writes instead of writing 0 (unlike the register-staged path, which
+      // yields 0 for OOB via its scf.if/else). That leaves the padded region of
+      // the LDS tile uninitialized; if it contains NaN it poisons downstream
+      // matmuls (NaN*0 = NaN). Only when the load can actually go out of bounds
+      // (the load transforms contain non-trivial padding), cooperatively zero
+      // the LDS tile first so OOB/padded elements are 0. When there is no
+      // padding the gather fills the whole tile, so this is skipped to avoid the
+      // extra LDS write + barrier.
+      if (directToLDS) {
+        SmallVector<TransformMapAttr> loadTransforms;
+        untransform(wrappedSource, loadTransforms);
+        bool canBeOutOfBounds = llvm::any_of(
+            loadTransforms,
+            [](TransformMapAttr t) { return mapImpactsValidity(t); });
+        if (canBeOutOfBounds) {
+          Value zeroVal = createZeroConstantOp(b, loc, elementType);
+          rock::BlockwiseFillOp::create(b, loc, loadBuffer, zeroVal,
+                                        static_cast<uint32_t>(blockSize));
+          rock::LDSBarrierOp::create(b, loc);
+        }
+      }
+
       ThreadwiseReadIntoOp::create(b, loc, vectorOfBoolShapedLike(loadBuffer),
                                    wrappedSource, loadBuffer,
                                    /*dynamicValidities=*/ValueRange{},

--- a/mlir/test/rocmlir-gen/attention-directtolds-oob-zero.mlir
+++ b/mlir/test/rocmlir-gen/attention-directtolds-oob-zero.mlir
@@ -1,0 +1,16 @@
+// The direct-to-LDS gather (amdgpu.gather_to_lds) drops out-of-bounds writes
+// instead of writing 0, so a padded tile would be left uninitialized in LDS and
+// poison the second attention GEMM (NaN*0 = NaN). For direct-to-LDS loads that
+// can go out of bounds (non-trivial padding), the LDS tile must be
+// cooperatively zeroed (rock.blockwise_fill) before the gather. Aligned loads
+// need no zeroing and must not pay for it.
+
+// Padded: seq_len_k (20) is not a multiple of the K-per-block, so the V load
+// can go out of bounds and the LDS tile must be zeroed first.
+// RUN: rocmlir-gen --arch gfx942:sramecc+:xnack- -operation attention -t f16 -seq_len_q 64 -seq_len_k 20 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --perf_config=attn:v3:32,32,32,8,32,32,16,4,1,4,2,2,1 | rocmlir-driver --kernel-pipeline=applicability - --mlir-print-ir-after=rock-blockwise-load-tile-to-threadwise 2>&1 | FileCheck %s --check-prefix=PADDED
+// PADDED: rock.blockwise_fill
+
+// Aligned: all dims are multiples of the tile, no out-of-bounds is possible, so
+// no LDS zeroing is emitted.
+// RUN: rocmlir-gen --arch gfx942:sramecc+:xnack- -operation attention -t f16 -seq_len_q 64 -seq_len_k 64 -head_dim_qk 64 -head_dim_v 64 --with-attn-scale --perf_config=attn:v3:32,32,32,8,32,32,16,4,1,4,2,2,1 | rocmlir-driver --kernel-pipeline=applicability - --mlir-print-ir-after=rock-blockwise-load-tile-to-threadwise 2>&1 | FileCheck %s --check-prefix=ALIGNED
+// ALIGNED-NOT: rock.blockwise_fill


### PR DESCRIPTION
## Motivation

The AttentionSweeps job on #2371 started failing on gfx950 with a single f16 attention configuration that fails numeric validation (large RMS, sometimes NaN), while every other sampled config passes. [https://ml-ci-internal.amd.com/blue/organizations/jenkins/MLIR%2Fmlir/detail/PR-2371/58/pipeline/937]
Padded attention configurations that use the direct-to-LDS path fail numeric validation on gfx950 (NaNs and large RMS errors), most visibly on the direct-to-LDS double-buffer schedule. The goal of this PR is to fix the underlying codegen bug so that padded direct-to-LDS loads produce correct results, instead of working around it by rejecting the affected configurations during tuning/sweeps.

## Technical Details

Root cause: the direct-to-LDS gather (`amdgpu.gather_to_lds`) drops out-of-bounds writes instead of writing `0`. This differs from the register-staged load path, which explicitly yields `0` for OOB elements via its `scf.if/else`. When a load tile is padded (e.g. attention with `seq_len_k` / `head_dim` not a multiple of the K-per-block), the padded region of the destination LDS tile is therefore left uninitialized. If that leftover LDS happens to contain NaN, it poisons the downstream GEMM (`NaN * 0 = NaN`) and propagates NaNs / large errors into the result.

Fix (`mlir/lib/Dialect/Rock/Transforms/BlockwiseLoadTileToThreadwise.cpp`): for a direct-to-LDS load, detect whether it can actually go out of bounds by walking its transform chain (`untransform` + `mapImpactsValidity`, i.e. the presence of non-trivial padding). When it can, cooperatively zero the LDS tile with `rock.blockwise_fill` followed by an `rock.lds_barrier` before issuing the gather, so all OOB/padded elements are guaranteed to be `0`. The zeroing is guarded on real padding: when the load cannot go out of bounds the gather fills the whole tile as before, so aligned loads pay no extra LDS write or barrier.

## Test Plan

- Added a lit regression test `mlir/test/rocmlir-gen/attention-directtolds-oob-zero.mlir` that lowers a padded direct-to-LDS attention config and checks that the cooperative zero-fill (`rock.blockwise_fill`) is emitted, plus an aligned config that must not emit it.
- Verified the new lit test FAILS when the fix is reverted and PASSES with the fix, confirming it is a real regression guard.
- Re-ran the originally failing padded attention config end-to-end on gfx950 with the full validation flags.
- Re-ran the previously-passing direct-to-LDS attention configs to check for numeric regressions.
- Ran the `Dialect/Rock`, `rocmlir-gen`, and `rocmlir-driver` lit suites.

## Test Result

- The new lit test passes with the fix and fails without it (valid regression guard).
- The originally failing gfx950 attention config now validates (`[1 1 1]`), with no numeric regressions on the previously-passing configs.
- [ ] PR CI
- [ ] Weekly CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.