### PR TITLE
[CI] External checkout

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -163,7 +163,10 @@ boolean isRetriableScmCheckoutError(String msg) {
         "transfer closed with outstanding read data remaining",
         "bytes of body are still expected",
         "unexpected disconnect while reading sideband packet",
-        "bad pack header"
+        "bad pack header",
+        "git-remote-https died of signal 15",
+        "early eof",
+        "invalid index-pack output"
     ].any { msg.contains(it) }
 }
 
@@ -222,6 +225,53 @@ void robustScmCheckout() {
                 echo "[SCM] Unrecoverable SCM error after ${attempt} attempt(s)."
                 throw err
             }
+        }
+    }
+}
+
+Map externalGitScm(String url, String branch) {
+    return [
+        $class: 'GitSCM',
+        branches: [[name: "*/${branch}"]],
+        doGenerateSubmoduleConfigurations: false,
+        extensions: [
+            [
+                $class: 'CloneOption',
+                depth: 0,
+                shallow: false,
+                noTags: false,
+                reference: '',
+                honorRefspec: false,
+                timeout: GIT_SCM_TIMEOUT_MINUTES
+            ],
+            [$class: 'CheckoutOption', timeout: GIT_SCM_TIMEOUT_MINUTES]
+        ],
+        submoduleCfg: [],
+        userRemoteConfigs: [[url: url]]
+    ]
+}
+
+void robustExternalCheckout(String url, String branch) {
+    int maxAttempts = 2
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            // Discard a partial pack before retrying the clone.
+            deleteDir()
+            checkout(
+                changelog: false,
+                poll: false,
+                scm: externalGitScm(url, branch)
+            )
+            return
+        } catch (err) {
+            String context = scmCheckoutRetryContext(err)
+            if (attempt == maxAttempts || !isRetriableScmCheckoutError(context)) {
+                throw err
+            }
+
+            echo "[SCM] External checkout attempt ${attempt}/${maxAttempts} failed due to a transient git fetch error."
+            echo "[SCM] Waiting 2 minutes before retrying..."
+            sleep(time: 2, unit: 'MINUTES')
         }
     }
 }
@@ -778,14 +828,12 @@ void buildMIGraphX(String cmakeOpts) {
 }
 
 void getAndBuildMIGraphX(String cmakeOpts) {
-    git branch: params.MIGraphXBranch, poll: false,\
-        url: 'https://github.com/ROCm/AMDMIGraphX.git'
+    robustExternalCheckout('https://github.com/ROCm/AMDMIGraphX.git', params.MIGraphXBranch)
     buildMIGraphX(cmakeOpts)
 }
 
 void getAndBuildCK(String cmakeOpts, String buildTarget = '') {
-    git branch: params.CKBranch, poll: false,\
-        url: 'https://github.com/ROCm/composable_kernel.git'
+    robustExternalCheckout('https://github.com/ROCm/composable_kernel.git', params.CKBranch)
     buildCK(cmakeOpts, buildTarget)
 }
 


### PR DESCRIPTION
## Motivation

The MLIR nightly build [#2503](https://ml-ci-internal.amd.com/job/MLIR/job/mlir-nightly-all/2503) failed while cloning MIGraphX over a slow connection. The transfer was still progressing and had reached 95%, but Jenkins terminated it after the Git plugin's default 10-minute timeout.

The existing 120-minute timeout and retry handling only covered the primary rocMLIR checkout. The shorthand `git` steps used for MIGraphX and Composable Kernel bypassed those protections.

## Technical Details

- Add `git-remote-https died of signal 15`, `early EOF`, and `invalid index-pack output` to the transient Git failure classifier.
- Add `externalGitScm()` to configure external Git checkouts with:
  - A 120-minute clone timeout.
  - A 120-minute checkout timeout.
  - A full, non-shallow clone.
- Add `robustExternalCheckout()` with two attempts and a two-minute retry delay.
- Delete partial checkout data before each attempt so an interrupted packfile cannot affect the retry.
- Use the robust checkout path for both MIGraphX and Composable Kernel.
- Preserve the branch-resolution behavior of the previous Jenkins `git` step.

## Test Plan

- Validate the modified Jenkinsfile with Jenkins' Pipeline Model Converter.
- Run repository formatting and premerge checks.
- Run the Jenkins PR pipeline to exercise the updated CI configuration.
- Confirm external checkouts report `# timeout=120`.
- Confirm a transient clone failure removes the partial checkout and retries once.

## Test Result

- Jenkinsfile validation passed:
  - `Jenkinsfile successfully validated.`
- `git diff --check` passed.
- C/C++ premerge checks passed.
- Python formatting, lint, and performance-script checks passed.
- Jenkins PR validation is currently in progress.

## Submission Checklist

- [x] The change is limited to CI checkout behavior.
- [x] Jenkinsfile syntax has been validated.
- [x] GitHub premerge checks pass.
- [ ] Jenkins PR validation completes successfully.
- [ ] Open the corresponding port for `rocmlirTriton`.