### PR TITLE
[AIROCMLIR-1146][CI] Always report required checks on external/llvm-project-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 name: rocMLIR GitHub Actions
 
+# Path gating deliberately lives in the relevant-changes job below rather than
+# in an `on: <event>: paths:` filter, for two reasons. GitHub evaluates those
+# filters against only the first 300 files of a diff, so an LLVM subtree pull
+# fills every slot with external/llvm-project/ entries and the workflow is
+# silently skipped even when the diff does contain files the filter matches.
+# And because the jobs below are required status checks, a workflow skipped
+# this way never reports a status at all, leaving the pull request stuck on
+# "Expected - waiting for status to be reported" until an admin bypasses it.
 on:
   pull_request:
-    # Deliberately no `paths` filter. The jobs below are required status
-    # checks, and a workflow skipped by path filtering never reports a status
-    # at all, which leaves such PRs stuck on "Expected - waiting for status to
-    # be reported" (only an admin can then merge). The same path set is
-    # evaluated by the relevant-changes job below, so a PR that only touches
-    # external/llvm-project still reports green without running any check.
     branches:
       - develop
       - 'release/**'
@@ -15,18 +17,8 @@ on:
     branches:
       - develop
       - 'release/**'
-    # Push runs only seed the build cache and are not required checks, so
-    # filtering them by path is safe.
-    paths:
-      - "mlir/**"
-      - "external/**"
-      - "!external/llvm-project/**"
-      - "CMakeLists.txt"
-      - "cmake/**"
-      - ".github/workflows/**"
-      - "pip_requirements.txt"
-      - ".clang-format"
-      - ".clang-tidy"
+  # Manual escape hatch. A dispatch has no diff to inspect, so everything runs.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -38,15 +30,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Evaluates the path set that used to live in `on.pull_request.paths`. The
-  # jobs below key their steps off this result, which keeps the required
-  # checks reporting a status even when there is nothing for them to do.
+  # Evaluates the path set that used to live in the trigger filters. It is the
+  # single place that decides what is in scope, and the jobs below key their
+  # steps off the result, so the required checks keep reporting a status even
+  # when there is nothing for them to do.
   relevant-changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       relevant: ${{ steps.detect.outputs.relevant }}
+      ignore_external: ${{ steps.detect.outputs.ignore_external }}
     steps:
       - name: Detect relevant changes
         id: detect
@@ -54,78 +48,102 @@ jobs:
         env:
           REPO_URL: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
         run: |
           set -uo pipefail
 
           # Every exit goes through here, and every case that cannot be proven
-          # answers "true": a required check must never be passed on a guess,
-          # only on evidence that there is nothing in scope.
+          # answers "relevant=true": a required check must never be passed on a
+          # guess, only on evidence that there is nothing in scope.
           answer() {
-            echo "relevant=$1" >> "$GITHUB_OUTPUT"
-            echo "==> relevant=$1"
+            { echo "relevant=$1"; echo "ignore_external=$2"; } >> "$GITHUB_OUTPUT"
+            echo "==> relevant=$1 ignore_external=$2"
             exit 0
           }
 
-          # The push trigger is still path-filtered, so a push run is relevant
-          # by definition.
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            answer true
-          fi
-
-          # refs/pull/N/merge is GitHub's own merge preview, so diffing it
-          # against its first parent is exactly the PR diff and no merge-base
-          # handling is needed. depth=2 with tree:0 fetches two commits and
-          # then only the trees along differing paths: no blobs, no history,
-          # no working tree. Measured at ~13 MB and ~5s on an 18k-file LLVM
-          # subtree pull, against 2.4 GB for a full clone of this repo.
           git init -q .
           git remote add origin "$REPO_URL"
 
-          # GitHub computes the merge ref asynchronously after a push, so a
-          # freshly pushed head can briefly have none yet. Retry before giving
-          # up, otherwise a harmless race would send every such run down the
-          # expensive path.
-          fetched=false
-          for attempt in 1 2 3; do
-            if git fetch -q --depth=2 --filter=tree:0 --no-tags origin \
-                 "refs/pull/$PR_NUMBER/merge"; then
-              fetched=true
-              break
-            fi
-            echo "Merge ref not available yet (attempt $attempt); retrying."
-            sleep 5
-          done
+          # Fetches the commits plus only the trees reached while walking the
+          # diff: no blobs, no history, no working tree. Measured at ~13 MB and
+          # ~5s on an 18k-file LLVM subtree pull, against 2.4 GB for a full
+          # clone of this repo.
+          fetch() {
+            git fetch -q --depth=2 --filter=tree:0 --no-tags origin "$@"
+          }
 
