### PR TITLE
[AIROCMLIR-942] Introduce gemm+gemm quick-tune lists

### DIFF
--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -2966,6 +2966,23 @@ const StringRef PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx9
 };
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx90a_DEFS
 
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx908_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx908[] = {
+    "attn:v3:128,128,16,8,16,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,16,16,32,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,16,8,16,16,16,16,1,1,2,0,1",
+    "attn:v3:128,128,32,4,16,32,16,8,1,1,2,0,1",
+    "attn:v3:32,128,32,8,16,32,16,8,1,2,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx908_DEFS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx908_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx908[] = {
+    "attn:v3:64,128,16,32,16,16,16,4,1,1,2,0,1",
+    "attn:v3:64,128,16,8,16,16,16,8,1,1,1,4,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx908_DEFS
+
 #endif  // GemmGemm_DEFINITIONS_GEN
 
 #ifdef GemmGemm_DECLARATIONS_GEN
@@ -3159,6 +3176,16 @@ static const StringRef initParametersF16GemmElementwiseGemmGfx90a[nInitParameter
 static constexpr size_t nInitParametersF32GemmElementwiseGemmGfx90a = 2;
 static const StringRef initParametersF32GemmElementwiseGemmGfx90a[nInitParametersF32GemmElementwiseGemmGfx90a];
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx90a_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx908_DECS
+static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx908 = 5;
+static const StringRef initParametersF16GemmElementwiseGemmGfx908[nInitParametersF16GemmElementwiseGemmGfx908];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx908_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx908_DECS
+static constexpr size_t nInitParametersF32GemmElementwiseGemmGfx908 = 2;
+static const StringRef initParametersF32GemmElementwiseGemmGfx908[nInitParametersF32GemmElementwiseGemmGfx908];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx908_DECS
 
 #endif  // GemmGemm_DECLARATIONS_GEN
 
@@ -3441,5 +3468,11 @@ static const StringRef initParametersF32GemmElementwiseGemmGfx90a[nInitParameter
 {"gfx90a_gemmelementwisegemm_f32", {PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx90a, PopulateParamsGemmGemm::nInitParametersF32GemmElementwiseGemmGfx90a}},
 
 {"gfx90a_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx90a, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx90a}},  // alias -> f16
+
+{"gfx908_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx908, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx908}},
+
+{"gfx908_gemmelementwisegemm_f32", {PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx908, PopulateParamsGemmGemm::nInitParametersF32GemmElementwiseGemmGfx908}},
+
+{"gfx908_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx908, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx908}},  // alias -> f16
 
 #endif  // GemmGemm_LOOKUP_TABLE_GEN

--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -2993,6 +2993,14 @@ const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1
 };
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1201_DEFS
 
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1101_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1101[] = {
+    "attn:v3:128,128,16,16,16,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,32,8,32,32,16,8,1,1,1,4,1",
+    "attn:v3:32,256,128,8,16,32,16,4,1,2,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1101_DEFS
+
 #endif  // GemmGemm_DEFINITIONS_GEN
 
 #ifdef GemmGemm_DECLARATIONS_GEN
@@ -3201,6 +3209,11 @@ static const StringRef initParametersF32GemmElementwiseGemmGfx908[nInitParameter
 static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx1201 = 5;
 static const StringRef initParametersF16GemmElementwiseGemmGfx1201[nInitParametersF16GemmElementwiseGemmGfx1201];
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1201_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1101_DECS
+static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx1101 = 3;
+static const StringRef initParametersF16GemmElementwiseGemmGfx1101[nInitParametersF16GemmElementwiseGemmGfx1101];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1101_DECS
 
 #endif  // GemmGemm_DECLARATIONS_GEN
 
@@ -3493,5 +3506,9 @@ static const StringRef initParametersF16GemmElementwiseGemmGfx1201[nInitParamete
 {"gfx1201_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1201, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1201}},
 
 {"gfx1201_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1201, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1201}},  // alias -> f16
+
+{"gfx1101_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1101, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1101}},
+
+{"gfx1101_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1101, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1101}},  // alias -> f16
 
 #endif  // GemmGemm_LOOKUP_TABLE_GEN

--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -2983,6 +2983,16 @@ const StringRef PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx9
 };
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx908_DEFS
 
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1201_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1201[] = {
+    "attn:v3:128,128,16,16,16,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,16,8,16,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,16,4,16,16,16,8,1,1,2,0,1",
+    "attn:v3:64,128,32,32,16,16,16,8,1,1,2,0,1",
+    "attn:v3:64,64,256,16,16,32,16,4,1,1,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1201_DEFS
+
 #endif  // GemmGemm_DEFINITIONS_GEN
 
 #ifdef GemmGemm_DECLARATIONS_GEN
@@ -3186,6 +3196,11 @@ static const StringRef initParametersF16GemmElementwiseGemmGfx908[nInitParameter
 static constexpr size_t nInitParametersF32GemmElementwiseGemmGfx908 = 2;
 static const StringRef initParametersF32GemmElementwiseGemmGfx908[nInitParametersF32GemmElementwiseGemmGfx908];
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx908_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1201_DECS
+static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx1201 = 5;
+static const StringRef initParametersF16GemmElementwiseGemmGfx1201[nInitParametersF16GemmElementwiseGemmGfx1201];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1201_DECS
 
 #endif  // GemmGemm_DECLARATIONS_GEN
 
@@ -3474,5 +3489,9 @@ static const StringRef initParametersF32GemmElementwiseGemmGfx908[nInitParameter
 {"gfx908_gemmelementwisegemm_f32", {PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx908, PopulateParamsGemmGemm::nInitParametersF32GemmElementwiseGemmGfx908}},
 
 {"gfx908_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx908, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx908}},  // alias -> f16
+
+{"gfx1201_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1201, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1201}},
+
+{"gfx1201_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1201, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1201}},  // alias -> f16
 
 #endif  // GemmGemm_LOOKUP_TABLE_GEN

--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -3001,6 +3001,23 @@ const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1
 };
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1101_DEFS
 
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx950_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx950[] = {
+    "attn:v3:128,256,16,32,16,16,16,8,1,1,2,0,1",
+    "attn:v3:128,256,16,32,16,16,16,8,1,2,2,0,1",
+    "attn:v3:128,128,16,4,16,16,16,16,1,2,2,0,1",
+    "attn:v3:64,64,32,8,64,32,32,8,1,3,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx950_DEFS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx950_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx950[] = {
+    "attn:v3:128,128,16,16,16,16,16,8,1,2,2,0,1",
+    "attn:v3:128,128,16,16,16,16,16,4,1,2,2,0,1",
+    "attn:v3:128,128,16,4,16,16,16,16,1,4,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx950_DEFS
+
 #endif  // GemmGemm_DEFINITIONS_GEN
 
 #ifdef GemmGemm_DECLARATIONS_GEN
@@ -3214,6 +3231,16 @@ static const StringRef initParametersF16GemmElementwiseGemmGfx1201[nInitParamete
 static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx1101 = 3;
 static const StringRef initParametersF16GemmElementwiseGemmGfx1101[nInitParametersF16GemmElementwiseGemmGfx1101];
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx1101_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx950_DECS
+static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx950 = 4;
+static const StringRef initParametersF16GemmElementwiseGemmGfx950[nInitParametersF16GemmElementwiseGemmGfx950];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx950_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx950_DECS
+static constexpr size_t nInitParametersF32GemmElementwiseGemmGfx950 = 3;
+static const StringRef initParametersF32GemmElementwiseGemmGfx950[nInitParametersF32GemmElementwiseGemmGfx950];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx950_DECS
 
 #endif  // GemmGemm_DECLARATIONS_GEN
 
@@ -3510,5 +3537,11 @@ static const StringRef initParametersF16GemmElementwiseGemmGfx1101[nInitParamete
 {"gfx1101_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1101, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1101}},
 
 {"gfx1101_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx1101, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx1101}},  // alias -> f16
+
+{"gfx950_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx950, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx950}},
+
+{"gfx950_gemmelementwisegemm_f32", {PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx950, PopulateParamsGemmGemm::nInitParametersF32GemmElementwiseGemmGfx950}},
+
+{"gfx950_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx950, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx950}},  // alias -> f16
 
 #endif  // GemmGemm_LOOKUP_TABLE_GEN

--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -2934,6 +2934,21 @@ const StringRef PopulateParamsGemmGemm::initParametersI8AttentionGfx1103[] = {
 };
 // END_ATTENTION_GemmGemm_i8_gfx1103_DEFS
 
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx942_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx942[] = {
+    "attn:v3:128,128,16,16,32,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,16,4,32,16,16,16,1,1,2,0,1",
+    "attn:v3:64,192,16,32,16,16,16,4,1,2,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx942_DEFS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx942_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx942[] = {
+    "attn:v3:64,128,16,32,16,16,16,4,1,1,2,0,1",
+    "attn:v3:64,64,16,16,16,16,16,4,1,2,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx942_DEFS
+
 #endif  // GemmGemm_DEFINITIONS_GEN
 
 #ifdef GemmGemm_DECLARATIONS_GEN
@@ -3107,6 +3122,16 @@ static const StringRef initParametersF16AttentionGfx1103[nInitParametersF16Atten
 static constexpr size_t nInitParametersI8AttentionGfx1103 = 12;
 static const StringRef initParametersI8AttentionGfx1103[nInitParametersI8AttentionGfx1103];
 // END_ATTENTION_GemmGemm_i8_gfx1103_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx942_DECS
+static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx942 = 3;
+static const StringRef initParametersF16GemmElementwiseGemmGfx942[nInitParametersF16GemmElementwiseGemmGfx942];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx942_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx942_DECS
+static constexpr size_t nInitParametersF32GemmElementwiseGemmGfx942 = 2;
+static const StringRef initParametersF32GemmElementwiseGemmGfx942[nInitParametersF32GemmElementwiseGemmGfx942];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx942_DECS
 
 #endif  // GemmGemm_DECLARATIONS_GEN
 
@@ -3377,5 +3402,11 @@ static const StringRef initParametersI8AttentionGfx1103[nInitParametersI8Attenti
 {"gfx1103_attention_f16", {PopulateParamsGemmGemm::initParametersF16AttentionGfx1103, PopulateParamsGemmGemm::nInitParametersF16AttentionGfx1103}},
 
 {"gfx1103_attention_i8", {PopulateParamsGemmGemm::initParametersI8AttentionGfx1103, PopulateParamsGemmGemm::nInitParametersI8AttentionGfx1103}},
+
+{"gfx942_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx942, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx942}},
+
+{"gfx942_gemmelementwisegemm_f32", {PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx942, PopulateParamsGemmGemm::nInitParametersF32GemmElementwiseGemmGfx942}},
+
+{"gfx942_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx942, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx942}},  // alias -> f16
 
 #endif  // GemmGemm_LOOKUP_TABLE_GEN

--- a/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
+++ b/mlir/include/mlir/Dialect/Rock/Tuning/QuickTuningPerfconfigs.inc
@@ -2949,6 +2949,23 @@ const StringRef PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx9
 };
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx942_DEFS
 
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx90a_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx90a[] = {
+    "attn:v3:128,128,16,8,32,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,16,16,16,16,16,4,1,1,2,0,1",
+    "attn:v3:128,128,16,16,32,16,16,8,1,1,2,0,1",
+    "attn:v3:128,128,16,8,32,16,16,16,1,1,2,0,1",
+    "attn:v3:32,256,64,16,16,16,16,4,1,2,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx90a_DEFS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx90a_DEFS
+const StringRef PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx90a[] = {
+    "attn:v3:64,64,16,16,16,16,16,4,1,2,2,0,1",
+    "attn:v3:64,128,16,4,16,16,16,8,1,1,2,0,1"
+};
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx90a_DEFS
+
 #endif  // GemmGemm_DEFINITIONS_GEN
 
 #ifdef GemmGemm_DECLARATIONS_GEN
@@ -3132,6 +3149,16 @@ static const StringRef initParametersF16GemmElementwiseGemmGfx942[nInitParameter
 static constexpr size_t nInitParametersF32GemmElementwiseGemmGfx942 = 2;
 static const StringRef initParametersF32GemmElementwiseGemmGfx942[nInitParametersF32GemmElementwiseGemmGfx942];
 // END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx942_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx90a_DECS
+static constexpr size_t nInitParametersF16GemmElementwiseGemmGfx90a = 5;
+static const StringRef initParametersF16GemmElementwiseGemmGfx90a[nInitParametersF16GemmElementwiseGemmGfx90a];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f16_gfx90a_DECS
+
+// BEGIN_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx90a_DECS
+static constexpr size_t nInitParametersF32GemmElementwiseGemmGfx90a = 2;
+static const StringRef initParametersF32GemmElementwiseGemmGfx90a[nInitParametersF32GemmElementwiseGemmGfx90a];
+// END_GEMMELEMENTWISEGEMM_GemmGemm_f32_gfx90a_DECS
 
 #endif  // GemmGemm_DECLARATIONS_GEN
 
@@ -3408,5 +3435,11 @@ static const StringRef initParametersF32GemmElementwiseGemmGfx942[nInitParameter
 {"gfx942_gemmelementwisegemm_f32", {PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx942, PopulateParamsGemmGemm::nInitParametersF32GemmElementwiseGemmGfx942}},
 
 {"gfx942_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx942, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx942}},  // alias -> f16
+
+{"gfx90a_gemmelementwisegemm_f16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx90a, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx90a}},
+
+{"gfx90a_gemmelementwisegemm_f32", {PopulateParamsGemmGemm::initParametersF32GemmElementwiseGemmGfx90a, PopulateParamsGemmGemm::nInitParametersF32GemmElementwiseGemmGfx90a}},
+
+{"gfx90a_gemmelementwisegemm_bf16", {PopulateParamsGemmGemm::initParametersF16GemmElementwiseGemmGfx90a, PopulateParamsGemmGemm::nInitParametersF16GemmElementwiseGemmGfx90a}},  // alias -> f16
 
 #endif  // GemmGemm_LOOKUP_TABLE_GEN

--- a/mlir/unittests/Dialect/Rock/ParamLookupTableTests.cpp
+++ b/mlir/unittests/Dialect/Rock/ParamLookupTableTests.cpp
@@ -74,12 +74,6 @@ TEST(FindFallbackTest, AnyGfxForNonAccel) {
       ParamLookupTable<GeneralGemmParamsAttr>::findFallback("gfx942_gemm_f32"));
 }
 
-TEST(FindFallbackTest, GemmElementwiseGemmHasNoRelative) {
-  // gemm+gemm has no quick-tuning entries and must not fall back to others
-  EXPECT_EQ("", ParamLookupTable<GemmGemmParamsAttr>::findFallback(
-                    "gfx942_gemmelementwisegemm_f16"));
-}
-
 TEST(FindFallbackTest, ConvElementwiseGemmHasNoRelative) {
   // conv+gemm has no quick-tuning entries and must not fall back to others
   EXPECT_EQ("", ParamLookupTable<GemmGemmParamsAttr>::findFallback(

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1609,6 +1609,11 @@ pipeline {
                                                                             -c ../mlir/utils/jenkins/ci-configs/selected-attention-configs \
                                                                             -o quick_tuning_attention.tsv
                                                                         [ -f quick_tuning_attention.tsv ]"""
+                                                                    shStrict """python3 ./bin/tuningRunner.py --abort-on-error \
+                                                                            --op gemm_gemm --tuning-space quick \
+                                                                            -c ../mlir/utils/jenkins/ci-configs/selected-gemmgemm-configs \
+                                                                            -o quick_tuning_gemmgemm.tsv
+                                                                        [ -f quick_tuning_gemmgemm.tsv ]"""
                                                                 }
                                                             }
                                                         }
@@ -1836,6 +1841,10 @@ pipeline {
                                                             shStrict """python3 ./bin/tuningRunner.py --abort-on-error \
                                                                 --op attention --tuning-space quick \
                                                                 -c ../mlir/utils/performance/configs/tier1-attention-configs \
+                                                                -o mlir_quick_tuning_${CHIP}.tsv 2>&1 | tee -a ${tuningLog}"""
+                                                            shStrict """python3 ./bin/tuningRunner.py --abort-on-error \
+                                                                --op gemm_gemm --tuning-space quick \
+                                                                -c ../mlir/utils/performance/configs/tier1-gemmgemm-configs \
                                                                 -o mlir_quick_tuning_${CHIP}.tsv 2>&1 | tee -a ${tuningLog}"""
                                                             shStrict """echo "=== Tuning rocMLIR for ${CHIP} completed ===" | tee -a ${tuningLog}"""
                                                             // Check for errors in the tuning log


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Introduce gemm+gemm quick-tune lists.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Generated quick-tune lists, based on exhaustive and greedy tuning data, for the following chips:
  - gfx950
  - gfx942
  - gfx90a
  - gfx908
  - gfx1201
  - gfx1101
- Enable quick tuning on PR and weekly Jenkins CI
- Remove now invalid gemm+gemm fallback test

> **NOTE:** A number of configs are failing exhaustive tune on gfx950 and gfx942 due to a backend compiler bug. Some are already fixed on upstream; those fixes were cherry-picked when these quick-tune lists were generated. Others are still failing on upstream, so the generated lists for gfx950 and gfx942 are incomplete and should be regenerated once the bug is addressed and the rest of the data is collected.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

PR CI and sanity checks.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
