### PR TITLE
[AIROCMLIR-1062] Add tuning timeout for GPU hangs

### DIFF
--- a/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
+++ b/mlir/tools/rocmlir-tuning-driver/rocmlir-tuning-driver.cpp
@@ -55,6 +55,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <mutex>
+#include <optional>
 #include <thread>
 
 #include "CacheFlush.h"
@@ -87,6 +88,11 @@ void pArgs(const std::tuple<Ts...> &formals, void **_vargs) {
 
 using namespace mlir;
 using namespace rocmlir::tuningdriver;
+
+/// Process exit code signalling that a perf config's GPU run exceeded the
+/// per-config run-timeout budget (--gpu-run-timeout) and the kernel is
+/// presumed hung. Must be non-zero and distinct from EXIT_FAILURE.
+static constexpr int kExitGpuTimeout = 3;
 
 //===----------------------------------------------------------------------===//
 // Shared Resources for Multi-threaded Compilation
@@ -183,6 +189,16 @@ static llvm::cl::opt<bool> waitForCompiles(
     llvm::cl::desc("Wait for all compilations to finish before benchmarking"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<unsigned> gpuRunTimeout(
+    "gpu-run-timeout",
+    llvm::cl::desc(
+        "Per-perf-config GPU-run timeout in seconds. 0 (default) disables the "
+        "timeout. This does not include compilation. When > 0, stream "
+        "synchronization is bounded with polling; a run that exceeds this "
+        "budget is presumed hung and the process exits with a distinct exit "
+        "code."),
+    llvm::cl::value_desc("seconds"), llvm::cl::init(0));
+
 // Ripped out of JitRunner.cpp
 static OwningOpRef<ModuleOp> parseMLIRInput(StringRef inputFilename,
                                             MLIRContext *context) {
@@ -204,6 +220,53 @@ static OwningOpRef<ModuleOp> parseMLIRInput(StringRef inputFilename,
   if (hipSuccess != (expr)) {                                                  \
     return failure();                                                          \
   }
+
+using SteadyTimePoint = std::chrono::steady_clock::time_point;
+
+static std::optional<SteadyTimePoint> makeTimeoutDeadline(unsigned timeoutSec) {
+  if (timeoutSec == 0)
+    return std::nullopt;
+  return std::chrono::steady_clock::now() + std::chrono::seconds(timeoutSec);
+}
+
+static bool hasTimedOut(const std::optional<SteadyTimePoint> &deadline) {
+  return deadline && std::chrono::steady_clock::now() >= *deadline;
+}
+
+static LogicalResult synchronizeStreamWithTimeout(
+    hipStream_t stream, const std::optional<SteadyTimePoint> &gpuRunDeadline,
+    unsigned timeoutSec, StringRef perfConfig, StringRef phase) {
+  // Preserve the historical behavior when no GPU-run timeout was requested.
+  if (!gpuRunDeadline) {
+    HIPCHECK(hipStreamSynchronize(stream));
+    return success();
+  }
+
+  // hipStreamSynchronize can block forever when a kernel wedges. Polling the
+  // stream gives the driver a chance to stop the run and let tuning advance.
+  while (true) {
+    hipError_t status = hipStreamQuery(stream);
+    if (status == hipSuccess)
+      return success();
+
+    if (status != hipErrorNotReady) {
+      llvm::errs() << "HIP error while synchronizing stream during " << phase
+                   << " for config: " << perfConfig << " - "
+                   << hipGetErrorString(status) << "\n";
+      return failure();
+    }
+
+    if (hasTimedOut(gpuRunDeadline)) {
+      llvm::errs() << "GPU run timed out after " << timeoutSec << "s during "
+                   << phase << " for config: " << perfConfig
+                   << " (kernel presumed hung)\n";
+      llvm::errs().flush();
+      std::_Exit(kExitGpuTimeout);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
 
 static double computeMedian(const std::vector<double> &values) {
   if (values.empty())
@@ -276,6 +339,7 @@ struct BenchmarkParams {
   const unsigned numCompileThreads;
   std::string benchmarkConfig;
   bool waitForCompiles;
+  unsigned gpuRunTimeoutSec;
 };
 
 enum class CompilationStatus {
@@ -345,13 +409,13 @@ struct ThreadResources {
   bool isValid() const { return sourceModule && *sourceModule; }
 };
 
-static LogicalResult
-measureSmallKernel(unsigned iterations, hipStream_t stream,
-                   const std::vector<hipFunction_t> &functions,
-                   ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
-                   std::vector<void *> &argPointers,
-                   std::vector<double> &measurements, double &smallKernelCpuMs,
-                   bool benchmarkMode) {
+static LogicalResult measureSmallKernel(
+    unsigned iterations, hipStream_t stream,
+    const std::vector<hipFunction_t> &functions, ArrayRef<uint32_t> blockSizes,
+    ArrayRef<uint32_t> gridSizes, std::vector<void *> &argPointers,
+    std::vector<double> &measurements, double &smallKernelCpuMs,
+    bool benchmarkMode, const std::optional<SteadyTimePoint> &gpuRunDeadline,
+    unsigned timeoutSec, StringRef perfConfig) {
   // Special case for small kernels, where we measure the time for all kernels
   // at once, using CPU timers.
   auto iterationStart = std::chrono::steady_clock::now();
@@ -374,7 +438,9 @@ measureSmallKernel(unsigned iterations, hipStream_t stream,
     }
   }
 
-  HIPCHECK(hipStreamSynchronize(stream));
+  if (failed(synchronizeStreamWithTimeout(stream, gpuRunDeadline, timeoutSec,
+                                          perfConfig, "measurement")))
+    return failure();
   smallKernelCpuMs = std::chrono::duration<double, std::milli>(
                          std::chrono::steady_clock::now() - iterationStart)
                          .count();
@@ -387,7 +453,9 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
                    const std::vector<hipFunction_t> &functions,
                    ArrayRef<uint32_t> blockSizes, ArrayRef<uint32_t> gridSizes,
                    std::vector<void *> &argPointers,
-                   std::vector<double> &measurements) {
+                   std::vector<double> &measurements,
+                   const std::optional<SteadyTimePoint> &gpuRunDeadline,
+                   unsigned timeoutSec, StringRef perfConfig) {
   // Measure runs normally.
   for (unsigned iter = 0; iter < iterations; ++iter) {
     if (failed(flushInstructionCache(stream))) {
@@ -408,7 +476,9 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
       HIPCHECK(hipExtModuleLaunchKernel(
           func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
           argPointers.data(), nullptr, startEvent, stopEvent));
-      HIPCHECK(hipEventSynchronize(stopEvent));
+      if (failed(synchronizeStreamWithTimeout(
+              stream, gpuRunDeadline, timeoutSec, perfConfig, "measurement")))
+        return failure();
 
       float currentMilliseconds = 0.0;
       HIPCHECK(
@@ -427,13 +497,12 @@ measureLargeKernel(unsigned iterations, hipStream_t stream,
 }
 
 // In order to match rocprof, returns time in nanoseconds
-static FailureOr<double> benchmarkKernels(ArrayRef<std::string> binaries,
-                                          ArrayRef<std::string> funcNames,
-                                          ArrayRef<uint32_t> blockSizes,
-                                          ArrayRef<uint32_t> gridSizes,
-                                          MutableArrayRef<void *> gpuBuffers,
-                                          hipStream_t stream,
-                                          const BenchmarkParams &params) {
+static FailureOr<double>
+benchmarkKernels(ArrayRef<std::string> binaries,
+                 ArrayRef<std::string> funcNames, ArrayRef<uint32_t> blockSizes,
+                 ArrayRef<uint32_t> gridSizes,
+                 MutableArrayRef<void *> gpuBuffers, hipStream_t stream,
+                 StringRef perfConfig, const BenchmarkParams &params) {
   bool benchmarkMode = !params.benchmarkConfig.empty();
 
   // HIP wants an array of pointers to each argument
@@ -474,6 +543,12 @@ static FailureOr<double> benchmarkKernels(ArrayRef<std::string> binaries,
     }
   });
 
+  // Apply one user-specified GPU-run deadline across all stream
+  // synchronization for this perf config. Compilation and module loading are
+  // not included.
+  std::optional<SteadyTimePoint> gpuRunDeadline =
+      makeTimeoutDeadline(params.gpuRunTimeoutSec);
+
   bool isSmallKernel = false;
   unsigned iterations = params.numIterations;
 
@@ -493,7 +568,10 @@ static FailureOr<double> benchmarkKernels(ArrayRef<std::string> binaries,
             func, gridSize * blockSize, 1, 1, blockSize, 1, 1, 0, stream,
             argPointers.data(), nullptr, startEvent, stopEvent));
 
-        HIPCHECK(hipStreamSynchronize(stream));
+        if (failed(synchronizeStreamWithTimeout(stream, gpuRunDeadline,
+                                                params.gpuRunTimeoutSec,
+                                                perfConfig, "warmup")))
+          return failure();
 
         float currentMilliseconds = 0.0;
         HIPCHECK(
@@ -540,13 +618,15 @@ static FailureOr<double> benchmarkKernels(ArrayRef<std::string> binaries,
   double smallKernelCpuMs = 0.0;
 
   if (isSmallKernel) {
-    if (failed(measureSmallKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, argPointers, measurements,
-                                  smallKernelCpuMs, benchmarkMode)))
+    if (failed(measureSmallKernel(
+            iterations, stream, functions, blockSizes, gridSizes, argPointers,
+            measurements, smallKernelCpuMs, benchmarkMode, gpuRunDeadline,
+            params.gpuRunTimeoutSec, perfConfig)))
       return failure();
   } else {
-    if (failed(measureLargeKernel(iterations, stream, functions, blockSizes,
-                                  gridSizes, argPointers, measurements)))
+    if (failed(measureLargeKernel(
+            iterations, stream, functions, blockSizes, gridSizes, argPointers,
+            measurements, gpuRunDeadline, params.gpuRunTimeoutSec, perfConfig)))
       return failure();
   }
 
@@ -733,7 +813,7 @@ static LogicalResult runTuningLoop(ModuleOp source) {
   const BenchmarkParams benchmarkParams = {
       numIterations,     warmupIterations, useMedian,           trimPercent,
       sleepUs,           showStats,        showAllMeasurements, tuningSpaceKind,
-      numCompileThreads, benchmarkConfig,  waitForCompiles};
+      numCompileThreads, benchmarkConfig,  waitForCompiles,     gpuRunTimeout};
 
   rock::TuningParamSetKind effectiveKind = benchmarkParams.tuningSpaceKind;
   unsigned numTuningIterations = rock::getNumberOfIterations(effectiveKind);
@@ -990,9 +1070,10 @@ static LogicalResult runTuningLoop(ModuleOp source) {
       assert(result.status == CompilationStatus::Success &&
              "Unexpected compilation status in benchmarking phase");
 
-      FailureOr<double> timing = benchmarkKernels(
-          result.hipModules, kernelFuncNames, result.blockSizes,
-          result.gridSizes, gpuBuffers, stream, benchmarkParams);
+      FailureOr<double> timing =
+          benchmarkKernels(result.hipModules, kernelFuncNames,
+                           result.blockSizes, result.gridSizes, gpuBuffers,
+                           stream, result.perfConfig, benchmarkParams);
 
       if (failed(timing)) {
         llvm::errs() << "Kernel execution failed\n";

--- a/mlir/utils/performance/tests/test_tuningRunner.py
+++ b/mlir/utils/performance/tests/test_tuningRunner.py
@@ -257,6 +257,7 @@ class TestTunedConfigsCache:
             wait_for_compiles=False,
             timeout=None,
             verify_timeout=None,
+            gpu_run_timeout=0,
         )
 
     def test_missing_file_returns_empty_cache(self):
@@ -469,6 +470,7 @@ class TestCanonicalizeTestVector:
                 wait_for_compiles=False,
                 timeout=None,
                 verify_timeout=None,
+                gpu_run_timeout=0,
             )
             cache = TunedConfigsCache.from_output_file(opts, GemmConfiguration)
             assert cache.count() == 1

--- a/mlir/utils/performance/tests/test_tuningRunner.py
+++ b/mlir/utils/performance/tests/test_tuningRunner.py
@@ -31,7 +31,8 @@ import tuningRunner  # noqa: E402 - must run after mock_hip
 from tuningRunner import (  # noqa: E402
     ConfigState, TuningState, TuningStateFile, TunedConfigsCache, Options, get_state_filepath,
     verify_mode_flags, format_error, get_config_class, get_git_commit_hash, NumaTopology, Operation,
-    NumaNodeLock, resolve_verify_mode, canonicalize_test_vector, DebugFileWriter, TuningResult)
+    NumaNodeLock, resolve_verify_mode, canonicalize_test_vector, DebugFileWriter, TuningResult,
+    tune_config)
 from perfRunner import (  # noqa: E402
     GemmConfiguration, ConvConfiguration, AttentionConfiguration, ConvGemmConfiguration,
     GemmGemmConfiguration, PerfConfiguration, canonicalize_config)
@@ -550,6 +551,24 @@ class TestParseArguments:
         )
         assert parsed.tuning_space == "quick"
 
+    def test_negative_gpu_run_timeout_rejected(self, capsys):
+        topology = _make_mock_gpu_topology([(0, "gfx900")])
+        available = [0]
+        with pytest.raises(SystemExit):
+            tuningRunner.parse_arguments(
+                topology,
+                available,
+                [
+                    "--op",
+                    "gemm",
+                    "--config",
+                    "-g 1 -m 1024 -k 769 -n 512",
+                    "--gpu-run-timeout",
+                    "-1",
+                ],
+            )
+        assert "argument --gpu-run-timeout: must be non-negative" in capsys.readouterr().err
+
 
 class TestNumaTopologyParseCpuList:
     """Tests for NumaTopology._parse_cpu_list (used when discovering NUMA)."""
@@ -619,6 +638,85 @@ class TestFindBestPerfconfig:
         assert winner == "perf_cfg_1"
         assert tflops == 1.5
         assert len(entries) == 1
+
+
+class TestTuneConfig:
+    """Tests for tune_config subprocess result handling."""
+
+    def test_gpu_timeout_exit_code_marks_result_gpu_timed_out(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        class FakeStdout:
+
+            def close(self):
+                pass
+
+        class FakeProcess:
+
+            def __init__(self, returncode, stdout=b"", stderr=b""):
+                self.returncode = returncode
+                self._stdout = stdout
+                self._stderr = stderr
+                self.stdout = FakeStdout()
+                self.pid = 1234
+
+            def communicate(self, timeout=None):
+                return self._stdout, self._stderr
+
+            def kill(self):
+                pass
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        class FakeConfig:
+
+            def generate_mlir_driver_commandline(self, rocmlir_gen_flags, kernel_repeats=None):
+                return "--fake-rocmlir-gen-arg"
+
+        class FakeConfiguration:
+
+            @staticmethod
+            def from_command_line(command_line, arch, num_cu, num_chiplets):
+                return FakeConfig()
+
+        rocmlir_gen = FakeProcess(returncode=0)
+        tuning_driver = FakeProcess(returncode=tuningRunner.GPU_TIMEOUT_EXIT_CODE,
+                                    stderr=b"gpu timeout")
+
+        def fake_popen(command, **kwargs):
+            if command[0] == "rocmlir-gen":
+                return rocmlir_gen
+            assert command[0] == "rocmlir-tuning-driver"
+            return tuning_driver
+
+        monkeypatch.setattr(tuningRunner.subprocess, "Popen", fake_popen)
+
+        paths = MagicMock()
+        paths.mlir_paths.rocmlir_gen_path = "rocmlir-gen"
+        paths.mlir_paths.rocmlir_tuning_driver_path = "rocmlir-tuning-driver"
+        options = MagicMock()
+        options.tuning_space_kind = "quick"
+        options.debug = False
+        options.wait_for_compiles = False
+        options.gpu_run_timeout = 30
+        options.timeout = None
+        options.arch = "gfx900"
+        options.num_cu = 64
+        options.num_chiplets = 1
+        options.rocmlir_gen_flags = ""
+
+        result = tune_config("-g 1 -m 1024 -k 769 -n 512",
+                             FakeConfiguration,
+                             paths,
+                             options,
+                             gpu_id=0,
+                             num_compile_threads=1,
+                             numa_lock=NumaNodeLock())
+
+        assert not result.success
+        assert result.gpu_timed_out
+        assert result.gpu_id == 0
 
 
 class TestResolveVerifyMode:

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -1446,9 +1446,13 @@ def tune_config(test_vector: str, conf_class: type, paths: Paths, options: Optio
     gpu_logger = get_gpu_logger(gpu_id)
 
     tuning_driver_args = [
-        f"--tuning-space={options.tuning_space_kind}", f"--num-iterations={MLIR_N_REPEATS}",
-        f"--warmup-iterations={WARMUP_ITERATIONS}", "--use-median", f"--sleep-us={SLEEP_US}",
-        f"--show-all-measurements={options.debug}", f"--num-compile-threads={num_compile_threads}",
+        f"--tuning-space={options.tuning_space_kind}",
+        f"--num-iterations={MLIR_N_REPEATS}",
+        f"--warmup-iterations={WARMUP_ITERATIONS}",
+        "--use-median",
+        f"--sleep-us={SLEEP_US}",
+        f"--show-all-measurements={options.debug}",
+        f"--num-compile-threads={num_compile_threads}",
         f"--wait-for-compiles={options.wait_for_compiles}",
         f"--gpu-run-timeout={options.gpu_run_timeout}",
     ]

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -70,6 +70,12 @@ MLIR_N_REPEATS = 10
 WARMUP_ITERATIONS = 1
 SLEEP_US = 100  # 0.1 ms
 
+# A GPU run timeout is different from the outer tuning subprocess timeout: an
+# in-process kernel may have hung and left the HIP context untrustworthy, so the
+# tuning driver exits the whole process with this distinct code.
+# Must stay in sync with kExitGpuTimeout in rocmlir-tuning-driver.cpp.
+GPU_TIMEOUT_EXIT_CODE = 3
+
 OUTPUT_HEADER_COLUMNS = [
     'arch', 'numCUs', 'numChiplets', 'testVector', 'perfConfig', 'TFlops', 'tuningSpace',
     'commitId', 'timestamp', 'durationSec'
@@ -189,6 +195,7 @@ class Options:
     wait_for_compiles: bool
     timeout: Optional[int]
     verify_timeout: Optional[int]
+    gpu_run_timeout: int
 
 
 @dataclass
@@ -197,6 +204,7 @@ class TuningResult:
     test_vector: str
     success: bool
     timed_out: bool = False
+    gpu_timed_out: bool = False
     gpu_id: int = -1
     duration_seconds: float = 0.0
     timestamp: Optional[str] = None
@@ -337,6 +345,7 @@ class ConfigState(Enum):
         RUNNING -> SUCCEEDED (implicit): Tuning completes successfully (removed from state, written to output)
         RUNNING -> FAILED: Tuning completes with error
         RUNNING -> TIMED_OUT: Tuning exceeded timeout
+        RUNNING -> GPU_TIMED_OUT: A perf config's GPU run hung (driver run-timeout tripped)
         RUNNING -> INTERRUPTED: User interrupted (Ctrl+C) during tuning
         RUNNING -> CRASHED: Detected on next startup (stale RUNNING state)
         <state> -> PENDING: User requests retry with --retry <state>
@@ -348,12 +357,14 @@ class ConfigState(Enum):
     RUNNING = "running"  # Currently being tuned
     FAILED = "failed"  # Tuning completed with error
     TIMED_OUT = "timed_out"  # Tuning exceeded timeout
+    GPU_TIMED_OUT = "gpu_timed_out"  # A perf config's GPU run hung
     INTERRUPTED = "interrupted"  # User interrupted during tuning (Ctrl+C)
     CRASHED = "crashed"  # Process crashed while tuning (detected on startup)
 
 
 # States representing unsuccessful tuning outcomes that are skipped by default
-UNSUCCESSFUL_STATES = frozenset({ConfigState.FAILED, ConfigState.TIMED_OUT, ConfigState.CRASHED})
+UNSUCCESSFUL_STATES = frozenset(
+    {ConfigState.FAILED, ConfigState.TIMED_OUT, ConfigState.GPU_TIMED_OUT, ConfigState.CRASHED})
 
 
 @dataclass
@@ -373,6 +384,10 @@ class TuningState:
 
     def set_timed_out(self, test_vector: str) -> None:
         self.configs[test_vector] = ConfigState.TIMED_OUT
+        self._pre_running_states.pop(test_vector, None)
+
+    def set_gpu_timed_out(self, test_vector: str) -> None:
+        self.configs[test_vector] = ConfigState.GPU_TIMED_OUT
         self._pre_running_states.pop(test_vector, None)
 
     def set_interrupted(self, test_vector: str) -> None:
@@ -395,6 +410,9 @@ class TuningState:
 
     def timed_out_count(self) -> int:
         return sum(1 for s in self.configs.values() if s == ConfigState.TIMED_OUT)
+
+    def gpu_timed_out_count(self) -> int:
+        return sum(1 for s in self.configs.values() if s == ConfigState.GPU_TIMED_OUT)
 
     def crashed_count(self) -> int:
         return sum(1 for s in self.configs.values() if s == ConfigState.CRASHED)
@@ -521,6 +539,11 @@ class TuningStateFile:
     def set_timed_out(self, test_vector: str) -> None:
         with self._lock:
             self._state.set_timed_out(test_vector)
+            self._save_locked()
+
+    def set_gpu_timed_out(self, test_vector: str) -> None:
+        with self._lock:
+            self._state.set_gpu_timed_out(test_vector)
             self._save_locked()
 
     def set_succeeded(self, test_vector: str) -> None:
@@ -1426,7 +1449,8 @@ def tune_config(test_vector: str, conf_class: type, paths: Paths, options: Optio
         f"--tuning-space={options.tuning_space_kind}", f"--num-iterations={MLIR_N_REPEATS}",
         f"--warmup-iterations={WARMUP_ITERATIONS}", "--use-median", f"--sleep-us={SLEEP_US}",
         f"--show-all-measurements={options.debug}", f"--num-compile-threads={num_compile_threads}",
-        f"--wait-for-compiles={options.wait_for_compiles}"
+        f"--wait-for-compiles={options.wait_for_compiles}",
+        f"--gpu-run-timeout={options.gpu_run_timeout}",
     ]
 
     env = make_isolated_gpu_env(gpu_id)
@@ -1512,6 +1536,19 @@ def tune_config(test_vector: str, conf_class: type, paths: Paths, options: Optio
         tuning_output = tuning_stdout.decode('utf-8')
         tuning_errors = tuning_stderr.decode('utf-8')
 
+        if tuning_driver.returncode == GPU_TIMEOUT_EXIT_CODE:
+            gpu_logger.error(
+                format_error(
+                    f"GPU run hung (exceeded --gpu-run-timeout={options.gpu_run_timeout}s)",
+                    command=tuning_pipeline,
+                    stderr=tuning_errors,
+                    exit_code=tuning_driver.returncode,
+                    gpu_id=gpu_id))
+            return TuningResult(test_vector=test_vector,
+                                success=False,
+                                gpu_timed_out=True,
+                                gpu_id=gpu_id)
+
         if tuning_driver.returncode != 0:
             gpu_logger.error(
                 format_error("Tuning pipeline failed",
@@ -1589,6 +1626,8 @@ def tune_configs(ctx: TuningContext, status_only: bool) -> bool:
         logger.warning(f"Found {state.crashed_count()} crashed config(s) in state file")
     if state.timed_out_count() > 0:
         logger.warning(f"Found {state.timed_out_count()} timed out config(s) in state file")
+    if state.gpu_timed_out_count() > 0:
+        logger.warning(f"Found {state.gpu_timed_out_count()} gpu-timed-out config(s) in state file")
     if state.failed_count() > 0:
         logger.warning(f"Found {state.failed_count()} failed config(s) in state file")
 
@@ -1685,6 +1724,8 @@ def tune_configs(ctx: TuningContext, status_only: bool) -> bool:
                     state_file.set_succeeded(result.test_vector)
                 elif result.timed_out:
                     state_file.set_timed_out(result.test_vector)
+                elif result.gpu_timed_out:
+                    state_file.set_gpu_timed_out(result.test_vector)
                 else:
                     state_file.set_failed(result.test_vector)
 
@@ -2020,7 +2061,7 @@ def parse_arguments(gpu_topology: GpuTopology,
 
     parser.add_argument("--retry",
                         nargs='+',
-                        choices=["failed", "timed_out", "crashed"],
+                        choices=["failed", "timed_out", "gpu_timed_out", "crashed"],
                         default=[],
                         metavar='STATE',
                         help="Retry configs in specified states")
@@ -2036,6 +2077,16 @@ def parse_arguments(gpu_topology: GpuTopology,
                         default=None,
                         metavar='SECONDS',
                         help="Timeout in seconds for each verification run")
+
+    parser.add_argument(
+        "--gpu-run-timeout",
+        type=int,
+        default=0,
+        metavar='SECONDS',
+        help="Per-perf-config GPU-run timeout in seconds (default: 0 = no timeout). "
+        "When > 0, the tuning driver bounds benchmarking for each perf config; "
+        "a run that exceeds this budget is presumed hung, the whole test vector is "
+        "marked 'gpu_timed_out', and tuning advances to the next config.")
 
     parser.add_argument("--gpus",
                         type=int,
@@ -2150,7 +2201,8 @@ def main(args=None):
                       num_cpus=parsed_args.num_cpus,
                       wait_for_compiles=parsed_args.wait_for_compiles,
                       timeout=parsed_args.timeout,
-                      verify_timeout=parsed_args.verify_timeout)
+                      verify_timeout=parsed_args.verify_timeout,
+                      gpu_run_timeout=parsed_args.gpu_run_timeout)
 
     ctx = TuningContext(configs=configs,
                         conf_class=get_config_class(op_type),

--- a/mlir/utils/performance/tuningRunner.py
+++ b/mlir/utils/performance/tuningRunner.py
@@ -2122,7 +2122,10 @@ def parse_arguments(gpu_topology: GpuTopology,
                         default=False,
                         help="Only show tuning status without performing any tuning")
 
-    return parser.parse_args(args)
+    parsed_args = parser.parse_args(args)
+    if parsed_args.gpu_run_timeout < 0:
+        parser.error("argument --gpu-run-timeout: must be non-negative")
+    return parsed_args
 
 
 def main(args=None):


### PR DESCRIPTION
## Motivation 
Prevent tuning runs from hanging indefinitely when a compiled perfConfig hangs during GPU execution. These hangs are now classified distinctly so tuning can fail the affected problem config and continue making progress. 

This is a port of the rocmlirTriton changes here: https://github.com/ROCm/rocmlirTriton/pull/344

## Technical Details 

Add a per-perfConfig GPU run timeout, enforced in rocmlir-tuning-driver via timed HIP stream polling that reuses the compile-timeout deadline pattern. Adds a distinct `gpu_timed_out` state, retry support, and Python-side handling for the tuning driver’s GPU-timeout exit code.

Differences from the rocmlirTriton PR:
* compileUtils.h is not changed in rocMLIR because that Rock utility header/path does not exist here. rocmlirTriton stores `rock::kExitGpuTimeout` in compileUtils.h; This version keeps `kExitGpuTimeout = 3` local to rocmlir-tuning-driver.cpp, with the Python constant mirrored in tuningRunner.py.
* The benchmark paths differ. rocmlirTriton’s driver has a more unified measurement flow whereas rocMLIR has separate `measureSmallKernel` and `measureLargeKernel` paths. The port wraps rocMLIR’s existing warmup/small/large synchronization points with the same polling timeout idea.

## Test Plan

- PR CI

## Test Result

- [X] PR CI: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2430/5/pipeline-overview/

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