-          if [[ "$fetched" != "true" ]]; then
-            echo "No usable merge ref (conflicted or closed PR); running the checks."
-            answer true
-          fi
+          case "${{ github.event_name }}" in
+            pull_request)
+              # refs/pull/N/merge is GitHub's own merge preview, so diffing it
+              # against its first parent is exactly the pull request's diff and
+              # no merge-base handling is needed. GitHub computes that ref
+              # asynchronously, so a freshly pushed head may briefly lack it and
+              # a bare failure here would be a race, not an answer.
+              fetched=false
+              for attempt in 1 2 3; do
+                if fetch "refs/pull/$PR_NUMBER/merge"; then fetched=true; break; fi
+                echo "Merge ref not available yet (attempt $attempt); retrying."
+                sleep 5
+              done
+              if [[ "$fetched" != true ]]; then
+                echo "No usable merge ref (conflicted or closed PR); running the checks."
+                answer true true
+              fi
+              BASE=FETCH_HEAD^1
+              HEAD_REV=FETCH_HEAD
+              ;;
+            push)
+              if [[ "$PUSH_BEFORE" =~ ^0*$ ]] || ! fetch "$PUSH_BEFORE" "$PUSH_AFTER"; then
+                echo "No usable push range (new branch or force push); running the checks."
+                answer true true
+              fi
+              BASE="$PUSH_BEFORE"
+              HEAD_REV="$PUSH_AFTER"
+              ;;
+            *)
+              echo "${{ github.event_name }} has no diff to inspect; running the checks."
+              answer true true
+              ;;
+          esac
 
-          if ! files=$(git diff-tree -r --no-commit-id --name-only \
-               FETCH_HEAD^1 FETCH_HEAD); then
+          if ! files=$(git diff-tree -r --no-commit-id --name-only "$BASE" "$HEAD_REV"); then
             echo "Could not compute the diff; running the checks."
-            answer true
+            answer true true
           fi
 
-          # An empty list means detection is broken, not that the PR is empty.
+          # An empty list means detection is broken, not that nothing changed.
           if [[ -z "$files" ]]; then
             echo "Diff came back empty; running the checks."
-            answer true
+            answer true true
           fi
 
-          # Kept in sync with the `paths` filter on the push trigger above.
-          matched=$(printf '%s\n' "$files" \
-            | grep -E '^(mlir/|external/|cmake/|\.github/workflows/)|^(CMakeLists\.txt|pip_requirements\.txt|\.clang-format|\.clang-tidy)$' \
+          # external/llvm-project is vendored upstream code held to upstream
+          # style, so linting it would bury an upstream merge in diagnostics.
+          # Jenkins makes the same call through its ignoreExternalLinting
+          # parameter, which is set by hand for upstream merges.
+          # Fed by here-string rather than a pipe on purpose: `grep -q` exits at
+          # the first match, which SIGPIPEs the writer, and under `pipefail`
+          # that turns a successful match into a non-zero condition. It only
+          # shows up once the list is long enough for the writer to still be
+          # going, i.e. exactly on upstream merges.
+          ignore_external=false
+          if grep -q '^external/llvm-project/' <<< "$files"; then
+            ignore_external=true
+          fi
+
+          # The paths these checks actually own.
+          matched=$(grep -E '^(mlir/|external/|cmake/|\.github/workflows/)|^(CMakeLists\.txt|pip_requirements\.txt|\.clang-format|\.clang-tidy)$' <<< "$files" \
             | grep -v '^external/llvm-project/' || true)
 
           if [[ -n "$matched" ]]; then
             echo "Relevant files changed:"
             printf '%s\n' "$matched" | head -n 50 || true
-            answer true
+            answer true "$ignore_external"
           fi
 
           echo "Only external/llvm-project (or out-of-scope) files changed."
-          answer false
+          answer false "$ignore_external"
 
   cpp-static-checks:
     name: C/C++ premerge checks
@@ -311,8 +329,16 @@ jobs:
           chmod +x "$git_clang_format"
           export PATH="$GITHUB_WORKSPACE/external/llvm-project/clang/tools/clang-format:$PATH"
 
+          # Vendored upstream sources are held to upstream style, so an
+          # upstream merge would otherwise report thousands of diagnostics that
+          # nobody here is expected to act on.
+          ignore_external=()
+          if [[ "${{ needs.relevant-changes.outputs.ignore_external }}" == "true" ]]; then
+            ignore_external=(--ignore-external)
+          fi
+
           python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py \
-            --base-commit="${{ steps.base.outputs.ref }}"
+            --base-commit="${{ steps.base.outputs.ref }}" "${ignore_external[@]}"
 
       - name: Nothing to check
         if: needs.relevant-changes.outputs.relevant == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,12 @@ jobs:
             exit 0
           }
 
