### PR TITLE
[Rock][NonAccel] Vectorize the C writeback along gemmM for M-contiguous outputs

### DIFF
--- a/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
+++ b/mlir/lib/Dialect/Rock/Transforms/GridwiseGemmToBlockwise.cpp
@@ -373,6 +373,13 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
     int64_t mPerThread = tuningParams.getMPerThread();
     int64_t nPerThread = tuningParams.getNPerThread();
 
+    // The OutputSwizzle pass reads the outputSwizzle tuning param from a func
+    // attribute.
+    IntegerAttr outputSwizzleAttr =
+        b.getI64IntegerAttr(tuningParams.getOutputSwizzle());
+    cast<func::FuncOp>(op->getParentOp())
+        ->setAttr(rock::OutputSwizzleAttr::getMnemonic(), outputSwizzleAttr);
+
     GeneralGemmBlockStructure blockStructure =
         *deriveGeneralGemmBlockStructure(blockSize);
     int64_t mThreadsPerCuwave = blockStructure.mThreadsPerCuwave;
@@ -453,8 +460,37 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
                         privateMemoryAddressSpace);
     Value registerMatrixCAllocOp =
         GpuAllocOp::create(b, loc, threadCRegisterMemRefType);
-    Value registerMatrixCViewOp = reshapeBuffer(
-        b, loc, registerMatrixCAllocOp, {"m", "n"}, {threadCNumM, threadCNumN});
+
+    // Iterate the C writeback along whichever gemm dimension the output
+    // tensor is actually vectorizable in. Layouts with a contiguous gemmM
+    // (e.g. NHWC convolutions, whose output is contiguous in k) need
+    // m_thread innermost, so the accumulator is kept n-major in registers.
+    constexpr uint32_t cDimM = 1, cDimN = 2;
+    int64_t cMVecLen =
+        getMaxVectorization(op.getC(), cDimM, /*inputDimLen=*/std::nullopt,
+                            op.getC().getDefiningOp())
+            .max;
+    int64_t cNVecLen =
+        getMaxVectorization(op.getC(), cDimN, /*inputDimLen=*/std::nullopt,
+                            op.getC().getDefiningOp())
+            .max;
+    bool storeMFast = cMVecLen > cNVecLen;
+
+    Value registerMatrixCViewOp;
+    if (storeMFast) {
+      registerMatrixCViewOp =
+          reshapeBuffer(b, loc, registerMatrixCAllocOp, {"n", "m"},
+                        {threadCNumN, threadCNumM});
+      TopDownTMBuilder transposeView(b, {"m", "n"},
+                                     {threadCNumM, threadCNumN}, loc);
+      transposeView.passThrough({"n", "m"}, {0, 1}, {"n", "m"});
+      registerMatrixCViewOp = transform(
+          b, registerMatrixCViewOp, b.getArrayAttr({transposeView.get()}));
+    } else {
+      registerMatrixCViewOp =
+          reshapeBuffer(b, loc, registerMatrixCAllocOp, {"m", "n"},
+                        {threadCNumM, threadCNumN});
+    }
 
     // Zero init Matrix C on registers.
     FillOp::create(b, loc, registerMatrixCAllocOp, zeroConstantFloatOp);
@@ -723,9 +759,17 @@ struct GridwiseGemmRewritePattern : public OpRewritePattern<GridwiseGemmOp> {
                             {3, 4, 5, 6}, "tid",
                             {mCuwavesPerBlock, nCuwavesPerBlock,
                              mThreadsPerCuwave, nThreadsPerCuwave});
-    splitMemoryCoords.merge({"m_repeat", "m_thread", "n_repeat", "n_thread"},
-                            {7, 8, 9, 10}, "iter",
-                            {gemmMRepeat, mPerThread, gemmNRepeat, nPerThread});
+    if (storeMFast) {
+      // The accumulator is n-major in registers (see registerMatrixCViewOp),
+      // so iterate with m_thread innermost to vectorize along gemmM.
+      splitMemoryCoords.merge(
+          {"n_repeat", "n_thread", "m_repeat", "m_thread"}, {7, 8, 9, 10},
+          "iter", {gemmNRepeat, nPerThread, gemmMRepeat, mPerThread});
+    } else {
+      splitMemoryCoords.merge(
+          {"m_repeat", "m_thread", "n_repeat", "n_thread"}, {7, 8, 9, 10},
+          "iter", {gemmMRepeat, mPerThread, gemmNRepeat, nPerThread});
+    }
     TransformMapAttr splitMemoryCoordsAttr = splitMemoryCoords.get();
     transformAttrs.push_back(splitMemoryCoordsAttr);
 


### PR DESCRIPTION
## Motivation

NHWC f32 convolutions on gfx1201 run ~7-9% slower than NCHW even with
exhaustive tuning (e.g. 512→1536 k=2 pad=1 @32x32: 408us vs 385us). These use
the non-accelerated GEMM path (no f32 WMMA), where the C writeback iterates
with `n_thread` innermost unconditionally. For NHWC outputs the
memory-contiguous dimension is gemmM (`k` innermost), so every thread issues
scalar `b32` stores scattered 6KB apart across lanes. The same problem applies
to any `--transC`-style GEMM: forcing an M-contiguous C through this path
costs ~10% (450us → 404us on a 1536x1089x2048 f32 GEMM once fixed).

Additionally, the `outputSwizzle` tuning parameter (9th field of `v3` perf
configs) was silently ignored on the non-accel path: the OutputSwizzle pass
reads it from a func attribute that only the accel and attention lowerings set.

## Technical Details

- In `GridwiseGemmRewritePattern` (GridwiseGemmToBlockwise.cpp), query
  `getMaxVectorization` on the C operand for gemmM and gemmN. When M
  vectorizes better than N (`storeMFast`):
  - Keep the accumulator **n-major** in registers: view the flat C register
    buffer as `[n, m]` and hand the blockwise gemm a transposed `[m, n]` view
    of it, so the register order matches the new store order.
  - Emit the writeback's `iter` merge as
    `{n_repeat, n_thread, m_repeat, m_thread}` instead of
    `{m_repeat, m_thread, n_repeat, n_thread}`, putting `m_thread` innermost
    so the threadwise write vectorizes along gemmM (`b64`/`b128` stores, with
    `m_cuwave` lanes forming contiguous 32-64B clusters).
- When N vectorizes at least as well as M, codegen is unchanged; NCHW kernels
  produce bit-identical ISA (their output vectorizes in neither dimension).
- Set the `outputSwizzle` func attribute from `GeneralGemmParams` in the
  non-accel lowering, matching the accel/attention paths. Default
  (`2` = heuristic) behavior is unchanged; this only makes the existing knob
  functional.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
