### PR TITLE
[AIROCMLIR-1061] Increase rocm-smi timeout

### DIFF
--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -252,11 +252,13 @@ class GpuTopology:
 
         rocm-smi reports physical device IDs regardless of environment variables (e.g., ROCR_VISIBLE_DEVICES and HIP_VISIBLE_DEVICES).
         """
+        # rocm-smi can take ~20s to enumerate large multi-GPU systems, so allow
+        # a generous timeout to avoid spurious TimeoutExpired failures.
         output = subprocess.check_output(
             ["rocm-smi", "--showproductname", "--showtoponuma", "--json"],
             text=True,
             stderr=subprocess.DEVNULL,
-            timeout=10)
+            timeout=60)
         data = json.loads(output)
 
         gpus = {}


### PR DESCRIPTION
## Motivation

This PR addresses some flaky/intermittent behavior observed in the `tuningRunner-*` LIT tests when calling into `rocm-smi` for GPU topology discovery.

## Technical Details

In https://github.com/ROCm/rocmlirTriton/pull/310 in rocmlirTriton we bumped the timeout from 10s -> 60s. Looking at the history of nightly CI runs since then shows that this issue has not come up. This PR just ports those same changes to rocMLIR.

## Test Plan

* Run the nightly CI

## Test Result

* [x] Nightly CI

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