+          # TEMPORARY EXPERIMENT - REVERT BEFORE MERGE
+          # Forces the external-only outcome so the guarded jobs can be observed
+          # on a real run. This PR touches .github/workflows/, so it can never
+          # reach that state on its own.
+          answer false false
+
           git init -q .
           git remote add origin "$REPO_URL"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
             exit 0
           }
 
+          # TEMPORARY EXPERIMENT - REVERT
+          answer false false
+
           git init -q .
           git remote add origin "$REPO_URL"
 
@@ -151,7 +154,7 @@ jobs:
     # Always run so the required check always reports. The steps no-op when
     # nothing relevant changed; `!= 'false'` keeps the fail-safe, so a failed
     # detection job still runs the real checks rather than passing silently.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.relevant-changes.outputs.relevant != 'false' }}
     runs-on: ubuntu-latest
     container:
       image: rocm/mlir:rocm7.2-latest
@@ -347,7 +350,7 @@ jobs:
   format-and-lint-checks:
     name: Python format and lint checks
     needs: relevant-changes
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.relevant-changes.outputs.relevant != 'false' }}
     runs-on: ubuntu-latest
     container:
       image: python:3.10
@@ -436,7 +439,7 @@ jobs:
   python-tests:
     name: Python performance script tests
     needs: relevant-changes
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.relevant-changes.outputs.relevant != 'false' }}
     runs-on: ubuntu-latest
     container:
       image: python:3.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,6 @@ jobs:
             exit 0
           }
 
-          # TEMPORARY EXPERIMENT - REVERT BEFORE MERGE
-          # Forces the external-only outcome so the guarded jobs can be observed
-          # on a real run. This PR touches .github/workflows/, so it can never
-          # reach that state on its own.
-          answer false false
-
           git init -q .
           git remote add origin "$REPO_URL"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,21 @@ name: rocMLIR GitHub Actions
 
 on:
   pull_request:
+    # Deliberately no `paths` filter. The jobs below are required status
+    # checks, and a workflow skipped by path filtering never reports a status
+    # at all, which leaves such PRs stuck on "Expected - waiting for status to
+    # be reported" (only an admin can then merge). The same path set is
+    # evaluated by the relevant-changes job below, so a PR that only touches
+    # external/llvm-project still reports green without running any check.
     branches:
       - develop
       - 'release/**'
-    paths:
-      - "mlir/**"
-      - "external/**"
-      - "!external/llvm-project/**"
-      - "CMakeLists.txt"
-      - "cmake/**"
-      - ".github/workflows/**"
-      - "pip_requirements.txt"
-      - ".clang-format"
-      - ".clang-tidy"
   push:
     branches:
       - develop
       - 'release/**'
+    # Push runs only seed the build cache and are not required checks, so
+    # filtering them by path is safe.
     paths:
       - "mlir/**"
       - "external/**"
@@ -29,27 +27,133 @@ on:
       - "pip_requirements.txt"
       - ".clang-format"
       - ".clang-tidy"
