### PR TITLE
Update Claude review to latest models

### DIFF
--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -541,9 +541,9 @@ jobs:
           ANTHROPIC_CUSTOM_HEADERS: |
             Ocp-Apim-Subscription-Key: ${{ secrets.LLM_GATEWAY_KEY }}
             user: ${{ secrets.USER_NTID }}
-          ANTHROPIC_MODEL: "Claude-Opus-4.7"
-          ANTHROPIC_DEFAULT_OPUS_MODEL: "Claude-Opus-4.7"
-          ANTHROPIC_DEFAULT_SONNET_MODEL: "Claude-Sonnet-4.6"
+          ANTHROPIC_MODEL: "Claude-Opus-5"
+          ANTHROPIC_DEFAULT_OPUS_MODEL: "Claude-Opus-5"
+          ANTHROPIC_DEFAULT_SONNET_MODEL: "Claude-Sonnet-5"
           ANTHROPIC_DEFAULT_HAIKU_MODEL: "Claude-Haiku-4.5"
           # Scrub secret env vars from any subprocess the model spawns.
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"


### PR DESCRIPTION
## Summary
- update the automated review model from Claude Opus 4.7 to Opus 5
- update the default Sonnet model from 4.6 to Sonnet 5
- retain Haiku 4.5 as the latest Haiku model

## Test plan
- [x] Run `git diff --check`
- [x] Run `.github/scripts/tests/test_sanitize.sh` (171 tests passed)
- [x] Verify the workflow YAML has no linter diagnostics


Made with [Cursor](https://cursor.com)