### PR TITLE
[AIROCMLIR-1169] Disable packed FP32 on gfx950

### DIFF
--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -335,8 +335,8 @@ void rock::buildBackendPipeline(OpPassManager &pm,
     opts.features = options.features;
     // gfx950 intermittently skips the low lane of v_pk_fma_f32 with
     // op_sel:[0,1,0], leaving f32 reductions short by whole product terms with
-    // no error reported. Keep the backend from forming it; remove this once the
-    // defect is fixed below us.
+    // no error reported. Keep the backend from forming it; remove this once
+    // ROCM-29896 is fixed.
     if (StringRef(options.chip).starts_with("gfx950")) {
       if (!opts.features.empty())
         opts.features += ",";

--- a/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
+++ b/mlir/lib/Dialect/Rock/Pipelines/Pipelines.cpp
@@ -333,6 +333,15 @@ void rock::buildBackendPipeline(OpPassManager &pm,
     opts.triple = options.triple;
     opts.chip = options.chip;
     opts.features = options.features;
+    // gfx950 intermittently skips the low lane of v_pk_fma_f32 with
+    // op_sel:[0,1,0], leaving f32 reductions short by whole product terms with
+    // no error reported. Keep the backend from forming it; remove this once the
+    // defect is fixed below us.
+    if (StringRef(options.chip).starts_with("gfx950")) {
+      if (!opts.features.empty())
+        opts.features += ",";
+      opts.features += "-packed-fp32-ops";
+    }
     opts.optLevel = options.optLevel;
     pm.addPass(createGpuROCDLAttachTarget(opts));
     pm.addPass(createGpuModuleToBinaryPass());

--- a/mlir/test/rocmlir-driver/pipelines.mlir
+++ b/mlir/test/rocmlir-driver/pipelines.mlir
@@ -145,7 +145,7 @@
 // BINARY_MI350-NEXT:cse,
 // BINARY_MI350-NEXT:rock-remove-redundant-casts,
 // BINARY_MI350-NEXT:rock-prepare-llvm)),
-// BINARY_MI350-NEXT:rocdl-attach-target{O=3 abi=600 chip=gfx950 correct-sqrt=true daz=false fast=false features= finite-only=false  module= triple=amdgcn-amd-amdhsa unsafe-math=false wave64=true},
+// BINARY_MI350-NEXT:rocdl-attach-target{O=3 abi=600 chip=gfx950 correct-sqrt=true daz=false fast=false features=-packed-fp32-ops finite-only=false  module= triple=amdgcn-amd-amdhsa unsafe-math=false wave64=true},
 // BINARY_MI350-NEXT:gpu-module-to-binary{format=fatbin  opts= section= toolkit=},
 // BINARY_MI350-NEXT:rock-check-residency,
 // BINARY_MI350-NEXT:emulate-fp8-ext-trunc{f8-conversion-instrs=false ocpf8-conversion-instrs=false})


### PR DESCRIPTION
## Motivation

Nightly CI has been failing intermittently on gfx950 with wrong results on large f32 convolutions — nightlies 2534, 2535, 2541 and 2543, on conv_regression_fwd, conv_regression_fwd_nonNavi3x and Resnet50. Because lit stops at the first failure a different test gets blamed each run, which made it look like several unrelated flakes.

The reported differences are corruption rather than tolerance. These tests normally agree bit-exactly — all 6,422,528 elements at relDiff 0 — so a report such as valNum = 31.0, gpuNum = 32.0 cannot be a rounding step.

The cause is outside rocMLIR. gfx950 mis-executes v_pk_fma_f32 with op_sel:[0,1,0], the form that broadcasts one source to both lanes from its high half: the low lane's accumulation is intermittently not performed, so an f32 reduction finishes short by whole product terms. The high lane, reading the same half of the same register, is always correct, and no HIP call reports an error. A ROCm ticket https://amd-hub.atlassian.net/browse/ROCM-29896 has been filed separately with a standalone reproducer; this PR keeps our generated code off the affected instruction in the meantime.

## Technical Details

buildBackendPipeline appends -packed-fp32-ops to the ROCDL target features when the chip is gfx950, so the backend cannot form the instruction. That is the single point where the target is attached, and all five compilation entry points reach it (rocmlir-driver, rocmlir-lib, the tuning driver, and both MIGraphX C API paths), so no other call site needs changing.

This is a workaround for a defect below us, not a fix, and the block should be deleted once that is addressed. The comment says so, and the reproducer in the ticket is the regression test — if it stays clean on a future driver or firmware, the feature can be turned back on.

Scoped to gfx950 deliberately. gfx942 emits an identical instruction mix for the same kernel (128 v_pk_fma_f32, 32 of them op_sel:[0,1,0]), so it is potentially affected, but no gfx942 hardware was available to test and I did not want to change codegen for a chip with no evidence. gfx90a and gfx908 lack the feature and already emit scalar v_fmac_f32.

Two narrower alternatives were tried and rejected. Restoring LLVM's SLP instruction-count check, which is what widened the exposure, only takes it from 17 of 24 kernels back to 9 of 24 — a build patched that way still failed. Avoiding just the bad op_sel form would keep three quarters of the packed math, but recovering roughly 2% on a non-critical path is not worth an instruction-selection change in the vendored LLVM that would be harder to review and to revert.

## Test Plan

The mechanism was isolated with a standalone HIP reproducer containing no rocMLIR and no MLIR, writing the instruction by hand as inline asm so the compiler does not select, schedule or allocate registers for it. All operands are 1.0f, so every lane must finish at exactly the iteration count and anything else is a lost accumulation rather than rounding. Both broadcast forms run in the same program as controls, and both halves of every accumulator are checked separately.

The change itself was validated by confirming the feature reaches the backend through the ordinary arch string, that gfx942 is untouched, that an accelerated kernel's assembly is unchanged, and by running the affected E2E families under CI-equivalent concurrency against unpatched baselines on the same machine. Runtime cost was measured by differencing two --kernel-repeats counts to remove harness overhead.

## Test Result

- [ ] PR CI
- [ ] Nightly CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