+
+permissions:
+  contents: read
+
+# Only the latest head of a PR needs checking; cancel superseded runs. Push
+# runs are left alone because they seed the build cache.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Evaluates the path set that used to live in `on.pull_request.paths`. The
+  # jobs below key their steps off this result, which keeps the required
+  # checks reporting a status even when there is nothing for them to do.
+  relevant-changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: detect
+        shell: bash
+        env:
+          REPO_URL: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+
+          # Every exit goes through here, and every case that cannot be proven
+          # answers "true": a required check must never be passed on a guess,
+          # only on evidence that there is nothing in scope.
+          answer() {
+            echo "relevant=$1" >> "$GITHUB_OUTPUT"
+            echo "==> relevant=$1"
+            exit 0
+          }
+
+          # The push trigger is still path-filtered, so a push run is relevant
+          # by definition.
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            answer true
+          fi
+
+          # refs/pull/N/merge is GitHub's own merge preview, so diffing it
+          # against its first parent is exactly the PR diff and no merge-base
+          # handling is needed. depth=2 with tree:0 fetches two commits and
+          # then only the trees along differing paths: no blobs, no history,
+          # no working tree. Measured at ~13 MB and ~5s on an 18k-file LLVM
+          # subtree pull, against 2.4 GB for a full clone of this repo.
+          git init -q .
+          git remote add origin "$REPO_URL"
+
+          # GitHub computes the merge ref asynchronously after a push, so a
+          # freshly pushed head can briefly have none yet. Retry before giving
+          # up, otherwise a harmless race would send every such run down the
+          # expensive path.
+          fetched=false
+          for attempt in 1 2 3; do
+            if git fetch -q --depth=2 --filter=tree:0 --no-tags origin \
+                 "refs/pull/$PR_NUMBER/merge"; then
+              fetched=true
+              break
+            fi
+            echo "Merge ref not available yet (attempt $attempt); retrying."
+            sleep 5
+          done
+
+          if [[ "$fetched" != "true" ]]; then
+            echo "No usable merge ref (conflicted or closed PR); running the checks."
+            answer true
+          fi
+
+          if ! files=$(git diff-tree -r --no-commit-id --name-only \
+               FETCH_HEAD^1 FETCH_HEAD); then
+            echo "Could not compute the diff; running the checks."
+            answer true
+          fi
+
+          # An empty list means detection is broken, not that the PR is empty.
+          if [[ -z "$files" ]]; then
+            echo "Diff came back empty; running the checks."
+            answer true
+          fi
+
+          # Kept in sync with the `paths` filter on the push trigger above.
+          matched=$(printf '%s\n' "$files" \
+            | grep -E '^(mlir/|external/|cmake/|\.github/workflows/)|^(CMakeLists\.txt|pip_requirements\.txt|\.clang-format|\.clang-tidy)$' \
+            | grep -v '^external/llvm-project/' || true)
+
+          if [[ -n "$matched" ]]; then
+            echo "Relevant files changed:"
+            printf '%s\n' "$matched" | head -n 50 || true
+            answer true
+          fi
+
+          echo "Only external/llvm-project (or out-of-scope) files changed."
+          answer false
+
   cpp-static-checks:
     name: C/C++ premerge checks
+    needs: relevant-changes
+    # Always run so the required check always reports. The steps no-op when
+    # nothing relevant changed; `!= 'false'` keeps the fail-safe, so a failed
+    # detection job still runs the real checks rather than passing silently.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     container:
       image: rocm/mlir:rocm7.2-latest
       options: --user root
     steps:
       - uses: actions/checkout@v4
+        if: needs.relevant-changes.outputs.relevant != 'false'
         with:
           # Full history is required for git-restore-mtime below (mtimes
           # are computed from the last commit touching each file).
           fetch-depth: 0
 
       - name: Fix git ownership
+        if: needs.relevant-changes.outputs.relevant != 'false'
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Determine base branch ref
         id: base
-        if: github.event_name == 'pull_request'
+        if: needs.relevant-changes.outputs.relevant != 'false' && github.event_name == 'pull_request'
         shell: bash
         run: |
           BASE_REF="origin/${{ github.base_ref }}"
@@ -67,6 +171,7 @@ jobs:
           echo "Base ref: $BASE_REF"
 
       - name: Restore source mtimes
+        if: needs.relevant-changes.outputs.relevant != 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -84,7 +189,7 @@ jobs:
           git restore-mtime --skip-missing --merge --quiet -- "${SCOPE[@]}"
 
       - name: Force-touch PR-modified files
-        if: github.event_name == 'pull_request'
+        if: needs.relevant-changes.outputs.relevant != 'false' && github.event_name == 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -97,7 +202,7 @@ jobs:
             | xargs -0r touch || true
 
       - name: Install Python dependencies for premerge checks
-        if: github.event_name == 'pull_request'
+        if: needs.relevant-changes.outputs.relevant != 'false' && github.event_name == 'pull_request'
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
@@ -105,6 +210,7 @@ jobs:
 
       - name: Compute external/ tree SHA (for cache key)
         id: ext
+        if: needs.relevant-changes.outputs.relevant != 'false'
         shell: bash
         run: |
           # external/ tree SHA in the cache key invalidates the cache on
@@ -112,6 +218,7 @@ jobs:
           echo "hash=$(git rev-parse HEAD:external | cut -c1-12)" >> "$GITHUB_OUTPUT"
 
       - name: Cache CMake build directory (compile_commands.json generation)
