### PR TITLE
[Rock] Guard inactive blockwise reduction threads

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -1961,19 +1961,21 @@ struct BlockwiseReduceRewritePattern
                  "active reduction threads must fit in the block");
           bool hasInactiveReductionThreads =
               activeReductionThreadCount < blockSize;
+          assert(!(hasInactiveReductionThreads && canUseDPP) &&
+                 "linear active-thread bound assumes the tree tid factoring");
           Value isActiveReductionThread;
-          if (hasInactiveReductionThreads) {
-            Value activeReductionThreadCountVal =
-                arith::ConstantIndexOp::create(rewriter, loc,
-                                               activeReductionThreadCount);
-            isActiveReductionThread =
-                arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ult,
-                                      tid, activeReductionThreadCountVal);
-          }
           auto emitForActiveReductionThread = [&](auto &&emit) {
             if (!hasInactiveReductionThreads) {
               emit(rewriter);
               return;
+            }
+            if (!isActiveReductionThread) {
+              Value activeReductionThreadCountVal =
+                  arith::ConstantIndexOp::create(rewriter, loc,
+                                                 activeReductionThreadCount);
+              isActiveReductionThread = arith::CmpIOp::create(
+                  rewriter, loc, arith::CmpIPredicate::ult, tid,
+                  activeReductionThreadCountVal);
             }
             scf::IfOp ifActive =
                 scf::IfOp::create(rewriter, loc, isActiveReductionThread,
@@ -2378,8 +2380,7 @@ struct BlockwiseReduceRewritePattern
               scf::IfOp ifb = scf::IfOp::create(rewriter, loc, isValid,
                                                 /*withElseRegion=*/false);
               {
-                OpBuilder thenb =
-                    ifb.getThenBodyBuilder(rewriter.getListener());
+                OpBuilder thenb = ifb.getThenBodyBuilder();
                 SmallVector<Value, 4> firstInits{nrtid, rtid, zeroConstantOp};
                 SmallVector<Value, 4> secondInits{nrtid, rtidPlusOffsetVal,
                                                   zeroConstantOp};

--- a/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/BlockwiseGemmToThreadwise.cpp
@@ -1096,13 +1096,10 @@ struct BlockwiseReduceRewritePattern
   // This should only be used if product non-reduction dims is
   // less than number threads in a block.
   //
-  // Given a input tensor : D0, ... , Dr , ... , DN to reduce,
-  // This function creates a view that maps the space of
-  // [D0, ... , Dr , ... , DN] --> [nrtid, rtid, rIter] where
-  // nrtid = tid / product(non-reduction dims) is a reduction subgroup leader.
-  // rtid = tid % product(non-reduction dims) is thread idx within a reduction
-  // subgroup. Size of the dimension 'rtid' is the number of threads
-  // that'd participate in the reduction
+  // Given an input tensor D0, ... , Dr , ... , DN to reduce, this function
+  // creates a view with upper coordinates [nrtid, rtid, rIter]. nrtid selects
+  // a non-reduction point, while rtid and rIter select a reduction participant
+  // and its elements. The caller chooses how to factor tid into nrtid and rtid.
   ArrayAttr createThreadViewforNRSmallerThanThreads(
       Location loc, ArrayRef<int64_t> toReduceShape, int64_t blockSize,
       size_t reduceAxis, PatternRewriter &rewriter) const {
@@ -1949,6 +1946,43 @@ struct BlockwiseReduceRewritePattern
                  canUsePermlaneSwap_NRSmall);
           assert(!canUseDsSwizzleBpermute_NRSmall_LdsSkip ||
                  canUseDsSwizzleBpermute_NRSmall);
+
+          // The tree layout can leave threads at the end of the block idle
+          // when blockSize is not divisible by the number of non-reduction
+          // elements; the shortfall grows when rthreads is further reduced to
+          // divide the reduction dimension. Fold the valid (rtid, nrtid)
+          // rectangle to a linear thread bound. Without the guard, idle
+          // workitems can race valid LDS updates through aliased coordinates
+          // or access beyond the logical workspace. Barriers remain outside so
+          // the whole workgroup reaches them.
+          int64_t activeReductionThreadCount =
+              maxActiveReductionThreads * nonReductionDimSizeProduct;
+          assert(activeReductionThreadCount <= blockSize &&
+                 "active reduction threads must fit in the block");
+          bool hasInactiveReductionThreads =
+              activeReductionThreadCount < blockSize;
+          Value isActiveReductionThread;
+          if (hasInactiveReductionThreads) {
+            Value activeReductionThreadCountVal =
+                arith::ConstantIndexOp::create(rewriter, loc,
+                                               activeReductionThreadCount);
+            isActiveReductionThread =
+                arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ult,
+                                      tid, activeReductionThreadCountVal);
+          }
+          auto emitForActiveReductionThread = [&](auto &&emit) {
+            if (!hasInactiveReductionThreads) {
+              emit(rewriter);
+              return;
+            }
+            scf::IfOp ifActive =
+                scf::IfOp::create(rewriter, loc, isActiveReductionThread,
+                                  /*withElseRegion=*/false);
+            OpBuilder thenBuilder =
+                ifActive.getThenBodyBuilder(rewriter.getListener());
+            emit(thenBuilder);
+          };
+
           // Two different tid → (rtid, nrtid) factorings are used:
           //
           // DPP path: rtid = tid % clusterSize, nrtid = tid / clusterSize.
@@ -2041,25 +2075,27 @@ struct BlockwiseReduceRewritePattern
             Value initVal = getReductionInitValue(op, rewriter);
             FillOp::create(rewriter, loc, accReg, initVal);
 
-            TransformingForOp reductionLoop = TransformingForOp::create(
-                rewriter, loc, ArrayRef<ValueRange>(inits),
-                ArrayRef<Attribute>{threadToLDSViewTrs},
-                ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
-                /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-            {
-              PatternRewriter::InsertionGuard guard(rewriter);
-              rewriter.setInsertionPointToStart(reductionLoop.getBody());
+            auto emitThreadwiseReduction = [&](OpBuilder &builder) {
+              TransformingForOp reductionLoop = TransformingForOp::create(
+                  builder, loc, ArrayRef<ValueRange>(inits),
+                  ArrayRef<Attribute>{threadToLDSViewTrs},
+                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+              OpBuilder::InsertionGuard guard(builder);
+              builder.setInsertionPointToStart(reductionLoop.getBody());
               Block::BlockArgListType LDSLoadCoords =
                   reductionLoop.getLowerCoords(/*domain=*/0);
               Value loadVal =
-                  InBoundsLoadOp::create(rewriter, loc, loadTypeInputReg,
+                  InBoundsLoadOp::create(builder, loc, loadTypeInputReg,
                                          workspaceLDSBuffer, LDSLoadCoords);
-              Value loadAcc = InBoundsLoadOp::create(rewriter, loc, elemType,
+              Value loadAcc = InBoundsLoadOp::create(builder, loc, elemType,
                                                      accReg, zeroConstantOp);
-              Value reduced = createReducingOp(op, loadVal, loadAcc, rewriter);
-              InBoundsStoreOp::create(rewriter, loc, reduced, accReg,
+              Value reduced = createReducingOp(op, loadVal, loadAcc, builder);
+              InBoundsStoreOp::create(builder, loc, reduced, accReg,
                                       zeroConstantOp);
-            }
+            };
+
+            emitForActiveReductionThread(emitThreadwiseReduction);
           }
 
           if (canUsePermlaneSwap_NRSmall) {
@@ -2304,21 +2340,23 @@ struct BlockwiseReduceRewritePattern
               SmallVector<int64_t> bounds{1, 1, 1};
               SmallVector<int64_t> strides{1, 1, 1};
 
-              TransformingForOp storeLoop = TransformingForOp::create(
-                  rewriter, loc, ArrayRef<ValueRange>(inits),
-                  ArrayRef<Attribute>{threadToLDSViewTrs},
-                  ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
-                  /*forceUnroll=*/true, /*useIndexDiffs=*/true);
-              {
-                PatternRewriter::InsertionGuard guard(rewriter);
-                rewriter.setInsertionPointToStart(storeLoop.getBody());
+              auto emitThreadwiseResultStore = [&](OpBuilder &builder) {
+                TransformingForOp storeLoop = TransformingForOp::create(
+                    builder, loc, ArrayRef<ValueRange>(inits),
+                    ArrayRef<Attribute>{threadToLDSViewTrs},
+                    ArrayRef<int64_t>(bounds), ArrayRef<int64_t>(strides),
+                    /*forceUnroll=*/true, /*useIndexDiffs=*/true);
+                OpBuilder::InsertionGuard guard(builder);
+                builder.setInsertionPointToStart(storeLoop.getBody());
                 Block::BlockArgListType LDSStoreCoords =
                     storeLoop.getLowerCoords(/*domain=*/0);
-                Value loadVal = InBoundsLoadOp::create(rewriter, loc, elemType,
+                Value loadVal = InBoundsLoadOp::create(builder, loc, elemType,
                                                        accReg, zeroConstantOp);
-                InBoundsStoreOp::create(rewriter, loc, loadVal,
+                InBoundsStoreOp::create(builder, loc, loadVal,
                                         workspaceLDSBuffer, LDSStoreCoords);
-              }
+              };
+
+              emitForActiveReductionThread(emitThreadwiseResultStore);
               LDSBarrierOp::create(rewriter, loc);
             }
 
@@ -2340,7 +2378,8 @@ struct BlockwiseReduceRewritePattern
               scf::IfOp ifb = scf::IfOp::create(rewriter, loc, isValid,
                                                 /*withElseRegion=*/false);
               {
-                OpBuilder thenb = ifb.getThenBodyBuilder();
+                OpBuilder thenb =
+                    ifb.getThenBodyBuilder(rewriter.getListener());
                 SmallVector<Value, 4> firstInits{nrtid, rtid, zeroConstantOp};
                 SmallVector<Value, 4> secondInits{nrtid, rtidPlusOffsetVal,
                                                   zeroConstantOp};

--- a/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
@@ -251,10 +251,9 @@ func.func @rock_blockwise_reducesum_nonpow2_nrdimprod(%input_reg : memref<5xf32,
 // CHECK: scf.if %[[ACTIVE]] {
 // CHECK:   rock.in_bounds_load {{.*}} : memref<120xf32, #gpu.address_space<workgroup>>, index -> vector<2xf32>
 // CHECK:   rock.in_bounds_store {{.*}} : f32 -> memref<120xf32, #gpu.address_space<workgroup>>, index
-// The brace chain places the barrier outside the guard, so it stays
-// workgroup-uniform. It counts two closing braces because canonicalization
-// merges the read and write guards into one scf.if: if that folding changes,
-// this chain fails even though the guard itself is still correct.
+// The two closing braces end the result-store loop and its active-thread guard.
+// Requiring the barrier immediately afterward keeps it outside the guard and
+// therefore workgroup-uniform, whether or not canonicalization merges guards.
 // CHECK: rock.yield
 // CHECK-NEXT: }
 // CHECK-NEXT: }

--- a/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
@@ -1,4 +1,7 @@
 // RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt -rock-blockwise-gemm-to-threadwise -canonicalize -split-input-file | FileCheck %s
+// Keep exact-packing checks in a separate invocation because CHECK and EXACT
+// both label the same functions; combining prefixes would require a second
+// match for each function.
 // RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt -rock-blockwise-gemm-to-threadwise -canonicalize -split-input-file | FileCheck %s --check-prefix=EXACT
 
 // CHECK-DAG: #[[MAP:.*]] =  affine_map<(d0) -> (d0, 0)>
@@ -131,6 +134,9 @@ func.func @rock_blockwise_reducesum_rthreads_fix(%input_reg : memref<4xf32, #gpu
 // CHECK-DAG: #[[TMAP13:.*]] = #rock.transform_map<#[[MAP7]]
 
 // CHECK: func @rock_blockwise_reducesum_nr_threads_lt_blocksize
+// EXACT-LABEL: func @rock_blockwise_reducesum_nr_threads_lt_blocksize
+// EXACT-NOT: arith.cmpi ult
+// EXACT: return
 
 // CHECK-DAG: %[[ZEROFP:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : index
@@ -264,16 +270,17 @@ func.func @rock_blockwise_reducesum_inactive_threads(%input_reg : memref<5xf32, 
 // NR-Small fallback where the rthreads clamp is what strands the workitems.
 // blockSize=20 and nrDimProd=3 give 6 reduction threads per row, but 6 does not
 // divide the 20-element reduction dimension, so rthreads drops to 5 and only
-// tids [0, 15) stay active. This is the shape the attention configs hit, and it
-// is the case the exact-packing sections above cannot reach.
+// tids [0, 15) stay active. This exercises the same rthreads-clamping mechanism
+// as the attention configs and is a case the exact-packing sections cannot hit.
 
 #inputView = #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["tid"] at [0] -> ["r"] at [1]>, <PassThrough ["iter"] at [1] -> ["nr_per_bid"] at [0]>] bounds = [20, 3] -> [3, 20]>
 #inputView_tid = #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 20} ["tid"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [20] -> [1, 20]>
 #inputView_iter = #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<Merge{3, 1} ["iter"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [3] -> [3, 1]>
 
-// The clamp landed on 5 reduction threads of 4 elements each, exactly covering
-// the reduction dimension, so the pad is empty and no coordinate aliases a
-// neighbouring row.
+// The clamp lands on 5 reduction threads of 4 elements each, so valid
+// coordinates exactly cover the reduction dimension without padding. Surplus
+// workitems still produce out-of-range rtid values that can alias neighbouring
+// rows or run past the logical workspace.
 // CHECK-DAG: <Unmerge{5, 4} ["rtid", "rIter"] at [1, 2] -> ["rDim"] at [1]>
 // CHECK-DAG: <Pad{0, 0} ["rDim"] at [1] -> ["rDim"] at [1]>
 

--- a/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
@@ -1,4 +1,5 @@
 // RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt -rock-blockwise-gemm-to-threadwise -canonicalize -split-input-file | FileCheck %s
+// RUN: sed s/##TOKEN_ARCH##/%arch/g %s | rocmlir-opt -rock-blockwise-gemm-to-threadwise -canonicalize -split-input-file | FileCheck %s --check-prefix=EXACT
 
 // CHECK-DAG: #[[MAP:.*]] =  affine_map<(d0) -> (d0, 0)>
 // CHECK-DAG: #[[MAP1:.*]] = affine_map<(d0, d1) -> (d0, d1)>
@@ -77,6 +78,9 @@ func.func @rock_blockwise_reducesum_nr_threads_gt_blocksize(%input_reg : memref<
 #inputView_tid = #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 8} ["tid"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [8] -> [1, 8]>
 #inputView_iter = #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<Merge{4, 1} ["iter"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [4] -> [4, 1]>
 // CHECK-LABEL: func @rock_blockwise_reducesum_rthreads_fix
+// EXACT-LABEL: func @rock_blockwise_reducesum_rthreads_fix
+// EXACT-NOT: arith.cmpi ult
+// EXACT: return
 func.func @rock_blockwise_reducesum_rthreads_fix(%input_reg : memref<4xf32, #gpu.address_space<private>>, %output_reg : memref<4xf32, #gpu.address_space<private>>, %ws_lds : memref<32xf32, #gpu.address_space<workgroup>>) attributes{rock.arch = "##TOKEN_ARCH##", block_size = 8 : i32, grid_size = 2 : i32, rock.kernel} {
     // Compute rthread index and nr index from tid
     // blockSize=8, nrDimProd=4, rTid=2, cs=2 -> cs*nrDimProd=8==blockSize
@@ -210,6 +214,9 @@ func.func @rock_blockwise_reducesum_nr_threads_lt_blocksize(%input_reg : memref<
 #inputView_iter = #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<Merge{5, 1} ["iter"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [5] -> [5, 1]>
 
 // CHECK-LABEL: func @rock_blockwise_reducesum_nonpow2_nrdimprod
+// EXACT-LABEL: func @rock_blockwise_reducesum_nonpow2_nrdimprod
+// EXACT-NOT: arith.cmpi ult
+// EXACT: return
 // CHECK-DAG: %[[TID:.*]] = rock.workitem_id : index
 // CHECK: %[[RTID:.*]] = arith.divsi %[[TID]], %c5
 // CHECK: %[[NRTID:.*]] = arith.remsi %[[TID]], %c5
@@ -218,5 +225,71 @@ func.func @rock_blockwise_reducesum_nr_threads_lt_blocksize(%input_reg : memref<
 
 func.func @rock_blockwise_reducesum_nonpow2_nrdimprod(%input_reg : memref<5xf32, #gpu.address_space<private>>, %output_reg : memref<5xf32, #gpu.address_space<private>>, %ws_lds : memref<75xf32, #gpu.address_space<workgroup>>) attributes{rock.arch = "##TOKEN_ARCH##", block_size = 15 : i32, grid_size = 8 : i32, rock.kernel} {
   rock.blockwise_broadcast_reduce sum [#inputView][#inputView_tid][#inputView_iter]%input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 15 : i32, nrDimPerThread = 5 : index} : memref<5xf32, #gpu.address_space<private>> using memref<75xf32, #gpu.address_space<workgroup>> into memref<5xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+// NR-Small fallback with four idle workitems. blockSize=24 and nrDimProd=5
+// produce four reduction threads per row, so only tids [0, 20) may access the
+// 5x24 LDS workspace through the (nrtid, rtid, rIter) view.
+
+#inputView = #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["tid"] at [0] -> ["r"] at [1]>, <PassThrough ["iter"] at [1] -> ["nr_per_bid"] at [0]>] bounds = [24, 5] -> [5, 24]>
+#inputView_tid = #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 24} ["tid"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [24] -> [1, 24]>
+#inputView_iter = #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<Merge{5, 1} ["iter"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [5] -> [5, 1]>
+
+// CHECK-LABEL: func @rock_blockwise_reducesum_inactive_threads
+// CHECK-DAG: %[[TID:.*]] = rock.workitem_id : index
+// CHECK-DAG: %[[ACTIVE_COUNT:.*]] = arith.constant 20 : index
+// CHECK: %[[ACTIVE:.*]] = arith.cmpi ult, %[[TID]], %[[ACTIVE_COUNT]] : index
+// CHECK: scf.if %[[ACTIVE]] {
+// CHECK:   rock.in_bounds_load {{.*}} : memref<120xf32, #gpu.address_space<workgroup>>, index -> vector<2xf32>
+// CHECK:   rock.in_bounds_store {{.*}} : f32 -> memref<120xf32, #gpu.address_space<workgroup>>, index
+// The brace chain places the barrier outside the guard, so it stays
+// workgroup-uniform. It counts two closing braces because canonicalization
+// merges the read and write guards into one scf.if: if that folding changes,
+// this chain fails even though the guard itself is still correct.
+// CHECK: rock.yield
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: rock.lds_barrier
+
+func.func @rock_blockwise_reducesum_inactive_threads(%input_reg : memref<5xf32, #gpu.address_space<private>>, %output_reg : memref<5xf32, #gpu.address_space<private>>, %ws_lds : memref<120xf32, #gpu.address_space<workgroup>>) attributes{rock.arch = "##TOKEN_ARCH##", block_size = 24 : i32, grid_size = 8 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#inputView][#inputView_tid][#inputView_iter]%input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 24 : i32, nrDimPerThread = 5 : index} : memref<5xf32, #gpu.address_space<private>> using memref<120xf32, #gpu.address_space<workgroup>> into memref<5xf32, #gpu.address_space<private>>
+  return
+}
+
+// -----
+
+// NR-Small fallback where the rthreads clamp is what strands the workitems.
+// blockSize=20 and nrDimProd=3 give 6 reduction threads per row, but 6 does not
+// divide the 20-element reduction dimension, so rthreads drops to 5 and only
+// tids [0, 15) stay active. This is the shape the attention configs hit, and it
+// is the case the exact-packing sections above cannot reach.
+
+#inputView = #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["tid"] at [0] -> ["r"] at [1]>, <PassThrough ["iter"] at [1] -> ["nr_per_bid"] at [0]>] bounds = [20, 3] -> [3, 20]>
+#inputView_tid = #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 20} ["tid"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [20] -> [1, 20]>
+#inputView_iter = #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<Merge{3, 1} ["iter"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [3] -> [3, 1]>
+
+// The clamp landed on 5 reduction threads of 4 elements each, exactly covering
+// the reduction dimension, so the pad is empty and no coordinate aliases a
+// neighbouring row.
+// CHECK-DAG: <Unmerge{5, 4} ["rtid", "rIter"] at [1, 2] -> ["rDim"] at [1]>
+// CHECK-DAG: <Pad{0, 0} ["rDim"] at [1] -> ["rDim"] at [1]>
+
+// CHECK-LABEL: func @rock_blockwise_reducesum_rthreads_clamped_inactive
+// CHECK-DAG: %[[TID:.*]] = rock.workitem_id : index
+// CHECK-DAG: %[[ACTIVE_COUNT:.*]] = arith.constant 15 : index
+// CHECK: %[[ACTIVE:.*]] = arith.cmpi ult, %[[TID]], %[[ACTIVE_COUNT]] : index
+// CHECK: scf.if %[[ACTIVE]] {
+// CHECK:   rock.in_bounds_load {{.*}} : memref<60xf32, #gpu.address_space<workgroup>>, index -> vector<4xf32>
+// CHECK:   rock.in_bounds_store {{.*}} : f32 -> memref<60xf32, #gpu.address_space<workgroup>>, index
+// CHECK: rock.yield
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: rock.lds_barrier
+
+func.func @rock_blockwise_reducesum_rthreads_clamped_inactive(%input_reg : memref<3xf32, #gpu.address_space<private>>, %output_reg : memref<3xf32, #gpu.address_space<private>>, %ws_lds : memref<60xf32, #gpu.address_space<workgroup>>) attributes{rock.arch = "##TOKEN_ARCH##", block_size = 20 : i32, grid_size = 8 : i32, rock.kernel} {
+  rock.blockwise_broadcast_reduce sum [#inputView][#inputView_tid][#inputView_iter]%input_reg into %output_reg using %ws_lds {axis = 1 : index, blockSize = 20 : i32, nrDimPerThread = 3 : index} : memref<3xf32, #gpu.address_space<private>> using memref<60xf32, #gpu.address_space<workgroup>> into memref<3xf32, #gpu.address_space<private>>
   return
 }

--- a/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
+++ b/mlir/test/Dialect/Rock/lowering_blockwise_broadcast_reduce.mlir
@@ -236,9 +236,8 @@ func.func @rock_blockwise_reducesum_nonpow2_nrdimprod(%input_reg : memref<5xf32,
 
 // -----
 
-// NR-Small fallback with four idle workitems. blockSize=24 and nrDimProd=5
-// produce four reduction threads per row, so only tids [0, 20) may access the
-// 5x24 LDS workspace through the (nrtid, rtid, rIter) view.
+// Verify floor division can leave workitems inactive. blockSize=24 and
+// nrDimProd=5 produce four reduction threads per row and 20 active workitems.
 
 #inputView = #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["tid"] at [0] -> ["r"] at [1]>, <PassThrough ["iter"] at [1] -> ["nr_per_bid"] at [0]>] bounds = [24, 5] -> [5, 24]>
 #inputView_tid = #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 24} ["tid"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [24] -> [1, 24]>
@@ -251,9 +250,8 @@ func.func @rock_blockwise_reducesum_nonpow2_nrdimprod(%input_reg : memref<5xf32,
 // CHECK: scf.if %[[ACTIVE]] {
 // CHECK:   rock.in_bounds_load {{.*}} : memref<120xf32, #gpu.address_space<workgroup>>, index -> vector<2xf32>
 // CHECK:   rock.in_bounds_store {{.*}} : f32 -> memref<120xf32, #gpu.address_space<workgroup>>, index
-// The two closing braces end the result-store loop and its active-thread guard.
-// Requiring the barrier immediately afterward keeps it outside the guard and
-// therefore workgroup-uniform, whether or not canonicalization merges guards.
+// The two closing braces end the result-store loop and active-thread guard.
+// The barrier must follow the guard so it remains workgroup-uniform.
 // CHECK: rock.yield
 // CHECK-NEXT: }
 // CHECK-NEXT: }
@@ -266,20 +264,17 @@ func.func @rock_blockwise_reducesum_inactive_threads(%input_reg : memref<5xf32, 
 
 // -----
 
-// NR-Small fallback where the rthreads clamp is what strands the workitems.
+// Verify the divisibility clamp can independently leave workitems inactive.
 // blockSize=20 and nrDimProd=3 give 6 reduction threads per row, but 6 does not
 // divide the 20-element reduction dimension, so rthreads drops to 5 and only
-// tids [0, 15) stay active. This exercises the same rthreads-clamping mechanism
-// as the attention configs and is a case the exact-packing sections cannot hit.
+// 15 workitems remain active.
 
 #inputView = #rock.transform_map<affine_map<(d0, d1) -> (d1, d0)> by [<PassThrough ["tid"] at [0] -> ["r"] at [1]>, <PassThrough ["iter"] at [1] -> ["nr_per_bid"] at [0]>] bounds = [20, 3] -> [3, 20]>
 #inputView_tid = #rock.transform_map<affine_map<(d0) -> (0, d0)> by [<Merge{1, 20} ["tid"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [20] -> [1, 20]>
 #inputView_iter = #rock.transform_map<affine_map<(d0) -> (d0, 0)> by [<Merge{3, 1} ["iter"] at [0] -> ["nr_per_bid", "r"] at [0, 1]>] bounds = [3] -> [3, 1]>
 
-// The clamp lands on 5 reduction threads of 4 elements each, so valid
-// coordinates exactly cover the reduction dimension without padding. Surplus
-// workitems still produce out-of-range rtid values that can alias neighbouring
-// rows or run past the logical workspace.
+// Check that the view uses five reduction threads with four elements each and
+// does not pad the reduction dimension.
 // CHECK-DAG: <Unmerge{5, 4} ["rtid", "rIter"] at [1, 2] -> ["rDim"] at [1]>
 // CHECK-DAG: <Pad{0, 0} ["rDim"] at [1] -> ["rDim"] at [1]>
 


### PR DESCRIPTION
## Motivation

Some NR-small reductions assign fewer useful reduction slots than there are threads in the block. The extra threads should be idle, but they were still reading and writing shared workgroup memory (LDS). This could make an idle thread overwrite or re-read another thread's partial result, producing a cross-wave race and incorrect output.

For example, one affected attention configuration launches 256 threads, but its reduction layout has only 192 valid thread slots (48 output positions × 4 reduction threads). The remaining 64 threads form an entire idle wave. One of those threads aliases a valid output position, while another starts an access immediately past the 768-element logical LDS workspace.

On the reported gfx90a configuration, the old lowering failed the original strict CPU verification (`[1 1 0]`) with a maximum absolute difference of 0.019589; randomized inputs reached 0.230480. This indicates a real correctness issue rather than only harmless floating-point accumulation-order noise.

## Terminology

- **Reduction:** combining many input values into fewer output values, such as computing a sum or maximum.
- **Reduction dimension:** the input axis whose values are combined.
- **Non-reduction (NR) dimensions:** the axes that remain in the output. Their product, `nrDimProd`, is the number of independent output positions handled by the block.
- **NR-small:** the lowering path used when `nrDimProd` is smaller than the block size. There are more threads than output positions, so several threads cooperate to reduce each position.
- **`rthreads`:** the number of threads assigned to reduce one output position. It may be reduced (clamped) so that each thread processes an even share of the reduction dimension.
- **`activeReductionThreadCount`:** `nrDimProd × rthreads`. Threads with `tid` below this count own a valid reduction slot; all remaining threads are inactive for the LDS read/write phases.
- **Exact packing:** `activeReductionThreadCount == blockSize`, meaning every launched thread owns a valid slot and no guard is needed.
- **LDS:** fast memory shared by all threads in one GPU workgroup. It is used here to exchange partial reduction results.
- **Wave:** a hardware group of threads that executes together (64 threads for these CDNA configurations). A cross-wave race occurs when different waves access the same LDS location without sufficient ordering.
- **Workgroup barrier:** a synchronization point that every thread in the workgroup must reach. Barriers therefore cannot be placed inside a condition that only active threads execute.

## Fix

- Compute how many threads actually own a reduction slot: `activeReductionThreadCount = nrDimProd × rthreads`.
- Guard the LDS reduction loads and result stores with `tid < activeReductionThreadCount` when the block contains idle threads.
- Keep every workgroup barrier outside the guard so all threads still synchronize safely.
- Preserve the existing guard-free lowering when every thread is active, including the exact-packing fast paths.
- Add focused positive tests for both ways idle threads arise and negative tests proving exact-packing cases do not gain unnecessary guards.

In simple terms: threads without assigned work now wait at the barriers but no longer touch another thread's shared-memory data.

## Test plan

- [x] Focused `lowering_blockwise_broadcast_reduce.mlir` lit test.
- [x] Affected Rock and rocmlir-gen suites: 159 passed, 6 unsupported, 0 failed.
- [x] Reproduced the reported gfx90a attention configuration with both default and randomized inputs; both now pass the original strict verifier (`[1 1 1]`) without relaxing the absolute-difference threshold.
- [x] Lowered both reported gfx942 configurations and confirmed the generated gfx942 IR guards all LDS accesses from the 64 inactive threads.
- [x] Ran the same two configurations on available gfx90a hardware; both pass the strict verifier (`[1 1 1]`).
- [ ] Re-run the two configurations on native gfx942 hardware.

Made with [Cursor](https://cursor.com)