### PR TITLE
Add attention scale/bias/transposed-bias tuning keys

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
+++ b/mlir/include/mlir/Dialect/Rock/utility/transformMapUtils.h
@@ -164,6 +164,25 @@ Value updateValidityAfter(OpBuilder &b, Location loc, TransformMapAttr map,
 /// Returns null when passed an empty array.
 AffineMap composeTransforms(ArrayRef<TransformMapAttr> transforms);
 
+/// Returns true if `map` acts as the identity on a coordinate system whose
+/// i-th input dim has bound `shape[i]`. A constant-zero result expression
+/// is accepted at any position whose shape is 1, since unit-bound dims
+/// only ever take the value 0. This matches the affine maps emitted by
+/// `AddDim{1}` and the corresponding inverse pieces of `Merge{1, ...}`,
+/// which produce a constant 0 in place of the missing dim.
+///
+/// Useful for checking whether a chain of `rock.transform` ops round-trips
+/// to identity (e.g. validating that two views are inverses of each other
+/// before fusing them away). Compose the chain with `composeTransforms`,
+/// then call this to check the result against the relevant shape.
+///
+/// Examples (with shape = [1, 124, 664]):
+///   `(d0,d1,d2) -> (d0,d1,d2)`   identity                    -> true
+///   `(d0,d1,d2) -> (0,d1,d2)`    identity modulo unit dim 0  -> true
+///   `(d0,d1,d2) -> (d0,d2,d1)`   transpose, not identity     -> false
+///   `(d0,d1,d2) -> (1,d1,d2)`    wrong constant on unit dim  -> false
+bool isIdentityOnShape(AffineMap map, ArrayRef<int64_t> shape);
+
 // This function will take a input Value and a index map that represents the
 // coordinate mapping that could be a combination of tranposes and broadcasts
 // and insert the necessary TransformOps

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Rock/IR/AmdArchDb.h"
 #include "mlir/Dialect/Rock/IR/GetRockInfo.h"
 #include "mlir/Dialect/Rock/IR/Rock.h"
@@ -23,10 +24,13 @@
 #include "mlir/Dialect/Rock/Tuning/RockTuning.h"
 #include "mlir/Dialect/Rock/utility/fusionUtils.h"
 #include "mlir/Dialect/Rock/utility/loweringUtils.h"
+#include "mlir/Dialect/Rock/utility/transformMapUtils.h"
+#include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -1197,6 +1201,111 @@ extractLayouts(Operation *op, llvm::StringMap<unsigned> &fLayoutMap,
   return success();
 }
 