+        if: needs.relevant-changes.outputs.relevant != 'false'
         uses: actions/cache@v4
         with:
           path: build
@@ -123,6 +230,7 @@ jobs:
             cpp-static-checks-${{ runner.os }}-ext${{ steps.ext.outputs.hash }}-
 
       - name: Generate compile_commands.json (CMake configure)
+        if: needs.relevant-changes.outputs.relevant != 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -164,6 +272,7 @@ jobs:
           ln -sf build/compile_commands.json compile_commands.json
 
       - name: Build TableGen-generated headers
+        if: needs.relevant-changes.outputs.relevant != 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -186,7 +295,7 @@ jobs:
             MLIRMIGraphXPassIncGen
 
       - name: Run premerge static checks (format + tidy)
-        if: github.event_name == 'pull_request'
+        if: needs.relevant-changes.outputs.relevant != 'false' && github.event_name == 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -205,28 +314,38 @@ jobs:
           python3 ./mlir/utils/jenkins/static-checks/premerge-checks.py \
             --base-commit="${{ steps.base.outputs.ref }}"
 
+      - name: Nothing to check
+        if: needs.relevant-changes.outputs.relevant == 'false'
+        run: echo "Only external/llvm-project/** changed - no C/C++ sources in scope."
+
   format-and-lint-checks:
     name: Python format and lint checks
+    needs: relevant-changes
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     container:
       image: python:3.10
       options: --user root
     steps:
       - uses: actions/checkout@v4
+        if: needs.relevant-changes.outputs.relevant != 'false'
         with:
           fetch-depth: 0
 
       - name: Fix git ownership
+        if: needs.relevant-changes.outputs.relevant != 'false'
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install dependencies
+        if: needs.relevant-changes.outputs.relevant != 'false'
         run: |
           python -m pip install --upgrade pip
           pip install -r pip_requirements.txt
 
       - name: Get changed Python files under mlir/
         id: changes
+        if: needs.relevant-changes.outputs.relevant != 'false'
         shell: bash
         run: |
           echo "Determining merge base..."
@@ -264,7 +383,7 @@ jobs:
           echo "$files"
 
       - name: Run flake8
-        if: steps.changes.outputs.files != ''
+        if: needs.relevant-changes.outputs.relevant != 'false' && steps.changes.outputs.files != ''
         run: |
           files="${{ steps.changes.outputs.files }}"
           if [ -n "$files" ]; then
@@ -272,7 +391,7 @@ jobs:
           fi
 
       - name: Run YAPF check
-        if: steps.changes.outputs.files != ''
+        if: needs.relevant-changes.outputs.relevant != 'false' && steps.changes.outputs.files != ''
         run: |
           files="${{ steps.changes.outputs.files }}"
           if [ -n "$files" ]; then
@@ -281,32 +400,46 @@ jobs:
           fi
 
       - name: No Python changes in mlir/
-        if: steps.changes.outputs.files == ''
+        if: needs.relevant-changes.outputs.relevant != 'false' && steps.changes.outputs.files == ''
         run: echo "No changed *.py files under mlir/ – skipping."
+
+      - name: Nothing to check
+        if: needs.relevant-changes.outputs.relevant == 'false'
+        run: echo "Only external/llvm-project/** changed - no Python sources in scope."
 
   python-tests:
     name: Python performance script tests
+    needs: relevant-changes
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     container:
       image: python:3.10
       options: --user root
     steps:
       - uses: actions/checkout@v4
+        if: needs.relevant-changes.outputs.relevant != 'false'
         with:
           fetch-depth: 0
 
       - name: Fix git ownership
+        if: needs.relevant-changes.outputs.relevant != 'false'
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install dependencies
+        if: needs.relevant-changes.outputs.relevant != 'false'
         run: |
           python -m pip install --upgrade pip
           pip install -r pip_requirements.txt
 
       - name: Run performance script tests (no GPU)
+        if: needs.relevant-changes.outputs.relevant != 'false'
         run: |
           cd mlir/utils/performance && python -m pytest tests/ -v
         env:
           # Tests mock HIP/GPU; no ROCm or GPU required
           PYTHONPATH: ${{ github.workspace }}/mlir/utils/performance
+
+      - name: Nothing to check
+        if: needs.relevant-changes.outputs.relevant == 'false'
+        run: echo "Only external/llvm-project/** changed - no Python sources in scope."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,6 @@ jobs:
             exit 0
           }
 
