### PR TITLE
Respect MFMA arch disablement in CI

### DIFF
--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1016,11 +1016,23 @@ void setHeartbeat() {
     }
 }
 
+List<String> getEnabledMfmaArchitectures() {
+    def architectures = []
+    if (params.disable942 == false) architectures << 'gfx942'
+    if (params.disable908 == false) architectures << 'gfx908'
+    if (params.disable90a == false) architectures << 'gfx90a'
+    return architectures
+}
+
 String getLabelFromCodepath(String codepath) {
     echo "codepath is ${codepath}"
     String label = ''
     if (codepath == "mfma") {
-        label = 'mlir && (gfx942 || gfx908 || gfx90a)'
+        def architectures = getEnabledMfmaArchitectures()
+        if (architectures.isEmpty()) {
+            error 'mfma codepath selected but all of gfx942/gfx908/gfx90a are disabled'
+        }
+        label = "mlir && (${architectures.join(' || ')})"
     } else if (codepath == "gfx950") {
         if (params.weekly) {
             label = 'mlir && linux-mi350-8'
@@ -1155,7 +1167,8 @@ boolean shouldRunFromCodepath(String codepath) {
         return true
     }
     // Run mfma on private CI
-    if ((codepath == "mfma") && params.canXdlops) {
+    if ((codepath == "mfma") && params.canXdlops &&
+        !getEnabledMfmaArchitectures().isEmpty()) {
         return true
     }
     if (codepath == "gfx950" && params.canXdlops && params.disable950 == false) {
@@ -1227,7 +1240,7 @@ boolean shouldRunBuildAndTest(String codepath) {
     // When a particular codepath is selected, we only test the codepath
     // on private CI
     if (params.codepath == codepath && params.canXdlops) {
-        if (params.codepath == "mfma") return true
+        if (params.codepath == "mfma") return !getEnabledMfmaArchitectures().isEmpty()
         if (params.codepath == "vanilla") return true
         if (params.codepath == "gfx950" && params.disable950 == false) return true
         if (params.codepath == "gfx103x" && params.disableGfx103x == false) return true

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1247,7 +1247,7 @@ boolean shouldRunBuildAndTest(String codepath) {
     // When a particular codepath is selected, we only test the codepath
     // on private CI
     if (params.codepath == codepath && params.canXdlops) {
-        if (params.codepath == "mfma") return !getEnabledMfmaArchitectures().isEmpty()
+        if (params.codepath == "mfma") return shouldRunFromCodepath("mfma")
         if (params.codepath == "vanilla") return true
         if (params.codepath == "gfx950" && params.disable950 == false) return true
         if (params.codepath == "gfx103x" && params.disableGfx103x == false) return true

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -2330,6 +2330,9 @@ pipeline {
                 // One big scripted step per matrix row
                 stages {
                     stage('Matrix row orchestration') {
+                        when {
+                            expression { shouldRunFromCodepath(CODEPATH) }
+                        }
                         steps {
                             // Do not fail the build on code coverage
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/mlir/utils/jenkins/Jenkinsfile
+++ b/mlir/utils/jenkins/Jenkinsfile
@@ -1167,8 +1167,15 @@ boolean shouldRunFromCodepath(String codepath) {
         return true
     }
     // Run mfma on private CI
-    if ((codepath == "mfma") && params.canXdlops &&
-        !getEnabledMfmaArchitectures().isEmpty()) {
+    if ((codepath == "mfma") && params.canXdlops) {
+        if (getEnabledMfmaArchitectures().isEmpty()) {
+            // Dropping the mfma row also drops preMergeCheck() and preMergeCheckPackage(),
+            // which have no vanilla row to fall back to on private CI.
+            echo 'Skipping mfma codepath: gfx942, gfx908 and gfx90a are all disabled, so ' +
+                 'the premerge static check and the librockcompiler_deps.cmake accuracy ' +
+                 'check will not run'
+            return false
+        }
         return true
     }
     if (codepath == "gfx950" && params.canXdlops && params.disable950 == false) {


### PR DESCRIPTION
## Motivation

Ensure PR and nightly MFMA CI jobs respect the architecture disable parameters. Previously, MFMA jobs could still run on any one of gfx908, gfx90a, or gfx942 even if those archs were explicitly disabled. This now matches the behavior that we can get for other archs (gfx950, Navi3x, etc.)

This is a port of https://github.com/ROCm/rocmlirTriton/pull/427 from rocmlirTriton.

## Technical Details

- Build the MFMA Jenkins node label dynamically from the enabled gfx908, gfx90a, and gfx942 architectures.
- Apply the enabled-architecture check when deciding whether to run the MFMA codepath.
- Skip MFMA testing when all supported MFMA architectures are disabled.

NOTE: rocMLIR already respects these disable flags in `shouldRunFromChip()` for chip specific tuning and performance matrix rows. However, build/test and other codepath-based rows still needed updating.

## Test Plan

- PR CI

## Test Result

- [X] PR CI
    - [X] Only run on gfx942: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2455/3/pipeline-overview/?selected-node=150
    - [X] Only run on gfx908: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2455/5/pipeline-overview/?selected-node=135
    - [x] Only run on gfx90a: https://ml-ci-internal.amd.com/job/MLIR/job/mlir/job/PR-2455/6/pipeline-overview/?selected-node=128

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