+// Walk backward through a transform chain and report whether any individual
+// transform preserves rank and element extents while applying a non-identity
+// permutation. This catches layout-only changes, such as transposed attention
+// bias, even when they are surrounded by flatten/unflatten transforms.
+static bool hasRankPreservingNonIdentityPermutation(Value value) {
+  while (auto transformOp = value.getDefiningOp<TransformOp>()) {
+    auto valueType = dyn_cast<ShapedType>(transformOp.getResult().getType());
+    auto inputType = dyn_cast<ShapedType>(transformOp.getInput().getType());
+    if (valueType && inputType && valueType.getRank() == inputType.getRank()) {
+      SmallVector<int64_t> valueShape(valueType.getShape());
+      SmallVector<int64_t> inputShape(inputType.getShape());
+      llvm::sort(valueShape);
+      llvm::sort(inputShape);
+
+      AffineMap map = transformOp.getTransform().getMap().getAffineMap();
+      if (valueShape == inputShape && map && map.isPermutation() &&
+          !isIdentityOnShape(map, valueType.getShape()))
+        return true;
+    }
+    value = transformOp.getInput();
+  }
+  return false;
+}
+
+// Determine whether an attention op fuses a pre-softmax scale and/or bias, as
+// created by rocmlir-gen's `--with-attn-scale` / `--with-attn-bias`. Scale
+// folds an extra elementwise multiply of the QK^T scores by an external input;
+// bias folds an elementwise add. Both change the generated kernel (and thus its
+// optimal perf config), so they are part of the tuning-problem identity and
+// must appear in the tuning key. A rank-preserving non-identity permutation on
+// the bias input records that the bias is loaded transposed.
+//
+// The fusion is encoded as ops inside the `preSoftmaxBody` region that consume
+// the region's block arguments. Block argument 0 is the QK^T product; the
+// remaining block arguments map 1:1 to `preSoftmaxElemWiseInputs`. Constant
+// scales/biases and causal masks are not external inputs (they are folded into
+// the body or captured by the `causal` attribute), so they are intentionally
+// not treated as attn scale/bias here. For quantized (i8) attention the first
+// two elementwise inputs are dequantization operands, not the attention
+// scale/bias, so they are skipped.
+static void getAttentionScaleBias(AttentionOp attnOp, bool isQuantized,
+                                  bool &hasAttnScale, bool &hasAttnBias,
+                                  bool &hasTransposedAttnBias) {
+  hasAttnScale = false;
+  hasAttnBias = false;
+  hasTransposedAttnBias = false;
+  Region &body = attnOp.getPreSoftmaxBody();
+  if (body.empty())
+    return;
+  Block &entry = body.front();
+  unsigned numInputs = attnOp.getPreSoftmaxElemWiseInputs().size();
+  unsigned numQuantInputs = isQuantized ? 2u : 0u;
+  if (numInputs <= numQuantInputs)
+    return;
+
+  // Entry block argument 0 is the QK^T product; arguments 1.. correspond 1:1 to
+  // the pre-softmax elementwise inputs. rocMLIR's AttentionOp verifier does not
+  // pin this arity, so clamp to the block's actual argument count to stay safe
+  // on malformed IR rather than reading past the block arguments.
+  unsigned numAvailInputs =
+      entry.getNumArguments() > 0 ? entry.getNumArguments() - 1 : 0;
+  numInputs = std::min(numInputs, numAvailInputs);
+
+  for (unsigned i = numQuantInputs; i < numInputs; ++i) {
+    // Walk forward from the input through its use chain until we reach the
+    // multiply (scale) or add (bias) that consumes it. Two intermediate steps
+    // are possible: a `rock.transform` reshaping the input to match the scores,
+    // and (in the bufferized rocMLIR form) a `linalg.generic` whose region body
+    // holds the actual `arith` op. When a value feeds an op that carries a
+    // region (e.g. `linalg.generic`), continue the walk from the region block
+    // argument that matches the operand position so the per-input attribution
+    // (and the i8 dequant exclusion) stays precise.
+    SmallVector<Value> worklist{entry.getArgument(i + 1)};
+    llvm::SmallPtrSet<Value, 8> seen;
+    bool isTransposedInput = hasRankPreservingNonIdentityPermutation(
+        attnOp.getPreSoftmaxElemWiseInputs()[i]);
+    while (!worklist.empty()) {
+      Value v = worklist.pop_back_val();
+      if (!seen.insert(v).second)
+        continue;
+      for (OpOperand &use : v.getUses()) {
+        Operation *user = use.getOwner();
+        if (isa<arith::MulFOp>(user)) {
+          hasAttnScale = true;
+        } else if (isa<arith::AddFOp>(user)) {
+          hasAttnBias = true;
+          hasTransposedAttnBias |= isTransposedInput;
+        } else {
+          // Descend into region-carrying ops (e.g. `linalg.generic`), mapping
+          // this operand to the matching entry-block argument of each region.
+          for (Region &region : user->getRegions()) {
+            if (region.empty())
+              continue;
+            Block &regionEntry = region.front();
+            unsigned operandNo = use.getOperandNumber();
+            if (operandNo < regionEntry.getNumArguments())
+              worklist.push_back(regionEntry.getArgument(operandNo));
+          }
+          llvm::append_range(worklist, user->getResults());
+        }
+      }
+    }
+  }
+}
+
 static LogicalResult
 getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
                     SmallVectorImpl<char> &out) {
@@ -1300,8 +1409,12 @@ getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
   else
     problemOS << "false" << sep;
 
+  bool hasAttnScale = false, hasAttnBias = false;
+  bool hasTransposedAttnBias = false;
   if (isAttention) {
     auto attentionOp = cast<AttentionOp>(gemmGemmOp);
+    getAttentionScaleBias(attentionOp, elemTypeQ.isInteger(8), hasAttnScale,
+                          hasAttnBias, hasTransposedAttnBias);
     problemOS << "-causal ";
     if (attentionOp.getCausal())
       problemOS << "true" << sep;
@@ -1328,6 +1441,13 @@ getTuningProblemStr(RockGemmGemmWrapperInterface gemmGemmOp,
     problemOS << "-seq_len_k " << seqLenK << sep;
     problemOS << "-head_dim_qk " << headDimQK << sep;
     problemOS << "-head_dim_v " << headDimV;
+    // Keep these last and in this order to match the layout parsed by
+    // AttentionConfiguration.from_command_line() in perfRunner.py.
+    problemOS << sep << "-with-attn-scale "
+              << (hasAttnScale ? "true" : "false");
+    problemOS << sep << "-with-attn-bias " << (hasAttnBias ? "true" : "false");
+    problemOS << sep << "-transBias "
+              << (hasTransposedAttnBias ? "true" : "false");
   } else if (isConvGemm) {
     auto convGemmOp = cast<ConvElementwiseGemmOp>(gemmGemmOp);
     ArrayRef<int64_t> inShape = convGemmOp.getInput().getType().getShape();

--- a/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
+++ b/mlir/lib/Dialect/Rock/Tuning/RockTuningImpl.cpp
@@ -1288,9 +1288,17 @@ static void getAttentionScaleBias(AttentionOp attnOp, bool isQuantized,
         } else if (isa<arith::AddFOp>(user)) {
           hasAttnBias = true;
           hasTransposedAttnBias |= isTransposedInput;
-        } else {
+        } else if (user->getNumRegions() > 0) {
           // Descend into region-carrying ops (e.g. `linalg.generic`), mapping
           // this operand to the matching entry-block argument of each region.
+          // Do not follow such an op's results: for an elementwise op the
+          // result is the accumulator/output, a different logical value than
+          // this input. Following it would let one input's chain reach a
+          // *different* input's scale/bias op -- e.g. flowing a transposed
+          // scale through the scores into the bias add and mis-recording it as
+          // a transposed bias. Each external input reaches its own scale/bias
+          // op directly as a non-accumulator operand, so descending into the
+          // region is sufficient.
           for (Region &region : user->getRegions()) {
             if (region.empty())
               continue;
@@ -1299,6 +1307,9 @@ static void getAttentionScaleBias(AttentionOp attnOp, bool isQuantized,
             if (operandNo < regionEntry.getNumArguments())
               worklist.push_back(regionEntry.getArgument(operandNo));
           }
+        } else {
+          // Follow value-carrying ops that only reshape/cast this input
+          // (e.g. `rock.transform`, `tensor.expand_shape`, `arith.truncf`).
           llvm::append_range(worklist, user->getResults());
         }
       }

--- a/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
+++ b/mlir/lib/Dialect/Rock/utility/transformMapUtils.cpp
@@ -1139,6 +1139,21 @@ AffineMap mlir::rock::composeTransforms(ArrayRef<TransformMapAttr> transforms) {
   return result;
 }
 
+bool mlir::rock::isIdentityOnShape(AffineMap map, ArrayRef<int64_t> shape) {
+  if (!map || map.getNumDims() != map.getNumResults() ||
+      map.getNumResults() != shape.size())
+    return false;
+
+  SmallVector<unsigned> broadcastedDims;
+  if (!map.isMinorIdentityWithBroadcasting(&broadcastedDims))
+    return false;
+
+  for (unsigned pos : broadcastedDims)
+    if (shape[pos] != 1)
+      return false;
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 // Converting general MLIR to transformations.
 //===----------------------------------------------------------------------===//

--- a/mlir/test/fusion/mixr-attention-causal-no-select-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-causal-no-select-problem-key.mlir
@@ -1,6 +1,6 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
 // CHECK: gfx942
-// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 14 -seq_len_q 8 -seq_len_k 8 -head_dim_qk 64 -head_dim_v 64
+// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 14 -seq_len_q 8 -seq_len_k 8 -head_dim_qk 64 -head_dim_v 64 -with-attn-scale false -with-attn-bias false -transBias false
 
 module {
   func.func @mlir_attention(%arg0: !migraphx.shaped<1x2x8x64xf16, 1024x512x64x1>, %arg1: !migraphx.shaped<1x14x8x64xf16, 7168x64x896x1>, %arg2: !migraphx.shaped<1x14x8x64xf16, 7168x512x64x1>) -> !migraphx.shaped<1x14x8x64xf16, 7168x512x64x1> attributes {rock.arch = "gfx942", rock.kernel = "mixr"} {

--- a/mlir/test/fusion/mixr-attention-causal-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-causal-problem-key.mlir
@@ -2,7 +2,7 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
 // CHECK: gfx942
 // CHECK-SAME: 304
-// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 32 -seq_len_q 2 -seq_len_k 64 -head_dim_qk 128 -head_dim_v 128
+// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal true -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 32 -seq_len_q 2 -seq_len_k 64 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale false -with-attn-bias false -transBias false
 module {
   func.func @mlir_attention(%arg0: !migraphx.shaped<1x96x2x128xf16, 24576x128x12288x1>, %arg1: !migraphx.shaped<1x32x64x128xf16, 262144x8192x128x1>, %arg2: !migraphx.shaped<1x32x64x128xf16, 262144x8192x128x1>) -> !migraphx.shaped<1x2x4096xf16, 8192x4096x1> attributes {rock.kernel, rock.arch = "gfx942", rock.num_cu = 304 : i64} {
     %0 = migraphx.literal(dense<[0, 1]> : tensor<2xsi32>) : <2xsi32, 1>

--- a/mlir/test/fusion/mixr-attention-gqa-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-gqa-problem-key.mlir
@@ -2,7 +2,7 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
 // CHECK: gfx942
 // CHECK-SAME: 304
-// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 32 -num_heads_kv 8 -g 1 -seq_len_q 1 -seq_len_k 64 -head_dim_qk 128 -head_dim_v 128
+// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 32 -num_heads_kv 8 -g 1 -seq_len_q 1 -seq_len_k 64 -head_dim_qk 128 -head_dim_v 128 -with-attn-scale false -with-attn-bias false -transBias false
 
 module {
   func.func @mlir_attention(%arg0: !migraphx.shaped<1x48x1x128xf16, 6144x128x128x1>, %arg1: !migraphx.shaped<1x8x64x128xf16, 65536x8192x128x1>, %arg2: !migraphx.shaped<1x8x64x128xf16, 65536x8192x128x1>, %arg3: !migraphx.shaped<1x1x1xsi32, 1x1x1>) -> !migraphx.shaped<1x1x4096xf16, 4096x4096x1> attributes {rock.kernel, rock.arch = "gfx942", rock.num_cu = 304 : i64} {

--- a/mlir/test/fusion/mixr-attention-lse-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-lse-problem-key.mlir
@@ -2,7 +2,7 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
 // CHECK: gfx942
 // CHECK-SAME: 304
-// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse true -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 32 -seq_len_k 32 -head_dim_qk 32 -head_dim_v 32
+// CHECK-SAME: -t f16 -transQ false -transK true -transV false -transO false -causal false -return_lse true -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 32 -seq_len_k 32 -head_dim_qk 32 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 
 module {
   func.func private @mlir_attention(%v: !migraphx.shaped<2x2x32x32xf16, 2048x1024x32x1> {mhal.read_access}, 

--- a/mlir/test/fusion/mixr-attention-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-problem-key.mlir
@@ -2,7 +2,7 @@
 // RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
 // CHECK: gfx942
 // CHECK-SAME: 304
-// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3
+// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3 -with-attn-scale false -with-attn-bias true -transBias false
 module 
 {
   func.func private @mlir_attention(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1> {mhal.read_access},

--- a/mlir/test/fusion/mixr-attention-scale-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-scale-problem-key.mlir
@@ -1,0 +1,21 @@
+// RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
+// A pre-softmax elementwise multiply by an external input (migraphx.mul, which
+// lowers to arith.mulf in preSoftmaxBody) is an attention scale fusion and must
+// be reflected in the tuning key.
+// CHECK: gfx942
+// CHECK-SAME: 304
+// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 7 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3 -with-attn-scale true -with-attn-bias false -transBias false
+module
+{
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>,
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg3: !migraphx.shaped<1x7x7xf32, 49x7x1>)
+                                    -> (!migraphx.shaped<1x7x3xf32, 21x3x1>)  attributes {rock.kernel, rock.arch = "gfx942", rock.num_cu = 304 : i64} {
+    %0 = migraphx.dot %arg0, %arg1: <1x7x3xf32, 21x3x1>, <1x3x7xf32, 21x7x1> -> <1x7x7xf32, 49x7x1>
+    %scaled = migraphx.mul %0, %arg3 : <1x7x7xf32, 49x7x1>, <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %1 = migraphx.softmax %scaled{axis = 2 : i64} : <1x7x7xf32, 49x7x1> -> <1x7x7xf32, 49x7x1>
+    %2 = migraphx.dot %1, %arg2: <1x7x7xf32, 49x7x1>, <1x7x3xf32, 21x3x1> -> <1x7x3xf32, 21x3x1>
+    return %2 : !migraphx.shaped<1x7x3xf32, 21x3x1>
+  }
+}

--- a/mlir/test/fusion/mixr-attention-scale-transposed-bias-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-scale-transposed-bias-problem-key.mlir
@@ -1,0 +1,24 @@
+// RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
+// A non-transposed pre-softmax multiply operand (scale) fused together with a
+// transposed add operand (bias). The transpose belongs to the bias, so
+// transBias must be true even when a scale fusion is present alongside it.
+// CHECK: gfx942
+// CHECK-SAME: 304
+// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 5 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3 -with-attn-scale true -with-attn-bias true -transBias true
+module
+{
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x5x3xf32, 15x3x1>,
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>,
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %scale: !migraphx.shaped<1x5x7xf32, 35x7x1>,
+                                    %bias_t: !migraphx.shaped<1x7x5xf32, 35x5x1>)
+                                    -> (!migraphx.shaped<1x5x3xf32, 15x3x1>)  attributes {rock.kernel, rock.arch = "gfx942", rock.num_cu = 304 : i64} {
+    %0 = migraphx.dot %arg0, %arg1: <1x5x3xf32, 15x3x1>, <1x3x7xf32, 21x7x1> -> <1x5x7xf32, 35x7x1>
+    %scaled = migraphx.mul %0, %scale : <1x5x7xf32, 35x7x1>, <1x5x7xf32, 35x7x1> -> <1x5x7xf32, 35x7x1>
+    %transposed_bias = migraphx.transpose %bias_t {permutation = [0, 2, 1]} : <1x7x5xf32, 35x5x1> -> <1x5x7xf32, 35x1x5>
+    %biased = migraphx.add %scaled, %transposed_bias : <1x5x7xf32, 35x7x1>, <1x5x7xf32, 35x1x5> -> <1x5x7xf32, 35x7x1>
+    %1 = migraphx.softmax %biased{axis = 2 : i64} : <1x5x7xf32, 35x7x1> -> <1x5x7xf32, 35x7x1>
+    %2 = migraphx.dot %1, %arg2: <1x5x7xf32, 35x7x1>, <1x7x3xf32, 21x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/mixr-attention-transposed-bias-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-transposed-bias-problem-key.mlir
@@ -1,0 +1,19 @@
+// RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
+// CHECK: gfx942
+// CHECK-SAME: 304
+// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 5 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3 -with-attn-scale false -with-attn-bias true -transBias true
+module
+{
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x5x3xf32, 15x3x1>,
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>,
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg3: !migraphx.shaped<1x7x5xf32, 35x5x1>)
+                                    -> (!migraphx.shaped<1x5x3xf32, 15x3x1>)  attributes {rock.kernel, rock.arch = "gfx942", rock.num_cu = 304 : i64} {
+    %0 = migraphx.dot %arg0, %arg1: <1x5x3xf32, 15x3x1>, <1x3x7xf32, 21x7x1> -> <1x5x7xf32, 35x7x1>
+    %transposed_bias = migraphx.transpose %arg3 {permutation = [0, 2, 1]} : <1x7x5xf32, 35x5x1> -> <1x5x7xf32, 35x1x5>
+    %biased = migraphx.add %0, %transposed_bias : <1x5x7xf32, 35x7x1>, <1x5x7xf32, 35x1x5> -> <1x5x7xf32, 35x7x1>
+    %1 = migraphx.softmax %biased{axis = 2 : i64} : <1x5x7xf32, 35x7x1> -> <1x5x7xf32, 35x7x1>
+    %2 = migraphx.dot %1, %arg2: <1x5x7xf32, 35x7x1>, <1x7x3xf32, 21x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/mixr-attention-transposed-scale-bias-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-transposed-scale-bias-problem-key.mlir
@@ -1,0 +1,25 @@
+// RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
+// A transposed pre-softmax multiply operand (scale) fused together with a
+// non-transposed add operand (bias). The transpose belongs to the scale, so
+// transBias must stay false: the scale's transpose must not leak across the
+// fused elementwise chain onto the bias add.
+// CHECK: gfx942
+// CHECK-SAME: 304
+// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 5 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3 -with-attn-scale true -with-attn-bias true -transBias false
+module
+{
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x5x3xf32, 15x3x1>,
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>,
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %scale_t: !migraphx.shaped<1x7x5xf32, 35x5x1>,
+                                    %bias: !migraphx.shaped<1x5x7xf32, 35x7x1>)
+                                    -> (!migraphx.shaped<1x5x3xf32, 15x3x1>)  attributes {rock.kernel, rock.arch = "gfx942", rock.num_cu = 304 : i64} {
+    %0 = migraphx.dot %arg0, %arg1: <1x5x3xf32, 15x3x1>, <1x3x7xf32, 21x7x1> -> <1x5x7xf32, 35x7x1>
+    %transposed_scale = migraphx.transpose %scale_t {permutation = [0, 2, 1]} : <1x7x5xf32, 35x5x1> -> <1x5x7xf32, 35x1x5>
+    %scaled = migraphx.mul %0, %transposed_scale : <1x5x7xf32, 35x7x1>, <1x5x7xf32, 35x1x5> -> <1x5x7xf32, 35x7x1>
+    %biased = migraphx.add %scaled, %bias : <1x5x7xf32, 35x7x1>, <1x5x7xf32, 35x7x1> -> <1x5x7xf32, 35x7x1>
+    %1 = migraphx.softmax %biased{axis = 2 : i64} : <1x5x7xf32, 35x7x1> -> <1x5x7xf32, 35x7x1>
+    %2 = migraphx.dot %1, %arg2: <1x5x7xf32, 35x7x1>, <1x7x3xf32, 21x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/mixr-attention-transposed-scale-problem-key.mlir
+++ b/mlir/test/fusion/mixr-attention-transposed-scale-problem-key.mlir
@@ -1,0 +1,21 @@
+// RUN: rocmlir-driver -kernel-pipeline=migraphx,highlevel %s | rocmlir-gen --emit-tuning-key - | FileCheck %s
+// A transposed pre-softmax multiply operand is an attention scale fusion, not a
+// transposed bias. This guards that transBias detection stays gated on the add.
+// CHECK: gfx942
+// CHECK-SAME: 304
+// CHECK-SAME: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 5 -seq_len_k 7 -head_dim_qk 3 -head_dim_v 3 -with-attn-scale true -with-attn-bias false -transBias false
+module
+{
+  func.func private @mlir_attention(%arg0: !migraphx.shaped<1x5x3xf32, 15x3x1>,
+                                    %arg1: !migraphx.shaped<1x3x7xf32, 21x7x1>,
+                                    %arg2: !migraphx.shaped<1x7x3xf32, 21x3x1>,
+                                    %arg3: !migraphx.shaped<1x7x5xf32, 35x5x1>)
+                                    -> (!migraphx.shaped<1x5x3xf32, 15x3x1>)  attributes {rock.kernel, rock.arch = "gfx942", rock.num_cu = 304 : i64} {
+    %0 = migraphx.dot %arg0, %arg1: <1x5x3xf32, 15x3x1>, <1x3x7xf32, 21x7x1> -> <1x5x7xf32, 35x7x1>
+    %transposed_scale = migraphx.transpose %arg3 {permutation = [0, 2, 1]} : <1x7x5xf32, 35x5x1> -> <1x5x7xf32, 35x1x5>
+    %scaled = migraphx.mul %0, %transposed_scale : <1x5x7xf32, 35x7x1>, <1x5x7xf32, 35x1x5> -> <1x5x7xf32, 35x7x1>
+    %1 = migraphx.softmax %scaled{axis = 2 : i64} : <1x5x7xf32, 35x7x1> -> <1x5x7xf32, 35x7x1>
+    %2 = migraphx.dot %1, %arg2: <1x5x7xf32, 35x7x1>, <1x7x3xf32, 21x3x1> -> <1x5x3xf32, 15x3x1>
+    return %2 : !migraphx.shaped<1x5x3xf32, 15x3x1>
+  }
+}

--- a/mlir/test/fusion/nightly-misc-e2e/mixr-attention/f16/rock-attention-transposed-bias.mlir
+++ b/mlir/test/fusion/nightly-misc-e2e/mixr-attention/f16/rock-attention-transposed-bias.mlir
@@ -1,0 +1,3 @@
+// RUN: rocmlir-gen --arch %arch --operation attention -t f16 -g 1 -seq_len_q 32 -seq_len_k 16 -num_heads_q 1 -num_heads_kv 1 -head_dim_qk 32 -head_dim_v 32 -with-attn-scale=False -with-attn-bias=True -transBias=True -transQ=False -transK=False -transV=False -transO=False -causal=False -return_lse=False -split_kv=1 -pv | rocmlir-driver -c | mlir-runner -O2 --shared-libs=%linalg_test_lib_dir/libmlir_rocm_runtime%shlibext,%conv_validation_wrapper_library_dir/libconv-validation-wrappers%shlibext,%linalg_test_lib_dir/libmlir_runner_utils%shlibext,%linalg_test_lib_dir/libmlir_float16_utils%shlibext --entry-point-result=void | FileCheck %s
+
+// CHECK: [1 1 1]

--- a/mlir/test/perf-scripts/attention-tuning-db-compat.py
+++ b/mlir/test/perf-scripts/attention-tuning-db-compat.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+#
+# Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
+# Exceptions. See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Pure-Python coverage for attention tuning DB compatibility.
+
+The tuning DB key for attention has grown optional boolean flags over time
+(``-with-attn-scale``, ``-with-attn-bias``, ``-transBias``). False-valued flags
+are identity cases, so old DB rows that omit them should still be readable:
+``read_tuning_db`` canonicalizes every stored key through
+``AttentionConfiguration``, which re-adds the (default false) flags. True-valued
+flags describe different generated kernels and must not be silently matched
+against an old all-false row.
+
+# RUN: %python %s %t
+"""
+
+from pathlib import Path
+import sys
+import types
+import unittest
+
+MLIR_DIR = Path(__file__).resolve().parents[2]
+PERF_DIR = MLIR_DIR / "utils" / "performance"
+TESTS_DIR = PERF_DIR / "tests"
+sys.path.insert(0, str(PERF_DIR))
+sys.path.insert(0, str(PERF_DIR / "analysis"))
+
+# Inject mock 'hip'/'amd_arch_db' modules so perfRunner imports without ROCm.
+exec(
+    open(TESTS_DIR / "mock_hip.py").read(), {
+        "__file__": str(TESTS_DIR / "mock_hip.py"),
+        "__name__": "mock_hip"
+    })
+
+
+def stub_optional_pulp():
+    """Let this parsing-only test import quickTuningGen without PuLP installed."""
+    sys.modules.setdefault("pulp", types.SimpleNamespace())
+
+
+stub_optional_pulp()
+
+import perfRunner  # noqa: E402
+from perfRunner import AttentionConfiguration, read_tuning_db  # noqa: E402
+from quickTuningGen import get_target_columns, load_data  # noqa: E402
+
+# Pin the attention dtype list so config construction never probes real hardware.
+perfRunner.DATA_TYPES_ATTENTION = perfRunner.DATA_TYPES_ATTENTION_MFMA
+
+ARCH = "gfx950:sramecc+:xnack-"
+NUM_CU = 256
+NUM_CHIPLETS = 8
+PERFCONFIG = "attn:v4:32,256,32,1,1,4,16,1,1,0,0,-1,-1,-1,-1,-1,-1"
+TMP_PREFIX = (Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/tmp/attention-tuning-db-compat"))
+
+
+def make_config(extra_flags):
+    """Build a canonical attention config with the requested optional flags."""
+    key = ("-t f16 "
+           "-transQ false -transK false -transV false -transO false "
+           "-causal false -return_lse false -split_kv 1 -g 1 "
+           "-seq_len_q 16 -seq_len_k 16 -num_heads_q 1 -num_heads_kv 1 "
+           "-head_dim_qk 32 -head_dim_v 32 "
+           f"{extra_flags}")
+    return AttentionConfiguration.from_command_line(key.split(), ARCH, NUM_CU, NUM_CHIPLETS)
+
+
+def write_tuning_db(path, config_field):
+    """Write a one-row tuning DB using the given attention problem key."""
+    path.write_text("# arch\tnumCUs\tnumChiplets\ttestVector\tperfConfig\tTFlops\n"
+                    f"{ARCH}\t{NUM_CU}\t{NUM_CHIPLETS}\t{config_field}\t{PERFCONFIG}\t0.0\n")
+
+
+def drop_flags(config_str, *flags):
+    """Return a legacy key by removing selected false-valued flags."""
+    for flag in flags:
+        config_str = config_str.replace(flag, "")
+    return config_str
+
+
+class AttentionTuningDbCompatTest(unittest.TestCase):
+    """Compatibility tests for attention tuning DB and debug TSV parsing."""
+
+    def setUp(self):
+        """Give each test its own temporary file prefix."""
+        self.tmp_prefix = Path(f"{TMP_PREFIX}.{self._testMethodName}")
+
+    def read_db_from_legacy_key(self, legacy_key):
+        """Read a tuning DB written with a legacy key (canonicalized on read)."""
+        path = Path(f"{self.tmp_prefix}.tsv")
+        write_tuning_db(path, legacy_key)
+        return read_tuning_db(str(path), AttentionConfiguration, NUM_CU, NUM_CHIPLETS)
+
+    def db_key(self, config):
+        return (ARCH, NUM_CU, NUM_CHIPLETS, config.to_command_line())
+
+    def test_read_tuning_db_matches_legacy_all_false_attention_flags(self):
+        """Old DB rows may omit all false-valued attention flags."""
+        current_config = make_config(
+            "-with-attn-scale false -with-attn-bias false -transBias false")
+        legacy_key = drop_flags(current_config.to_command_line(), " -with-attn-scale false",
+                                " -with-attn-bias false", " -transBias false")
+
+        db = self.read_db_from_legacy_key(legacy_key)
+        self.assertEqual(db.get(self.db_key(current_config)), PERFCONFIG)
+
+    def test_read_tuning_db_matches_pre_transbias_scale_bias_key(self):
+        """Scale+bias DB rows from before transBias still match non-transposed bias."""
+        current_config = make_config("-with-attn-scale true -with-attn-bias true -transBias false")
+        legacy_key = drop_flags(current_config.to_command_line(), " -transBias false")
+
+        db = self.read_db_from_legacy_key(legacy_key)
+        self.assertEqual(db.get(self.db_key(current_config)), PERFCONFIG)
+
+    def test_read_tuning_db_keeps_true_scale_bias_distinct(self):
+        """True scale/bias flags must not fall back to old all-false DB rows."""
+        all_false_config = make_config(
+            "-with-attn-scale false -with-attn-bias false -transBias false")
+        legacy_all_false_key = drop_flags(all_false_config.to_command_line(),
+                                          " -with-attn-scale false", " -with-attn-bias false",
+                                          " -transBias false")
+
+        scale_bias_config = make_config(
+            "-with-attn-scale true -with-attn-bias true -transBias false")
+
+        db = self.read_db_from_legacy_key(legacy_all_false_key)
+        self.assertNotIn(self.db_key(scale_bias_config), db)
+
+    def test_read_tuning_db_keeps_true_trans_bias_distinct(self):
+        """Transposed bias must not fall back to an old all-false DB row."""
+        all_false_config = make_config(
+            "-with-attn-scale false -with-attn-bias false -transBias false")
+        legacy_all_false_key = drop_flags(all_false_config.to_command_line(),
+                                          " -with-attn-scale false", " -with-attn-bias false",
+                                          " -transBias false")
+
+        trans_bias_config = make_config(
+            "-with-attn-scale false -with-attn-bias true -transBias true")
+
+        self.assertIn("-transBias true", trans_bias_config.to_command_line())
+        db = self.read_db_from_legacy_key(legacy_all_false_key)
+        self.assertNotIn(self.db_key(trans_bias_config), db)
+
+    def test_quick_tuning_gen_defaults_missing_trans_bias_column(self):
+        """Legacy debug TSV rows without TransBias get a false default."""
+        debug_path = Path(f"{self.tmp_prefix}.debug")
+        debug_path.write_text(
+            "DataType\tChip\tnumCU\tnumChiplets\tTransQ\tTransK\tTransV\tTransO\t"
+            "Causal\tReturnLSE\tSplitKV\tWithAttnScale\tWithAttnBias\tG\tSeqLenQ\t"
+            "SeqLenK\tNumHeadsQ\tNumHeadsKV\tHeadDimQK\tHeadDimV\tPerfConfig\tTFlops\n"
+            f"f16\tgfx950\t{NUM_CU}\t{NUM_CHIPLETS}\tFalse\tFalse\tFalse\tFalse\t"
+            f"False\tFalse\t1\tTrue\tTrue\t1\t16\t16\t1\t1\t32\t32\t{PERFCONFIG}\t1.0\n")
+
+        df = load_data([str(debug_path)], no_splitk=False)
+        self.assertIn("TransBias", df.columns)
+        self.assertTrue(df["TransBias"].eq(False).all())
+
+        grouped = df.groupby(get_target_columns("attention") + ["PerfConfig"],
+                             as_index=False)["TFlops"].max()
+        self.assertFalse(grouped.empty)
+
+    def test_quick_tuning_gen_fills_trans_bias_nan_in_mixed_files(self):
+        """Mixing legacy (no TransBias) and new (TransBias) TSVs must not drop
+        the legacy rows: concat leaves NaN in the legacy rows, and TransBias is
+        a groupby key, so an unfilled NaN would be silently dropped."""
+        cols_no_tb = ("DataType\tChip\tnumCU\tnumChiplets\tTransQ\tTransK\tTransV\tTransO\t"
+                      "Causal\tReturnLSE\tSplitKV\tWithAttnScale\tWithAttnBias\tG\tSeqLenQ\t"
+                      "SeqLenK\tNumHeadsQ\tNumHeadsKV\tHeadDimQK\tHeadDimV\tPerfConfig\tTFlops\n")
+        legacy_path = Path(f"{self.tmp_prefix}.legacy.debug")
+        legacy_path.write_text(
+            cols_no_tb + f"f16\tgfx950\t{NUM_CU}\t{NUM_CHIPLETS}\tFalse\tFalse\tFalse\tFalse\t"
+            f"False\tFalse\t1\tTrue\tTrue\t1\t16\t16\t1\t1\t32\t32\t{PERFCONFIG}\t1.0\n")
+
+        cols_tb = (
+            "DataType\tChip\tnumCU\tnumChiplets\tTransQ\tTransK\tTransV\tTransO\t"
+            "Causal\tReturnLSE\tSplitKV\tWithAttnScale\tWithAttnBias\tTransBias\tG\tSeqLenQ\t"
+            "SeqLenK\tNumHeadsQ\tNumHeadsKV\tHeadDimQK\tHeadDimV\tPerfConfig\tTFlops\n")
+        new_path = Path(f"{self.tmp_prefix}.new.debug")
+        new_path.write_text(
+            cols_tb + f"f16\tgfx950\t{NUM_CU}\t{NUM_CHIPLETS}\tFalse\tFalse\tFalse\tFalse\t"
+            f"False\tFalse\t1\tTrue\tTrue\tTrue\t1\t16\t16\t1\t1\t32\t32\t{PERFCONFIG}\t2.0\n")
+
+        df = load_data([str(legacy_path), str(new_path)], no_splitk=False)
+        self.assertFalse(df["TransBias"].isna().any())
+
+        grouped = df.groupby(get_target_columns("attention") + ["PerfConfig"],
+                             as_index=False)["TFlops"].max()
+        # Both problems survive: legacy TransBias=False and new TransBias=True.
+        # Without the NaN fill, the legacy row would be dropped and only one
+        # group would remain.
+        self.assertEqual(len(grouped), 2)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]], verbosity=2)

--- a/mlir/test/perf-scripts/attention-tuning-db-compat.py
+++ b/mlir/test/perf-scripts/attention-tuning-db-compat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Pure-Python coverage for attention tuning DB compatibility.

--- a/mlir/test/perf-scripts/attention-tuning-db-compat.py
+++ b/mlir/test/perf-scripts/attention-tuning-db-compat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# Part of the rocMLIR Project, under the Apache License v2.0 with LLVM
-# Exceptions. See https://llvm.org/LICENSE.txt for license information.
+# Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Pure-Python coverage for attention tuning DB compatibility.
 

--- a/mlir/test/rocmlir-gen/attention-kernel.mlir
+++ b/mlir/test/rocmlir-gen/attention-kernel.mlir
@@ -103,3 +103,34 @@
 // TRANS_O: rock.attention
 // O (flat 8192) becomes head_v x seq_q instead of seq_q x head_v.
 // TRANS_O: tr %{{.*}} = softmax(qk) * %{{.*}} : memref<1x256x64xf16> -> memref<1x64x128xf16>
+
+// ----
+
+// Attention bias fusion. The bias is a pre-softmax elementwise add whose input
+// has the [seq_q, seq_k] score layout, so it feeds `rock.attention` as an
+// `otherIns` of the pre-softmax `elementwise` region.
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 128 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 64 -t f16 --with-attn-bias | FileCheck %s --enable-var-scope --check-prefix=BIAS
+// BIAS-LABEL: func.func @rock_attention
+// Without -transBias the bias argument is already laid out as seq_q x seq_k and
+// is fed to the pre-softmax elementwise add directly (no extra transpose).
+// BIAS: %[[bias:.*]] = rock.transform %{{.*}} : memref<32768xf16> to memref<1x128x256xf16>
+// BIAS: rock.attention
+// BIAS: qk = elementwise otherIns(%[[bias]] : memref<1x128x256xf16>)
+
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 128 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 64 -t f16 --with-attn-bias --transBias | FileCheck %s --enable-var-scope --check-prefix=TRANS_BIAS
+// TRANS_BIAS-LABEL: func.func @rock_attention
+// With -transBias the bias argument is materialized transposed in memory
+// (seq_k x seq_q), then a rank-preserving permutation restores the logical
+// seq_q x seq_k layout before it feeds the pre-softmax elementwise add.
+// TRANS_BIAS: %[[biasRaw:.*]] = rock.transform %{{.*}} : memref<32768xf16> to memref<1x256x128xf16>
+// TRANS_BIAS: %[[bias:.*]] = rock.transform %[[biasRaw]] {{.*}} : memref<1x256x128xf16> to memref<1x128x256xf16>
+// TRANS_BIAS: rock.attention
+// TRANS_BIAS: qk = elementwise otherIns(%[[bias]] : memref<1x128x256xf16>)
+
+// The host reference must mirror the transpose so validation stays correct: the
+// seq_k x seq_q bias is permuted to seq_q x seq_k before the pre-softmax add.
+// RUN: rocmlir-gen --arch gfx90a:sramecc+:xnack- --operation attention -seq_len_q 128 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 64 -t f16 --with-attn-bias --transBias -pv | FileCheck %s --enable-var-scope --check-prefix=TRANS_BIAS_HOST
+// TRANS_BIAS_HOST-LABEL: func.func @host_naive_attention
+// TRANS_BIAS_HOST: memref.expand_shape %{{.*}} : memref<32768xf16> into memref<1x256x128xf16>
+// TRANS_BIAS_HOST: linalg.transpose ins(%{{.*}} : memref<1x256x128xf16>) outs(%{{.*}} : memref<1x128x256xf16>) permutation = [0, 2, 1]

--- a/mlir/test/rocmlir-gen/options.mlir
+++ b/mlir/test/rocmlir-gen/options.mlir
@@ -33,6 +33,10 @@
 // RUN: not rocmlir-gen --arch %arch --operation attention -t f16 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 -split_kv 2 2>&1 | FileCheck %s --check-prefix=ERR_SPLITKV
 // ERR_SPLITKV: If split-kv > 1 (flash decoding), we need to return LSE
 
+// Transposed bias layout is only meaningful when an attention bias is present.
+// RUN: not rocmlir-gen --arch %arch --operation attention -t f16 -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 -transBias 2>&1 | FileCheck %s --check-prefix=ERR_TRANS_BIAS_WITHOUT_BIAS
+// ERR_TRANS_BIAS_WITHOUT_BIAS: --transBias requires --with-attn-bias
+
 // Attention, gemm+gemm, and conv+gemm pipelines require -t (dataTypeAlias).
 // RUN: not rocmlir-gen --arch %arch --operation attention -seq_len_q 256 -seq_len_k 256 -head_dim_qk 32 -head_dim_v 32 2>&1 | FileCheck %s --check-prefix=ERR_NO_DTYPE
 // ERR_NO_DTYPE: Type of the attention/gemm+gemm/conv+gemm operation is not specified

--- a/mlir/test/rocmlir-gen/problem-key.mlir
+++ b/mlir/test/rocmlir-gen/problem-key.mlir
@@ -1,23 +1,42 @@
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_1
-// CHECK_1: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_1: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -g 4 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_2
-// CHECK_2: -t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_2: -t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_3
-// CHECK_3: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_3: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -num_heads_q 4 -num_heads_kv 4 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_4
-// CHECK_4: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 4 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_4: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 4 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -num_heads_q 4 -num_heads_kv 2 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_5
-// CHECK_5: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 2 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_5: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 2 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -current_seq_len=16 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_6
-// CHECK_6: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 2 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_6: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 2 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -current_seq_len=16,16,17,1,30,40,38,12 -num_heads_q 4 -num_heads_kv 2 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_7
-// CHECK_7: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 2 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_7: -t i8 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 4 -num_heads_kv 2 -g 8 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -causal -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_8
-// CHECK_8: -t f16 -transQ false -transK false -transV false -transO false -causal true -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_8: -t f16 -transQ false -transK false -transV false -transO false -causal true -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -return_lse -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_9
-// CHECK_9: -t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse true -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_9: -t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse true -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 // RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f16 -return_lse -split_kv 8 -g 1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_10
-// CHECK_10: -t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse true -split_kv 8 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32
+// CHECK_10: -t f16 -transQ false -transK false -transV false -transO false -causal false -return_lse true -split_kv 8 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
+
+// Attention scale/bias/transposed-bias fusion is part of the problem key. These
+// flags must round-trip through --emit-tuning-key (kept in sync with
+// AttentionConfiguration in perfRunner.py).
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 --with-attn-scale --with-attn-bias | rocmlir-gen --emit-tuning-key - | FileCheck %s --check-prefixes=CHECK_SCALE_BIAS
+// CHECK_SCALE_BIAS: -t f32 -transQ false -transK false -transV false -transO false -causal false -return_lse false -split_kv 1 -num_heads_q 1 -num_heads_kv 1 -g 1 -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -with-attn-scale true -with-attn-bias true -transBias false
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 --with-attn-scale | rocmlir-gen --emit-tuning-key - | FileCheck %s --check-prefixes=CHECK_SCALE_ONLY
+// CHECK_SCALE_ONLY: -head_dim_v 32 -with-attn-scale true -with-attn-bias false -transBias false
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 --with-attn-bias | rocmlir-gen --emit-tuning-key - | FileCheck %s --check-prefixes=CHECK_BIAS_ONLY
+// CHECK_BIAS_ONLY: -head_dim_v 32 -with-attn-scale false -with-attn-bias true -transBias false
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t f32 -g 1 --with-attn-bias --transBias | rocmlir-gen --emit-tuning-key - | FileCheck %s --check-prefixes=CHECK_TRANS_BIAS
+// CHECK_TRANS_BIAS: -head_dim_v 32 -with-attn-scale false -with-attn-bias true -transBias true
+// Quantized (i8) dequantization inputs must not be mistaken for attn scale/bias.
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 --with-attn-scale --with-attn-bias | rocmlir-gen --emit-tuning-key - | FileCheck %s --check-prefixes=CHECK_I8_SCALE_BIAS
+// CHECK_I8_SCALE_BIAS: -t i8 {{.*}} -head_dim_v 32 -with-attn-scale true -with-attn-bias true -transBias false
+// The same i8 kernel without scale/bias must classify both as false, proving the
+// dequantization mul/add are not counted as attn scale/bias.
+// RUN: rocmlir-gen --arch gfx942 --operation attention -seq_len_q 256 -seq_len_k 512 -head_dim_qk 64 -head_dim_v 32 -t i8 -g 8 | rocmlir-gen --emit-tuning-key - | FileCheck %s --check-prefixes=CHECK_I8_NO_SCALE_BIAS
+// CHECK_I8_NO_SCALE_BIAS: -t i8 {{.*}} -head_dim_v 32 -with-attn-scale false -with-attn-bias false -transBias false
 
 // RUN: rocmlir-gen --arch gfx942 --operation conv -t f16 --fil_layout gkc01 --in_layout ngc01 --out_layout ngk01 --batchsize 64 --in_channels 256 --in_h 20 --in_w 20 --out_channels 256 --fil_h 7 --fil_w 7 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 3 --padding_w 3 --groupsize 256 --perf_config=v3:32,256,2,32,32,4,1,1,2,1,1 | rocmlir-gen --emit-tuning-key - | FileCheck %s  --check-prefixes=CHECK_DEPTHWISE_CONV
 // CHECK_DEPTHWISE_CONV: convfp16 -F 1 -f GNC01 -I NGC01 -O NGC01 -n 64 -c 256 -H 20 -W 20 -k 256 -y 7 -x 7 -p 3 -q 3 -u 1 -v 1 -l 1 -j 1 -g 256

--- a/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
+++ b/mlir/tools/rocmlir-gen/rocmlir-gen.cpp
@@ -652,6 +652,13 @@ static llvm::cl::opt<bool> hasAttnBias(
     llvm::cl::desc("Generate an attention kernel that is using a bias"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool>
+    transposeBias("transBias",
+                  llvm::cl::desc("whether the attention bias input is stored "
+                                 "as Gxseq_len_kxseq_len_q instead of the "
+                                 "default score layout Gxseq_len_qxseq_len_k"),
+                  llvm::cl::init(false));
+
 static llvm::cl::opt<bool> transposeQ(
     "transQ",
     llvm::cl::desc("whether matrix Q of attention op is "
@@ -1323,6 +1330,10 @@ static LogicalResult detectMissingArguments() {
   }
 
   if (operation == rock::KernelType::Attention) {
+    if (transposeBias && !hasAttnBias) {
+      llvm::errs() << "--transBias requires --with-attn-bias\n";
+      return failure();
+    }
     if (splitKV > 1 && !returnLSE) {
       llvm::errs()
           << "If split-kv > 1 (flash decoding), we need to return LSE\n";
@@ -2761,8 +2772,10 @@ static void getAttentionTypes(SmallVectorImpl<Type> &result,
     result.push_back(sType);
   }
   if (hasAttnBias) {
-    SmallVector<int64_t> biasDims{groupSize * numHeadsQ, sequenceLengthQ,
-                                  sequenceLengthK};
+    SmallVector<int64_t> biasDims{
+        groupSize * numHeadsQ,
+        transposeBias ? sequenceLengthK : sequenceLengthQ,
+        transposeBias ? sequenceLengthQ : sequenceLengthK};
     MemRefType bType = MemRefType::get(biasDims, elemTypes[biasIndex]);
     result.push_back(bType);
   }
@@ -2816,7 +2829,9 @@ getAttentionDimNames(SmallVectorImpl<SmallVector<StringRef>> &result,
   if (hasAttnScale)
     result.emplace_back(SmallVector<StringRef>{gName, seqQName, seqKName});
   if (hasAttnBias)
-    result.emplace_back(SmallVector<StringRef>{gName, seqQName, seqKName});
+    result.emplace_back(
+        SmallVector<StringRef>{gName, transposeBias ? seqKName : seqQName,
+                               transposeBias ? seqQName : seqKName});
   if (!currentSeqLen.empty())
     result.emplace_back(SmallVector<StringRef>{gName});
   if (!prefixOffset.empty())
@@ -3480,6 +3495,14 @@ static func::FuncOp createGpuAttentionKernel(ModuleOp module,
   }
   if (hasAttnBias) {
     bias = unflattenedArgs[optionalArgsCounter++];
+    if (transposeBias) {
+      auto biasType = cast<ShapedType>(bias.getType());
+      SmallVector<uint32_t> startDims{0, 2, 1};
+      SmallVector<uint32_t> endDims{0, 1, 2};
+      rock::BottomUpTMBuilder transform(builder, biasType.getShape(), loc);
+      transform.passThrough(endDims, startDims);
+      bias = rock::TransformOp::create(builder, loc, bias, transform.get());
+    }
     elemwiseInputs.push_back(bias);
   }
   if (!currentSeqLen.empty()) {
@@ -4441,6 +4464,9 @@ static func::FuncOp createCpuAttentionKernelWithMlir(ModuleOp module,
 
   if (hasAttnBias) {
     auto biasTensor = getTensorForBlockArg(optionalArgsCounter++);
+    if (transposeBias)
+      biasTensor =
+          rock::tosa::getTransposeOp(builder, loc, biasTensor, {0, 2, 1});
     biasTensor = applyPreSoftmaxInputMask(biasTensor, 0.0f);
 
     if (fuseQuantizedScaleBias) {

--- a/mlir/unittests/Dialect/Rock/transformMapUtilsTests.cpp
+++ b/mlir/unittests/Dialect/Rock/transformMapUtilsTests.cpp
@@ -12,6 +12,8 @@
 #include "mlir/Dialect/Rock/IR/Rock.h"
 #include "mlir/Dialect/Rock/IR/TransformMapBuilder.h"
 #include "mlir/Dialect/Rock/utility/transformMapUtils.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -357,6 +359,75 @@ TEST(GetMaxVectorizationTest, UnmergeHeldConstantNonUnitDim) {
   EXPECT_EQ(result.max, 4);
 
   func::ReturnOp::create(b, loc);
+}
+
+//===----------------------------------------------------------------------===//
+// isIdentityOnShape Tests
+//===----------------------------------------------------------------------===//
+//
+// isIdentityOnShape is used by the attention tuning-key builder to decide
+// whether a rank-preserving transform is a pure layout change (transposed bias)
+// or a no-op. It must accept an identity map, accept broadcasts only on size-1
+// dims, and reject permutations and rank/shape mismatches.
+
+// Square identity map over a shape is identity-on-shape.
+TEST(IsIdentityOnShapeTest, IdentityMapReturnsTrue) {
+  MLIRContext ctx;
+  AffineMap identity = AffineMap::getMultiDimIdentityMap(3, &ctx);
+  EXPECT_TRUE(isIdentityOnShape(identity, {4, 5, 6}));
+}
+
+// A permutation (e.g. transposed bias) is not identity-on-shape.
+TEST(IsIdentityOnShapeTest, PermutationReturnsFalse) {
+  MLIRContext ctx;
+  AffineExpr d0 = getAffineDimExpr(0, &ctx);
+  AffineExpr d1 = getAffineDimExpr(1, &ctx);
+  AffineExpr d2 = getAffineDimExpr(2, &ctx);
+  // (d0, d1, d2) -> (d2, d1, d0)
+  AffineMap perm = AffineMap::get(3, 0, {d2, d1, d0}, &ctx);
+  EXPECT_FALSE(isIdentityOnShape(perm, {4, 5, 6}));
+}
+
+// A broadcast (constant 0) on a size-1 dim is still identity-on-shape.
+TEST(IsIdentityOnShapeTest, BroadcastOnUnitDimReturnsTrue) {
+  MLIRContext ctx;
+  AffineExpr d0 = getAffineDimExpr(0, &ctx);
+  AffineExpr d2 = getAffineDimExpr(2, &ctx);
+  AffineExpr c0 = getAffineConstantExpr(0, &ctx);
+  // (d0, d1, d2) -> (d0, 0, d2), broadcasting dim 1.
+  AffineMap bcast = AffineMap::get(3, 0, {d0, c0, d2}, &ctx);
+  EXPECT_TRUE(isIdentityOnShape(bcast, {4, 1, 6}));
+}
+
+// A broadcast on a non-unit dim changes the data, so it is not identity.
+TEST(IsIdentityOnShapeTest, BroadcastOnNonUnitDimReturnsFalse) {
+  MLIRContext ctx;
+  AffineExpr d0 = getAffineDimExpr(0, &ctx);
+  AffineExpr d2 = getAffineDimExpr(2, &ctx);
+  AffineExpr c0 = getAffineConstantExpr(0, &ctx);
+  AffineMap bcast = AffineMap::get(3, 0, {d0, c0, d2}, &ctx);
+  EXPECT_FALSE(isIdentityOnShape(bcast, {4, 5, 6}));
+}
+
+// The shape rank must match the map result count.
+TEST(IsIdentityOnShapeTest, ShapeRankMismatchReturnsFalse) {
+  MLIRContext ctx;
+  AffineMap identity = AffineMap::getMultiDimIdentityMap(3, &ctx);
+  EXPECT_FALSE(isIdentityOnShape(identity, {4, 5}));
+}
+
+// A non-square map (numDims != numResults) is rejected up front.
+TEST(IsIdentityOnShapeTest, NonSquareMapReturnsFalse) {
+  MLIRContext ctx;
+  AffineExpr d1 = getAffineDimExpr(1, &ctx);
+  // (d0, d1) -> (d1): 2 dims, 1 result.
+  AffineMap projection = AffineMap::get(2, 0, {d1}, &ctx);
+  EXPECT_FALSE(isIdentityOnShape(projection, {5}));
+}
+
+// A null map is not identity-on-shape.
+TEST(IsIdentityOnShapeTest, NullMapReturnsFalse) {
+  EXPECT_FALSE(isIdentityOnShape(AffineMap(), {4, 5, 6}));
 }
 
 } // end anonymous namespace

--- a/mlir/utils/performance/analysis/quickTuningGen.py
+++ b/mlir/utils/performance/analysis/quickTuningGen.py
@@ -24,7 +24,8 @@ CONV_COLUMNS = [
 ]
 ATTENTION_COLUMNS = [
     'TransQ', 'TransK', 'TransV', 'TransO', 'Causal', 'ReturnLSE', 'SplitKV', 'WithAttnScale',
-    'WithAttnBias', 'G', 'SeqLenQ', 'SeqLenK', 'NumHeadsQ', 'NumHeadsKV', 'HeadDimQK', 'HeadDimV'
+    'WithAttnBias', 'TransBias', 'G', 'SeqLenQ', 'SeqLenK', 'NumHeadsQ', 'NumHeadsKV', 'HeadDimQK',
+    'HeadDimV'
 ]
 GEMM_GEMM_COLUMNS = ['TransA', 'TransB', 'TransC', 'TransO', 'G', 'M', 'K', 'N', 'O']
 CONV_GEMM_COLUMNS = [
@@ -185,6 +186,16 @@ def load_data(files, no_splitk):
         # Read TSV content from stdin
         print("Reading from stdin...")
         df = pd.read_csv(sys.stdin, sep='\t', index_col=None)
+
+    # Legacy attention TSVs predate the TransBias column. When such files are
+    # mixed with newer ones, pd.concat leaves NaN in the legacy rows rather than
+    # omitting the column, so fill both the missing-column and missing-value
+    # cases; otherwise groupby (dropna=True) would silently drop those rows.
+    if 'WithAttnBias' in df.columns:
+        if 'TransBias' not in df.columns:
+            df['TransBias'] = False
+        else:
+            df['TransBias'] = df['TransBias'].fillna(False)
 
     if no_splitk and not df.empty:
         # Filter out configs where Split-K != 1

--- a/mlir/utils/performance/perfRunner.py
+++ b/mlir/utils/performance/perfRunner.py
@@ -1107,7 +1107,8 @@ def get_attn_configurations(filename, arch, num_cu, num_chiplets):
         "-causal": default_to_false,
         "-return_lse": default_to_false,
         "-with-attn-scale": default_to_false,
-        "-with-attn-bias": default_to_false
+        "-with-attn-bias": default_to_false,
+        "-transBias": default_to_false
     }
 
     configs = []
@@ -1718,11 +1719,14 @@ class AttentionConfiguration(PerfConfiguration):
                  arch: str,
                  num_cu: int,
                  num_chiplets: int,
-                 perf_config: str = ''):
+                 perf_config: str = '',
+                 trans_bias: bool = False):
         if DATA_TYPES_ATTENTION is None:
             initialize_dtypes_attn()
         if dtype not in DATA_TYPES_ATTENTION:
             raise ValueError(f"Invalid datatype for a: {dtype}")
+        if trans_bias and not with_attn_bias:
+            raise ValueError("--transBias requires --with-attn-bias")
 
         self.datatype = dtype
         self.g = g
@@ -1734,6 +1738,7 @@ class AttentionConfiguration(PerfConfiguration):
         self.head_dim_v = head_dim_v
         self.with_attn_scale = with_attn_scale
         self.with_attn_bias = with_attn_bias
+        self.trans_bias = trans_bias
         self.trans_q = trans_q
         self.trans_k = trans_k
         self.trans_v = trans_v
@@ -1777,8 +1782,9 @@ class AttentionConfiguration(PerfConfiguration):
         values = [
             self.datatype, self.chip, self.num_cu, self.num_chiplets, self.trans_q, self.trans_k,
             self.trans_v, self.trans_o, self.causal, self.return_lse, self.split_kv,
-            self.with_attn_scale, self.with_attn_bias, self.g, self.seq_len_q, self.seq_len_k,
-            self.num_heads_q, self.num_heads_kv, self.head_dim_qk, self.head_dim_v, self.perfconfig,
+            self.with_attn_scale, self.with_attn_bias, self.trans_bias, self.g, self.seq_len_q,
+            self.seq_len_k, self.num_heads_q, self.num_heads_kv, self.head_dim_qk, self.head_dim_v,
+            self.perfconfig,
             self.compute_tflops(nanoseconds)
         ]
         assert (len(self.TABLE_COLUMNS) == len(values))
@@ -1801,9 +1807,9 @@ class AttentionConfiguration(PerfConfiguration):
             str(self.num_heads_kv), '-head_dim_qk',
             str(self.head_dim_qk), '-head_dim_v',
             str(self.head_dim_v), f"-with-attn-scale={self.with_attn_scale}",
-            f"-with-attn-bias={self.with_attn_bias}", f"-transQ={self.trans_q}",
-            f"-transK={self.trans_k}", f"-transV={self.trans_v}", f"-transO={self.trans_o}",
-            f"-causal={self.causal}", f"-return_lse={self.return_lse}",
+            f"-with-attn-bias={self.with_attn_bias}", f"-transBias={self.trans_bias}",
+            f"-transQ={self.trans_q}", f"-transK={self.trans_k}", f"-transV={self.trans_v}",
+            f"-transO={self.trans_o}", f"-causal={self.causal}", f"-return_lse={self.return_lse}",
             f"-split_kv={self.split_kv}",
             *(['--kernel-repeats', str(kernel_repeats)] if kernel_repeats is not None else []),
             f"--perf_config={self.perfconfig}"
@@ -1834,6 +1840,7 @@ class AttentionConfiguration(PerfConfiguration):
         split_kv = 1
         with_attn_scale = False
         with_attn_bias = False
+        trans_bias = False
         # Please keep this in sync with mlir::rock::getTuningProblemStr()
         for i in range(0, len(argv), 2):
             opt = argv[i]
@@ -1858,6 +1865,8 @@ class AttentionConfiguration(PerfConfiguration):
                 with_attn_scale = (val.lower() in ["1", "true"])
             elif opt.endswith("-with-attn-bias"):
                 with_attn_bias = (val.lower() in ["1", "true"])
+            elif opt.endswith("-transBias"):
+                trans_bias = (val.lower() in ["1", "true"])
             elif opt.endswith("-transQ"):
                 trans_q = (val.lower() in ["1", "true"])
             elif opt.endswith("-transK"):
@@ -1884,9 +1893,28 @@ class AttentionConfiguration(PerfConfiguration):
             if v is None:
                 raise ValueError("Incomplete Attention configuration")
 
-        return cls(dtype, g, seq_len_q, seq_len_k, num_heads_q, num_heads_kv, head_dim_qk,
-                   head_dim_v, with_attn_scale, with_attn_bias, trans_q, trans_k, trans_v, trans_o,
-                   causal, return_lse, split_kv, arch, num_cu, num_chiplets, perf_config)
+        return cls(dtype,
+                   g,
+                   seq_len_q,
+                   seq_len_k,
+                   num_heads_q,
+                   num_heads_kv,
+                   head_dim_qk,
+                   head_dim_v,
+                   with_attn_scale,
+                   with_attn_bias,
+                   trans_q,
+                   trans_k,
+                   trans_v,
+                   trans_o,
+                   causal,
+                   return_lse,
+                   split_kv,
+                   arch,
+                   num_cu,
+                   num_chiplets,
+                   perf_config,
+                   trans_bias=trans_bias)
 
     def to_command_line(self):
         return (
@@ -1898,7 +1926,8 @@ class AttentionConfiguration(PerfConfiguration):
             f"-g {self.g} " +
             f"-seq_len_q {str(self.seq_len_q)} -seq_len_k {str(self.seq_len_k)} -num_heads_q {str(self.num_heads_q)} -num_heads_kv {str(self.num_heads_kv)} -head_dim_qk {str(self.head_dim_qk)} -head_dim_v {str(self.head_dim_v)} "
             + f"-with-attn-scale {str(self.with_attn_scale).lower()} " +
-            f"-with-attn-bias {str(self.with_attn_bias).lower()}")
+            f"-with-attn-bias {str(self.with_attn_bias).lower()} " +
+            f"-transBias {str(self.trans_bias).lower()}")
 
 
 class HipBLASLtGemmConfig(GemmConfiguration):

--- a/mlir/utils/performance/reportUtils.py
+++ b/mlir/utils/performance/reportUtils.py
@@ -39,8 +39,8 @@ GEMM_TEST_PARAMETERS = [
 ]
 ATTN_TEST_PARAMETERS = [
     'DataType', 'Chip', 'numCU', 'numChiplets', 'TransQ', 'TransK', 'TransV', 'TransO', 'Causal',
-    'ReturnLSE', 'SplitKV', 'WithAttnScale', 'WithAttnBias', 'G', 'SeqLenQ', 'SeqLenK', 'NumHeadsQ',
-    'NumHeadsKV', 'HeadDimQK', 'HeadDimV', 'PerfConfig'
+    'ReturnLSE', 'SplitKV', 'WithAttnScale', 'WithAttnBias', 'TransBias', 'G', 'SeqLenQ', 'SeqLenK',
+    'NumHeadsQ', 'NumHeadsKV', 'HeadDimQK', 'HeadDimV', 'PerfConfig'
 ]
 GEMM_GEMM_TEST_PARAMETERS = [
     'DataType', 'Chip', 'numCU', 'numChiplets', 'TransA', 'TransB', 'TransC', 'TransO', 'G', 'M',

--- a/mlir/utils/performance/tests/test_tuningRunner.py
+++ b/mlir/utils/performance/tests/test_tuningRunner.py
@@ -341,12 +341,12 @@ _SAMPLE_TEST_VECTORS = {
                       "-causal false -return_lse false -split_kv 1 -g 1 "
                       "-seq_len_q 256 -seq_len_k 256 -num_heads_q 8 -num_heads_kv 8 "
                       "-head_dim_qk 64 -head_dim_v 64 "
-                      "-with-attn-scale false -with-attn-bias false"),
+                      "-with-attn-scale false -with-attn-bias false -transBias false"),
         "idempotent": ("-t f16 -transQ false -transK false -transV false -transO false "
                        "-causal false -return_lse false -split_kv 1 -g 1 "
                        "-seq_len_q 128 -seq_len_k 128 -num_heads_q 4 -num_heads_kv 4 "
                        "-head_dim_qk 32 -head_dim_v 32 "
-                       "-with-attn-scale false -with-attn-bias false"),
+                       "-with-attn-scale false -with-attn-bias false -transBias false"),
     },
     "gemm_gemm": {
         "conf_class":


### PR DESCRIPTION
## Summary

Ports rocmlirTriton [#345](https://github.com/ROCm/rocmlirTriton/pull/345) and [#355](https://github.com/ROCm/rocmlirTriton/pull/355) to rocMLIR. It makes a fused pre-softmax **scale** (mul) and **bias** (add) -- and whether the bias is loaded **transposed** -- part of the attention tuning-problem identity, so kernels are tuned and selected correctly for these fusions.

- **`RockTuningImpl.cpp`**: detect fused scale/bias and transposed bias from the attention `preSoftmaxBody`, and emit `-with-attn-scale`, `-with-attn-bias`, and `-transBias` (in that order, last) in the attention tuning key. Detection is adapted to rocMLIR's *bufferized* `linalg.generic` body (it descends into region blocks and correlates operands to region block args), which differs from rocmlirTriton's tensor form. i8 dequant inputs are excluded.
- **`transformMapUtils`**: add `isIdentityOnShape` helper (used to distinguish a layout-only transpose from a no-op), with gtest coverage.
- **`rocmlir-gen`**: add `-transBias` (validated to require `--with-attn-bias`) plus the bias transpose codegen on both the device kernel and the host reference paths; the generated bias arg is materialized in `seq_k x seq_q` and restored to the logical `seq_q x seq_k` score layout.
- **`perfRunner` / `quickTuningGen` / `reportUtils`**: plumb `trans_bias` through the attention config, tuning-DB columns, and canonicalization. Legacy DB rows without the column default (and NaN-fill on mixed-file concat) to `false` for backward compatibility.



## Test plan

- New/updated lit tests: attention problem-key (`scale`, `transposed-bias`, `transposed-scale`, plus the existing causal/gqa/lse keys), `rocmlir-gen/problem-key.mlir`, `rocmlir-gen/options.mlir` (`--transBias` validation), and `rocmlir-gen/attention-kernel.mlir` (device + host bias transpose IR).
- Nightly transposed-bias E2E (`nightly-misc-e2e/mixr-attention/f16/rock-attention-transposed-bias.mlir`).
- `mlir/unittests/Dialect/Rock/transformMapUtilsTests.cpp`: `isIdentityOnShape` suite.
- `mlir/test/perf-scripts/attention-tuning-db-compat.py`: tuning-DB backward-compat (legacy all-false rows still match; true scale/bias/transBias stay distinct; missing-column and mixed-file-NaN defaults).
- `git clang-format` clean; clang-tidy (changed lines) warnings only; yapf/flake8 clean; perf pytest suite green (126 passed).