-          # TEMPORARY EXPERIMENT - REVERT
-          answer false false
-
           git init -q .
           git remote add origin "$REPO_URL"
 
@@ -154,7 +151,7 @@ jobs:
     # Always run so the required check always reports. The steps no-op when
     # nothing relevant changed; `!= 'false'` keeps the fail-safe, so a failed
     # detection job still runs the real checks rather than passing silently.
-    if: ${{ !cancelled() && needs.relevant-changes.outputs.relevant != 'false' }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     container:
       image: rocm/mlir:rocm7.2-latest
@@ -350,7 +347,7 @@ jobs:
   format-and-lint-checks:
     name: Python format and lint checks
     needs: relevant-changes
-    if: ${{ !cancelled() && needs.relevant-changes.outputs.relevant != 'false' }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     container:
       image: python:3.10
@@ -439,7 +436,7 @@ jobs:
   python-tests:
     name: Python performance script tests
     needs: relevant-changes
-    if: ${{ !cancelled() && needs.relevant-changes.outputs.relevant != 'false' }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     container:
       image: python:3.10


### PR DESCRIPTION
## Motivation

The GitHub Actions workflow never runs on LLVM upstream merges, nor on PRs confined to `external/llvm-project/**`. Its required checks then sit as "Expected - waiting for status to be reported" and the PR cannot merge without an admin bypass. A skipped workflow is not a skipped job: the former never creates a check run, so branch protection has nothing to observe.

Two causes. GitHub evaluates `on: <event>: paths:` filters against only the first 300 files of a diff, so an LLVM subtree pull fills every slot with `external/llvm-project/` entries and no run is created at all — which is why #2427  produced zero runs despite changing 12 files this workflow owns.

## Technical Details

The path set moves out of the trigger filters into a single `relevant-changes` job that the three existing jobs key their steps off. They now always run and always report, but do no work when nothing relevant changed. The path set is unchanged, so which PRs get checked does not change, only how that decision is computed, and the required check names are untouched, so no branch protection changes are needed. The filter is dropped from the `push` trigger too, since the 300-file cap applies there as well and the path set should live in one place.

Detection needs no checkout. For a pull request it fetches GitHub's merge preview ref with `--depth=2 --filter=tree:0` and diffs it against its first parent; for a push it diffs the event's before/after range.

So every branch that cannot *prove* there is nothing in scope answers `true`, and the guards test `!= 'false'` rather than `== 'true'`: a failed or missing detection runs the real checks instead of passing them.

`--ignore-external` is passed to `premerge-checks.py` when the diff touches `external/llvm-project`, mirroring the `ignoreExternalLinting` parameter Jenkins sets by hand. Without it the first upstream merge to reach this workflow would lint ~18k vendored files held to upstream style.

Also added: `permissions: contents: read`, a `concurrency` group matching the `claude_auto_review*` convention, and `timeout-minutes` on the detection job.

## Test Plan

The exact `run:` block was extracted from the workflow and executed under GitHub's own shell invocation, `bash --noprofile --norc -e -o pipefail`, with `GITHUB_OUTPUT` redirected to a file — so the tested code is the code that ships, with `errexit` active. It was exercised against real PRs and a real push range covering both outcomes, all four event types, and the failure paths. Since this PR touches `.github/workflows/` it always resolves to `relevant=true`, so the external-only outcome was observed on a live run by temporarily forcing the result and reverting immediately after.

## Test Result

| case | input | result |
|---|---|---|
| PR #2427 | 18,690 files, 18,678 vendored, 12 relevant | `relevant=true ignore_external=true` |
| PR #2336 | 1 file under `external/llvm-project/` | `relevant=false ignore_external=true` |
| push range | `develop~3..develop` | `relevant=true ignore_external=true` |
| `workflow_dispatch` | no diff to inspect | `relevant=true ignore_external=true` |
| closed / nonexistent PR | merge ref absent | `relevant=true` (fail-safe) |

Every case exits `0` under `-e`. Live runs on this PR:

| scenario | Detect | C/C++ premerge | Python lint | Python tests |
|---|---|---|---|---|
| `relevant=true` | 4s | 8m39s | 4m46s | 4m49s |
| `relevant=false` (forced, then reverted) | 2s | 2m25s | 30s | 22s |

In the forced run all three jobs reported `SUCCESS` under their required check names, confirming that a job whose steps are all guarded off still reports success rather than a skipped conclusion — the behaviour an external-only PR depends on, now measured rather than assumed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.